### PR TITLE
Remove warning message about AnsibleAWSModule not being ready for use

### DIFF
--- a/plugins/module_utils/core.py
+++ b/plugins/module_utils/core.py
@@ -18,14 +18,6 @@
 
 """This module adds shared support for generic Amazon AWS modules
 
-**This code is not yet ready for use in user modules.  As of 2017**
-**and through to 2018, the interface is likely to change**
-**aggressively as the exact correct interface for ansible AWS modules**
-**is identified.  In particular, until this notice goes away or is**
-**changed, methods may disappear from the interface.  Please don't**
-**publish modules using this except directly to the main Ansible**
-**development repository.**
-
 In order to use this module, include it as part of a custom
 module as shown below.
 


### PR DESCRIPTION
##### SUMMARY

Remove warning from plugins/module_utils/core.py that AnsibleAWSModule "is not yet ready for use in user modules."

We've been heavily using this code for a while now and specifically document that people **should** be using it.  Any breaking changes at this point are going to cause a lot of disruption, it's effectively stable by default at this point.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/module_utils/core.py

##### ADDITIONAL INFORMATION
