### PR TITLE
Attempt to improve vpc_subnet / vpc_net stability

### DIFF
--- a/changelogs/fragments/270-vpc-waiters.yaml
+++ b/changelogs/fragments/270-vpc-waiters.yaml
@@ -1,0 +1,3 @@
+minor_changes:
+- ec2_vpc_net - use a custom waiter which can handle API rate limiting (https://github.com/ansible-collections/amazon.aws/pull/270).
+- ec2_vpc_subnet - use AWSRetry decorator to more consistently handle API rate limiting (https://github.com/ansible-collections/amazon.aws/pull/270).

--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -162,6 +162,19 @@ ec2_data = {
                 },
             ]
         },
+        "SubnetAvailable": {
+            "delay": 15,
+            "operation": "DescribeSubnets",
+            "maxAttempts": 40,
+            "acceptors": [
+                {
+                    "expected": "available",
+                    "matcher": "pathAll",
+                    "state": "success",
+                    "argument": "Subnets[].State"
+                }
+            ]
+        },
         "SubnetExists": {
             "delay": 5,
             "maxAttempts": 40,
@@ -248,6 +261,36 @@ ec2_data = {
                     "expected": "InvalidSubnetID.NotFound",
                     "state": "success"
                 },
+            ]
+        },
+        "VpcAvailable": {
+            "delay": 15,
+            "operation": "DescribeVpcs",
+            "maxAttempts": 40,
+            "acceptors": [
+                {
+                    "expected": "available",
+                    "matcher": "pathAll",
+                    "state": "success",
+                    "argument": "Vpcs[].State"
+                }
+            ]
+        },
+        "VpcExists": {
+            "operation": "DescribeVpcs",
+            "delay": 1,
+            "maxAttempts": 5,
+            "acceptors": [
+                {
+                    "matcher": "status",
+                    "expected": 200,
+                    "state": "success"
+                },
+                {
+                    "matcher": "error",
+                    "expected": "InvalidVpcID.NotFound",
+                    "state": "retry"
+                }
             ]
         },
         "VpcEndpointExists": {
@@ -478,6 +521,12 @@ waiters_by_name = {
         core_waiter.NormalizedOperationMethod(
             ec2.describe_security_groups
         )),
+    ('EC2', 'subnet_available'): lambda ec2: core_waiter.Waiter(
+        'subnet_available',
+        ec2_model('SubnetAvailable'),
+        core_waiter.NormalizedOperationMethod(
+            ec2.describe_subnets
+        )),
     ('EC2', 'subnet_exists'): lambda ec2: core_waiter.Waiter(
         'subnet_exists',
         ec2_model('SubnetExists'),
@@ -513,6 +562,18 @@ waiters_by_name = {
         ec2_model('SubnetDeleted'),
         core_waiter.NormalizedOperationMethod(
             ec2.describe_subnets
+        )),
+    ('EC2', 'vpc_available'): lambda ec2: core_waiter.Waiter(
+        'vpc_available',
+        ec2_model('VpcAvailable'),
+        core_waiter.NormalizedOperationMethod(
+            ec2.describe_vpcs
+        )),
+    ('EC2', 'vpc_exists'): lambda ec2: core_waiter.Waiter(
+        'vpc_exists',
+        ec2_model('VpcExists'),
+        core_waiter.NormalizedOperationMethod(
+            ec2.describe_vpcs
         )),
     ('EC2', 'vpc_endpoint_exists'): lambda ec2: core_waiter.Waiter(
         'vpc_endpoint_exists',

--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -243,12 +243,14 @@ def vpc_exists(module, vpc, name, cidr_block, multi):
     return None
 
 
-def get_classic_link_with_backoff(connection, vpc_id):
+def get_classic_link_status(module, connection, vpc_id):
     try:
         results = connection.describe_vpc_classic_link(aws_retry=True, VpcIds=[vpc_id])
         return results['Vpcs'][0].get('ClassicLinkEnabled')
     except is_boto3_error_message('The functionality you requested is not available in this region.'):
         return False
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Failed to describe VPCs")
 
 
 def wait_for_vpc_to_exist(module, connection, **params):
@@ -273,10 +275,8 @@ def get_vpc(module, connection, vpc_id):
         vpc_obj = connection.describe_vpcs(VpcIds=[vpc_id], aws_retry=True)['Vpcs'][0]
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to describe VPCs")
-    try:
-        vpc_obj['ClassicLinkEnabled'] = get_classic_link_with_backoff(connection, vpc_id)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to describe VPCs")
+
+    vpc_obj['ClassicLinkEnabled'] = get_classic_link_status(module, connection, vpc_id)
 
     return vpc_obj
 

--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -214,6 +214,7 @@ from ..module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ..module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ..module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ..module_utils.ec2 import compare_aws_tags
+from ..module_utils.waiters import get_waiter
 
 
 def vpc_exists(module, vpc, name, cidr_block, multi):
@@ -242,21 +243,32 @@ def vpc_exists(module, vpc, name, cidr_block, multi):
     return None
 
 
-@AWSRetry.backoff(delay=3, tries=8, catch_extra_error_codes=['InvalidVpcID.NotFound'])
 def get_classic_link_with_backoff(connection, vpc_id):
     try:
-        return connection.describe_vpc_classic_link(VpcIds=[vpc_id])['Vpcs'][0].get('ClassicLinkEnabled')
+        results = connection.describe_vpc_classic_link(aws_retry=True, VpcIds=[vpc_id])
+        return results['Vpcs'][0].get('ClassicLinkEnabled')
     except is_boto3_error_message('The functionality you requested is not available in this region.'):
         return False
 
 
-def get_vpc(module, connection, vpc_id):
+def wait_for_vpc_to_exist(module, connection, **params):
     # wait for vpc to be available
     try:
-        connection.get_waiter('vpc_available').wait(VpcIds=[vpc_id])
+        get_waiter(connection, 'vpc_exists').wait(**params)
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Unable to wait for VPC {0} to be available.".format(vpc_id))
+        module.fail_json_aws(e, msg="Unable to wait for VPC creation.")
 
+
+def wait_for_vpc(module, connection, **params):
+    # wait for vpc to be available
+    try:
+        get_waiter(connection, 'vpc_available').wait(**params)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Unable to wait for VPC state to update.")
+
+
+def get_vpc(module, connection, vpc_id):
+    wait_for_vpc(module, connection, VpcIds=[vpc_id])
     try:
         vpc_obj = connection.describe_vpcs(VpcIds=[vpc_id], aws_retry=True)['Vpcs'][0]
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
@@ -287,7 +299,7 @@ def update_vpc_tags(connection, module, vpc_id, tags, name):
                 # Wait for tags to be updated
                 expected_tags = boto3_tag_list_to_ansible_dict(tags)
                 filters = [{'Name': 'tag:{0}'.format(key), 'Values': [value]} for key, value in expected_tags.items()]
-                connection.get_waiter('vpc_available').wait(VpcIds=[vpc_id], Filters=filters)
+                wait_for_vpc(module, connection, VpcIds=[vpc_id], Filters=filters)
 
             return True
         else:
@@ -304,12 +316,9 @@ def update_dhcp_opts(connection, module, vpc_obj, dhcp_id):
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 module.fail_json_aws(e, msg="Failed to associate DhcpOptionsId {0}".format(dhcp_id))
 
-            try:
-                # Wait for DhcpOptionsId to be updated
-                filters = [{'Name': 'dhcp-options-id', 'Values': [dhcp_id]}]
-                connection.get_waiter('vpc_available').wait(VpcIds=[vpc_obj['VpcId']], Filters=filters)
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                module.fail_json_aws(e, msg="Failed to wait for DhcpOptionsId to be updated")
+            # Wait for DhcpOptionsId to be updated
+            filters = [{'Name': 'dhcp-options-id', 'Values': [dhcp_id]}]
+            wait_for_vpc(module, connection, VpcIds=[vpc_obj['VpcId']], Filters=filters)
 
         return True
     else:
@@ -326,13 +335,17 @@ def create_vpc(connection, module, cidr_block, tenancy):
         module.fail_json_aws(e, "Failed to create the VPC")
 
     # wait up to 30 seconds for vpc to exist
-    try:
-        connection.get_waiter('vpc_exists').wait(
-            VpcIds=[vpc_obj['Vpc']['VpcId']],
-            WaiterConfig=dict(MaxAttempts=30)
-        )
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Unable to wait for VPC {0} to be created.".format(vpc_obj['Vpc']['VpcId']))
+    wait_for_vpc_to_exist(
+        module, connection,
+        VpcIds=[vpc_obj['Vpc']['VpcId']],
+        WaiterConfig=dict(MaxAttempts=30)
+    )
+    # Wait for the VPC to enter an 'Available' State
+    wait_for_vpc_to_exist(
+        module, connection,
+        VpcIds=[vpc_obj['Vpc']['VpcId']],
+        WaiterConfig=dict(MaxAttempts=30)
+    )
 
     return vpc_obj['Vpc']['VpcId']
 
@@ -495,13 +508,11 @@ def main():
 
         # wait for associated cidrs to match
         if to_add or to_remove:
-            try:
-                connection.get_waiter('vpc_available').wait(
-                    VpcIds=[vpc_id],
-                    Filters=[{'Name': 'cidr-block-association.cidr-block', 'Values': expected_cidrs}]
-                )
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                module.fail_json_aws(e, "Failed to wait for CIDRs to update", vpc_id=vpc_id)
+            wait_for_vpc(
+                module, connection,
+                VpcIds=[vpc_id],
+                Filters=[{'Name': 'cidr-block-association.cidr-block', 'Values': expected_cidrs}]
+            )
 
         # try to wait for enableDnsSupport and enableDnsHostnames to match
         wait_for_vpc_attribute(connection, module, vpc_id, 'enableDnsSupport', dns_support)

--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -257,6 +257,8 @@ def wait_for_vpc_to_exist(module, connection, **params):
     # wait for vpc to be available
     try:
         get_waiter(connection, 'vpc_exists').wait(**params)
+    except botocore.exceptions.WaiterError as e:
+        module.fail_json_aws(e, msg="VPC failed to reach expected state (exists)")
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Unable to wait for VPC creation.")
 
@@ -265,6 +267,8 @@ def wait_for_vpc(module, connection, **params):
     # wait for vpc to be available
     try:
         get_waiter(connection, 'vpc_available').wait(**params)
+    except botocore.exceptions.WaiterError as e:
+        module.fail_json_aws(e, msg="VPC failed to reach expected state (available)")
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Unable to wait for VPC state to update.")
 

--- a/plugins/modules/ec2_vpc_subnet.py
+++ b/plugins/modules/ec2_vpc_subnet.py
@@ -251,11 +251,6 @@ def get_subnet_info(subnet):
     return subnet
 
 
-@AWSRetry.exponential_backoff()
-def describe_subnets_with_backoff(client, **params):
-    return client.describe_subnets(**params)
-
-
 def waiter_params(module, params, start_time):
     if not module.botocore_at_least("1.7.0"):
         remaining_wait_timeout = int(module.params['wait_timeout'] + start_time - time.time())
@@ -288,7 +283,7 @@ def create_subnet(conn, module, vpc_id, cidr, ipv6_cidr=None, az=None, start_tim
         params['AvailabilityZone'] = az
 
     try:
-        subnet = get_subnet_info(conn.create_subnet(**params))
+        subnet = get_subnet_info(conn.create_subnet(aws_retry=True, **params))
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Couldn't create subnet")
 
@@ -297,13 +292,8 @@ def create_subnet(conn, module, vpc_id, cidr, ipv6_cidr=None, az=None, start_tim
     # exception.
     if wait and subnet.get('state') != 'available':
         handle_waiter(conn, module, 'subnet_exists', {'SubnetIds': [subnet['id']]}, start_time)
-        try:
-            conn.get_waiter('subnet_available').wait(
-                **waiter_params(module, {'SubnetIds': [subnet['id']]}, start_time)
-            )
-            subnet['state'] = 'available'
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, "Create subnet action timed out waiting for subnet to become available")
+        handle_waiter(conn, module, 'subnet_available', {'SubnetIds': [subnet['id']]}, start_time)
+        subnet['state'] = 'available'
 
     return subnet
 
@@ -313,7 +303,7 @@ def ensure_tags(conn, module, subnet, tags, purge_tags, start_time):
 
     filters = ansible_dict_to_boto3_filter_list({'resource-id': subnet['id'], 'resource-type': 'subnet'})
     try:
-        cur_tags = conn.describe_tags(Filters=filters)
+        cur_tags = conn.describe_tags(aws_retry=True, Filters=filters)
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Couldn't describe tags")
 
@@ -322,7 +312,8 @@ def ensure_tags(conn, module, subnet, tags, purge_tags, start_time):
     if to_update:
         try:
             if not module.check_mode:
-                AWSRetry.exponential_backoff(
+                AWSRetry.jittered_backoff(
+                    retries=10,
                     catch_extra_error_codes=['InvalidSubnetID.NotFound']
                 )(conn.create_tags)(
                     Resources=[subnet['id']],
@@ -340,7 +331,8 @@ def ensure_tags(conn, module, subnet, tags, purge_tags, start_time):
                 for key in to_delete:
                     tags_list.append({'Key': key})
 
-                AWSRetry.exponential_backoff(
+                AWSRetry.jittered_backoff(
+                    retries=10,
                     catch_extra_error_codes=['InvalidSubnetID.NotFound']
                 )(conn.delete_tags)(Resources=[subnet['id']], Tags=tags_list)
 
@@ -361,7 +353,8 @@ def ensure_map_public(conn, module, subnet, map_public, check_mode, start_time):
     if check_mode:
         return
     try:
-        conn.modify_subnet_attribute(SubnetId=subnet['id'], MapPublicIpOnLaunch={'Value': map_public})
+        conn.modify_subnet_attribute(aws_retry=True, SubnetId=subnet['id'],
+                                     MapPublicIpOnLaunch={'Value': map_public})
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Couldn't modify subnet attribute")
 
@@ -370,7 +363,8 @@ def ensure_assign_ipv6_on_create(conn, module, subnet, assign_instances_ipv6, ch
     if check_mode:
         return
     try:
-        conn.modify_subnet_attribute(SubnetId=subnet['id'], AssignIpv6AddressOnCreation={'Value': assign_instances_ipv6})
+        conn.modify_subnet_attribute(aws_retry=True, SubnetId=subnet['id'],
+                                     AssignIpv6AddressOnCreation={'Value': assign_instances_ipv6})
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Couldn't modify subnet attribute")
 
@@ -380,7 +374,7 @@ def disassociate_ipv6_cidr(conn, module, subnet, start_time):
         ensure_assign_ipv6_on_create(conn, module, subnet, False, False, start_time)
 
     try:
-        conn.disassociate_subnet_cidr_block(AssociationId=subnet['ipv6_association_id'])
+        conn.disassociate_subnet_cidr_block(aws_retry=True, AssociationId=subnet['ipv6_association_id'])
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Couldn't disassociate ipv6 cidr block id {0} from subnet {1}"
                              .format(subnet['ipv6_association_id'], subnet['id']))
@@ -409,7 +403,8 @@ def ensure_ipv6_cidr_block(conn, module, subnet, ipv6_cidr, check_mode, start_ti
                                                      'vpc-id': subnet['vpc_id']})
 
         try:
-            check_subnets = get_subnet_info(describe_subnets_with_backoff(conn, Filters=filters))
+            _subnets = conn.describe_subnets(aws_retry=True, Filters=filters)
+            check_subnets = get_subnet_info(_subnets)
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg="Couldn't get subnet info")
 
@@ -423,7 +418,8 @@ def ensure_ipv6_cidr_block(conn, module, subnet, ipv6_cidr, check_mode, start_ti
 
         try:
             if not check_mode:
-                associate_resp = conn.associate_subnet_cidr_block(SubnetId=subnet['id'], Ipv6CidrBlock=ipv6_cidr)
+                associate_resp = conn.associate_subnet_cidr_block(aws_retry=True, SubnetId=subnet['id'],
+                                                                  Ipv6CidrBlock=ipv6_cidr)
             changed = True
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.fail_json_aws(e, msg="Couldn't associate ipv6 cidr {0} to {1}".format(ipv6_cidr, subnet['id']))
@@ -450,7 +446,8 @@ def ensure_ipv6_cidr_block(conn, module, subnet, ipv6_cidr, check_mode, start_ti
 def get_matching_subnet(conn, module, vpc_id, cidr):
     filters = ansible_dict_to_boto3_filter_list({'vpc-id': vpc_id, 'cidr-block': cidr})
     try:
-        subnets = get_subnet_info(describe_subnets_with_backoff(conn, Filters=filters))
+        _subnets = conn.describe_subnets(aws_retry=True, Filters=filters)
+        subnets = get_subnet_info(_subnets)
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Couldn't get matching subnet")
 
@@ -547,7 +544,7 @@ def ensure_subnet_absent(conn, module):
 
     try:
         if not module.check_mode:
-            conn.delete_subnet(SubnetId=subnet['id'])
+            conn.delete_subnet(aws_retry=True, SubnetId=subnet['id'])
             if module.params['wait']:
                 handle_waiter(conn, module, 'subnet_deleted', {'SubnetIds': [subnet['id']]}, time.time())
         return {'changed': True}
@@ -580,7 +577,8 @@ def main():
     if not module.botocore_at_least("1.7.0"):
         module.warn("botocore >= 1.7.0 is required to use wait_timeout for custom wait times")
 
-    connection = module.client('ec2')
+    retry_decorator = AWSRetry.jittered_backoff(retries=10)
+    connection = module.client('ec2', retry_decorator=retry_decorator)
 
     state = module.params.get('state')
 


### PR DESCRIPTION
##### SUMMARY

Over in community.aws we're seeing repeated failures due to API rate limits with the subnet/net changes (mostly waiter related)
Switch to a custom waiter that knows how to cope with the API Rate limits.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vpc_subnet
ec2_vpc_net

##### ADDITIONAL INFORMATION

Will push changelog once tests complete