### PR TITLE
Rearrange security_token sources as AWS_SECURITY_TOKEN is deprecated (breaking change)

### DIFF
--- a/changelogs/fragments/221-security_token-order.yml
+++ b/changelogs/fragments/221-security_token-order.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- AWS modules - the ``AWS_SESSION_TOKEN`` environment variable now takes precendence over the (deprecated) ``AWS_SECURITY_TOKEN`` environment variable (https://github.com/ansible-collections/amazon.aws/pull/221).

--- a/plugins/doc_fragments/aws_credentials.py
+++ b/plugins/doc_fragments/aws_credentials.py
@@ -40,6 +40,6 @@ options:
     type: str
     env:
       - name: EC2_SECURITY_TOKEN
-      - name: AWS_SESSION_TOKEN
       - name: AWS_SECURITY_TOKEN
+      - name: AWS_SESSION_TOKEN
 '''

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -310,10 +310,10 @@ def get_aws_connection_info(module, boto3=False):
             secret_key = None
 
     if not security_token:
-        if os.environ.get('AWS_SECURITY_TOKEN'):
-            security_token = os.environ['AWS_SECURITY_TOKEN']
-        elif os.environ.get('AWS_SESSION_TOKEN'):
+        if os.environ.get('AWS_SESSION_TOKEN'):
             security_token = os.environ['AWS_SESSION_TOKEN']
+        elif os.environ.get('AWS_SECURITY_TOKEN'):
+            security_token = os.environ['AWS_SECURITY_TOKEN']
         elif os.environ.get('EC2_SECURITY_TOKEN'):
             security_token = os.environ['EC2_SECURITY_TOKEN']
         elif HAS_BOTO and boto.config.get('Credentials', 'aws_security_token'):

--- a/tests/integration/targets/module_utils_ec2/roles/ec2_connect/tasks/credentials.yml
+++ b/tests/integration/targets/module_utils_ec2/roles/ec2_connect/tasks/credentials.yml
@@ -54,6 +54,20 @@
     that:
     - credential_result is successful
 
+- name: 'Test basic operation using simple credentials (aws-environment)'
+  example_module:
+  environment:
+    AWS_REGION: '{{ aws_region }}'
+    AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
+    AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
+    AWS_SECURITY_TOKEN: 'junk-example'
+    AWS_SESSION_TOKEN: '{{ security_token }}'
+  register: credential_result
+
+- assert:
+    that:
+    - credential_result is successful
+
 - name: 'Test basic operation using simple credentials (aws2-environment)'
   example_module:
   environment:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Rearranges security_token sources as AWS_SECURITY_TOKEN is deprecated.

As mentioned in [boto documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html) (and a bunch of other SDKs) `AWS_SECURITY_TOKEN` environment variable can be considered deprecated, it is only supported for backward-compatibility purposes. Only `AWS_SESSION_TOKEN` is mentioned as a session token environment variable in [AWS documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html#envvars-list).
So it is more logical to check `AWS_SESSION_TOKEN` before `AWS_SECURITY_TOKEN`.  Empty `AWS_SECURITY_TOKEN` could cause errors even if `AWS_SESSION_TOKEN` is defined. 


Some tools already removed `AWS_SECURITY_TOKEN` support. For example, there is an issue with [saml2aws](https://github.com/Versent/saml2aws/issues/586).

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins.module_utils.ec2

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The problem is fully described in https://github.com/Versent/saml2aws/issues/586. The issue is caused by an empty `AWS_SECURITY_TOKEN`. Despite `AWS_SESSION_TOKEN` is defined, ansible uses deprecated `AWS_SECURITY_TOKEN` in the first place.
