### PR TITLE
Changing order of ec2_url resolution

### DIFF
--- a/changelogs/fragments/121-ec2_url-resolution-order.yaml
+++ b/changelogs/fragments/121-ec2_url-resolution-order.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2 module_utils - Update ``ec2_connect`` (boto2) behaviour so that ``ec2_url`` overrides ``region``.

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -394,16 +394,16 @@ def ec2_connect(module):
 
     region, ec2_url, boto_params = get_aws_connection_info(module)
 
-    # If we have a region specified, connect to its endpoint.
-    if region:
-        try:
-            ec2 = connect_to_aws(boto.ec2, region, **boto_params)
-        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError, boto.provider.ProfileNotFoundError) as e:
-            module.fail_json(msg=str(e))
-    # Otherwise, no region so we fallback to the old connection method
-    elif ec2_url:
+    # If ec2_url is present use it
+    if ec2_url:
         try:
             ec2 = boto.connect_ec2_endpoint(ec2_url, **boto_params)
+        except (boto.exception.NoAuthHandlerFound, AnsibleAWSError, boto.provider.ProfileNotFoundError) as e:
+            module.fail_json(msg=str(e))
+    # Otherwise, if we have a region specified, connect to its endpoint.
+    elif region:
+        try:
+            ec2 = connect_to_aws(boto.ec2, region, **boto_params)
         except (boto.exception.NoAuthHandlerFound, AnsibleAWSError, boto.provider.ProfileNotFoundError) as e:
             module.fail_json(msg=str(e))
     else:

--- a/tests/integration/targets/module_utils_ec2/roles/ec2_connect/tasks/endpoints.yml
+++ b/tests/integration/targets/module_utils_ec2/roles/ec2_connect/tasks/endpoints.yml
@@ -2,16 +2,27 @@
 # Note 1: With boto3 we can use the FIPS endpoints as a minimal proxy for testing that
 # we're using something different.  With boto2 the authentication fails.
 #
-# Note 2: Region currently overrides the Endpoint which is different to the
-# ec2_connect based behaviour.  Once changed we should update the test cases.
-#
 ##################################################################################
 # Tests using Endpoints
 
 - name: 'Test basic operation using standard endpoint (aws-parameters)'
   example_module:
+    region: '{{ aws_region }}'
+    aws_endpoint_url: 'https://ec2.{{ aws_region }}.amazonaws.com'
+    aws_access_key: '{{ aws_access_key }}'
+    aws_secret_key: '{{ aws_secret_key }}'
+    aws_security_token: '{{ security_token }}'
+  register: standard_endpoint_result
+
+- name: 'Check that we connected to the standard endpoint'
+  assert:
+    that:
+    - standard_endpoint_result is successful
+    #- '"ec2:DescribeImages" in standard_endpoint_result.resource_actions'
+
+- name: 'Test basic operation using standard endpoint - no region (aws-parameters)'
+  example_module:
     region: '{{ omit }}'
-    #region: '{{ aws_region }}'
     aws_endpoint_url: 'https://ec2.{{ aws_region }}.amazonaws.com'
     aws_access_key: '{{ aws_access_key }}'
     aws_secret_key: '{{ aws_secret_key }}'
@@ -26,9 +37,8 @@
 
 - name: 'Test basic operation using standard endpoint (aws-parameters)'
   example_module:
-    region: '{{ omit }}'
-    #region: '{{ aws_region }}'
-    endpoint_url: 'https://ec2.us-east-1.amazonaws.com'
+    region: '{{ aws_region }}'
+    endpoint_url: 'https://ec2.{{ aws_region }}.amazonaws.com'
     aws_access_key: '{{ aws_access_key }}'
     aws_secret_key: '{{ aws_secret_key }}'
     aws_security_token: '{{ security_token }}'
@@ -42,9 +52,8 @@
 
 - name: 'Test basic operation using standard endpoint (aws-parameters)'
   example_module:
-    region: '{{ omit }}'
-    #region: '{{ aws_region }}'
-    ec2_url: 'https://ec2.us-east-1.amazonaws.com'
+    region: '{{ aws_region }}'
+    ec2_url: 'https://ec2.{{ aws_region }}.amazonaws.com'
     aws_access_key: '{{ aws_access_key }}'
     aws_secret_key: '{{ aws_secret_key }}'
     aws_security_token: '{{ security_token }}'
@@ -61,13 +70,12 @@
 
 - name: 'Test basic operation using standard endpoint (aws-environment)'
   example_module:
-    region: '{{ omit }}'
-    #region: '{{ aws_region }}'
+    region: '{{ aws_region }}'
     aws_access_key: '{{ aws_access_key }}'
     aws_secret_key: '{{ aws_secret_key }}'
     aws_security_token: '{{ security_token }}'
   environment:
-    AWS_URL: 'https://ec2.us-east-1.amazonaws.com'
+    AWS_URL: 'https://ec2.{{ aws_region }}.amazonaws.com'
   register: standard_endpoint_result
 
 - name: 'Check that we connected to the standard endpoint'
@@ -78,13 +86,12 @@
 
 - name: 'Test basic operation using standard endpoint (ec2-environment)'
   example_module:
-    region: '{{ omit }}'
-    #region: '{{ aws_region }}'
+    region: '{{ aws_region }}'
     aws_access_key: '{{ aws_access_key }}'
     aws_secret_key: '{{ aws_secret_key }}'
     aws_security_token: '{{ security_token }}'
   environment:
-    EC2_URL: 'https://ec2.us-east-1.amazonaws.com'
+    EC2_URL: 'https://ec2.{{ aws_region }}.amazonaws.com'
   register: standard_endpoint_result
 
 - name: 'Check that we connected to the standard endpoint'
@@ -99,8 +106,7 @@
 
 - name: 'Test with bad endpoint URL'
   example_module:
-    region: '{{ omit }}'
-    # region: '{{ aws_region }}'
+    region: '{{ aws_region }}'
     endpoint_url: 'https://junk.{{ aws_region }}.amazonaws.com'
     access_key: '{{ aws_access_key }}'
     secret_key: '{{ aws_secret_key }}'


### PR DESCRIPTION
If we use localstack (AWS local-dev stack) we overwrite aws_url.
Until now if region has been specified, the aws_url was ignored.
Now aws_url will have precedence over region

##### SUMMARY
I was trying to work with localstack, but I have noticed that presence of region overwrites my localstack URL, so this is my proposal to fix it

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
ec2
