### PR TITLE
ec2_vol: returns an up to date tag dict of the volume

### DIFF
--- a/changelogs/fragments/241_ec2_vol-returns-an-up-to-date-tag-dict-of-the-volume.yaml
+++ b/changelogs/fragments/241_ec2_vol-returns-an-up-to-date-tag-dict-of-the-volume.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- ec2_vol - a creation or update now returns a structure with an up to date list of tags (https://github.com/ansible-collections/amazon.aws/pull/241).

--- a/tests/integration/targets/ec2_vol/tasks/tests.yml
+++ b/tests/integration/targets/ec2_vol/tasks/tests.yml
@@ -75,6 +75,7 @@
           - "'instance_id' in volume1.volume.attachment_set"
           - not volume1.volume.attachment_set.instance_id
           - not volume1.volume.encrypted
+          - volume1.volume.tags.ResourcePrefix == "{{ resource_prefix }}"
 
     # no idempotency check needed here
 
@@ -103,6 +104,7 @@
           - volume2.volume.iops == 101
           - volume2.volume.size == 4
           - volume2.volume.encrypted
+          - volume2.volume.tags.ResourcePrefix == "{{ resource_prefix }}"
 
     - name: create another volume (override module defaults) (idempotent)
       ec2_vol:


### PR DESCRIPTION
This patch ensures a `ec2_vol` calls will return the up to date
tag structure.
Previously, the module was returning the origin tag dictionary.