### PR TITLE
Ensure that waiters.get_waiter() can support a wrapped client

### DIFF
--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -9,6 +9,8 @@ try:
 except ImportError:
     pass  # caught by HAS_BOTO3
 
+import ansible_collections.amazon.aws.plugins.module_utils.core as aws_core
+
 
 ec2_data = {
     "version": 2,
@@ -398,6 +400,8 @@ waiters_by_name = {
 
 
 def get_waiter(client, waiter_name):
+    if isinstance(client, aws_core._RetryingBotoClientWrapper):
+        return get_waiter(client.client, waiter_name)
     try:
         return waiters_by_name[(client.__class__.__name__, waiter_name)](client)
     except KeyError:

--- a/tests/integration/targets/module_utils_waiter/aliases
+++ b/tests/integration/targets/module_utils_waiter/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group2

--- a/tests/integration/targets/module_utils_waiter/inventory
+++ b/tests/integration/targets/module_utils_waiter/inventory
@@ -1,0 +1,6 @@
+[tests]
+localhost
+
+[all:vars]
+ansible_connection=local
+ansible_python_interpreter="{{ ansible_playbook_python }}"

--- a/tests/integration/targets/module_utils_waiter/main.yml
+++ b/tests/integration/targets/module_utils_waiter/main.yml
@@ -1,0 +1,7 @@
+- hosts: all
+  gather_facts: no
+  collections:
+  - amazon.aws
+  roles:
+  # Test the behaviour of module_utils.core.AnsibleAWSModule.client (boto3)
+  - 'get_waiter'

--- a/tests/integration/targets/module_utils_waiter/meta/main.yml
+++ b/tests/integration/targets/module_utils_waiter/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/tests/integration/targets/module_utils_waiter/roles/get_waiter/library/example_module.py
+++ b/tests/integration/targets/module_utils_waiter/roles/get_waiter/library/example_module.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python
+# Copyright (c) 2017 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# A bare-minimum Ansible Module based on AnsibleAWSModule used for testing some
+# of the core behaviour around AWS/Boto3 connection details
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+try:
+    from botocore.exceptions import BotoCoreError, ClientError
+except ImportError:
+    pass  # Handled by AnsibleAWSModule
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.waiters import get_waiter
+
+
+def main():
+    argument_spec = dict(
+        client=dict(required=True, type='str'),
+        waiter_name=dict(required=True, type='str'),
+        with_decorator=dict(required=False, type='bool', default=False),
+    )
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    decorator = None
+    if module.params.get('with_decorator'):
+        decorator = AWSRetry.jittered_backoff()
+
+    client = module.client(module.params.get('client'), retry_decorator=decorator)
+    waiter = get_waiter(client, module.params.get('waiter_name'))
+
+    module.exit_json(changed=False, waiter_attributes=dir(waiter))
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/module_utils_waiter/roles/get_waiter/meta/main.yml
+++ b/tests/integration/targets/module_utils_waiter/roles/get_waiter/meta/main.yml
@@ -1,0 +1,5 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2
+collections:
+  - amazon.aws

--- a/tests/integration/targets/module_utils_waiter/roles/get_waiter/tasks/main.yml
+++ b/tests/integration/targets/module_utils_waiter/roles/get_waiter/tasks/main.yml
@@ -1,0 +1,36 @@
+---
+- module_defaults:
+    example_module:
+      region: '{{ aws_region }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      security_token: '{{ security_token | default(omit) }}'
+  block:
+  - name: 'Attempt to get a waiter (no retry decorator)'
+    example_module:
+      client: 'ec2'
+      waiter_name: 'internet_gateway_exists'
+    register: test_no_decorator
+
+  - assert:
+      that:
+      - test_no_decorator is succeeded
+      # Standard methods on a boto3 wrapper
+      - '"wait" in test_no_decorator.waiter_attributes'
+      - '"name" in test_no_decorator.waiter_attributes'
+      - '"config" in test_no_decorator.waiter_attributes'
+
+  - name: 'Attempt to get a waiter (with decorator)'
+    example_module:
+      client: 'ec2'
+      waiter_name: 'internet_gateway_exists'
+      with_decorator: True
+    register: test_with_decorator
+
+  - assert:
+      that:
+      - test_with_decorator is succeeded
+      # Standard methods on a boto3 wrapper
+      - '"wait" in test_with_decorator.waiter_attributes'
+      - '"name" in test_with_decorator.waiter_attributes'
+      - '"config" in test_with_decorator.waiter_attributes'

--- a/tests/integration/targets/module_utils_waiter/runme.sh
+++ b/tests/integration/targets/module_utils_waiter/runme.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+
+set -eux
+
+ANSIBLE_ROLES_PATH="../"
+export ANSIBLE_ROLES_PATH
+
+ansible-playbook main.yml -i inventory "$@"


### PR DESCRIPTION
##### SUMMARY

`module_utils.waiters.get_waiter` can't determine the endpoint type if you use retry_decorator when creating a boto3 client:

```
client = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff(retries=10))
waiter = get_waiter(connection, 'network_interface_attached')
```

```
Traceback (most recent call last):
  File "/root/.ansible/tmp/ansible-tmp-1597767032.9567437-717-98528024196376/AnsiballZ_ec2_eni.py", line 128, in <module>
    _ansiballz_main()
  File "/root/.ansible/tmp/ansible-tmp-1597767032.9567437-717-98528024196376/AnsiballZ_ec2_eni.py", line 120, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/root/.ansible/tmp/ansible-tmp-1597767032.9567437-717-98528024196376/AnsiballZ_ec2_eni.py", line 66, in invoke_module
    runpy.run_module(mod_name='ansible_collections.amazon.aws.plugins.modules.ec2_eni', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib/python3.7/runpy.py", line 205, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.7/runpy.py", line 96, in _run_module_code
    mod_name, mod_spec, pkg_name, script_name)
  File "/usr/lib/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_ec2_eni_payload_jygm6ixp/ansible_ec2_eni_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_eni.py", line 837, in <module>
  File "/tmp/ansible_ec2_eni_payload_jygm6ixp/ansible_ec2_eni_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_eni.py", line 830, in main
  File "/tmp/ansible_ec2_eni_payload_jygm6ixp/ansible_ec2_eni_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_eni.py", line 601, in modify_eni
  File "/tmp/ansible_ec2_eni_payload_jygm6ixp/ansible_ec2_eni_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/waiters.py", line 429, in get_waiter
NotImplementedError: Waiter network_interface_attached could not be found for client <class 'ansible_collections.amazon.aws.plugins.module_utils.core._RetryingBotoClientWrapper'>. Available waiters: ...
```
##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/module_utils/waiters.py

##### ADDITIONAL INFORMATION

fixes: #143 