### PR TITLE
Fixed ec2_group_info module to work with Python 3.8

### DIFF
--- a/changelogs/fragments/181-ec2-group-info-python-fix.yaml
+++ b/changelogs/fragments/181-ec2-group-info-python-fix.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Code fix in ec2_group_info so module works with Python 3.8 (make dict immutable in loop)

--- a/changelogs/fragments/181-ec2-group-info-python-fix.yaml
+++ b/changelogs/fragments/181-ec2-group-info-python-fix.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - Code fix in ec2_group_info so module works with Python 3.8 (make dict immutable in loop)
+  - ec2_group_info - Code fix so module works with Python 3.8 (make dict immutable in loop) (https://github.com/ansible-collections/amazon.aws/pull/181)

--- a/plugins/modules/ec2_group_info.py
+++ b/plugins/modules/ec2_group_info.py
@@ -115,10 +115,12 @@ def main():
     connection = module.client('ec2')
 
     # Replace filter key underscores with dashes, for compatibility, except if we're dealing with tags
-    sanitized_filters = module.params.get("filters")
-    for key in list(sanitized_filters):
+    filters = module.params.get("filters")
+    sanitized_filters = dict()
+
+    for key in filters:
         if not key.startswith("tag:"):
-            sanitized_filters[key.replace("_", "-")] = sanitized_filters.pop(key)
+            sanitized_filters[key.replace("_", "-")] = filters[key]
 
     try:
         security_groups = connection.describe_security_groups(

--- a/plugins/modules/ec2_group_info.py
+++ b/plugins/modules/ec2_group_info.py
@@ -119,7 +119,9 @@ def main():
     sanitized_filters = dict()
 
     for key in filters:
-        if not key.startswith("tag:"):
+        if key.startswith("tag:"):
+            sanitized_filters[key] = filters[key]
+        else:
             sanitized_filters[key.replace("_", "-")] = filters[key]
 
     try:

--- a/tests/integration/targets/ec2_group/aliases
+++ b/tests/integration/targets/ec2_group/aliases
@@ -1,3 +1,4 @@
 cloud/aws
 shippable/aws/group2
 unstable
+ec2_group_info

--- a/tests/integration/targets/ec2_group/tasks/group_info.yml
+++ b/tests/integration/targets/ec2_group/tasks/group_info.yml
@@ -1,0 +1,84 @@
+---
+
+# file for testing the ec2_group_info module
+
+- block:
+    # ======================== Setup =====================================
+    - name: Create a group for testing group info retrieval below
+      ec2_group:
+        name: '{{ ec2_group_name }}-info-1'
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        description: '{{ ec2_group_description }}'
+        rules:
+          - proto: tcp
+            ports:
+              - 90
+            cidr_ip: 10.2.2.2/32
+        tags:
+          - test: ec2_group_info_module
+        register: group_info_test_setup
+
+    - name: Create another group for testing group info retrieval below
+      ec2_group:
+        name: '{{ ec2_group_name }}-info-2'
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        description: '{{ ec2_group_description }}'
+        rules:
+          - proto: tcp
+            ports:
+              - 91
+            cidr_ip: 10.2.2.2/32
+
+    # ========================= ec2_group_info tests ====================
+
+    - name: Retrieve security group info based on SG name
+      ec2_group_info:
+        filters:
+          name: '{{ ec2_group_name }}-info-2'
+      register: result_1
+
+    - name: Assert results found
+      assert:
+        that:
+          - result_1.security_groups is defined
+          - (result_1.security_groups|first).group_name == '{{ ec2_group_name }}-info-2'
+
+    - name: Retrieve security group info based on SG VPC
+      ec2_group_info:
+        filters:
+          vpc-id: '{{ vpc_result.vpc.id }}'
+      register: result_2
+
+    - name: Assert results found
+      assert:
+        that:
+          - result_2.security_groups is defined
+          - (result_2.security_groups|first).vpc_id == vpc_result.vpc.id
+          - (result_2.security_groups|length) > 2
+
+    - name: Retrieve security group info based on SG tags
+      ec2_group_info:
+        filters:
+          "tag:test": "ec2_group_info_module"
+      register: result_3
+
+    - name: Assert results found
+      assert:
+        that:
+          - result_3.security_groups is defined
+          - (result_3.security_groups|first).group_id == group_info_test_setup.group_id
+
+  always:
+    # ========================= Cleanup =================================
+    - name: tidy up test security group 1
+      ec2_group:
+        name: '{{ ec2_group_name }}-info-1'
+        state: absent
+      ignore_errors: yes
+
+    - name: tidy up test security group 2
+      ec2_group:
+        name: '{{ ec2_group_name }}-info-2'
+        state: absent
+      ignore_errors: yes
+

--- a/tests/integration/targets/ec2_group/tasks/group_info.yml
+++ b/tests/integration/targets/ec2_group/tasks/group_info.yml
@@ -15,7 +15,7 @@
               - 90
             cidr_ip: 10.2.2.2/32
         tags:
-          - test: '{{ test_prefix }}_ec2_group_info_module'
+          - test: '{{ resource_prefix }}_ec2_group_info_module'
         register: group_info_test_setup
 
     - name: Create another group for testing group info retrieval below
@@ -59,7 +59,7 @@
     - name: Retrieve security group info based on SG tags
       ec2_group_info:
         filters:
-          "tag:test": "{{ test_prefix }}_ec2_group_info_module"
+          "tag:test": "{{ resource_prefix }}_ec2_group_info_module"
       register: result_3
 
     - name: Assert results found
@@ -81,4 +81,3 @@
         name: '{{ ec2_group_name }}-info-2'
         state: absent
       ignore_errors: yes
-

--- a/tests/integration/targets/ec2_group/tasks/group_info.yml
+++ b/tests/integration/targets/ec2_group/tasks/group_info.yml
@@ -34,7 +34,7 @@
     - name: Retrieve security group info based on SG name
       ec2_group_info:
         filters:
-          name: '{{ ec2_group_name }}-info-2'
+          group-name: '{{ ec2_group_name }}-info-2'
       register: result_1
 
     - name: Assert results found
@@ -67,6 +67,19 @@
         that:
           - result_3.security_groups is defined
           - (result_3.security_groups|first).group_id == group_info_test_setup.group_id
+
+    - name: Retrieve security group info based on SG ID
+      ec2_group_info:
+        filters:
+          group-id: '{{ group_info_test_setup.group_id }}'
+      register: result_4
+
+    - name: Assert correct result found
+      assert:
+        that:
+          - result_4.security_groups is defined
+          - (result_4.security_groups|first).group_id == group_info_test_setup.group_id
+          - (result_4.security_groups|length) == 1
 
   always:
     # ========================= Cleanup =================================

--- a/tests/integration/targets/ec2_group/tasks/group_info.yml
+++ b/tests/integration/targets/ec2_group/tasks/group_info.yml
@@ -16,7 +16,7 @@
             cidr_ip: 10.2.2.2/32
         tags:
           - test: '{{ resource_prefix }}_ec2_group_info_module'
-        register: group_info_test_setup
+      register: group_info_test_setup
 
     - name: Create another group for testing group info retrieval below
       ec2_group:

--- a/tests/integration/targets/ec2_group/tasks/group_info.yml
+++ b/tests/integration/targets/ec2_group/tasks/group_info.yml
@@ -15,7 +15,7 @@
               - 90
             cidr_ip: 10.2.2.2/32
         tags:
-          - test: ec2_group_info_module
+          - test: '{{ test_prefix }}_ec2_group_info_module'
         register: group_info_test_setup
 
     - name: Create another group for testing group info retrieval below
@@ -59,7 +59,7 @@
     - name: Retrieve security group info based on SG tags
       ec2_group_info:
         filters:
-          "tag:test": "ec2_group_info_module"
+          "tag:test": "{{ test_prefix }}_ec2_group_info_module"
       register: result_3
 
     - name: Assert results found

--- a/tests/integration/targets/ec2_group/tasks/group_info.yml
+++ b/tests/integration/targets/ec2_group/tasks/group_info.yml
@@ -15,7 +15,7 @@
               - 90
             cidr_ip: 10.2.2.2/32
         tags:
-          - test: '{{ resource_prefix }}_ec2_group_info_module'
+          test: '{{ resource_prefix }}_ec2_group_info_module'
       register: group_info_test_setup
 
     - name: Create another group for testing group info retrieval below

--- a/tests/integration/targets/ec2_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_group/tasks/main.yml
@@ -66,6 +66,7 @@
     - include: ./egress_tests.yml
     - include: ./data_validation.yml
     - include: ./multi_nested_target.yml
+    - include: ./group_info.yml
 
     # ============================================================
     - name: test state=absent (CHECK MODE)


### PR DESCRIPTION
…without modifying the dict in loop (immutable).

##### SUMMARY
Fixes Python runtime error `dictionary keys changed during iteration`

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ec2_group_info module

##### ADDITIONAL INFORMATION
Output of ansible --version (on Ubuntu 20.04):
```
ansible 2.9.1
  config file = /xx/ansible.cfg
  configured module search path = ['/xx/library']
  ansible python module location = /xx/.local/lib/python3.8/site-packages/ansible
  executable location = /xx/.local/bin/ansible
  python version = 3.8.5 (default, Jul 28 2020, 12:59:40) [GCC 9.3.0]
```

Error output of module without the fix:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: RuntimeError: dictionary keys changed during iteration
fatal: [localhost]: FAILED! => {"changed": false, "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 102, in <module>\n  File \"<stdin>\", line 94, in _ansiballz_main\n  File \"<stdin>\", line 40, in invoke_module\n  File \"/usr/lib/python3.8/runpy.py\", line 207, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.8/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.8/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_ec2_group_info_payload_80im7jvm/ansible_ec2_group_info_payload.zip/ansible/modules/cloud/amazon/ec2_group_info.py\", line 165, in <module>\n  File \"/tmp/ansible_ec2_group_info_payload_80im7jvm/ansible_ec2_group_info_payload.zip/ansible/modules/cloud/amazon/ec2_group_info.py\", line 142, in main\nRuntimeError: dictionary keys changed during iteration\n", "module_stdout": "", "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error", "rc": 1}
```

Which goes away with this patch.

**NOTE:** Perhaps a test with Python 3.8 should be added to testsuite.