### PR TITLE
Add AWSRetry to remaining _info modules

### DIFF
--- a/changelogs/fragments/208-info-retries.yaml
+++ b/changelogs/fragments/208-info-retries.yaml
@@ -1,0 +1,4 @@
+minor_changes:
+  - aws_caller_info - add AWSRetry decorator to automatically retry on common temporary failures (https://github.com/ansible-collections/amazon.aws/pull/208)
+  - ec2_snapshot_info - add AWSRetry decorator to automatically retry on common temporary failures (https://github.com/ansible-collections/amazon.aws/pull/208)
+  - ec2_vpc_dhcp_option_info - add AWSRetry decorator to automatically retry on common temporary failures (https://github.com/ansible-collections/amazon.aws/pull/208)


### PR DESCRIPTION
##### SUMMARY

Add automatic retries for common temporary AWS errors to remaining _info modules

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

aws_caller_info
ec2_snapshot_info
ec2_vpc_dhcp_option_info

##### ADDITIONAL INFORMATION