### PR TITLE
aws_ec2 inventory plugin: added ability for using Jinja on AWS credentials

### DIFF
--- a/changelogs/fragments/57-aws_ec2-support-for-templates.yml
+++ b/changelogs/fragments/57-aws_ec2-support-for-templates.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- "aws_ec2 inventory plugin - Added support for using Jinja2 templates in the authentication fields (https://github.com/ansible-collections/amazon.aws/pull/57)."

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -90,7 +90,7 @@ plugin: aws_ec2
 # The values for profile, access key, secret key and token can be hardcoded like:
 boto_profile: aws_profile
 # or you could use Jinja as:
-# boto_profile: "{{ lookup('env', 'MY_PROJECT_AWS_PROFILE') | default('aws_profile', true) }}"
+# boto_profile: "{{ lookup('env', 'AWS_PROFILE') | default('aws_profile', true) }}"
 # Populate inventory with instances in these regions
 regions:
   - us-east-1

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -87,7 +87,10 @@ regions:
 
 # Example using filters, ignoring permission errors, and specifying the hostname precedence
 plugin: aws_ec2
+# The values for profile, access key, secret key and token can be hardcoded like:
 boto_profile: aws_profile
+# or you could use Jinja as:
+# boto_profile: "{{ lookup('env', 'MY_PROJECT_AWS_PROFILE') | default('aws_profile', true) }}"
 # Populate inventory with instances in these regions
 regions:
   - us-east-1
@@ -161,7 +164,11 @@ except ImportError:
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native
 from ansible.module_utils._text import to_text
-from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+from ansible.plugins.inventory import BaseInventoryPlugin
+from ansible.plugins.inventory import Cacheable
+from ansible.plugins.inventory import Constructable
+from ansible.template import Templar
+from ansible.utils.display import Display
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
@@ -579,16 +586,25 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             # Create groups based on variable values and add the corresponding hosts to it
             self._add_host_to_keyed_groups(self.get_option('keyed_groups'), host, hostname, strict=strict)
 
-    def _set_credentials(self):
+    def _set_credentials(self, loader):
         '''
             :param config_data: contents of the inventory config file
         '''
 
-        self.boto_profile = self.get_option('aws_profile')
-        self.aws_access_key_id = self.get_option('aws_access_key')
-        self.aws_secret_access_key = self.get_option('aws_secret_key')
-        self.aws_security_token = self.get_option('aws_security_token')
-        self.iam_role_arn = self.get_option('iam_role_arn')
+        t = Templar(loader=loader)
+        credentials = {}
+
+        for credential_type in ['aws_profile', 'aws_access_key', 'aws_secret_key', 'aws_security_token', 'iam_role_arn']:
+            if t.is_template(self.get_option(credential_type)):
+                credentials[credential_type] = t.template(variable=self.get_option(credential_type), disable_lookups=False)
+            else:
+                credentials[credential_type] = self.get_option(credential_type)
+
+        self.boto_profile = credentials['aws_profile']
+        self.aws_access_key_id = credentials['aws_access_key']
+        self.aws_secret_access_key = credentials['aws_secret_key']
+        self.aws_security_token = credentials['aws_security_token']
+        self.iam_role_arn = credentials['iam_role_arn']
 
         if not self.boto_profile and not (self.aws_access_key_id and self.aws_secret_access_key):
             session = botocore.session.get_session()
@@ -629,7 +645,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if self.get_option('use_contrib_script_compatible_sanitization'):
             self._sanitize_group_name = self._legacy_script_compatible_group_sanitization
 
-        self._set_credentials()
+        self._set_credentials(loader)
 
         # get user specifications
         regions = self.get_option('regions')

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/create_environment_script.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/create_environment_script.yml
@@ -1,0 +1,9 @@
+---
+- hosts: localhost
+  connection: local
+  gather_facts: no
+  tasks:
+  - name: 'Write access key to file we can source'
+    copy:
+      dest: '../access_key.sh'
+      content: 'export MY_ACCESS_KEY="{{ aws_access_key }}"'

--- a/tests/integration/targets/inventory_aws_ec2/runme.sh
+++ b/tests/integration/targets/inventory_aws_ec2/runme.sh
@@ -8,16 +8,16 @@ ansible-playbook playbooks/empty_inventory_config.yml "$@"
 export ANSIBLE_INVENTORY_ENABLED="amazon.aws.aws_ec2"
 
 # test with default inventory file
-#ansible-playbook playbooks/test_invalid_aws_ec2_inventory_config.yml "$@"
+ansible-playbook playbooks/test_invalid_aws_ec2_inventory_config.yml "$@"
 
 export ANSIBLE_INVENTORY=test.aws_ec2.yml
 
 # test empty inventory config
-#ansible-playbook playbooks/test_invalid_aws_ec2_inventory_config.yml "$@"
+ansible-playbook playbooks/test_invalid_aws_ec2_inventory_config.yml "$@"
 
 # generate inventory config and test using it
-#ansible-playbook playbooks/create_inventory_config.yml "$@"
-#ansible-playbook playbooks/test_populating_inventory.yml "$@"
+ansible-playbook playbooks/create_inventory_config.yml "$@"
+ansible-playbook playbooks/test_populating_inventory.yml "$@"
 
 # generate inventory config with caching and test using it
 ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_cache.yml.j2'" "$@"
@@ -28,8 +28,8 @@ ansible-playbook playbooks/test_inventory_cache.yml "$@"
 rm -r aws_ec2_cache_dir/
 
 # generate inventory config with constructed features and test using it
-#ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml.j2'" "$@"
-#ansible-playbook playbooks/test_populating_inventory_with_constructed.yml "$@"
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.yml.j2'" "$@"
+ansible-playbook playbooks/test_populating_inventory_with_constructed.yml "$@"
 ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_concatenation.yml.j2'" "$@"
 ansible-playbook playbooks/test_populating_inventory_with_concatenation.yml "$@"
 

--- a/tests/integration/targets/inventory_aws_ec2/runme.sh
+++ b/tests/integration/targets/inventory_aws_ec2/runme.sh
@@ -19,6 +19,12 @@ ansible-playbook playbooks/test_invalid_aws_ec2_inventory_config.yml "$@"
 ansible-playbook playbooks/create_inventory_config.yml "$@"
 ansible-playbook playbooks/test_populating_inventory.yml "$@"
 
+# generate inventory with access_key provided through a templated variable
+ansible-playbook playbooks/create_environment_script.yml "$@"
+source access_key.sh
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_template.yml.j2'" "$@"
+ansible-playbook playbooks/test_populating_inventory.yml "$@"
+
 # generate inventory config with caching and test using it
 ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_cache.yml.j2'" "$@"
 ansible-playbook playbooks/populate_cache.yml "$@"

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_template.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_template.yml.j2
@@ -1,0 +1,14 @@
+plugin: amazon.aws.aws_ec2
+aws_access_key_id: '{{ '{{ lookup("env", "MY_ACCESS_KEY") }}' }}'
+aws_secret_access_key: '{{ aws_secret_key }}'
+{% if security_token | default(false) %}
+aws_security_token: '{{ security_token }}'
+{% endif %}
+regions:
+- '{{ aws_region }}'
+filters:
+  tag:Name:
+  - '{{ resource_prefix }}'
+hostnames:
+- tag:Name
+- dns-name


### PR DESCRIPTION
##### SUMMARY
Added ability for using Jinja on AWS Credentials

##### ISSUE TYPE
- Feature Pull Request


##### COMPONENT NAME
aws_ec2.py

##### ADDITIONAL INFORMATION
This change allows to do something like this: 
```paste below
boto_profile: "{{ lookup('env', 'CI_AWS_PROFILE') | default('aws_profile', true) }}"
```
This can be very useful in scenarios where you want to have a default profile for when executing Ansible locally (by a user) but you also need to overwrite it when running from any kind of automation/CI etc, for example.