### PR TITLE
Don't hardcode max_attempts, as it leads to errors when AMI builds lo…

### DIFF
--- a/changelogs/fragments/194-ec2-ami-max-attempts.yaml
+++ b/changelogs/fragments/194-ec2-ami-max-attempts.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ec2_ami - fixed and streamlined max_attempts logic when waiting for AMIs to finish and increased wait_timeout to 1200 for a more reliably module run.

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -507,7 +507,7 @@ def create_image(module, connection):
     if wait:
         delay = 15
         max_attempts = wait_timeout // delay
-        waiter = connection.get_waiter('image_available')
+        waiter = get_waiter(connection, 'image_available')
         waiter.wait(ImageIds=[image_id], WaiterConfig=dict(Delay=delay, MaxAttempts=max_attempts))
 
     if tags:

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -48,7 +48,7 @@ options:
   wait_timeout:
     description:
       - How long before wait gives up, in seconds.
-    default: 900
+    default: 1200
     type: int
   state:
     description:
@@ -505,9 +505,9 @@ def create_image(module, connection):
         module.fail_json_aws(e, msg="Error registering image")
 
     if wait:
-        waiter = get_waiter(connection, 'image_available')
-        delay = wait_timeout // 30
-        max_attempts = 30
+        delay = 15
+        max_attempts = wait_timeout // delay
+        waiter = connection.get_waiter('image_available')
         waiter.wait(ImageIds=[image_id], WaiterConfig=dict(Delay=delay, MaxAttempts=max_attempts))
 
     if tags:
@@ -718,7 +718,7 @@ def main():
         delete_snapshot=dict(default=False, type='bool'),
         name=dict(),
         wait=dict(type='bool', default=False),
-        wait_timeout=dict(default=900, type='int'),
+        wait_timeout=dict(default=1200, type='int'),
         description=dict(default=''),
         no_reboot=dict(default=False, type='bool'),
         state=dict(default='present', choices=['present', 'absent']),


### PR DESCRIPTION
…ng and timeout setting won't have any effect.

##### SUMMARY
For AMIs that will take a little longer you will get a 
```
botocore.exceptions.WaiterError: Waiter ImageAvailable failed: Max attempts exceeded
```
Increasing the `wait_timeout` module param won't help you, as this module - for some reason - has a hardcoded `max_attempts` value which is not relative to the `wait_timeout` value (as most other modules do it).

So I adjusted that section to follow the same pattern as other AWS modules, such as `ec2_ami_copy`, `ec2_instance` etc.

Also while at it I increased the default wait time to 1200 as this won't make it necessary for the user to set the `wait_timeout` param in most cases and it doesn't hurt to have a high value here as we have retries every 15 seconds anyway.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_ami module
