### PR TITLE
[AWS Secret Lookup] Support querying logically nested secrets

### DIFF
--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -92,7 +92,8 @@ EXAMPLES = r"""
 
  - name: lookup secretsmanager secret in the current region using the nested feature
    debug: msg="{{ lookup('amazon.aws.aws_secret', 'secrets.environments.production.password', nested=true) }}"
-   # The secret can be queried using the following syntax: `aws_secret_object_name.key1.key2.key3`. If an object is of the form `{"key1":{"key2":{"key3":1}}}` the query would return the value `1`.
+   # The secret can be queried using the following syntax: `aws_secret_object_name.key1.key2.key3`.
+   # If an object is of the form `{"key1":{"key2":{"key3":1}}}` the query would return the value `1`.
 """
 
 RETURN = r"""
@@ -116,6 +117,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_er
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 import json
+
 
 def _boto3_conn(region, credentials):
     boto_profile = credentials.pop('aws_profile', None)
@@ -243,7 +245,7 @@ class LookupModule(LookupBase):
                         if key in ret_val:
                             ret_val = ret_val[key]
                         else:
-                            raise AnsibleError("Successfully retrieved secret but there exists no key {} in the secret".format(key))
+                            raise AnsibleError("Successfully retrieved secret but there exists no key {0} in the secret".format(key))
                     return str(ret_val)
                 else:
                     return response['SecretString']

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -30,6 +30,11 @@ options:
     default: false
     type: boolean
     version_added: 1.4.0
+  nested:
+    description: A boolean to indicate the secret contains nested values.
+    type: boolean
+    default: false
+    version_added: 1.4.0
   version_id:
     description: Version of the secret(s).
     required: False
@@ -84,6 +89,10 @@ EXAMPLES = r"""
 
  - name: warn if access to the secret is denied
    debug: msg="{{ lookup('amazon.aws.aws_secret', 'secret-denied', on_denied='warn')}}"
+
+ - name: lookup secretsmanager secret in the current region using the nested feature
+   debug: msg="{{ lookup('amazon.aws.aws_secret', 'secrets.environments.production.password', nested=true) }}"
+   # The secret can be queried using the following syntax: `aws_secret_object_name.key1.key2.key3`. If an object is of the form `{"key1":{"key2":{"key3":1}}}` the query would return the value `1`.
 """
 
 RETURN = r"""
@@ -106,6 +115,7 @@ from ansible.module_utils._text import to_native
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
+import json
 
 def _boto3_conn(region, credentials):
     boto_profile = credentials.pop('aws_profile', None)
@@ -126,7 +136,7 @@ def _boto3_conn(region, credentials):
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, boto_profile=None, aws_profile=None,
             aws_secret_key=None, aws_access_key=None, aws_security_token=None, region=None,
-            bypath=False, join=False, version_stage=None, version_id=None, on_missing='error',
+            bypath=False, nested=False, join=False, version_stage=None, version_id=None, on_missing='error',
             on_denied='error'):
         '''
                    :arg terms: a list of lookups to run.
@@ -138,6 +148,7 @@ class LookupModule(LookupBase):
                    :kwarg decrypt: Set to True to get decrypted parameters
                    :kwarg region: AWS region in which to do the lookup
                    :kwarg bypath: Set to True to do a lookup of variables under a path
+                   :kwarg nested: Set to True to do a lookup of nested secrets
                    :kwarg join: Join two or more entries to form an extended secret
                    :kwarg version_stage: Stage of the secret version
                    :kwarg version_id: Version of the secret(s)
@@ -195,7 +206,7 @@ class LookupModule(LookupBase):
             for term in terms:
                 value = self.get_secret_value(term, client,
                                               version_stage=version_stage, version_id=version_id,
-                                              on_missing=missing, on_denied=denied)
+                                              on_missing=missing, on_denied=denied, nested=nested)
                 if value:
                     secrets.append(value)
             if join:
@@ -205,20 +216,37 @@ class LookupModule(LookupBase):
 
         return secrets
 
-    def get_secret_value(self, term, client, version_stage=None, version_id=None, on_missing=None, on_denied=None):
+    def get_secret_value(self, term, client, version_stage=None, version_id=None, on_missing=None, on_denied=None, nested=False):
         params = {}
         params['SecretId'] = term
         if version_id:
             params['VersionId'] = version_id
         if version_stage:
             params['VersionStage'] = version_stage
+        if nested:
+            if len(term.split('.')) < 2:
+                raise AnsibleError("Nested query must use the following syntax: `aws_secret_name.<key_name>.<key_name>")
+            secret_name = term.split('.')[0]
+            params['SecretId'] = secret_name
 
         try:
             response = client.get_secret_value(**params)
             if 'SecretBinary' in response:
                 return response['SecretBinary']
             if 'SecretString' in response:
-                return response['SecretString']
+                if nested:
+                    secrets = []
+                    query = term.split('.')[1:]
+                    secret_string = json.loads(response['SecretString'])
+                    ret_val = secret_string
+                    for key in query:
+                        if key in ret_val:
+                            ret_val = ret_val[key]
+                        else:
+                            raise AnsibleError("Successfully retrieved secret but there exists no key {} in the secret".format(key))
+                    return str(ret_val)
+                else:
+                    return response['SecretString']
         except is_boto3_error_code('ResourceNotFoundException'):
             if on_missing == 'error':
                 raise AnsibleError("Failed to find secret %s (ResourceNotFound)" % term)

--- a/tests/unit/plugins/lookup/test_aws_secret.py
+++ b/tests/unit/plugins/lookup/test_aws_secret.py
@@ -128,6 +128,38 @@ def test_on_denied_option(mocker, dummy_credentials):
     retval = lookup_loader.get('amazon.aws.aws_secret').run(["denied_secret"], None, **args)
     assert(retval == [])
 
+def test_nested_lookup_variable(mocker, dummy_credentials):
+    dateutil_tz = pytest.importorskip("dateutil.tz")
+    simple_variable_success_response = {
+        'Name': 'simple_variable',
+        'VersionId': 'cafe8168-e6ce-4e59-8830-5b143faf6c52',
+        'SecretString': '{"key1": {"key2": {"key3": 1 } } }',
+        'VersionStages': ['AWSCURRENT'],
+        'CreatedDate': datetime.datetime(2019, 4, 4, 11, 41, 0, 878000, tzinfo=dateutil_tz.tzlocal()),
+        'ResponseMetadata': {
+            'RequestId': '21099462-597c-490a-800f-8b7a41e5151c',
+            'HTTPStatusCode': 200,
+            'HTTPHeaders': {
+                'date': 'Thu, 04 Apr 2019 10:43:12 GMT',
+                'content-type': 'application/x-amz-json-1.1',
+                'content-length': '252',
+                'connection': 'keep-alive',
+                'x-amzn-requestid': '21099462-597c-490a-800f-8b7a41e5151c'
+            },
+            'RetryAttempts': 0
+        }
+    }
+    lookup = lookup_loader.get('amazon.aws.aws_secret')
+    boto3_double = mocker.MagicMock()
+    boto3_double.Session.return_value.client.return_value.get_secret_value.return_value = simple_variable_success_response
+    boto3_client_double = boto3_double.Session.return_value.client
+
+    mocker.patch.object(boto3, 'session', boto3_double)
+    dummy_credentials["nested"] = 'true'
+    retval = lookup.run(["simple_variable.key1.key2.key3"], None, **dummy_credentials)
+    assert(retval[0] == '1')
+    boto3_client_double.assert_called_with('secretsmanager', 'eu-west-1', aws_access_key_id='notakey',
+                                           aws_secret_access_key="notasecret", aws_session_token=None)
 
 def test_path_lookup_variable(mocker, dummy_credentials):
     lookup = aws_secret.LookupModule()

--- a/tests/unit/plugins/lookup/test_aws_secret.py
+++ b/tests/unit/plugins/lookup/test_aws_secret.py
@@ -128,6 +128,7 @@ def test_on_denied_option(mocker, dummy_credentials):
     retval = lookup_loader.get('amazon.aws.aws_secret').run(["denied_secret"], None, **args)
     assert(retval == [])
 
+
 def test_nested_lookup_variable(mocker, dummy_credentials):
     dateutil_tz = pytest.importorskip("dateutil.tz")
     simple_variable_success_response = {
@@ -160,6 +161,7 @@ def test_nested_lookup_variable(mocker, dummy_credentials):
     assert(retval[0] == '1')
     boto3_client_double.assert_called_with('secretsmanager', 'eu-west-1', aws_access_key_id='notakey',
                                            aws_secret_access_key="notasecret", aws_session_token=None)
+
 
 def test_path_lookup_variable(mocker, dummy_credentials):
     lookup = aws_secret.LookupModule()


### PR DESCRIPTION
##### SUMMARY

Adds `nested` functionality to the `aws_secrets` lookup. This allows a user to query a nested secret.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

aws_secrets

##### ADDITIONAL INFORMATION

This change adds the ability to query a secrets object that contains secrets that are nested logically. For example, assume there is a secrets object of the following shape: 

```
{
    "secrets": {
        "environments": {
            "production": {
                "database_url": "postgres://user:pass@ec2-11-11-111-11.us-east-1.compute.amazonaws.com:5432",
                "password": "db_password_1"
            },
            "staging": {
                "database_url": "postgres://user:pass@ec2-22-22-222-22.us-east-1.compute.amazonaws.com:5432",
                "password": "db_password_2"
            }
        }
    },
    "config": {
        ...
    }
}
```

If a user would like to query for the production database's password, they can do so using the `nested` lookup feature as follows: 
```
- name: Create RDS instance with aws_secret lookup for password param
  rds:
    command: create
    instance_name: app-db
    db_engine: MySQL
    size: 10
    instance_type: db.m1.small
    username: dbadmin
    password: "{{ lookup('aws_secret', 'secrets.environments.production.password', nested=True) }}"

```

The `nested` feature is not required and off by default. Furthermore, the codepath for the standard flows was not modified.