### PR TITLE
typo(ec2_vpc_dhcp_option.py): Fix simple doc typo

### DIFF
--- a/plugins/modules/ec2_vpc_dhcp_option.py
+++ b/plugins/modules/ec2_vpc_dhcp_option.py
@@ -180,7 +180,7 @@ EXAMPLES = """
     tags:
       Name: google servers
       Environment: Test
-  state: absent
+    state: absent
 
 ## Associate a DHCP options set with a VPC by ID
 - amazon.aws.ec2_vpc_dhcp_option:


### PR DESCRIPTION
Fix alignment of `state` parameter to be passed as a module parameter instead of a task parameter.

##### SUMMARY
Simple typo fix

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ec2_vpc_dhcp_option

##### ADDITIONAL INFORMATION
None