### PR TITLE
Allow to manipulate buckets on minio

### DIFF
--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -466,7 +466,7 @@ def boto3_tag_list_to_ansible_dict(tags_list, tag_name_key_name=None, tag_value_
         tag_candidates = {'key': 'value', 'Key': 'Value'}
 
     # minio seems to return [{}] as an empty tags_list
-    if not tags_list or not tags_list[0]:
+    if not tags_list or not any(tag for tag in tags_list):
         return {}
     for k, v in tag_candidates.items():
         if k in tags_list[0] and v in tags_list[0]:

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -465,7 +465,8 @@ def boto3_tag_list_to_ansible_dict(tags_list, tag_name_key_name=None, tag_value_
     else:
         tag_candidates = {'key': 'value', 'Key': 'Value'}
 
-    if not tags_list:
+    # minio seems to return [{}] as an empty tags_list
+    if not tags_list or not tags_list[0]:
         return {}
     for k, v in tag_candidates.items():
         if k in tags_list[0] and v in tags_list[0]:

--- a/tests/unit/module_utils/test_ec2.py
+++ b/tests/unit/module_utils/test_ec2.py
@@ -394,6 +394,12 @@ class Ec2Utils(unittest.TestCase):
         converted_dict = boto3_tag_list_to_ansible_dict(self.tag_example_boto3_list)
         self.assertEqual(converted_dict, self.tag_example_dict)
 
+    def test_boto3_tag_list_to_ansible_dict_empty(self):
+        # AWS returns [] when there are no tags
+        self.assertEqual(boto3_tag_list_to_ansible_dict([], {}))
+        # Minio returns [{}] when there are no tags
+        self.assertEqual(boto3_tag_list_to_ansible_dict([{}], {}))
+
     # ========================================================
     #   ec2.compare_aws_tags
     # ========================================================

--- a/tests/unit/module_utils/test_ec2.py
+++ b/tests/unit/module_utils/test_ec2.py
@@ -396,9 +396,9 @@ class Ec2Utils(unittest.TestCase):
 
     def test_boto3_tag_list_to_ansible_dict_empty(self):
         # AWS returns [] when there are no tags
-        self.assertEqual(boto3_tag_list_to_ansible_dict([], {}))
+        self.assertEqual(boto3_tag_list_to_ansible_dict([]), {})
         # Minio returns [{}] when there are no tags
-        self.assertEqual(boto3_tag_list_to_ansible_dict([{}], {}))
+        self.assertEqual(boto3_tag_list_to_ansible_dict([{}]), {})
 
     # ========================================================
     #   ec2.compare_aws_tags


### PR DESCRIPTION
##### SUMMARY
This allows [{}] to be recognized as an empty tags_list in boto3_tag_list_to_ansible_dict.

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
ec2 module_utils