### PR TITLE
new helper function : normalize_boto3_result

### DIFF
--- a/changelogs/fragments/271-normalize_boto3_result.yml
+++ b/changelogs/fragments/271-normalize_boto3_result.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- module_utils/core - add a helper function ``normalize_boto3_result`` (https://github.com/ansible-collections/amazon.aws/pull/271).

--- a/plugins/module_utils/core.py
+++ b/plugins/module_utils/core.py
@@ -53,6 +53,7 @@ don't need to be wrapped in the backoff decorator.
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+import json
 import re
 import logging
 import traceback
@@ -379,3 +380,21 @@ def scrub_none_parameters(parameters):
             clean_parameters[k] = v
 
     return clean_parameters
+
+
+def _boto3_handler(obj):
+    if hasattr(obj, 'isoformat'):
+        return obj.isoformat()
+    else:
+        return obj
+
+
+def normalize_boto3_result(result):
+    """
+    Because Boto3 returns datetime objects where it knows things are supposed to
+    be dates we need to mass-convert them over to strings which Ansible/Jinja
+    handle better.  This also makes it easier to compare complex objects which
+    include a mix of dates in string format (from parameters) and dates as
+    datetime objects.  Boto3 is happy to be passed ISO8601 format strings.
+    """
+    return json.loads(json.dumps(result, default=_boto3_handler))

--- a/tests/unit/module_utils/core/test_normalize_boto3_result.py
+++ b/tests/unit/module_utils/core/test_normalize_boto3_result.py
@@ -1,0 +1,55 @@
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+import datetime
+from dateutil import parser as date_parser
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import normalize_boto3_result
+
+example_date_txt = '2020-12-30T00:00:00.000Z'
+example_date_iso = '2020-12-30T00:00:00+00:00'
+example_date = date_parser.parse(example_date_txt)
+
+
+normalize_boto3_result_data = [
+    (dict(),
+     dict()
+     ),
+    # Bool
+    (dict(param1=False),
+     dict(param1=False)
+     ),
+    # Simple string (shouldn't be touched
+    (dict(date_example=example_date_txt),
+     dict(date_example=example_date_txt)
+     ),
+    (dict(date_example=example_date_iso),
+     dict(date_example=example_date_iso)
+     ),
+    # Datetime -> String
+    (dict(date_example=example_date),
+     dict(date_example=example_date_iso)
+     ),
+    (list(),
+     list()
+     ),
+    (list([False]),
+     list([False])
+     ),
+    (list([example_date_txt]),
+     list([example_date_txt])
+     ),
+    (list([example_date_iso]),
+     list([example_date_iso])
+     ),
+    (list([example_date]),
+     list([example_date_iso])
+     ),
+]
+
+
+@pytest.mark.parametrize("input_params, output_params", normalize_boto3_result_data)
+def test_normalize_boto3_result(input_params, output_params):
+
+    assert normalize_boto3_result(input_params) == output_params


### PR DESCRIPTION
##### SUMMARY

We have  a number of modules using JSON round-tripping to convert dates into ISO-formatted strings.  Move this into a common helper.

Right now this only does something unusual to datetime resources, but it's been left generic in case something else is needed (Booleans?)

Todo:

- [x] Changelog
- [x] Unit tests

##### ISSUE TYPE

- New Module Pull Request

##### COMPONENT NAME

plugins/module_utils/core.py

##### ADDITIONAL INFORMATION