### PR TITLE
Fix typo in cloudformation_info.py module docs

### DIFF
--- a/plugins/modules/cloudformation_info.py
+++ b/plugins/modules/cloudformation_info.py
@@ -147,12 +147,12 @@ stack_template:
     type: dict
 stack_resource_list:
     description: Describes stack resources for the stack
-    returned: only if all_facts or stack_resourses is true and the stack exists
+    returned: only if all_facts or stack_resources is true and the stack exists
     type: list
 stack_resources:
     description: Dictionary of stack resources keyed by the value of each resource 'LogicalResourceId' parameter and corresponding value of each
                  resource 'PhysicalResourceId' parameter
-    returned: only if all_facts or stack_resourses is true and the stack exists
+    returned: only if all_facts or stack_resources is true and the stack exists
     type: dict
     sample:
       AutoScalingGroup: "dev-someapp-AutoscalingGroup-1SKEXXBCAN0S7"


### PR DESCRIPTION
##### SUMMARY
On the returned column for the "stack_resource_list" and the "stack_resources" rows, the parameter "stack_resources" was written as "stack_resourses"

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
cloudformation_info.py
