### PR TITLE
Add instructions for installing boto3

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,16 @@ You can also include it in a `requirements.yml` file and install it with `ansibl
 collections:
   - name: amazon.aws
 ```
+
+The python module dependencies are not installed by `ansible-galaxy`.  They can
+be manually installed using pip:
+
+    pip install requirements.txt
+
+or:
+
+    pip install boto boto3 botocore
+
 ## Using this collection
 
 


### PR DESCRIPTION
##### SUMMARY

#167 asked the valid question "Do I need to install the python deps?".  Since ansible-galaxy doesn't handle this it seems reasonable to explicitly list the step.

fixes: #167 

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

README.md

##### ADDITIONAL INFORMATION