### PR TITLE
Add AWSRetry to ec2_key

### DIFF
--- a/changelogs/fragments/213-ec2_key-retries.yml
+++ b/changelogs/fragments/213-ec2_key-retries.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_key - add AWSRetry decorator to automatically retry on common temporary failures (https://github.com/ansible-collections/amazon.aws/pull/213).


### PR DESCRIPTION
##### SUMMARY

AWS often throws rate limiting errors on busy accounts, add the AWSRetry decorator to retry common failure modes.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_key

##### ADDITIONAL INFORMATION