### PR TITLE
Fix typo in cloudformation_info_module documentation

### DIFF
--- a/docs/amazon.aws.cloudformation_info_module.rst
+++ b/docs/amazon.aws.cloudformation_info_module.rst
@@ -532,7 +532,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                       <span style="color: purple">list</span>
                     </div>
                 </td>
-                <td>only if all_facts or stack_resourses is true and the stack exists</td>
+                <td>only if all_facts or stack_resources is true and the stack exists</td>
                 <td>
                             <div>Describes stack resources for the stack</div>
                     <br/>
@@ -547,7 +547,7 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                       <span style="color: purple">dictionary</span>
                     </div>
                 </td>
-                <td>only if all_facts or stack_resourses is true and the stack exists</td>
+                <td>only if all_facts or stack_resources is true and the stack exists</td>
                 <td>
                             <div>Dictionary of stack resources keyed by the value of each resource &#x27;LogicalResourceId&#x27; parameter and corresponding value of each resource &#x27;PhysicalResourceId&#x27; parameter</div>
                     <br/>


### PR DESCRIPTION
##### SUMMARY
On the returned column for the "stack_resource_list" and the "stack_resources" rows, the parameter "stack_resources" was written as "stack_resourses"


##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
amazon.aws.cloudformation_info

