### PR TITLE
Migrations to AnsibleAWSModule (and related cleanup)

### DIFF
--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -339,7 +339,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dic
                                                                      AWSRetry,
                                                                      boto3_conn,
                                                                      boto_exception,
-                                                                     ec2_argument_spec,
                                                                      get_aws_connection_info,
                                                                      )
 from ansible.module_utils._text import to_bytes, to_native
@@ -631,8 +630,7 @@ def get_stack_facts(cfn, stack_name):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         stack_name=dict(required=True),
         template_parameters=dict(required=False, type='dict', default={}),
         state=dict(default='present', choices=['present', 'absent']),
@@ -655,7 +653,6 @@ def main():
         backoff_delay=dict(type='int', default=3, required=False),
         backoff_max_delay=dict(type='int', default=30, required=False),
         capabilities=dict(type='list', default=['CAPABILITY_IAM', 'CAPABILITY_NAMED_IAM'])
-    )
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -334,13 +334,13 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_tag_list,
-                                                                     AWSRetry,
-                                                                     boto3_conn,
-                                                                     boto_exception,
-                                                                     get_aws_connection_info,
-                                                                     )
-from ansible.module_utils._text import to_bytes, to_native
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto_exception
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_native
 
 
 def get_stack_events(cfn, stack_name, events_limit, token_filter=None):

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -336,9 +336,7 @@ except ImportError:
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto_exception
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils._text import to_native
 
@@ -725,11 +723,7 @@ def main():
 
     result = {}
 
-    try:
-        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-        cfn = boto3_conn(module, conn_type='client', resource='cloudformation', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    except botocore.exceptions.NoCredentialsError as e:
-        module.fail_json(msg=boto_exception(e))
+    cfn = module.client('cloudformation')
 
     # Wrap the cloudformation client methods that this module uses with
     # automatic backoff / retry for throttling error codes

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -334,6 +334,7 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_tag_list,
                                                                      AWSRetry,
                                                                      boto3_conn,
@@ -341,7 +342,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dic
                                                                      ec2_argument_spec,
                                                                      get_aws_connection_info,
                                                                      )
-from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils._text import to_bytes, to_native
 
 
@@ -658,7 +658,7 @@ def main():
     )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
         mutually_exclusive=[['template_url', 'template', 'template_body'],
                             ['disable_rollback', 'on_create_failure']],

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -330,9 +330,8 @@ from hashlib import sha1
 try:
     import boto3
     import botocore
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_tag_list,
@@ -661,8 +660,6 @@ def main():
                             ['disable_rollback', 'on_create_failure']],
         supports_check_mode=True
     )
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 and botocore are required for this module')
 
     invalid_capabilities = []
     user_capabilities = module.params.get('capabilities')

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -333,12 +333,12 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_native
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto_exception
-from ansible.module_utils._text import to_bytes
-from ansible.module_utils._text import to_native
 
 
 def get_stack_events(cfn, stack_name, events_limit, token_filter=None):

--- a/plugins/modules/ec2.py
+++ b/plugins/modules/ec2.py
@@ -586,7 +586,7 @@ import traceback
 from ast import literal_eval
 from distutils.version import LooseVersion
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, ec2_connect
 from ansible.module_utils.six import get_function_code, string_types
 from ansible.module_utils._text import to_bytes, to_text
@@ -966,7 +966,7 @@ def create_instances(module, ec2, vpc, override_count=None):
     """
     Creates new instances
 
-    module : AnsibleModule object
+    module : AnsibleAWSModule object
     ec2: authenticated ec2 connection object
 
     Returns:
@@ -1649,8 +1649,9 @@ def main():
         )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
+        check_boto3=False,
         mutually_exclusive=[
             # Can be uncommented when we finish the deprecation cycle.
             # ['group', 'group_id'],

--- a/plugins/modules/ec2.py
+++ b/plugins/modules/ec2.py
@@ -596,14 +596,14 @@ try:
 except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
-from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_connect
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible.module_utils.six import get_function_code
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils._text import to_text
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_connect
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def find_running_instances_by_count_tag(module, ec2, vpc, count_tag, zone=None):

--- a/plugins/modules/ec2.py
+++ b/plugins/modules/ec2.py
@@ -586,21 +586,25 @@ import traceback
 from ast import literal_eval
 from distutils.version import LooseVersion
 
-from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, ec2_connect
-from ansible.module_utils.six import get_function_code, string_types
-from ansible.module_utils._text import to_bytes, to_text
-
 try:
     import boto.ec2
-    from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
+    from boto.ec2.blockdevicemapping import BlockDeviceType
+    from boto.ec2.blockdevicemapping import BlockDeviceMapping
     from boto.exception import EC2ResponseError
     from boto import connect_ec2_endpoint
     from boto import connect_vpc
 except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_connect
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible.module_utils.six import get_function_code
+from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_bytes
+from ansible.module_utils._text import to_text
+
 
 def find_running_instances_by_count_tag(module, ec2, vpc, count_tag, zone=None):
 

--- a/plugins/modules/ec2.py
+++ b/plugins/modules/ec2.py
@@ -597,10 +597,10 @@ try:
     from boto.exception import EC2ResponseError
     from boto import connect_ec2_endpoint
     from boto import connect_vpc
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Taken care of by ec2.HAS_BOTO
 
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 
 def find_running_instances_by_count_tag(module, ec2, vpc, count_tag, zone=None):
 

--- a/plugins/modules/ec2.py
+++ b/plugins/modules/ec2.py
@@ -587,7 +587,7 @@ from ast import literal_eval
 from distutils.version import LooseVersion
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, ec2_argument_spec, ec2_connect
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info, ec2_connect
 from ansible.module_utils.six import get_function_code, string_types
 from ansible.module_utils._text import to_bytes, to_text
 
@@ -1608,45 +1608,42 @@ def warn_if_public_ip_assignment_changed(module, instance):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            key_name=dict(aliases=['keypair']),
-            id=dict(),
-            group=dict(type='list', aliases=['groups']),
-            group_id=dict(type='list'),
-            zone=dict(aliases=['aws_zone', 'ec2_zone']),
-            instance_type=dict(aliases=['type']),
-            spot_price=dict(),
-            spot_type=dict(default='one-time', choices=["one-time", "persistent"]),
-            spot_launch_group=dict(),
-            image=dict(),
-            kernel=dict(),
-            count=dict(type='int', default='1'),
-            monitoring=dict(type='bool', default=False),
-            ramdisk=dict(),
-            wait=dict(type='bool', default=False),
-            wait_timeout=dict(type='int', default=300),
-            spot_wait_timeout=dict(type='int', default=600),
-            placement_group=dict(),
-            user_data=dict(),
-            instance_tags=dict(type='dict'),
-            vpc_subnet_id=dict(),
-            assign_public_ip=dict(type='bool'),
-            private_ip=dict(),
-            instance_profile_name=dict(),
-            instance_ids=dict(type='list', aliases=['instance_id']),
-            source_dest_check=dict(type='bool', default=None),
-            termination_protection=dict(type='bool', default=None),
-            state=dict(default='present', choices=['present', 'absent', 'running', 'restarted', 'stopped']),
-            instance_initiated_shutdown_behavior=dict(default='stop', choices=['stop', 'terminate']),
-            exact_count=dict(type='int', default=None),
-            count_tag=dict(type='raw'),
-            volumes=dict(type='list'),
-            ebs_optimized=dict(type='bool', default=False),
-            tenancy=dict(default='default', choices=['default', 'dedicated']),
-            network_interfaces=dict(type='list', aliases=['network_interface'])
-        )
+    argument_spec = dict(
+        key_name=dict(aliases=['keypair']),
+        id=dict(),
+        group=dict(type='list', aliases=['groups']),
+        group_id=dict(type='list'),
+        zone=dict(aliases=['aws_zone', 'ec2_zone']),
+        instance_type=dict(aliases=['type']),
+        spot_price=dict(),
+        spot_type=dict(default='one-time', choices=["one-time", "persistent"]),
+        spot_launch_group=dict(),
+        image=dict(),
+        kernel=dict(),
+        count=dict(type='int', default='1'),
+        monitoring=dict(type='bool', default=False),
+        ramdisk=dict(),
+        wait=dict(type='bool', default=False),
+        wait_timeout=dict(type='int', default=300),
+        spot_wait_timeout=dict(type='int', default=600),
+        placement_group=dict(),
+        user_data=dict(),
+        instance_tags=dict(type='dict'),
+        vpc_subnet_id=dict(),
+        assign_public_ip=dict(type='bool'),
+        private_ip=dict(),
+        instance_profile_name=dict(),
+        instance_ids=dict(type='list', aliases=['instance_id']),
+        source_dest_check=dict(type='bool', default=None),
+        termination_protection=dict(type='bool', default=None),
+        state=dict(default='present', choices=['present', 'absent', 'running', 'restarted', 'stopped']),
+        instance_initiated_shutdown_behavior=dict(default='stop', choices=['stop', 'terminate']),
+        exact_count=dict(type='int', default=None),
+        count_tag=dict(type='raw'),
+        volumes=dict(type='list'),
+        ebs_optimized=dict(type='bool', default=False),
+        tenancy=dict(default='default', choices=['default', 'dedicated']),
+        network_interfaces=dict(type='list', aliases=['network_interface'])
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/ec2_elb_lb.py
+++ b/plugins/modules/ec2_elb_lb.py
@@ -373,13 +373,13 @@ try:
 except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
+from ansible.module_utils.six import string_types
+from ansible.module_utils._text import to_native
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
-from ansible.module_utils.six import string_types
-from ansible.module_utils._text import to_native
 
 
 def _throttleable_operation(max_retries):

--- a/plugins/modules/ec2_elb_lb.py
+++ b/plugins/modules/ec2_elb_lb.py
@@ -374,8 +374,10 @@ except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws, AnsibleAWSError, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 

--- a/plugins/modules/ec2_elb_lb.py
+++ b/plugins/modules/ec2_elb_lb.py
@@ -375,7 +375,7 @@ except ImportError:
     HAS_BOTO = False
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec, connect_to_aws, AnsibleAWSError, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws, AnsibleAWSError, get_aws_connection_info
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 
@@ -1221,8 +1221,7 @@ class ElbManager(object):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         state={'required': True, 'choices': ['present', 'absent']},
         name={'required': True},
         listeners={'default': None, 'required': False, 'type': 'list'},
@@ -1245,7 +1244,6 @@ def main():
         wait={'default': False, 'type': 'bool', 'required': False},
         wait_timeout={'default': 60, 'type': 'int', 'required': False},
         tags={'default': None, 'required': False, 'type': 'dict'}
-    )
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/ec2_elb_lb.py
+++ b/plugins/modules/ec2_elb_lb.py
@@ -370,12 +370,12 @@ try:
     import boto.vpc
     from boto.ec2.elb.healthcheck import HealthCheck
     from boto.ec2.tag import Tag
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Taken care of by ec2.HAS_BOTO
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws, AnsibleAWSError, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
 

--- a/plugins/modules/ec2_elb_lb.py
+++ b/plugins/modules/ec2_elb_lb.py
@@ -374,7 +374,7 @@ try:
 except ImportError:
     HAS_BOTO = False
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec, connect_to_aws, AnsibleAWSError, get_aws_connection_info
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
@@ -1248,8 +1248,9 @@ def main():
     )
     )
 
-    module = AnsibleModule(
+    module = AnsibleAWSModule(
         argument_spec=argument_spec,
+        check_boto3=False,
         mutually_exclusive=[['security_group_ids', 'security_group_names']]
     )
 

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -360,7 +360,7 @@ def create_eni(connection, vpc_id, module):
         changed = True
 
     except BotoServerError as e:
-        module.fail_json(msg=e.message)
+        module.fail_json_aws(e)
 
     module.exit_json(changed=changed, interface=get_eni_info(eni))
 
@@ -449,7 +449,7 @@ def modify_eni(connection, vpc_id, module, eni):
             detach_eni(eni, module)
 
     except BotoServerError as e:
-        module.fail_json(msg=e.message)
+        module.fail_json_aws(e)
 
     eni.update()
     module.exit_json(changed=changed, interface=get_eni_info(eni))
@@ -482,7 +482,7 @@ def delete_eni(connection, module):
         if regex.search(e.message) is not None:
             module.exit_json(changed=False)
         else:
-            module.fail_json(msg=e.message)
+            module.fail_json_aws(e)
 
 
 def detach_eni(eni, module):
@@ -535,7 +535,7 @@ def uniquely_find_eni(connection, module):
             return None
 
     except BotoServerError as e:
-        module.fail_json(msg=e.message)
+        module.fail_json_aws(e)
 
     return None
 
@@ -555,7 +555,7 @@ def _get_vpc_id(connection, module, subnet_id):
     try:
         return connection.get_all_subnets(subnet_ids=[subnet_id])[0].vpc_id
     except BotoServerError as e:
-        module.fail_json(msg=e.message)
+        module.fail_json_aws(e)
 
 
 def main():
@@ -601,7 +601,7 @@ def main():
             connection = connect_to_aws(boto.ec2, region, **aws_connect_params)
             vpc_connection = connect_to_aws(boto.vpc, region, **aws_connect_params)
         except (boto.exception.NoAuthHandlerFound, AnsibleAWSError) as e:
-            module.fail_json(msg=str(e))
+            module.fail_json_aws(e)
     else:
         module.fail_json(msg="region must be specified")
 

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -259,11 +259,11 @@ try:
     import boto.ec2
     import boto.vpc
     from boto.exception import BotoServerError
-    HAS_BOTO = True
 except ImportError:
-    HAS_BOTO = False
+    pass  # Taken care of by ec2.HAS_BOTO
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AnsibleAWSError, connect_to_aws,
                                                                      get_aws_connection_info,
                                                                      get_ec2_security_group_ids_from_names)

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -263,7 +263,7 @@ try:
 except ImportError:
     HAS_BOTO = False
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AnsibleAWSError, connect_to_aws,
                                                                      ec2_argument_spec, get_aws_connection_info,
                                                                      get_ec2_security_group_ids_from_names)
@@ -580,16 +580,18 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           mutually_exclusive=[
-                               ['secondary_private_ip_addresses', 'secondary_private_ip_address_count']
-                           ],
-                           required_if=([
-                               ('state', 'absent', ['eni_id']),
-                               ('attached', True, ['instance_id']),
-                               ('purge_secondary_private_ip_addresses', True, ['secondary_private_ip_addresses'])
-                           ])
-                           )
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        check_boto3=False,
+        mutually_exclusive=[
+            ['secondary_private_ip_addresses', 'secondary_private_ip_address_count']
+        ],
+        required_if=([
+            ('state', 'absent', ['eni_id']),
+            ('attached', True, ['instance_id']),
+            ('purge_secondary_private_ip_addresses', True, ['secondary_private_ip_addresses'])
+        ])
+    )
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -265,7 +265,7 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AnsibleAWSError, connect_to_aws,
-                                                                     ec2_argument_spec, get_aws_connection_info,
+                                                                     get_aws_connection_info,
                                                                      get_ec2_security_group_ids_from_names)
 
 
@@ -558,26 +558,23 @@ def _get_vpc_id(connection, module, subnet_id):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            eni_id=dict(default=None, type='str'),
-            instance_id=dict(default=None, type='str'),
-            private_ip_address=dict(type='str'),
-            subnet_id=dict(type='str'),
-            description=dict(type='str'),
-            security_groups=dict(default=[], type='list'),
-            device_index=dict(default=0, type='int'),
-            state=dict(default='present', choices=['present', 'absent']),
-            force_detach=dict(default='no', type='bool'),
-            source_dest_check=dict(default=None, type='bool'),
-            delete_on_termination=dict(default=None, type='bool'),
-            secondary_private_ip_addresses=dict(default=None, type='list'),
-            purge_secondary_private_ip_addresses=dict(default=False, type='bool'),
-            secondary_private_ip_address_count=dict(default=None, type='int'),
-            allow_reassignment=dict(default=False, type='bool'),
-            attached=dict(default=None, type='bool')
-        )
+    argument_spec = dict(
+        eni_id=dict(default=None, type='str'),
+        instance_id=dict(default=None, type='str'),
+        private_ip_address=dict(type='str'),
+        subnet_id=dict(type='str'),
+        description=dict(type='str'),
+        security_groups=dict(default=[], type='list'),
+        device_index=dict(default=0, type='int'),
+        state=dict(default='present', choices=['present', 'absent']),
+        force_detach=dict(default='no', type='bool'),
+        source_dest_check=dict(default=None, type='bool'),
+        delete_on_termination=dict(default=None, type='bool'),
+        secondary_private_ip_addresses=dict(default=None, type='list'),
+        purge_secondary_private_ip_addresses=dict(default=False, type='bool'),
+        secondary_private_ip_address_count=dict(default=None, type='int'),
+        allow_reassignment=dict(default=False, type='bool'),
+        attached=dict(default=None, type='bool')
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -264,9 +264,10 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (AnsibleAWSError, connect_to_aws,
-                                                                     get_aws_connection_info,
-                                                                     get_ec2_security_group_ids_from_names)
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_ec2_security_group_ids_from_names
 
 
 def get_eni_info(interface):

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -177,13 +177,16 @@ network_interfaces:
 '''
 
 try:
-    from botocore.exceptions import ClientError, NoCredentialsError
+    from botocore.exceptions import ClientError
+    from botocore.exceptions import NoCredentialsError
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_conn
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -182,10 +182,10 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def list_eni(connection, module):

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -178,9 +178,8 @@ network_interfaces:
 
 try:
     from botocore.exceptions import ClientError, NoCredentialsError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_conn
@@ -257,9 +256,6 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'ec2_eni_facts':
         module.deprecate("The 'ec2_eni_facts' module has been renamed to 'ec2_eni_info'", version='2.13')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -182,7 +182,7 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info
@@ -257,7 +257,7 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec)
     if module._name == 'ec2_eni_facts':
         module.deprecate("The 'ec2_eni_facts' module has been renamed to 'ec2_eni_info'", version='2.13')
 

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -198,7 +198,7 @@ def list_eni(connection, module):
     try:
         network_interfaces_result = connection.describe_network_interfaces(Filters=filters)['NetworkInterfaces']
     except (ClientError, NoCredentialsError) as e:
-        module.fail_json(msg=e.message)
+        module.fail_json_aws(e)
 
     # Modify boto3 tags list to be ansible friendly dict and then camel_case
     camel_network_interfaces = []

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -184,10 +184,8 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def list_eni(connection, module):
@@ -260,9 +258,7 @@ def main():
     if module._name == 'ec2_eni_facts':
         module.deprecate("The 'ec2_eni_facts' module has been renamed to 'ec2_eni_info'", version='2.13')
 
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-
-    connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
+    connection = module.client('ec2')
 
     list_eni(connection, module)
 

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -185,7 +185,7 @@ except ImportError:
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict, camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_argument_spec, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def list_eni(connection, module):
@@ -250,11 +250,8 @@ def get_eni_info(interface):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            filters=dict(default=None, type='dict')
-        )
+    argument_spec = dict(
+        filters=dict(default=None, type='dict')
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec)

--- a/plugins/modules/ec2_snapshot.py
+++ b/plugins/modules/ec2_snapshot.py
@@ -147,7 +147,8 @@ except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, ec2_connect
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ec2_connect
 
 
 # Find the most recent snapshot

--- a/plugins/modules/ec2_snapshot.py
+++ b/plugins/modules/ec2_snapshot.py
@@ -146,7 +146,7 @@ try:
 except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, ec2_argument_spec, ec2_connect
 
 
@@ -287,7 +287,7 @@ def create_snapshot_ansible_module():
             state=dict(choices=['absent', 'present'], default='present'),
         )
     )
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec, check_boto3=False)
     return module
 
 

--- a/plugins/modules/ec2_snapshot.py
+++ b/plugins/modules/ec2_snapshot.py
@@ -220,7 +220,7 @@ def create_snapshot(module, ec2, state=None, description=None, wait=None,
         try:
             volumes = ec2.get_all_volumes(filters={'attachment.instance-id': instance_id, 'attachment.device': device_name})
         except boto.exception.BotoServerError as e:
-            module.fail_json(msg="%s: %s" % (e.error_code, e.error_message))
+            module.fail_json_aws(e)
 
         if not volumes:
             module.fail_json(msg="Could not find volume with name %s attached to instance %s" % (device_name, instance_id))
@@ -237,7 +237,7 @@ def create_snapshot(module, ec2, state=None, description=None, wait=None,
             if e.error_code == 'InvalidSnapshot.NotFound':
                 module.exit_json(changed=False)
             else:
-                module.fail_json(msg="%s: %s" % (e.error_code, e.error_message))
+                module.fail_json_aws(e)
 
         # successful delete
         module.exit_json(changed=True)
@@ -246,7 +246,7 @@ def create_snapshot(module, ec2, state=None, description=None, wait=None,
         try:
             current_snapshots = ec2.get_all_snapshots(filters={'volume_id': volume_id})
         except boto.exception.BotoServerError as e:
-            module.fail_json(msg="%s: %s" % (e.error_code, e.error_message))
+            module.fail_json_aws(e)
 
         last_snapshot_min_age = last_snapshot_min_age * 60  # Convert to seconds
         snapshot = _get_most_recent_snapshot(current_snapshots,
@@ -263,7 +263,7 @@ def create_snapshot(module, ec2, state=None, description=None, wait=None,
             for k, v in snapshot_tags.items():
                 snapshot.add_tag(k, v)
     except boto.exception.BotoServerError as e:
-        module.fail_json(msg="%s: %s" % (e.error_code, e.error_message))
+        module.fail_json_aws(e)
 
     module.exit_json(changed=changed,
                      snapshot_id=snapshot.id,

--- a/plugins/modules/ec2_snapshot.py
+++ b/plugins/modules/ec2_snapshot.py
@@ -147,7 +147,7 @@ except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, ec2_argument_spec, ec2_connect
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, ec2_connect
 
 
 # Find the most recent snapshot
@@ -272,20 +272,17 @@ def create_snapshot(module, ec2, state=None, description=None, wait=None,
 
 
 def create_snapshot_ansible_module():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            volume_id=dict(),
-            description=dict(),
-            instance_id=dict(),
-            snapshot_id=dict(),
-            device_name=dict(),
-            wait=dict(type='bool', default=True),
-            wait_timeout=dict(type='int', default=0),
-            last_snapshot_min_age=dict(type='int', default=0),
-            snapshot_tags=dict(type='dict', default=dict()),
-            state=dict(choices=['absent', 'present'], default='present'),
-        )
+    argument_spec = dict(
+        volume_id=dict(),
+        description=dict(),
+        instance_id=dict(),
+        snapshot_id=dict(),
+        device_name=dict(),
+        wait=dict(type='bool', default=True),
+        wait_timeout=dict(type='int', default=0),
+        last_snapshot_min_age=dict(type='int', default=0),
+        snapshot_tags=dict(type='dict', default=dict()),
+        state=dict(choices=['absent', 'present'], default='present'),
     )
     module = AnsibleAWSModule(argument_spec=argument_spec, check_boto3=False)
     return module

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -185,7 +185,7 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
                                                                      boto3_conn,
                                                                      boto3_tag_list_to_ansible_dict,
@@ -237,11 +237,12 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           mutually_exclusive=[
-                               ['snapshot_ids', 'owner_ids', 'restorable_by_user_ids', 'filters']
-                           ]
-                           )
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        mutually_exclusive=[
+            ['snapshot_ids', 'owner_ids', 'restorable_by_user_ids', 'filters']
+        ]
+    )
     if module._name == 'ec2_snapshot_facts':
         module.deprecate("The 'ec2_snapshot_facts' module has been renamed to 'ec2_snapshot_info'", version='2.13')
 

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -186,10 +186,8 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def list_ec2_snapshots(connection, module):
@@ -240,12 +238,7 @@ def main():
     if module._name == 'ec2_snapshot_facts':
         module.deprecate("The 'ec2_snapshot_facts' module has been renamed to 'ec2_snapshot_info'", version='2.13')
 
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-
-    if region:
-        connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
-    else:
-        module.fail_json(msg="region must be specified")
+    connection = module.client('ec2')
 
     list_ec2_snapshots(connection, module)
 

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -181,9 +181,8 @@ data_encryption_key_id:
 try:
     import boto3
     from botocore.exceptions import ClientError
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
@@ -241,9 +240,6 @@ def main():
     )
     if module._name == 'ec2_snapshot_facts':
         module.deprecate("The 'ec2_snapshot_facts' module has been renamed to 'ec2_snapshot_info'", version='2.13')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -190,7 +190,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dic
                                                                      boto3_conn,
                                                                      boto3_tag_list_to_ansible_dict,
                                                                      camel_dict_to_snake_dict,
-                                                                     ec2_argument_spec,
                                                                      get_aws_connection_info,
                                                                      )
 
@@ -227,14 +226,11 @@ def list_ec2_snapshots(connection, module):
 
 def main():
 
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            snapshot_ids=dict(default=[], type='list'),
-            owner_ids=dict(default=[], type='list'),
-            restorable_by_user_ids=dict(default=[], type='list'),
-            filters=dict(default={}, type='dict')
-        )
+    argument_spec = dict(
+        snapshot_ids=dict(default=[], type='list'),
+        owner_ids=dict(default=[], type='list'),
+        restorable_by_user_ids=dict(default=[], type='list'),
+        filters=dict(default={}, type='dict')
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -184,10 +184,10 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def list_ec2_snapshots(connection, module):

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -185,12 +185,11 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ansible_dict_to_boto3_filter_list,
-                                                                     boto3_conn,
-                                                                     boto3_tag_list_to_ansible_dict,
-                                                                     camel_dict_to_snake_dict,
-                                                                     get_aws_connection_info,
-                                                                     )
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def list_ec2_snapshots(connection, module):

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -237,7 +237,7 @@ try:
 except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (HAS_BOTO,
                                                                      AnsibleAWSError,
                                                                      connect_to_aws,
@@ -510,7 +510,7 @@ def main():
         tags=dict(type='dict', default={})
     )
     )
-    module = AnsibleModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec, check_boto3=False)
 
     if not HAS_BOTO:
         module.fail_json(msg='boto required for this module')

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -241,7 +241,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.aws.core import Ansible
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (HAS_BOTO,
                                                                      AnsibleAWSError,
                                                                      connect_to_aws,
-                                                                     ec2_argument_spec,
                                                                      get_aws_connection_info,
                                                                      )
 
@@ -492,8 +491,7 @@ def get_volume_info(volume, state):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         instance=dict(),
         id=dict(),
         name=dict(),
@@ -508,7 +506,6 @@ def main():
         snapshot=dict(),
         state=dict(choices=['absent', 'present', 'list'], default='present'),
         tags=dict(type='dict', default={})
-    )
     )
     module = AnsibleAWSModule(argument_spec=argument_spec, check_boto3=False)
 

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -233,16 +233,16 @@ try:
     import boto.ec2
     import boto.exception
     from boto.exception import BotoServerError
-    from boto.ec2.blockdevicemapping import BlockDeviceType, BlockDeviceMapping
+    from boto.ec2.blockdevicemapping import BlockDeviceType
+    from boto.ec2.blockdevicemapping import BlockDeviceMapping
 except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (HAS_BOTO,
-                                                                     AnsibleAWSError,
-                                                                     connect_to_aws,
-                                                                     get_aws_connection_info,
-                                                                     )
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleAWSError
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def get_volume(module, ec2):

--- a/plugins/modules/ec2_vpc_dhcp_option.py
+++ b/plugins/modules/ec2_vpc_dhcp_option.py
@@ -197,7 +197,7 @@ EXAMPLES = """
 import collections
 import traceback
 from time import sleep, time
-from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, connect_to_aws, ec2_argument_spec, get_aws_connection_info
 
 if HAS_BOTO:
@@ -294,7 +294,11 @@ def main():
     )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        check_boto3=False,
+        supports_check_mode=True
+    )
 
     params = module.params
     found = False

--- a/plugins/modules/ec2_vpc_dhcp_option.py
+++ b/plugins/modules/ec2_vpc_dhcp_option.py
@@ -195,7 +195,6 @@ EXAMPLES = """
 """
 
 import collections
-import traceback
 from time import sleep, time
 
 try:
@@ -244,7 +243,7 @@ def ensure_tags(module, vpc_conn, resource_id, tags, add_only, check_mode):
         latest_tags = get_resource_tags(vpc_conn, resource_id)
         return {'changed': True, 'tags': latest_tags}
     except EC2ResponseError as e:
-        module.fail_json(msg="Failed to modify tags: %s" % e.message, exception=traceback.format_exc())
+        module.fail_json_aws(e, msg='Failed to modify tags')
 
 
 def fetch_dhcp_options_for_vpc(vpc_conn, vpc_id):
@@ -395,7 +394,7 @@ def main():
             try:
                 found_dhcp_opt = retry_not_found(connection.get_all_dhcp_options, dhcp_options_ids=[dhcp_option.id])
             except EC2ResponseError as e:
-                module.fail_json(msg="Failed to describe DHCP options", exception=traceback.format_exc)
+                module.fail_json_aws(e, msg="Failed to describe DHCP options")
             if not found_dhcp_opt:
                 module.fail_json(msg="Failed to wait for {0} to be available.".format(dhcp_option.id))
 

--- a/plugins/modules/ec2_vpc_dhcp_option.py
+++ b/plugins/modules/ec2_vpc_dhcp_option.py
@@ -198,7 +198,7 @@ import collections
 import traceback
 from time import sleep, time
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, connect_to_aws, ec2_argument_spec, get_aws_connection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, connect_to_aws, get_aws_connection_info
 
 if HAS_BOTO:
     import boto.vpc
@@ -278,8 +278,7 @@ def remove_dhcp_options_by_id(vpc_conn, dhcp_options_id):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         dhcp_options_id=dict(type='str', default=None),
         domain_name=dict(type='str', default=None),
         dns_servers=dict(type='list', default=None),
@@ -291,7 +290,6 @@ def main():
         inherit_existing=dict(type='bool', default=False),
         tags=dict(type='dict', default=None, aliases=['resource_tags']),
         state=dict(type='str', default='present', choices=['present', 'absent'])
-    )
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/ec2_vpc_dhcp_option.py
+++ b/plugins/modules/ec2_vpc_dhcp_option.py
@@ -200,10 +200,13 @@ from time import sleep, time
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, connect_to_aws, get_aws_connection_info
 
+try:
 if HAS_BOTO:
     import boto.vpc
     import boto.ec2
     from boto.exception import EC2ResponseError
+except ImportError:
+    pass  # Taken care of by ec2.HAS_BOTO
 
 
 def get_resource_tags(vpc_conn, resource_id):

--- a/plugins/modules/ec2_vpc_dhcp_option.py
+++ b/plugins/modules/ec2_vpc_dhcp_option.py
@@ -197,16 +197,18 @@ EXAMPLES = """
 import collections
 import traceback
 from time import sleep, time
-from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO, connect_to_aws, get_aws_connection_info
 
 try:
-if HAS_BOTO:
     import boto.vpc
     import boto.ec2
     from boto.exception import EC2ResponseError
 except ImportError:
     pass  # Taken care of by ec2.HAS_BOTO
+
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import connect_to_aws
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def get_resource_tags(vpc_conn, resource_id):

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -87,11 +87,10 @@ import traceback
 try:
     import botocore
 except ImportError:
-    pass  # caught by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (boto3_conn,
-                                                                     HAS_BOTO3,
                                                                      ansible_dict_to_boto3_filter_list,
                                                                      get_aws_connection_info,
                                                                      camel_dict_to_snake_dict,
@@ -138,10 +137,6 @@ def main():
     )
     if module._name == 'ec2_vpc_dhcp_option_facts':
         module.deprecate("The 'ec2_vpc_dhcp_option_facts' module has been renamed to 'ec2_vpc_dhcp_option_info'", version='2.13')
-
-    # Validate Requirements
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 and botocore are required.')
 
     try:
         region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -89,7 +89,7 @@ try:
 except ImportError:
     pass  # caught by imported HAS_BOTO3
 
-from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ec2_argument_spec,
                                                                      boto3_conn,
                                                                      HAS_BOTO3,
@@ -136,8 +136,10 @@ def main():
         )
     )
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True)
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
     if module._name == 'ec2_vpc_dhcp_option_facts':
         module.deprecate("The 'ec2_vpc_dhcp_option_facts' module has been renamed to 'ec2_vpc_dhcp_option_info'", version='2.13')
 

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -114,8 +114,7 @@ def list_dhcp_options(client, module):
     try:
         all_dhcp_options = client.describe_dhcp_options(**params)
     except botocore.exceptions.ClientError as e:
-        module.fail_json(msg=str(e), exception=traceback.format_exc(),
-                         **camel_dict_to_snake_dict(e.response))
+        module.fail_json_aws(e)
 
     return [camel_dict_to_snake_dict(get_dhcp_options_info(option))
             for option in all_dhcp_options['DhcpOptions']]

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -90,8 +90,7 @@ except ImportError:
     pass  # caught by imported HAS_BOTO3
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (ec2_argument_spec,
-                                                                     boto3_conn,
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (boto3_conn,
                                                                      HAS_BOTO3,
                                                                      ansible_dict_to_boto3_filter_list,
                                                                      get_aws_connection_info,
@@ -127,13 +126,10 @@ def list_dhcp_options(client, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(
-        dict(
-            filters=dict(type='dict', default={}),
-            dry_run=dict(type='bool', default=False, aliases=['DryRun']),
-            dhcp_options_ids=dict(type='list', aliases=['DhcpOptionIds'])
-        )
+    argument_spec = dict(
+        filters=dict(type='dict', default={}),
+        dry_run=dict(type='bool', default=False, aliases=['DryRun']),
+        dhcp_options_ids=dict(type='list', aliases=['DhcpOptionIds'])
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -89,10 +89,10 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 def get_dhcp_options_info(dhcp_option):

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -90,12 +90,11 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (boto3_conn,
-                                                                     ansible_dict_to_boto3_filter_list,
-                                                                     get_aws_connection_info,
-                                                                     camel_dict_to_snake_dict,
-                                                                     boto3_tag_list_to_ansible_dict,
-                                                                     )
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def get_dhcp_options_info(dhcp_option):

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -91,10 +91,8 @@ except ImportError:
 
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 
 def get_dhcp_options_info(dhcp_option):
@@ -137,11 +135,7 @@ def main():
     if module._name == 'ec2_vpc_dhcp_option_facts':
         module.deprecate("The 'ec2_vpc_dhcp_option_facts' module has been renamed to 'ec2_vpc_dhcp_option_info'", version='2.13')
 
-    try:
-        region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-        connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_kwargs)
-    except botocore.exceptions.NoCredentialsError as e:
-        module.fail_json(msg="Can't authorize connection - " + str(e))
+    connection = module.client('ec2')
 
     # call your function here
     results = list_dhcp_options(connection, module)

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -154,11 +154,11 @@ vpcs:
 import traceback
 
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 try:
     import botocore

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -158,7 +158,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     boto3_conn,
     get_aws_connection_info,
     AWSRetry,
-    HAS_BOTO3,
     boto3_tag_list_to_ansible_dict,
     camel_dict_to_snake_dict,
     ansible_dict_to_boto3_filter_list
@@ -167,7 +166,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
 try:
     import botocore
 except ImportError:
-    pass  # caught by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 
 @AWSRetry.exponential_backoff()
@@ -289,9 +288,6 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_vpc_net_facts':
         module.deprecate("The 'ec2_vpc_net_facts' module has been renamed to 'ec2_vpc_net_info'", version='2.13')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 and botocore are required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
     connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -153,7 +153,7 @@ vpcs:
 
 import traceback
 from ansible.module_utils._text import to_native
-from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     boto3_conn,
     ec2_argument_spec,
@@ -189,7 +189,7 @@ def describe_vpcs(connection, module):
     Describe VPCs.
 
     connection  : boto3 client connection object
-    module  : AnsibleModule object
+    module  : AnsibleAWSModule object
     """
     # collect parameters
     filters = ansible_dict_to_boto3_filter_list(module.params.get('filters'))
@@ -288,7 +288,7 @@ def main():
         filters=dict(type='dict', default={})
     ))
 
-    module = AnsibleModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_vpc_net_facts':
         module.deprecate("The 'ec2_vpc_net_facts' module has been renamed to 'ec2_vpc_net_info'", version='2.13')
 

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -156,7 +156,6 @@ from ansible.module_utils._text import to_native
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     boto3_conn,
-    ec2_argument_spec,
     get_aws_connection_info,
     AWSRetry,
     HAS_BOTO3,
@@ -282,11 +281,10 @@ def describe_vpcs(connection, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         vpc_ids=dict(type='list', default=[]),
         filters=dict(type='dict', default={})
-    ))
+    )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_vpc_net_facts':

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -152,16 +152,15 @@ vpcs:
 '''
 
 import traceback
+
 from ansible.module_utils._text import to_native
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    boto3_conn,
-    get_aws_connection_info,
-    AWSRetry,
-    boto3_tag_list_to_ansible_dict,
-    camel_dict_to_snake_dict,
-    ansible_dict_to_boto3_filter_list
-)
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 try:
     import botocore

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -157,10 +157,8 @@ from ansible.module_utils._text import to_native
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 
 try:
     import botocore
@@ -288,8 +286,7 @@ def main():
     if module._name == 'ec2_vpc_net_facts':
         module.deprecate("The 'ec2_vpc_net_facts' module has been renamed to 'ec2_vpc_net_info'", version='2.13')
 
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-    connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
+    connection = module.client('ec2')
 
     describe_vpcs(connection, module)
 

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -152,21 +152,20 @@ subnets:
 '''
 
 import traceback
-from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    boto3_conn,
-    get_aws_connection_info,
-    AWSRetry,
-    boto3_tag_list_to_ansible_dict,
-    camel_dict_to_snake_dict,
-    ansible_dict_to_boto3_filter_list
-)
-from ansible.module_utils._text import to_native
 
 try:
     import botocore
 except ImportError:
     pass  # Handled by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
+from ansible.module_utils._text import to_native
 
 
 @AWSRetry.exponential_backoff()

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -151,14 +151,11 @@ subnets:
                             type: str
 '''
 
-import traceback
-
 try:
     import botocore
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
@@ -199,8 +196,8 @@ def describe_subnets(connection, module):
     # Get the basic VPC info
     try:
         response = describe_subnets_with_backoff(connection, subnet_ids, filters)
-    except botocore.exceptions.ClientError as e:
-        module.fail_json(msg=to_native(e), exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Failed to describe subnets')
 
     for subnet in response['Subnets']:
         # for backwards compatibility

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -158,12 +158,12 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
+from ansible.module_utils._text import to_native
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.module_utils._text import to_native
 
 
 @AWSRetry.exponential_backoff()

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -159,11 +159,11 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 @AWSRetry.exponential_backoff()

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -157,7 +157,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     boto3_conn,
     get_aws_connection_info,
     AWSRetry,
-    HAS_BOTO3,
     boto3_tag_list_to_ansible_dict,
     camel_dict_to_snake_dict,
     ansible_dict_to_boto3_filter_list
@@ -167,7 +166,7 @@ from ansible.module_utils._text import to_native
 try:
     import botocore
 except ImportError:
-    pass  # caught by imported HAS_BOTO3
+    pass  # Handled by AnsibleAWSModule
 
 
 @AWSRetry.exponential_backoff()
@@ -228,9 +227,6 @@ def main():
     )
     if module._name == 'ec2_vpc_subnet_facts':
         module.deprecate("The 'ec2_vpc_subnet_facts' module has been renamed to 'ec2_vpc_subnet_info'", version='2.13')
-
-    if not HAS_BOTO3:
-        module.fail_json(msg='boto3 is required for this module')
 
     region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
 

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -161,10 +161,8 @@ except ImportError:
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
 from ansible.module_utils._text import to_native
 
 
@@ -227,15 +225,7 @@ def main():
     if module._name == 'ec2_vpc_subnet_facts':
         module.deprecate("The 'ec2_vpc_subnet_facts' module has been renamed to 'ec2_vpc_subnet_info'", version='2.13')
 
-    region, ec2_url, aws_connect_params = get_aws_connection_info(module, boto3=True)
-
-    if region:
-        try:
-            connection = boto3_conn(module, conn_type='client', resource='ec2', region=region, endpoint=ec2_url, **aws_connect_params)
-        except (botocore.exceptions.NoCredentialsError, botocore.exceptions.ProfileNotFound) as e:
-            module.fail_json(msg=to_native(e), exception=traceback.format_exc(), **camel_dict_to_snake_dict(e.response))
-    else:
-        module.fail_json(msg="Region must be specified")
+    connection = module.client('ec2')
 
     describe_subnets(connection, module)
 

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -152,7 +152,7 @@ subnets:
 '''
 
 import traceback
-from ansible.module_utils.basic import AnsibleModule
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     boto3_conn,
     ec2_argument_spec,
@@ -187,7 +187,7 @@ def describe_subnets(connection, module):
     """
     Describe Subnets.
 
-    module  : AnsibleModule object
+    module  : AnsibleAWSModule object
     connection  : boto3 client connection object
     """
     # collect parameters
@@ -224,8 +224,10 @@ def main():
         filters=dict(type='dict', default={})
     ))
 
-    module = AnsibleModule(argument_spec=argument_spec,
-                           supports_check_mode=True)
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True
+    )
     if module._name == 'ec2_vpc_subnet_facts':
         module.deprecate("The 'ec2_vpc_subnet_facts' module has been renamed to 'ec2_vpc_subnet_info'", version='2.13')
 

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -155,7 +155,6 @@ import traceback
 from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     boto3_conn,
-    ec2_argument_spec,
     get_aws_connection_info,
     AWSRetry,
     HAS_BOTO3,
@@ -218,11 +217,10 @@ def describe_subnets(connection, module):
 
 
 def main():
-    argument_spec = ec2_argument_spec()
-    argument_spec.update(dict(
+    argument_spec = dict(
         subnet_ids=dict(type='list', default=[], aliases=['subnet_id']),
         filters=dict(type='dict', default={})
-    ))
+    )
 
     module = AnsibleAWSModule(
         argument_spec=argument_spec,

--- a/tests/integration/targets/ec2_elb_lb/tasks/main.yml
+++ b/tests/integration/targets/ec2_elb_lb/tasks/main.yml
@@ -234,8 +234,7 @@
       assert:
         that:
            - 'result.failed'
-           - 'result.msg.startswith("missing required arguments: ")'
-
+           - '"missing required arguments" in result.msg'
 
 
     # ============================================================
@@ -273,7 +272,7 @@
       assert:
         that:
            - 'result.failed'
-           - 'result.msg.startswith("Region asdf querty 1234 does not seem to be available ")'
+           - '"Region asdf querty 1234 does not seem to be available" in result.msg'
 
 
     # ============================================================
@@ -298,7 +297,7 @@
       assert:
         that:
            - 'result.failed'
-           - 'result.msg.startswith("No handler was ready to authenticate.")'
+           - '"No handler was ready to authenticate" in result.msg'
 
 
     # ============================================================
@@ -325,7 +324,7 @@
       assert:
         that:
            - 'result.failed'
-           - 'result.msg.startswith("No handler was ready to authenticate.")'
+           - '"No handler was ready to authenticate" in result.msg'
 
 
     # ============================================================
@@ -351,7 +350,7 @@
       assert:
         that:
            - 'result.failed'
-           - 'result.msg.startswith("No handler was ready to authenticate.")'
+           - '"No handler was ready to authenticate" in result.msg'
 
 
     # ============================================================


### PR DESCRIPTION
##### SUMMARY
Migrate a batch of modules to AnsibleAWSModule and perform related cleanup

- remove ec2_argument_spec use
- remove HAS_BOTO3 logic
- cleanup HAS_BOTO logic
- Use module.client() to get boto3 clients
- Pull camel_dict_to_snake_dict from its canonical source
- Use module.fail_json_aws and is_boto3_error_code to simplify error handling

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/cloudformation.py
plugins/modules/ec2.py
plugins/modules/ec2_elb_lb.py
plugins/modules/ec2_eni.py
plugins/modules/ec2_eni_info.py
plugins/modules/ec2_snapshot.py
plugins/modules/ec2_snapshot_info.py
plugins/modules/ec2_vol.py
plugins/modules/ec2_vpc_dhcp_option.py
plugins/modules/ec2_vpc_dhcp_option_info.py
plugins/modules/ec2_vpc_net_info.py
plugins/modules/ec2_vpc_subnet_info.py

##### ADDITIONAL INFORMATION
