### PR TITLE
Ignore terminated instances when starting/stopping

### DIFF
--- a/changelogs/fragments/197-ignore-terminated-instances.yaml
+++ b/changelogs/fragments/197-ignore-terminated-instances.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2 - ignore terminated instances and instances that are shutting down when starting and stopping (https://github.com/ansible-collections/amazon.aws/issues/146).

--- a/plugins/modules/ec2.py
+++ b/plugins/modules/ec2.py
@@ -1413,6 +1413,8 @@ def startstop_instances(module, ec2, instance_ids, state, instance_tags):
         for key, value in instance_tags.items():
             filters["tag:" + key] = value
 
+    filters['instance-state-name'] = ["!terminated", "!shutting-down"]
+
     if module.params.get('id'):
         filters['client-token'] = module.params['id']
     # Check that our instances are not in the state we want to take

--- a/tests/integration/targets/ec2/aliases
+++ b/tests/integration/targets/ec2/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+shippable/aws/group4

--- a/tests/integration/targets/ec2/defaults/main.yml
+++ b/tests/integration/targets/ec2/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'
+subnet_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.1.0/24'
+ec2_ami_name: 'ami-8c1be5f6'

--- a/tests/integration/targets/ec2/defaults/main.yml
+++ b/tests/integration/targets/ec2/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'
 subnet_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.1.0/24'
-ec2_ami_name: 'ami-8c1be5f6'
+ec2_ami_name: 'amzn2-ami-hvm-2.*-x86_64-gp2'

--- a/tests/integration/targets/ec2/meta/main.yml
+++ b/tests/integration/targets/ec2/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/tests/integration/targets/ec2/tasks/main.yml
+++ b/tests/integration/targets/ec2/tasks/main.yml
@@ -5,6 +5,9 @@
       aws_access_key: '{{ aws_access_key | default(omit) }}'
       aws_secret_key: '{{ aws_secret_key | default(omit) }}'
       security_token: '{{ security_token | default(omit) }}'
+  collections:
+    - community.aws
+
   block:
 
     # SETUP: vpc, ec2 key pair, subnet, security group, ec2 instance
@@ -123,15 +126,15 @@
           - "result.changed == False"
 
     - name: test second instance not terminated
-      community.aws.ec2_instance_info:
+      ec2_instance_info:
         instance_ids: "{{ test_instance_2.instance_ids }}"
-      register: instances
+      register: result
 
     - name: assert second instance still running
       assert:
         that:
-          - "{{ instances|length }}" == 1
-          - "{{ instances[0] }}.state.name == 'running'"
+          - (result.instances|length) == 1
+          - "{{ result.instances[0] }}.state.name == 'running'"
 
     # ========================================================
 
@@ -146,14 +149,14 @@
         msg: "***** TESTING COMPLETE. COMMENCE TEARDOWN *****"
 
     - name: get list of test instances
-      community.aws.ec2_instance_info:
+      ec2_instance_info:
         filters:
           "tag:ResourcePrefix": "{{ resource_prefix }}-*"
       register: test_instances
 
     - name: delete test instances
       ec2:
-        instance_ids: "{{ test_instances|map('instance_id') }}"
+        instance_ids: "{{ test_instances.instances|map(attribute='instance_id') }}"
         state: absent
         wait: yes
       ignore_errors: yes

--- a/tests/integration/targets/ec2/tasks/main.yml
+++ b/tests/integration/targets/ec2/tasks/main.yml
@@ -134,7 +134,7 @@
       assert:
         that:
           - (result.instances|length) == 1
-          - "{{ result.instances[0] }}.state.name == 'running'"
+          - "result.instances[0].state.name == 'running'"
 
     # ========================================================
 

--- a/tests/integration/targets/ec2/tasks/main.yml
+++ b/tests/integration/targets/ec2/tasks/main.yml
@@ -1,0 +1,141 @@
+---
+- module_defaults:
+    group/aws:
+      aws_region: '{{ aws_region }}'
+      aws_access_key: '{{ aws_access_key | default(omit) }}'
+      aws_secret_key: '{{ aws_secret_key | default(omit) }}'
+      security_token: '{{ security_token | default(omit) }}'
+  block:
+
+    # SETUP: vpc, ec2 key pair, subnet, security group, ec2 instance
+    - name: create a VPC to work in
+      ec2_vpc_net:
+        cidr_block: '{{ vpc_cidr }}'
+        state: present
+        name: '{{ resource_prefix }}_setup'
+        resource_tags:
+          Name: '{{ resource_prefix }}_setup'
+      register: setup_vpc
+
+    - name: create a key pair to use for creating an ec2 instance
+      ec2_key:
+        name: '{{ resource_prefix }}_setup'
+        state: present
+      register: setup_key
+
+    - name: create a subnet to use for creating an ec2 instance
+      ec2_vpc_subnet:
+        az: '{{ ec2_region }}a'
+        tags: '{{ resource_prefix }}_setup'
+        vpc_id: '{{ setup_vpc.vpc.id }}'
+        cidr: '{{ subnet_cidr }}'
+        state: present
+        resource_tags:
+          Name: '{{ resource_prefix }}_setup'
+      register: setup_subnet
+
+    - name: create a security group to use for creating an ec2 instance
+      ec2_group:
+        name: '{{ resource_prefix }}_setup'
+        description: 'created by Ansible integration tests'
+        state: present
+        vpc_id: '{{ setup_vpc.vpc.id }}'
+      register: setup_sg
+
+    # ============================================================
+
+    - name: test instance is started
+      ec2:
+        instance_type: t2.micro
+        key_name: '{{ setup_key.key.name }}'
+        state: present
+        image: '{{ ec2_ami_name }}'
+        wait: yes
+        instance_tags:
+          ResourcePrefix: '{{ resource_prefix }}-integration_tests'
+        group_id: '{{ setup_sg.group_id }}'
+        vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
+      register: test_instance
+
+    - name: assert instance started
+      assert:
+        that:
+          - "test_instance.instances[0].state == 'running'"
+
+    - name: test instance is terminated
+      ec2:
+        instance_ids: "{{ test_instance.instance_ids }}"
+        state: absent
+        wait: yes
+      register: result
+
+    - name: assert instance terminated
+      assert:
+        that:
+          - "result.instances[0].state == 'terminated'"
+
+    - name: test terminated instance is ignored when stopping
+      ec2:
+        instance_tags:
+          ResourcePrefix: '{{ resource_prefix }}-integration_tests'
+        state: stopped
+        wait: yes
+      register: result
+
+    - name: assert resource not changed
+      assert:
+        that:
+          - "result.changed == False"
+
+    # ========================================================
+
+  always:
+
+    # ============================================================
+
+
+    # TEAR DOWN: ec2 instance, ec2 key pair, security group, vpc
+    - name: Announce teardown start
+      debug:
+        msg: "***** TESTING COMPLETE. COMMENCE TEARDOWN *****"
+
+    - name: delete test instance
+      ec2:
+        instance_ids: '{{ test_instance.instance_ids }}'
+        state: absent
+        wait: yes
+      ignore_errors: yes
+
+    - name: remove setup keypair
+      ec2_key:
+        name: '{{resource_prefix}}_setup'
+        state: absent
+      ignore_errors: yes
+
+    - name: remove setup security group
+      ec2_group:
+        name: '{{ resource_prefix }}_setup'
+        description: 'created by Ansible integration tests'
+        state: absent
+        vpc_id: '{{ setup_vpc.vpc.id }}'
+      ignore_errors: yes
+
+    - name: remove setup subnet
+      ec2_vpc_subnet:
+        az: '{{ ec2_region }}a'
+        tags: '{{resource_prefix}}_setup'
+        vpc_id: '{{ setup_vpc.vpc.id }}'
+        cidr: '{{ subnet_cidr }}'
+        state: absent
+        resource_tags:
+          Name: '{{ resource_prefix }}_setup'
+      ignore_errors: yes
+
+    - name: remove setup VPC
+      ec2_vpc_net:
+        cidr_block: '{{ vpc_cidr }}'
+        state: absent
+        name: '{{ resource_prefix }}_setup'
+        resource_tags:
+          Name: '{{ resource_prefix }}_setup'
+      ignore_errors: yes

--- a/tests/integration/targets/ec2/tasks/main.yml
+++ b/tests/integration/targets/ec2/tasks/main.yml
@@ -8,6 +8,14 @@
   block:
 
     # SETUP: vpc, ec2 key pair, subnet, security group, ec2 instance
+    - name: list available AZs
+      aws_az_info:
+      register: region_azs
+
+    - name: pick an AZ for testing
+      set_fact:
+        availability_zone: "{{ region_azs.availability_zones[0].zone_name }}"
+
     - name: create a VPC to work in
       ec2_vpc_net:
         cidr_block: '{{ vpc_cidr }}'
@@ -25,7 +33,7 @@
 
     - name: create a subnet to use for creating an ec2 instance
       ec2_vpc_subnet:
-        az: '{{ ec2_region }}a'
+        az: '{{ availability_zone }}'
         tags: '{{ resource_prefix }}_setup'
         vpc_id: '{{ setup_vpc.vpc.id }}'
         cidr: '{{ subnet_cidr }}'
@@ -42,29 +50,56 @@
         vpc_id: '{{ setup_vpc.vpc.id }}'
       register: setup_sg
 
+    - name: Find AMI to use
+      ec2_ami_info:
+        owners: 'amazon'
+        filters:
+          name: '{{ ec2_ami_name }}'
+      register: ec2_amis
+
+    - name: Set fact with latest AMI
+      vars:
+        latest_ami: '{{ ec2_amis.images | sort(attribute="creation_date") | last }}'
+      set_fact:
+        ec2_ami_image: '{{ latest_ami.image_id }}'
+
     # ============================================================
 
-    - name: test instance is started
+    - name: test first instance is started
       ec2:
         instance_type: t2.micro
         key_name: '{{ setup_key.key.name }}'
         state: present
-        image: '{{ ec2_ami_name }}'
+        image: '{{ ec2_ami_image }}'
         wait: yes
         instance_tags:
           ResourcePrefix: '{{ resource_prefix }}-integration_tests'
         group_id: '{{ setup_sg.group_id }}'
         vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
-      register: test_instance
+      register: test_instance_1
 
-    - name: assert instance started
+    - name: test second instance is started
+      ec2:
+        instance_type: t2.micro
+        key_name: '{{ setup_key.key.name }}'
+        state: present
+        image: '{{ ec2_ami_image }}'
+        wait: yes
+        instance_tags:
+          ResourcePrefix: '{{ resource_prefix }}-another_tag'
+        group_id: '{{ setup_sg.group_id }}'
+        vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
+      register: test_instance_2
+
+    - name: assert instances started
       assert:
         that:
-          - "test_instance.instances[0].state == 'running'"
+          - "test_instance_1.instances[0].state == 'running'"
+          - "test_instance_2.instances[0].state == 'running'"
 
-    - name: test instance is terminated
+    - name: test first instance is terminated
       ec2:
-        instance_ids: "{{ test_instance.instance_ids }}"
+        instance_ids: "{{ test_instance_1.instance_ids }}"
         state: absent
         wait: yes
       register: result
@@ -87,6 +122,11 @@
         that:
           - "result.changed == False"
 
+    - name: assert second instance still running
+      assert:
+        that:
+          - "test_instance_2.instances[0].state == 'running'"
+
     # ========================================================
 
   always:
@@ -99,9 +139,12 @@
       debug:
         msg: "***** TESTING COMPLETE. COMMENCE TEARDOWN *****"
 
-    - name: delete test instance
+    - name: delete test instances
       ec2:
-        instance_ids: '{{ test_instance.instance_ids }}'
+        instance_ids:
+          - "{{ test_instance_1.instance_ids[0] }}"
+          - "{{ test_instance_2.instance_ids[0] }}"
+
         state: absent
         wait: yes
       ignore_errors: yes

--- a/tests/integration/targets/ec2/tasks/main.yml
+++ b/tests/integration/targets/ec2/tasks/main.yml
@@ -122,10 +122,16 @@
         that:
           - "result.changed == False"
 
+    - name: test second instance not terminated
+      community.aws.ec2_instance_info:
+        instance_ids: "{{ test_instance_2.instance_ids }}"
+      register: instances
+
     - name: assert second instance still running
       assert:
         that:
-          - "test_instance_2.instances[0].state == 'running'"
+          - "{{ instances|length }}" == 1
+          - "{{ instances[0] }}.state.name == 'running'"
 
     # ========================================================
 
@@ -139,12 +145,15 @@
       debug:
         msg: "***** TESTING COMPLETE. COMMENCE TEARDOWN *****"
 
+    - name: get list of test instances
+      community.aws.ec2_instance_info:
+        filters:
+          "tag:ResourcePrefix": "{{ resource_prefix }}-*"
+      register: test_instances
+
     - name: delete test instances
       ec2:
-        instance_ids:
-          - "{{ test_instance_1.instance_ids[0] }}"
-          - "{{ test_instance_2.instance_ids[0] }}"
-
+        instance_ids: "{{ test_instances|map('instance_id') }}"
         state: absent
         wait: yes
       ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
In the ec2 module, if tags are used to select which instances to start/stop it will produce an error. This filters out terminated instances or instances that are in the process of being terminated. I have also added a new integration test suite for the ec2 module with a test covering the behavior.

Fixes #146 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2.py

##### ADDITIONAL INFORMATION