### PR TITLE
aws_secrets.py: add on_missing and on_denied option

### DIFF
--- a/changelogs/fragments/122-aws_secret-add-on_missing-and-on_denied-option.yml
+++ b/changelogs/fragments/122-aws_secret-add-on_missing-and-on_denied-option.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - aws_secret - add "on_missing" and "on_denied" option

--- a/changelogs/fragments/122-aws_secret-add-on_missing-and-on_denied-option.yml
+++ b/changelogs/fragments/122-aws_secret-add-on_missing-and-on_denied-option.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - aws_secret - add "on_missing" and "on_denied" option
+  - aws_secret - add "on_missing" and "on_denied" option (https://github.com/ansible-collections/amazon.aws/pull/122).

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -39,7 +39,7 @@ options:
     default: false
   on_missing:
     description:
-        - action to take if secret is missing
+        - Action to take if the secret is missing.
         - Error will raise a fatal error
         - Skip will just ignore the term
         - Warn will skip over it but issue a warning

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -73,8 +73,8 @@ EXAMPLES = r"""
  - name: skip if secret does not exist
    debug: msg="{{ lookup('aws_secret', 'secret-not-exist', on_missing='skip')}}"
 
- - name: skip if access to the secret is denied
-   debug: msg="{{ lookup('aws_secret', 'secret-denied', on_denied='skip')}}"
+ - name: warn if access to the secret is denied
+   debug: msg="{{ lookup('aws_secret', 'secret-denied', on_denied='warn')}}"
 """
 
 RETURN = r"""

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -40,7 +40,7 @@ options:
   on_missing:
     description:
         - Action to take if the secret is missing.
-        - Error will raise a fatal error
+        - C(error) will raise a fatal error when the secret is missing.
         - Skip will just ignore the term
         - Warn will skip over it but issue a warning
     default: error

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -37,6 +37,24 @@ options:
         - This is useful for overcoming the 4096 character limit imposed by AWS.
     type: boolean
     default: false
+  on_missing:
+    description:
+        - action to take if secret is missing
+        - Error will raise a fatal error
+        - Skip will just ignore the term
+        - Warn will skip over it but issue a warning
+    default: error
+    type: string
+    choices: ['error', 'skip', 'warn']
+  on_denied:
+    description:
+        - action to take if access to secret is denied
+        - Error will raise a fatal error
+        - Skip will just ignore the term
+        - Warn will skip over it but issue a warning
+    default: error
+    type: string
+    choices: ['error', 'skip', 'warn']
 '''
 
 EXAMPLES = r"""
@@ -51,6 +69,12 @@ EXAMPLES = r"""
      password: "{{ lookup('aws_secret', 'DbSecret') }}"
      tags:
        Environment: staging
+
+- name: skip if secret does not exist
+   debug: msg="{{ lookup('aws_secret', 'secret-not-exist', on_missing='skip')}}"
+
+ - name: skip if access to the secret is denied
+   debug: msg="{{ lookup('aws_secret', 'secret-denied', on_denied='skip')}}"
 """
 
 RETURN = r"""
@@ -60,6 +84,7 @@ _raw:
 """
 
 from ansible.errors import AnsibleError
+from ansible.module_utils.six import string_types
 
 try:
     import boto3
@@ -108,6 +133,14 @@ class LookupModule(LookupBase):
 
     def run(self, terms, variables, **kwargs):
 
+        missing = kwargs.get('on_missing', 'error').lower()
+        if not isinstance(missing, string_types) or missing not in ['error', 'warn', 'skip']:
+            raise AnsibleError('"on_missing" must be a string and one of "error", "warn" or "skip", not %s' % missing)
+
+        denied = kwargs.get('on_denied', 'error').lower()
+        if not isinstance(denied, string_types) or denied not in ['error', 'warn', 'skip']:
+            raise AnsibleError('"on_denied" must be a string and one of "error", "warn" or "skip", not %s' % denied)
+
         self.set_options(var_options=variables, direct=kwargs)
         boto_credentials = self._get_credentials()
 
@@ -130,7 +163,14 @@ class LookupModule(LookupBase):
                 if 'SecretString' in response:
                     secrets.append(response['SecretString'])
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                raise AnsibleError("Failed to retrieve secret: %s" % to_native(e))
+                if e.response['Error']['Code'] == 'ResourceNotFoundException' and missing in ['warn', 'skip']:
+                    if missing == 'warn':
+                        self._display.warning('Skipping, did not find secret %s' % term)
+                elif e.response['Error']['Code'] == 'AccessDeniedException' and denied in ['warn', 'skip']:
+                    if denied == 'warn':
+                        self._display.warning('Skipping, access denied for secret %s' % term)
+                else:
+                    raise AnsibleError("Failed to retrieve secret: %s" % to_native(e))
 
         if kwargs.get('join'):
             joined_secret = []

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -42,7 +42,7 @@ options:
         - Action to take if the secret is missing.
         - C(error) will raise a fatal error when the secret is missing.
         - C(skip) will silently ignore the missing secret.
-        - Warn will skip over it but issue a warning
+        - C(warn) will skip over the missing secret but issue a warning.
     default: error
     type: string
     choices: ['error', 'skip', 'warn']

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -97,6 +97,7 @@ from ansible.plugins.lookup import LookupBase
 from ansible.module_utils._text import to_native
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 
+
 def _boto3_conn(region, credentials):
     boto_profile = credentials.pop('aws_profile', None)
 

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -168,12 +168,12 @@ class LookupModule(LookupBase):
                     raise AnsibleError("Failed to find secret %s (ResourceNotFound)" % term)
                 elif missing == 'warn':
                     self._display.warning('Skipping, did not find secret %s' % term)
-            except is_boto3_error_code('AccessDeniedException'):
+            except is_boto3_error_code('AccessDeniedException'):  # pylint: disable=duplicate-except
                 if denied == 'error':
                     raise AnsibleError("Failed to access secret %s (AccessDenied)" % term)
                 elif denied == 'warn':
                     self._display.warning('Skipping, access denied for secret %s' % term)
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
                 raise AnsibleError("Failed to retrieve secret: %s" % to_native(e))
 
         if kwargs.get('join'):

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -70,7 +70,7 @@ EXAMPLES = r"""
      tags:
        Environment: staging
 
-- name: skip if secret does not exist
+ - name: skip if secret does not exist
    debug: msg="{{ lookup('aws_secret', 'secret-not-exist', on_missing='skip')}}"
 
  - name: skip if access to the secret is denied

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -41,7 +41,7 @@ options:
     description:
         - Action to take if the secret is missing.
         - C(error) will raise a fatal error when the secret is missing.
-        - Skip will just ignore the term
+        - C(skip) will silently ignore the missing secret.
         - Warn will skip over it but issue a warning
     default: error
     type: string

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -48,10 +48,10 @@ options:
     choices: ['error', 'skip', 'warn']
   on_denied:
     description:
-        - action to take if access to secret is denied
-        - Error will raise a fatal error
-        - Skip will just ignore the term
-        - Warn will skip over it but issue a warning
+        - Action to take if access to the secret is denied.
+        - C(error) will raise a fatal error when access to the secret is denied.
+        - C(skip) will silently ignore the denied secret.
+        - C(warn) will skip over the denied secret but issue a warning.
     default: error
     type: string
     choices: ['error', 'skip', 'warn']

--- a/tests/unit/plugins/lookup/test_aws_secret.py
+++ b/tests/unit/plugins/lookup/test_aws_secret.py
@@ -82,6 +82,7 @@ error_response_missing = {'Error': {'Code': 'ResourceNotFoundException', 'Messag
 error_response_denied = {'Error': {'Code': 'AccessDeniedException', 'Message': 'Fake Denied Error'}}
 operation_name = 'FakeOperation'
 
+
 def test_on_missing_option(mocker, dummy_credentials):
     boto3_double = mocker.MagicMock()
     boto3_double.Session.return_value.client.return_value.get_secret_value.side_effect = ClientError(error_response_missing, operation_name)
@@ -101,6 +102,7 @@ def test_on_missing_option(mocker, dummy_credentials):
     args["on_missing"] = 'warn'
     retval = lookup_loader.get('amazon.aws.aws_secret').run(["missing_secret"], None, **args)
     assert(retval == [])
+
 
 def test_on_denied_option(mocker, dummy_credentials):
     boto3_double = mocker.MagicMock()

--- a/tests/unit/plugins/lookup/test_aws_secret.py
+++ b/tests/unit/plugins/lookup/test_aws_secret.py
@@ -22,11 +22,9 @@ __metaclass__ = type
 import pytest
 import datetime
 import sys
-from cStringIO import StringIO
 from copy import copy
 
 from ansible.errors import AnsibleError
-
 from ansible.plugins.loader import lookup_loader
 
 try:
@@ -101,13 +99,8 @@ def test_on_missing_option(mocker, dummy_credentials):
     mocker.patch.object(boto3, 'session', boto3_double)
     args = copy(dummy_credentials)
     args["on_missing"] = 'warn'
-    old_stderr = sys.stderr
-    redirected_error = sys.stderr = StringIO()
     retval = lookup_loader.get('amazon.aws.aws_secret').run(["missing_secret"], None, **args)
-    error_msg = redirected_error.getvalue()
-    sys.stderr = old_stderr
     assert(retval == [])
-    assert(error_msg.find("[WARNING]") >= 0)
 
 def test_on_denied_option(mocker, dummy_credentials):
     boto3_double = mocker.MagicMock()
@@ -126,12 +119,5 @@ def test_on_denied_option(mocker, dummy_credentials):
     mocker.patch.object(boto3, 'session', boto3_double)
     args = copy(dummy_credentials)
     args["on_denied"] = 'warn'
-    old_stderr = sys.stderr
-    redirected_error = sys.stderr = StringIO()
     retval = lookup_loader.get('amazon.aws.aws_secret').run(["denied_secret"], None, **args)
-    error_msg = redirected_error.getvalue()
-    sys.stderr = old_stderr
     assert(retval == [])
-    assert(error_msg.find("[WARNING]") >= 0)
-
-

--- a/tests/unit/plugins/lookup/test_aws_secret.py
+++ b/tests/unit/plugins/lookup/test_aws_secret.py
@@ -21,6 +21,9 @@ __metaclass__ = type
 
 import pytest
 import datetime
+import sys
+from cStringIO import StringIO
+from copy import copy
 
 from ansible.errors import AnsibleError
 
@@ -77,14 +80,58 @@ def test_lookup_variable(mocker, dummy_credentials):
                                            aws_secret_access_key="notasecret", aws_session_token=None)
 
 
-error_response = {'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Fake Testing Error'}}
+error_response_missing = {'Error': {'Code': 'ResourceNotFoundException', 'Message': 'Fake Not Found Error'}}
+error_response_denied = {'Error': {'Code': 'AccessDeniedException', 'Message': 'Fake Denied Error'}}
 operation_name = 'FakeOperation'
 
-
-def test_warn_denied_variable(mocker, dummy_credentials):
+def test_on_missing_option(mocker, dummy_credentials):
     boto3_double = mocker.MagicMock()
-    boto3_double.Session.return_value.client.return_value.get_secret_value.side_effect = ClientError(error_response, operation_name)
+    boto3_double.Session.return_value.client.return_value.get_secret_value.side_effect = ClientError(error_response_missing, operation_name)
 
-    with pytest.raises(AnsibleError):
+    with pytest.raises(AnsibleError, match="ResourceNotFoundException"):
         mocker.patch.object(boto3, 'session', boto3_double)
-        lookup_loader.get('amazon.aws.aws_secret').run(["denied_variable"], None, **dummy_credentials)
+        lookup_loader.get('amazon.aws.aws_secret').run(["missing_secret"], None, **dummy_credentials)
+
+    mocker.patch.object(boto3, 'session', boto3_double)
+    args = copy(dummy_credentials)
+    args["on_missing"] = 'skip'
+    retval = lookup_loader.get('amazon.aws.aws_secret').run(["missing_secret"], None, **args)
+    assert(retval == [])
+
+    mocker.patch.object(boto3, 'session', boto3_double)
+    args = copy(dummy_credentials)
+    args["on_missing"] = 'warn'
+    old_stderr = sys.stderr
+    redirected_error = sys.stderr = StringIO()
+    retval = lookup_loader.get('amazon.aws.aws_secret').run(["missing_secret"], None, **args)
+    error_msg = redirected_error.getvalue()
+    sys.stderr = old_stderr
+    assert(retval == [])
+    assert(error_msg.find("[WARNING]") >= 0)
+
+def test_on_denied_option(mocker, dummy_credentials):
+    boto3_double = mocker.MagicMock()
+    boto3_double.Session.return_value.client.return_value.get_secret_value.side_effect = ClientError(error_response_denied, operation_name)
+
+    with pytest.raises(AnsibleError, match="AccessDeniedException"):
+        mocker.patch.object(boto3, 'session', boto3_double)
+        lookup_loader.get('amazon.aws.aws_secret').run(["denied_secret"], None, **dummy_credentials)
+
+    mocker.patch.object(boto3, 'session', boto3_double)
+    args = copy(dummy_credentials)
+    args["on_denied"] = 'skip'
+    retval = lookup_loader.get('amazon.aws.aws_secret').run(["denied_secret"], None, **args)
+    assert(retval == [])
+
+    mocker.patch.object(boto3, 'session', boto3_double)
+    args = copy(dummy_credentials)
+    args["on_denied"] = 'warn'
+    old_stderr = sys.stderr
+    redirected_error = sys.stderr = StringIO()
+    retval = lookup_loader.get('amazon.aws.aws_secret').run(["denied_secret"], None, **args)
+    error_msg = redirected_error.getvalue()
+    sys.stderr = old_stderr
+    assert(retval == [])
+    assert(error_msg.find("[WARNING]") >= 0)
+
+

--- a/tests/unit/plugins/lookup/test_aws_secret.py
+++ b/tests/unit/plugins/lookup/test_aws_secret.py
@@ -87,7 +87,7 @@ def test_on_missing_option(mocker, dummy_credentials):
     boto3_double = mocker.MagicMock()
     boto3_double.Session.return_value.client.return_value.get_secret_value.side_effect = ClientError(error_response_missing, operation_name)
 
-    with pytest.raises(AnsibleError, match="ResourceNotFoundException"):
+    with pytest.raises(AnsibleError, match="ResourceNotFound"):
         mocker.patch.object(boto3, 'session', boto3_double)
         lookup_loader.get('amazon.aws.aws_secret').run(["missing_secret"], None, **dummy_credentials)
 
@@ -108,7 +108,7 @@ def test_on_denied_option(mocker, dummy_credentials):
     boto3_double = mocker.MagicMock()
     boto3_double.Session.return_value.client.return_value.get_secret_value.side_effect = ClientError(error_response_denied, operation_name)
 
-    with pytest.raises(AnsibleError, match="AccessDeniedException"):
+    with pytest.raises(AnsibleError, match="AccessDenied"):
         mocker.patch.object(boto3, 'session', boto3_double)
         lookup_loader.get('amazon.aws.aws_secret').run(["denied_secret"], None, **dummy_credentials)
 


### PR DESCRIPTION
##### SUMMARY
Add "on_missing" and "on_denied" option for aws_secret lookup. 
This option controls how to handle a not existing secret (ResourceNotFoundException) or missing access rights (AccessDeniedException). The option naming is based on the "config" lookup.

At some places we are using aws secrets optional when they are configured or the running user has access to it. With the generic lookup error control we can not differentiate between such state and a regular error.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
aws_secret

##### ADDITIONAL INFORMATION

The option "on_missing" and "on_denied" can be set to:

- 'error' - return a fatal error (default, old behavior)
- 'warn' - return empty list and print a warning
- 'skip' - return empty list

playbook:
```
---
- name: test read a secret
  hosts: localhost
  connection: local
  gather_facts: no
  vars:
    aws_access_key: <aws_access_key>
    aws_secret_key: <aws_secret_key>
  tasks:
    - name: secret successfull
      debug:
        var: bla
      vars:
        bla: "{{ lookup('amazon.aws.aws_secret','secret_test',region='eu-west-1',aws_access_key=aws_access_key,aws_secret_key=aws_secret_key) }}"
    - name: secret not found error
      debug:
        var: bla
      vars:
        bla: "{{ lookup('amazon.aws.aws_secret','secret_not_exist',region='eu-west-1',aws_access_key=aws_access_key,aws_secret_key=aws_secret_key) }}"
      ignore_errors: true
    - name: secret denied error
      debug:
        var: bla
      vars:
        bla: "{{ lookup('amazon.aws.aws_secret','secret_test',region='eu-west-1') }}"
      ignore_errors: true
    - name: secret not found warning
      debug:
        var: bla
      vars:
        bla: "{{ lookup('amazon.aws.aws_secret','secret_not_exist',region='eu-west-1',aws_access_key=aws_access_key,aws_secret_key=aws_secret_key,on_missing='warn') }}"
    - name: secret denied warning
      debug:
        var: bla
      vars:
        bla: "{{ lookup('amazon.aws.aws_secret','secret_test',region='eu-west-1',on_denied='warn') }}"
    - name: secret not found skipped
      debug:
        var: bla
      vars:
        bla: "{{ lookup('amazon.aws.aws_secret','secret_not_exist',region='eu-west-1',aws_access_key=aws_access_key,aws_secret_key=aws_secret_key,on_missing='skip') }}"
    - name: secret denied skipped
      debug:
        var: bla
      vars:
        bla: "{{ lookup('amazon.aws.aws_secret','secret_test',region='eu-west-1',on_denied='skip') }}"
```
output:

```
PLAY [test read a secret] ********************************************************************************************************************

TASK [secret successfull] ********************************************************************************************************************
ok: [localhost] => {
    "bla": {
        "secret_test": "secret_test_value"
    }
}

TASK [secret not found error] ****************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while templating '{{ lookup('amazon.aws.aws_secret','secret_not_exist',region='eu-west-1',aws_access_key=aws_access_key,aws_secret_key=aws_secret_key) }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while running the lookup plugin 'amazon.aws.aws_secret'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Failed to retrieve secret: An error occurred (ResourceNotFoundException) when calling the GetSecretValue operation: Secrets Manager can't find the specified secret."}
...ignoring

TASK [secret denied error] *******************************************************************************************************************
fatal: [localhost]: FAILED! => {"msg": "An unhandled exception occurred while templating '{{ lookup('amazon.aws.aws_secret','secret_test',region='eu-west-1') }}'. Error was a <class 'ansible.errors.AnsibleError'>, original message: An unhandled exception occurred while running the lookup plugin 'amazon.aws.aws_secret'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Failed to retrieve secret: An error occurred (AccessDeniedException) when calling the GetSecretValue operation: User: arn:aws:sts::963812274078:assumed-role/AnsibleBTServiceZoneStandard/i-0d041a344eb853269 is not authorized to perform: secretsmanager:GetSecretValue on resource: arn:aws:secretsmanager:eu-west-1:963812274078:secret:secret_test-u3hpk5"}
...ignoring

TASK [secret not found warning] **************************************************************************************************************
[WARNING]: Skipping, did not find secret secret_not_exist
ok: [localhost] => {
    "bla": []
}

TASK [secret denied warning] *****************************************************************************************************************
[WARNING]: Skipping, access denied for secret secret_test
ok: [localhost] => {
    "bla": []
}

TASK [secret not found skipped] **************************************************************************************************************
ok: [localhost] => {
    "bla": []
}

TASK [secret denied skipped] *****************************************************************************************************************
ok: [localhost] => {
    "bla": []
}

PLAY RECAP ***********************************************************************************************************************************
localhost                  : ok=7    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=2
```
