### PR TITLE
Use 'fail_json_aws' in the tags_need_modify check

### DIFF
--- a/changelogs/fragments/211-fix-error-handling-during-tagging-failure.yaml
+++ b/changelogs/fragments/211-fix-error-handling-during-tagging-failure.yaml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_group - Fixes error handling during tagging failures (https://github.com/ansible-collections/amazon.aws/issues/210).

--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -899,7 +899,7 @@ def update_tags(client, module, group_id, current_tags, tags, purge_tags):
             try:
                 client.create_tags(Resources=[group_id], Tags=ansible_dict_to_boto3_tag_list(tags_need_modify))
             except (BotoCoreError, ClientError) as e:
-                module.fail_json(e, msg="Unable to add tags {0}".format(tags_need_modify))
+                module.fail_json_aws(e, msg="Unable to add tags {0}".format(tags_need_modify))
 
     return bool(tags_need_modify or tags_to_delete)
 


### PR DESCRIPTION
In reference to issue #210 ec2_group: error returned does not return AWS insufficient permissions error when adding tags

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This is the fix described in issue #210 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
amazon.aws/plugins/modules/ec2_group.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Change detailed in issue #210 
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
