### PR TITLE
Document instance_life_cycle in ec2_metadata_facts

### DIFF
--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -243,8 +243,12 @@ ansible_facts:
             description: Data that can be used by other parties to verify its origin and authenticity.
             type: str
             sample: ""
+        ansible_ec2_instance_life_cycle:
+            description: The life cycle of the instance.
+            type: str
+            sample: "on-demand"
         ansible_ec2_instance_type:
-            description: The type of instance.
+            description: The type of the instance.
             type: str
             sample: "m4.large"
         ansible_ec2_local_hostname:

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -244,7 +244,7 @@ ansible_facts:
             type: str
             sample: ""
         ansible_ec2_instance_life_cycle:
-            description: The life cycle of the instance.
+            description: The purchasing option of the instance.
             type: str
             sample: "on-demand"
         ansible_ec2_instance_type:


### PR DESCRIPTION
##### SUMMARY

Document a missing field (`ansible_ec2_instance_life_cycle`) in the output of `ec2_metadata_facts`.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
ec2_metadata_facts

##### ADDITIONAL INFORMATION

The goal is to have the information available in the online documentation.
