### PR TITLE
Don't require specific boto3 revision in elbv2 mod_utils

### DIFF
--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -74,9 +74,6 @@ class ElasticLoadBalancerV2(object):
         else:
             self.elb_attributes = None
 
-        if not self.module.boto3_at_least('1.16.57'):
-            self.module.fail_json(msg="elbv2 requires boto3 >= 1.16.57")
-
     def wait_for_status(self, elb_arn):
         """
         Wait for load balancer to reach 'active' status


### PR DESCRIPTION
##### SUMMARY

For features which require a very recent boto3, the module implementing
the feature should check for that when it is utilized.

Fixes: #256

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/elbv2.py
