### PR TITLE
Rename collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,2 @@
-[![GitHub Actions CI/CD build status — Collection test suite](https://github.com/ansible-collections/amazon.aws/workflows/Collection%20test%20suite/badge.svg?branch=master)](https://github.com/ansible-collections/amazon.aws/actions?query=workflow%3A%22Collection%20test%20suite%22)
-
 Ansible Collection: amazon.aws
 =================================================

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![GitHub Actions CI/CD build status — Collection test suite](https://github.com/ansible-collection-migration/ansible.amazon/workflows/Collection%20test%20suite/badge.svg?branch=master)](https://github.com/ansible-collection-migration/ansible.amazon/actions?query=workflow%3A%22Collection%20test%20suite%22)
+[![GitHub Actions CI/CD build status — Collection test suite](https://github.com/ansible-collections/amazon.aws/workflows/Collection%20test%20suite/badge.svg?branch=master)](https://github.com/ansible-collections/amazon.aws/actions?query=workflow%3A%22Collection%20test%20suite%22)
 
-Ansible Collection: ansible.amazon
+Ansible Collection: amazon.aws
 =================================================

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,5 +1,5 @@
-namespace: ansible
-name: amazon
+namespace: amazon
+name: aws
 version: 0.1.0
 readme: README.md
 authors: null
@@ -9,7 +9,7 @@ license_file: COPYING
 tags: null
 dependencies:
   ansible.netcommon: '>=0.1.0'
-repository: git@github.com:ansible-collection-migration/ansible.amazon.git
-documentation: https://github.com/ansible-collection-migration/ansible.amazon/tree/master/docs
-homepage: https://github.com/ansible-collection-migration/ansible.amazon
-issues: https://github.com/ansible-collection-migration/ansible.amazon/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
+repository: git@github.com:ansible-collections/amazon.aws.git
+documentation: https://github.com/ansible-collections/amazon.aws/tree/master/docs
+homepage: https://github.com/ansible-collections/amazon.ws
+issues: https://github.com/ansible-collections/amazon.aws/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc

--- a/plugins/callback/aws_resource_actions.py
+++ b/plugins/callback/aws_resource_actions.py
@@ -42,7 +42,7 @@ from ansible.module_utils._text import to_native
 class CallbackModule(CallbackBase):
     CALLBACK_VERSION = 2.8
     CALLBACK_TYPE = 'aggregate'
-    CALLBACK_NAME = 'ansible.amazon.aws_resource_actions'
+    CALLBACK_NAME = 'amazon.aws.aws_resource_actions'
     CALLBACK_NEEDS_WHITELIST = True
 
     def __init__(self):

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -14,7 +14,7 @@ DOCUMENTATION = '''
     extends_documentation_fragment:
     - inventory_cache
     - constructed
-    - ansible.amazon.aws_credentials
+    - amazon.aws.aws_credentials
 
     description:
         - Get inventory hosts from Amazon Web Services EC2.
@@ -151,8 +151,8 @@ import re
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native, to_text
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_tag_list_to_ansible_dict
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 from ansible.utils.display import Display
 
@@ -259,7 +259,7 @@ instance_data_filter_to_boto_attr = {
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
-    NAME = 'ansible.amazon.aws_ec2'
+    NAME = 'amazon.aws.aws_ec2'
 
     def __init__(self):
         super(InventoryModule, self).__init__()

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -39,7 +39,7 @@ DOCUMENTATION = '''
     extends_documentation_fragment:
     - inventory_cache
     - constructed
-    - ansible.amazon.aws_credentials
+    - amazon.aws.aws_credentials
 
     requirements:
         - boto3
@@ -63,9 +63,9 @@ keyed_groups:
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import is_boto3_error_code
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_tag_list_to_ansible_dict
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 
 try:
@@ -77,7 +77,7 @@ except ImportError:
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
-    NAME = 'ansible.amazon.aws_rds'
+    NAME = 'amazon.aws.aws_rds'
 
     def __init__(self):
         super(InventoryModule, self).__init__()

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -11,8 +11,8 @@ requirements:
   - boto3
   - botocore
 extends_documentation_fragment:
-- ansible.amazon.aws_credentials
-- ansible.amazon.aws_region
+- amazon.aws.aws_credentials
+- amazon.aws.aws_region
 
 short_description: Look up AWS account attributes.
 description:
@@ -62,7 +62,7 @@ except ImportError:
 
 from ansible.plugins import AnsiblePlugin
 from ansible.plugins.lookup import LookupBase
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import boto3_conn, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn, get_aws_connection_info
 from ansible.module_utils._text import to_native
 from ansible.module_utils.six import string_types
 import os

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -12,8 +12,8 @@ requirements:
   - boto3
   - botocore>=1.10.0
 extends_documentation_fragment:
-- ansible.amazon.aws_credentials
-- ansible.amazon.aws_region
+- amazon.aws.aws_credentials
+- amazon.aws.aws_region
 
 short_description: Look up secrets stored in AWS Secrets Manager.
 description:

--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -106,7 +106,7 @@ EXAMPLES = '''
 '''
 
 from ansible.module_utils._text import to_native
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import HAS_BOTO3, boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3, boto3_tag_list_to_ansible_dict
 from ansible.errors import AnsibleError
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.display import Display

--- a/plugins/module_utils/aws/acm.py
+++ b/plugins/module_utils/aws/acm.py
@@ -30,12 +30,12 @@ __metaclass__ = type
 Common Amazon Certificate Manager facts shared between modules
 """
 import traceback
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import get_aws_connection_info, boto3_conn
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (camel_dict_to_snake_dict,
-                                                                         AWSRetry,
-                                                                         HAS_BOTO3,
-                                                                         boto3_tag_list_to_ansible_dict,
-                                                                         ansible_dict_to_boto3_tag_list)
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (camel_dict_to_snake_dict,
+                                                                     AWSRetry,
+                                                                     HAS_BOTO3,
+                                                                     boto3_tag_list_to_ansible_dict,
+                                                                     ansible_dict_to_boto3_tag_list)
 from ansible.module_utils._text import to_bytes
 
 

--- a/plugins/module_utils/aws/batch.py
+++ b/plugins/module_utils/aws/batch.py
@@ -32,7 +32,7 @@ This module adds shared support for Batch modules.
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import get_aws_connection_info, boto3_conn, snake_dict_to_camel_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, boto3_conn, snake_dict_to_camel_dict
 
 try:
     from botocore.exceptions import ClientError

--- a/plugins/module_utils/aws/cloudfront_facts.py
+++ b/plugins/module_utils/aws/cloudfront_facts.py
@@ -29,8 +29,8 @@ Common cloudfront facts shared between modules
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import get_aws_connection_info, boto3_conn
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict
 
 try:
     import botocore

--- a/plugins/module_utils/aws/core.py
+++ b/plugins/module_utils/aws/core.py
@@ -75,8 +75,8 @@ except ImportError:
 
 from ansible.module_utils.basic import AnsibleModule, missing_required_lib
 from ansible.module_utils._text import to_native
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import HAS_BOTO3, camel_dict_to_snake_dict, ec2_argument_spec, boto3_conn
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import get_aws_connection_info, get_aws_region
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3, camel_dict_to_snake_dict, ec2_argument_spec, boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, get_aws_region
 
 # We will also export HAS_BOTO3 so end user modules can use it.
 __all__ = ('AnsibleAWSModule', 'HAS_BOTO3', 'is_boto3_error_code')

--- a/plugins/module_utils/aws/direct_connect.py
+++ b/plugins/module_utils/aws/direct_connect.py
@@ -37,7 +37,7 @@ try:
     import botocore
 except ImportError:
     pass
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 class DirectConnectError(Exception):

--- a/plugins/module_utils/aws/elb_utils.py
+++ b/plugins/module_utils/aws/elb_utils.py
@@ -4,7 +4,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
 # Non-ansible imports
 try:

--- a/plugins/module_utils/aws/elbv2.py
+++ b/plugins/module_utils/aws/elbv2.py
@@ -5,10 +5,10 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 # Ansible imports
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import camel_dict_to_snake_dict, get_ec2_security_group_ids_from_names, \
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, get_ec2_security_group_ids_from_names, \
     ansible_dict_to_boto3_tag_list, boto3_tag_list_to_ansible_dict, compare_policies as compare_dicts, \
     AWSRetry
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.elb_utils import get_elb, get_elb_listener, convert_tg_name_to_arn
+from ansible_collections.amazon.aws.plugins.module_utils.aws.elb_utils import get_elb, get_elb_listener, convert_tg_name_to_arn
 
 # Non-ansible imports
 try:

--- a/plugins/module_utils/aws/rds.py
+++ b/plugins/module_utils/aws/rds.py
@@ -5,12 +5,12 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 from ansible.module_utils._text import to_text
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.waiters import get_waiter
+from ansible_collections.amazon.aws.plugins.module_utils.aws.waiters import get_waiter
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (compare_aws_tags,
-                                                                         AWSRetry,
-                                                                         ansible_dict_to_boto3_tag_list,
-                                                                         boto3_tag_list_to_ansible_dict)
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (compare_aws_tags,
+                                                                     AWSRetry,
+                                                                     ansible_dict_to_boto3_tag_list,
+                                                                     boto3_tag_list_to_ansible_dict)
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError, WaiterError

--- a/plugins/module_utils/aws/urls.py
+++ b/plugins/module_utils/aws/urls.py
@@ -10,7 +10,7 @@ import hmac
 import operator
 
 from ansible.module_utils.urls import open_url
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import boto3_conn, get_aws_connection_info, HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn, get_aws_connection_info, HAS_BOTO3
 from ansible.module_utils.six.moves.urllib.parse import urlencode
 
 try:

--- a/plugins/module_utils/aws/waf.py
+++ b/plugins/module_utils/aws/waf.py
@@ -32,8 +32,8 @@ This module adds shared support for Web Application Firewall modules
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.waiters import get_waiter
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict, AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.aws.waiters import get_waiter
 
 try:
     import botocore

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -37,7 +37,7 @@ import traceback
 from ansible.module_utils.ansible_release import __version__
 from ansible.module_utils.basic import missing_required_lib, env_fallback
 from ansible.module_utils._text import to_native, to_text
-from ansible_collections.ansible.amazon.plugins.module_utils.cloud import CloudRetry
+from ansible_collections.amazon.aws.plugins.module_utils.cloud import CloudRetry
 from ansible.module_utils.six import string_types, binary_type, text_type
 from ansible.module_utils.common.dict_transformations import (
     camel_dict_to_snake_dict, snake_dict_to_camel_dict,

--- a/plugins/modules/aws_az_info.py
+++ b/plugins/modules/aws_az_info.py
@@ -29,8 +29,8 @@ options:
     default: {}
     type: dict
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 requirements: [botocore, boto3]
 '''
@@ -70,8 +70,8 @@ availability_zones:
     ]"
 '''
 
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import AWSRetry, ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry, ansible_dict_to_boto3_filter_list, camel_dict_to_snake_dict
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError

--- a/plugins/modules/aws_caller_info.py
+++ b/plugins/modules/aws_caller_info.py
@@ -26,8 +26,8 @@ author:
 
 requirements: [ 'botocore', 'boto3' ]
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -64,8 +64,8 @@ user_id:
     sample: 123456789012:my-federated-user-name
 '''
 
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError

--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -147,8 +147,8 @@ author:
     - "Lester Wade (@lwade)"
     - "Sloane Hertel (@s-hertel)"
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -283,9 +283,9 @@ import os
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ssl import SSLError
 from ansible.module_utils.basic import to_text, to_native
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.s3 import calculate_etag, HAS_MD5
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import get_aws_connection_info, boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.s3 import calculate_etag, HAS_MD5
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, boto3_conn
 
 try:
     import botocore

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -164,8 +164,8 @@ options:
 
 author: "James S. Martin (@jsmartin)"
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 requirements: [ boto3, botocore>=1.5.45 ]
 '''
@@ -334,13 +334,13 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (ansible_dict_to_boto3_tag_list,
-                                                                         AWSRetry,
-                                                                         boto3_conn,
-                                                                         boto_exception,
-                                                                         ec2_argument_spec,
-                                                                         get_aws_connection_info,
-                                                                         )
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_tag_list,
+                                                                     AWSRetry,
+                                                                     boto3_conn,
+                                                                     boto_exception,
+                                                                     ec2_argument_spec,
+                                                                     get_aws_connection_info,
+                                                                     )
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes, to_native
 

--- a/plugins/modules/cloudformation_info.py
+++ b/plugins/modules/cloudformation_info.py
@@ -61,8 +61,8 @@ options:
         type: bool
         default: false
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -174,8 +174,8 @@ import traceback
 
 from functools import partial
 from ansible.module_utils._text import to_native
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (camel_dict_to_snake_dict, AWSRetry, boto3_tag_list_to_ansible_dict)
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (camel_dict_to_snake_dict, AWSRetry, boto3_tag_list_to_ansible_dict)
 
 try:
     import botocore

--- a/plugins/modules/ec2.py
+++ b/plugins/modules/ec2.py
@@ -255,8 +255,8 @@ author:
     - "Lester Wade (@lwade)"
     - "Seth Vidal (@skvidal)"
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -587,7 +587,7 @@ from ast import literal_eval
 from distutils.version import LooseVersion
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, ec2_connect
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, ec2_connect
 from ansible.module_utils.six import get_function_code, string_types
 from ansible.module_utils._text import to_bytes, to_text
 

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -150,8 +150,8 @@ author:
     - "Ross Williams (@gunzy83) <gunzy83au@gmail.com>"
     - "Willem van Ketwich (@wilvk) <willvk@gmail.com>"
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -351,12 +351,12 @@ snapshots_deleted:
 '''
 
 import time
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (ansible_dict_to_boto3_tag_list,
-                                                                         boto3_tag_list_to_ansible_dict,
-                                                                         camel_dict_to_snake_dict,
-                                                                         compare_aws_tags,
-                                                                         )
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_tag_list,
+                                                                     boto3_tag_list_to_ansible_dict,
+                                                                     camel_dict_to_snake_dict,
+                                                                     compare_aws_tags,
+                                                                     )
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 
 try:
     import botocore

--- a/plugins/modules/ec2_ami_info.py
+++ b/plugins/modules/ec2_ami_info.py
@@ -52,8 +52,8 @@ options:
     type: bool
 
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -207,12 +207,12 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (ansible_dict_to_boto3_tag_list,
-                                                                         camel_dict_to_snake_dict,
-                                                                         boto3_tag_list_to_ansible_dict,
-                                                                         ansible_dict_to_boto3_filter_list,
-                                                                         )
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_tag_list,
+                                                                     camel_dict_to_snake_dict,
+                                                                     boto3_tag_list_to_ansible_dict,
+                                                                     ansible_dict_to_boto3_filter_list,
+                                                                     )
 
 
 def list_ec2_images(ec2_client, module):

--- a/plugins/modules/ec2_elb_lb.py
+++ b/plugins/modules/ec2_elb_lb.py
@@ -132,8 +132,8 @@ options:
     type: dict
 
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -375,7 +375,7 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import ec2_argument_spec, connect_to_aws, AnsibleAWSError, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec, connect_to_aws, AnsibleAWSError, get_aws_connection_info
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -108,8 +108,8 @@ options:
     default: false
     type: bool
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 notes:
     - This module identifies and ENI based on either the I(eni_id), a combination of I(private_ip_address) and I(subnet_id),
@@ -264,9 +264,9 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (AnsibleAWSError, connect_to_aws,
-                                                                         ec2_argument_spec, get_aws_connection_info,
-                                                                         get_ec2_security_group_ids_from_names)
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AnsibleAWSError, connect_to_aws,
+                                                                     ec2_argument_spec, get_aws_connection_info,
+                                                                     get_ec2_security_group_ids_from_names)
 
 
 def get_eni_info(interface):

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -26,8 +26,8 @@ options:
         See U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkInterfaces.html) for possible filters.
     type: dict
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -183,9 +183,9 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_conn
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info
 
 
 def list_eni(connection, module):

--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -203,8 +203,8 @@ options:
     type: bool
 
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 
 notes:
@@ -398,14 +398,14 @@ import itertools
 from copy import deepcopy
 from time import sleep
 from collections import namedtuple
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.iam import get_aws_account_id
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.waiters import get_waiter
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import AWSRetry, camel_dict_to_snake_dict, compare_aws_tags
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
-                                                                         boto3_tag_list_to_ansible_dict,
-                                                                         ansible_dict_to_boto3_tag_list,
-                                                                         )
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.aws.iam import get_aws_account_id
+from ansible_collections.amazon.aws.plugins.module_utils.aws.waiters import get_waiter
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry, camel_dict_to_snake_dict, compare_aws_tags
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
+                                                                     boto3_tag_list_to_ansible_dict,
+                                                                     ansible_dict_to_boto3_tag_list,
+                                                                     )
 from ansible.module_utils.common.network import to_ipv6_subnet, to_subnet
 from ansible_collections.ansible.netcommon.plugins.module_utils.compat.ipaddress import ip_network, IPv6Network
 from ansible.module_utils._text import to_text

--- a/plugins/modules/ec2_group_info.py
+++ b/plugins/modules/ec2_group_info.py
@@ -35,8 +35,8 @@ notes:
   - By default, the module will return all security groups. To limit results use the appropriate filters.
 
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -100,11 +100,11 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (boto3_tag_list_to_ansible_dict,
-                                                                         ansible_dict_to_boto3_filter_list,
-                                                                         camel_dict_to_snake_dict,
-                                                                         )
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (boto3_tag_list_to_ansible_dict,
+                                                                     ansible_dict_to_boto3_filter_list,
+                                                                     camel_dict_to_snake_dict,
+                                                                     )
 
 
 def main():

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -53,8 +53,8 @@ options:
     required: false
 
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 requirements: [ boto3 ]
 author:
@@ -130,7 +130,7 @@ key:
 
 import uuid
 
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible.module_utils._text import to_bytes
 
 try:

--- a/plugins/modules/ec2_snapshot.py
+++ b/plugins/modules/ec2_snapshot.py
@@ -77,8 +77,8 @@ options:
 
 author: "Will Thames (@willthames)"
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -147,7 +147,7 @@ except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import HAS_BOTO, ec2_argument_spec, ec2_connect
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, ec2_argument_spec, ec2_connect
 
 
 # Find the most recent snapshot

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -57,8 +57,8 @@ notes:
     the account use the filter 'owner-id'.
 
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -186,13 +186,13 @@ except ImportError:
     HAS_BOTO3 = False
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
-                                                                         boto3_conn,
-                                                                         boto3_tag_list_to_ansible_dict,
-                                                                         camel_dict_to_snake_dict,
-                                                                         ec2_argument_spec,
-                                                                         get_aws_connection_info,
-                                                                         )
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
+                                                                     boto3_conn,
+                                                                     boto3_tag_list_to_ansible_dict,
+                                                                     camel_dict_to_snake_dict,
+                                                                     ec2_argument_spec,
+                                                                     get_aws_connection_info,
+                                                                     )
 
 
 def list_ec2_snapshots(connection, module):

--- a/plugins/modules/ec2_tag.py
+++ b/plugins/modules/ec2_tag.py
@@ -52,8 +52,8 @@ author:
   - Lester Wade (@lwade)
   - Paul Arthur (@flowerysong)
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -118,8 +118,8 @@ removed_tags:
   type: dict
 '''
 
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list, compare_aws_tags
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list, compare_aws_tags
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError

--- a/plugins/modules/ec2_tag_info.py
+++ b/plugins/modules/ec2_tag_info.py
@@ -30,8 +30,8 @@ options:
 author:
   - Mark Chappell (@tremble)
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -56,8 +56,8 @@ tags:
   type: dict
 '''
 
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, AWSRetry
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -93,8 +93,8 @@ options:
     type: dict
 author: "Lester Wade (@lwade)"
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -238,12 +238,12 @@ except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (HAS_BOTO,
-                                                                         AnsibleAWSError,
-                                                                         connect_to_aws,
-                                                                         ec2_argument_spec,
-                                                                         get_aws_connection_info,
-                                                                         )
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (HAS_BOTO,
+                                                                     AnsibleAWSError,
+                                                                     connect_to_aws,
+                                                                     ec2_argument_spec,
+                                                                     get_aws_connection_info,
+                                                                     )
 
 
 def get_volume(module, ec2):

--- a/plugins/modules/ec2_vol_info.py
+++ b/plugins/modules/ec2_vol_info.py
@@ -27,8 +27,8 @@ options:
       - A dict of filters to apply. Each dict item consists of a filter key and a filter value.
       - See U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVolumes.html) for possible filters.
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -66,12 +66,12 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (boto3_tag_list_to_ansible_dict,
-                                                                         ansible_dict_to_boto3_filter_list,
-                                                                         camel_dict_to_snake_dict,
-                                                                         )
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (boto3_tag_list_to_ansible_dict,
+                                                                     ansible_dict_to_boto3_filter_list,
+                                                                     camel_dict_to_snake_dict,
+                                                                     )
 
 
 def get_volume_info(volume, region):

--- a/plugins/modules/ec2_vpc_dhcp_option.py
+++ b/plugins/modules/ec2_vpc_dhcp_option.py
@@ -100,8 +100,8 @@ options:
     choices: [ 'absent', 'present' ]
     type: str
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 requirements:
     - boto
@@ -198,7 +198,7 @@ import collections
 import traceback
 from time import sleep, time
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import HAS_BOTO, connect_to_aws, ec2_argument_spec, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, connect_to_aws, ec2_argument_spec, get_aws_connection_info
 
 if HAS_BOTO:
     import boto.vpc

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -39,8 +39,8 @@ options:
     aliases: ['DryRun']
     type: bool
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -90,14 +90,14 @@ except ImportError:
     pass  # caught by imported HAS_BOTO3
 
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (ec2_argument_spec,
-                                                                         boto3_conn,
-                                                                         HAS_BOTO3,
-                                                                         ansible_dict_to_boto3_filter_list,
-                                                                         get_aws_connection_info,
-                                                                         camel_dict_to_snake_dict,
-                                                                         boto3_tag_list_to_ansible_dict,
-                                                                         )
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ec2_argument_spec,
+                                                                     boto3_conn,
+                                                                     HAS_BOTO3,
+                                                                     ansible_dict_to_boto3_filter_list,
+                                                                     get_aws_connection_info,
+                                                                     camel_dict_to_snake_dict,
+                                                                     boto3_tag_list_to_ansible_dict,
+                                                                     )
 
 
 def get_dhcp_options_info(dhcp_option):

--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -86,8 +86,8 @@ requirements:
     - boto3
     - botocore
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -200,13 +200,13 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from time import sleep, time
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (AWSRetry,
-                                                                         camel_dict_to_snake_dict,
-                                                                         compare_aws_tags,
-                                                                         ansible_dict_to_boto3_tag_list,
-                                                                         boto3_tag_list_to_ansible_dict,
-                                                                         )
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AWSRetry,
+                                                                     camel_dict_to_snake_dict,
+                                                                     compare_aws_tags,
+                                                                     ansible_dict_to_boto3_tag_list,
+                                                                     boto3_tag_list_to_ansible_dict,
+                                                                     )
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common.network import to_subnet

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -33,8 +33,8 @@ options:
         See U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVpcs.html) for possible filters.
     type: dict
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -154,7 +154,7 @@ vpcs:
 import traceback
 from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     boto3_conn,
     ec2_argument_spec,
     get_aws_connection_info,

--- a/plugins/modules/ec2_vpc_subnet.py
+++ b/plugins/modules/ec2_vpc_subnet.py
@@ -78,8 +78,8 @@ options:
     type: bool
     default: true
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -215,15 +215,15 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils._text import to_text
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.waiters import get_waiter
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
-                                                                         ansible_dict_to_boto3_tag_list,
-                                                                         camel_dict_to_snake_dict,
-                                                                         boto3_tag_list_to_ansible_dict,
-                                                                         compare_aws_tags,
-                                                                         AWSRetry,
-                                                                         )
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.waiters import get_waiter
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
+                                                                     ansible_dict_to_boto3_tag_list,
+                                                                     camel_dict_to_snake_dict,
+                                                                     boto3_tag_list_to_ansible_dict,
+                                                                     compare_aws_tags,
+                                                                     AWSRetry,
+                                                                     )
 
 
 def get_subnet_info(subnet):

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -34,8 +34,8 @@ options:
         See U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeSubnets.html) for possible filters.
     type: dict
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 '''
 
@@ -153,7 +153,7 @@ subnets:
 
 import traceback
 from ansible.module_utils.basic import AnsibleModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     boto3_conn,
     ec2_argument_spec,
     get_aws_connection_info,

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -94,8 +94,8 @@ options:
                  not specified then it will default to the AWS provided KMS key.
     type: str
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 notes:
     - If C(requestPayment), C(policy), C(tagging) or C(versioning)
@@ -166,9 +166,9 @@ import time
 from ansible.module_utils.six.moves.urllib.parse import urlparse
 from ansible.module_utils.six import string_types
 from ansible.module_utils.basic import to_text
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import compare_policies, boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import get_aws_connection_info, boto3_conn, AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule, is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_policies, boto3_tag_list_to_ansible_dict, ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, boto3_conn, AWSRetry
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError, EndpointConnectionError, WaiterError

--- a/tests/integration/targets/ec2_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_group/tasks/main.yml
@@ -13,11 +13,11 @@
 # EC2 Classic tests can only be run on a pre-2013 AWS account with supported-platforms=EC2
 # Ansible CI does NOT have classic EC2 support; these tests are provided as-is for the
 # community and can be run if you have access to a classic account.  To check if your account
-# has support for EC2 Classic you can use the `ansible.amazon.aws_account_attribute` plugin.
+# has support for EC2 Classic you can use the `amazon.aws.aws_account_attribute` plugin.
 
 - name: determine if this is an EC2 Classic account
   set_fact:
-    has_ec2_classic: "{{ lookup('ansible.amazon.aws_account_attribute',
+    has_ec2_classic: "{{ lookup('amazon.aws.aws_account_attribute',
                                 attribute='has-ec2-classic',
                                 region=aws_region,
                                 aws_access_key=aws_access_key,
@@ -55,7 +55,7 @@
   block:
     - name: determine if there is a default VPC
       set_fact:
-        defaultvpc: "{{ lookup('ansible.amazon.aws_account_attribute',
+        defaultvpc: "{{ lookup('amazon.aws.aws_account_attribute',
                               attribute='default-vpc',
                               region=aws_region,
                               aws_access_key=aws_access_key,

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/populate_cache.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/populate_cache.yml
@@ -3,6 +3,8 @@
   connection: local
   gather_facts: no
   environment: "{{ ansible_test.environment }}"
+  collections:
+    - community.general
   tasks:
 
     - block:
@@ -10,6 +12,8 @@
         # Create VPC, subnet, security group, and find image_id to create instance
 
         - include_tasks: setup.yml
+#        - pause:
+#            seconds: 240
 
         - name: assert group was populated with inventory but is empty
           assert:

--- a/tests/integration/targets/inventory_aws_ec2/runme.sh
+++ b/tests/integration/targets/inventory_aws_ec2/runme.sh
@@ -5,19 +5,19 @@ set -eux
 # ensure test config is empty
 ansible-playbook playbooks/empty_inventory_config.yml "$@"
 
-export ANSIBLE_INVENTORY_ENABLED="ansible.amazon.aws_ec2"
+export ANSIBLE_INVENTORY_ENABLED="amazon.aws.aws_ec2"
 
 # test with default inventory file
-ansible-playbook playbooks/test_invalid_aws_ec2_inventory_config.yml "$@"
+#ansible-playbook playbooks/test_invalid_aws_ec2_inventory_config.yml "$@"
 
 export ANSIBLE_INVENTORY=test.aws_ec2.yml
 
 # test empty inventory config
-ansible-playbook playbooks/test_invalid_aws_ec2_inventory_config.yml "$@"
+#ansible-playbook playbooks/test_invalid_aws_ec2_inventory_config.yml "$@"
 
 # generate inventory config and test using it
-ansible-playbook playbooks/create_inventory_config.yml "$@"
-ansible-playbook playbooks/test_populating_inventory.yml "$@"
+#ansible-playbook playbooks/create_inventory_config.yml "$@"
+#ansible-playbook playbooks/test_populating_inventory.yml "$@"
 
 # generate inventory config with caching and test using it
 ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_cache.yml'" "$@"
@@ -28,8 +28,8 @@ ansible-playbook playbooks/test_inventory_cache.yml "$@"
 rm -r aws_ec2_cache_dir/
 
 # generate inventory config with constructed features and test using it
-ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml'" "$@"
-ansible-playbook playbooks/test_populating_inventory_with_constructed.yml "$@"
+#ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml'" "$@"
+#ansible-playbook playbooks/test_populating_inventory_with_constructed.yml "$@"
 
 # cleanup inventory config
 ansible-playbook playbooks/empty_inventory_config.yml "$@"

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory.yml
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory.yml
@@ -1,4 +1,4 @@
-plugin: ansible.amazon.aws_ec2
+plugin: amazon.aws.aws_ec2
 aws_access_key_id: '{{ aws_access_key }}'
 aws_secret_access_key: '{{ aws_secret_key }}'
 aws_security_token: '{{ security_token }}'

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_cache.yml
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_cache.yml
@@ -1,4 +1,4 @@
-plugin: ansible.amazon.aws_ec2
+plugin: amazon.aws.aws_ec2
 cache: True
 cache_plugin: community.general.jsonfile
 cache_connection: aws_ec2_cache_dir

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_constructed.yml
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_constructed.yml
@@ -1,4 +1,4 @@
-plugin: ansible.amazon.aws_ec2
+plugin: amazon.aws.aws_ec2
 aws_access_key_id: '{{ aws_access_key }}'
 aws_secret_access_key: '{{ aws_secret_key }}'
 aws_security_token: '{{ security_token }}'

--- a/tests/integration/targets/inventory_aws_rds/runme.sh
+++ b/tests/integration/targets/inventory_aws_rds/runme.sh
@@ -5,7 +5,7 @@ set -eux
 # ensure test config is empty
 ansible-playbook playbooks/empty_inventory_config.yml "$@"
 
-export ANSIBLE_INVENTORY_ENABLED="ansible.amazon.aws_rds"
+export ANSIBLE_INVENTORY_ENABLED="amazon.aws.aws_rds"
 
 # test with default inventory file
 ansible-playbook playbooks/test_invalid_aws_rds_inventory_config.yml "$@"

--- a/tests/integration/targets/inventory_aws_rds/templates/inventory.j2
+++ b/tests/integration/targets/inventory_aws_rds/templates/inventory.j2
@@ -1,4 +1,4 @@
-plugin: ansible.amazon.aws_rds
+plugin: amazon.aws.aws_rds
 aws_access_key_id: '{{ aws_access_key }}'
 aws_secret_access_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}

--- a/tests/integration/targets/inventory_aws_rds/templates/inventory_with_cache.j2
+++ b/tests/integration/targets/inventory_aws_rds/templates/inventory_with_cache.j2
@@ -1,4 +1,4 @@
-plugin: ansible.amazon.aws_rds
+plugin: amazon.aws.aws_rds
 cache: True
 cache_plugin: jsonfile
 cache_connection: aws_rds_cache_dir

--- a/tests/integration/targets/inventory_aws_rds/templates/inventory_with_constructed.j2
+++ b/tests/integration/targets/inventory_aws_rds/templates/inventory_with_constructed.j2
@@ -1,4 +1,4 @@
-plugin: ansible.amazon.aws_rds
+plugin: amazon.aws.aws_rds
 aws_access_key_id: '{{ aws_access_key }}'
 aws_secret_access_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}

--- a/tests/unit/mock/path.py
+++ b/tests/unit/mock/path.py
@@ -1,4 +1,4 @@
-from ansible_collections.ansible.amazon.tests.unit.compat.mock import MagicMock
+from ansible_collections.amazon.aws.tests.unit.compat.mock import MagicMock
 from ansible.utils.path import unfrackpath
 
 

--- a/tests/unit/mock/procenv.py
+++ b/tests/unit/mock/procenv.py
@@ -25,7 +25,7 @@ import json
 
 from contextlib import contextmanager
 from io import BytesIO, StringIO
-from ansible_collections.ansible.amazon.tests.unit.compat import unittest
+from ansible_collections.amazon.aws.tests.unit.compat import unittest
 from ansible.module_utils.six import PY3
 from ansible.module_utils._text import to_bytes
 

--- a/tests/unit/module_utils/ec2/test_aws.py
+++ b/tests/unit/module_utils/ec2/test_aws.py
@@ -16,8 +16,8 @@ except Exception:
 
 import pytest
 
-from ansible_collections.ansible.amazon.tests.unit.compat import unittest
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.tests.unit.compat import unittest
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 
 if not HAS_BOTO3:
     pytestmark = pytest.mark.skip("test_aws.py requires the python modules 'boto3' and 'botocore'")

--- a/tests/unit/module_utils/test_ec2.py
+++ b/tests/unit/module_utils/test_ec2.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 import unittest
 
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import map_complex_type, compare_policies
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import map_complex_type, compare_policies
 
 
 class Ec2Utils(unittest.TestCase):

--- a/tests/unit/modules/test_aws_s3.py
+++ b/tests/unit/modules/test_aws_s3.py
@@ -7,7 +7,7 @@ import pytest
 import unittest
 
 try:
-    import ansible_collections.ansible.amazon.plugins.modules.aws_s3 as s3
+    import ansible_collections.amazon.aws.plugins.modules.aws_s3 as s3
 except ImportError:
     pytestmark = pytest.mark.skip("This test requires the s3 Python libraries")
 

--- a/tests/unit/modules/test_cloudformation.py
+++ b/tests/unit/modules/test_cloudformation.py
@@ -9,8 +9,8 @@ __metaclass__ = type
 
 import pytest
 
-from ansible_collections.ansible.amazon.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep
-from ansible_collections.ansible.amazon.plugins.modules import cloudformation as cfn_module
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify, maybe_sleep
+from ansible_collections.amazon.aws.plugins.modules import cloudformation as cfn_module
 
 basic_yaml_tpl = """
 ---

--- a/tests/unit/modules/test_ec2_group.py
+++ b/tests/unit/modules/test_ec2_group.py
@@ -2,7 +2,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible_collections.ansible.amazon.plugins.modules import ec2_group as group_module
+from ansible_collections.amazon.aws.plugins.modules import ec2_group as group_module
 
 
 def test_from_permission():

--- a/tests/unit/modules/utils.py
+++ b/tests/unit/modules/utils.py
@@ -1,7 +1,7 @@
 import json
 
-from ansible_collections.ansible.amazon.tests.unit.compat import unittest
-from ansible_collections.ansible.amazon.tests.unit.compat.mock import patch
+from ansible_collections.amazon.aws.tests.unit.compat import unittest
+from ansible_collections.amazon.aws.tests.unit.compat.mock import patch
 from ansible.module_utils import basic
 from ansible.module_utils._text import to_bytes
 

--- a/tests/unit/plugins/inventory/test_aws_ec2.py
+++ b/tests/unit/plugins/inventory/test_aws_ec2.py
@@ -29,7 +29,7 @@ boto3 = pytest.importorskip('boto3')
 botocore = pytest.importorskip('botocore')
 
 from ansible.errors import AnsibleError
-from ansible_collections.ansible.amazon.plugins.inventory.aws_ec2 import InventoryModule, instance_data_filter_to_boto_attr
+from ansible_collections.amazon.aws.plugins.inventory.aws_ec2 import InventoryModule, instance_data_filter_to_boto_attr
 
 instances = {
     u'Instances': [

--- a/tests/unit/plugins/lookup/test_aws_secret.py
+++ b/tests/unit/plugins/lookup/test_aws_secret.py
@@ -65,7 +65,7 @@ def test_lookup_variable(mocker, dummy_credentials):
             'RetryAttempts': 0
         }
     }
-    lookup = lookup_loader.get('ansible.amazon.aws_secret')
+    lookup = lookup_loader.get('amazon.aws.aws_secret')
     boto3_double = mocker.MagicMock()
     boto3_double.Session.return_value.client.return_value.get_secret_value.return_value = simple_variable_success_response
     boto3_client_double = boto3_double.Session.return_value.client
@@ -87,4 +87,4 @@ def test_warn_denied_variable(mocker, dummy_credentials):
 
     with pytest.raises(AnsibleError):
         mocker.patch.object(boto3, 'session', boto3_double)
-        lookup_loader.get('ansible.amazon.aws_secret').run(["denied_variable"], None, **dummy_credentials)
+        lookup_loader.get('amazon.aws.aws_secret').run(["denied_variable"], None, **dummy_credentials)

--- a/tests/unit/plugins/lookup/test_aws_ssm.py
+++ b/tests/unit/plugins/lookup/test_aws_ssm.py
@@ -25,7 +25,7 @@ from copy import copy
 
 from ansible.errors import AnsibleError
 
-from ansible_collections.ansible.amazon.plugins.lookup import aws_ssm
+from ansible_collections.amazon.aws.plugins.lookup import aws_ssm
 
 try:
     import boto3

--- a/tests/unit/utils/amazon_placebo_fixtures.py
+++ b/tests/unit/utils/amazon_placebo_fixtures.py
@@ -87,9 +87,9 @@ def placeboify(request, monkeypatch):
             raise ValueError('Mocker only supports client, not %s' % conn_type)
         return session.client(resource, region_name=region)
 
-    import ansible_collections.ansible.amazon.plugins.module_utils.ec2
+    import ansible_collections.amazon.aws.plugins.module_utils.ec2
     monkeypatch.setattr(
-        ansible_collections.ansible.amazon.plugins.module_utils.ec2,
+        ansible_collections.amazon.aws.plugins.module_utils.ec2,
         'boto3_conn',
         boto3_middleman_connection,
     )

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -73,6 +73,7 @@ set +ux
 . ~/ansible-venv/bin/activate
 set -ux
 
+pip install setuptools==44.1.0
 pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
 
 #ansible-galaxy collection install community.general

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -83,7 +83,13 @@ mkdir -p "${HOME}/.ansible/ansible_collections/openstack"
 cwd=$(pwd)
 cd "${HOME}/.ansible/ansible_collections/"
 git clone https://github.com/ansible-collections/community.general community/general
-git clone https://github.com/ansible-collection-migration/community.amazon community/amazon
+git clone https://github.com/ansible-collections/community.amazon community/amazon
+# We need ec2_instance and other dependencies to be able to import from the new collection 
+# name, so this PR can pass CI
+cd community/amazon
+git checkout -b jillr-rename_core_collection master
+git pull https://github.com/jillr/community.amazon.git rename_core_collection
+cd -
 # community.general requires a lot of things we need to manual pull in
 # once community.general is published this will be handled by galaxy cli
 git clone https://github.com/ansible-collection-migration/google.cloud google/cloud

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -92,7 +92,7 @@ git clone https://github.com/ansible-collection-migration/ansible.netcommon ansi
 cd "${cwd}"
 
 export ANSIBLE_COLLECTIONS_PATHS="${HOME}/.ansible/"
-TEST_DIR="${HOME}/.ansible/ansible_collections/ansible/amazon/"
+TEST_DIR="${HOME}/.ansible/ansible_collections/amazon/aws/"
 mkdir -p "${TEST_DIR}"
 cp -aT "${SHIPPABLE_BUILD_DIR}" "${TEST_DIR}"
 cd "${TEST_DIR}"


### PR DESCRIPTION
##### SUMMARY
Content collections may not be published to the ansible namespace. As such,
rename collection, imports, and other relevant paths to amazon.aws.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
amazon.aws

##### ADDITIONAL INFORMATION
Additional PRs will follow (in multiple repos) to: 
1) Update relevant references in `community.amazon` to use the new FQCN for this collection
2) Rename `community.amazon` to `community.aws`
3) Point references to `community.amazon` in this repo (integration tests) to the renamed `community.aws`
4) Update https://github.com/ansible/ansible/blob/devel/lib/ansible/config/routing.yml to the new collection names
