### PR TITLE
Update changelog from PR 188

### DIFF
--- a/changelogs/fragments/188-httprequestmethodconfig-keyerror.yaml
+++ b/changelogs/fragments/188-httprequestmethodconfig-keyerror.yaml
@@ -1,5 +1,4 @@
 ---
-bugfixes:
+minor_changes:
   - module_utils/elbv2 - add logic to compare_rules to suit Values list nested within dicts unique to each field type. 
     Fixes issue (https://github.com/ansible-collections/amazon.aws/issues/187)
-  - module_utils/elbv2 - Requires 1.16.57 as minimum boto3 version.


### PR DESCRIPTION
##### SUMMARY
This was a minor change rather than a bugfix
In #257 we removed the boto3 version restriction but missed the changelog
 "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
changelogs/fragments/188-httprequestmethodconfig-keyerror.yaml

