### PR TITLE
Use HAS_BOTO3 consistently in non-module plugins

### DIFF
--- a/changelogs/fragments/288-has_boto3.yml
+++ b/changelogs/fragments/288-has_boto3.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- AWS inventory plugins - use shared HAS_BOTO3 helper rather than copying code (https://github.com/ansible-collections/amazon.aws/pull/288).
+- AWS lookup plugins - use shared HAS_BOTO3 helper rather than copying code (https://github.com/ansible-collections/amazon.aws/pull/288).

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -155,15 +155,15 @@ import re
 try:
     import boto3
     import botocore
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # will be captured by imported HAS_BOTO3
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native
 from ansible.module_utils._text import to_text
 from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
 
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -152,19 +152,22 @@ compose:
 
 import re
 
-from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_native, to_text
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
-
-
 try:
     import boto3
     import botocore
     HAS_BOTO3 = True
 except ImportError:
     HAS_BOTO3 = False
+
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_text
+from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+
 
 # The mappings give an array of keys to get from the filter name to the value
 # returned by boto3's EC2 describe_instances method.

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -67,9 +67,8 @@ keyed_groups:
 try:
     import boto3
     import botocore
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # will be captured by imported HAS_BOTO3
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native
@@ -78,6 +77,7 @@ from ansible.plugins.inventory import Cacheable
 from ansible.plugins.inventory import Constructable
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -64,19 +64,23 @@ keyed_groups:
   - key: region
 '''
 
-from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_native
-from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list, boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible.plugins.inventory import BaseInventoryPlugin, Constructable, Cacheable
-
 try:
     import boto3
     import botocore
     HAS_BOTO3 = True
 except ImportError:
     HAS_BOTO3 = False
+
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native
+from ansible.plugins.inventory import BaseInventoryPlugin
+from ansible.plugins.inventory import Cacheable
+from ansible.plugins.inventory import Constructable
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
 
 
 class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -51,10 +51,6 @@ _raw:
     Returns a boolean when I(attribute) is check_ec2_classic. Otherwise returns the value(s) of the attribute
     (or all attributes if one is not specified).
 """
-
-from ansible.errors import AnsibleError
-
-
 try:
     import boto3
     import botocore
@@ -62,6 +58,7 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
+from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native
 from ansible.plugins.lookup import LookupBase
 

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -51,16 +51,18 @@ _raw:
     Returns a boolean when I(attribute) is check_ec2_classic. Otherwise returns the value(s) of the attribute
     (or all attributes if one is not specified).
 """
+
 try:
     import boto3
     import botocore
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # will be captured by imported HAS_BOTO3
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native
 from ansible.plugins.lookup import LookupBase
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 
 
 def _boto3_conn(region, credentials):

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -102,8 +102,7 @@ _raw:
     Returns the value of the secret stored in AWS Secrets Manager.
 """
 
-from ansible.errors import AnsibleError
-from ansible.module_utils.six import string_types
+import json
 
 try:
     import boto3
@@ -112,12 +111,13 @@ try:
 except ImportError:
     HAS_BOTO3 = False
 
-from ansible.plugins.lookup import LookupBase
+from ansible.errors import AnsibleError
+from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
+from ansible.plugins.lookup import LookupBase
+
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
-
-import json
 
 
 def _boto3_conn(region, credentials):

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -107,9 +107,8 @@ import json
 try:
     import boto3
     import botocore
-    HAS_BOTO3 = True
 except ImportError:
-    HAS_BOTO3 = False
+    pass  # will be captured by imported HAS_BOTO3
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.six import string_types

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -44,10 +44,13 @@ _raw:
 import json
 
 from ansible.errors import AnsibleError
-from ansible.plugins.lookup import LookupBase
-from ansible.module_utils.urls import open_url, ConnectionError, SSLValidationError
+from ansible.module_utils.six.moves.urllib.error import HTTPError
+from ansible.module_utils.six.moves.urllib.error import URLError
 from ansible.module_utils._text import to_native
-from ansible.module_utils.six.moves.urllib.error import HTTPError, URLError
+from ansible.module_utils.urls import ConnectionError
+from ansible.module_utils.urls import open_url
+from ansible.module_utils.urls import SSLValidationError
+from ansible.plugins.lookup import LookupBase
 
 
 class LookupModule(LookupBase):

--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -106,7 +106,6 @@ EXAMPLES = '''
 '''
 
 try:
-    from botocore.exceptions import ClientError
     import botocore
     import boto3
 except ImportError:
@@ -189,7 +188,7 @@ class LookupModule(LookupBase):
                 display.vvv("AWS_ssm path lookup term: %s in region: %s" % (term, region))
                 try:
                     response = client.get_parameters_by_path(**ssm_dict)
-                except ClientError as e:
+                except botocore.exceptions.ClientError as e:
                     raise AnsibleError("SSM lookup exception: {0}".format(to_native(e)))
                 paramlist = list()
                 paramlist.extend(response['Parameters'])
@@ -217,7 +216,7 @@ class LookupModule(LookupBase):
             ssm_dict["Names"] = terms
             try:
                 response = client.get_parameters(**ssm_dict)
-            except ClientError as e:
+            except botocore.exceptions.ClientError as e:
                 raise AnsibleError("SSM lookup exception: {0}".format(to_native(e)))
             params = boto3_tag_list_to_ansible_dict(response['Parameters'], tag_name_key_name="Name",
                                                     tag_value_key_name="Value")

--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -116,8 +116,8 @@ from ansible.module_utils._text import to_native
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.display import Display
 
-from ..module_utils.ec2 import HAS_BOTO3
-from ..module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 
 display = Display()
 


### PR DESCRIPTION
##### SUMMARY

We have a HAS_BOTO3 helper use it consistently for the non-module plugins.

In one case we even defined HAS_BOTO3 and then imported it from module_utils.ec2...

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/inventory/aws_ec2.py
plugins/inventory/aws_rds.py
plugins/lookup/aws_account_attribute.py
plugins/lookup/aws_secret.py
plugins/lookup/aws_service_ip_ranges.py
plugins/lookup/aws_ssm.py
plugins/module_utils/cloud.py
plugins/module_utils/cloudfront_facts.py
plugins/module_utils/core.py

##### ADDITIONAL INFORMATION