### PR TITLE
module_utils.direct_connect - Add minimal AWSRetry decorator to client calls

### DIFF
--- a/plugins/module_utils/direct_connect.py
+++ b/plugins/module_utils/direct_connect.py
@@ -41,6 +41,8 @@ except ImportError:
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
+from .ec2 import AWSRetry
+
 
 class DirectConnectError(Exception):
     def __init__(self, msg, last_traceback=None, exception=None):
@@ -51,7 +53,7 @@ class DirectConnectError(Exception):
 
 def delete_connection(client, connection_id):
     try:
-        client.delete_connection(connectionId=connection_id)
+        AWSRetry.jittered_backoff()(client.delete_connection)(connectionId=connection_id)
     except botocore.exceptions.ClientError as e:
         raise DirectConnectError(msg="Failed to delete DirectConnection {0}.".format(connection_id),
                                  last_traceback=traceback.format_exc(),
@@ -60,8 +62,8 @@ def delete_connection(client, connection_id):
 
 def associate_connection_and_lag(client, connection_id, lag_id):
     try:
-        client.associate_connection_with_lag(connectionId=connection_id,
-                                             lagId=lag_id)
+        AWSRetry.jittered_backoff()(client.associate_connection_with_lag)(connectionId=connection_id,
+                                                                          lagId=lag_id)
     except botocore.exceptions.ClientError as e:
         raise DirectConnectError(msg="Failed to associate Direct Connect connection {0}"
                                  " with link aggregation group {1}.".format(connection_id, lag_id),
@@ -71,8 +73,8 @@ def associate_connection_and_lag(client, connection_id, lag_id):
 
 def disassociate_connection_and_lag(client, connection_id, lag_id):
     try:
-        client.disassociate_connection_from_lag(connectionId=connection_id,
-                                                lagId=lag_id)
+        AWSRetry.jittered_backoff()(client.disassociate_connection_from_lag)(connectionId=connection_id,
+                                                                             lagId=lag_id)
     except botocore.exceptions.ClientError as e:
         raise DirectConnectError(msg="Failed to disassociate Direct Connect connection {0}"
                                  " from link aggregation group {1}.".format(connection_id, lag_id),
@@ -82,7 +84,7 @@ def disassociate_connection_and_lag(client, connection_id, lag_id):
 
 def delete_virtual_interface(client, virtual_interface):
     try:
-        client.delete_virtual_interface(virtualInterfaceId=virtual_interface)
+        AWSRetry.jittered_backoff()(client.delete_virtual_interface)(virtualInterfaceId=virtual_interface)
     except botocore.exceptions.ClientError as e:
         raise DirectConnectError(msg="Could not delete virtual interface {0}".format(virtual_interface),
                                  last_traceback=traceback.format_exc(),


### PR DESCRIPTION
#### SUMMARY

Adds minimal AWSRetry decoration to boto3 calls to catch standard AWS temporary errors.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/direct_connect.py

##### ADDITIONAL INFORMATION