### PR TITLE
Add hostname options concatenation in aws_ec2 inventory plugin

### DIFF
--- a/changelogs/fragments/25-aws_ec2-hostname-options-concatenation.yaml
+++ b/changelogs/fragments/25-aws_ec2-hostname-options-concatenation.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- aws_ec2 - Add hostname options concatenation

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -512,9 +512,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 if 'name' not in preference:
                     raise AnsibleError("A 'name' key must be defined in a hostnames dictionary.")
                 hostname = self._get_hostname(instance, [preference["name"]])
+                hostname_from_prefix = self._get_hostname(instance, [preference["prefix"]])
                 separator = preference.get("separator", "_")
-                if hostname and 'prefix' in preference:
-                    hostname_from_prefix = self._get_hostname(instance, [preference["prefix"]]) or ''
+                if hostname and hostname_from_prefix and 'prefix' in preference:
                     hostname = hostname_from_prefix + separator + hostname
             elif preference.startswith('tag:'):
                 if not re.match(r'^tag:\S+=\S+$', preference):

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -514,9 +514,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 hostname = self._get_hostname(instance, [preference["name"]])
                 separator = preference.get("separator", "_")
                 if hostname and 'prefix' in preference:
-                    hostname = self._get_hostname(instance, [preference["prefix"]]) + separator + hostname
-            elif 'tag' in preference:
-                if not preference.startswith('tag:'):
+                    hostname_from_prefix = self._get_hostname(instance, [preference["prefix"]]) or ''
+                    hostname = hostname_from_prefix + separator + hostname
+            elif preference.startswith('tag:'):
+                if not re.match(r'^tag:\S+=\S+$', preference):
                     raise AnsibleError("To name a host by tags name_value, use 'tag:name=value'.")
                 hostname = self._get_tag_hostname(preference, instance)
             else:

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -517,8 +517,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                 if hostname and hostname_from_prefix and 'prefix' in preference:
                     hostname = hostname_from_prefix + separator + hostname
             elif preference.startswith('tag:'):
-                if not re.match(r'^tag:\S+=\S+$', preference):
-                    raise AnsibleError("To name a host by tags name_value, use 'tag:name=value'.")
                 hostname = self._get_tag_hostname(preference, instance)
             else:
                 hostname = self._get_boto_attr_chain(preference, instance)

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -57,7 +57,6 @@ DOCUMENTATION = '''
               - Spot instances may be persistent and instances may have associated events.
           type: bool
           default: False
-          version_added: '1.2.2'
         strict_permissions:
           description:
               - By default if a 403 (Forbidden) error code is encountered this plugin will fail.
@@ -77,7 +76,6 @@ DOCUMENTATION = '''
               which group names end up being used as.
           type: bool
           default: False
-          version_added: '1.2.2'
 '''
 
 EXAMPLES = '''
@@ -107,7 +105,7 @@ strict_permissions: False
 # Note: I(hostnames) sets the inventory_hostname. To modify ansible_host without modifying
 # inventory_hostname use compose (see example below).
 hostnames:
-  - tag:Name=Tag1,Name=Tag2         # Return specific hosts only
+  - tag:Name=Tag1,Name=Tag2  # Return specific hosts only
   - tag:CustomDNSName
   - dns-name
   - name: 'tag:Name=Tag1,Name=Tag2'
@@ -515,7 +513,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     raise AnsibleError("A 'name' key must be defined in a hostnames dictionary.")
                 hostname = self._get_hostname(instance, [preference["name"]])
                 separator = preference.get("separator", "_")
-                if 'prefix' in preference:
+                if hostname and 'prefix' in preference:
                     hostname = self._get_hostname(instance, [preference["prefix"]]) + separator + hostname
             elif 'tag' in preference:
                 if not preference.startswith('tag:'):

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_concatenation.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_concatenation.yml
@@ -36,12 +36,12 @@
 
         - name: register the current hostname
           set_fact:
-            hostname: "{{ resource_prefix | replace('-', '_') }}_value"
+            expected_hostname: "value_{{ resource_prefix }}"
 
-        - name: "assert the hostname  is properly formed, '{{ hostname }}' should equal '{{ inventory_hostname }}'"
+        - name: "Ensure we've got a hostvars entry for the new host"
           assert:
             that:
-              - hostname == inventory_hostname
+              - expected_hostname in hostvars
 
       always:
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_concatenation.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_concatenation.yml
@@ -1,0 +1,62 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+  environment: "{{ ansible_test.environment }}"
+  tasks:
+
+    - module_defaults:
+        group/aws:
+          aws_access_key: '{{ aws_access_key }}'
+          aws_secret_key: '{{ aws_secret_key }}'
+          security_token: '{{ security_token | default(omit) }}'
+          region: '{{ aws_region }}'
+      block:
+
+        # Create VPC, subnet, security group, and find image_id to create instance
+        - include_tasks: setup.yml
+
+        # Create new host, refresh inventory
+        - name: create a new host
+          ec2:
+            image: '{{ image_id }}'
+            exact_count: 1
+            count_tag:
+              Name: '{{ resource_prefix }}'
+            instance_tags:
+              Name: '{{ resource_prefix }}'
+              tag1: value1
+              tag2: value2
+            instance_type: t2.micro
+            wait: yes
+            group_id: '{{ sg_id }}'
+            vpc_subnet_id: '{{ subnet_id }}'
+          register: setup_instance
+
+        - meta: refresh_inventory
+
+        - name: register the current hostname
+          set_fact:
+            hostname: "{{ resource_prefix | replace('-', '_') }}_{{ ansible_default_ipv4.address }}"
+
+        - name: "assert the hostname  is properly formed, '{{ hostname }}' should equal '{{ inventory_hostname }}'"
+          assert:
+            that:
+              - hostname == inventory_hostname
+
+      always:
+
+        - name: remove setup ec2 instance
+          ec2:
+            instance_type: t2.micro
+            instance_ids: '{{ setup_instance.instance_ids }}'
+            state: absent
+            wait: yes
+            instance_tags:
+              Name: '{{ resource_prefix }}'
+            group_id: "{{ sg_id }}"
+            vpc_subnet_id: "{{ subnet_id }}"
+          ignore_errors: yes
+          when: setup_instance is defined
+
+        - include_tasks: tear_down.yml

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_concatenation.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_concatenation.yml
@@ -25,8 +25,7 @@
               Name: '{{ resource_prefix }}'
             instance_tags:
               Name: '{{ resource_prefix }}'
-              tag1: value1
-              tag2: value2
+              OtherTag: value
             instance_type: t2.micro
             wait: yes
             group_id: '{{ sg_id }}'
@@ -37,7 +36,7 @@
 
         - name: register the current hostname
           set_fact:
-            hostname: "{{ resource_prefix | replace('-', '_') }}_{{ ansible_default_ipv4.address }}"
+            hostname: "{{ resource_prefix | replace('-', '_') }}_value"
 
         - name: "assert the hostname  is properly formed, '{{ hostname }}' should equal '{{ inventory_hostname }}'"
           assert:

--- a/tests/integration/targets/inventory_aws_ec2/runme.sh
+++ b/tests/integration/targets/inventory_aws_ec2/runme.sh
@@ -30,6 +30,7 @@ rm -r aws_ec2_cache_dir/
 # generate inventory config with constructed features and test using it
 #ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml.j2'" "$@"
 #ansible-playbook playbooks/test_populating_inventory_with_constructed.yml "$@"
+ansible-playbook playbooks/test_populating_inventory_with_concatenation.yml -e "template='inventory_with_concatenation.yml'" "$@"
 
 # cleanup inventory config
 ansible-playbook playbooks/empty_inventory_config.yml "$@"

--- a/tests/integration/targets/inventory_aws_ec2/runme.sh
+++ b/tests/integration/targets/inventory_aws_ec2/runme.sh
@@ -30,7 +30,8 @@ rm -r aws_ec2_cache_dir/
 # generate inventory config with constructed features and test using it
 #ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml.j2'" "$@"
 #ansible-playbook playbooks/test_populating_inventory_with_constructed.yml "$@"
-ansible-playbook playbooks/test_populating_inventory_with_concatenation.yml -e "template='inventory_with_concatenation.yml'" "$@"
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_concatenation.yml.j2'" "$@"
+ansible-playbook playbooks/test_populating_inventory_with_concatenation.yml "$@"
 
 # cleanup inventory config
 ansible-playbook playbooks/empty_inventory_config.yml "$@"

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_concatenation.yml
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_concatenation.yml
@@ -1,0 +1,15 @@
+plugin: amazon.aws.aws_ec2
+aws_access_key_id: '{{ aws_access_key }}'
+aws_secret_access_key: '{{ aws_secret_key }}'
+{% if security_token | default(false) %}
+aws_security_token: '{{ security_token }}'
+{% endif %}
+regions:
+- '{{ aws_region }}'
+filters:
+  tag:Name:
+  - '{{ resource_prefix }}'
+hostnames:
+  - name: 'private-ip-address'
+    separator: '_'
+    prefix: 'tag:Name'

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_concatenation.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_concatenation.yml.j2
@@ -10,6 +10,6 @@ filters:
   tag:Name:
   - '{{ resource_prefix }}'
 hostnames:
-  - name: 'private-ip-address'
+  - name: 'tag:Name'
     separator: '_'
-    prefix: 'tag:Name'
+    prefix: 'tag:OtherTag'

--- a/tests/unit/plugins/inventory/test_aws_ec2.py
+++ b/tests/unit/plugins/inventory/test_aws_ec2.py
@@ -102,7 +102,7 @@ instances = {
          u'RootDeviceType': 'ebs',
          u'RootDeviceName': '/dev/xvda',
          u'VirtualizationType': 'hvm',
-         u'Tags': [{u'Value': 'test', u'Key': 'ansible'}, {u'Value': 'aws_ec2', u'Key': 'name'}],
+         u'Tags': [{u'Value': 'test', u'Key': 'ansible'}, {u'Value': 'aws_ec2', u'Key': 'Name'}],
          u'AmiLaunchIndex': 0}],
     u'ReservationId': 'r-01234567890000000',
     u'Groups': [],
@@ -149,6 +149,12 @@ def test_get_hostname(inventory):
     hostnames = ['ip-address', 'dns-name']
     instance = instances['Instances'][0]
     assert inventory._get_hostname(instance, hostnames) == "12.345.67.890"
+
+
+def test_get_hostname_dict(inventory):
+    hostnames = [{'name': 'private-ip-address', 'separator': '_', 'prefix': 'tag:Name'}]
+    instance = instances['Instances'][0]
+    assert inventory._get_hostname(instance, hostnames) == "aws_ec2_098.76.54.321"
 
 
 def test_set_credentials(inventory):


### PR DESCRIPTION
Reborn of https://github.com/ansible/ansible/pull/58052.
Fixes https://github.com/ansible/ansible/issues/55911.
##### SUMMARY
Adds hostname options concatenation in the aws_ec2 inventory plugin. 

This change adds support for list of options, that will be concatenated with an by default an underscore to create the inventory name.

Example:
```yml
hostnames:
  - name: 'private-ip-address'
    prefix: 'tag:Name'
```
Result: `myinstance_10.10.10.10`

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ansible.inventory.plugins.aws_ec2

##### ADDITIONAL INFORMATION
[Amazon Auto Scaling Groups](https://docs.aws.amazon.com/autoscaling/ec2/userguide/AutoScalingGroup.html) allows to have a group of one or multiple instances, that scales depending of policies.
However, they all share the same tags and dns name. If the ASG includes several instances, only 1 will be targeted when using this options. IPs and Instance IDs are unique, but using them isn't user-friendly.

In order to still use the tag:Name, an unique identifier like an IP or an Instance ID has to be appended.