### PR TITLE
add no_log=False to ec2_key 'key_material'

### DIFF
--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -241,7 +241,7 @@ def main():
 
     argument_spec = dict(
         name=dict(required=True),
-        key_material=dict(),
+        key_material=dict(no_log=False),
         force=dict(type='bool', default=True),
         state=dict(default='present', choices=['present', 'absent']),
         wait=dict(type='bool', removed_at_date='2022-06-01', removed_from_collection='amazon.aws'),


### PR DESCRIPTION
##### SUMMARY

add no_log=False to ec2_key's 'key_material' parameter.  It's being falsely identified by the sanity tests as potentially containing secret material.

It only contains the material for the *public* part of an SSH key (non-secret)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_key

##### ADDITIONAL INFORMATION
https://github.com/ansible/ansible/pull/73508