### PR TITLE
Update netcommon dependency revision

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -2,13 +2,14 @@ namespace: amazon
 name: aws
 version: 0.1.0
 readme: README.md
-authors: null
+authors:
+  - Ansible (https://github.com/ansible)
 description: null
 license: GPL-3.0-or-later
 license_file: COPYING
 tags: null
 dependencies:
-  ansible.netcommon: '>=0.1.0'
+  ansible.netcommon: '>=0.0.1'
 repository: git@github.com:ansible-collections/amazon.aws.git
 documentation: https://github.com/ansible-collections/amazon.aws/tree/master/docs
 homepage: https://github.com/ansible-collections/amazon.ws

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -88,8 +88,7 @@ git clone https://github.com/ansible-collections/community.aws community/aws
 # once community.general is published this will be handled by galaxy cli
 git clone https://github.com/ansible-collections/ansible_collections_google google/cloud
 git clone https://opendev.org/openstack/ansible-collections-openstack openstack/cloud
-git clone https://github.com/ansible-collections/netcommon ansible/netcommon
-#ansible-galaxy collection install ansible.netcommon
+ansible-galaxy collection install ansible.netcommon
 cd "${cwd}"
 
 export ANSIBLE_COLLECTIONS_PATHS="${HOME}/.ansible/"

--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -77,11 +77,11 @@ pip install setuptools==44.1.0
 pip install https://github.com/ansible/ansible/archive/devel.tar.gz --disable-pip-version-check
 
 #ansible-galaxy collection install community.general
-mkdir -p "${HOME}/.ansible/ansible_collections/community"
-mkdir -p "${HOME}/.ansible/ansible_collections/google"
-mkdir -p "${HOME}/.ansible/ansible_collections/openstack"
+mkdir -p "${HOME}/.ansible/collections/ansible_collections/community"
+mkdir -p "${HOME}/.ansible/collections/ansible_collections/google"
+mkdir -p "${HOME}/.ansible/collections/ansible_collections/openstack"
 cwd=$(pwd)
-cd "${HOME}/.ansible/ansible_collections/"
+cd "${HOME}/.ansible/collections/ansible_collections/"
 git clone https://github.com/ansible-collections/community.general community/general
 git clone https://github.com/ansible-collections/community.aws community/aws
 # community.general requires a lot of things we need to manual pull in
@@ -92,7 +92,7 @@ ansible-galaxy collection install ansible.netcommon
 cd "${cwd}"
 
 export ANSIBLE_COLLECTIONS_PATHS="${HOME}/.ansible/"
-TEST_DIR="${HOME}/.ansible/ansible_collections/amazon/aws/"
+TEST_DIR="${HOME}/.ansible/collections/ansible_collections/amazon/aws/"
 mkdir -p "${TEST_DIR}"
 cp -aT "${SHIPPABLE_BUILD_DIR}" "${TEST_DIR}"
 cd "${TEST_DIR}"


### PR DESCRIPTION
##### SUMMARY
galaxy.yml has 0.1.0, as autogenerated by migrate.py.  ansible.netcommon has not actually released a 0.1.0 though.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
galaxy.yml
