### PR TITLE
ec2_group: Ensure group-based rule targets have consistent data formats

### DIFF
--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -487,6 +487,16 @@ def to_permission(rule):
 
 
 def rule_from_group_permission(perm):
+    """
+    Returns a rule dict from an existing security group.
+
+    When using a security group as a target all 3 fields (OwnerId, GroupId, and
+    GroupName) need to exist in the target. This ensures consistency of the
+    values that will be compared to desired_ingress or desired_egress
+    in wait_for_rule_propagation().
+    GroupId is preferred as it is more specific except when targeting 'amazon-'
+    prefixed security groups (such as EC2 Classic ELBs).
+    """
     def ports_from_permission(p):
         if 'FromPort' not in p and 'ToPort' not in p:
             return (None, None)
@@ -512,24 +522,24 @@ def rule_from_group_permission(perm):
     if 'UserIdGroupPairs' in perm and perm['UserIdGroupPairs']:
         for pair in perm['UserIdGroupPairs']:
             target = (
-                pair.get('UserId', None),
+                pair.get(None),
                 pair.get('GroupId', None),
-                pair.get('GroupName', None),
+                pair.get(None),
             )
             if pair.get('UserId', '').startswith('amazon-'):
                 # amazon-elb and amazon-prefix rules don't need
                 # group-id specified, so remove it when querying
                 # from permission
                 target = (
-                    target[0],
-                    None,
-                    target[2],
+                    pair.get('UserId', None),
+                    pair.get(None),
+                    pair.get('GroupName', None),
                 )
             elif 'VpcPeeringConnectionId' in pair or pair['UserId'] != current_account_id:
                 target = (
-                    pair.get('UserId', None),
+                    pair.get(None),
                     pair.get('GroupId', None),
-                    pair.get('GroupName', None),
+                    pair.get(None),
                 )
 
             yield Rule(
@@ -596,8 +606,14 @@ def get_target_from_rule(module, client, rule, name, group, groups, vpc_id):
     AWS accepts an ip range or a security group as target of a rule. This
     function validate the rule specification and return either a non-None
     group_id or a non-None ip range.
+
+    When using a security group as a target all 3 fields (OwnerId, GroupId, and
+    GroupName) need to exist in the target. This ensures consistency of the
+    values that will be compared to current_rules (from current_ingress and
+    current_egress) in wait_for_rule_propagation().
     """
     FOREIGN_SECURITY_GROUP_REGEX = r'^([^/]+)/?(sg-\S+)?/(\S+)'
+    owner_id = None
     group_id = None
     group_name = None
     target_group_created = False
@@ -605,16 +621,24 @@ def get_target_from_rule(module, client, rule, name, group, groups, vpc_id):
     validate_rule(module, rule)
     if rule.get('group_id') and re.match(FOREIGN_SECURITY_GROUP_REGEX, rule['group_id']):
         # this is a foreign Security Group. Since you can't fetch it you must create an instance of it
+        # Matches on groups like amazon-elb/sg-5a9c116a/amazon-elb-sg, amazon-elb/amazon-elb-sg,
+        # and peer-VPC groups like 0987654321/sg-1234567890/example
         owner_id, group_id, group_name = re.match(FOREIGN_SECURITY_GROUP_REGEX, rule['group_id']).groups()
         group_instance = dict(UserId=owner_id, GroupId=group_id, GroupName=group_name)
         groups[group_id] = group_instance
         groups[group_name] = group_instance
-        # group_id/group_name are mutually exclusive - give group_id more precedence as it is more specific
         if group_id and group_name:
-            group_name = None
+            if group_name.startswith('amazon-'):
+                # amazon-elb and amazon-prefix rules don't need group_id specified,
+                group_id = None
+            else:
+                # group_id/group_name are mutually exclusive - give group_id more precedence as it is more specific
+                # Strip owner_id, it's not required and will cause wait_for_rule_propagation() to not match.
+                owner_id = None
+                group_name = None
         return 'group', (owner_id, group_id, group_name), False
     elif 'group_id' in rule:
-        return 'group', rule['group_id'], False
+        return 'group', (None, rule['group_id'], None), False
     elif 'group_name' in rule:
         group_name = rule['group_name']
         if group_name == name:
@@ -673,7 +697,7 @@ def get_target_from_rule(module, client, rule, name, group, groups, vpc_id):
                 groups[group_id] = auto_group
                 groups[group_name] = auto_group
             target_group_created = True
-        return 'group', group_id, target_group_created
+        return 'group', (None, group_id, None), target_group_created
     elif 'cidr_ip' in rule:
         return 'ipv4', validate_ip(module, rule['cidr_ip']), False
     elif 'cidr_ipv6' in rule:
@@ -1293,7 +1317,7 @@ def main():
         else:
             revoke_egress = []
 
-        # named_tuple_ingress_list and named_tuple_egress_list got updated by
+        # named_tuple_ingress_list and named_tuple_egress_list get updated by
         # method update_rule_descriptions, deep copy these two lists to new
         # variables for the record of the 'desired' ingress and egress sg permissions
         desired_ingress = deepcopy(named_tuple_ingress_list)

--- a/tests/integration/targets/ec2_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_group/tasks/main.yml
@@ -519,6 +519,7 @@
       assert:
         that:
           - result.changed
+          - result.warning is not defined
           - result.ip_permissions|length == 2
           - result.ip_permissions[0].user_id_group_pairs or
             result.ip_permissions[1].user_id_group_pairs
@@ -626,6 +627,7 @@
         that:
            - 'result.changed'
            - 'result.group_id.startswith("sg-")'
+           - result.warning is not defined
 
     # ============================================================
     - name: test adding a range of ports and ports given as strings (expected changed=true) (CHECK MODE)

--- a/tests/integration/targets/ec2_group/tasks/multi_nested_target.yml
+++ b/tests/integration/targets/ec2_group/tasks/multi_nested_target.yml
@@ -220,6 +220,7 @@
   - assert:
       that:
         - result.changed
+        - result.warning is not defined
         - 'result.ip_permissions[0].ip_ranges | length == 3 or result.ip_permissions[1].ip_ranges | length == 3'
         - 'result.ip_permissions[0].ipv6_ranges | length == 3 or result.ip_permissions[1].ipv6_ranges | length == 3'
 

--- a/tests/integration/targets/ec2_group/tasks/rule_group_create.yml
+++ b/tests/integration/targets/ec2_group/tasks/rule_group_create.yml
@@ -51,6 +51,10 @@
         - 60
         - 80
 
+    - assert:
+        that:
+          - result.warning is not defined
+
     - name: Create a group with only the default rule
       ec2_group:
         name: '{{ec2_group_name}}-auto-create-1'
@@ -87,6 +91,10 @@
         state: present
       register: result
 
+    - assert:
+        that:
+          - result.warning is not defined
+
     - name: Create a 4th group
       ec2_group:
         name: '{{ec2_group_name}}-auto-create-4'
@@ -112,6 +120,10 @@
           group_name: '{{ec2_group_name}}-auto-create-4'
         <<: *aws_connection_info
         state: present
+
+    - assert:
+        that:
+          - result.warning is not defined
 
   always:
     - name: tidy up egress rule test security group


### PR DESCRIPTION
##### SUMMARY
Ensure group-based rule targets have consistent data formats throughout the module.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_group

##### ADDITIONAL INFORMATION
There are several possible inputs a user could supply to `ec2_group` to add/update a security group targeted rule.  Some of these - and the way we've been handling them in the code - differ somewhat from the data AWS will return when querying groups for existing rules.  There are two data structures at issue.

[`get_target_from_rule()`](https://github.com/ansible-collections/amazon.aws/blob/master/plugins/modules/ec2_group.py#L588) operates on the module args to create a `named_tuple_ingress_list` and `named_tuple_egress_list` (later deep copied to `desired_ingress` and `desired_egress`).

[`rule_from_group_permission()`](https://github.com/ansible-collections/amazon.aws/blob/master/plugins/modules/ec2_group.py#L489) takes a `group` variable, which contains any current [groups](https://github.com/ansible-collections/amazon.aws/blob/master/plugins/modules/ec2_group.py#L1175) as returned by `connection.describe_security_groups()`.  It uses this input to build a `current_ingress` and `current_egress` list, and later (and more problematically) when building the [current_rules](https://github.com/ansible-collections/amazon.aws/blob/master/plugins/modules/ec2_group.py#L934) var in wait_for_rule_propogation().

Over the years there have been several patches to these code paths to deal with warnings and errors arising when these rule lists are compared at https://github.com/ansible-collections/amazon.aws/blob/master/plugins/modules/ec2_group.py#L935.  This has been an ongoing game of whack-a-mole, as patching one scenario tends to break others.  I do not believe this has been examined holistically, nor the rationale behind what is going on documented (in any of the bugs I dug up at least).  Hopefully this PR can be a more comprehensive fix and explanation of the overarching problem.

Recent issues:
https://github.com/ansible/ansible/issues/68729
https://github.com/ansible/ansible/issues/68217
https://github.com/ansible/ansible/issues/66852
https://github.com/ansible/ansible/issues/66641

Subset of past issues:
https://github.com/ansible/ansible/issues/57247
https://github.com/ansible/ansible/issues/44788
https://github.com/ansible/ansible/pull/45815
https://github.com/ansible/ansible-modules-core/issues/373
https://github.com/ansible/ansible/issues/7109

Possible valid inputs to group_id or group_name:
|Type | Example|
|------|-----|
|EC2 Classic ELB| amazon-elb/amazon-elb-sg|
|EC2 Classic ELB| amazon-elb/sg-5a9c116a/amazon-elb-sg|
|Same VPC, "full path"| 0987654321/sg-1234567890/example|
|Peered VPC Group| 0987654321/sg-1234567890/example|
|GroupId| sg-1234567890|
|GroupName| example|

The [AWS docs](https://docs.aws.amazon.com/vpc/latest/peering/vpc-peering-security-groups.html) suggest using a 2-field Peer VPC Group (123456789012/sg-1a2b3c4d) however I can find no indication of the module supporting this, and testing on 2.8.10, 2.9.1, and devel.  So I think we can call that an unsupported module option.

Bugs exist when the Rule `target` tuple values for the current and desired rules list do not match.  For example, before 62374 using `amazon-elb/amazon-elb-sg` would result in: 
|VAR|Value|
|---|---|
|`current_ingress`|`('s', None, '-')`|
| `desired_ingress`| `('amazon-elb', 'sg-5a9c116a', None)`|

And specifying a peered VPC `group_id` of `0987654321/sg-1234567890/example` would result in
|VAR|Value|
|---|---|
|`current_ingress`|`sg-1234567890` (as a string - no tuple)|
| `desired_ingress`| `('0987654321', 'sg-1234567890', None)`|

In most cases the rule is successfully changed, but `wait_for_rule_propagation()` hangs and reports a [warning](https://github.com/ansible-collections/amazon.aws/blob/master/plugins/modules/ec2_group.py#L950) that the rules being compared do not match.  It's notable that the module does not fail at this point - we have generally always missed this problem in CI.  Tests need to be expanded.