### PR TITLE
Allow fully qualified collection plugin name for aws_ec2 inventory

### DIFF
--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -28,7 +28,7 @@ DOCUMENTATION = '''
         plugin:
             description: Token that ensures this is a source file for the plugin.
             required: True
-            choices: ['aws_ec2']
+            choices: ['aws_ec2', 'amazon.aws.aws_ec2']
         iam_role_arn:
           description: The ARN of the IAM role to assume to perform the inventory lookup. You should still provide AWS
               credentials with enough privilege to perform the AssumeRole action.


### PR DESCRIPTION
##### SUMMARY
Since ansible/ansible #73162 this is being validated, and we're not
allowing the FQCN path to the plugin. Add that to choices.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/aws_ec2.py
