### PR TITLE
Ensure boto3 verify parameter isn't overridden by setting a profile

### DIFF
--- a/changelogs/fragments/129-verify_overridden.yml
+++ b/changelogs/fragments/129-verify_overridden.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2 module_utils - Ensure boto3 verify parameter isn't overridden by setting a profile (https://github.com/ansible-collections/amazon.aws/issues/129)

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -323,14 +323,15 @@ def get_aws_connection_info(module, boto3=False):
         boto_params = dict(aws_access_key_id=access_key,
                            aws_secret_access_key=secret_key,
                            aws_session_token=security_token)
-        if validate_certs and ca_bundle:
-            boto_params['verify'] = ca_bundle
-        else:
-            boto_params['verify'] = validate_certs
 
         if profile_name:
             boto_params = dict(aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None)
             boto_params['profile_name'] = profile_name
+
+        if validate_certs and ca_bundle:
+            boto_params['verify'] = ca_bundle
+        else:
+            boto_params['verify'] = validate_certs
 
     else:
         boto_params = dict(aws_access_key_id=access_key,

--- a/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/ca_bundle.yml
+++ b/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/ca_bundle.yml
@@ -9,11 +9,13 @@
   copy:
     src: 'amazonroot.pem'
     dest: '{{ ca_tmp.path }}/amazonroot.pem'
+    mode: 0644
 
 - name: 'Ensure we have a another CA (ISRG-X1) bundle available to us'
   copy:
     src: 'isrg-x1.pem'
     dest: '{{ ca_tmp.path }}/isrg-x1.pem'
+    mode: 0644
 
 ##################################################################################
 # Test disabling cert validation (make sure we don't error)

--- a/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/ca_bundle.yml
+++ b/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/ca_bundle.yml
@@ -156,3 +156,45 @@
 - assert:
     that:
     - isrg_ca_result is successful
+
+##################################################################################
+# https://github.com/ansible-collections/amazon.aws/issues/129
+- name: 'Test CA bundle is used when authenticating with a profile - implied validation'
+  example_module:
+    profile: 'test_profile'
+    aws_ca_bundle: '{{ ca_tmp.path }}/isrg-x1.pem'
+  register: isrg_ca_result
+  ignore_errors: yes
+
+- assert:
+    that:
+    - isrg_ca_result is failed
+    # Caught when we try to do something, and passed to fail_json_aws
+    - '"CERTIFICATE_VERIFY_FAILED" in isrg_ca_result.msg'
+    - '"Fail JSON AWS" in isrg_ca_result.msg'
+
+- name: 'Test CA bundle is used when authenticating with a profile - explicit validation'
+  example_module:
+    profile: 'test_profile'
+    aws_ca_bundle: '{{ ca_tmp.path }}/isrg-x1.pem'
+    validate_certs: True
+  register: isrg_ca_result
+  ignore_errors: yes
+
+- assert:
+    that:
+    - isrg_ca_result is failed
+    # Caught when we try to do something, and passed to fail_json_aws
+    - '"CERTIFICATE_VERIFY_FAILED" in isrg_ca_result.msg'
+    - '"Fail JSON AWS" in isrg_ca_result.msg'
+
+- name: 'Test CA bundle is used when authenticating with a profile - explicitly disable validation'
+  example_module:
+    profile: 'test_profile'
+    aws_ca_bundle: '{{ ca_tmp.path }}/isrg-x1.pem'
+    validate_certs: False
+  register: isrg_ca_result
+
+- assert:
+    that:
+    - isrg_ca_result is success


### PR DESCRIPTION
fixes: https://github.com/ansible-collections/amazon.aws/issues/129

##### SUMMARY

If, in your playbook, you set

```
validate_certs: False
profile: profile_name_here
```

the code would set `boto_params['verify'] = validate_certs`  but then immediately afterwards, overwrite that with `boto_params = dict(aws_access_key_id=None, aws_secret_access_key=None, aws_session_token=None)` That would mean the default boto3 value of verify is used instead of the value set in the playbook.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/module_utils/ec2.py

##### ADDITIONAL INFORMATION