### PR TITLE
Fix typo for deleting a DHCP Option Set

### DIFF
--- a/docs/amazon.aws.ec2_vpc_dhcp_option_module.rst
+++ b/docs/amazon.aws.ec2_vpc_dhcp_option_module.rst
@@ -439,7 +439,7 @@ Examples
         tags:
           Name: google servers
           Environment: Test
-      state: absent
+        state: absent
 
     ## Associate a DHCP options set with a VPC by ID
     - amazon.aws.ec2_vpc_dhcp_option:


### PR DESCRIPTION
Fix alignment of `state` parameter to be passed as a module parameter instead of a task parameter.

##### SUMMARY
Simple typo fix

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ec2_vpc_dhcp_option

##### ADDITIONAL INFORMATION
None