### PR TITLE
Ignore duplicate-except pylint errors

### DIFF
--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -339,10 +339,10 @@ def key_check(module, s3, bucket, obj, version=None, validate=True):
             s3.head_object(Bucket=bucket, Key=obj)
     except is_boto3_error_code('404'):
         return False
-    except is_boto3_error_code('403') as e:
+    except is_boto3_error_code('403') as e:  # pylint: disable=duplicate-except
         if validate is True:
             module.fail_json_aws(e, msg="Failed while looking up object (during key check) %s." % obj)
-    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Failed while looking up object (during key check) %s." % obj)
 
     return True
@@ -374,12 +374,12 @@ def bucket_check(module, s3, bucket, validate=True):
         s3.head_bucket(Bucket=bucket)
     except is_boto3_error_code('404'):
         return False
-    except is_boto3_error_code('403') as e:
+    except is_boto3_error_code('403') as e:  # pylint: disable=duplicate-except
         if validate is True:
             module.fail_json_aws(e, msg="Failed while looking up bucket (during bucket_check) %s." % bucket)
-    except botocore.exceptions.EndpointConnectionError as e:
+    except botocore.exceptions.EndpointConnectionError as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Invalid endpoint provided")
-    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Failed while looking up bucket (during bucket_check) %s." % bucket)
     return exists
 
@@ -404,7 +404,7 @@ def create_bucket(module, s3, bucket, location=None):
             )(s3.put_bucket_acl)(ACL=acl, Bucket=bucket)
     except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
         module.warn("PutBucketAcl is not implemented by your storage provider. Set the permission parameters to the empty list to avoid this warning")
-    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Failed while creating bucket or setting acl (check that you have CreateBucket and PutBucketAcl permission).")
 
     if bucket:
@@ -455,7 +455,7 @@ def delete_bucket(module, s3, bucket):
         return True
     except is_boto3_error_code('NoSuchBucket'):
         return False
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Failed while deleting bucket %s." % bucket)
 
 
@@ -484,7 +484,7 @@ def create_dirkey(module, s3, bucket, obj, encrypt):
             s3.put_object_acl(ACL=acl, Bucket=bucket, Key=obj)
     except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
         module.warn("PutObjectAcl is not implemented by your storage provider. Set the permissions parameters to the empty list to avoid this warning")
-    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Failed while creating object %s." % obj)
     module.exit_json(msg="Virtual directory %s created in bucket %s" % (obj, bucket), changed=True)
 
@@ -552,7 +552,7 @@ def upload_s3file(module, s3, bucket, obj, expiry, metadata, encrypt, headers, s
             s3.put_object_acl(ACL=acl, Bucket=bucket, Key=obj)
     except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
         module.warn("PutObjectAcl is not implemented by your storage provider. Set the permission parameters to the empty list to avoid this warning")
-    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Unable to set object ACL")
     try:
         url = s3.generate_presigned_url(ClientMethod='put_object',
@@ -577,7 +577,7 @@ def download_s3file(module, s3, bucket, obj, dest, retries, version=None):
         # AccessDenied errors may be triggered if 1) file does not exist or 2) file exists but
         # user does not have the s3:GetObject permission. 404 errors are handled by download_file().
         module.fail_json_aws(e, msg="Could not find the key %s." % obj)
-    except is_boto3_error_message('require AWS Signature Version 4'):
+    except is_boto3_error_message('require AWS Signature Version 4'):  # pylint: disable=duplicate-except
         raise Sigv4Required()
     except is_boto3_error_code('InvalidArgument') as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Could not find the key %s." % obj)

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -578,7 +578,7 @@ def deregister_image(module, connection):
             # Don't error out if root volume snapshot was already deregistered as part of deregister_image
             except is_boto3_error_code('InvalidSnapshot.NotFound'):
                 pass
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
                 module.fail_json_aws(e, msg='Failed to delete snapshot.')
         exit_params['snapshots_deleted'] = snapshots
 
@@ -671,7 +671,7 @@ def get_image_by_id(module, connection, image_id):
                                                                              ImageId=image_id)['ProductCodes']
             except is_boto3_error_code('InvalidAMIID.Unavailable'):
                 pass
-            except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+            except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
                 module.fail_json_aws(e, msg="Error retrieving image attributes for image %s" % image_id)
             return result
         module.fail_json(msg="Invalid number of instances (%s) found for image_id: %s." % (str(len(images)), image_id))

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -221,7 +221,7 @@ def list_eni(connection, module):
         network_interfaces_result = connection.describe_network_interfaces(aws_retry=True, **params)['NetworkInterfaces']
     except is_boto3_error_code('InvalidNetworkInterfaceID.NotFound'):
         module.exit_json(network_interfaces=[])
-    except (ClientError, NoCredentialsError) as e:
+    except (ClientError, NoCredentialsError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e)
 
     # Modify boto3 tags list to be ansible friendly dict and then camel_case

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -174,7 +174,7 @@ def find_key_pair(module, ec2_client, name):
         key = ec2_client.describe_key_pairs(aws_retry=True, KeyNames=[name])['KeyPairs'][0]
     except is_boto3_error_code('InvalidKeyPair.NotFound'):
         return None
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as err:
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as err:  # pylint: disable=duplicate-except
         module.fail_json_aws(err, msg="error finding keypair")
     except IndexError:
         key = None

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -266,7 +266,7 @@ def create_or_update_bucket(s3_client, module, location):
     except is_boto3_error_code(['NotImplemented', 'XNotImplemented']) as exp:
         if versioning is not None:
             module.fail_json_aws(exp, msg="Failed to get bucket versioning")
-    except (BotoCoreError, ClientError) as exp:
+    except (BotoCoreError, ClientError) as exp:  # pylint: disable=duplicate-except
         module.fail_json_aws(exp, msg="Failed to get bucket versioning")
     else:
         if versioning is not None:
@@ -297,7 +297,7 @@ def create_or_update_bucket(s3_client, module, location):
     except is_boto3_error_code(['NotImplemented', 'XNotImplemented']):
         if requester_pays is not None:
             module.fail_json_aws(exp, msg="Failed to get bucket request payment")
-    except (BotoCoreError, ClientError) as exp:
+    except (BotoCoreError, ClientError) as exp:  # pylint: disable=duplicate-except
         module.fail_json_aws(exp, msg="Failed to get bucket request payment")
     else:
         if requester_pays is not None:
@@ -320,7 +320,7 @@ def create_or_update_bucket(s3_client, module, location):
     except is_boto3_error_code(['NotImplemented', 'XNotImplemented']):
         if policy is not None:
             module.fail_json_aws(exp, msg="Failed to get bucket policy")
-    except (BotoCoreError, ClientError) as exp:
+    except (BotoCoreError, ClientError) as exp:  # pylint: disable=duplicate-except
         module.fail_json_aws(exp, msg="Failed to get bucket policy")
     else:
         if policy is not None:
@@ -355,7 +355,7 @@ def create_or_update_bucket(s3_client, module, location):
     except is_boto3_error_code(['NotImplemented', 'XNotImplemented']):
         if tags is not None:
             module.fail_json_aws(exp, msg="Failed to get bucket tags")
-    except (ClientError, BotoCoreError) as exp:
+    except (ClientError, BotoCoreError) as exp:  # pylint: disable=duplicate-except
         module.fail_json_aws(exp, msg="Failed to get bucket tags")
     else:
         if tags is not None:


### PR DESCRIPTION
##### SUMMARY

There's a known issue with pylint not understanding the logic we're using.  Explicitly ignore 
```
duplicate-except: Catching previously caught exception type ClientError (0%)
```
Where we're using `is_boto3_error_code`

##### ISSUE TYPE

- Tests Pull Request

##### COMPONENT NAME

plugins/modules/aws_s3.py
plugins/modules/ec2_ami.py
plugins/modules/ec2_eni_info.py
plugins/modules/ec2_key.py
plugins/modules/s3_bucket.py

##### ADDITIONAL INFORMATION

Pylint issue: https://github.com/PyCQA/pylint/issues/2174