### PR TITLE
address pylint errors

### DIFF
--- a/plugins/module_utils/cloud.py
+++ b/plugins/module_utils/cloud.py
@@ -142,7 +142,7 @@ class CloudRetry(object):
                     try:
                         return f(*args, **kwargs)
                     except Exception as e:
-                        if isinstance(e, cls.base_class):
+                        if cls.base_class and isinstance(e, cls.base_class):
                             response_code = cls.status_code_from_exception(e)
                             if cls.found(response_code, catch_extra_error_codes):
                                 msg = "{0}: Retrying in {1} seconds...".format(str(e), delay)

--- a/plugins/module_utils/cloudfront_facts.py
+++ b/plugins/module_utils/cloudfront_facts.py
@@ -163,7 +163,7 @@ class CloudFrontFactsServiceManager(object):
                 temp_distribution = {}
                 for key_name in key_list:
                     temp_distribution[key_name] = dist[key_name]
-                temp_distribution['Aliases'] = [alias for alias in dist['Aliases'].get('Items', [])]
+                temp_distribution['Aliases'] = dist['Aliases'].get('Items', [])
                 temp_distribution['ETag'] = self.get_etag_from_distribution_id(dist['Id'], streaming)
                 if not streaming:
                     temp_distribution['WebACLId'] = dist['WebACLId']

--- a/plugins/module_utils/core.py
+++ b/plugins/module_utils/core.py
@@ -188,7 +188,6 @@ class AnsibleAWSModule(object):
         return boto3_conn(self, conn_type='resource', resource=service,
                           region=region, endpoint=ec2_url, **aws_connect_kwargs)
 
-    @property
     def region(self, boto3=True):
         return get_aws_region(self, boto3)
 


### PR DESCRIPTION
This commit addresses the three following pylint errors:

- plugins/module_utils/cloud.py:145:27: isinstance-second-argument-not-valid-type: Second argument of isinstance is not a type
- plugins/module_utils/cloudfront_facts.py:166:0: unnecessary-comprehension: Unnecessary use of a comprehension
- plugins/module_utils/core.py:192:4: property-with-parameters: Cannot have defined parameters for properties