### PR TITLE
Add porting guide entries from Ansible-base porting guide

### DIFF
--- a/changelogs/fragments/porting-guide.yml
+++ b/changelogs/fragments/porting-guide.yml
@@ -1,0 +1,11 @@
+---
+breaking_changes:
+  - aws_s3 - can now delete versioned buckets even when they are not empty - set mode to delete to delete a versioned bucket and everything in it.
+major_changes:
+  - "ec2 module_utils: The ``AWSRetry`` decorator no longer catches ``NotFound`` exceptions by default.  ``NotFound`` exceptions need to be explicitly added using ``catch_extra_error_codes``.  Some AWS modules may see an increase in transient failures due to AWS's eventual consistency model."
+deprecated_features:
+  - cloudformation - the ``template_format`` option has been deprecated and will be removed in a later release. It has been ignored by the module since Ansible 2.3.
+  - ec2_key - the ``wait`` option has been deprecated and will be removed in a later release. It has had no effect since Ansible 2.5.
+  - ec2_key - the ``wait_timeout`` option has been deprecated and will be removed in a later release. It has had no effect since Ansible 2.5.
+  - ec2_tag - support for ``list`` as a state has been deprecated and will be removed in a later release.  The ``ec2_tag_info`` can be used to fetch the tags on an EC2 resource.
+  - ec2 - in a later release, the ``group`` and ``group_id`` options will become mutually exclusive.  Currently ``group_id`` is ignored if you pass both.


### PR DESCRIPTION
##### SUMMARY
This adds entries from the Ansible-base porting guide that do not belong there (because they belong to this collection). This data has already been moved to the ansible changelog (https://github.com/ansible-community/ansible-build-data/blob/main/2.10/changelog.yaml), but it would be better if it appears in the changelog of the collection it applies to.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelog
