### PR TITLE
Add retry decorator to ansibleawsmodule.client example module

### DIFF
--- a/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/library/example_module.py
+++ b/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/library/example_module.py
@@ -15,6 +15,7 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
@@ -25,7 +26,8 @@ def main():
         supports_check_mode=True,
     )
 
-    client = module.client('ec2')
+    decorator = AWSRetry.jittered_backoff()
+    client = module.client('ec2', retry_decorator=decorator)
 
     filters = ansible_dict_to_boto3_filter_list({'name': 'amzn2-ami-hvm-2.0.202006*-x86_64-gp2'})
 


### PR DESCRIPTION
##### SUMMARY

The minimal module in ansibleawsmodule.client makes a call to the AWS APIs and sometimes runs into rate limiting errors.  Add a retry

##### ISSUE TYPE

- Bugfix Pull Request


##### COMPONENT NAME

tests/integration/targets/module_utils_core

##### ADDITIONAL INFORMATION
