### PR TITLE
scrub_none_parameters - set default for descend_into_lists to True (breaking change)

### DIFF
--- a/changelogs/fragments/297-scrub_none_parameters-descend-default.yml
+++ b/changelogs/fragments/297-scrub_none_parameters-descend-default.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- module_utils/core - updated the ``scrub_none_parameters`` function so that ``descend_into_lists`` is set to ``True`` by default (https://github.com/ansible-collections/amazon.aws/pull/297).

--- a/plugins/module_utils/core.py
+++ b/plugins/module_utils/core.py
@@ -359,7 +359,7 @@ def get_boto3_client_method_parameters(client, method_name, required=False):
     return parameters
 
 
-def scrub_none_parameters(parameters, descend_into_lists=False):
+def scrub_none_parameters(parameters, descend_into_lists=True):
     """
     Iterate over a dictionary removing any keys that have a None value
 

--- a/tests/unit/module_utils/core/test_scrub_none_parameters.py
+++ b/tests/unit/module_utils/core/test_scrub_none_parameters.py
@@ -83,6 +83,6 @@ scrub_none_test_data = [
 
 @pytest.mark.parametrize("input_params, output_params_no_descend, output_params_descend", scrub_none_test_data)
 def test_scrub_none_parameters(input_params, output_params_no_descend, output_params_descend):
-    assert scrub_none_parameters(input_params) == output_params_no_descend
+    assert scrub_none_parameters(input_params) == output_params_descend
     assert scrub_none_parameters(input_params, descend_into_lists=False) == output_params_no_descend
     assert scrub_none_parameters(input_params, descend_into_lists=True) == output_params_descend


### PR DESCRIPTION
##### SUMMARY

Follow up to #262 set the default for descend_into_lists to True since this is what folks will want most of the time.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/core.py

##### ADDITIONAL INFORMATION

Needs to wait for the 2.0 freeze.