### PR TITLE
add connection by URL endpoint when region not specified

### DIFF
--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -548,8 +548,13 @@ def main():
             ec2 = connect_to_aws(boto.ec2, region, **aws_connect_params)
         except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
             module.fail_json(msg=str(e))
+    elif ec2_url:
+        try:
+            ec2 = boto.connect_ec2_endpoint(ec2_url, **aws_connect_params)
+        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError, boto.provider.ProfileNotFoundError) as e:
+            module.fail_json(msg=str(e))
     else:
-        module.fail_json(msg="region must be specified")
+        module.fail_json(msg="Either region or ec2_url must be specified")
 
     if state == 'list':
         returned_volumes = []


### PR DESCRIPTION
##### SUMMARY
The **ec2_vol** module connects to AWS endpoint using legacy *boto* Python library (instead of newer *boto3* Python lib) and require to specify the AWS region because it uses ```boto.ec2.connect_to_region()``` method

Altrough this is not an issue when operation with official **Amazon Web Services** this will irremebiably fail with alternate cloud providers that propose an AWS-compliant API, like [Outscale](https://wiki.outscale.net/display/EN/3DS+OUTSCALE+APIs+Reference)
In such case, we **require** to specify an API endpoint instead of an AWS region, and use ```boto.connect_ec2_endpoint()``` in place of ```boto.ec2.connect_to_region()```

This PR adds an alternate EC2 connection method when **region** parameter is not set:
```python
    if region:
        try:
            ec2 = connect_to_aws(boto.ec2, region, **aws_connect_params)
        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
            module.fail_json(msg=str(e))
    elif ec2_url:
        try:
            ec2 = boto.connect_ec2_endpoint(ec2_url, **aws_connect_params)
        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError, boto.provider.ProfileNotFoundError) as e:
            module.fail_json(msg=str(e))
    else:
        module.fail_json(msg="Either region or ec2_url must be specified")
```

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_vol

##### ADDITIONAL INFORMATION
Without this patch, **ec2_vol** will fail with an erroneous error message:
```shell
 ansible localhost -vv -m ec2_vol -a "ec2_url=https://fcu.eu-west-2.outscale.com region=eu-west-2 volume_type=gp2 volume_size=5 zone=eu-west-2a"
ansible 2.9.6
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/rico/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible-lint/lib/python3.7/site-packages/ansible
  executable location = /opt/ansible-lint/bin/ansible
  python version = 3.7.3 (default, Dec 20 2019, 18:57:59) [GCC 8.3.0]
Using /etc/ansible/ansible.cfg as config file
META: ran handlers
localhost | FAILED! => {
    "changed": false,
    "msg": "AuthFailure: AWS was not able to validate the provided access credentials"
}
```

With the patch, things got better:
```shell
$ ansible localhost -vv -m ec2_vol -a "ec2_url=https://fcu.eu-west-2.outscale.com volume_type=gp2 volume_size=5 zone=eu-west-2a"
Wed 01 Apr 2020 10:31:36 PM CEST
ansible 2.9.6
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/rico/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /opt/ansible-lint/lib/python3.7/site-packages/ansible
  executable location = /opt/ansible-lint/bin/ansible
  python version = 3.7.3 (default, Dec 20 2019, 18:57:59) [GCC 8.3.0]
Using /etc/ansible/ansible.cfg as config file
META: ran handlers
localhost | CHANGED => {
    "changed": true,
    "device": null,
    "volume": {
        "attachment_set": {
            "attach_time": null,
            "device": null,
            "instance_id": null,
            "status": null
        },
        "create_time": "2020-04-01T20:31:38.620Z",
        "encrypted": null,
        "id": "vol-29e31b6d",
        "iops": 100,
        "size": 5,
        "snapshot_id": "",
        "status": "available",
        "tags": {},
        "type": "gp2",
        "zone": "eu-west-2a"
    },
    "volume_id": "vol-29e31b6d",
    "volume_type": "gp2"
}
```
