### PR TITLE
Enable inventory_aws_ec2 integration tests

### DIFF
--- a/tests/integration/targets/inventory_aws_ec2/aliases
+++ b/tests/integration/targets/inventory_aws_ec2/aliases
@@ -1,3 +1,2 @@
 cloud/aws
 shippable/aws/group1
-disabled


### PR DESCRIPTION
##### SUMMARY

The caching tests should be fixed by https://github.com/ansible/ansible/commit/59454153984da2e9127931194d26180ca3e99ee6.

##### ISSUE TYPE
- Bugfix Pull Request
