### PR TITLE
Remove unused imports

### DIFF
--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -325,7 +325,6 @@ import uuid
 from hashlib import sha1
 
 try:
-    import boto3
     import botocore
 except ImportError:
     pass  # Handled by AnsibleAWSModule

--- a/plugins/modules/cloudformation_info.py
+++ b/plugins/modules/cloudformation_info.py
@@ -166,15 +166,12 @@ stack_change_sets:
 '''
 
 import json
-import traceback
-from functools import partial
 
 try:
     import botocore
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ..module_utils.core import AnsibleAWSModule

--- a/plugins/modules/ec2_ami_info.py
+++ b/plugins/modules/ec2_ami_info.py
@@ -208,7 +208,6 @@ from ansible.module_utils.common.dict_transformations import camel_dict_to_snake
 
 from ..module_utils.core import AnsibleAWSModule
 from ..module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ..module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ..module_utils.ec2 import boto3_tag_list_to_ansible_dict
 
 

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -175,7 +175,6 @@ data_encryption_key_id:
 '''
 
 try:
-    import boto3
     from botocore.exceptions import ClientError
 except ImportError:
     pass  # Handled by AnsibleAWSModule

--- a/plugins/modules/ec2_vol_info.py
+++ b/plugins/modules/ec2_vol_info.py
@@ -112,8 +112,6 @@ volumes:
             sample: "us-east-1b"
 '''
 
-import traceback
-
 try:
     from botocore.exceptions import ClientError
 except ImportError:

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -78,8 +78,6 @@ changed:
     returned: always
 '''
 
-import traceback
-
 try:
     import botocore
 except ImportError:

--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -199,7 +199,6 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
-from ansible.module_utils.six import string_types
 from ansible.module_utils.common.network import to_subnet
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -148,8 +148,6 @@ vpcs:
                             type: str
 '''
 
-import traceback
-
 try:
     import botocore
 except ImportError:


### PR DESCRIPTION
##### SUMMARY

A number of our modules have been refactored over the years and we've left various unused imports behind.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/cloudformation.py
plugins/modules/cloudformation_info.py
plugins/modules/ec2_ami_info.py
plugins/modules/ec2_snapshot_info.py
plugins/modules/ec2_vol_info.py
plugins/modules/ec2_vpc_dhcp_option_info.py
plugins/modules/ec2_vpc_net.py
plugins/modules/ec2_vpc_net_info.py

##### ADDITIONAL INFORMATION