### PR TITLE
Don't run code coverage analyze on 2.9

### DIFF
--- a/tests/utils/shippable/shippable.sh
+++ b/tests/utils/shippable/shippable.sh
@@ -118,8 +118,10 @@ function cleanup
             ansible-test coverage xml --color --requirements --group-by command --group-by version ${stub:+"$stub"}
             cp -a tests/output/reports/coverage=*.xml "$SHIPPABLE_RESULT_DIR/codecoverage/"
 
-            # analyze and capture code coverage aggregated by integration test target
-            ansible-test coverage analyze targets generate -v "$SHIPPABLE_RESULT_DIR/testresults/coverage-analyze-targets.json"
+            # analyze and capture code coverage aggregated by integration test target if not on 2.9
+            if [ -n "${ANSIBLE_BASE_REV:-}" ] || [ "${ANSIBLE_BASE_REV:-}" != "2.9" ]; then
+                ansible-test coverage analyze targets generate -v "$SHIPPABLE_RESULT_DIR/testresults/coverage-analyze-targets.json"
+            fi
 
             # upload coverage report to codecov.io only when using complete on-demand coverage
             if [ "${COVERAGE}" == "--coverage" ] && [ "${CHANGED}" == "" ]; then


### PR DESCRIPTION
##### SUMMARY

This wasn't added until 2.10; #67141
See failures in https://app.shippable.com/github/ansible-collections/amazon.aws/runs/333/8/console

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/utils/shippable/shippable.sh
