### PR TITLE
is_boto3_error_code() - support list of codes and make heavier use of it

### DIFF
--- a/plugins/module_utils/core.py
+++ b/plugins/module_utils/core.py
@@ -318,7 +318,9 @@ def is_boto3_error_code(code, e=None):
     if e is None:
         import sys
         dummy, e, dummy = sys.exc_info()
-    if isinstance(e, ClientError) and e.response['Error']['Code'] == code:
+    if not isinstance(code, list):
+        code = [code]
+    if isinstance(e, ClientError) and e.response['Error']['Code'] in code:
         return ClientError
     return type('NeverEverRaisedException', (Exception,), {})
 

--- a/plugins/module_utils/elb_utils.py
+++ b/plugins/module_utils/elb_utils.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     pass
 
+from .core import is_boto3_error_code
 from .ec2 import AWSRetry
 
 
@@ -41,11 +42,8 @@ def _get_elb(connection, module, elb_name):
     try:
         load_balancer_paginator = connection.get_paginator('describe_load_balancers')
         return (load_balancer_paginator.paginate(Names=[elb_name]).build_full_result())['LoadBalancers'][0]
-    except (BotoCoreError, ClientError) as e:
-        if e.response['Error']['Code'] == 'LoadBalancerNotFound':
-            return None
-        else:
-            raise e
+    except is_boto3_error_code('LoadBalancerNotFound'):
+        return None
 
 
 def get_elb_listener(connection, module, elb_arn, listener_port):

--- a/plugins/module_utils/iam.py
+++ b/plugins/module_utils/iam.py
@@ -7,11 +7,12 @@ __metaclass__ = type
 import traceback
 
 try:
-    from botocore.exceptions import ClientError, NoCredentialsError
+    import botocore
 except ImportError:
     pass
 
 from ansible.module_utils._text import to_native
+from .core import is_boto3_error_code
 
 
 def get_aws_account_id(module):
@@ -28,22 +29,17 @@ def get_aws_account_id(module):
         account_id = sts_client.get_caller_identity().get('Account')
     # non-STS sessions may also get NoCredentialsError from this STS call, so
     # we must catch that too and try the IAM version
-    except (ClientError, NoCredentialsError):
+    except (botocore.exceptions.ClientError, botocore.exceptions.NoCredentialsError):
         try:
             iam_client = module.client('iam')
             account_id = iam_client.get_user()['User']['Arn'].split(':')[4]
-        except ClientError as e:
-            if (e.response['Error']['Code'] == 'AccessDenied'):
-                except_msg = to_native(e)
-                # don't match on `arn:aws` because of China region `arn:aws-cn` and similar
-                account_id = except_msg.search(r"arn:\w+:iam::([0-9]{12,32}):\w+/").group(1)
-            if account_id is None:
-                module.fail_json_aws(e, msg="Could not get AWS account information")
-        except Exception as e:
-            module.fail_json(
-                msg="Failed to get AWS account information, Try allowing sts:GetCallerIdentity or iam:GetUser permissions.",
-                exception=traceback.format_exc()
-            )
+        except is_boto3_error_code('AccessDenied') as e:
+            except_msg = to_native(e)
+            # don't match on `arn:aws:` because of China region `arn:aws-cn` and similar
+            account_id = except_msg.search(r"arn:\w+:iam::([0-9]{12,32}):\w+/").group(1)
+        except (LookupError, botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+            account_id = None
+
     if not account_id:
         module.fail_json(msg="Failed while determining AWS account ID. Try allowing sts:GetCallerIdentity or iam:GetUser permissions.")
     return to_native(account_id)

--- a/plugins/module_utils/iam.py
+++ b/plugins/module_utils/iam.py
@@ -37,7 +37,7 @@ def get_aws_account_id(module):
             except_msg = to_native(e)
             # don't match on `arn:aws:` because of China region `arn:aws-cn` and similar
             account_id = except_msg.search(r"arn:\w+:iam::([0-9]{12,32}):\w+/").group(1)
-        except (LookupError, botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+        except (LookupError, botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
             account_id = None
 
     if not account_id:

--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -302,25 +302,20 @@ class Sigv4Required(Exception):
 
 
 def key_check(module, s3, bucket, obj, version=None, validate=True):
-    exists = True
     try:
         if version:
             s3.head_object(Bucket=bucket, Key=obj, VersionId=version)
         else:
             s3.head_object(Bucket=bucket, Key=obj)
-    except botocore.exceptions.ClientError as e:
-        # if a client error is thrown, check if it's a 404 error
-        # if it's a 404 error, then the object does not exist
-        error_code = int(e.response['Error']['Code'])
-        if error_code == 404:
-            exists = False
-        elif error_code == 403 and validate is False:
-            pass
-        else:
+    except is_boto3_error_code('404'):
+        return False
+    except is_boto3_error_code('403') as e:
+        if validate is True:
             module.fail_json_aws(e, msg="Failed while looking up object (during key check) %s." % obj)
-    except botocore.exceptions.BotoCoreError as e:
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed while looking up object (during key check) %s." % obj)
-    return exists
+
+    return True
 
 
 def etag_compare(module, local_file, s3, bucket, obj, version=None):
@@ -344,19 +339,14 @@ def bucket_check(module, s3, bucket, validate=True):
     exists = True
     try:
         s3.head_bucket(Bucket=bucket)
-    except botocore.exceptions.ClientError as e:
-        # If a client error is thrown, then check that it was a 404 error.
-        # If it was a 404 error, then the bucket does not exist.
-        error_code = int(e.response['Error']['Code'])
-        if error_code == 404:
-            exists = False
-        elif error_code == 403 and validate is False:
-            pass
-        else:
+    except is_boto3_error_code('404'):
+        return False
+    except is_boto3_error_code('403') as e:
+        if validate is True:
             module.fail_json_aws(e, msg="Failed while looking up bucket (during bucket_check) %s." % bucket)
     except botocore.exceptions.EndpointConnectionError as e:
         module.fail_json_aws(e, msg="Invalid endpoint provided")
-    except botocore.exceptions.BotoCoreError as e:
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Failed while looking up bucket (during bucket_check) %s." % bucket)
     return exists
 
@@ -379,12 +369,9 @@ def create_bucket(module, s3, bucket, location=None):
             AWSRetry.jittered_backoff(
                 max_delay=120, catch_extra_error_codes=['NoSuchBucket']
             )(s3.put_bucket_acl)(ACL=acl, Bucket=bucket)
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] in IGNORE_S3_DROP_IN_EXCEPTIONS:
-            module.warn("PutBucketAcl is not implemented by your storage provider. Set the permission parameters to the empty list to avoid this warning")
-        else:
-            module.fail_json_aws(e, msg="Failed while creating bucket or setting acl (check that you have CreateBucket and PutBucketAcl permission).")
-    except botocore.exceptions.BotoCoreError as e:
+    except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
+        module.warn("PutBucketAcl is not implemented by your storage provider. Set the permission parameters to the empty list to avoid this warning")
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Failed while creating bucket or setting acl (check that you have CreateBucket and PutBucketAcl permission).")
 
     if bucket:
@@ -404,10 +391,9 @@ def paginated_versioned_list_with_fallback(s3, **pagination_params):
             delete_markers = [{'Key': data['Key'], 'VersionId': data['VersionId']} for data in page.get('DeleteMarkers', [])]
             current_objects = [{'Key': data['Key'], 'VersionId': data['VersionId']} for data in page.get('Versions', [])]
             yield delete_markers + current_objects
-    except botocore.exceptions.ClientError as e:
-        if to_text(e.response['Error']['Code']) in IGNORE_S3_DROP_IN_EXCEPTIONS + ['AccessDenied']:
-            for page in paginated_list(s3, **pagination_params):
-                yield [{'Key': data['Key']} for data in page]
+    except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS + ['AccessDenied']):
+        for page in paginated_list(s3, **pagination_params):
+            yield [{'Key': data['Key']} for data in page]
 
 
 def list_keys(module, s3, bucket, prefix, marker, max_keys):
@@ -463,12 +449,9 @@ def create_dirkey(module, s3, bucket, obj, encrypt):
         s3.put_object(**params)
         for acl in module.params.get('permission'):
             s3.put_object_acl(ACL=acl, Bucket=bucket, Key=obj)
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] in IGNORE_S3_DROP_IN_EXCEPTIONS:
-            module.warn("PutObjectAcl is not implemented by your storage provider. Set the permissions parameters to the empty list to avoid this warning")
-        else:
-            module.fail_json_aws(e, msg="Failed while creating object %s." % obj)
-    except botocore.exceptions.BotoCoreError as e:
+    except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
+        module.warn("PutObjectAcl is not implemented by your storage provider. Set the permissions parameters to the empty list to avoid this warning")
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Failed while creating object %s." % obj)
     module.exit_json(msg="Virtual directory %s created in bucket %s" % (obj, bucket), changed=True)
 
@@ -528,12 +511,9 @@ def upload_s3file(module, s3, bucket, obj, src, expiry, metadata, encrypt, heade
     try:
         for acl in module.params.get('permission'):
             s3.put_object_acl(ACL=acl, Bucket=bucket, Key=obj)
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] in IGNORE_S3_DROP_IN_EXCEPTIONS:
-            module.warn("PutObjectAcl is not implemented by your storage provider. Set the permission parameters to the empty list to avoid this warning")
-        else:
-            module.fail_json_aws(e, msg="Unable to set object ACL")
-    except botocore.exceptions.BotoCoreError as e:
+    except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
+        module.warn("PutObjectAcl is not implemented by your storage provider. Set the permission parameters to the empty list to avoid this warning")
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Unable to set object ACL")
     try:
         url = s3.generate_presigned_url(ClientMethod='put_object',
@@ -554,14 +534,15 @@ def download_s3file(module, s3, bucket, obj, dest, retries, version=None):
             key = s3.get_object(Bucket=bucket, Key=obj, VersionId=version)
         else:
             key = s3.get_object(Bucket=bucket, Key=obj)
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == 'InvalidArgument' and 'require AWS Signature Version 4' in to_text(e):
+    except is_boto3_error_code(['404', '403']) as e:
+        # AccessDenied errors may be triggered if 1) file does not exist or 2) file exists but
+        # user does not have the s3:GetObject permission. 404 errors are handled by download_file().
+        module.fail_json_aws(e, msg="Could not find the key %s." % obj)
+    except is_boto3_error_code('InvalidArgument') as e:
+        if 'require AWS Signature Version 4' in to_text(e):
             raise Sigv4Required()
-        elif e.response['Error']['Code'] not in ("403", "404"):
-            # AccessDenied errors may be triggered if 1) file does not exist or 2) file exists but
-            # user does not have the s3:GetObject permission. 404 errors are handled by download_file().
-            module.fail_json_aws(e, msg="Could not find the key %s." % obj)
-    except botocore.exceptions.BotoCoreError as e:
+        module.fail_json_aws(e, msg="Could not find the key %s." % obj)
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Could not find the key %s." % obj)
 
     optional_kwargs = {'ExtraArgs': {'VersionId': version}} if version else {}
@@ -590,12 +571,11 @@ def download_s3str(module, s3, bucket, obj, version=None, validate=True):
         else:
             contents = to_native(s3.get_object(Bucket=bucket, Key=obj)["Body"].read())
         module.exit_json(msg="GET operation complete", contents=contents, changed=True)
-    except botocore.exceptions.ClientError as e:
-        if e.response['Error']['Code'] == 'InvalidArgument' and 'require AWS Signature Version 4' in to_text(e):
+    except is_boto3_error_code('InvalidArgument') as e:
+        if 'require AWS Signature Version 4' in to_text(e):
             raise Sigv4Required()
-        else:
-            module.fail_json_aws(e, msg="Failed while getting contents of object %s as a string." % obj)
-    except botocore.exceptions.BotoCoreError as e:
+        module.fail_json_aws(e, msg="Failed while getting contents of object %s as a string." % obj)
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Failed while getting contents of object %s as a string." % obj)
 
 

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -127,13 +127,14 @@ key:
 import uuid
 
 try:
-    from botocore.exceptions import ClientError
+    import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
 from ansible.module_utils._text import to_bytes
 
 from ..module_utils.core import AnsibleAWSModule
+from ..module_utils.core import is_boto3_error_code
 
 
 def extract_key_data(key):
@@ -170,9 +171,9 @@ def find_key_pair(module, ec2_client, name):
 
     try:
         key = ec2_client.describe_key_pairs(KeyNames=[name])['KeyPairs'][0]
-    except ClientError as err:
-        if err.response['Error']['Code'] == "InvalidKeyPair.NotFound":
-            return None
+    except is_boto3_error_code('InvalidKeyPair.NotFound'):
+        return None
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as err:
         module.fail_json_aws(err, msg="error finding keypair")
     except IndexError:
         key = None
@@ -205,7 +206,7 @@ def create_key_pair(module, ec2_client, name, key_material, force):
             else:
                 try:
                     key = ec2_client.create_key_pair(KeyName=name)
-                except ClientError as err:
+                except botocore.exceptions.ClientError as err:
                     module.fail_json_aws(err, msg="error creating key")
             key_data = extract_key_data(key)
         module.exit_json(changed=True, key=key_data, msg="key pair created")
@@ -215,7 +216,7 @@ def import_key_pair(module, ec2_client, name, key_material):
 
     try:
         key = ec2_client.import_key_pair(KeyName=name, PublicKeyMaterial=to_bytes(key_material))
-    except ClientError as err:
+    except botocore.exceptions.ClientError as err:
         module.fail_json_aws(err, msg="error importing key")
     return key
 
@@ -227,7 +228,7 @@ def delete_key_pair(module, ec2_client, name, finish_task=True):
         if not module.check_mode:
             try:
                 ec2_client.delete_key_pair(KeyName=name)
-            except ClientError as err:
+            except botocore.exceptions.ClientError as err:
                 module.fail_json_aws(err, msg="error deleting key")
         if not finish_task:
             return

--- a/tests/unit/module_utils/core/test_is_boto3_error_code.py
+++ b/tests/unit/module_utils/core/test_is_boto3_error_code.py
@@ -1,0 +1,149 @@
+# -*- coding: utf-8 -*-
+# (c) 2020 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import boto3
+import botocore
+
+from ansible_collections.amazon.aws.tests.unit.compat import unittest
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+
+
+class Boto3ErrorTestCase(unittest.TestCase):
+
+    def setUp(self):
+        # Basic information that ClientError needs to spawn off an error
+        self.EXAMPLE_EXCEPTION_DATA = {
+            "Error": {
+                "Code": "InvalidParameterValue",
+                "Message": "The filter 'exampleFilter' is invalid"
+            },
+            "ResponseMetadata": {
+                "RequestId": "01234567-89ab-cdef-0123-456789abcdef",
+                "HTTPStatusCode": 400,
+                "HTTPHeaders": {
+                    "transfer-encoding": "chunked",
+                    "date": "Fri, 13 Nov 2020 00:00:00 GMT",
+                    "connection": "close",
+                    "server": "AmazonEC2"
+                },
+                "RetryAttempts": 0
+            }
+        }
+
+    def test_client_error_match_single(self):
+        error_caught = 0
+        try:
+            raise botocore.exceptions.ClientError(self.EXAMPLE_EXCEPTION_DATA, "testCall")
+        except is_boto3_error_code('InvalidParameterValue'):
+            error_caught = 1
+        except botocore.exceptions.ClientError:
+            error_caught = 2
+        except Exception:
+            error_caught = 3
+        assert error_caught == 1
+
+        try:
+            raise botocore.exceptions.ClientError(self.EXAMPLE_EXCEPTION_DATA, "testCall")
+        except is_boto3_error_code('SomeError'):
+            error_caught = 4
+        except botocore.exceptions.ClientError:
+            error_caught = 5
+        except Exception:
+            error_caught = 6
+        assert error_caught == 5
+
+    def test_client_error_match_list(self):
+        error_caught = 0
+        try:
+            raise botocore.exceptions.ClientError(self.EXAMPLE_EXCEPTION_DATA, "testCall")
+        except is_boto3_error_code(['SomeError', 'InvalidParameterValue']):
+            error_caught = 1
+        except botocore.exceptions.ClientError:
+            error_caught = 2
+        except Exception:
+            error_caught = 3
+        assert error_caught == 1
+
+        try:
+            raise botocore.exceptions.ClientError(self.EXAMPLE_EXCEPTION_DATA, "testCall")
+        except is_boto3_error_code(['InvalidParameterValue', 'SomeError']):
+            error_caught = 4
+        except botocore.exceptions.ClientError:
+            error_caught = 5
+        except Exception:
+            error_caught = 6
+        assert error_caught == 4
+
+        try:
+            raise botocore.exceptions.ClientError(self.EXAMPLE_EXCEPTION_DATA, "testCall")
+        except is_boto3_error_code(['SomeError', 'AnotherError']):
+            error_caught = 7
+        except botocore.exceptions.ClientError:
+            error_caught = 8
+        except Exception:
+            error_caught = 9
+        assert error_caught == 8
+
+        try:
+            raise botocore.exceptions.ClientError(self.EXAMPLE_EXCEPTION_DATA, "testCall")
+        except is_boto3_error_code(['AnotherError', 'SomeError']):
+            error_caught = 10
+        except botocore.exceptions.ClientError:
+            error_caught = 11
+        except Exception:
+            error_caught = 12
+        assert error_caught == 11
+
+    def test_botocore_error(self):
+        # Tests that we cope with a non-ClientError and don't match
+        error_caught = 0
+        try:
+            raise botocore.exceptions.BotoCoreError()
+        except is_boto3_error_code('InvalidParameterValue'):
+            error_caught = 1
+        except botocore.exceptions.BotoCoreError:
+            error_caught = 2
+        except Exception:
+            error_caught = 3
+        assert error_caught == 2
+
+        try:
+            raise botocore.exceptions.BotoCoreError()
+        # This is the error *Message*, but we shouldn't catch it.
+        except is_boto3_error_code('An unspecified error occurred'):
+            error_caught = 4
+        except botocore.exceptions.BotoCoreError:
+            error_caught = 5
+        except Exception:
+            error_caught = 6
+        assert error_caught == 5
+
+    def test_botocore_error_list(self):
+        error_caught = 0
+
+        try:
+            raise botocore.exceptions.BotoCoreError()
+        except is_boto3_error_code(['An unspecified error occurred', 'InvalidParameterValue']):
+            error_caught = 1
+        except botocore.exceptions.BotoCoreError:
+            error_caught = 2
+        except Exception:
+            error_caught = 3
+        assert error_caught == 2
+
+        try:
+            raise botocore.exceptions.BotoCoreError()
+        # This is the error *Message*, but we shouldn't catch it.
+        except is_boto3_error_code(['InvalidParameterValue', 'An unspecified error occurred']):
+            error_caught = 4
+        except botocore.exceptions.BotoCoreError:
+            error_caught = 5
+        except Exception:
+            error_caught = 6
+        assert error_caught == 5

--- a/tests/unit/module_utils/core/test_is_boto3_error_code.py
+++ b/tests/unit/module_utils/core/test_is_boto3_error_code.py
@@ -42,7 +42,7 @@ class Boto3ErrorTestCase(unittest.TestCase):
             raise botocore.exceptions.ClientError(self.EXAMPLE_EXCEPTION_DATA, "testCall")
         except is_boto3_error_code('InvalidParameterValue'):
             error_caught = 1
-        except botocore.exceptions.ClientError:
+        except botocore.exceptions.ClientError:  # pylint: disable=duplicate-except
             error_caught = 2
         except Exception:
             error_caught = 3
@@ -52,7 +52,7 @@ class Boto3ErrorTestCase(unittest.TestCase):
             raise botocore.exceptions.ClientError(self.EXAMPLE_EXCEPTION_DATA, "testCall")
         except is_boto3_error_code('SomeError'):
             error_caught = 4
-        except botocore.exceptions.ClientError:
+        except botocore.exceptions.ClientError:  # pylint: disable=duplicate-except
             error_caught = 5
         except Exception:
             error_caught = 6
@@ -64,7 +64,7 @@ class Boto3ErrorTestCase(unittest.TestCase):
             raise botocore.exceptions.ClientError(self.EXAMPLE_EXCEPTION_DATA, "testCall")
         except is_boto3_error_code(['SomeError', 'InvalidParameterValue']):
             error_caught = 1
-        except botocore.exceptions.ClientError:
+        except botocore.exceptions.ClientError:  # pylint: disable=duplicate-except
             error_caught = 2
         except Exception:
             error_caught = 3
@@ -74,7 +74,7 @@ class Boto3ErrorTestCase(unittest.TestCase):
             raise botocore.exceptions.ClientError(self.EXAMPLE_EXCEPTION_DATA, "testCall")
         except is_boto3_error_code(['InvalidParameterValue', 'SomeError']):
             error_caught = 4
-        except botocore.exceptions.ClientError:
+        except botocore.exceptions.ClientError:  # pylint: disable=duplicate-except
             error_caught = 5
         except Exception:
             error_caught = 6
@@ -84,7 +84,7 @@ class Boto3ErrorTestCase(unittest.TestCase):
             raise botocore.exceptions.ClientError(self.EXAMPLE_EXCEPTION_DATA, "testCall")
         except is_boto3_error_code(['SomeError', 'AnotherError']):
             error_caught = 7
-        except botocore.exceptions.ClientError:
+        except botocore.exceptions.ClientError:  # pylint: disable=duplicate-except
             error_caught = 8
         except Exception:
             error_caught = 9
@@ -94,7 +94,7 @@ class Boto3ErrorTestCase(unittest.TestCase):
             raise botocore.exceptions.ClientError(self.EXAMPLE_EXCEPTION_DATA, "testCall")
         except is_boto3_error_code(['AnotherError', 'SomeError']):
             error_caught = 10
-        except botocore.exceptions.ClientError:
+        except botocore.exceptions.ClientError:  # pylint: disable=duplicate-except
             error_caught = 11
         except Exception:
             error_caught = 12

--- a/tests/unit/module_utils/core/test_is_boto3_error_code.py
+++ b/tests/unit/module_utils/core/test_is_boto3_error_code.py
@@ -36,7 +36,7 @@ class Boto3ErrorCodeTestSuite(unittest.TestCase):
 
     def _make_unexpected_exception(self):
         return botocore.exceptions.ClientError(
-           {
+            {
                 "Error": {
                     "Code": "SomeThingWentWrong",
                     "Message": "Boom!"
@@ -48,10 +48,19 @@ class Boto3ErrorCodeTestSuite(unittest.TestCase):
 
     def _make_encoded_exception(self):
         return botocore.exceptions.ClientError(
-           {
+            {
                 "Error": {
                     "Code": "PermissionDenied",
-                    "Message": "You are not authorized to perform this operation. Encoded authorization failure message: fEwXX6llx3cClm9J4pURgz1XPnJPrYexEbrJcLhFkwygMdOgx_-aEsj0LqRM6Kxt2HVI6prUhDwbJqBo9U2V7iRKZT6ZdJvHH02cXmD0Jwl5vrTsf0PhBcWYlH5wl2qME7xTfdolEUr4CzumCiti7ETiO-RDdHqWlasBOW5bWsZ4GSpPdU06YAX0TfwVBs48uU5RpCHfz1uhSzez-3elbtp9CmTOHLt5pzJodiovccO55BQKYLPtmJcs6S9YLEEogmpI4Cb1D26fYahDh51jEmaohPnW5pb1nQe2yPEtuIhtRzNjhFCOOMwY5DBzNsymK-Gj6eJLm7FSGHee4AHLU_XmZMe_6bcLAiOx6Zdl65Kdd0hLcpwVxyZMi27HnYjAdqRlV3wuCW2PkhAW14qZQLfiuHZDEwnPe2PBGSlFcCmkQvJvX-YLoA7Uyc2wfNX5RJm38STwfiJSkQaNDhHKTWKiLOsgY4Gze6uZoG7zOcFXFRyaA4cbMmI76uyBO7j-9uQUCtBYqYto8x_9CUJcxIVC5SPG_C1mk-WoDMew01f0qy-bNaCgmJ9TOQGd08FyuT1SaMpCC0gX6mHuOnEgkFw3veBIowMpp9XcM-yc42fmIOpFOdvQO6uE9p55Qc-uXvsDTTvT3A7EeFU8a_YoAIt9UgNYM6VTvoprLz7dBI_P6C-bdPPZCY2amm-dJNVZelT6TbJBH_Vxh0fzeiSUBersy_QzB0moc-vPWgnB-IkgnYLV-4L3K0L2"
+                    "Message": "You are not authorized to perform this operation. Encoded authorization failure message: " +
+                               "fEwXX6llx3cClm9J4pURgz1XPnJPrYexEbrJcLhFkwygMdOgx_-aEsj0LqRM6Kxt2HVI6prUhDwbJqBo9U2V7iRKZ" +
+                               "T6ZdJvHH02cXmD0Jwl5vrTsf0PhBcWYlH5wl2qME7xTfdolEUr4CzumCiti7ETiO-RDdHqWlasBOW5bWsZ4GSpPdU" +
+                               "06YAX0TfwVBs48uU5RpCHfz1uhSzez-3elbtp9CmTOHLt5pzJodiovccO55BQKYLPtmJcs6S9YLEEogmpI4Cb1D26" +
+                               "fYahDh51jEmaohPnW5pb1nQe2yPEtuIhtRzNjhFCOOMwY5DBzNsymK-Gj6eJLm7FSGHee4AHLU_XmZMe_6bcLAiOx" +
+                               "6Zdl65Kdd0hLcpwVxyZMi27HnYjAdqRlV3wuCW2PkhAW14qZQLfiuHZDEwnPe2PBGSlFcCmkQvJvX-YLoA7Uyc2wf" +
+                               "NX5RJm38STwfiJSkQaNDhHKTWKiLOsgY4Gze6uZoG7zOcFXFRyaA4cbMmI76uyBO7j-9uQUCtBYqYto8x_9CUJcxI" +
+                               "VC5SPG_C1mk-WoDMew01f0qy-bNaCgmJ9TOQGd08FyuT1SaMpCC0gX6mHuOnEgkFw3veBIowMpp9XcM-yc42fmIOp" +
+                               "FOdvQO6uE9p55Qc-uXvsDTTvT3A7EeFU8a_YoAIt9UgNYM6VTvoprLz7dBI_P6C-bdPPZCY2amm-dJNVZelT6TbJB" +
+                               "H_Vxh0fzeiSUBersy_QzB0moc-vPWgnB-IkgnYLV-4L3K0L2"
                 },
                 "ResponseMetadata": {
                     "RequestId": "01234567-89ab-cdef-0123-456789abcdef"
@@ -60,7 +69,6 @@ class Boto3ErrorCodeTestSuite(unittest.TestCase):
 
     def _make_botocore_exception(self):
         return botocore.exceptions.EndpointConnectionError(endpoint_url='junk.endpoint')
-
 
     def setUp(self):
         pass
@@ -73,7 +81,7 @@ class Boto3ErrorCodeTestSuite(unittest.TestCase):
         except is_boto3_error_code('AccessDenied') as e:
             caught_exception = e
             caught = 'Code'
-        except botocore.exceptions.ClientError as e:
+        except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
             caught_exception = e
             caught = 'ClientError'
         except botocore.exceptions.BotoCoreError as e:
@@ -93,7 +101,7 @@ class Boto3ErrorCodeTestSuite(unittest.TestCase):
         except is_boto3_error_code('AccessDenied') as e:
             caught_exception = e
             caught = 'Code'
-        except botocore.exceptions.ClientError as e:
+        except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
             caught_exception = e
             caught = 'ClientError'
         except botocore.exceptions.BotoCoreError as e:
@@ -113,7 +121,7 @@ class Boto3ErrorCodeTestSuite(unittest.TestCase):
         except is_boto3_error_code('AccessDenied') as e:
             caught_exception = e
             caught = 'Code'
-        except botocore.exceptions.ClientError as e:
+        except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
             caught_exception = e
             caught = 'ClientError'
         except botocore.exceptions.BotoCoreError as e:
@@ -133,7 +141,7 @@ class Boto3ErrorCodeTestSuite(unittest.TestCase):
         except is_boto3_error_code(['NotAccessDenied', 'AccessDenied']) as e:
             caught_exception = e
             caught = 'Code'
-        except botocore.exceptions.ClientError as e:
+        except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
             caught_exception = e
             caught = 'ClientError'
         except botocore.exceptions.BotoCoreError as e:
@@ -150,7 +158,7 @@ class Boto3ErrorCodeTestSuite(unittest.TestCase):
         except is_boto3_error_code(['AccessDenied', 'NotAccessDenied']) as e:
             caught_exception = e
             caught = 'Code'
-        except botocore.exceptions.ClientError as e:
+        except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
             caught_exception = e
             caught = 'ClientError'
         except botocore.exceptions.BotoCoreError as e:
@@ -170,7 +178,7 @@ class Boto3ErrorCodeTestSuite(unittest.TestCase):
         except is_boto3_error_code(['NotAccessDenied', 'AccessDenied']) as e:
             caught_exception = e
             caught = 'Code'
-        except botocore.exceptions.ClientError as e:
+        except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
             caught_exception = e
             caught = 'ClientError'
         except botocore.exceptions.BotoCoreError as e:
@@ -190,7 +198,7 @@ class Boto3ErrorCodeTestSuite(unittest.TestCase):
         except is_boto3_error_code(['NotAccessDenied', 'AccessDenied']) as e:
             caught_exception = e
             caught = 'Code'
-        except botocore.exceptions.ClientError as e:
+        except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
             caught_exception = e
             caught = 'ClientError'
         except botocore.exceptions.BotoCoreError as e:


### PR DESCRIPTION
##### SUMMARY

Add support for passing multiple error codes to is_boto3_error_code

Also move various modules and utils over to using the simpler is_boto3_error code workflows.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/core.py
plugins/module_utils/elb_utils.py
plugins/module_utils/iam.py
plugins/modules/aws_s3.py
plugins/modules/ec2_ami.py
plugins/modules/ec2_key.py
plugins/modules/s3_bucket.py

##### ADDITIONAL INFORMATION

Includes more unit tests