### PR TITLE
Test Groups rebalance

### DIFF
--- a/tests/integration/targets/ec2_ami/aliases
+++ b/tests/integration/targets/ec2_ami/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-shippable/aws/group2
+shippable/aws/group3
 ec2_ami_info

--- a/tests/integration/targets/ec2_eni/aliases
+++ b/tests/integration/targets/ec2_eni/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-shippable/aws/group2
+shippable/aws/group1
 ec2_eni_info


### PR DESCRIPTION
##### SUMMARY

shippable/aws/group2 was up to almost 35 minutes

- Move ec2_eni (takes about 10 minutes) to group1 (took around 10 minutes)
- Move ec2_ami (takes about 5 minutes) to group3 (takes around 15 minutes)

This should balance the 4 groups out to around the 15-20 minute mark each.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

integration tests

##### ADDITIONAL INFORMATION
