### PR TITLE
Add the waiter for ec2_vpc_nat_gateway

### DIFF
--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -329,7 +329,7 @@ ec2_data = {
                     "argument": "NatGateways[].State"
                 },
                 {
-                    "state": "success",
+                    "state": "retry",
                     "matcher": "error",
                     "expected": "NatGatewayNotFound"
                 }

--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -299,6 +299,24 @@ ec2_data = {
                 },
             ]
         },
+         "NatGatewayDeleted": {
+            "operation": "DescribeNatGateways",
+            "delay": 15,
+            "maxAttempts": 40,
+            "acceptors": [
+               {
+                    "state": "retry",
+                    "matcher": "pathAll",
+                    "argument": "NatGateways[].State != 'deleted'",
+                    "expected": True
+                },
+                {
+                    "matcher": "error",
+                    "expected": "NatGatewayNotFound",
+                    "state": "retry"
+                },
+            ]
+        },
     }
 }
 
@@ -531,6 +549,12 @@ waiters_by_name = {
         ec2_model('VpnGatewayDetached'),
         core_waiter.NormalizedOperationMethod(
             ec2.describe_vpn_gateways
+        )),
+    ('EC2', 'nat_gateway_deleted'): lambda ec2: core_waiter.Waiter(
+        'nat_gateway_deleted',
+        ec2_model('NatGatewayDeleted'),
+        core_waiter.NormalizedOperationMethod(
+            ec2.describe_nat_gateways
         )),
     ('WAF', 'change_token_in_sync'): lambda waf: core_waiter.Waiter(
         'change_token_in_sync',

--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -299,22 +299,40 @@ ec2_data = {
                 },
             ]
         },
-         "NatGatewayDeleted": {
-            "operation": "DescribeNatGateways",
-            "delay": 15,
+        "NatGatewayDeleted": {
+            "delay": 5,
             "maxAttempts": 40,
+            "operation": "DescribeNatGateways",
             "acceptors": [
-               {
-                    "state": "retry",
+                {
+                    "state": "success",
                     "matcher": "pathAll",
-                    "argument": "NatGateways[].State != 'deleted'",
-                    "expected": True
+                    "expected": "deleted",
+                    "argument": "NatGateways[].State"
                 },
                 {
+                    "state": "success",
                     "matcher": "error",
-                    "expected": "NatGatewayNotFound",
-                    "state": "retry"
+                    "expected": "NatGatewayNotFound"
+                }
+            ]
+        },
+        "NatGatewayAvailable": {
+            "delay": 5,
+            "maxAttempts": 40,
+            "operation": "DescribeNatGateways",
+            "acceptors": [
+                {
+                    "state": "success",
+                    "matcher": "pathAll",
+                    "expected": "available",
+                    "argument": "NatGateways[].State"
                 },
+                {
+                    "state": "success",
+                    "matcher": "error",
+                    "expected": "NatGatewayNotFound"
+                }
             ]
         },
     }
@@ -553,6 +571,12 @@ waiters_by_name = {
     ('EC2', 'nat_gateway_deleted'): lambda ec2: core_waiter.Waiter(
         'nat_gateway_deleted',
         ec2_model('NatGatewayDeleted'),
+        core_waiter.NormalizedOperationMethod(
+            ec2.describe_nat_gateways
+        )),
+    ('EC2', 'nat_gateway_available'): lambda ec2: core_waiter.Waiter(
+        'nat_gateway_available',
+        ec2_model('NatGatewayAvailable'),
         core_waiter.NormalizedOperationMethod(
             ec2.describe_nat_gateways
         )),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add waiters for ec2_vpc_nat_gateway (https://github.com/ansible-collections/community.aws/pull/445) to manage deleted and available states.
