### PR TITLE
Ensure remaining _info modules support check_mode

### DIFF
--- a/changelogs/fragments/107_info_check_mode.yml
+++ b/changelogs/fragments/107_info_check_mode.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- Added check_mode support to aws_az_info
+- Added check_mode support to ec2_eni_info
+- Added check_mode support to ec2_snapshot_info

--- a/plugins/modules/aws_az_info.py
+++ b/plugins/modules/aws_az_info.py
@@ -85,7 +85,7 @@ def main():
         filters=dict(default={}, type='dict')
     )
 
-    module = AnsibleAWSModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'aws_az_facts':
         module.deprecate("The 'aws_az_facts' module has been renamed to 'aws_az_info'", date='2022-06-01', collection_name='amazon.aws')
 

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -252,7 +252,7 @@ def main():
         filters=dict(default=None, type='dict')
     )
 
-    module = AnsibleAWSModule(argument_spec=argument_spec)
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
     if module._name == 'ec2_eni_facts':
         module.deprecate("The 'ec2_eni_facts' module has been renamed to 'ec2_eni_info'", date='2021-12-01', collection_name='amazon.aws')
 

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -230,7 +230,8 @@ def main():
         argument_spec=argument_spec,
         mutually_exclusive=[
             ['snapshot_ids', 'owner_ids', 'restorable_by_user_ids', 'filters']
-        ]
+        ],
+        supports_check_mode=True
     )
     if module._name == 'ec2_snapshot_facts':
         module.deprecate("The 'ec2_snapshot_facts' module has been renamed to 'ec2_snapshot_info'", date='2021-12-01', collection_name='amazon.aws')

--- a/tests/integration/targets/aws_az_info/tasks/tests.yml
+++ b/tests/integration/targets/aws_az_info/tasks/tests.yml
@@ -28,6 +28,28 @@
       - '"zone_name" in first_az'
       - '"zone_type" in first_az'
 
+  - name: 'List available AZs in current Region - check_mode'
+    aws_az_info:
+    check_mode: yes
+    register: check_azs
+
+  - name: check task return attributes
+    vars:
+      first_az: '{{ check_azs.availability_zones[0] }}'
+    assert:
+      that:
+      - check_azs is successful
+      - '"availability_zones" in check_azs'
+      - '"group_name" in first_az'
+      - '"messages" in first_az'
+      - '"network_border_group" in first_az'
+      - '"opt_in_status" in first_az'
+      - '"region_name" in first_az'
+      - '"state" in first_az'
+      - '"zone_id" in first_az'
+      - '"zone_name" in first_az'
+      - '"zone_type" in first_az'
+
 
   # Be specific - aws_region isn't guaranteed to be any specific value
   - name: 'List Available AZs in us-east-1'

--- a/tests/integration/targets/ec2_snapshot/tasks/main.yml
+++ b/tests/integration/targets/ec2_snapshot/tasks/main.yml
@@ -79,11 +79,28 @@
     - assert:
         that:
           - result is changed
+          - info_result is not changed
           - info_result.snapshots| length == 1
           - info_result.snapshots[0].snapshot_id == result.snapshot_id
           - info_result.snapshots[0].volume_id == result.volume_id
           - info_result.snapshots[0].volume_size == result.volume_size
           - info_result.snapshots[0].tags == result.tags
+
+    - name: Get info about snapshots (check_mode)
+      ec2_snapshot_info:
+        filters:
+          "tag:Name": '{{ resource_prefix }}'
+      register: info_check
+      check_mode: yes
+
+    - assert:
+        that:
+          - info_check is not changed
+          - info_check.snapshots| length == 1
+          - info_check.snapshots[0].snapshot_id == result.snapshot_id
+          - info_check.snapshots[0].volume_id == result.volume_id
+          - info_check.snapshots[0].volume_size == result.volume_size
+          - info_check.snapshots[0].tags == result.tags
 
 #    JR: Check mode not supported
 #    - name: Take snapshot if most recent >1hr (False) (check mode)


### PR DESCRIPTION
##### SUMMARY

They make no changes, it's standard for _info modules to still return status

fixes: #106 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

aws_az_info
ec2_eni_info
ec2_snapshot_info

##### ADDITIONAL INFORMATION
