### PR TITLE
Add execution environment metadata

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-boto
-botocore>=1.10.0
-boto3>=1.0.0
+boto>=2.49.0
+botocore>=1.12.249
+boto3>=1.9.249

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+boto
+botocore>=1.10.0
+boto3>=1.0.0


### PR DESCRIPTION
##### SUMMARY
We are trying to kickstart a new project that allows building a container image tailored to run content inside of Ansible collections.

https://github.com/ansible/ansible-builder

I have been scraping data inside of module & plugin DOCUMENTATION, and thought that this set of python requirements arguably meets the `requirements:` listed by stuff in this collection.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
N/A

##### ADDITIONAL INFORMATION
The idea here is that `requirements.txt` will get automatically read by the `ansible-builder` tool. I have been testing this as a branch in my fork. Historically, we have installed these requirements inside of AWX & Ansible Tower

https://github.com/ansible/awx/blob/devel/requirements/requirements_ansible.in#L44

The idea is that maintaining these requirements will be put into the collection itself, and consumed downstream by tooling.