### PR TITLE
Deprecate state=list in ec2_vol

### DIFF
--- a/changelogs/fragments/108-ec2_vol-deprecate-list.yml
+++ b/changelogs/fragments/108-ec2_vol-deprecate-list.yml
@@ -1,3 +1,2 @@
 deprecated_features:
-- 'ec2_vol: deprecate the `list` option in favor of ec2_vol_info'
-
+  - 'ec2_vol: deprecate the `list` option in favor of ec2_vol_info'

--- a/changelogs/fragments/108-ec2_vol-deprecate-list.yml
+++ b/changelogs/fragments/108-ec2_vol-deprecate-list.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+- 'ec2_vol: deprecate the `list` option in favor of ec2_vol_info'
+

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -78,7 +78,10 @@ options:
     default: true
   state:
     description:
-      - Whether to ensure the volume is present or absent, or to list existing volumes (The C(list) option was added in version 1.8).
+      - Whether to ensure the volume is present or absent.
+      - The use of I(state=list) to interrogate the volume has been deprecated
+        and will be removed after 2022-06-01.  The 'list' functionality
+        has been moved to a dedicated module M(amazon.aws.ec2_vol_info).
     default: present
     choices: ['absent', 'present', 'list']
     type: str
@@ -519,6 +522,10 @@ def main():
     snapshot = module.params.get('snapshot')
     state = module.params.get('state')
     tags = module.params.get('tags')
+
+    if state == 'list':
+        module.deprecate(
+            'Using the "list" state has been deprecated.  Please use the ec2_vol_info module instead', date='2022-06-01', collection_name='amazon.aws')
 
     # Ensure we have the zone or can get the zone
     if instance is None and zone is None and state == 'present':

--- a/plugins/modules/ec2_vol_info.py
+++ b/plugins/modules/ec2_vol_info.py
@@ -51,9 +51,66 @@ EXAMPLES = '''
 
 '''
 
-# TODO: Disabled the RETURN as it was breaking docs building. Someone needs to
-# fix this
-RETURN = '''# '''
+RETURN = '''
+volumes:
+    description: Volumes that match the provided filters. Each element consists of a dict with all the information related to that volume.
+    type: list
+    elements: dict
+    returned: always
+    contains:
+        attachment_set:
+            description: Information about the volume attachments.
+            type: dict
+            sample: {
+                "attach_time": "2015-10-23T00:22:29.000Z",
+                "deleteOnTermination": "false",
+                "device": "/dev/sdf",
+                "instance_id": "i-8356263c",
+                "status": "attached"
+            }
+        create_time:
+            description: The time stamp when volume creation was initiated.
+            type: str
+            sample: "2015-10-21T14:36:08.870Z"
+        encrypted:
+            description: Indicates whether the volume is encrypted.
+            type: bool
+            sample: False
+        id:
+            description: The ID of the volume.
+            type: str
+            sample: "vol-35b333d9"
+        iops:
+            description: The number of I/O operations per second (IOPS) that the volume supports.
+            type: int
+            sample: null
+        size:
+            description: The size of the volume, in GiBs.
+            type: int
+            sample: 1
+        snapshot_id:
+            description: The snapshot from which the volume was created, if applicable.
+            type: str
+            sample: ""
+        status:
+            description: The volume state.
+            type: str
+            sample: "in-use"
+        tags:
+            description: Any tags assigned to the volume.
+            type: dict
+            sample: {
+                env: "dev"
+                }
+        type:
+            description: The volume type. This can be gp2, io1, st1, sc1, or standard.
+            type: str
+            sample: "standard"
+        zone:
+         description:
+            type: str
+            sample: "us-east-1b"
+'''
 
 import traceback
 

--- a/plugins/modules/ec2_vol_info.py
+++ b/plugins/modules/ec2_vol_info.py
@@ -107,7 +107,7 @@ volumes:
             type: str
             sample: "standard"
         zone:
-         description:
+            description:
             type: str
             sample: "us-east-1b"
 '''

--- a/plugins/modules/ec2_vol_info.py
+++ b/plugins/modules/ec2_vol_info.py
@@ -107,7 +107,7 @@ volumes:
             type: str
             sample: "standard"
         zone:
-            description:
+            description: The Availability Zone of the volume.
             type: str
             sample: "us-east-1b"
 '''

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -7,6 +7,7 @@ plugins/modules/ec2_eni_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_group_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_snapshot_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_tag.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2_vol.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_vol_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_vpc_dhcp_option_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_vpc_net_info.py pylint:ansible-deprecated-no-version


### PR DESCRIPTION
##### SUMMARY
Deprecate state=list in ec2_vol
Functionality is already available in ec2_vol_info
Add missing return docs to ec2_vol_info


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
 ec2_vol
 ec2_vol_info