### PR TITLE
remove instance-state-name inverse filters in favor of standard value…

### DIFF
--- a/changelogs/fragments/237_replace_inverse_ec2_aws_filter.yaml
+++ b/changelogs/fragments/237_replace_inverse_ec2_aws_filter.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- aws_ec2 module - Replace inverse aws instance-state-name filters !terminated, !shutting-down in favor of postive filters pending, running, stopping, stopped. Issue 235. (https://github.com/ansible-collections/amazon.aws/pull/237)

--- a/plugins/modules/ec2.py
+++ b/plugins/modules/ec2.py
@@ -1416,7 +1416,7 @@ def startstop_instances(module, ec2, instance_ids, state, instance_tags):
         for key, value in instance_tags.items():
             filters["tag:" + key] = value
 
-    filters['instance-state-name'] = ["!terminated", "!shutting-down"]
+    filters['instance-state-name'] = ["pending", "running", "stopping", "stopped"]
 
     if module.params.get('id'):
         filters['client-token'] = module.params['id']

--- a/tests/integration/targets/ec2/tasks/main.yml
+++ b/tests/integration/targets/ec2/tasks/main.yml
@@ -136,6 +136,18 @@
           - (result.instances|length) == 1
           - "result.instances[0].state.name == 'running'"
 
+    - name: test second instance is stopped
+      ec2:
+        instance_ids: "{{ test_instance_2.instance_ids }}"
+        state: stopped
+        wait: yes
+      register: result
+
+    - name: assert second instance is stopped
+      assert:
+        that:
+          - "result.instances[0].state == 'stopped'"
+
     # ========================================================
 
   always:


### PR DESCRIPTION
remove instance-state-name inverse filters in favor of standard value filters on other 4 accepted options to fix bad aws return

##### SUMMARY

This fixes: https://github.com/ansible-collections/amazon.aws/issues/235

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

amazon aws ec2.py

##### ADDITIONAL INFORMATION
Instead of using inverse filters (which to my knowledge are not allowed by any or all version of aws cli and can cause issues as noted in https://github.com/ansible-collections/amazon.aws/issues/235) use the other 4 allowed values as normal outlined in https://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html for instance-state-name

