### PR TITLE
more no_log=False to fix sanity tests (fixes CI)

### DIFF
--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -191,7 +191,7 @@ def aws_common_argument_spec():
     return dict(
         debug_botocore_endpoint_logs=dict(fallback=(env_fallback, ['ANSIBLE_DEBUG_BOTOCORE_LOGS']), default=False, type='bool'),
         ec2_url=dict(aliases=['aws_endpoint_url', 'endpoint_url']),
-        aws_access_key=dict(aliases=['ec2_access_key', 'access_key']),
+        aws_access_key=dict(aliases=['ec2_access_key', 'access_key'], no_log=False),
         aws_secret_key=dict(aliases=['ec2_secret_key', 'secret_key'], no_log=True),
         security_token=dict(aliases=['access_token', 'aws_security_token'], no_log=True),
         validate_certs=dict(default=True, type='bool'),

--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -678,7 +678,7 @@ def main():
         expiry=dict(default=600, type='int', aliases=['expiration']),
         headers=dict(type='dict'),
         marker=dict(default=""),
-        max_keys=dict(default=1000, type='int'),
+        max_keys=dict(default=1000, type='int', no_log=False),
         metadata=dict(type='dict'),
         mode=dict(choices=['get', 'put', 'delete', 'create', 'geturl', 'getstr', 'delobj', 'list'], required=True),
         object=dict(),


### PR DESCRIPTION
##### SUMMARY
The no_log validate-modules test was improved, and now flags some more things. This adds `no_log=False` to two false-positives. This fixes the sanity tests for amazon.aws.

CC @tremble @jillr

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
plugins/module_utils/ec2.py
plugins/modules/aws_s3.py
