### PR TITLE
[WIP] Attempt to catch and retry on RateLimiting errors while waiting

### DIFF
--- a/changelogs/fragments/93-deprecate-accidental.yml
+++ b/changelogs/fragments/93-deprecate-accidental.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+- "ec2_ami - The ``virtual_name`` alias ``VirtualName`` has been deprecated and will be removed after 2022-06-01"
+- "ec2_ami - The ``no_device`` alias ``NoDevice`` has been deprecated  and will be removed after 2022-06-01"

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -95,8 +95,11 @@ class AWSRetry(CloudRetry):
 
     @staticmethod
     def status_code_from_exception(error):
-        if hasattr(error, "last_response"):
-            return error.last_response['Error']['Code']
+        try:
+            if hasattr(error, "last_response"):
+                return error.last_response['Error']['Code']
+        except KeyError:
+            pass
         return error.response['Error']['Code']
 
     @staticmethod

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -86,7 +86,7 @@ def _botocore_exception_maybe():
     botocore.exceptions instead of assigning from it directly.
     """
     if HAS_BOTO3:
-        return botocore.exceptions.ClientError
+        return (botocore.exceptions.ClientError, botocore.exceptions.WaiterError,)
     return type(None)
 
 
@@ -95,6 +95,8 @@ class AWSRetry(CloudRetry):
 
     @staticmethod
     def status_code_from_exception(error):
+        if hasattr(error, "last_response"):
+            return error.last_response['Error']['Code']
         return error.response['Error']['Code']
 
     @staticmethod

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -86,10 +86,14 @@ options:
           description:
           - The virtual name for the device.
           - See the AWS documentation for more detail U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html).
+          - Alias C(VirtualName) has been deprecated and will be removed after 2022-06-01.
+          aliases: ['VirtualName']
         no_device:
           type: bool
           description:
           - Suppresses the specified device included in the block device mapping of the AMI.
+          - Alias C(NoDevice) has been deprecated and will be removed after 2022-06-01.
+          aliases: ['NoDevice']
         volume_type:
           type: str
           description: The volume type.  Defaults to C(gp2) when not set.
@@ -684,8 +688,12 @@ def rename_item_if_exists(dict_object, attribute, new_attribute, child_node=None
 def main():
     mapping_options = dict(
         device_name=dict(type='str', required=True),
-        virtual_name=dict(type='str'),
-        no_device=dict(type='bool'),
+        virtual_name=dict(
+            type='str', aliases=['VirtualName'],
+            deprecated_aliases=[dict(name='VirtualName', date='2022-06-01', collection_name='amazon.aws')]),
+        no_device=dict(
+            type='bool', aliases=['NoDevice'],
+            deprecated_aliases=[dict(name='NoDevice', date='2022-06-01', collection_name='amazon.aws')]),
         volume_type=dict(type='str'),
         delete_on_termination=dict(type='bool'),
         snapshot_id=dict(type='str'),

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -450,9 +450,11 @@ def create_image(module, connection):
 
         block_device_mapping = None
 
+        # Remove empty values injected by using options
         if device_mapping:
             block_device_mapping = []
             for device in device_mapping:
+                device = {k: v for k, v in device.items() if v is not None}
                 device['Ebs'] = {}
                 device = rename_item_if_exists(device, 'device_name', 'DeviceName')
                 device = rename_item_if_exists(device, 'virtual_name', 'VirtualName')
@@ -681,7 +683,7 @@ def rename_item_if_exists(dict_object, attribute, new_attribute, child_node=None
 
 def main():
     mapping_options = dict(
-        device_name=dict(type='str', aliases=['DeviceName'], required=True),
+        device_name=dict(type='str', required=True),
         virtual_name=dict(type='str'),
         no_device=dict(type='bool'),
         volume_type=dict(type='str'),

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -369,6 +369,7 @@ except ImportError:
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ..module_utils.core import AnsibleAWSModule
+from ..module_utils.ec2 import AWSRetry
 from ..module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ..module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ..module_utils.ec2 import compare_aws_tags
@@ -476,7 +477,7 @@ def create_image(module, connection):
         if instance_id:
             params['InstanceId'] = instance_id
             params['NoReboot'] = no_reboot
-            image_id = connection.create_image(**params).get('ImageId')
+            image_id = connection.create_image(aws_retry=True, **params).get('ImageId')
         else:
             if architecture:
                 params['Architecture'] = architecture
@@ -496,7 +497,7 @@ def create_image(module, connection):
                 params['KernelId'] = kernel_id
             if root_device_name:
                 params['RootDeviceName'] = root_device_name
-            image_id = connection.register_image(**params).get('ImageId')
+            image_id = connection.register_image(aws_retry=True, **params).get('ImageId')
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Error registering image")
 
@@ -509,7 +510,7 @@ def create_image(module, connection):
 
     if tags:
         try:
-            connection.create_tags(Resources=[image_id], Tags=ansible_dict_to_boto3_tag_list(tags))
+            connection.create_tags(aws_retry=True, Resources=[image_id], Tags=ansible_dict_to_boto3_tag_list(tags))
         except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
             module.fail_json_aws(e, msg="Error tagging image")
 
@@ -521,7 +522,7 @@ def create_image(module, connection):
             for user_id in launch_permissions.get('user_ids', []):
                 params['LaunchPermission']['Add'].append(dict(UserId=str(user_id)))
             if params['LaunchPermission']['Add']:
-                connection.modify_image_attribute(**params)
+                connection.modify_image_attribute(aws_retry=True, **params)
         except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
             module.fail_json_aws(e, msg="Error setting launch permissions for image %s" % image_id)
 
@@ -550,7 +551,7 @@ def deregister_image(module, connection):
     # When trying to re-deregister an already deregistered image it doesn't raise an exception, it just returns an object without image attributes.
     if 'ImageId' in image:
         try:
-            connection.deregister_image(ImageId=image_id)
+            connection.deregister_image(aws_retry=True, ImageId=image_id)
         except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
             module.fail_json_aws(e, msg="Error deregistering image")
     else:
@@ -571,7 +572,7 @@ def deregister_image(module, connection):
     if delete_snapshot:
         try:
             for snapshot_id in snapshots:
-                connection.delete_snapshot(SnapshotId=snapshot_id)
+                connection.delete_snapshot(aws_retry=True, SnapshotId=snapshot_id)
         except botocore.exceptions.ClientError as e:
             # Don't error out if root volume snapshot was already deregistered as part of deregister_image
             if e.response['Error']['Code'] == 'InvalidSnapshot.NotFound':
@@ -606,7 +607,8 @@ def update_image(module, connection, image_id):
 
         if to_add or to_remove:
             try:
-                connection.modify_image_attribute(ImageId=image_id, Attribute='launchPermission',
+                connection.modify_image_attribute(aws_retry=True,
+                                                  ImageId=image_id, Attribute='launchPermission',
                                                   LaunchPermission=dict(Add=to_add, Remove=to_remove))
                 changed = True
             except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
@@ -619,14 +621,14 @@ def update_image(module, connection, image_id):
 
         if tags_to_remove:
             try:
-                connection.delete_tags(Resources=[image_id], Tags=[dict(Key=tagkey) for tagkey in tags_to_remove])
+                connection.delete_tags(aws_retry=True, Resources=[image_id], Tags=[dict(Key=tagkey) for tagkey in tags_to_remove])
                 changed = True
             except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
                 module.fail_json_aws(e, msg="Error updating tags")
 
         if tags_to_add:
             try:
-                connection.create_tags(Resources=[image_id], Tags=ansible_dict_to_boto3_tag_list(tags_to_add))
+                connection.create_tags(aws_retry=True, Resources=[image_id], Tags=ansible_dict_to_boto3_tag_list(tags_to_add))
                 changed = True
             except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
                 module.fail_json_aws(e, msg="Error updating tags")
@@ -634,7 +636,7 @@ def update_image(module, connection, image_id):
     description = module.params.get('description')
     if description and description != image['Description']:
         try:
-            connection.modify_image_attribute(Attribute='Description ', ImageId=image_id, Description=dict(Value=description))
+            connection.modify_image_attribute(aws_retry=True, Attribute='Description ', ImageId=image_id, Description=dict(Value=description))
             changed = True
         except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
             module.fail_json_aws(e, msg="Error setting description for image %s" % image_id)
@@ -650,7 +652,7 @@ def update_image(module, connection, image_id):
 def get_image_by_id(module, connection, image_id):
     try:
         try:
-            images_response = connection.describe_images(ImageIds=[image_id])
+            images_response = connection.describe_images(aws_retry=True, ImageIds=[image_id])
         except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
             module.fail_json_aws(e, msg="Error retrieving image %s" % image_id)
         images = images_response.get('Images')
@@ -660,8 +662,8 @@ def get_image_by_id(module, connection, image_id):
         if no_images == 1:
             result = images[0]
             try:
-                result['LaunchPermissions'] = connection.describe_image_attribute(Attribute='launchPermission', ImageId=image_id)['LaunchPermissions']
-                result['ProductCodes'] = connection.describe_image_attribute(Attribute='productCodes', ImageId=image_id)['ProductCodes']
+                result['LaunchPermissions'] = connection.describe_image_attribute(aws_retry=True, Attribute='launchPermission', ImageId=image_id)['LaunchPermissions']
+                result['ProductCodes'] = connection.describe_image_attribute(aws_retry=True, Attribute='productCodes', ImageId=image_id)['ProductCodes']
             except botocore.exceptions.ClientError as e:
                 if e.response['Error']['Code'] != 'InvalidAMIID.Unavailable':
                     module.fail_json_aws(e, msg="Error retrieving image attributes for image %s" % image_id)
@@ -739,7 +741,7 @@ def main():
     if not any([module.params['image_id'], module.params['name']]):
         module.fail_json(msg="one of the following is required: name, image_id")
 
-    connection = module.client('ec2')
+    connection = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 
     if module.params.get('state') == 'absent':
         deregister_image(module, connection)

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -504,7 +504,8 @@ def create_image(module, connection):
         waiter = connection.get_waiter('image_available')
         delay = wait_timeout // 30
         max_attempts = 30
-        waiter.wait(ImageIds=[image_id], WaiterConfig=dict(Delay=delay, MaxAttempts=max_attempts))
+        # This isn't perfect: throttling errors mid-wait would reset the count.
+        AWSRetry.jittered_backoff()(waiter.wait)(ImageIds=[image_id], WaiterConfig=dict(Delay=delay, MaxAttempts=max_attempts))
 
     if tags:
         try:

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -458,7 +458,7 @@ def create_image(module, connection):
         if device_mapping:
             block_device_mapping = []
             for device in device_mapping:
-                device = {k: v for k, v in device.items() if v is not None}
+                device = dict((k, v) for k, v in device.items() if v is not None)
                 device['Ebs'] = {}
                 device = rename_item_if_exists(device, 'device_name', 'DeviceName')
                 device = rename_item_if_exists(device, 'virtual_name', 'VirtualName')


### PR DESCRIPTION
##### SUMMARY

While we can currently catch and retry API-RateLimit related errors for single API calls, using a waiter will result in an immediate failure if the API Rate Limits are triggered.

Attempt to catch and retry on RateLimiting errors while waiting by extending AWSRetry

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/ec2.py
plugins/modules/ec2_ami.py

##### ADDITIONAL INFORMATION
Example:
https://app.shippable.com/github/ansible-collections/amazon.aws/runs/482/24/console