### PR TITLE
Update plugin import handling for new sanity tests

### DIFF
--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -158,11 +158,13 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 
+
 try:
     import boto3
     import botocore
+    HAS_BOTO3 = True
 except ImportError:
-    raise AnsibleError('The ec2 dynamic inventory plugin requires boto3 and botocore.')
+    HAS_BOTO3 = False
 
 # The mappings give an array of keys to get from the filter name to the value
 # returned by boto3's EC2 describe_instances method.
@@ -615,6 +617,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
     def parse(self, inventory, loader, path, cache=True):
 
         super(InventoryModule, self).parse(inventory, loader, path)
+
+        if not HAS_BOTO3:
+            raise AnsibleError('The ec2 dynamic inventory plugin requires boto3 and botocore.')
 
         self._read_config_data(path)
 

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -74,8 +74,9 @@ from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cachea
 try:
     import boto3
     import botocore
+    HAS_BOTO3 = True
 except ImportError:
-    raise AnsibleError('The RDS dynamic inventory plugin requires boto3 and botocore.')
+    HAS_BOTO3 = False
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
@@ -326,6 +327,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def parse(self, inventory, loader, path, cache=True):
         super(InventoryModule, self).parse(inventory, loader, path)
+
+        if not HAS_BOTO3:
+            raise AnsibleError('The RDS dynamic inventory plugin requires boto3 and botocore.')
 
         config_data = self._read_config_data(path)
         self._set_credentials()

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -54,11 +54,13 @@ _raw:
 
 from ansible.errors import AnsibleError
 
+
 try:
     import boto3
     import botocore
+    HAS_BOTO3 = True
 except ImportError:
-    raise AnsibleError("The lookup aws_account_attribute requires boto3 and botocore.")
+    HAS_BOTO3 = False
 
 from ansible.module_utils._text import to_native
 from ansible.plugins.lookup import LookupBase
@@ -93,6 +95,9 @@ def _get_credentials(options):
 
 class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
+
+        if not HAS_BOTO3:
+            raise AnsibleError("The lookup aws_account_attribute requires boto3 and botocore.")
 
         self.set_options(var_options=variables, direct=kwargs)
         boto_credentials = _get_credentials(self._options)

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -108,8 +108,9 @@ from ansible.module_utils.six import string_types
 try:
     import boto3
     import botocore
+    HAS_BOTO3 = True
 except ImportError:
-    raise AnsibleError("The lookup aws_secret requires boto3 and botocore.")
+    HAS_BOTO3 = False
 
 from ansible.plugins.lookup import LookupBase
 from ansible.module_utils._text import to_native


### PR DESCRIPTION
##### SUMMARY
Catch and handle boto import failures like we do in modules,
rather than directly raise AnsibleError via ImportError

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/inventory/aws_ec2.py
plugins/inventory/aws_rds.py
plugins/lookup/aws_account_attribute.py
plugins/lookup/aws_secret.py

