### PR TITLE
s3_bucket module: fix failed to get bucket tags (NoSuchTagSetError)

### DIFF
--- a/changelogs/fragments/71484-ceph-tag-set-compat.yaml
+++ b/changelogs/fragments/71484-ceph-tag-set-compat.yaml
@@ -1,2 +1,2 @@
 bugfixes:
-  - s3_bucket - Ceph compatibility: treat error code NoSuchTagSetError used by Ceph synonymously to NoSuchTagSet used by AWS
+  - 's3_bucket - Ceph compatibility: treat error code NoSuchTagSetError used by Ceph synonymously to NoSuchTagSet used by AWS'

--- a/changelogs/fragments/71484-ceph-tag-set-compat.yaml
+++ b/changelogs/fragments/71484-ceph-tag-set-compat.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - s3_bucket - Ceph compatibility: treat error code NoSuchTagSetError used by Ceph synonymously to NoSuchTagSet used by AWS

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -585,7 +585,7 @@ def get_current_bucket_tags_dict(s3_client, bucket_name):
     try:
         current_tags = s3_client.get_bucket_tagging(Bucket=bucket_name).get('TagSet')
     except ClientError as e:
-        if e.response['Error']['Code'] == 'NoSuchTagSet':
+        if e.response['Error']['Code'] == 'NoSuchTagSetError':
             return {}
         raise e
 

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -584,10 +584,11 @@ def wait_tags_are_applied(module, s3_client, bucket_name, expected_tags_dict):
 def get_current_bucket_tags_dict(s3_client, bucket_name):
     try:
         current_tags = s3_client.get_bucket_tagging(Bucket=bucket_name).get('TagSet')
-    except ClientError as e:
-        if e.response['Error']['Code'] == 'NoSuchTagSetError':
-            return {}
-        raise e
+    except is_boto3_error_code('NoSuchTagSet'):
+        return {}
+    # The Ceph S3 API returns a different error code to AWS
+    except is_boto3_error_code('NoSuchTagSetError'):  # pylint: disable=duplicate-except
+        return {}
 
     return boto3_tag_list_to_ansible_dict(current_tags)
 


### PR DESCRIPTION
##### SUMMARY
Correctly handle the absence of tag sets.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
s3_bucket module

##### ADDITIONAL INFORMATION

According to Amazon's documentation [1] the error code returned
when no tag set can be found is `NoSuchTagSetError` rather than
`NoSuchTagSet`.

Associated error:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: botocore.exceptions.ClientError: An error occurred (NoSuchTagSetError) when calling the GetBucketTagging operation: Unknown
fatal: [abc]: FAILED! => changed=false
  boto3_version: 1.14.49
  botocore_version: 1.17.49
  error:
    bucket_name: abc
    code: NoSuchTagSetError
  msg: 'Failed to get bucket tags: An error occurred (NoSuchTagSetError) when calling the GetBucketTagging operation: Unknown'
  response_metadata:
    host_id: ''
    http_headers:
      accept-ranges: bytes
      content-length: '229'
      content-type: application/xml
      date: Thu, 27 Aug 2020 07:11:11 GMT
      strict-transport-security: max-age=31536000; includeSubDomains
      x-amz-request-id: tx0000000000000003aaad6-005f475c8f-36fd35b6f-rma1
    http_status_code: 404
    request_id: tx0000000000000003aaad6-005f475c8f-36fd35b6f-rma1
    retry_attempts: 0
```

[1]: https://docs.aws.amazon.com/AmazonS3/latest/API/API_GetBucketTagging.html
