### PR TITLE
add object ownership controls options for s3 bucket

### DIFF
--- a/changelogs/fragments/311-s3_bucket-allow-object-ownership-configuration.yaml
+++ b/changelogs/fragments/311-s3_bucket-allow-object-ownership-configuration.yaml
@@ -1,0 +1,2 @@
+minor_changes:
+  - s3_bucket - add new option to configure object ownership (https://github.com/ansible-collections/amazon.aws/pull/311)

--- a/changelogs/fragments/311-s3_bucket-allow-object-ownership-configuration.yaml
+++ b/changelogs/fragments/311-s3_bucket-allow-object-ownership-configuration.yaml
@@ -1,2 +1,2 @@
 minor_changes:
-  - s3_bucket - add new option to configure object ownership (https://github.com/ansible-collections/amazon.aws/pull/311)
+  - s3_bucket - add new option ``object_ownership`` to configure object ownership (https://github.com/ansible-collections/amazon.aws/pull/311)

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -132,14 +132,14 @@ options:
       - This option cannot be used together with a I(delete_object_ownership) definition.
     choices: [ 'BucketOwnerPreferred', 'ObjectWriter' ]
     type: str
-    version_added: 1.5.0
+    version_added: 2.0.0
   delete_object_ownership:
     description:
       - Delete bucket's ownership controls.
       - This option cannot be used together with a I(object_ownership) definition.
     default: false
     type: bool
-    version_added: 1.5.0
+    version_added: 2.0.0
 
 extends_documentation_fragment:
 - amazon.aws.aws

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -125,7 +125,7 @@ options:
   object_ownership:
     description:
       - Allow bucket's ownership controls.
-      - BucketOwnerPreferred : Objects uploaded to the bucket change ownership to the bucket owner
+      - C(BucketOwnerPreferred) - Objects uploaded to the bucket change ownership to the bucket owner
       if the objects are uploaded with the bucket-owner-full-control canned ACL.
       - ObjectWriter: The uploading account will own the object
       if the object is uploaded with the bucket-owner-full-control canned ACL.

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -888,8 +888,8 @@ def main():
             block_public_policy=dict(type='bool', default=False),
             restrict_public_buckets=dict(type='bool', default=False))),
         delete_public_access=dict(type='bool', default=False),
-        object_ownership=dict(type='str',choices=['BucketOwnerPreferred','ObjectWriter']),
-        delete_object_ownership=dict(type='bool',default=False)
+        object_ownership=dict(type='str', choices=['BucketOwnerPreferred', 'ObjectWriter']),
+        delete_object_ownership=dict(type='bool', default=False),
     )
 
     required_by = dict(

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -132,6 +132,7 @@ options:
       - This option cannot be used together with a I(delete_object_ownership) definition.
     choices: [ 'BucketOwnerPreferred', 'ObjectWriter' ]
     type: str
+    version_added: 1.5.0
   delete_object_ownership:
     description:
       - Delete bucket's ownership controls.

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -760,14 +760,14 @@ def get_bucket_public_access(s3_client, bucket_name):
     except is_boto3_error_code('NoSuchPublicAccessBlockConfiguration'):
         return {}
 
-def get_bucket_ownership_cntrl(s3_client,bucket_name) :
+def get_bucket_ownership_cntrl(s3_client, bucket_name):
     '''
     Get current bucket public access block
     '''
     try:
         bucket_ownership = s3_client.get_bucket_ownership_controls(Bucket=bucket_name)
         return bucket_ownership['OwnershipControls']['Rules'][0]['ObjectOwnership']
-    except is_boto3_error_code([ 'OwnershipControlsNotFoundError','NoSuchOwnershipControls' ]):
+    except is_boto3_error_code(['OwnershipControlsNotFoundError', 'NoSuchOwnershipControls']):
         return None
 
 def paginated_list(s3_client, **pagination_params):

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -480,7 +480,7 @@ def create_or_update_bucket(s3_client, module, location):
     if delete_object_ownership or object_ownership is not None :
         if delete_object_ownership :
             # delete S3 buckect ownership
-            if bucket_ownership != {} :
+            if bucket_ownership != {}:
                 delete_bucket_ownership(s3_client,name)
                 changed=True
                 result['object_ownership']=None

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -638,6 +638,7 @@ def delete_bucket_public_access(s3_client, bucket_name):
     '''
     s3_client.delete_public_access_block(Bucket=bucket_name)
 
+
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def delete_bucket_ownership(s3_client, bucket_name):
     '''
@@ -656,6 +657,7 @@ def put_bucket_ownership(s3_client, bucket_name, target):
         OwnershipControls={
             'Rules': [{'ObjectOwnership': target}]
         })
+
 
 def wait_policy_is_applied(module, s3_client, bucket_name, expected_policy, should_fail=True):
     for dummy in range(0, 12):

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -126,9 +126,9 @@ options:
     description:
       - Allow bucket's ownership controls.
       - C(BucketOwnerPreferred) - Objects uploaded to the bucket change ownership to the bucket owner
-      if the objects are uploaded with the bucket-owner-full-control canned ACL.
+        if the objects are uploaded with the bucket-owner-full-control canned ACL.
       - C(ObjectWriter) - The uploading account will own the object
-      if the object is uploaded with the bucket-owner-full-control canned ACL.
+        if the object is uploaded with the bucket-owner-full-control canned ACL.
       - This option cannot be used together with a I(delete_object_ownership) definition.
     choices: [ 'BucketOwnerPreferred', 'ObjectWriter' ]
     type: str
@@ -475,23 +475,21 @@ def create_or_update_bucket(s3_client, module, location):
             result['public_access_block'] = {}
 
     # -- Bucket ownership
-    bucket_ownership = get_bucket_ownership_cntrl(s3_client,name)
+    bucket_ownership = get_bucket_ownership_cntrl(s3_client, name)
     result['object_ownership'] = bucket_ownership
-    if delete_object_ownership or object_ownership is not None :
-        if delete_object_ownership :
+    if delete_object_ownership or object_ownership is not None:
+        if delete_object_ownership:
             # delete S3 buckect ownership
             if bucket_ownership != {}:
-                delete_bucket_ownership(s3_client,name)
-                changed=True
-                result['object_ownership']=None
+                delete_bucket_ownership(s3_client, name)
+                changed = True
+                result['object_ownership'] = None
         else:
             # update S3 bucket ownership
-            if bucket_ownership != object_ownership :
-                put_bucket_ownership(s3_client,name,object_ownership)
-                changed=True
+            if bucket_ownership != object_ownership:
+                put_bucket_ownership(s3_client, name, object_ownership)
+                changed = True
                 result['object_ownership'] = object_ownership
-
-
 
     # Module exit
     module.exit_json(changed=changed, name=name, **result)
@@ -647,12 +645,14 @@ def delete_bucket_ownership(s3_client, bucket_name):
     '''
     s3_client.delete_bucket_ownership_controls(Bucket=bucket_name)
 
+
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
-def put_bucket_ownership(s3_client, bucket_name, target) :
+def put_bucket_ownership(s3_client, bucket_name, target):
     '''
     Put bucket ownership controls for S3 bucket
     '''
-    s3_client.put_bucket_ownership_controls(Bucket=bucket_name,
+    s3_client.put_bucket_ownership_controls(
+        Bucket=bucket_name,
         OwnershipControls={
             'Rules': [{'ObjectOwnership': target}]
         })
@@ -760,6 +760,7 @@ def get_bucket_public_access(s3_client, bucket_name):
     except is_boto3_error_code('NoSuchPublicAccessBlockConfiguration'):
         return {}
 
+
 def get_bucket_ownership_cntrl(s3_client, bucket_name):
     '''
     Get current bucket public access block
@@ -769,6 +770,7 @@ def get_bucket_ownership_cntrl(s3_client, bucket_name):
         return bucket_ownership['OwnershipControls']['Rules'][0]['ObjectOwnership']
     except is_boto3_error_code(['OwnershipControlsNotFoundError', 'NoSuchOwnershipControls']):
         return None
+
 
 def paginated_list(s3_client, **pagination_params):
     pg = s3_client.get_paginator('list_objects_v2')

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -767,6 +767,8 @@ def get_bucket_ownership_cntrl(s3_client, bucket_name):
     '''
     Get current bucket public access block
     '''
+    if not module.botocore_at_least('1.8.11'):
+        return None
     try:
         bucket_ownership = s3_client.get_bucket_ownership_controls(Bucket=bucket_name)
         return bucket_ownership['OwnershipControls']['Rules'][0]['ObjectOwnership']

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -273,7 +273,7 @@ def create_or_update_bucket(s3_client, module, location):
     public_access = module.params.get("public_access")
     delete_public_access = module.params.get("delete_public_access")
     delete_object_ownership = module.params.get("delete_object_ownership")
-    object_ownership=module.params.get("object_ownership")
+    object_ownership = module.params.get("object_ownership")
     changed = False
     result = {}
 

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -127,7 +127,7 @@ options:
       - Allow bucket's ownership controls.
       - C(BucketOwnerPreferred) - Objects uploaded to the bucket change ownership to the bucket owner
       if the objects are uploaded with the bucket-owner-full-control canned ACL.
-      - ObjectWriter: The uploading account will own the object
+      - C(ObjectWriter) - The uploading account will own the object
       if the object is uploaded with the bucket-owner-full-control canned ACL.
       - This option cannot be used together with a I(delete_object_ownership) definition.
     choices: [ 'BucketOwnerPreferred', 'ObjectWriter' ]

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -944,6 +944,12 @@ def main():
     state = module.params.get("state")
     encryption = module.params.get("encryption")
     encryption_key_id = module.params.get("encryption_key_id")
+    delete_object_ownership = module.params.get('delete_object_ownership')
+    object_ownership = module.params.get('object_ownership')
+
+    if delete_object_ownership is not None or object_ownership is not None:
+        if not module.botocore_at_least('1.8.11'):
+            module.fail_json(msg="Managing bucket ownership controls requires botocore version >= 1.8.11")
 
     if not hasattr(s3_client, "get_bucket_encryption"):
         if encryption is not None:

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -475,7 +475,7 @@ def create_or_update_bucket(s3_client, module, location):
             result['public_access_block'] = {}
 
     # -- Bucket ownership
-    bucket_ownership = get_bucket_ownership_cntrl(s3_client, name)
+    bucket_ownership = get_bucket_ownership_cntrl(s3_client, module, name)
     result['object_ownership'] = bucket_ownership
     if delete_object_ownership or object_ownership is not None:
         if delete_object_ownership:
@@ -763,7 +763,7 @@ def get_bucket_public_access(s3_client, bucket_name):
         return {}
 
 
-def get_bucket_ownership_cntrl(s3_client, bucket_name):
+def get_bucket_ownership_cntrl(s3_client, module, bucket_name):
     '''
     Get current bucket public access block
     '''

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -641,22 +641,21 @@ def delete_bucket_public_access(s3_client, bucket_name):
     s3_client.delete_public_access_block(Bucket=bucket_name)
 
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
-def delete_bucket_ownership(s3_client,bucket_name) :
+def delete_bucket_ownership(s3_client, bucket_name):
     '''
     Delete bucket ownership controls from S3 bucket
     '''
     s3_client.delete_bucket_ownership_controls(Bucket=bucket_name)
 
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
-def put_bucket_ownership(s3_client,bucket_name,target) :
+def put_bucket_ownership(s3_client, bucket_name, target) :
     '''
     Put bucket ownership controls for S3 bucket
     '''
     s3_client.put_bucket_ownership_controls(Bucket=bucket_name,
         OwnershipControls={
-            'Rules': [ { 'ObjectOwnership': target } ]
+            'Rules': [{'ObjectOwnership': target}]
         })
-
 
 def wait_policy_is_applied(module, s3_client, bucket_name, expected_policy, should_fail=True):
     for dummy in range(0, 12):

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -138,7 +138,7 @@ options:
       - This option cannot be used together with a I(object_ownership) definition.
     default: false
     type: bool
-    version_added: 1.3.0
+    version_added: 1.5.0
 
 extends_documentation_fragment:
 - amazon.aws.aws

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -480,7 +480,7 @@ def create_or_update_bucket(s3_client, module, location):
     if delete_object_ownership or object_ownership is not None:
         if delete_object_ownership:
             # delete S3 buckect ownership
-            if bucket_ownership != {}:
+            if bucket_ownership is not None:
                 delete_bucket_ownership(s3_client, name)
                 changed = True
                 result['object_ownership'] = None

--- a/tests/integration/targets/s3_bucket/inventory
+++ b/tests/integration/targets/s3_bucket/inventory
@@ -7,6 +7,7 @@ tags
 encryption_kms
 encryption_sse
 public_access
+ownership_controls
 
 [all:vars]
 ansible_connection=local

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
@@ -90,6 +90,18 @@
         that:
           - output.changed
           - not output.object_ownership|bool
+    
+    - name: 'delete s3 bucket ownership controls once again (idempotency)'
+      s3_bucket:
+        name: '{{ local_bucket_name }}'
+        state: present
+        delete_object_ownership: true
+      register: idempotency
+
+    - assert:
+        that:
+          - not idempotency.changed
+          - not idempotency.object_ownership|bool
 
   # ============================================================
   always:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
@@ -8,10 +8,12 @@
   block:
 
     # ============================================================
+    - set_fact:
+        local_bucket_name: "{{ bucket_name | hash('md5')}}ownership"
 
     - name: 'Create a simple bucket bad value for ownership controls'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         object_ownership: default
       ignore_errors: true
@@ -23,7 +25,7 @@
 
     - name: 'Create bucket with object_ownership set to object_writer'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
       ignore_errors: true
       register: output
@@ -35,12 +37,12 @@
 
     - name: delete s3 bucket
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
 
     - name: 'create s3 bucket with object ownership controls'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         object_ownership: ObjectWriter
       register: output
@@ -53,7 +55,7 @@
 
     - name: 'update s3 bucket ownership controls'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         object_ownership: BucketOwnerPreferred
       register: output
@@ -66,7 +68,7 @@
 
     - name: 'test idempotency update s3 bucket ownership controls'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         object_ownership: BucketOwnerPreferred
       register: output
@@ -79,7 +81,7 @@
 
     - name: 'delete s3 bucket ownership controls'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         delete_object_ownership: true
       register: output
@@ -93,13 +95,13 @@
   always:
     - name: delete s3 bucket ownership controls
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         delete_object_ownership: true
       ignore_errors: yes
 
     - name: Ensure all buckets are deleted
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       ignore_errors: yes

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
@@ -91,6 +91,13 @@
 
   # ============================================================
   always:
+    - name: delete s3 bucket ownership controls
+      s3_bucket:
+        name: '{{ bucket_name }}'
+        state: present
+        delete_object_ownership: true
+      ignore_errors: yes
+
     - name: Ensure all buckets are deleted
       s3_bucket:
         name: '{{ bucket_name }}'

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
@@ -1,0 +1,98 @@
+---
+- module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+
+    # ============================================================
+
+    - name: 'Create a simple bucket bad value for ownership controls'
+      s3_bucket:
+        name: '{{ bucket_name }}'
+        state: present
+        object_ownership: default
+      ignore_errors: true
+      register: output
+
+    - assert:
+        that:
+          - output.failed
+
+    - name: 'Create bucket with object_ownership set to object_writer'
+      s3_bucket:
+        name: '{{ bucket_name }}'
+        state: present
+      ignore_errors: true
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+          - not output.object_ownership|bool
+
+    - name: delete s3 bucket
+      s3_bucket:
+        name: '{{ bucket_name }}'
+        state: absent
+
+    - name: 'create s3 bucket with object ownership controls'
+      s3_bucket:
+        name: '{{ bucket_name }}'
+        state: present
+        object_ownership: ObjectWriter
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+          - output.object_ownership
+          - output.object_ownership == 'ObjectWriter'
+
+    - name: 'update s3 bucket ownership controls'
+      s3_bucket:
+        name: '{{ bucket_name }}'
+        state: present
+        object_ownership: BucketOwnerPreferred
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+          - output.object_ownership
+          - output.object_ownership == 'BucketOwnerPreferred'
+
+    - name: 'test idempotency update s3 bucket ownership controls'
+      s3_bucket:
+        name: '{{ bucket_name }}'
+        state: present
+        object_ownership: BucketOwnerPreferred
+      register: output
+
+    - assert:
+        that:
+          - output.changed is false
+          - output.object_ownership
+          - output.object_ownership == 'BucketOwnerPreferred'
+
+    - name: 'delete s3 bucket ownership controls'
+      s3_bucket:
+        name: '{{ bucket_name }}'
+        state: present
+        delete_object_ownership: true
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+          - not output.object_ownership|bool
+
+  # ============================================================
+  always:
+    - name: Ensure all buckets are deleted
+      s3_bucket:
+        name: '{{ bucket_name }}'
+        state: absent
+      ignore_errors: yes


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/345

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This feature would allow the bucket settting "Object Ownership" to be changed from the default of "Object writer" to "Bucket owner preferred". In conjunction with a bucket policy condition, this allows a bucket owner to ensure that all objects uploaded to a bucket are always owned by them.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#245
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
