### PR TITLE
Only use the AWS profile environment variables if we've not been passed a credential as a parameter

### DIFF
--- a/changelogs/fragments/151-deprecate-profile-credential-combination.yml
+++ b/changelogs/fragments/151-deprecate-profile-credential-combination.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- All AWS Modules - `aws_access_key`, `aws_secret_key` and `security_token` will be made mutually exclusive with `profile` after 2022-06-01.

--- a/changelogs/fragments/151-deprecate-profile-credential-combination.yml
+++ b/changelogs/fragments/151-deprecate-profile-credential-combination.yml
@@ -1,2 +1,2 @@
 deprecated_features:
-- All AWS Modules - `aws_access_key`, `aws_secret_key` and `security_token` will be made mutually exclusive with `profile` after 2022-06-01.
+- All AWS Modules - ``aws_access_key``, ``aws_secret_key`` and ``security_token`` will be made mutually exclusive with ``profile`` after 2022-06-01.

--- a/plugins/doc_fragments/aws.py
+++ b/plugins/doc_fragments/aws.py
@@ -29,16 +29,22 @@ options:
   aws_secret_key:
     description:
       - AWS secret key. If not set then the value of the AWS_SECRET_ACCESS_KEY, AWS_SECRET_KEY, or EC2_SECRET_KEY environment variable is used.
+      - If I(profile) is set this parameter is ignored.
+      - Passing the I(aws_secret_key) and I(profile) options at the same time has been deprecated and the options will be made mutually exclusive after 2022-06-01.
     type: str
     aliases: [ ec2_secret_key, secret_key ]
   aws_access_key:
     description:
       - AWS access key. If not set then the value of the AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY or EC2_ACCESS_KEY environment variable is used.
+      - If I(profile) is set this parameter is ignored.
+      - Passing the I(aws_access_key) and I(profile) options at the same time has been deprecated and the options will be made mutually exclusive after 2022-06-01.
     type: str
     aliases: [ ec2_access_key, access_key ]
   security_token:
     description:
       - AWS STS security token. If not set then the value of the AWS_SECURITY_TOKEN or EC2_SECURITY_TOKEN environment variable is used.
+      - If I(profile) is set this parameter is ignored.
+      - Passing the I(security_token) and I(profile) options at the same time has been deprecated and the options will be made mutually exclusive after 2022-06-01.
     type: str
     aliases: [ aws_security_token, access_token ]
   aws_ca_bundle:
@@ -55,6 +61,8 @@ options:
   profile:
     description:
       - Uses a boto profile. Only works with boto >= 2.24.0.
+      - Using I(profile) will override I(aws_access_key), I(aws_secret_key) and I(security_token) and support for passing them at the same time as I(profile) has been deprecated.
+      - I(aws_access_key), I(aws_secret_key) and I(security_token) will be made mutually exclusive with I(profile) after 2022-06-01.
     type: str
     aliases: [ aws_profile ]
   aws_config:

--- a/plugins/doc_fragments/aws.py
+++ b/plugins/doc_fragments/aws.py
@@ -30,21 +30,24 @@ options:
     description:
       - AWS secret key. If not set then the value of the AWS_SECRET_ACCESS_KEY, AWS_SECRET_KEY, or EC2_SECRET_KEY environment variable is used.
       - If I(profile) is set this parameter is ignored.
-      - Passing the I(aws_secret_key) and I(profile) options at the same time has been deprecated and the options will be made mutually exclusive after 2022-06-01.
+      - Passing the I(aws_secret_key) and I(profile) options at the same time has been deprecated
+        and the options will be made mutually exclusive after 2022-06-01.
     type: str
     aliases: [ ec2_secret_key, secret_key ]
   aws_access_key:
     description:
       - AWS access key. If not set then the value of the AWS_ACCESS_KEY_ID, AWS_ACCESS_KEY or EC2_ACCESS_KEY environment variable is used.
       - If I(profile) is set this parameter is ignored.
-      - Passing the I(aws_access_key) and I(profile) options at the same time has been deprecated and the options will be made mutually exclusive after 2022-06-01.
+      - Passing the I(aws_access_key) and I(profile) options at the same time has been deprecated
+        and the options will be made mutually exclusive after 2022-06-01.
     type: str
     aliases: [ ec2_access_key, access_key ]
   security_token:
     description:
       - AWS STS security token. If not set then the value of the AWS_SECURITY_TOKEN or EC2_SECURITY_TOKEN environment variable is used.
       - If I(profile) is set this parameter is ignored.
-      - Passing the I(security_token) and I(profile) options at the same time has been deprecated and the options will be made mutually exclusive after 2022-06-01.
+      - Passing the I(security_token) and I(profile) options at the same time has been deprecated
+        and the options will be made mutually exclusive after 2022-06-01.
     type: str
     aliases: [ aws_security_token, access_token ]
   aws_ca_bundle:
@@ -61,7 +64,8 @@ options:
   profile:
     description:
       - Uses a boto profile. Only works with boto >= 2.24.0.
-      - Using I(profile) will override I(aws_access_key), I(aws_secret_key) and I(security_token) and support for passing them at the same time as I(profile) has been deprecated.
+      - Using I(profile) will override I(aws_access_key), I(aws_secret_key) and I(security_token)
+        and support for passing them at the same time as I(profile) has been deprecated.
       - I(aws_access_key), I(aws_secret_key) and I(security_token) will be made mutually exclusive with I(profile) after 2022-06-01.
     type: str
     aliases: [ aws_profile ]

--- a/plugins/doc_fragments/aws.py
+++ b/plugins/doc_fragments/aws.py
@@ -82,11 +82,11 @@ notes:
   - If parameters are not set within the module, the following
     environment variables can be used in decreasing order of precedence
     C(AWS_URL) or C(EC2_URL),
+    C(AWS_PROFILE) or C(AWS_DEFAULT_PROFILE),
     C(AWS_ACCESS_KEY_ID) or C(AWS_ACCESS_KEY) or C(EC2_ACCESS_KEY),
     C(AWS_SECRET_ACCESS_KEY) or C(AWS_SECRET_KEY) or C(EC2_SECRET_KEY),
     C(AWS_SECURITY_TOKEN) or C(EC2_SECURITY_TOKEN),
     C(AWS_REGION) or C(EC2_REGION),
-    C(AWS_PROFILE) or C(AWS_DEFAULT_PROFILE),
     C(AWS_CA_BUNDLE)
   - Ansible uses the boto configuration file (typically ~/.boto) if no
     credentials are provided. See https://boto.readthedocs.io/en/latest/boto_config_tut.html

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -272,7 +272,6 @@ def get_aws_connection_info(module, boto3=False):
                          "  In later versions of Ansible the options will be mutually exclusive",
                          date='2022-06-01', collection_name='amazon.aws')
 
-
     if not ec2_url:
         if 'AWS_URL' in os.environ:
             ec2_url = os.environ['AWS_URL']

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -266,6 +266,13 @@ def get_aws_connection_info(module, boto3=False):
         if os.environ.get('AWS_DEFAULT_PROFILE'):
             profile_name = os.environ.get('AWS_DEFAULT_PROFILE')
 
+    if profile_name and (access_key or secret_key or security_token):
+        module.deprecate("Passing both a profile and access tokens has been deprecated."
+                         "  Only the profile will be used."
+                         "  In later versions of Ansible the options will be mutually exclusive",
+                         date='2022-06-01', collection_name='amazon.aws')
+
+
     if not ec2_url:
         if 'AWS_URL' in os.environ:
             ec2_url = os.environ['AWS_URL']

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -258,6 +258,14 @@ def get_aws_connection_info(module, boto3=False):
     ca_bundle = module.params.get('aws_ca_bundle')
     config = module.params.get('aws_config')
 
+    # Only read the profile environment variables if we've *not* been passed
+    # any credentials as parameters.
+    if not profile_name and not access_key and not secret_key:
+        if os.environ.get('AWS_PROFILE'):
+            profile_name = os.environ.get('AWS_PROFILE')
+        if os.environ.get('AWS_DEFAULT_PROFILE'):
+            profile_name = os.environ.get('AWS_DEFAULT_PROFILE')
+
     if not ec2_url:
         if 'AWS_URL' in os.environ:
             ec2_url = os.environ['AWS_URL']
@@ -312,12 +320,6 @@ def get_aws_connection_info(module, boto3=False):
     if not ca_bundle:
         if os.environ.get('AWS_CA_BUNDLE'):
             ca_bundle = os.environ.get('AWS_CA_BUNDLE')
-
-    if not profile_name:
-        if os.environ.get('AWS_PROFILE'):
-            profile_name = os.environ.get('AWS_PROFILE')
-        if os.environ.get('AWS_DEFAULT_PROFILE'):
-            profile_name = os.environ.get('AWS_DEFAULT_PROFILE')
 
     if HAS_BOTO3 and boto3:
         boto_params = dict(aws_access_key_id=access_key,

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -12,5 +12,6 @@ plugins/modules/ec2_vol_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_vpc_dhcp_option_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_vpc_net_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_vpc_subnet_info.py pylint:ansible-deprecated-no-version
+plugins/module_utils/ec2.py pylint:ansible-deprecated-no-version
 tests/utils/shippable/check_matrix.py replace-urlopen
 tests/utils/shippable/timing.py shebang


### PR DESCRIPTION
##### SUMMARY

fixes: #130 

- Deprecate support for profile *and* AWS credentials being passed at the same time.
- Only read the profile from environment variables if we're not passed credentials as a parameter

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/module_utils/ec2.py

##### ADDITIONAL INFORMATION
