### PR TITLE
Add basic support for Amazon MQ

### DIFF
--- a/plugins/modules/mq_broker.py
+++ b/plugins/modules/mq_broker.py
@@ -1,0 +1,119 @@
+#!/usr/bin/python
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: mq_broker
+version_added: 0.9.0
+short_description: MQ broker configurations except user/config changes
+description:
+    - Get details about a broker
+    - reboot a broker
+author: FCO (frank-christian.otto@web.de)
+requirements:
+  - boto3
+  - botocore
+options:
+  broker_id:
+    description:
+      - "The ID of the MQ broker to work on"
+    type: str
+  operation:
+    description:
+      - "Operation to perform: info, reboot"
+    type: str
+    default: info
+
+extends_documentation_fragment:
+- amazon.aws.aws
+
+'''
+
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+#       or check tests/integration/targets/mq/tasks/test_mq_broker.yml
+- name: get current broker settings - explicitly requesting info operation
+  amazon.aws.mq_broker:
+    broker_id: "aws-mq-broker-id"
+    operation: "info"
+  register: broker_info
+- name: get current broker settings - relying on default operation
+  amazon.aws.mq_broker:
+    broker_id: "aws-mq-broker-id"
+  register: broker_info 
+- name: request broker reboot - does not wait for reboot to finish
+  amazon.aws.mq_broker:
+    broker_id: "aws-mq-broker-id"
+    operation: "reboot"
+'''
+
+RETURN = '''
+broker:
+    description: API response of describe_broker() after operation has been performed
+'''
+
+try:
+    import botocore
+except ImportError:
+    pass  # Handled by AnsibleAWSModule
+
+from ansible.module_utils.core import AnsibleAWSModule
+
+
+def get_broker_info(conn, module):
+    try:
+        return conn.describe_broker(BrokerId=module.params['broker_id'])
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't get broker details.")
+
+
+def reboot_broker(conn, module, broker_id):
+    try:
+        return conn.reboot_broker(
+            BrokerId=broker_id
+        )
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't reboot broker.")
+
+
+def main():
+    argument_spec = dict(
+        broker_id=dict(required=True, type='str'),
+        operation=dict(required=False, type='str', default='info'),
+    )
+
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    connection = module.client('mq')
+
+    if module.params['operation'] == 'info':
+        try:
+            result = get_broker_info(connection, module)
+        except botocore.exceptions.ClientError as e:
+            module.fail_json_aws(e)
+        #
+        module.exit_json(broker=result)
+    elif module.params['operation'] == 'reboot':
+        try:
+            changed = True
+            if not module.check_mode:
+                reboot_broker(connection, module, module.params['broker_id'])
+            #
+            result = get_broker_info(connection, module)
+        except botocore.exceptions.ClientError as e:
+            module.fail_json_aws(e)
+        module.exit_json(broker=result, changed=changed)
+    else:
+        module.fail_json_aws(RuntimeError,
+                             msg="Invalid broker operation requested ({}). Valid are: 'info', 'reboot'".format(module.params['operation']))
+
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mq_broker_config.py
+++ b/plugins/modules/mq_broker_config.py
@@ -1,0 +1,225 @@
+#!/usr/bin/python
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: mq_broker_config
+version_added: 0.9.0
+short_description: Update broker configuration
+description:
+    - Update configuration for an MQ broker
+    - Optionally allows broker reboot to make changes effective immediately
+author: FCO (frank-christian.otto@web.de)
+requirements:
+  - boto3
+  - botocore
+options:
+  broker_id:
+    description:
+      - "The ID of the MQ broker to work on"
+    type: str
+  config_xml:
+    description:
+      - "The maximum number of results to return"
+    type: str
+  config_description:
+    description:
+      - "Description to set on new configuration revision"
+    type: str
+  reboot:
+    description:
+      - "Reboot broker after new config has been applied"
+    type: bool
+    default: false
+
+extends_documentation_fragment:
+- amazon.aws.aws
+
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+#       or check tests/integration/targets/mq/tasks/test_mq_broker_config.yml
+- name: send new XML config to broker
+  amazon.aws.mq_broker_config:
+    broker_id: "aws-mq-broker-id"
+    config_xml: "{{ lookup('file', 'activemq.xml' )}}"
+- name: reboot broker to make new config active
+  amazon.aws.mq_broker:
+    broker_id: "aws-mq-broker-id"
+    operation: "reboot"
+'''
+
+RETURN = '''
+broker:
+    description: API response of describe_broker() after changes have been applied
+    type: complex
+configuration: 
+    description: details about new configuration object
+    returned: I(changed=true)
+    type: complex
+    contains:
+        id: 
+            description: configuration ID of broker configuration
+            type: str
+            example: c-386541b8-3139-42c2-9c2c-a4c267c1714f
+        revision: 
+            description: revision of the configuration that will be active after next reboot
+            type: int
+            example: 4
+'''
+
+import base64
+import re
+import sys
+IS_PYTHON3 = True
+if sys.version_info.major < 3:
+    IS_PYTHON3 = False
+
+try:
+    import botocore
+except ImportError:
+    pass  # Handled by AnsibleAWSModule
+
+from ansible.module_utils.core import AnsibleAWSModule
+
+DEFAULTS = {
+    'reboot': False
+}
+FULL_DEBUG = False
+
+# we a simple comparision here: strip down spaces and compare the rest
+# TODO: use same XML normalizer on new as used by AWS before comparing strings
+def is_same_config(old, new):
+    old_stripped = re.sub('\s+',' ', old, flags=re.S).rstrip()
+    new_stripped = re.sub('\s+',' ', new, flags=re.S).rstrip()
+    return old_stripped == new_stripped
+
+def get_broker_info(conn, module):
+    try:
+        return conn.describe_broker(BrokerId=module.params['broker_id'])
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't get broker details.")
+
+
+def get_current_configuration(conn, module, cfg_id, cfg_revision):
+    try:
+        return conn.describe_configuration_revision(
+            ConfigurationId=cfg_id,
+            ConfigurationRevision=str(cfg_revision)
+        )
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't get configuration revision.")
+
+
+def create_and_assign_config(conn, module, broker_id, cfg_id, cfg_xml_encoded):
+    kwargs = {
+        'ConfigurationId': cfg_id,
+        'Data': cfg_xml_encoded
+    }
+    if 'config_description' in module.params and module.params['config_description']:
+        kwargs['Description'] = module.params['config_description']
+    else:
+        kwargs['Description'] = 'Updated through amazon.aws.mq_broker_config ansible module'
+    #
+    try:
+        c_response = conn.update_configuration(**kwargs)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't create new configuration revision.")
+    #
+    new_config_revision = c_response['LatestRevision']['Revision']
+    try:
+        b_response = conn.update_broker(BrokerId=broker_id, Configuration={
+                      'Id': cfg_id,
+                      'Revision': new_config_revision
+                  })
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't assign new configuration revision to broker.")
+    #
+    return (c_response, b_response)
+
+def reboot_broker(conn, module, broker_id):
+    try:
+        return conn.reboot_broker(
+            BrokerId=broker_id
+        )
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't reboot broker.")
+
+
+def ensure_config(conn, module):
+    broker_id = module.params['broker_id']
+    broker_info = get_broker_info(conn, module)
+    changed = False
+    current_cfg = broker_info['Configurations']['Current']
+    if 'Pending' in broker_info['Configurations']:
+        current_cfg = broker_info['Configurations']['Pending']
+    current_cfg_encoded = get_current_configuration(conn, module,
+                                            current_cfg['Id'], current_cfg['Revision'])['Data']
+    if IS_PYTHON3:
+        current_cfg_decoded = base64.b64decode(current_cfg_encoded.encode()).decode()
+    else:
+        current_cfg_decoded = base64.b64decode(current_cfg_encoded)
+    if is_same_config(current_cfg_decoded, module.params['config_xml']):
+        return {
+            'changed': changed,
+            'broker': broker_info
+        }
+    else:
+        (c_response, b_response) = (None, None)
+        if not module.check_mode:
+            if IS_PYTHON3:
+                new_cfg_encoded = base64.b64encode(module.params['config_xml'].encode()).decode()
+            else:
+                new_cfg_encoded = base64.b64encode(module.params['config_xml'])
+            (c_response, b_response) = create_and_assign_config(conn, module, broker_id,
+                                     current_cfg['Id'], new_cfg_encoded)
+        #
+        changed = True
+    #
+    if changed and module.params['reboot'] and not module.check_mode:
+        reboot_broker(conn, module, broker_id)
+    #
+    broker_info = get_broker_info(conn, module)
+    return_struct = {
+        'changed': changed,
+        'broker': broker_info,
+        'configuration': {
+            'id': c_response['Id'],
+            'revision': c_response['LatestRevision']['Revision']
+        }
+    }
+    if FULL_DEBUG:
+        return_struct['old_config_xml'] = base64.b64decode(current_cfg_encoded)
+        return_struct['new_config_xml'] = module.params['config_xml']
+        return_struct['old_config_revision'] = current_cfg['Revision']
+    return return_struct
+
+
+def main():
+    argument_spec = dict(
+        broker_id=dict(required=True, type='str'),
+        config_xml=dict(required=True, type='str'),
+        config_description=dict(required=False, type='str'),
+        reboot=dict(required=False, type='bool', default=DEFAULTS['reboot']),
+    )
+
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    connection = module.client('mq')
+
+    try:
+        result = ensure_config(connection, module)
+    except botocore.exceptions.ClientError as e:
+        module.fail_json_aws(e)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mq_user.py
+++ b/plugins/modules/mq_user.py
@@ -1,0 +1,276 @@
+#!/usr/bin/python
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: mq_user
+version_added: 0.9.0
+short_description: Manage users in existing Amazon MQ broker
+description:
+    - Manage Amazon MQ users
+author:
+- FCO (frank-christian.otto@web.de)
+requirements: [ boto3 ]
+options:
+  broker_id:
+    description:
+      - "The ID of the MQ broker to work on"
+    type: str
+  username:
+    description:
+      - "The name of the user to create/update/delete"
+    type: str
+  state:
+    description:
+      - "Create/Update vs Delete of user."
+    default: present
+    choices: [ 'present', 'absent' ]
+  console_access:
+    description:
+      - "True: user can use MQ Console."
+      - "Will not be changed on update unless explicitly defined"
+    type: bool
+    default: false
+  groups:
+    description:
+      - "Set group memberships for user"
+      - "Will not be changed on update unless explicitly defined"
+    type: list
+    default: empty list
+  password:
+    description:
+      - "Set password for user"
+      - "on create: if not defined a random password will be set"
+      - "on update: will be ignored unless 'allow_pw_update' is set to true"
+    type: str
+  allow_pw_update:
+    description:
+      - "Only used of 'password' parameter set for existing user"
+    default: false
+    type: bool
+extends_documentation_fragment:
+- amazon.aws.aws
+
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+# check tests/integration/targets/mq/tasks/test_mq_user.yml for more examples
+- name: create/update user - set provided password if user doesn't exist, yet
+  amazon.aws.mq_user:
+    state: present
+    broker_id: "aws-mq-broker-id"
+    username: "sample_user1"
+    console_access: false
+    groups: [ "g1", "g2" ]
+    password: "plain-text-password"
+- name: allow console access and update group list - relying on default state
+  amazon.aws.mq_user:
+    broker_id: "aws-mq-broker-id"
+    username: "sample_user1"
+    console_access: true
+    groups: [ "g1", "g2", "g3" ]
+- name: remove user
+  amazon.aws.mq_user:
+    state: absent
+    broker_id: "aws-mq-broker-id"
+    username: "other_user"
+  - name: reboot broker to apply pending user changes
+  amazon.aws.mq_broker:
+    broker_id: "aws-mq-broker-id"
+    operation: "reboot"
+'''
+
+RETURN = '''
+user:
+    description: API response from create or update operation.
+    type: complex
+'''
+
+# python3.6 or higher
+#import secrets
+# python2.7
+import random
+import hashlib
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+#from ansible.module_utils._text import to_text
+#from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible.module_utils.core import AnsibleAWSModule
+
+CREATE_DEFAULTS = {
+    'console_access': False,
+    'groups': [],
+
+}
+
+def _group_change_required(user_response, requested_groups):
+    current_groups = []
+    if 'Groups' in user_response:
+        current_groups = user_response['Groups']
+    elif 'Pending' in user_response:
+        # to support automatic testing without broker reboot
+        current_groups = user_response['Pending']['Groups']
+    if len(current_groups) != len(requested_groups):
+        return True
+    if len(current_groups) != len(set(current_groups) & set(requested_groups)):
+        return True
+    #
+    return False
+
+def _console_access_change_required(user_response, requested_boolean):
+    current_boolean = CREATE_DEFAULTS['console_access']
+    if 'ConsoleAccess' in user_response:
+        current_boolean = user_response['ConsoleAccess']
+    elif 'Pending' in user_response:
+        # to support automatic testing without broker reboot
+        current_boolean = user_response['Pending']['ConsoleAccess']
+    #
+    return current_boolean != requested_boolean
+
+
+def generate_password():
+    # python3.6 or higher
+    #return secrets.token_hex(20)
+    # python2.7:
+    in_str = ''
+    for i in range(0,19):
+        in_str += str(random.randint(10000, 99999))
+    #
+    h = hashlib.md5()
+    h.update(in_str)
+    return h.hexdigest()
+
+# returns API response object
+def _create_user(conn, module):
+    kwargs = { 'BrokerId': module.params['broker_id'],
+               'Username': module.params['username'] }
+    if 'groups' in module.params and module.params['groups'] is not None:
+        kwargs['Groups'] = module.params['groups']
+    else:
+        kwargs['Groups'] = CREATE_DEFAULTS['groups']
+    if 'password' in module.params and module.params['password']:
+        kwargs['Password'] = module.params['password']
+    else:
+        kwargs['Password'] = generate_password()
+    if 'console_access' in module.params  and module.params['console_access'] is not None:
+        kwargs['ConsoleAccess'] = module.params['console_access']
+    else:
+        kwargs['ConsoleAccess'] = CREATE_DEFAULTS['console_access']
+    try:
+        response = conn.create_user(**kwargs)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't create user")
+    return response
+
+# returns API response object
+def _update_user(conn, module, kwargs):
+    try:
+        response = conn.update_user(**kwargs)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't update user")
+    return response
+
+def get_matching_user(conn, module, broker_id, username):
+    try:
+        return conn.describe_user(BrokerId=broker_id, Username=username)
+    except botocore.exceptions.ClientError as e:
+        if e.response['Error']['Code'] == 'NotFoundException':
+            return None
+        else:
+            module.fail_json_aws(e, msg="Couldn't get user details")
+    except botocore.exceptions.BotoCoreError as e:
+        module.fail_json_aws(e, msg="Couldn't get user details")
+
+def ensure_user_present(conn, module):
+    user = get_matching_user(conn, module, module.params['broker_id'], module.params['username'])
+    changed = False
+
+    if user is None:
+        if not module.check_mode:
+            response = _create_user(conn, module)
+        changed = True
+    else:
+        kwargs = {}
+        if 'groups' in module.params and module.params['groups'] is not None:
+            if _group_change_required(user, module.params['groups']):
+                kwargs['Groups'] = module.params['groups']
+        if 'console_access' in module.params  and module.params['console_access'] is not None:
+            if _console_access_change_required(user, module.params['console_access']):
+                kwargs['ConsoleAccess'] = module.params['console_access']
+        if 'password' in module.params and module.params['password']:
+            if 'allow_pw_update' in module.params and module.params['allow_pw_update']:
+                kwargs['Password'] = module.params['password']
+        if len(kwargs) == 0:
+            changed = False
+        else:
+            if not module.check_mode:
+                kwargs['BrokerId'] = module.params['broker_id']
+                kwargs['Username'] = module.params['username']
+                response = _update_user(conn, module, kwargs)
+            #
+            changed = True
+    #
+    user = get_matching_user(conn, module, module.params['broker_id'], module.params['username'])
+
+    return {
+        'changed': changed,
+        'user': user
+    }
+
+def ensure_user_absent(conn, module):
+    user = get_matching_user(conn, module, module.params['broker_id'], module.params['username'])
+    if user is None:
+        return {'changed': False}
+    # better support for testing
+    if 'Pending' in user and 'PendingChange' in user['Pending'] \
+        and user['Pending']['PendingChange'] == 'DELETE':
+        return {'changed': False}
+    try:
+        if not module.check_mode:
+            conn.delete_user(BrokerId=user['BrokerId'], Username=user['Username'])
+        return {'changed': True}
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't delete user")
+
+
+def main():
+    argument_spec = dict(
+        broker_id=dict(required=True, type='str'),
+        username=dict(required=True, type='str'),
+        console_access=dict(required=False, type='bool'),
+        groups=dict(required=False, type='list'),
+        password=dict(required=False, type='str', no_log=True),
+        allow_pw_update=dict(default=False, required=False, type='bool'),
+        state=dict(default='present', choices=['present', 'absent'])
+    )
+
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    connection = module.client('mq')
+
+    state = module.params.get('state')
+
+    try:
+        if state == 'present':
+            result = ensure_user_present(connection, module)
+        elif state == 'absent':
+            result = ensure_user_absent(connection, module)
+    except botocore.exceptions.ClientError as e:
+        module.fail_json_aws(e)
+
+    module.exit_json(**result)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/mq_user_info.py
+++ b/plugins/modules/mq_user_info.py
@@ -1,0 +1,150 @@
+#!/usr/bin/python
+#
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: mq_user_info
+version_added: 0.9.0
+short_description: List users of an Amazon MQ broker
+description:
+    - list users for the specified broker id
+    - Pending creations and deletions can be skipped by options
+author: FCO (frank-christian.otto@web.de)
+requirements:
+  - boto3
+  - botocore
+options:
+  broker_id:
+    description:
+      - "The ID of the MQ broker to work on"
+    type: str
+  max_results:
+    description:
+      - "The maximum number of results to return"
+    type: int
+    default: 100
+  skip_pending_create:
+    description:
+      - "Will skip pending creates from the result set"
+    type: bool
+    default: false
+  skip_pending_delete:
+    description:
+      - "Will skip pending deletes from the result set"
+    type: bool
+    default: false
+  as_dict:
+    description:
+      - "convert result into lookup table by username"
+    type: bool
+    default: false
+
+extends_documentation_fragment:
+- amazon.aws.aws
+
+'''
+
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+#       or check tests/integration/targets/mq/tasks/test_mq_user_info.yml
+- name: get all users as list
+  amazon.aws.mq_user_info:
+    broker_id: "aws-mq-broker-id"
+    max_results: 1000
+  register: result
+- name: show number of users retrieved
+  debug:
+    msg: "{{ result.users | length }}"
+- name: get users as dict - relying on default limit
+  amazon.aws.mq_user_info:
+    broker_id: "aws-mq-broker-id"
+    as_dict: true
+  register: result
+- name: check if some specific user exists
+  debug:
+    msg: "user sample_user1 exists"
+  when: 'sample_user1' in result.users
+'''
+
+RETURN = '''
+user:
+    type: complex
+    description: 
+    - list of users as array or as dict keyed by username (if as_dict=true)
+    - each elements/entry are 1:1 those from the 'Users' list in the API response of list_users()
+'''
+
+
+try:
+    import botocore
+except ImportError:
+    pass  # Handled by AnsibleAWSModule
+
+from ansible.module_utils.core import AnsibleAWSModule
+
+DEFAULTS = {
+    'max_results': 100,
+    'skip_pending_create': False,
+    'skip_pending_delete': False
+}
+
+def get_user_info(conn, module):
+    try:
+        response = conn.list_users(BrokerId=module.params['broker_id'],
+                            MaxResults=module.params['max_results'])
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Failed to describe users')
+    #
+    if not module.params['skip_pending_create'] and not module.params['skip_pending_delete']:
+        # we can simply return the sub-object from the response
+        records = response['Users']
+    else:
+        records = []
+        for record in response['Users']:
+            if 'PendingChange' in record:
+                if record['PendingChange'] == 'CREATE' and module.params['skip_pending_create']:
+                    continue
+                if record['PendingChange'] == 'DELETE' and module.params['skip_pending_delete']:
+                    continue
+            #
+            records.append(record)
+    #
+    if module.params['as_dict']:
+        user_records = {}
+        for record in records:
+            user_records[record['Username']] = record
+        #
+        return user_records
+    else:
+        return records
+
+
+def main():
+    argument_spec = dict(
+        broker_id=dict(required=True, type='str'),
+        max_results=dict(required=False, type=int, default=DEFAULTS['max_results']),
+        skip_pending_create=dict(required=False, type='bool', default=DEFAULTS['skip_pending_create']),
+        skip_pending_delete=dict(required=False, type='bool', default=DEFAULTS['skip_pending_delete']),
+        as_dict=dict(required=False, type='bool', default=False),
+    )
+
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    connection = module.client('mq')
+
+    try:
+        user_list = get_user_info(connection, module)
+    except botocore.exceptions.ClientError as e:
+        module.fail_json_aws(e)
+
+    module.exit_json(users=user_list)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/mq/files/broker_cfg.1.xml
+++ b/tests/integration/targets/mq/files/broker_cfg.1.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<broker schedulePeriodForDestinationPurge="10000" xmlns="http://activemq.apache.org/schema/core">
+  <!-- update 1 -->
+  <destinationPolicy>
+    <policyMap>
+      <policyEntries>
+        <policyEntry gcInactiveDestinations="true" inactiveTimoutBeforeGC="600000" topic="&gt;">
+          <pendingMessageLimitStrategy>
+            <constantPendingMessageLimitStrategy limit="1000"/>
+          </pendingMessageLimitStrategy>
+        </policyEntry>
+        <policyEntry gcInactiveDestinations="true" inactiveTimoutBeforeGC="600000" queue="&gt;"/>
+      </policyEntries>
+    </policyMap>
+  </destinationPolicy>
+  <plugins/>
+</broker>

--- a/tests/integration/targets/mq/files/broker_cfg.1a.xml
+++ b/tests/integration/targets/mq/files/broker_cfg.1a.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<broker schedulePeriodForDestinationPurge="10000" xmlns="http://activemq.apache.org/schema/core">
+  <!-- update 1 -->
+
+  <destinationPolicy>
+    <policyMap>
+      <policyEntries>
+        <policyEntry gcInactiveDestinations="true" inactiveTimoutBeforeGC="600000" topic="&gt;">
+          <pendingMessageLimitStrategy>
+            <constantPendingMessageLimitStrategy limit="1000"/>
+          </pendingMessageLimitStrategy>
+        </policyEntry>
+   <policyEntry                gcInactiveDestinations="true" inactiveTimoutBeforeGC="600000" queue="&gt;"/>
+      </policyEntries>
+    </policyMap>
+  </destinationPolicy>
+  <plugins/>  
+
+</broker>
+
+

--- a/tests/integration/targets/mq/files/broker_cfg.2.xml
+++ b/tests/integration/targets/mq/files/broker_cfg.2.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<broker schedulePeriodForDestinationPurge="10000" xmlns="http://activemq.apache.org/schema/core">
+  <!-- update 2 -->
+  <destinationPolicy>
+    <policyMap>
+      <policyEntries>
+        <policyEntry gcInactiveDestinations="true" inactiveTimoutBeforeGC="600000" topic="&gt;">
+          <pendingMessageLimitStrategy>
+            <constantPendingMessageLimitStrategy limit="1000"/>
+          </pendingMessageLimitStrategy>
+        </policyEntry>
+        <policyEntry gcInactiveDestinations="true" inactiveTimoutBeforeGC="600000" queue="&gt;"/>
+      </policyEntries>
+    </policyMap>
+  </destinationPolicy>
+  <plugins/>
+</broker>

--- a/tests/integration/targets/mq/inventory.ini
+++ b/tests/integration/targets/mq/inventory.ini
@@ -1,0 +1,5 @@
+[virtual]
+dummy
+
+[virtual:vars]
+ansible_connection=local

--- a/tests/integration/targets/mq/run_tests.sh
+++ b/tests/integration/targets/mq/run_tests.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# to have debugging:  export DEGUG="-vv"
+THIS_DIR=$(dirname $0)
+
+export ANSIBLE_LIBRARY=${THIS_DIR}/../../../../plugins/
+export ANSIBLE_MODULE_UTILS=${ANSIBLE_LIBRARY}/module_utils/
+
+if [ -z "$MQ_BROKER_ID" ]; then
+  echo "MQ_BROKER_ID must be set"
+  exit 1
+fi
+if [ -z "$AWS_REGION" ]; then
+  echo "AWS_REGION must be set"
+  exit 1
+fi
+if [ -z "$AWS_ACCESS_KEY_ID" ]; then
+  echo "AWS_ACCESS_KEY_ID must be set"
+  exit 1
+fi
+if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+  echo "AWS_SECRET_ACCESS_KEY must be set"
+  exit 1
+fi
+if [ -z "$AWS_SESSION_TOKEN" ]; then
+  echo "AWS_SESSION_TOKEN must be set"
+  exit 1
+fi
+
+FAILED_PLAYBOOKS=0
+TEST_PLAYBOOKS="test_mq_user.yml test_mq_user_info.yml test_mq_broker.yml test_mq_broker_config.yml"
+for playbook in $TEST_PLAYBOOKS; do
+  echo "Run test playbook $playbook"
+  ansible-playbook -i inventory.ini tasks/$playbook $DEBUG
+  RC=$?
+  if [ $RC != 0 ]; then
+    echo "test playbook $playbook failed"
+    FAILED_PLAYBOOKS=$(( $FAILED_PLAYBOOKS + 1 ))
+  fi
+done
+
+if [ $FAILED_PLAYBOOKS -gt 0 ]; then
+  echo "$FAILED_PLAYBOOKS test playbooks failed"
+  exit 1
+fi

--- a/tests/integration/targets/mq/tasks/test_mq_broker.yml
+++ b/tests/integration/targets/mq/tasks/test_mq_broker.yml
@@ -1,0 +1,65 @@
+---
+- name: MQ User test suite
+  hosts: dummy
+  gather_facts: false
+  vars:
+    broker_id: "{{ lookup('env', 'MQ_BROKER_ID') }}"
+    aws_access_key_id: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
+    aws_secret_access_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
+    aws_session_token: "{{ lookup('env', 'AWS_SESSION_TOKEN') }}"
+    aws_region: "{{ lookup('env', 'AWS_REGION') }}"
+
+
+  tasks:
+    - name: show env
+      debug:
+        msg: "Will run tests against broker '{{ broker_id }}' in AWS region '{{ aws_region }}'"
+    - name: test1 - show broker details
+      # amazon.aws.mq_broker:
+      mq_broker:
+        broker_id: "{{ broker_id }}"
+        region: "{{ aws_region }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+      register: result
+    - name: verify test1
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test1 failed
+        that:
+          - not (result.changed | bool)
+          - result.broker['BrokerId'] == broker_id
+    - name: test2 - show broker details - explicitly requesting info
+      # amazon.aws.mq_broker:
+      mq_broker:
+        broker_id: "{{ broker_id }}"
+        operation: "info"
+        region: "{{ aws_region }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: verify test2
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test2 failed
+        that:
+          - not (result.changed | bool)
+          - result.broker['BrokerId'] == broker_id
+    - name: test3 - reboot broker
+      # amazon.aws.mq_broker:
+      mq_broker:
+        broker_id: "{{ broker_id }}"
+        operation: "reboot"
+        region: "{{ aws_region }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: verify test3
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test3 failed
+        that:
+          - result.changed | bool
+          - result.broker['BrokerState'] == 'REBOOT_IN_PROGRESS'

--- a/tests/integration/targets/mq/tasks/test_mq_broker_config.yml
+++ b/tests/integration/targets/mq/tasks/test_mq_broker_config.yml
@@ -1,0 +1,72 @@
+---
+- name: MQ User test suite
+  hosts: dummy
+  gather_facts: false
+  vars:
+    broker_id: "{{ lookup('env', 'MQ_BROKER_ID') }}"
+    aws_access_key_id: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
+    aws_secret_access_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
+    aws_session_token: "{{ lookup('env', 'AWS_SESSION_TOKEN') }}"
+    aws_region: "{{ lookup('env', 'AWS_REGION') }}"
+
+
+  tasks:
+    - name: show env
+      debug:
+        msg: "Will run tests against broker '{{ broker_id }}' in AWS region '{{ aws_region }}'"
+    - name: test 1 - send update to broker config
+      # amazon.aws.mq_broker:
+      mq_broker_config:
+        broker_id: "{{ broker_id }}"
+        config_xml: "{{ lookup('file', '../files/broker_cfg.1.xml')}}"
+        region: "{{ aws_region }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: verify test1
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test1 failed
+        that:
+          - result.changed | bool
+          - result.broker['BrokerId'] == broker_id
+          - result.configuration['id'] == result.broker['Configurations']['Pending']['Id']
+          - result.configuration['revision'] == result.broker['Configurations']['Pending']['Revision']
+    - name: test 2 - send (almost) same config again
+      # amazon.aws.mq_broker_info:
+      mq_broker_config:
+        broker_id: "{{ broker_id }}"
+        config_xml: "{{ lookup('file', '../files/broker_cfg.1a.xml')}}"
+        region: "{{ aws_region }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: verify test2
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test2 failed
+        that:
+          - not (result.changed | bool )
+    - name: test 3 - send new config with custom description and request reboot
+      # amazon.aws.mq_broker_info:
+      mq_broker_config:
+        broker_id: "{{ broker_id }}"
+        config_xml: "{{ lookup('file', '../files/broker_cfg.2.xml')}}"
+        config_description: "test 3 used custom description"
+        reboot: true
+        region: "{{ aws_region }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: verify test3
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test2 failed
+        that:
+          - result.changed | bool
+          - result.broker['BrokerState'] == 'REBOOT_IN_PROGRESS'
+
+

--- a/tests/integration/targets/mq/tasks/test_mq_user.yml
+++ b/tests/integration/targets/mq/tasks/test_mq_user.yml
@@ -1,0 +1,251 @@
+---
+- name: MQ User test suite
+  hosts: dummy
+  gather_facts: false
+  vars:
+    broker_id: "{{ lookup('env', 'MQ_BROKER_ID') }}"
+    aws_access_key_id: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
+    aws_secret_access_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
+    aws_session_token: "{{ lookup('env', 'AWS_SESSION_TOKEN') }}"
+    aws_region: "{{ lookup('env', 'AWS_REGION') }}"
+    usernames:
+      - "test_user1"
+      - "test_user2"
+      - "test_user3"
+
+  tasks:
+    - name: show env
+      debug:
+        msg: "Will run tests against broker '{{ broker_id }}' in AWS region '{{ aws_region }}'"
+    - name: test1 - create user with default settings
+      # amazon.aws.mq_user:
+      mq_user:
+        broker_id: "{{ broker_id }}"
+        username: "{{ usernames[0] }}"
+        region: "{{ aws_region }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test1 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test1 failed
+        that:
+          - result.changed | bool
+          - result.user['Username'] == usernames[0]
+          - not (result.user['Pending']['ConsoleAccess'] | bool)
+          - result.user['Pending']['Groups'] | length == 0
+    - name: test2 - create user with console access and group list
+      # amazon.aws.mq_user:
+      mq_user:
+        state: present
+        broker_id: "{{ broker_id }}"
+        username: "{{ usernames[1] }}"
+        region: "{{ aws_region }}"
+        console_access: true
+        groups: [ "g1", "g2" ]
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test2 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test2 failed
+        that:
+          - result.changed | bool
+          - result.user['Username'] == usernames[1]
+          - result.user['Pending']['ConsoleAccess'] | bool
+          - result.user['Pending']['Groups'] | length == 2
+    - name: test3 - create user with defined password
+      # amazon.aws.mq_user:
+      mq_user:
+        broker_id: "{{ broker_id }}"
+        username: "{{ usernames[2] }}"
+        region: "{{ aws_region }}"
+        password: "09234092jzxkjvjk23kn23qn5lk34"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test3 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test3 failed
+        that:
+          - result.changed | bool
+          - result.user['Username'] == usernames[2]
+          - not (result.user['Pending']['ConsoleAccess'] | bool)
+          - result.user['Pending']['Groups'] | length == 0
+    - name: test4 - update user password - ignore mode
+      # amazon.aws.mq_user:
+      mq_user:
+        broker_id: "{{ broker_id }}"
+        username: "{{ usernames[2] }}"
+        region: "{{ aws_region }}"
+        password: "new_password_ignored"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test4 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test4 failed
+        that:
+          - not (result.changed | bool)
+    - name: test5 - update user password - force mode
+      # amazon.aws.mq_user:
+      mq_user:
+        broker_id: "{{ broker_id }}"
+        username: "{{ usernames[2] }}"
+        region: "{{ aws_region }}"
+        password: "new_Password_Accepted0815%"
+        allow_pw_update: true
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test5 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test5 failed
+        that:
+          - result.changed | bool
+    - name: test6 - update console access - same value
+      # amazon.aws.mq_user:
+      mq_user:
+        broker_id: "{{ broker_id }}"
+        username: "{{ usernames[2] }}"
+        region: "{{ aws_region }}"
+        console_access: false
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test6 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test6 failed
+        that:
+          - not (result.changed | bool)
+    - name: test7 - update console access - new value
+      # amazon.aws.mq_user:
+      mq_user:
+        broker_id: "{{ broker_id }}"
+        username: "{{ usernames[1] }}"
+        region: "{{ aws_region }}"
+        console_access: false
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test7 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test7 failed
+        that:
+          - result.changed | bool
+          - not( result.user['Pending']['ConsoleAccess'] | bool )
+          - result.user['Pending']['Groups'] | length == 2
+    - name: test8 - update group list - same list but different order
+      # amazon.aws.mq_user:
+      mq_user:
+        broker_id: "{{ broker_id }}"
+        username: "{{ usernames[1] }}"
+        region: "{{ aws_region }}"
+        groups: [ "g2", "g1" ]
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test8 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test8 failed
+        that:
+          - not (result.changed | bool)
+    - name: test9 - update group list - add element
+      # amazon.aws.mq_user:
+      mq_user:
+        broker_id: "{{ broker_id }}"
+        username: "{{ usernames[1] }}"
+        region: "{{ aws_region }}"
+        groups: [ "g2", "g1", "g3" ]
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test9 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test9 failed
+        that:
+          - result.changed | bool
+          - result.user['Pending']['Groups'] | length == 3
+    - name: test10 - update group list - remove element
+      # amazon.aws.mq_user:
+      mq_user:
+        broker_id: "{{ broker_id }}"
+        username: "{{ usernames[1] }}"
+        region: "{{ aws_region }}"
+        groups: [ "g2", "g3" ]
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test10 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test10 failed
+        that:
+          - result.changed | bool
+          - result.user['Pending']['Groups'] | length == 2
+    - name: test11 - update group list - set to empty list
+      # amazon.aws.mq_user:
+      mq_user:
+        broker_id: "{{ broker_id }}"
+        username: "{{ usernames[1] }}"
+        region: "{{ aws_region }}"
+        groups: []
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test11 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test11 failed
+        that:
+          - result.changed | bool
+          - result.user['Pending']['Groups'] | length == 0
+    - name: delete all users
+      # amazon.aws.mq_user:
+      mq_user:
+        state: absent
+        broker_id: "{{ broker_id }}"
+        username: "{{ item }}"
+        region: "{{ aws_region }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      loop: "{{ usernames | flatten(levels=1) }}"
+    - name: test13 - delete deleted user
+      # amazon.aws.mq_user:
+      mq_user:
+        state: absent
+        broker_id: "{{ broker_id }}"
+        username: "{{ usernames[1] }}"
+        region: "{{ aws_region }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test13 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test13 failed
+        that:
+          - not(result.changed | bool)
+

--- a/tests/integration/targets/mq/tasks/test_mq_user_info.yml
+++ b/tests/integration/targets/mq/tasks/test_mq_user_info.yml
@@ -1,0 +1,123 @@
+---
+- name: MQ User test suite
+  hosts: dummy
+  gather_facts: false
+  vars:
+    broker_id: "{{ lookup('env', 'MQ_BROKER_ID') }}"
+    aws_access_key_id: "{{ lookup('env', 'AWS_ACCESS_KEY_ID') }}"
+    aws_secret_access_key: "{{ lookup('env', 'AWS_SECRET_ACCESS_KEY') }}"
+    aws_session_token: "{{ lookup('env', 'AWS_SESSION_TOKEN') }}"
+    aws_region: "{{ lookup('env', 'AWS_REGION') }}"
+    create_users:
+      - "info_user1"
+      - "info_user2"
+      - "info_user3"
+      - "info_user4"
+      - "info_user5"
+    delete_users:
+      - "info_user2"
+      - "info_user5"
+
+  tasks:
+    - name: show env
+      debug:
+        msg: "Will run tests against broker '{{ broker_id }}' in AWS region '{{ aws_region }}'"
+    - name: prepare tests - create users
+      # amazon.aws.mq_user:
+      mq_user:
+        state: present
+        broker_id: "{{ broker_id }}"
+        username: "{{ item }}"
+        region: "{{ aws_region }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      loop: "{{ create_users | flatten(levels=1) }}"
+    - name: prepare tests - delete users
+      # amazon.aws.mq_user:
+      mq_user:
+        state: absent
+        broker_id: "{{ broker_id }}"
+        username: "{{ item }}"
+        region: "{{ aws_region }}"
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      loop: "{{ delete_users | flatten(levels=1) }}"
+    - name: test1 - list all users with custom limit
+      # amazon.aws.mq_user_info:
+      mq_user_info:
+        broker_id: "{{ broker_id }}"
+        region: "{{ aws_region }}"
+        max_results: 5
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test1 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test1 failed
+        that:
+          - (result.users | length) == 5
+    - name: test2 - list all users as dict
+      # amazon.aws.mq_user_info:
+      mq_user_info:
+        broker_id: "{{ broker_id }}"
+        region: "{{ aws_region }}"
+        as_dict: true
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test2 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test2 failed
+        that:
+          - result.users['info_user1']
+          - result.users['info_user2']
+          - result.users['info_user3']
+    - name: test3 - list only user currently being active until next broker reboot
+      # amazon.aws.mq_user_info:
+      mq_user_info:
+        broker_id: "{{ broker_id }}"
+        region: "{{ aws_region }}"
+        as_dict: true
+        skip_pending_create: true
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test3 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test3 failed
+        that:
+          - not ('info_user1' in result.users)
+          - result.users['info_user2']
+          - not ('info_user3' in result.users)
+          - not ('info_user4' in result.users)
+          - result.users['info_user5']
+    - name: test4 - list only user that will be active after next broker reboot
+      # amazon.aws.mq_user_info:
+      mq_user_info:
+        broker_id: "{{ broker_id }}"
+        region: "{{ aws_region }}"
+        as_dict: true
+        skip_pending_delete: true
+        aws_access_key: "{{ aws_access_key_id }}"
+        aws_secret_key: "{{ aws_secret_access_key }}"
+        security_token: "{{ aws_session_token }}"
+      register: result
+    - name: test4 - verify
+      #ansible.builtin.assert:
+      assert:
+        fail_msg: test4 failed
+        that:
+          - result.users['info_user1']
+          - not ('info_user2' in result.users)
+          - result.users['info_user3']
+          - result.users['info_user4']
+          - not ('info_user5' in result.users)
+


### PR DESCRIPTION
##### SUMMARY
This PR contains some basic support for Amazon MQ. It covers

* Managing Amazon MQ configurations
* Managing Amazon MQ (local) users
* Broker reboot

not in scope of the PR
* management of the brokers itself (create, delete)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Amazon MQ

##### ADDITIONAL INFORMATION

We use those modules to manage our MQ Brokers. The context of usage is

* brokers are created by different means (e.g. terraform)
* we've developed a custom role around those modules
* to manage MQ user credentials we use another local extension of amazon.aws collection (will come as separate PR) that interfaces with AWS SecretsManager
* that role uses the reboot broker feature (part of this PR) to implement a custom handler that reboots a broker whenever a configuration run sees any changes in configuration and/or users

The functionality of the added modules is illustrated in the added test suite (tests/integration/targets/mq) which
basically requires just a running MQ broker to be usuable.


