### PR TITLE
Add common helper for ec2 client 'ensure_tags'

### DIFF
--- a/changelogs/fragments/309-ec2_tags.yml
+++ b/changelogs/fragments/309-ec2_tags.yml
@@ -1,0 +1,6 @@
+minor_changes:
+- module_utils/ec2 - added additional helper functions for tagging EC2 resources (https://github.com/ansible-collections/amazon.aws/pull/309).
+- ec2_tag - use common code for tagging resources (https://github.com/ansible-collections/amazon.aws/pull/309).
+- ec2_tag_info - use common code for tagging resources (https://github.com/ansible-collections/amazon.aws/pull/309).
+- ec2_vol - use common code for tagging resources (https://github.com/ansible-collections/amazon.aws/pull/309).
+- ec2_vpc_subnet - use common code for tagging resources (https://github.com/ansible-collections/amazon.aws/pull/309).

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -935,10 +935,7 @@ def ensure_ec2_tags(client, module, resource_id, resource_type=None, tags=None, 
     if purge_tags and not tags:
         tags_to_unset = current_tags
 
-    if tags_to_unset:
-        changed |= remove_ec2_tags(client, module, resource_id, tags_to_unset, retry_codes)
-
-    if tags_to_set:
-        changed |= add_ec2_tags(client, module, resource_id, tags_to_set, retry_codes)
+    changed |= remove_ec2_tags(client, module, resource_id, tags_to_unset, retry_codes)
+    changed |= add_ec2_tags(client, module, resource_id, tags_to_set, retry_codes)
 
     return changed

--- a/plugins/modules/ec2_tag_info.py
+++ b/plugins/modules/ec2_tag_info.py
@@ -58,13 +58,7 @@ except Exception:
     pass    # Handled by AnsibleAWSModule
 
 from ..module_utils.core import AnsibleAWSModule
-from ..module_utils.ec2 import boto3_tag_list_to_ansible_dict, AWSRetry
-
-
-@AWSRetry.jittered_backoff()
-def get_tags(ec2, module, resource):
-    filters = [{'Name': 'resource-id', 'Values': [resource]}]
-    return boto3_tag_list_to_ansible_dict(ec2.describe_tags(Filters=filters)['Tags'])
+from ..module_utils.ec2 import describe_ec2_tags
 
 
 def main():
@@ -76,10 +70,7 @@ def main():
     resource = module.params['resource']
     ec2 = module.client('ec2')
 
-    try:
-        current_tags = get_tags(ec2, module, resource)
-    except (BotoCoreError, ClientError) as e:
-        module.fail_json_aws(e, msg='Failed to fetch tags for resource {0}'.format(resource))
+    current_tags = describe_ec2_tags(ec2, module, resource)
 
     module.exit_json(changed=False, tags=current_tags)
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/876

##### SUMMARY

We're copy&pasting our 'ensure_tags' code all over the place.  Move the ensure_tags code for EC2 resources into module_utils

**Note:** It *might* work for other boto3 clients, but it's intended only for ec2 boto3 clients (unfortunately boto3 isn't consistent)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vol
ec2_vpc_subnet
ec2_tag
ec2_tag_info

##### ADDITIONAL INFORMATION

Todo:

- [x] unit tests
- [x] changelog