### PR TITLE
Logic for nested HttpRequestMethodConfig Values

### DIFF
--- a/changelogs/fragments/188-httprequestmethodconfig-keyerror.yaml
+++ b/changelogs/fragments/188-httprequestmethodconfig-keyerror.yaml
@@ -2,3 +2,4 @@
 bugfixes:
   - module_utils/elbv2 - add logic to compare_rules to suit Values list nested within dicts unique to each field type. 
     Fixes issue (https://github.com/ansible-collections/amazon.aws/issues/187)
+  - module_utils/elbv2 - Requires 1.16.57 as minimum boto3 version.

--- a/changelogs/fragments/188-httprequestmethodconfig-keyerror.yaml
+++ b/changelogs/fragments/188-httprequestmethodconfig-keyerror.yaml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - module_utils/elbv2 - add logic to compare_rules to suit Values list nested within HttpRequestMethodConfig dict. 
+    Fixes issue (https://github.com/ansible-collections/amazon.aws/issues/187)

--- a/changelogs/fragments/188-httprequestmethodconfig-keyerror.yaml
+++ b/changelogs/fragments/188-httprequestmethodconfig-keyerror.yaml
@@ -1,4 +1,4 @@
 ---
 bugfixes:
-  - module_utils/elbv2 - add logic to compare_rules to suit Values list nested within HttpRequestMethodConfig dict. 
+  - module_utils/elbv2 - add logic to compare_rules to suit Values list nested within dicts unique to each field type. 
     Fixes issue (https://github.com/ansible-collections/amazon.aws/issues/187)

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -743,7 +743,7 @@ class ELBListenerRules(object):
             elif current_condition.get('QueryStringConfig'):
                 # QueryString Values is not sorted as it is the only list of dicts (not strings).
                 if (current_condition['Field'] == condition['Field'] and
-                        current_condition['QueryStringConfig']['Values']) == condition['QueryStringConfig']['Values'])):
+                        current_condition['QueryStringConfig']['Values'] == condition['QueryStringConfig']['Values']):
                     condition_found = True
                     break
             elif current_condition.get('SourceIpConfig'):

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -724,6 +724,11 @@ class ELBListenerRules(object):
                         current_condition['SourceIpConfig']['Values'][0] == condition['SourceIpConfig']['Values'][0]):
                     condition_found = True
                     break
+            elif current_condition.get('HttpRequestMethodConfig'):
+                if (current_condition['Field'] == condition['Field'] and
+                        sorted(current_condition['HttpRequestMethodConfig']['Values']) == sorted(condition['HttpRequestMethodConfig']['Values'])):
+                    condition_found = True
+                    break
             elif current_condition['Field'] == condition['Field'] and sorted(current_condition['Values']) == sorted(condition['Values']):
                 condition_found = True
                 break

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -719,7 +719,10 @@ class ELBListenerRules(object):
         condition_found = False
 
         for current_condition in current_conditions:
-            if current_condition.get('HostHeaderConfig'):
+            # host-header: current_condition includes both HostHeaderConfig AND Values while
+            # condition can be defined with either HostHeaderConfig OR Values. Only use
+            # HostHeaderConfig['Values'] comparison if both conditions includes HostHeaderConfig.
+            if current_condition.get('HostHeaderConfig') and condition.get('HostHeaderConfig'):
                 if (current_condition['Field'] == condition['Field'] and
                         sorted(current_condition['HostHeaderConfig']['Values']) == sorted(condition['HostHeaderConfig']['Values'])):
                     condition_found = True
@@ -735,7 +738,10 @@ class ELBListenerRules(object):
                         sorted(current_condition['HttpRequestMethodConfig']['Values']) == sorted(condition['HttpRequestMethodConfig']['Values'])):
                     condition_found = True
                     break
-            elif current_condition.get('PathPatternConfig'):
+            # path-pattern: current_condition includes both PathPatternConfig AND Values while
+            # condition can be defined with either PathPatternConfig OR Values. Only use
+            # PathPatternConfig['Values'] comparison if both conditions includes PathPatternConfig.
+            elif current_condition.get('PathPatternConfig') and condition.get('PathPatternConfig'):
                 if (current_condition['Field'] == condition['Field'] and
                         sorted(current_condition['PathPatternConfig']['Values']) == sorted(condition['PathPatternConfig']['Values'])):
                     condition_found = True

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -719,9 +719,15 @@ class ELBListenerRules(object):
         condition_found = False
 
         for current_condition in current_conditions:
-            if current_condition.get('SourceIpConfig'):
+            if current_condition.get('HostHeaderConfig'):
                 if (current_condition['Field'] == condition['Field'] and
-                        current_condition['SourceIpConfig']['Values'][0] == condition['SourceIpConfig']['Values'][0]):
+                        sorted(current_condition['HostHeaderConfig']['Values']) == sorted(condition['HostHeaderConfig']['Values'])):
+                    condition_found = True
+                    break
+            elif current_condition.get('HttpHeaderConfig'):
+                if (current_condition['Field'] == condition['Field'] and
+                        sorted(current_condition['HttpHeaderConfig']['Values']) == sorted(condition['HttpHeaderConfig']['Values']) and
+                        current_condition['HttpHeaderConfig']['HttpHeaderName'] == condition['HttpHeaderConfig']['HttpHeaderName']):
                     condition_found = True
                     break
             elif current_condition.get('HttpRequestMethodConfig'):
@@ -729,6 +735,24 @@ class ELBListenerRules(object):
                         sorted(current_condition['HttpRequestMethodConfig']['Values']) == sorted(condition['HttpRequestMethodConfig']['Values'])):
                     condition_found = True
                     break
+            elif current_condition.get('PathPatternConfig'):
+                if (current_condition['Field'] == condition['Field'] and
+                        sorted(current_condition['PathPatternConfig']['Values']) == sorted(condition['PathPatternConfig']['Values'])):
+                    condition_found = True
+                    break
+            elif current_condition.get('QueryStringConfig'):
+                # QueryString Values is not sorted as it is the only list of dicts (not strings).
+                if (current_condition['Field'] == condition['Field'] and
+                        current_condition['QueryStringConfig']['Values']) == condition['QueryStringConfig']['Values'])):
+                    condition_found = True
+                    break
+            elif current_condition.get('SourceIpConfig'):
+                if (current_condition['Field'] == condition['Field'] and
+                        sorted(current_condition['SourceIpConfig']['Values']) == sorted(condition['SourceIpConfig']['Values'])):
+                    condition_found = True
+                    break
+            # Not all fields are required to have Values list nested within a *Config dict
+            # e.g. fields host-header/path-pattern can directly list Values
             elif current_condition['Field'] == condition['Field'] and sorted(current_condition['Values']) == sorted(condition['Values']):
                 condition_found = True
                 break

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -51,6 +51,9 @@ class ElasticLoadBalancerV2(object):
         else:
             self.elb_attributes = None
 
+        if not self.module.boto3_at_least('1.16.57'):
+            self.module.fail_json(msg="elbv2 requires boto3 >= 1.16.57")
+
     def wait_for_status(self, elb_arn):
         """
         Wait for load balancer to reach 'active' status


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #187. Adds logic to the compare_condition function to suit when the 'Values' key is nested within 'HttpRequestMethodConfig'. Otherwise trying to access 'Values' directly throws "KeyError: 'Values'".
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
elbv2.py
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
As per [Boto docs](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.create_rule), when condition Field is equal to 'http-request-method', the 'Values' list should then be nested within 'HttpRequestMethodConfig' dict.
<!--- Paste verbatim command output below, e.g. before and after your change -->

