### PR TITLE
galaxy: Fix ansible.common collection version

### DIFF
--- a/changelogs/fragments/fix_netcommon.yml
+++ b/changelogs/fragments/fix_netcommon.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- netcommon - fix ansible.netcommon version lesser than 2.0.0 (https://github.com/ansible-collections/amazon.aws/issues/273).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ description: null
 license_file: COPYING
 tags: [amazon, aws, cloud]
 dependencies:
-  ansible.netcommon: '>=0.0.1'
+  ansible.netcommon: '>=0.0.1,<2.0.0'
 repository: https://github.com/ansible-collections/amazon.aws
 documentation: https://github.com/ansible-collections/amazon.aws/tree/main/docs
 homepage: https://github.com/ansible-collections/amazon.aws


### PR DESCRIPTION
##### SUMMARY

ansible.common removed ipaddress which is required by ec2_group module.
Fix ansible.common version <2.0.0 to handle this dependency.

Fixes: #273

Signed-off-by: Abhijeet Kasurde <akasurde@redhat.com>


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
changelogs/fragments/fix_netcommon.yml
galaxy.yml
