### PR TITLE
module.client integration test retries

### DIFF
--- a/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/library/example_module.py
+++ b/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/library/example_module.py
@@ -32,7 +32,7 @@ def main():
     filters = ansible_dict_to_boto3_filter_list({'name': 'amzn2-ami-hvm-2.0.202006*-x86_64-gp2'})
 
     try:
-        images = client.describe_images(ImageIds=[], Filters=filters, Owners=['amazon'], ExecutableUsers=[])
+        images = client.describe_images(aws_retry=True, ImageIds=[], Filters=filters, Owners=['amazon'], ExecutableUsers=[])
     except (BotoCoreError, ClientError) as e:
         module.fail_json_aws(e, msg='Fail JSON AWS')
 

--- a/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/credentials.yml
+++ b/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/credentials.yml
@@ -147,6 +147,19 @@
     - missing_token.error.code == 'AuthFailure'
     - '"message" in missing_token.error'
 
+##################################################################################
+# Run an additional authentication request to ensure that we're out of any
+# deny-lists caused by bad requests
+- name: 'Perform valid authentication to avoid deny-listing'
+  example_module:
+    aws_region: '{{ aws_region }}'
+    aws_access_key: '{{ aws_access_key }}'
+    aws_secret_key: '{{ aws_secret_key }}'
+    aws_security_token: '{{ security_token }}'
+  register: anti_denylist
+  until: anti_denylist is success
+  retries: 5
+  delay: 5
 
 ##################################################################################
 # Tests for bad parameters
@@ -188,6 +201,19 @@
     - bad_access.error.code == 'AuthFailure'
     - '"message" in bad_access.error'
 
+# Run an additional authentication request to ensure that we're out of any
+# deny-lists caused by bad requests
+- name: 'Perform valid authentication to avoid deny-listing'
+  example_module:
+    aws_region: '{{ aws_region }}'
+    aws_access_key: '{{ aws_access_key }}'
+    aws_secret_key: '{{ aws_secret_key }}'
+    aws_security_token: '{{ security_token }}'
+  register: anti_denylist
+  until: anti_denylist is success
+  retries: 5
+  delay: 5
+
 - name: 'Test with bad secret key'
   example_module:
     region: '{{ aws_region }}'
@@ -208,6 +234,19 @@
     - bad_secret.error.code == 'AuthFailure'
     - '"message" in bad_secret.error'
 
+# Run an additional authentication request to ensure that we're out of any
+# deny-lists caused by bad requests
+- name: 'Perform valid authentication to avoid deny-listing'
+  example_module:
+    aws_region: '{{ aws_region }}'
+    aws_access_key: '{{ aws_access_key }}'
+    aws_secret_key: '{{ aws_secret_key }}'
+    aws_security_token: '{{ security_token }}'
+  register: anti_denylist
+  until: anti_denylist is success
+  retries: 5
+  delay: 5
+
 - name: 'Test with bad security token'
   example_module:
     region: '{{ aws_region }}'
@@ -227,3 +266,16 @@
     - '"code" in bad_token.error'
     - bad_token.error.code == 'AuthFailure'
     - '"message" in bad_token.error'
+
+# Run an additional authentication request to ensure that we're out of any
+# deny-lists caused by bad requests
+- name: 'Perform valid authentication to avoid deny-listing'
+  example_module:
+    aws_region: '{{ aws_region }}'
+    aws_access_key: '{{ aws_access_key }}'
+    aws_secret_key: '{{ aws_secret_key }}'
+    aws_security_token: '{{ security_token }}'
+  register: anti_denylist
+  until: anti_denylist is success
+  retries: 5
+  delay: 5


### PR DESCRIPTION
##### SUMMARY

- Actually enable the automatic retries
- Run a successful auth after the bad auth tests to reduce the chance of, and mitigate, being temporarily deny-listed due to multiple failures

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

AnsibleAWSModule

##### ADDITIONAL INFORMATION
