### PR TITLE
Enable all sanity tests

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.9,<2.11'
+requires_ansible: '>=2.9'
 action_groups:
   aws:
   - aws_s3

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,4 +1,15 @@
-plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice
-plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice
+plugins/modules/aws_az_info.py pylint:ansible-deprecated-no-version
+plugins/modules/aws_caller_info.py pylint:ansible-deprecated-no-version
+plugins/modules/cloudformation_info.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2_ami_info.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2_eni_info.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2_group_info.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2_snapshot_info.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2_tag.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2_vol_info.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2_vpc_dhcp_option_info.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2_vpc_net_info.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2_vpc_subnet_info.py pylint:ansible-deprecated-no-version
 tests/utils/shippable/check_matrix.py replace-urlopen
 tests/utils/shippable/timing.py shebang

--- a/tests/utils/shippable/sanity.sh
+++ b/tests/utils/shippable/sanity.sh
@@ -2,26 +2,13 @@
 
 set -o pipefail -eux
 
-declare -a args
-IFS='/:' read -ra args <<< "$1"
-
-group="${args[1]}"
-
 if [ "${BASE_BRANCH:-}" ]; then
     base_branch="origin/${BASE_BRANCH}"
 else
     base_branch=""
 fi
 
-case "${group}" in
-    1) options=(--skip-test pylint --skip-test ansible-doc --skip-test validate-modules) ;;
-    2) options=(                   --test      ansible-doc) ;;
-    3) options=(--test pylint --exclude test/units/ --exclude lib/ansible/module_utils/) ;;
-    4) options=(--test pylint           test/units/           lib/ansible/module_utils/) ;;
-    5) options=(                                                                                                --test validate-modules) ;;
-esac
-
 # shellcheck disable=SC2086
 ansible-test sanity --color -v --junit ${COVERAGE:+"$COVERAGE"} ${CHANGED:+"$CHANGED"} \
     --docker --base-branch "${base_branch}" \
-    "${options[@]}" --allow-disabled
+    --allow-disabled


### PR DESCRIPTION
##### SUMMARY
Right now, the `pylint`, `validate-modules` and `ansible-doc` sanity tests are not run in CI. This removes the expectation from tests/utils/shippable/sanity.sh that there are five sanity check groups so that all tests are run.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
CI
