### PR TITLE
catch ImportError rather than Exception when testing Boto3 imports

### DIFF
--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -64,7 +64,7 @@ try:
     import boto3
     import botocore
     HAS_BOTO3 = True
-except Exception:
+except ImportError:
     BOTO3_IMP_ERR = traceback.format_exc()
     HAS_BOTO3 = False
 

--- a/plugins/modules/ec2_tag.py
+++ b/plugins/modules/ec2_tag.py
@@ -116,7 +116,7 @@ removed_tags:
 
 try:
     from botocore.exceptions import BotoCoreError, ClientError
-except Exception:
+except ImportError:
     pass    # Handled by AnsibleAWSModule
 
 from ..module_utils.core import AnsibleAWSModule


### PR DESCRIPTION
##### SUMMARY

Cleanup for consistency.

Catching `Exception` is generally considered bad. Our boto3/botocore import stanzas generally use `ImportError` instead.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/ec2.py
plugins/modules/ec2_tag.py

##### ADDITIONAL INFORMATION