### PR TITLE
Add missing return values to ec2_vpc_net documentation

### DIFF
--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -128,7 +128,7 @@ vpc:
         "cidr_block_association_set": [
             {
                 "association_id": "vpc-cidr-assoc-97aeeefd",
-                "cidr_block": "20.0.0.0/24",
+                "cidr_block": "10.0.0.0/24",
                 "cidr_block_state": {
                     "state": "associated"
                 }
@@ -143,12 +143,12 @@ vpc:
       description: the id of the DHCP options associated with this VPC
       returned: always
       type: str
-      sample: dopt-0fb8bd6b
+      sample: dopt-12345678
     id:
       description: VPC resource id
       returned: always
       type: str
-      sample: vpc-c2e00da5
+      sample: vpc-12345678
     instance_tenancy:
       description: indicates whether VPC uses default or dedicated tenancy
       returned: always
@@ -188,6 +188,11 @@ vpc:
           returned: always
           type: str
           sample: pk_vpc4
+    owner_id:
+      description: The AWS account which owns the VPC
+      returned: always
+      type: str
+      sample: 123456789012
 '''
 
 from time import sleep

--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -189,7 +189,7 @@ vpc:
           type: str
           sample: pk_vpc4
     owner_id:
-      description: The AWS account which owns the VPC
+      description: The AWS account which owns the VPC.
       returned: always
       type: str
       sample: 123456789012

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -146,6 +146,16 @@ vpcs:
                             description: The CIDR block association state.
                             returned: always
                             type: str
+        owner_id:
+            description: The AWS account which owns the VPC
+            returned: always
+            type: str
+            sample: 123456789012
+        dhcp_options_id:
+            description: the id of the DHCP options associated with this VPC
+            returned: always
+            type: str
+            sample: dopt-12345678
 '''
 
 try:

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -147,12 +147,12 @@ vpcs:
                             returned: always
                             type: str
         owner_id:
-            description: The AWS account which owns the VPC
+            description: The AWS account which owns the VPC.
             returned: always
             type: str
             sample: 123456789012
         dhcp_options_id:
-            description: the id of the DHCP options associated with this VPC
+            description: The ID of the DHCP options associated with this VPC.
             returned: always
             type: str
             sample: dopt-12345678


### PR DESCRIPTION
##### SUMMARY

Ensure  owner_id and dhcp_options_id return values are documented for ec2_vpc_net and ec2_vpc_net_info.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

ec2_vpc_net
ec2_vpc_net_info

##### ADDITIONAL INFORMATION

examples from integration tests:
```
TASK [ec2_vpc_net : create a VPC] **********************************************
changed: [testhost] => {
    "changed": true,
    "debugging": {
        "expected_cidrs": [
            "10.47.0.0/24"
        ],
        "to_add": [],
        "to_remove": []
    },
    "invocation": {
        "module_args": {
            "aws_access_key": "ASIA6CCDWXDOOHLZMEU4",
            "aws_ca_bundle": null,
            "aws_config": null,
            "aws_secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "cidr_block": [
                "10.47.0.0/24"
            ],
            "debug_botocore_endpoint_logs": true,
            "dhcp_opts_id": null,
            "dns_hostnames": true,
            "dns_support": true,
            "ec2_url": null,
            "ipv6_cidr": true,
            "multi_ok": false,
            "name": "ansible-test-mchappel-33038011",
            "profile": null,
            "purge_cidrs": false,
            "region": "us-east-1",
            "security_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "state": "present",
            "tags": null,
            "tenancy": "default",
            "validate_certs": true
        }
    },
    "resource_actions": [
        "ec2:DescribeTags",
        "ec2:AssociateVpcCidrBlock",
        "ec2:ModifyVpcAttribute",
        "ec2:DescribeVpcs",
        "ec2:DescribeVpcAttribute",
        "ec2:CreateVpc",
        "ec2:CreateTags",
        "ec2:DescribeVpcClassicLink"
    ],
    "vpc": {
        "cidr_block": "10.47.0.0/24",
        "cidr_block_association_set": [
            {
                "association_id": "vpc-cidr-assoc-04fa3f768a53984c5",
                "cidr_block": "10.47.0.0/24",
                "cidr_block_state": {
                    "state": "associated"
                }
            }
        ],
        "classic_link_enabled": false,
        "dhcp_options_id": "dopt-17917671",
        "id": "vpc-09965e9cdc68edc88",
        "instance_tenancy": "default",
        "ipv6_cidr_block_association_set": [
            {
                "association_id": "vpc-cidr-assoc-0d4b4eeac7506bb93",
                "ipv6_cidr_block": "2600:1f18:4615:f600::/56",
                "ipv6_cidr_block_state": {
                    "state": "associated"
                },
                "ipv6_pool": "Amazon",
                "network_border_group": "us-east-1"
            }
        ],
        "is_default": false,
        "owner_id": "966509639900",
        "state": "available",
        "tags": {
            "Name": "ansible-test-mchappel-33038011"
        }
    }
}

TASK [ec2_vpc_net : ec2_vpc_net_info] ******************************************
ok: [testhost] => {
    "changed": false,
    "invocation": {
        "module_args": {
            "aws_access_key": "ASIA6CCDWXDOOHLZMEU4",
            "aws_ca_bundle": null,
            "aws_config": null,
            "aws_secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "debug_botocore_endpoint_logs": true,
            "ec2_url": null,
            "filters": {
                "tag:Name": "ansible-test-mchappel-33038011"
            },
            "profile": null,
            "region": "us-east-1",
            "security_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "validate_certs": true,
            "vpc_ids": []
        }
    },
    "resource_actions": [
        "ec2:DescribeVpcs",
        "ec2:DescribeVpcAttribute",
        "ec2:DescribeVpcClassicLinkDnsSupport",
        "ec2:DescribeVpcClassicLink"
    ],
    "vpcs": [
        {
            "cidr_block": "10.47.0.0/24",
            "cidr_block_association_set": [
                {
                    "association_id": "vpc-cidr-assoc-04fa3f768a53984c5",
                    "cidr_block": "10.47.0.0/24",
                    "cidr_block_state": {
                        "state": "associated"
                    }
                }
            ],
            "classic_link_dns_supported": false,
            "classic_link_enabled": false,
            "dhcp_options_id": "dopt-17917671",
            "enable_dns_hostnames": true,
            "enable_dns_support": true,
            "id": "vpc-09965e9cdc68edc88",
            "instance_tenancy": "default",
            "ipv6_cidr_block_association_set": [
                {
                    "association_id": "vpc-cidr-assoc-0d4b4eeac7506bb93",
                    "ipv6_cidr_block": "2600:1f18:4615:f600::/56",
                    "ipv6_cidr_block_state": {
                        "state": "associated"
                    },
                    "ipv6_pool": "Amazon",
                    "network_border_group": "us-east-1"
                }
            ],
            "is_default": false,
            "owner_id": "966509639900",
            "state": "available",
            "tags": {
                "Name": "ansible-test-mchappel-33038011"
            },
            "vpc_id": "vpc-09965e9cdc68edc88"
        }
    ]
}

```