### PR TITLE
Mass-migrate integration tests over to module_defaults instead of set_fact hack

### DIFF
--- a/tests/integration/targets/aws_caller_info/tasks/main.yaml
+++ b/tests/integration/targets/aws_caller_info/tasks/main.yaml
@@ -1,15 +1,18 @@
-- name: retrieve caller facts
-  aws_caller_info:
-    region: "{{ aws_region }}"
-    aws_access_key: "{{ aws_access_key }}"
-    aws_secret_key: "{{ aws_secret_key }}"
-    security_token: "{{ security_token }}"
-  register: result
+- module_defaults:
+    group/aws:
+        region: "{{ aws_region }}"
+        aws_access_key: "{{ aws_access_key }}"
+        aws_secret_key: "{{ aws_secret_key }}"
+        security_token: "{{ security_token | default(omit) }}"
+  block:
+  - name: retrieve caller facts
+    aws_caller_info:
+    register: result
 
-- name: assert correct keys are returned
-  assert:
-    that:
-      - result.account is not none
-      - result.arn is not none
-      - result.user_id is not none
-      - result.account_alias is not none
+  - name: assert correct keys are returned
+    assert:
+      that:
+        - result.account is not none
+        - result.arn is not none
+        - result.user_id is not none
+        - result.account_alias is not none

--- a/tests/integration/targets/aws_s3/tasks/main.yml
+++ b/tests/integration/targets/aws_s3/tasks/main.yml
@@ -1,16 +1,13 @@
 ---
-# tasks file for test_s3
-
-- name: set up aws connection info
-  set_fact:
-    aws_connection_info: &aws_connection_info
+# Test suite for aws_s3
+- module_defaults:
+    group/aws:
       aws_access_key: "{{ aws_access_key }}"
       aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token }}"
+      security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
-  no_log: yes
 
-- block:
+  block:
     - name: Create temporary directory
       tempfile:
         state: directory
@@ -21,6 +18,7 @@
           content: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits,punctuation') }}"
 
     - name: test create bucket without permissions
+      module_defaults: { group/aws: {} }
       aws_s3:
         bucket: "{{ bucket_name }}"
         mode: create
@@ -36,7 +34,6 @@
       aws_s3:
         bucket: "{{ bucket_name }}"
         mode: create
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -47,7 +44,6 @@
       aws_s3:
         bucket: "{{ bucket_name }}"
         mode: create
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -71,7 +67,6 @@
         mode: put
         src: "{{ tmpdir.path }}/upload.txt"
         object: delete.txt
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -87,7 +82,6 @@
         mode: put
         src: "{{ tmpdir.path }}/upload.txt"
         object: delete.txt
-        <<: *aws_connection_info
       register: test_async
       async: 30
       poll: 0
@@ -106,7 +100,6 @@
         src: "{{ tmpdir.path }}/upload.txt"
         object: delete.txt
         overwrite: different
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -121,7 +114,6 @@
         mode: put
         src: hello.txt
         object: delete.txt
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -138,7 +130,6 @@
         src: "{{ tmpdir.path }}/upload.txt"
         object: delete.txt
         overwrite: never
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -154,7 +145,6 @@
         src: "{{ tmpdir.path }}/upload.txt"
         object: delete.txt
         overwrite: different
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -170,7 +160,6 @@
         src: "{{ tmpdir.path }}/upload.txt"
         object: delete.txt
         overwrite: always
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -185,7 +174,6 @@
         mode: get
         dest: "{{ tmpdir.path }}/download.txt"
         object: delete.txt
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -208,7 +196,6 @@
         dest: "{{ tmpdir.path }}/download.txt"
         object: delete.txt
         overwrite: different
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -229,7 +216,6 @@
         dest: "{{ tmpdir.path }}/download.txt"
         object: delete.txt
         overwrite: never
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -245,7 +231,6 @@
         dest: "{{ tmpdir.path }}/download.txt"
         object: delete.txt
         overwrite: different
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -261,7 +246,6 @@
         dest: "{{ tmpdir.path }}/download.txt"
         object: delete.txt
         overwrite: always
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -275,7 +259,6 @@
         bucket: "{{ bucket_name }}"
         mode: geturl
         object: delete.txt
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -291,7 +274,6 @@
         bucket: "{{ bucket_name }}"
         mode: getstr
         object: delete.txt
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -305,7 +287,6 @@
       aws_s3:
         bucket: "{{ bucket_name }}"
         mode: list
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -320,7 +301,6 @@
         bucket: "{{ bucket_name }}"
         mode: delobj
         object: delete.txt
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -337,7 +317,6 @@
         src: "{{ tmpdir.path }}/upload.txt"
         encrypt: yes
         object: delete_encrypt.txt
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -353,7 +332,6 @@
         mode: get
         dest: "{{ tmpdir.path }}/download_encrypted.txt"
         object: delete_encrypt.txt
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -374,7 +352,6 @@
         bucket: "{{ bucket_name }}"
         mode: delobj
         object: delete_encrypt.txt
-        <<: *aws_connection_info
       retries: 3
       delay: 3
 
@@ -386,7 +363,6 @@
         encrypt: yes
         encryption_mode: aws:kms
         object: delete_encrypt_kms.txt
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -402,7 +378,6 @@
         mode: get
         dest: "{{ tmpdir.path }}/download_kms.txt"
         object: delete_encrypt_kms.txt
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -425,7 +400,6 @@
         bucket: "{{ bucket_name }}"
         mode: delobj
         object: delete_encrypt_kms.txt
-        <<: *aws_connection_info
       retries: 3
       delay: 3
 
@@ -438,7 +412,6 @@
         bucket: "{{ bucket_name }}"
         mode: create
         object: foo/bar/baz/
-        <<: *aws_connection_info
       retries: 3
       delay: 3
       register: result
@@ -453,7 +426,6 @@
         bucket: "{{ bucket_name }}"
         mode: delobj
         object: foo/bar/baz/
-        <<: *aws_connection_info
       retries: 3
       delay: 3
 
@@ -461,7 +433,6 @@
       aws_s3:
         bucket: "{{ bucket_name }}"
         mode: delete
-        <<: *aws_connection_info
       register: result
       retries: 3
       delay: 3
@@ -475,7 +446,6 @@
       aws_s3:
         bucket: "{{ bucket_name + '.bucket' }}"
         mode: create
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -486,7 +456,6 @@
       aws_s3:
         bucket: "{{ bucket_name + '.bucket' }}"
         mode: delete
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -497,7 +466,6 @@
       aws_s3:
         bucket: "{{ bucket_name + '.bucket' }}"
         mode: delete
-        <<: *aws_connection_info
       register: result
 
     - assert:
@@ -520,7 +488,6 @@
           aws_s3:
             bucket: "{{ bucket_name }}"
             mode: create
-            <<: *aws_connection_info
 
         - name: upload the file to the bucket
           aws_s3:
@@ -528,7 +495,6 @@
             mode: put
             src: "{{ tmpdir.path }}/largefile"
             object: multipart.txt
-            <<: *aws_connection_info
 
         - name: download file once
           aws_s3:
@@ -537,7 +503,6 @@
             dest: "{{ tmpdir.path }}/download.txt"
             object: multipart.txt
             overwrite: different
-            <<: *aws_connection_info
           retries: 3
           delay: 3
           until: "result.msg == 'GET operation complete'"
@@ -554,7 +519,6 @@
             dest: "{{ tmpdir.path }}/download.txt"
             object: multipart.txt
             overwrite: different
-            <<: *aws_connection_info
           register: result
 
         - assert:
@@ -568,7 +532,6 @@
         bucket: "{{ bucket_name }}"
         mode: delobj
         object: "{{ item }}"
-        <<: *aws_connection_info
       loop:
         - hello.txt
         - delete.txt
@@ -586,5 +549,4 @@
       aws_s3:
         bucket: "{{ bucket_name }}"
         mode: delete
-        <<: *aws_connection_info
       ignore_errors: yes

--- a/tests/integration/targets/ec2_ami/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami/tasks/main.yml
@@ -1,20 +1,16 @@
 ---
-# tasks file for test_ec2_ami
-
-- block:
+# Test suite for ec2_ami
+- module_defaults:
+    group/aws:
+      aws_region: '{{ aws_region }}'
+      aws_access_key: '{{ aws_access_key }}'
+      aws_secret_key: '{{ aws_secret_key }}'
+      security_token: '{{ security_token | default(omit) }}'
+  block:
 
     # ============================================================
 
     # SETUP: vpc, ec2 key pair, subnet, security group, ec2 instance, snapshot
-    - name: set aws_connection_info fact
-      set_fact:
-        aws_connection_info: &aws_connection_info
-          aws_region: '{{aws_region}}'
-          aws_access_key: '{{aws_access_key}}'
-          aws_secret_key: '{{aws_secret_key}}'
-          security_token: '{{security_token}}'
-      no_log: yes
-
     - name: create a VPC to work in
       ec2_vpc_net:
         cidr_block: 10.0.0.0/24
@@ -22,14 +18,12 @@
         name: '{{ ec2_ami_name }}_setup'
         resource_tags:
           Name: '{{ ec2_ami_name }}_setup'
-        <<: *aws_connection_info
       register: setup_vpc
 
     - name: create a key pair to use for creating an ec2 instance
       ec2_key:
         name: '{{ ec2_ami_name }}_setup'
         state: present
-        <<: *aws_connection_info
       register: setup_key
 
     - name: create a subnet to use for creating an ec2 instance
@@ -41,7 +35,6 @@
         state: present
         resource_tags:
           Name: '{{ ec2_ami_name }}_setup'
-        <<: *aws_connection_info
       register: setup_subnet
 
     - name: create a security group to use for creating an ec2 instance
@@ -50,7 +43,6 @@
         description: 'created by Ansible integration tests'
         state: present
         vpc_id: '{{ setup_vpc.vpc.id }}'
-        <<: *aws_connection_info
       register: setup_sg
 
     - name: provision ec2 instance to create an image
@@ -64,7 +56,6 @@
           '{{ec2_ami_name}}_instance_setup': 'integration_tests'
         group_id: '{{ setup_sg.group_id }}'
         vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
-        <<: *aws_connection_info
       register: setup_instance
 
     - name: take a snapshot of the instance to create an image
@@ -72,7 +63,6 @@
         instance_id: '{{ setup_instance.instance_ids[0] }}'
         device_name: /dev/xvda
         state: present
-        <<: *aws_connection_info
       register: setup_snapshot
 
     # ============================================================
@@ -86,7 +76,6 @@
           Name: '{{ ec2_ami_name }}_ami'
         wait: yes
         root_device_name: /dev/xvda
-        <<: *aws_connection_info
       register: result
       ignore_errors: yes
 
@@ -108,7 +97,6 @@
           Name: '{{ ec2_ami_name }}_ami'
         wait: yes
         root_device_name: /dev/xvda
-        <<: *aws_connection_info
       register: result
 
     - name: set image id fact for deletion later
@@ -127,7 +115,6 @@
     - name: gather facts about the image created
       ec2_ami_info:
         image_ids: '{{ ec2_ami_image_id }}'
-        <<: *aws_connection_info
       register: ami_facts_result
       ignore_errors: true
 
@@ -149,7 +136,6 @@
         tags:
           Name: '{{ ec2_ami_name }}_ami'
         wait: yes
-        <<: *aws_connection_info
       ignore_errors: true
       register: result
 
@@ -165,7 +151,6 @@
     - name: test removing an ami if no image ID is provided (expected failed=true)
       ec2_ami:
         state: absent
-        <<: *aws_connection_info
       register: result
       ignore_errors: yes
 
@@ -193,7 +178,6 @@
             size: 8
             delete_on_termination: true
             snapshot_id: '{{ setup_snapshot.snapshot_id }}'
-        <<: *aws_connection_info
       register: result
       ignore_errors: true
 
@@ -227,7 +211,6 @@
             size: 8
             delete_on_termination: true
             snapshot_id: '{{ setup_snapshot.snapshot_id }}'
-        <<: *aws_connection_info
       register: result
 
     - name: assert a new ami has not been created
@@ -246,7 +229,6 @@
         name: '{{ ec2_ami_name }}_ami'
         tags:
           New: Tag
-        <<: *aws_connection_info
       register: result
 
     - name: assert a tag was added
@@ -264,7 +246,6 @@
         tags:
           New: Tag
         purge_tags: yes
-        <<: *aws_connection_info
       register: result
 
     - name: assert a tag was removed
@@ -284,7 +265,6 @@
           Name: '{{ ec2_ami_name }}_ami'
         launch_permissions:
           group_names: ['all']
-        <<: *aws_connection_info
       register: result
 
     - name: assert launch permissions were updated
@@ -304,7 +284,6 @@
           Name: '{{ ec2_ami_name }}_ami'
         launch_permissions:
           group_names: ['all']
-        <<: *aws_connection_info
       register: result
 
     - name: assert the description changed
@@ -323,7 +302,6 @@
           Name: '{{ ec2_ami_name }}_ami'
         launch_permissions:
           group_names: []
-        <<: *aws_connection_info
       register: result
 
     - name: assert launch permissions were updated
@@ -342,7 +320,6 @@
         tags:
           Name: '{{ ec2_ami_name }}_ami'
         wait: yes
-        <<: *aws_connection_info
       ignore_errors: true
       register: result
 
@@ -356,7 +333,6 @@
       ec2_snapshot_info:
         snapshot_ids:
           - '{{ ec2_ami_snapshot }}'
-        <<: *aws_connection_info
       register: snapshot_result
 
     - name: assert the snapshot wasn't deleted
@@ -373,7 +349,6 @@
         tags:
           Name: '{{ ec2_ami_name }}_ami'
         wait: yes
-        <<: *aws_connection_info
       register: result
 
     - name: assert that image does not exist
@@ -400,14 +375,12 @@
         image_id: "{{ ec2_ami_image_id }}"
         name: '{{ ec2_ami_name }}_ami'
         wait: yes
-        <<: *aws_connection_info
       ignore_errors: yes
 
     - name: remove setup snapshot of ec2 instance
       ec2_snapshot:
         state: absent
         snapshot_id: '{{ setup_snapshot.snapshot_id }}'
-        <<: *aws_connection_info
       ignore_errors: yes
 
     - name: remove setup ec2 instance
@@ -420,14 +393,12 @@
           '{{ec2_ami_name}}_instance_setup': 'integration_tests'
         group_id: '{{ setup_sg.group_id }}'
         vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
-        <<: *aws_connection_info
       ignore_errors: yes
 
     - name: remove setup keypair
       ec2_key:
         name: '{{ec2_ami_name}}_setup'
         state: absent
-        <<: *aws_connection_info
       ignore_errors: yes
 
     - name: remove setup security group
@@ -436,7 +407,6 @@
         description: 'created by Ansible integration tests'
         state: absent
         vpc_id: '{{ setup_vpc.vpc.id }}'
-        <<: *aws_connection_info
       ignore_errors: yes
 
     - name: remove setup subnet
@@ -448,7 +418,6 @@
         state: absent
         resource_tags:
           Name: '{{ ec2_ami_name }}_setup'
-        <<: *aws_connection_info
       ignore_errors: yes
 
     - name: remove setup VPC
@@ -458,5 +427,4 @@
         name: '{{ ec2_ami_name }}_setup'
         resource_tags:
           Name: '{{ ec2_ami_name }}_setup'
-        <<: *aws_connection_info
       ignore_errors: yes

--- a/tests/integration/targets/ec2_group/tasks/data_validation.yml
+++ b/tests/integration/targets/ec2_group/tasks/data_validation.yml
@@ -1,25 +1,15 @@
 ---
 - block:
-    - name: set up aws connection info
-      set_fact:
-        aws_connection_info: &aws_connection_info
-          aws_access_key: "{{ aws_access_key }}"
-          aws_secret_key: "{{ aws_secret_key }}"
-          security_token: "{{ security_token }}"
-          region: "{{ aws_region }}"
-      no_log: yes
     - name: Create a group with only the default rule
       ec2_group:
         name: '{{ec2_group_name}}-input-tests'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
 
     - name: Run through some common weird port specs
       ec2_group:
         name: '{{ec2_group_name}}-input-tests'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         rules:
           - "{{ item }}"
       with_items:
@@ -40,5 +30,4 @@
         name: '{{ec2_group_name}}-input-tests'
         vpc_id: '{{ vpc_result.vpc.id }}'
         state: absent
-        <<: *aws_connection_info
       ignore_errors: yes

--- a/tests/integration/targets/ec2_group/tasks/diff_mode.yml
+++ b/tests/integration/targets/ec2_group/tasks/diff_mode.yml
@@ -1,13 +1,4 @@
 ---
-  - name: set up aws connection info
-    set_fact:
-      aws_connection_info: &aws_connection_info
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        region: "{{ aws_region }}"
-    no_log: yes
-
   # ============================================================
 
   - name: create a group with a rule (CHECK MODE + DIFF)
@@ -23,7 +14,6 @@
       rules_egress:
       - proto: all
         cidr_ip: 0.0.0.0/0
-      <<: *aws_connection_info
     register: check_mode_result
     check_mode: true
     diff: true
@@ -45,7 +35,6 @@
       rules_egress:
       - proto: all
         cidr_ip: 0.0.0.0/0
-      <<: *aws_connection_info
     register: result
     diff: true
 
@@ -76,7 +65,6 @@
       rules_egress:
       - proto: all
         cidr_ip: 0.0.0.0/0
-      <<: *aws_connection_info
     register: check_mode_result
     check_mode: true
     diff: true
@@ -106,7 +94,6 @@
       rules_egress:
       - proto: all
         cidr_ip: 0.0.0.0/0
-      <<: *aws_connection_info
     register: result
     diff: true
 
@@ -127,7 +114,6 @@
         to_port: 80
         cidr_ip: 0.0.0.0/0
       rules_egress: []
-      <<: *aws_connection_info
     register: check_mode_result
     check_mode: true
     diff: true
@@ -147,7 +133,6 @@
         to_port: 80
         cidr_ip: 0.0.0.0/0
       rules_egress: []
-      <<: *aws_connection_info
     register: result
     diff: true
 
@@ -161,7 +146,6 @@
     ec2_group:
       name: '{{ ec2_group_name }}'
       state: absent
-      <<: *aws_connection_info
     register: check_mode_result
     diff: true
     check_mode: true
@@ -174,7 +158,6 @@
     ec2_group:
       name: '{{ ec2_group_name }}'
       state: absent
-      <<: *aws_connection_info
     register: result
     diff: true
 

--- a/tests/integration/targets/ec2_group/tasks/ec2_classic.yml
+++ b/tests/integration/targets/ec2_group/tasks/ec2_classic.yml
@@ -6,15 +6,13 @@
       region: "{{ aws_region }}"
   block:
   - name: Get available AZs
-    aws_az_facts:
-      aws_access_key: "{{ aws_connection_info['aws_access_key'] }}"
-      aws_secret_key: "{{ aws_connection_info['aws_secret_key'] }}"
+    aws_az_info:
       filters:
-        region-name: "{{ aws_connection_info['region'] }}"
+        region-name: "{{ aws_region }}"
     register: az_facts
 
   - name: Create a classic ELB with classic networking
-    ec2_elb_lb: 
+    ec2_elb_lb:
       name: "{{ resource_prefix }}-elb"
       state: present
       zones:

--- a/tests/integration/targets/ec2_group/tasks/egress_tests.yml
+++ b/tests/integration/targets/ec2_group/tasks/egress_tests.yml
@@ -1,21 +1,10 @@
 ---
 - block:
-    - name: set up aws connection info
-      set_fact:
-        aws_connection_info: &aws_connection_info
-          aws_access_key: "{{ aws_access_key }}"
-          aws_secret_key: "{{ aws_secret_key }}"
-          security_token: "{{ security_token }}"
-          region: "{{ aws_region }}"
-      no_log: yes
-
-
     - name: Create a group with only the default rule
       ec2_group:
         name: '{{ec2_group_name}}-egress-tests'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
       register: result
 
@@ -33,7 +22,6 @@
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
         purge_rules_egress: false
-        <<: *aws_connection_info
         state: present
       register: result
 
@@ -52,7 +40,6 @@
         vpc_id: '{{ vpc_result.vpc.id }}'
         purge_rules_egress: false
         rules_egress: []
-        <<: *aws_connection_info
         state: present
       register: result
 
@@ -71,7 +58,6 @@
         vpc_id: '{{ vpc_result.vpc.id }}'
         purge_rules_egress: true
         rules_egress: []
-        <<: *aws_connection_info
         state: present
       register: result
 
@@ -92,7 +78,6 @@
           ports:
           - 1212
           cidr_ip: 1.2.1.2/32
-        <<: *aws_connection_info
         state: present
       register: result
 
@@ -112,7 +97,6 @@
           ports:
           - 2323
           cidr_ip: 2.3.2.3/32
-        <<: *aws_connection_info
         state: present
       register: result
 
@@ -131,7 +115,6 @@
           ports:
           - 1212
           cidr_ip: 1.2.1.2/32
-        <<: *aws_connection_info
         state: present
       register: result
       check_mode: True
@@ -154,7 +137,6 @@
           ports:
           - 1212
           cidr_ip: 1.2.1.2/32
-        <<: *aws_connection_info
         state: present
       register: result
 
@@ -172,7 +154,6 @@
         - proto: tcp
           ports: 0-65535
           cidr_ip: 0.0.0.0/0
-        <<: *aws_connection_info
         state: present
         vpc_id: '{{ vpc_result.vpc.id }}'
       register: result
@@ -184,7 +165,6 @@
         rules_egress:
         - proto: -1
           cidr_ip: 0.0.0.0/0
-        <<: *aws_connection_info
         state: present
         vpc_id: '{{ vpc_result.vpc.id }}'
       register: result
@@ -194,5 +174,4 @@
         name: '{{ec2_group_name}}-egress-tests'
         state: absent
         vpc_id: '{{ vpc_result.vpc.id }}'
-        <<: *aws_connection_info
       ignore_errors: yes

--- a/tests/integration/targets/ec2_group/tasks/ipv6_default_tests.yml
+++ b/tests/integration/targets/ec2_group/tasks/ipv6_default_tests.yml
@@ -1,18 +1,9 @@
 ---
-- name: set up aws connection info
-  set_fact:
-    aws_connection_info: &aws_connection_info
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token }}"
-      region: "{{ aws_region }}"
-  no_log: yes
 # ============================================================
 - name: test state=present for ipv6 (expected changed=true) (CHECK MODE)
   ec2_group:
     name: '{{ec2_group_name}}'
     description: '{{ec2_group_description}}'
-    <<: *aws_connection_info
     state: present
     rules:
     - proto: "tcp"
@@ -32,7 +23,6 @@
   ec2_group:
     name: '{{ec2_group_name}}'
     description: '{{ec2_group_description}}'
-    <<: *aws_connection_info
     state: present
     rules:
     - proto: "tcp"
@@ -52,7 +42,6 @@
   ec2_group:
     name: '{{ec2_group_name}}'
     description: '{{ec2_group_description}}'
-    <<: *aws_connection_info
     state: present
     rules:
     - proto: "tcp"
@@ -77,7 +66,6 @@
   ec2_group:
     name: '{{ec2_group_name}}'
     description: '{{ec2_group_description}}'
-    <<: *aws_connection_info
     state: present
     rules:
     - proto: "tcp"
@@ -99,5 +87,4 @@
 - name: delete it
   ec2_group:
     name: '{{ec2_group_name}}'
-    <<: *aws_connection_info
     state: absent

--- a/tests/integration/targets/ec2_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_group/tasks/main.yml
@@ -1,14 +1,7 @@
 ---
-# A Note about ec2 environment variable name preference:
-#  - EC2_URL -> AWS_URL
-#  - EC2_ACCESS_KEY -> AWS_ACCESS_KEY_ID -> AWS_ACCESS_KEY
-#  - EC2_SECRET_KEY -> AWS_SECRET_ACCESS_KEY -> AWX_SECRET_KEY
-#  - EC2_REGION -> AWS_REGION
-#
-
-# - include: ../../setup_ec2/tasks/common.yml module_name: ec2_group
-
+# Runs a set of tets without the AWS connection credentials configured
 - include: ./credential_tests.yml
+
 # ============================================================
 # EC2 Classic tests can only be run on a pre-2013 AWS account with supported-platforms=EC2
 # Ansible CI does NOT have classic EC2 support; these tests are provided as-is for the
@@ -24,16 +17,6 @@
                                 aws_secret_key=aws_secret_key,
                                 aws_security_token=security_token,
                                 wantlist=True) }}"
-# ============================================================
--
-- name: set up aws connection info
-  set_fact:
-    aws_connection_info: &aws_connection_info
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token }}"
-      region: "{{ aws_region }}"
-  no_log: yes
 
 # ============================================================
 - name: Run EC2 Classic accounts if account type is EC2
@@ -50,7 +33,7 @@
       group/aws:
         aws_access_key: "{{ aws_access_key }}"
         aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
+        security_token: "{{ security_token | default(omit)}}"
         region: "{{ aws_region }}"
   block:
     - name: determine if there is a default VPC
@@ -68,7 +51,6 @@
         name: "{{ resource_prefix }}-vpc"
         state: present
         cidr_block: "10.232.232.128/26"
-        <<: *aws_connection_info
         tags:
           Name: "{{ resource_prefix }}-vpc"
           Description: "Created by ansible-test"
@@ -87,7 +69,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: absent
       check_mode: true
       register: result
@@ -102,7 +83,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: absent
       register: result
 
@@ -111,7 +91,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
       check_mode: true
       register: result
@@ -126,7 +105,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
       register: result
 
@@ -141,7 +119,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}CHANGED'
-        <<: *aws_connection_info
         state: present
       check_mode: true
       register: result
@@ -156,7 +133,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}CHANGED'
-        <<: *aws_connection_info
         state: present
       ignore_errors: true
       register: result
@@ -172,7 +148,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
       register: result
 
@@ -197,7 +172,6 @@
             description: '{{ ec2_group_description }}-2'
             state: present
             vpc_id: '{{ vpc_result.vpc.id }}'
-            <<: *aws_connection_info
           check_mode: true
           register: result
 
@@ -213,7 +187,6 @@
             description: '{{ ec2_group_description }}-2'
             state: present
             vpc_id: '{{ vpc_result.vpc.id }}'
-            <<: *aws_connection_info
           register: result
 
         - name: assert state=present (expected changed=true)
@@ -234,7 +207,6 @@
               from_port: 8182
               to_port: 8182
               cidr_ipv6: "64:ff9b::/96"
-            <<: *aws_connection_info
           check_mode: true
           register: result
 
@@ -255,7 +227,6 @@
               from_port: 8182
               to_port: 8182
               cidr_ipv6: "64:ff9b::/96"
-            <<: *aws_connection_info
           register: result
 
         - name: assert state=present (expected changed=true)
@@ -276,7 +247,6 @@
               from_port: 8182
               to_port: 8182
               cidr_ipv6: "64:ff9b::/96"
-            <<: *aws_connection_info
           check_mode: true
           register: result
 
@@ -297,7 +267,6 @@
               from_port: 8182
               to_port: 8182
               cidr_ipv6: "64:ff9b::/96"
-            <<: *aws_connection_info
           register: result
 
         - name: assert nothing changed
@@ -322,7 +291,6 @@
               from_port: 8181
               to_port: 8181
               cidr_ipv6: "64:ff9b::/96"
-            <<: *aws_connection_info
           check_mode: true
           diff: true
           register: result
@@ -351,7 +319,6 @@
               from_port: 8181
               to_port: 8181
               cidr_ipv6: "64:ff9b::/96"
-            <<: *aws_connection_info
           register: result
 
         - name: assert state=present (expected changed=true)
@@ -367,7 +334,6 @@
             description: '{{ ec2_group_description }}-2'
             state: absent
             vpc_id: '{{ vpc_result.vpc.id }}'
-            <<: *aws_connection_info
           check_mode: true
           diff: true
           register: result
@@ -385,7 +351,6 @@
             description: '{{ ec2_group_description }}-2'
             state: absent
             vpc_id: '{{ vpc_result.vpc.id }}'
-            <<: *aws_connection_info
           register: result
 
         - name: assert group was removed
@@ -398,7 +363,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         rules:
         - proto: "tcp"
           from_port: 8182
@@ -417,7 +381,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         rules:
         - proto: "tcp"
           from_port: 8182
@@ -438,7 +401,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         rules:
         - proto: "tcp"
@@ -459,7 +421,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         rules:
         - proto: "tcp"
@@ -484,7 +445,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         purge_rules: no
         rules:
@@ -505,7 +465,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         purge_rules: no
         rules:
@@ -530,7 +489,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         rules:
         - proto: "tcp"
@@ -555,7 +513,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         rules:
         - proto: "tcp"
@@ -583,7 +540,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         rules:
         - proto: "tcp"
@@ -608,7 +564,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         rules:
         - proto: "tcp"
@@ -634,7 +589,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         # set purge_rules to false so we don't get a false positive from previously added rules
         purge_rules: false
@@ -657,7 +611,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         # set purge_rules to false so we don't get a false positive from previously added rules
         purge_rules: false
@@ -680,7 +633,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         # set purge_rules to false so we don't get a false positive from previously added rules
         purge_rules: false
@@ -702,7 +654,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         # set purge_rules to false so we don't get a false positive from previously added rules
         purge_rules: false
@@ -724,7 +675,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         # set purge_rules to false so we don't get a false positive from previously added rules
         purge_rules: false
@@ -741,7 +691,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         # set purge_rules to false so we don't get a false positive from previously added rules
         purge_rules: false
@@ -772,7 +721,6 @@
           ec2_group:
             name: '{{ec2_group_name}}'
             description: '{{ec2_group_description}}'
-            <<: *aws_connection_info
             state: present
             # set purge_rules to false so we don't get a false positive from previously added rules
             purge_rules: false
@@ -794,7 +742,6 @@
           ec2_group:
             name: '{{ec2_group_name}}'
             description: '{{ec2_group_description}}'
-            <<: *aws_connection_info
             state: present
             # set purge_rules to false so we don't get a false positive from previously added rules
             purge_rules: false
@@ -817,7 +764,6 @@
           ec2_group:
             name: '{{ec2_group_name}}'
             description: '{{ec2_group_description}}'
-            <<: *aws_connection_info
             state: present
             # set purge_rules to false so we don't get a false positive from previously added rules
             purge_rules: false
@@ -842,7 +788,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         state: absent
-        <<: *aws_connection_info
       check_mode: true
       register: result
 
@@ -856,7 +801,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         state: absent
-        <<: *aws_connection_info
       register: result
 
     - name: assert state=absent (expected changed=true)
@@ -870,7 +814,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         state: present
         rules:
@@ -891,7 +834,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         state: present
         rules:
@@ -913,7 +855,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         state: present
         rules:
@@ -941,7 +882,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         state: present
         rules:
@@ -965,7 +905,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         state: present
         purge_rules_egress: false
@@ -990,7 +929,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         state: present
         purge_rules_egress: false
@@ -1015,7 +953,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         state: present
         rules:
@@ -1038,7 +975,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         state: present
         rules:
@@ -1062,7 +998,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         state: present
         rules:
@@ -1084,7 +1019,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         state: present
         rules:
@@ -1106,7 +1040,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         # purge the other rules so assertions work for the subsequent tests for rule descriptions
         purge_rules_egress: true
@@ -1147,7 +1080,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         # purge the other rules so assertions work for the subsequent tests for rule descriptions
         purge_rules_egress: true
@@ -1170,7 +1102,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         # purge the other rules so assertions work for the subsequent tests for rule descriptions
         purge_rules_egress: true
@@ -1212,7 +1143,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         purge_rules_egress: false
         purge_rules: false
@@ -1253,7 +1183,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         purge_rules_egress: false
         purge_rules: false
@@ -1295,7 +1224,6 @@
       ec2_group:
         name: '{{ec2_group_name}}-default-vpc'
         description: '{{ec2_group_description}} default VPC'
-        <<: *aws_connection_info
         purge_rules_egress: true
         state: present
         rules:
@@ -1326,7 +1254,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         purge_rules_egress: false
         purge_rules: false
@@ -1366,7 +1293,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         purge_rules_egress: false
         purge_rules: false
@@ -1407,7 +1333,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         purge_rules_egress: false
         purge_rules: false
@@ -1447,7 +1372,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         vpc_id: '{{ vpc_result.vpc.id }}'
         purge_rules_egress: false
         purge_rules: false
@@ -1489,7 +1413,6 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         state: absent
-        <<: *aws_connection_info
       register: result
 
     - name: assert state=absent (expected changed=true)
@@ -1505,28 +1428,24 @@
       ec2_group:
         name: '{{ec2_group_name}}'
         state: absent
-        <<: *aws_connection_info
       ignore_errors: yes
 
     - name: tidy up security group for IPv6 EC2-Classic tests
       ec2_group:
         name: '{{ ec2_group_name }}-2'
         state: absent
-        <<: *aws_connection_info
       ignore_errors: yes
 
     - name: tidy up default VPC security group
       ec2_group:
         name: '{{ec2_group_name}}-default-vpc'
         state: absent
-        <<: *aws_connection_info
       ignore_errors: yes
 
     - name: tidy up automatically created SG
       ec2_group:
         name: "{{ resource_prefix }} - Another security group"
         state: absent
-        <<: *aws_connection_info
       ignore_errors: yes
 
     - name: tidy up VPC
@@ -1534,5 +1453,4 @@
         name: "{{ resource_prefix }}-vpc"
         state: absent
         cidr_block: "10.232.232.128/26"
-        <<: *aws_connection_info
       ignore_errors: yes

--- a/tests/integration/targets/ec2_group/tasks/multi_nested_target.yml
+++ b/tests/integration/targets/ec2_group/tasks/multi_nested_target.yml
@@ -1,13 +1,4 @@
 ---
-  - name: set up aws connection info
-    set_fact:
-      aws_connection_info: &aws_connection_info
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token }}"
-        region: "{{ aws_region }}"
-    no_log: yes
-
   # ============================================================
 
   - name: test state=present for multiple ipv6 and ipv4 targets (expected changed=true) (CHECK MODE)
@@ -28,7 +19,6 @@
           - 172.16.1.0/24
           - 172.16.17.0/24
           - ["10.0.0.0/24", "20.0.0.0/24"]
-      <<: *aws_connection_info
     check_mode: true
     register: result
 
@@ -55,7 +45,6 @@
           - 172.16.1.0/24
           - 172.16.17.0/24
           - ["10.0.0.0/24", "20.0.0.0/24"]
-      <<: *aws_connection_info
     register: result
 
   - name: assert state=present (expected changed=true)
@@ -84,7 +73,6 @@
           - 172.16.1.0/24
           - 172.16.17.0/24
           - ["10.0.0.0/24", "20.0.0.0/24"]
-      <<: *aws_connection_info
     check_mode: true
     register: result
 
@@ -111,7 +99,6 @@
           - 172.16.1.0/24
           - 172.16.17.0/24
           - ["10.0.0.0/24", "20.0.0.0/24"]
-      <<: *aws_connection_info
     register: result
 
   - name: assert state=present (expected changed=true)
@@ -137,7 +124,6 @@
           - 172.16.1.0/24
           - 172.16.17.0/24
           - ["10.0.0.0/24"]
-      <<: *aws_connection_info
     check_mode: true
     register: result
 
@@ -163,7 +149,6 @@
           - 172.16.1.0/24
           - 172.16.17.0/24
           - ["10.0.0.0/24"]
-      <<: *aws_connection_info
     register: result
 
   - assert:
@@ -189,7 +174,6 @@
           - 172.16.1.0/24
           - 172.16.17.0/24
           - ["10.0.0.0/24"]
-      <<: *aws_connection_info
     register: result
 
   - assert:
@@ -214,7 +198,6 @@
           - 172.16.1.0/24
           - 172.16.17.0/24
           - ["10.0.0.0/24"]
-      <<: *aws_connection_info
     register: result
 
   - assert:
@@ -228,4 +211,3 @@
     ec2_group:
       name: '{{ ec2_group_name }}'
       state: absent
-      <<: *aws_connection_info

--- a/tests/integration/targets/ec2_group/tasks/numeric_protos.yml
+++ b/tests/integration/targets/ec2_group/tasks/numeric_protos.yml
@@ -1,14 +1,8 @@
 ---
 - block:
-    - name: set up aws connection info
+    - name: set up temporary group name for tests
       set_fact:
         group_tmp_name: '{{ec2_group_name}}-numbered-protos'
-        aws_connection_info: &aws_connection_info
-          aws_access_key: "{{ aws_access_key }}"
-          aws_secret_key: "{{ aws_secret_key }}"
-          security_token: "{{ security_token }}"
-          region: "{{ aws_region }}"
-      no_log: yes
 
     - name: Create a group with numbered protocol (GRE)
       ec2_group:
@@ -20,7 +14,6 @@
           to_port: -1
           from_port: -1
           cidr_ip: 0.0.0.0/0
-        <<: *aws_connection_info
         state: present
       register: result
 
@@ -34,7 +27,6 @@
           to_port: -1
           from_port: -1
           cidr_ip: 0.0.0.0/0
-        <<: *aws_connection_info
         state: present
       register: result
     - assert:
@@ -47,7 +39,6 @@
         description: '{{ ec2_group_description }}'
         tags:
           foo: 1
-        <<: *aws_connection_info
     - name: Read a tag with a numeric value
       ec2_group:
         name: '{{ group_tmp_name }}'
@@ -55,7 +46,6 @@
         description: '{{ ec2_group_description }}'
         tags:
           foo: 1
-        <<: *aws_connection_info
       register: result
     - assert:
         that:
@@ -67,5 +57,4 @@
         name: '{{group_tmp_name}}'
         state: absent
         vpc_id: '{{ vpc_result.vpc.id }}'
-        <<: *aws_connection_info
       ignore_errors: yes

--- a/tests/integration/targets/ec2_group/tasks/rule_group_create.yml
+++ b/tests/integration/targets/ec2_group/tasks/rule_group_create.yml
@@ -1,14 +1,5 @@
 ---
 - block:
-    - name: set up aws connection info
-      set_fact:
-        aws_connection_info: &aws_connection_info
-          aws_access_key: "{{ aws_access_key }}"
-          aws_secret_key: "{{ aws_secret_key }}"
-          security_token: "{{ security_token }}"
-          region: "{{ aws_region }}"
-      no_log: yes
-
     - name: Create a group with self-referring rule
       ec2_group:
         name: '{{ec2_group_name}}-auto-create-1'
@@ -19,7 +10,6 @@
           from_port: 8000
           to_port: 8100
           group_name: '{{ec2_group_name}}-auto-create-1'
-        <<: *aws_connection_info
         state: present
       register: result
 
@@ -28,7 +18,6 @@
         name: '{{ec2_group_name}}-auto-create-2'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
 
     - name: Create a series of rules with a recently created group as target
@@ -42,7 +31,6 @@
           from_port: "{{ item }}"
           to_port: "{{ item }}"
           group_name: '{{ec2_group_name}}-auto-create-2'
-        <<: *aws_connection_info
         state: present
       register: result
       with_items:
@@ -65,7 +53,6 @@
           from_port: 8182
           to_port: 8182
           group_name: '{{ec2_group_name}}-auto-create-3'
-        <<: *aws_connection_info
         state: present
       register: result
       ignore_errors: true
@@ -87,7 +74,6 @@
             - 80
           group_name: '{{ec2_group_name}}-auto-create-3'
           group_desc: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
       register: result
 
@@ -100,7 +86,6 @@
         name: '{{ec2_group_name}}-auto-create-4'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
-        <<: *aws_connection_info
         state: present
         rules:
         - proto: tcp
@@ -118,7 +103,6 @@
           ports:
             - 443
           group_name: '{{ec2_group_name}}-auto-create-4'
-        <<: *aws_connection_info
         state: present
 
     - assert:
@@ -131,7 +115,6 @@
         name: '{{ec2_group_name}}-auto-create-{{ item }}'
         state: absent
         vpc_id: '{{ vpc_result.vpc.id }}'
-        <<: *aws_connection_info
       ignore_errors: yes
       with_items: [5, 4, 3, 2, 1]
     - name: tidy up egress rule test security group
@@ -139,6 +122,5 @@
         name: '{{ec2_group_name}}-auto-create-{{ item }}'
         state: absent
         vpc_id: '{{ vpc_result.vpc.id }}'
-        <<: *aws_connection_info
       ignore_errors: yes
       with_items: [1, 2, 3, 4, 5]

--- a/tests/integration/targets/ec2_tag/tasks/main.yml
+++ b/tests/integration/targets/ec2_tag/tasks/main.yml
@@ -1,7 +1,6 @@
 ---
 # tasks file for test_ec2_tag
-- name: Set up AWS connection info
-  module_defaults:
+- module_defaults:
     group/aws:
       aws_access_key: "{{ aws_access_key }}"
       aws_secret_key: "{{ aws_secret_key }}"

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/populate_cache.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/populate_cache.yml
@@ -7,7 +7,13 @@
     - community.general
   tasks:
 
-    - block:
+    - module_defaults:
+        group/aws:
+          aws_access_key: '{{ aws_access_key }}'
+          aws_secret_key: '{{ aws_secret_key }}'
+          security_token: '{{ security_token | default(omit) }}'
+          region: '{{ aws_region }}'
+      block:
 
         # Create VPC, subnet, security group, and find image_id to create instance
 
@@ -23,15 +29,6 @@
 
         # Create new host, add it to inventory and then terminate it without updating the cache
 
-        - name: set connection information for all tasks
-          set_fact:
-            aws_connection_info: &aws_connection_info
-              aws_access_key: '{{ aws_access_key }}'
-              aws_secret_key: '{{ aws_secret_key }}'
-              security_token: '{{ security_token }}'
-              region: '{{ aws_region }}'
-          no_log: yes
-
         - name: create a new host
           ec2:
             image: '{{ image_id }}'
@@ -44,7 +41,6 @@
             wait: yes
             group_id: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
-            <<: *aws_connection_info
           register: setup_instance
 
         - meta: refresh_inventory
@@ -61,7 +57,6 @@
               Name: '{{ resource_prefix }}'
             group_id: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
-            <<: *aws_connection_info
           ignore_errors: yes
           when: setup_instance is defined
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/setup.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/setup.yml
@@ -1,14 +1,3 @@
-- name: set connection information for all tasks
-  set_fact:
-    aws_connection_info: &aws_connection_info
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token }}'
-      region: '{{ aws_region }}'
-  no_log: yes
-  collections:
-    - community.aws
-
 - name: get image ID to create an instance
   ec2_ami_info:
     filters:
@@ -17,7 +6,6 @@
       virtualization-type: hvm
       root-device-type: ebs
       name: 'Fedora-Atomic-27*'
-    <<: *aws_connection_info
   register: fedora_images
 
 - set_fact:
@@ -30,7 +18,6 @@
     name: '{{ resource_prefix }}_setup'
     resource_tags:
       Name: '{{ resource_prefix }}_setup'
-    <<: *aws_connection_info
   register: setup_vpc
 
 - set_fact:
@@ -45,7 +32,6 @@
     state: present
     resource_tags:
       Name: '{{ resource_prefix }}_setup'
-    <<: *aws_connection_info
   register: setup_subnet
 
 - set_fact:
@@ -57,7 +43,6 @@
     description: 'created by Ansible integration tests'
     state: present
     vpc_id: '{{ setup_vpc.vpc.id }}'
-    <<: *aws_connection_info
   register: setup_sg
 
 - set_fact:

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/tear_down.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/tear_down.yml
@@ -1,19 +1,9 @@
-- name: set connection information for all tasks
-  set_fact:
-    aws_connection_info: &aws_connection_info
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token }}'
-      region: '{{ aws_region }}'
-  no_log: yes
-
 - name: remove setup security group
   ec2_group:
     name: '{{ resource_prefix }}_setup'
     description: 'created by Ansible integration tests'
     state: absent
     vpc_id: '{{ vpc_id }}'
-    <<: *aws_connection_info
   ignore_errors: yes
 
 - name: remove setup subnet
@@ -25,7 +15,6 @@
     state: absent
     resource_tags:
       Name: '{{ resource_prefix }}_setup'
-    <<: *aws_connection_info
   ignore_errors: yes
 
 - name: remove setup VPC
@@ -35,5 +24,4 @@
     name: '{{ resource_prefix }}_setup'
     resource_tags:
       Name: '{{ resource_prefix }}_setup'
-    <<: *aws_connection_info
   ignore_errors: yes

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory.yml
@@ -5,7 +5,14 @@
   environment: "{{ ansible_test.environment }}"
   tasks:
 
-    - block:
+    - module_defaults:
+        group/aws:
+          aws_access_key: '{{ aws_access_key }}'
+          aws_secret_key: '{{ aws_secret_key }}'
+          security_token: '{{ security_token | default(omit) }}'
+          region: '{{ aws_region }}'
+
+      block:
 
         # Create VPC, subnet, security group, and find image_id to create instance
 
@@ -19,15 +26,6 @@
 
         # Create new host, refresh inventory, remove host, refresh inventory
 
-        - name: set connection information for all tasks
-          set_fact:
-            aws_connection_info: &aws_connection_info
-              aws_access_key: '{{ aws_access_key }}'
-              aws_secret_key: '{{ aws_secret_key }}'
-              security_token: '{{ security_token }}'
-              region: '{{ aws_region }}'
-          no_log: yes
-
         - name: create a new host
           ec2:
             image: '{{ image_id }}'
@@ -40,7 +38,6 @@
             wait: yes
             group_id: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
-            <<: *aws_connection_info
           register: setup_instance
 
         - meta: refresh_inventory
@@ -62,7 +59,6 @@
               Name: '{{ resource_prefix }}'
             group_id: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
-            <<: *aws_connection_info
 
         - meta: refresh_inventory
 
@@ -84,7 +80,6 @@
               Name: '{{ resource_prefix }}'
             group_id: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
-            <<: *aws_connection_info
           ignore_errors: yes
           when: setup_instance is defined
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml
@@ -5,22 +5,19 @@
   environment: "{{ ansible_test.environment }}"
   tasks:
 
-    - block:
+    - module_defaults:
+        group/aws:
+          aws_access_key: '{{ aws_access_key }}'
+          aws_secret_key: '{{ aws_secret_key }}'
+          security_token: '{{ security_token | default(omit) }}'
+          region: '{{ aws_region }}'
+      block:
 
         # Create VPC, subnet, security group, and find image_id to create instance
 
         - include_tasks: setup.yml
 
         # Create new host, refresh inventory
-
-        - name: set connection information for all tasks
-          set_fact:
-            aws_connection_info: &aws_connection_info
-              aws_access_key: '{{ aws_access_key }}'
-              aws_secret_key: '{{ aws_secret_key }}'
-              security_token: '{{ security_token }}'
-              region: '{{ aws_region }}'
-          no_log: yes
 
         - name: create a new host
           ec2:
@@ -36,7 +33,6 @@
             wait: yes
             group_id: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
-            <<: *aws_connection_info
           register: setup_instance
 
         - meta: refresh_inventory
@@ -72,7 +68,6 @@
               Name: '{{ resource_prefix }}'
             group_id: "{{ sg_id }}"
             vpc_subnet_id: "{{ subnet_id }}"
-            <<: *aws_connection_info
           ignore_errors: yes
           when: setup_instance is defined
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_refresh_inventory.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_refresh_inventory.yml
@@ -1,19 +1,16 @@
-- name: test updating inventory
+- name: Test updating inventory
+  module_defaults:
+    group/aws:
+       aws_access_key: '{{ aws_access_key }}'
+       aws_secret_key: '{{ aws_secret_key }}'
+       security_token: '{{ security_token | default(omit) }}'
+       region: '{{ aws_region }}'
   block:
     - name: assert group was populated with inventory but is empty
       assert:
         that:
           - "'aws_ec2' in groups"
           - "not groups.aws_ec2"
-
-    - name: set connection information for all tasks
-      set_fact:
-        aws_connection_info: &aws_connection_info
-          aws_access_key: "{{ aws_access_key }}"
-          aws_secret_key: "{{ aws_secret_key }}"
-          security_token: "{{ security_token }}"
-          region: "{{ aws_region }}"
-      no_log: yes
 
     - name: create a new host
       ec2:
@@ -27,7 +24,6 @@
         wait: yes
         group_id: '{{ setup_sg.group_id }}'
         vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
-        <<: *aws_connection_info
       register: setup_instance
 
     - meta: refresh_inventory
@@ -49,7 +45,6 @@
           Name: '{{ resource_prefix }}'
         group_id: '{{ setup_sg.group_id }}'
         vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
-        <<: *aws_connection_info
 
     - meta: refresh_inventory
 
@@ -70,5 +65,4 @@
           Name: '{{ resource_prefix }}'
         group_id: '{{ setup_sg.group_id }}'
         vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
-        <<: *aws_connection_info
       ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY

Prior to module_defaults we had to use a YAML hack with set_fact.  This change migrates the integration tests over to module_defaults:
1) Reduces the risk of accidentally exposing credentials
2) Tests that modules are available through our module_defaults 'group' (group/aws)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

aws_caller_info
aws_s3
ec2_ami
ec2_group

aws_ec2 (inventory)

##### ADDITIONAL INFORMATION
