### PR TITLE
Add comments to sanity ignore files explaining why things are ignored

### DIFF
--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,6 +1,6 @@
-plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice
-plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice
-tests/utils/shippable/check_matrix.py replace-urlopen
-tests/utils/shippable/timing.py shebang
-plugins/module_utils/compat/_ipaddress.py no-assert
-plugins/module_utils/compat/_ipaddress.py no-unicode-literals
+plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
+plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
+plugins/module_utils/compat/_ipaddress.py no-assert  # Vendored library
+plugins/module_utils/compat/_ipaddress.py no-unicode-literals  # Vendored library
+tests/utils/shippable/check_matrix.py replace-urlopen  # Standalone script used as part of testing
+tests/utils/shippable/timing.py shebang  # Standalone script used as part of testing

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,9 +1,9 @@
-plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice
-plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice
-tests/utils/shippable/check_matrix.py replace-urlopen
-tests/utils/shippable/timing.py shebang
-plugins/module_utils/compat/_ipaddress.py no-assert
-plugins/module_utils/compat/_ipaddress.py no-unicode-literals
-plugins/module_utils/cloud.py pylint:isinstance-second-argument-not-valid-type
-plugins/module_utils/cloudfront_facts.py pylint:unnecessary-comprehension
-plugins/module_utils/core.py pylint:property-with-parameters
+plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
+plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
+plugins/module_utils/cloudfront_facts.py pylint:unnecessary-comprehension  # New test simple fix - https://github.com/ansible-collections/amazon.aws/pull/291
+plugins/module_utils/cloud.py pylint:isinstance-second-argument-not-valid-type  # New test simple fix - https://github.com/ansible-collections/amazon.aws/pull/291
+plugins/module_utils/compat/_ipaddress.py no-assert  # Vendored library
+plugins/module_utils/compat/_ipaddress.py no-unicode-literals  # Vendored library
+plugins/module_utils/core.py pylint:property-with-parameters  # Breaking change required to fix - https://github.com/ansible-collections/amazon.aws/pull/290
+tests/utils/shippable/check_matrix.py replace-urlopen  # Standalone script used as part of testing
+tests/utils/shippable/timing.py shebang  # Standalone script used as part of testing

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,19 +1,19 @@
-plugins/modules/aws_az_info.py pylint:ansible-deprecated-no-version
-plugins/modules/aws_caller_info.py pylint:ansible-deprecated-no-version
-plugins/modules/cloudformation_info.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2_ami_info.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2_eni_info.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2_group_info.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2_snapshot_info.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2_tag.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2_vol.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2_vol_info.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2_vpc_dhcp_option_info.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2_vpc_net_info.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2_vpc_subnet_info.py pylint:ansible-deprecated-no-version
-plugins/module_utils/ec2.py pylint:ansible-deprecated-no-version
-tests/utils/shippable/check_matrix.py replace-urlopen
-tests/utils/shippable/timing.py shebang
-plugins/module_utils/compat/_ipaddress.py no-assert
-plugins/module_utils/compat/_ipaddress.py no-unicode-literals
+plugins/modules/aws_az_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/aws_caller_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/cloudformation_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2_ami_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2_eni_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2_group_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2_snapshot_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2_tag.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2_vol_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2_vol.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2_vpc_dhcp_option_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2_vpc_net_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2_vpc_subnet_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/module_utils/compat/_ipaddress.py no-assert  # Vendored library
+plugins/module_utils/compat/_ipaddress.py no-unicode-literals  # Vendored library
+plugins/module_utils/ec2.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+tests/utils/shippable/check_matrix.py replace-urlopen  # Standalone script used as part of testing
+tests/utils/shippable/timing.py shebang  # Standalone script used as part of testing


### PR DESCRIPTION
##### SUMMARY

While in theory it's possible to track down the origin of sanity ignore entries by digging through commit histories this is work that would need to be done every time anyone wanted to cleanup.  Add comments instead.

##### ISSUE TYPE

- Tests Pull Request

##### COMPONENT NAME

sanity

##### ADDITIONAL INFORMATION