### PR TITLE
ec2_eni - Yet Another Stabilization PR

### DIFF
--- a/changelogs/fragments/180-ec2_eni-stabilisation.yml
+++ b/changelogs/fragments/180-ec2_eni-stabilisation.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- ec2_eni - Improve reliability of the module (https://github.com/ansible-collections/amazon.aws/pull/180).
+- ec2_eni_info - Improve reliability of the module (https://github.com/ansible-collections/amazon.aws/pull/180).

--- a/changelogs/fragments/180-ec2_eni-stabilisation.yml
+++ b/changelogs/fragments/180-ec2_eni-stabilisation.yml
@@ -1,3 +1,3 @@
 minor_changes:
-- ec2_eni - Improve reliability of the module (https://github.com/ansible-collections/amazon.aws/pull/180).
-- ec2_eni_info - Improve reliability of the module (https://github.com/ansible-collections/amazon.aws/pull/180).
+- ec2_eni - Improve reliability of the module by adding waiters and performing lookups by ENI ID rather than repeated searches (https://github.com/ansible-collections/amazon.aws/pull/180).
+- ec2_eni_info - Improve reliability of the module by adding waiters and performing lookups by ENI ID rather than repeated searches (https://github.com/ansible-collections/amazon.aws/pull/180).

--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -53,6 +53,60 @@ ec2_data = {
                 },
             ]
         },
+        "NetworkInterfaceAvailable": {
+            "operation": "DescribeNetworkInterfaces",
+            "delay": 5,
+            "maxAttempts": 40,
+            "acceptors": [
+                {
+                    "expected": "available",
+                    "matcher": "pathAll",
+                    "state": "success",
+                    "argument": "NetworkInterfaces[].Status"
+                },
+                {
+                    "expected": "InvalidNetworkInterfaceID.NotFound",
+                    "matcher": "error",
+                    "state": "retry"
+                },
+            ]
+        },
+        "NetworkInterfaceDeleteOnTerminate": {
+            "operation": "DescribeNetworkInterfaces",
+            "delay": 5,
+            "maxAttempts": 10,
+            "acceptors": [
+                {
+                    "expected": True,
+                    "matcher": "pathAll",
+                    "state": "success",
+                    "argument": "NetworkInterfaces[].Attachment.DeleteOnTermination"
+                },
+                {
+                    "expected": "InvalidNetworkInterfaceID.NotFound",
+                    "matcher": "error",
+                    "state": "failure"
+                },
+            ]
+        },
+        "NetworkInterfaceNoDeleteOnTerminate": {
+            "operation": "DescribeNetworkInterfaces",
+            "delay": 5,
+            "maxAttempts": 10,
+            "acceptors": [
+                {
+                    "expected": False,
+                    "matcher": "pathAll",
+                    "state": "success",
+                    "argument": "NetworkInterfaces[].Attachment.DeleteOnTermination"
+                },
+                {
+                    "expected": "InvalidNetworkInterfaceID.NotFound",
+                    "matcher": "error",
+                    "state": "failure"
+                },
+            ]
+        },
         "RouteTableExists": {
             "delay": 5,
             "maxAttempts": 40,
@@ -348,6 +402,24 @@ waiters_by_name = {
     ('EC2', 'network_interface_attached'): lambda ec2: core_waiter.Waiter(
         'network_interface_attached',
         ec2_model('NetworkInterfaceAttached'),
+        core_waiter.NormalizedOperationMethod(
+            ec2.describe_network_interfaces
+        )),
+    ('EC2', 'network_interface_available'): lambda ec2: core_waiter.Waiter(
+        'network_interface_available',
+        ec2_model('NetworkInterfaceAvailable'),
+        core_waiter.NormalizedOperationMethod(
+            ec2.describe_network_interfaces
+        )),
+    ('EC2', 'network_interface_delete_on_terminate'): lambda ec2: core_waiter.Waiter(
+        'network_interface_delete_on_terminate',
+        ec2_model('NetworkInterfaceDeleteOnTerminate'),
+        core_waiter.NormalizedOperationMethod(
+            ec2.describe_network_interfaces
+        )),
+    ('EC2', 'network_interface_no_delete_on_terminate'): lambda ec2: core_waiter.Waiter(
+        'network_interface_no_delete_on_terminate',
+        ec2_model('NetworkInterfaceNoDeleteOnTerminate'),
         core_waiter.NormalizedOperationMethod(
             ec2.describe_network_interfaces
         )),

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -445,7 +445,7 @@ def create_eni(connection, vpc_id, module):
         eni = eni_dict["NetworkInterface"]
         # Once we have an ID make sure we're always modifying the same object
         eni_id = eni["NetworkInterfaceId"]
-        get_waiter(connection.client, 'network_interface_available').wait(NetworkInterfaceIds=[eni_id])
+        get_waiter(connection, 'network_interface_available').wait(NetworkInterfaceIds=[eni_id])
 
         if attached and instance_id is not None:
             try:
@@ -458,7 +458,7 @@ def create_eni(connection, vpc_id, module):
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
                 connection.delete_network_interface(aws_retry=True, NetworkInterfaceId=eni_id)
                 raise
-            get_waiter(connection.client, 'network_interface_attached').wait(NetworkInterfaceIds=[eni_id])
+            get_waiter(connection, 'network_interface_attached').wait(NetworkInterfaceIds=[eni_id])
 
         if secondary_private_ip_address_count is not None:
             try:
@@ -559,7 +559,7 @@ def modify_eni(connection, module, eni):
                     waiter = "network_interface_delete_on_terminate"
                 else:
                     waiter = "network_interface_no_delete_on_terminate"
-                get_waiter(connection.client, waiter).wait(NetworkInterfaceIds=[eni_id])
+                get_waiter(connection, waiter).wait(NetworkInterfaceIds=[eni_id])
 
         current_secondary_addresses = []
         if "PrivateIpAddresses" in eni:
@@ -617,7 +617,7 @@ def modify_eni(connection, module, eni):
                     DeviceIndex=device_index,
                     NetworkInterfaceId=eni_id,
                 )
-                get_waiter(connection.client, 'network_interface_attached').wait(NetworkInterfaceIds=[eni_id])
+                get_waiter(connection, 'network_interface_attached').wait(NetworkInterfaceIds=[eni_id])
                 changed = True
             if "Attachment" not in eni:
                 connection.attach_network_interface(
@@ -626,12 +626,12 @@ def modify_eni(connection, module, eni):
                     DeviceIndex=device_index,
                     NetworkInterfaceId=eni_id,
                 )
-                get_waiter(connection.client, 'network_interface_attached').wait(NetworkInterfaceIds=[eni_id])
+                get_waiter(connection, 'network_interface_attached').wait(NetworkInterfaceIds=[eni_id])
                 changed = True
 
         elif attached is False:
             changed |= detach_eni(connection, eni, module)
-            get_waiter(connection.client, 'network_interface_available').wait(NetworkInterfaceIds=[eni_id])
+            get_waiter(connection, 'network_interface_available').wait(NetworkInterfaceIds=[eni_id])
 
         changed |= manage_tags(eni, name, tags, purge_tags, connection)
 
@@ -660,7 +660,7 @@ def delete_eni(connection, module):
                     Force=True
                 )
                 # Wait to allow detachment to finish
-                get_waiter(connection.client, 'network_interface_available').wait(NetworkInterfaceIds=[eni_id])
+                get_waiter(connection, 'network_interface_available').wait(NetworkInterfaceIds=[eni_id])
             connection.delete_network_interface(aws_retry=True, NetworkInterfaceId=eni_id)
             changed = True
         else:
@@ -686,7 +686,7 @@ def detach_eni(connection, eni, module):
             AttachmentId=eni["Attachment"]["AttachmentId"],
             Force=force_detach
         )
-        get_waiter(connection.client, 'network_interface_available').wait(NetworkInterfaceIds=[eni_id])
+        get_waiter(connection, 'network_interface_available').wait(NetworkInterfaceIds=[eni_id])
         return True
 
     return False

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -445,6 +445,8 @@ def create_eni(connection, vpc_id, module):
         eni = eni_dict["NetworkInterface"]
         # Once we have an ID make sure we're always modifying the same object
         eni_id = eni["NetworkInterfaceId"]
+        get_waiter(connection.client, 'network_interface_available').wait(NetworkInterfaceIds=[eni_id])
+
         if attached and instance_id is not None:
             try:
                 connection.attach_network_interface(

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -553,6 +553,11 @@ def modify_eni(connection, module, eni):
                                 'DeleteOnTermination': delete_on_termination}
                 )
                 changed = True
+                if delete_on_termination:
+                    waiter = "network_interface_delete_on_terminate"
+                else:
+                    waiter = "network_interface_no_delete_on_terminate"
+                get_waiter(connection.client, waiter).wait(NetworkInterfaceIds=[eni_id])
 
         current_secondary_addresses = []
         if "PrivateIpAddresses" in eni:

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -676,6 +676,17 @@ def detach_eni(connection, eni, module):
         module.exit_json(changed=False, interface=get_eni_info(eni))
 
 
+def describe_eni(connection, module, eni_id):
+    try:
+        eni_result = connection.describe_network_interfaces(aws_retry=True, NetworkInterfaceIds=[eni_id])
+        if eni_result["NetworkInterfaces"]:
+            return eni_result["NetworkInterfaces"][0]
+        else:
+            return None
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, "Failed to describe eni with id: {0}".format(eni_id))
+
+
 def uniquely_find_eni(connection, module, eni=None):
 
     if eni:

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -829,7 +829,10 @@ def main():
         ])
     )
 
-    connection = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
+    retry_decorator = AWSRetry.jittered_backoff(
+        catch_extra_error_codes=['IncorrectState'],
+    )
+    connection = module.client('ec2', retry_decorator=retry_decorator)
     state = module.params.get("state")
 
     if state == 'present':

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -449,7 +449,6 @@ def create_eni(connection, vpc_id, module):
                 raise
             # Wait to allow creation / attachment to finish
             get_waiter(connection.client, 'network_interface_attached').wait(NetworkInterfaceIds=[eni["NetworkInterfaceId"]])
-            eni = uniquely_find_eni(connection, module, eni)
 
         if secondary_private_ip_address_count is not None:
             try:
@@ -458,7 +457,6 @@ def create_eni(connection, vpc_id, module):
                     NetworkInterfaceId=eni["NetworkInterfaceId"],
                     SecondaryPrivateIpAddressCount=secondary_private_ip_address_count
                 )
-                eni = uniquely_find_eni(connection, module, eni)
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
                 connection.delete_network_interface(aws_retry=True, NetworkInterfaceId=eni["NetworkInterfaceId"])
                 raise
@@ -469,7 +467,6 @@ def create_eni(connection, vpc_id, module):
                     NetworkInterfaceId=eni["NetworkInterfaceId"],
                     PrivateIpAddresses=secondary_private_ip_addresses
                 )
-                eni = uniquely_find_eni(connection, module, eni)
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
                 connection.delete_network_interface(aws_retry=True, NetworkInterfaceId=eni["NetworkInterfaceId"])
                 raise

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -295,7 +295,6 @@ interface:
 import time
 
 try:
-    import boto3
     import botocore.exceptions
 except ImportError:
     pass  # Handled by AnsibleAWSModule


### PR DESCRIPTION
##### SUMMARY

https://app.shippable.com/github/ansible-collections/amazon.aws/runs/885/28/console

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_eni

##### ADDITIONAL INFORMATION

```
04:56 TASK [ec2_eni : create a network interface] ************************************
04:58 An exception occurred during task execution. To see the full traceback, use -vvv. The error was: TypeError: argument of type 'NoneType' is not iterable
04:58 fatal: [testhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"/root/.ansible/tmp/ansible-tmp-1603452258.07-1895-100042642436240/AnsiballZ_ec2_eni.py\", line 128, in <module>\n    _ansiballz_main()\n  File \"/root/.ansible/tmp/ansible-tmp-1603452258.07-1895-100042642436240/AnsiballZ_ec2_eni.py\", line 120, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/root/.ansible/tmp/ansible-tmp-1603452258.07-1895-100042642436240/AnsiballZ_ec2_eni.py\", line 66, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.amazon.aws.plugins.modules.ec2_eni', init_globals=None, run_name='__main__', alter_sys=True)\n  File \"/usr/lib/python2.7/runpy.py\", line 188, in run_module\n    fname, loader, pkg_name)\n  File \"/usr/lib/python2.7/runpy.py\", line 82, in _run_module_code\n    mod_name, mod_fname, mod_loader, pkg_name)\n  File \"/usr/lib/python2.7/runpy.py\", line 72, in _run_code\n    exec code in run_globals\n  File \"/tmp/ansible_ec2_eni_payload_N2pvfe/ansible_ec2_eni_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_eni.py\", line 853, in <module>\n  File \"/tmp/ansible_ec2_eni_payload_N2pvfe/ansible_ec2_eni_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_eni.py\", line 844, in main\n  File \"/tmp/ansible_ec2_eni_payload_N2pvfe/ansible_ec2_eni_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_eni.py\", line 491, in create_eni\n  File \"/tmp/ansible_ec2_eni_payload_N2pvfe/ansible_ec2_eni_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_eni.py\", line 317, in get_eni_info\nTypeError: argument of type 'NoneType' is not iterable\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```