### PR TITLE
Replace use of 1.1.1.1 - it's not really 'ours' to use in examples

### DIFF
--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -365,7 +365,7 @@ ip_permissions:
     - from_port: 8182
       ip_protocol: tcp
       ip_ranges:
-        - cidr_ip: "1.1.1.1/32"
+        - cidr_ip: "198.51.100.1/32"
       ipv6_ranges: []
       prefix_list_ids: []
       to_port: 8182

--- a/tests/integration/targets/ec2_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_group/tasks/main.yml
@@ -367,7 +367,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
       check_mode: true
       register: result
 
@@ -385,7 +385,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
       register: result
 
     - name: assert state=present (expected changed=true)
@@ -406,7 +406,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
       check_mode: true
       diff: true
       register: check_result
@@ -426,7 +426,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
       register: result
 
     - name: assert state=present (expected changed=false)
@@ -494,12 +494,12 @@
         - proto: "tcp"
           from_port: "8183"
           to_port: "8183"
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
         rules_egress:
         - proto: "tcp"
           from_port: "8184"
           to_port: "8184"
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
       check_mode: true
       register: result
 
@@ -518,12 +518,12 @@
         - proto: "tcp"
           from_port: "8183"
           to_port: "8183"
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
         rules_egress:
         - proto: "tcp"
           from_port: "8184"
           to_port: "8184"
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
       register: result
 
     - name: assert state=present (expected changed=true)
@@ -597,7 +597,7 @@
           ports:
             - 8183-8190
             - '8192'
-          cidr_ip: 1.1.1.1/32
+          cidr_ip: 10.1.1.1/32
       check_mode: true
       register: result
 
@@ -619,7 +619,7 @@
           ports:
             - 8183-8190
             - '8192'
-          cidr_ip: 1.1.1.1/32
+          cidr_ip: 10.1.1.1/32
       register: result
 
     - name: assert state=present (expected changed=true)
@@ -820,7 +820,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
       check_mode: true
       register: result
 
@@ -840,7 +840,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
       register: result
 
     - name: assert state=present (expected changed=true)
@@ -861,7 +861,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
         tags:
           tag1: test1
           tag2: test2
@@ -888,7 +888,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
         tags:
           tag1: test1
           tag2: test2
@@ -912,7 +912,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
         tags:
           tag1: test1
           tag2: test2
@@ -936,7 +936,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
         tags:
           tag1: test1
           tag2: test2
@@ -959,7 +959,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
         tags:
           tag1: test1
       check_mode: true
@@ -981,7 +981,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
         tags:
           tag1: test1
       register: result
@@ -1004,7 +1004,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
       register: result
 
     - name: assert that the tags stayed the same (expected changed=false)
@@ -1025,7 +1025,7 @@
         - proto: "tcp"
           from_port: 8182
           to_port: 8182
-          cidr_ip: "1.1.1.1/32"
+          cidr_ip: "10.1.1.1/32"
         tags: {}
       register: result
 
@@ -1055,7 +1055,7 @@
         - proto: "tcp"
           ports:
           - 8282
-          cidr_ip: 2.2.2.2/32
+          cidr_ip: 10.2.2.2/32
           rule_desc: egress rule desc 1
       check_mode: true
       register: result
@@ -1094,7 +1094,7 @@
         - proto: "tcp"
           ports:
           - 8282
-          cidr_ip: 2.2.2.2/32
+          cidr_ip: 10.2.2.2/32
       register: result
 
     # ============================================================
@@ -1117,7 +1117,7 @@
         - proto: "tcp"
           ports:
           - 8282
-          cidr_ip: 2.2.2.2/32
+          cidr_ip: 10.2.2.2/32
           rule_desc: egress rule desc 1
       register: result
 
@@ -1157,7 +1157,7 @@
         - proto: "tcp"
           ports:
           - 8282
-          cidr_ip: 2.2.2.2/32
+          cidr_ip: 10.2.2.2/32
           rule_desc: egress rule desc 2
       check_mode: true
       register: result
@@ -1197,7 +1197,7 @@
         - proto: "tcp"
           ports:
           - 8282
-          cidr_ip: 2.2.2.2/32
+          cidr_ip: 10.2.2.2/32
           rule_desc: egress rule desc 2
       register: result
 
@@ -1230,13 +1230,13 @@
         - proto: "tcp"
           ports:
           - 8281
-          cidr_ip: 1.1.1.1/24
+          cidr_ip: 10.1.1.1/24
           rule_desc: ipv4 rule desc
         rules_egress:
         - proto: "tcp"
           ports:
           - 8282
-          cidr_ip: 2.2.2.2/32
+          cidr_ip: 10.2.2.2/32
           rule_desc: egress rule desc 2
       register: result
 
@@ -1268,7 +1268,7 @@
         - proto: "tcp"
           ports:
           - 8282
-          cidr_ip: 2.2.2.2/32
+          cidr_ip: 10.2.2.2/32
           rule_desc: egress rule desc 2
       check_mode: true
       register: result
@@ -1307,7 +1307,7 @@
         - proto: "tcp"
           ports:
           - 8282
-          cidr_ip: 2.2.2.2/32
+          cidr_ip: 10.2.2.2/32
           rule_desc: egress rule desc 2
       register: result
 
@@ -1347,7 +1347,7 @@
         - proto: "tcp"
           ports:
           - 8282
-          cidr_ip: 2.2.2.2/32
+          cidr_ip: 10.2.2.2/32
           rule_desc:
       check_mode: true
       register: result
@@ -1386,7 +1386,7 @@
         - proto: "tcp"
           ports:
           - 8282
-          cidr_ip: 2.2.2.2/32
+          cidr_ip: 10.2.2.2/32
           rule_desc:
       register: result
       ignore_errors: true

--- a/tests/unit/modules/test_ec2_group.py
+++ b/tests/unit/modules/test_ec2_group.py
@@ -76,7 +76,7 @@ def test_validate_ip():
         ('10.1.1.1/24', '10.1.1.0/24'),
         ('192.168.56.101/16', '192.168.0.0/16'),
         # Don't modify IPv6 CIDRs, AWS supports /128 and device ranges
-        ('1203:8fe0:fe80:b897:8990:8a7c:99bf:323d/128', '1203:8fe0:fe80:b897:8990:8a7c:99bf:323d/128'),
+        ('fc00:8fe0:fe80:b897:8990:8a7c:99bf:323d/128', 'fc00:8fe0:fe80:b897:8990:8a7c:99bf:323d/128'),
     ]
 
     for ip, net in ips:

--- a/tests/unit/modules/test_ec2_group.py
+++ b/tests/unit/modules/test_ec2_group.py
@@ -73,7 +73,7 @@ def test_validate_ip():
         def warn(self, msg):
             return
     ips = [
-        ('1.1.1.1/24', '1.1.1.0/24'),
+        ('10.1.1.1/24', '10.1.1.0/24'),
         ('192.168.56.101/16', '192.168.0.0/16'),
         # Don't modify IPv6 CIDRs, AWS supports /128 and device ranges
         ('1203:8fe0:fe80:b897:8990:8a7c:99bf:323d/128', '1203:8fe0:fe80:b897:8990:8a7c:99bf:323d/128'),


### PR DESCRIPTION
##### SUMMARY

Replace use of 1.1.1.1 - it's not really 'ours' to use in examples and we were requested in https://github.com/ansible/ansible/issues/38959 not to use it

- In the unit tests just use a 'real' but reserved IP address in the 10/8 range
- In the documentation use 198.51.100.1 which is in a range explicitly reserved for documentation

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_group

##### ADDITIONAL INFORMATION
