### PR TITLE
Update the default module requirements from python-2.6/boto to python-3.6/botocore-1.16 (breaking change)

### DIFF
--- a/changelogs/fragments/298-python3.6.yml
+++ b/changelogs/fragments/298-python3.6.yml
@@ -1,0 +1,2 @@
+major_changes:
+- amazon.aws collection - Due to the AWS SDKs announcing the end of support for Python less than 3.6 (https://boto3.amazonaws.com/v1/documentation/api/1.17.64/guide/migrationpy3.html) this collection now requires Python 3.6+ (https://github.com/ansible-collections/amazon.aws/pull/298).

--- a/plugins/doc_fragments/aws.py
+++ b/plugins/doc_fragments/aws.py
@@ -77,8 +77,8 @@ options:
     type: dict
 requirements:
   - python >= 3.6
-  - boto3
-  - botocore
+  - boto3 >= 1.13.0
+  - botocore >= 1.16.0
 notes:
   - If parameters are not set within the module, the following
     environment variables can be used in decreasing order of precedence

--- a/plugins/doc_fragments/aws.py
+++ b/plugins/doc_fragments/aws.py
@@ -53,17 +53,17 @@ options:
   aws_ca_bundle:
     description:
       - "The location of a CA Bundle to use when validating SSL certificates."
-      - "Only used for boto3 based modules."
+      - "Not used by boto 2 based modules."
       - "Note: The CA Bundle is read 'module' side and may need to be explicitly copied from the controller if not run locally."
     type: path
   validate_certs:
     description:
-      - When set to "no", SSL certificates will not be validated for boto versions >= 2.6.0.
+      - When set to "no", SSL certificates will not be validated for
+        communication with the AWS APIs.
     type: bool
     default: yes
   profile:
     description:
-      - Uses a boto profile. Only works with boto >= 2.24.0.
       - Using I(profile) will override I(aws_access_key), I(aws_secret_key) and I(security_token)
         and support for passing them at the same time as I(profile) has been deprecated.
       - I(aws_access_key), I(aws_secret_key) and I(security_token) will be made mutually exclusive with I(profile) after 2022-06-01.
@@ -76,8 +76,9 @@ options:
       - Only the 'user_agent' key is used for boto modules. See U(http://boto.cloudhackers.com/en/latest/boto_config_tut.html#boto) for more boto configuration.
     type: dict
 requirements:
-  - python >= 2.6
-  - boto
+  - python >= 3.6
+  - boto3
+  - botocore
 notes:
   - If parameters are not set within the module, the following
     environment variables can be used in decreasing order of precedence

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -8,6 +8,7 @@ lookup: aws_account_attribute
 author:
   - Sloane Hertel <shertel@redhat.com>
 requirements:
+  - python >= 3.6
   - boto3
   - botocore
 extends_documentation_fragment:

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -10,7 +10,7 @@ author:
 requirements:
   - python >= 3.6
   - boto3
-  - botocore
+  - botocore >= 1.16.0
 extends_documentation_fragment:
 - amazon.aws.aws_credentials
 - amazon.aws.aws_region

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -9,8 +9,9 @@ lookup: aws_secret
 author:
   - Aaron Smith <ajsmith10381@gmail.com>
 requirements:
+  - python >= 3.6
   - boto3
-  - botocore>=1.10.0
+  - botocore >= 1.10.0
 extends_documentation_fragment:
 - amazon.aws.aws_credentials
 - amazon.aws.aws_region

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -11,7 +11,7 @@ author:
 requirements:
   - python >= 3.6
   - boto3
-  - botocore >= 1.10.0
+  - botocore >= 1.16.0
 extends_documentation_fragment:
 - amazon.aws.aws_credentials
 - amazon.aws.aws_region

--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -14,6 +14,7 @@ author:
   - Marat Bakeev <hawara(at)gmail.com>
   - Michael De La Rue <siblemitcom.mddlr@spamgourmet.com>
 requirements:
+  - python >= 3.6
   - boto3
   - botocore
 short_description: Get the value for a SSM parameter or all parameters under a path.

--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -16,7 +16,7 @@ author:
 requirements:
   - python >= 3.6
   - boto3
-  - botocore
+  - botocore >= 1.16.0
 short_description: Get the value for a SSM parameter or all parameters under a path.
 description:
   - Get the value for an Amazon Simple Systems Manager parameter or a hierarchy of parameters.

--- a/plugins/modules/aws_az_info.py
+++ b/plugins/modules/aws_az_info.py
@@ -29,8 +29,6 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements: [botocore, boto3]
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/aws_caller_info.py
+++ b/plugins/modules/aws_caller_info.py
@@ -20,7 +20,6 @@ author:
     - Ed Costello (@orthanc)
     - Stijn Dubrul (@sdubrul)
 
-requirements: [ 'botocore', 'boto3' ]
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -157,7 +157,6 @@ options:
     description:
       - KMS key id to use when encrypting objects using I(encrypting=aws:kms). Ignored if I(encryption) is not C(aws:kms).
     type: str
-requirements: [ "boto3", "botocore" ]
 author:
     - "Lester Wade (@lwade)"
     - "Sloane Hertel (@s-hertel)"

--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -14,7 +14,6 @@ short_description: manage objects in S3.
 description:
     - This module allows the user to manage S3 buckets and the objects within them. Includes support for creating and
       deleting both objects and buckets, retrieving objects as files or strings and generating download links.
-      This module has a dependency on boto3 and botocore.
 options:
   bucket:
     description:
@@ -118,7 +117,6 @@ options:
   dualstack:
     description:
       - Enables Amazon S3 Dual-Stack Endpoints, allowing S3 communications using both IPv4 and IPv6.
-      - Requires at least botocore version 1.4.45.
     type: bool
     default: false
   rgw:

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -175,7 +175,10 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 
-requirements: [ boto3, botocore>=1.5.45 ]
+requirements:
+- python >= 3.6
+- boto3
+- botocore >= 1.5.45
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -128,7 +128,7 @@ options:
     type: str
   termination_protection:
     description:
-    - Enable or disable termination protection on the stack. Only works with botocore >= 1.7.18.
+    - Enable or disable termination protection on the stack.
     type: bool
   template_body:
     description:
@@ -174,11 +174,6 @@ author: "James S. Martin (@jsmartin)"
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-- python >= 3.6
-- boto3
-- botocore >= 1.5.45
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/cloudformation_info.py
+++ b/plugins/modules/cloudformation_info.py
@@ -15,9 +15,6 @@ description:
   - Gets information about an AWS CloudFormation stack.
   - This module was called C(amazon.aws.cloudformation_facts) before Ansible 2.9, returning C(ansible_facts).
     Note that the M(amazon.aws.cloudformation_info) module no longer returns C(ansible_facts)!
-requirements:
-  - boto3 >= 1.0.0
-  - python >= 2.6
 author:
     - Justin Menga (@jmenga)
     - Kevin Coming (@waffie1)

--- a/plugins/modules/ec2.py
+++ b/plugins/modules/ec2.py
@@ -257,6 +257,9 @@ author:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
+requirements:
+- python >= 2.6
+- boto
 
 '''
 

--- a/plugins/modules/ec2_ami_info.py
+++ b/plugins/modules/ec2_ami_info.py
@@ -16,7 +16,6 @@ description:
   - This module was called C(amazon.aws.ec2_ami_facts) before Ansible 2.9. The usage did not change.
 author:
   - Prasad Katti (@prasadkatti)
-requirements: [ boto3 ]
 options:
   image_ids:
     description: One or more image IDs.

--- a/plugins/modules/ec2_elb_lb.py
+++ b/plugins/modules/ec2_elb_lb.py
@@ -132,6 +132,10 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 
+requirements:
+- python >= 2.6
+- boto
+
 '''
 
 EXAMPLES = """

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -15,7 +15,6 @@ description:
     - Gather information about ec2 ENI interfaces in AWS.
     - This module was called C(ec2_eni_facts) before Ansible 2.9. The usage did not change.
 author: "Rob White (@wimnat)"
-requirements: [ boto3 ]
 options:
   eni_id:
     description:

--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -12,7 +12,6 @@ DOCUMENTATION = '''
 module: ec2_group
 version_added: 1.0.0
 author: "Andrew de Quincey (@adq)"
-requirements: [ boto3 ]
 short_description: maintain an ec2 VPC security group.
 description:
     - Maintains ec2 security groups.

--- a/plugins/modules/ec2_group_info.py
+++ b/plugins/modules/ec2_group_info.py
@@ -14,7 +14,6 @@ short_description: Gather information about ec2 security groups in AWS.
 description:
     - Gather information about ec2 security groups in AWS.
     - This module was called C(amazon.aws.ec2_group_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 author:
 - Henrique Rodrigues (@Sodki)
 options:

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -52,7 +52,6 @@ extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
 
-requirements: [ boto3 ]
 author:
   - "Vincent Viallet (@zbal)"
   - "Prasad Katti (@prasadkatti)"

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -14,7 +14,6 @@ short_description: Gather information about ec2 volume snapshots in AWS
 description:
     - Gather information about ec2 volume snapshots in AWS.
     - This module was called C(ec2_snapshot_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 author:
     - "Rob White (@wimnat)"
     - Aubin Bikouo (@abikouo)

--- a/plugins/modules/ec2_tag.py
+++ b/plugins/modules/ec2_tag.py
@@ -15,7 +15,6 @@ description:
     - Creates, modifies and removes tags for any EC2 resource.
     - Resources are referenced by their resource id (for example, an instance being i-XXXXXXX, a VPC being vpc-XXXXXXX).
     - This module is designed to be used with complex args (tags), see the examples.
-requirements: [ "boto3", "botocore" ]
 options:
   resource:
     description:

--- a/plugins/modules/ec2_tag_info.py
+++ b/plugins/modules/ec2_tag_info.py
@@ -15,7 +15,6 @@ description:
     - Lists tags for any EC2 resource.
     - Resources are referenced by their resource id (e.g. an instance being i-XXXXXXX, a vpc being vpc-XXXXXX).
     - Resource tags can be managed using the M(amazon.aws.ec2_tag) module.
-requirements: [ "boto3", "botocore" ]
 options:
   resource:
     description:

--- a/plugins/modules/ec2_vol_info.py
+++ b/plugins/modules/ec2_vol_info.py
@@ -14,7 +14,6 @@ short_description: Gather information about ec2 volumes in AWS
 description:
     - Gather information about ec2 volumes in AWS.
     - This module was called C(ec2_vol_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 author: "Rob White (@wimnat)"
 options:
   filters:

--- a/plugins/modules/ec2_vpc_dhcp_option.py
+++ b/plugins/modules/ec2_vpc_dhcp_option.py
@@ -104,9 +104,6 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-    - boto
 '''
 
 RETURN = """

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -14,7 +14,6 @@ short_description: Gather information about dhcp options sets in AWS
 description:
     - Gather information about dhcp options sets in AWS.
     - This module was called C(ec2_vpc_dhcp_option_facts) before Ansible 2.9. The usage did not change.
-requirements: [ boto3 ]
 author: "Nick Aslanidis (@naslanidis)"
 options:
   filters:

--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -78,9 +78,6 @@ options:
         duplicate VPCs created.
     type: bool
     default: false
-requirements:
-    - boto3
-    - botocore
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -15,9 +15,6 @@ description:
     - Gather information about ec2 VPCs in AWS
     - This module was called C(ec2_vpc_net_facts) before Ansible 2.9. The usage did not change.
 author: "Rob White (@wimnat)"
-requirements:
-  - boto3
-  - botocore
 options:
   vpc_ids:
     description:

--- a/plugins/modules/ec2_vpc_subnet.py
+++ b/plugins/modules/ec2_vpc_subnet.py
@@ -16,7 +16,6 @@ description:
 author:
 - Robert Estelle (@erydo)
 - Brad Davidson (@brandond)
-requirements: [ boto3 ]
 options:
   az:
     description:

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -15,9 +15,6 @@ description:
     - Gather information about ec2 VPC subnets in AWS
     - This module was called C(ec2_vpc_subnet_facts) before Ansible 2.9. The usage did not change.
 author: "Rob White (@wimnat)"
-requirements:
-  - boto3
-  - botocore
 options:
   subnet_ids:
     description:

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -24,7 +24,6 @@ version_added: 1.0.0
 short_description: Manage S3 buckets in AWS, DigitalOcean, Ceph, Walrus, FakeS3 and StorageGRID
 description:
     - Manage S3 buckets in AWS, DigitalOcean, Ceph, Walrus, FakeS3 and StorageGRID.
-requirements: [ boto3 ]
 author:
     - Rob White (@wimnat)
     - Aubin Bikouo (@abikouo)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto>=2.49.0
-botocore>=1.12.249
-boto3>=1.9.249
+botocore>=1.16.0
+boto3>=1.13.0

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,2 +1,2 @@
-boto3
+boto3>=1.13.0
 placebo


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/302

##### SUMMARY

The vast bulk of modules are now boto3 based, but some even list python2.6/boto as their requirements because they've picked the default from the aws docs fragment.

Switch the defaults over to reduce the copy&paste and reflect that

- boto v2 is deprecated
- python 2.6 is no longer supported by the AWS collections

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/doc_fragments/aws.py

##### ADDITIONAL INFORMATION

Should wait for the 2.0 release so we can cleanly update everything.