### PR TITLE
Update plugin choices to FQCN

### DIFF
--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -28,7 +28,7 @@ DOCUMENTATION = '''
         plugin:
             description: Token that ensures this is a source file for the plugin.
             required: True
-            choices: ['aws_ec2']
+            choices: ['amazon.aws.aws_ec2']
         iam_role_arn:
           description: The ARN of the IAM role to assume to perform the inventory lookup. You should still provide AWS
               credentials with enough privilege to perform the AssumeRole action.


### PR DESCRIPTION
##### SUMMARY
I wrote a more detailed blurb in https://github.com/ansible-collections/azure/pull/398

A change in Ansible core made inventory options parsing more strict https://github.com/ansible/ansible/pull/73162, this means that this plugin will always error with Ansible `devel` until this change is made.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/aws_ec2.py

##### ADDITIONAL INFORMATION
Inventory file:

```yaml
plugin: amazon.aws.aws_ec2
```

Error before this change:

```
[WARNING]:  * Failed to parse /home/alancoding/repos/ansible/aws_ec2.yml with auto plugin: Invalid value
"amazon.aws.aws_ec2" for configuration option "plugin_type: inventory plugin:
ansible_collections.amazon.aws.plugins.inventory.aws_ec2 setting: plugin ", valid values are: ['aws_ec2']
  File "/home/alancoding/repos/ansible/lib/ansible/inventory/manager.py", line 290, in parse_source
    plugin.parse(self._inventory, self._loader, source, cache=cache)
  File "/home/alancoding/repos/ansible/lib/ansible/plugins/inventory/auto.py", line 58, in parse
    plugin.parse(inventory, loader, path, cache=cache)
  File "/home/alancoding/.ansible/collections/ansible_collections/amazon/aws/plugins/inventory/aws_ec2.py", line 613, in parse
    self._read_config_data(path)
  File "/home/alancoding/repos/ansible/lib/ansible/plugins/inventory/__init__.py", line 234, in _read_config_data
    self.set_options(direct=config, var_options=self._vars)
  File "/home/alancoding/repos/ansible/lib/ansible/plugins/__init__.py", line 75, in set_options
    self._options = C.config.get_plugin_options(get_plugin_class(self), self._load_name, keys=task_keys, variables=var_options, direct=direct)
  File "/home/alancoding/repos/ansible/lib/ansible/config/manager.py", line 362, in get_plugin_options
    options[option] = self.get_config_value(option, plugin_type=plugin_type, plugin_name=name, keys=keys, variables=variables, direct=direct)
  File "/home/alancoding/repos/ansible/lib/ansible/config/manager.py", line 435, in get_config_value
    value, _drop = self.get_config_value_and_origin(config, cfile=cfile, plugin_type=plugin_type, plugin_name=plugin_name,
  File "/home/alancoding/repos/ansible/lib/ansible/config/manager.py", line 547, in get_config_value_and_origin
    raise AnsibleOptionsError('Invalid value "%s" for configuration option "%s", valid values are: %s' %
```

If you apply this change, you get correct error that

> Insufficient boto credentials found.

