### PR TITLE
ec2_snapshot_info add options for paginated requests

### DIFF
--- a/changelogs/fragments/320-ec2_snapshot_info-add_max_results_and_next_token_parameters.yaml
+++ b/changelogs/fragments/320-ec2_snapshot_info-add_max_results_and_next_token_parameters.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- ec2_snapshot_info - add the ``max_results`` along with ``next_token`` option (https://github.com/ansible-collections/amazon.aws/pull/320).

--- a/changelogs/fragments/xxx-ecs_snapshot_info-add_max_results_and_next_token_parameters.yaml
+++ b/changelogs/fragments/xxx-ecs_snapshot_info-add_max_results_and_next_token_parameters.yaml
@@ -1,3 +1,0 @@
----
-minor_changes:
-- ec2_snapshot_info - add the ``max_results`` along with ``next_token`` option (https://github.com/ansible-collections/amazon.aws/pull/xxx).

--- a/changelogs/fragments/xxx-ecs_snapshot_info-add_max_results_and_next_token_parameters.yaml
+++ b/changelogs/fragments/xxx-ecs_snapshot_info-add_max_results_and_next_token_parameters.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- ec2_snapshot_info - add the ``max_results`` along with ``next_token`` option (https://github.com/ansible-collections/amazon.aws/pull/xxx).

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -243,7 +243,7 @@ class ElasticLoadBalancerV2(object):
         self.elb = get_elb(self.connection, self.module, self.module.params.get("name"))
         self.elb['tags'] = self.get_elb_tags()
 
-    def modify_ip_address_type(self,ip_addr_type):
+    def modify_ip_address_type(self, ip_addr_type):
         """
         Modify ELB ip address type
         :return:

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -71,8 +71,10 @@ class ElasticLoadBalancerV2(object):
         if self.elb is not None:
             self.elb_attributes = self.get_elb_attributes()
             self.elb['tags'] = self.get_elb_tags()
+            self.elb_ip_addr_type = self.get_elb_ip_address_type()
         else:
             self.elb_attributes = None
+            self.elb_ip_addr_type = None
 
     def wait_for_status(self, elb_arn):
         """
@@ -106,6 +108,23 @@ class ElasticLoadBalancerV2(object):
 
         # Replace '.' with '_' in attribute key names to make it more Ansibley
         return dict((k.replace('.', '_'), v) for k, v in elb_attributes.items())
+
+    def get_elb_ip_address_type(self):
+        """
+        Retrieve load balancer ip address type using describe_load_balancers
+
+        :return:
+        """
+
+        try:
+            self.elb_ip_addr_type = AWSRetry.jittered_backoff()(
+                self.connection.describe_load_balancers
+            )(LoadBalancerArns=[ self.elb['LoadBalancerArn'] ])['LoadBalancers'][0]['IpAddressType']
+            return self.elb_ip_addr_type
+
+        except (BotoCoreError, ClientError) as e:
+            self.module.fail_json_aws(e)
+
 
     def update_elb_attributes(self):
         """
@@ -231,6 +250,21 @@ class ElasticLoadBalancerV2(object):
 
         self.elb = get_elb(self.connection, self.module, self.module.params.get("name"))
         self.elb['tags'] = self.get_elb_tags()
+
+    def modify_ip_address_type(self,ip_addr_type) :
+        """
+        Modify ELB ip address type
+        :return:
+        """
+        if self.elb_ip_addr_type != ip_addr_type :
+            try:
+                AWSRetry.jittered_backoff()(
+                    self.connection.set_ip_address_type
+                )(LoadBalancerArn=self.elb['LoadBalancerArn'], IpAddressType=ip_addr_type)
+            except (BotoCoreError, ClientError) as e:
+                self.module.fail_json_aws(e)
+
+            self.changed = True
 
 
 class ApplicationLoadBalancer(ElasticLoadBalancerV2):
@@ -359,7 +393,6 @@ class ApplicationLoadBalancer(ElasticLoadBalancerV2):
             self.module.fail_json_aws(e)
 
         self.changed = True
-
 
 class NetworkLoadBalancer(ElasticLoadBalancerV2):
 

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -125,7 +125,6 @@ class ElasticLoadBalancerV2(object):
         except (BotoCoreError, ClientError) as e:
             self.module.fail_json_aws(e)
 
-
     def update_elb_attributes(self):
         """
         Update the elb_attributes parameter

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -119,7 +119,7 @@ class ElasticLoadBalancerV2(object):
         try:
             self.elb_ip_addr_type = AWSRetry.jittered_backoff()(
                 self.connection.describe_load_balancers
-            )(LoadBalancerArns=[ self.elb['LoadBalancerArn'] ])['LoadBalancers'][0]['IpAddressType']
+            )(LoadBalancerArns=[self.elb['LoadBalancerArn']])['LoadBalancers'][0]['IpAddressType']
             return self.elb_ip_addr_type
 
         except (BotoCoreError, ClientError) as e:
@@ -251,12 +251,12 @@ class ElasticLoadBalancerV2(object):
         self.elb = get_elb(self.connection, self.module, self.module.params.get("name"))
         self.elb['tags'] = self.get_elb_tags()
 
-    def modify_ip_address_type(self,ip_addr_type) :
+    def modify_ip_address_type(self,ip_addr_type):
         """
         Modify ELB ip address type
         :return:
         """
-        if self.elb_ip_addr_type != ip_addr_type :
+        if self.elb_ip_addr_type != ip_addr_type:
             try:
                 AWSRetry.jittered_backoff()(
                     self.connection.set_ip_address_type
@@ -393,6 +393,7 @@ class ApplicationLoadBalancer(ElasticLoadBalancerV2):
             self.module.fail_json_aws(e)
 
         self.changed = True
+
 
 class NetworkLoadBalancer(ElasticLoadBalancerV2):
 

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -116,14 +116,7 @@ class ElasticLoadBalancerV2(object):
         :return:
         """
 
-        try:
-            self.elb_ip_addr_type = AWSRetry.jittered_backoff()(
-                self.connection.describe_load_balancers
-            )(LoadBalancerArns=[self.elb['LoadBalancerArn']])['LoadBalancers'][0]['IpAddressType']
-            return self.elb_ip_addr_type
-
-        except (BotoCoreError, ClientError) as e:
-            self.module.fail_json_aws(e)
+        return self.elb.get('IpAddressType', None)
 
     def update_elb_attributes(self):
         """

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -15,7 +15,9 @@ description:
     - Gather information about ec2 volume snapshots in AWS.
     - This module was called C(ec2_snapshot_facts) before Ansible 2.9. The usage did not change.
 requirements: [ boto3 ]
-author: "Rob White (@wimnat)"
+author:
+    - "Rob White (@wimnat)"
+    - Aubin Bikouo (@abikouo)
 options:
   snapshot_ids:
     description:
@@ -48,6 +50,23 @@ options:
     required: false
     type: dict
     default: {}
+  max_results:
+    description:
+    - The maximum number of snapshot results returned in paginated output.
+    - When this parameter is used, `ec2_snapshot_facts` only returns results in a single page along with a C(next_token) response element.
+    - The remaining results of the initial request can be seen by sending another request with the returned C(next_token) value.
+    - This value can be between 5 and 1000; if C(next_token) is given a value larger than 1000, only 1000 results are returned.
+    - If this parameter is not used, then DescribeSnapshots returns all results.
+    - This parameter is mutually exclusive with C(snapshot_ids)
+    required: False
+    type: int
+  next_token:
+    description:
+    - Contains the value returned from a previous paginated request where C(max_results) was used and the results exceeded the value of that parameter.
+    - Pagination continues from the end of the previous results that returned the C(next_token) value.
+    - This parameter is mutually exclusive with C(snapshot_ids)
+    required: false
+    type: str
 notes:
   - By default, the module will return all snapshots, including public ones. To limit results to snapshots owned by
     the account use the filter 'owner-id'.
@@ -97,81 +116,90 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-snapshot_id:
-    description: The ID of the snapshot. Each snapshot receives a unique identifier when it is created.
+snapshots:
+    description: snapshots retrieved
+    type: list
+    elements: dict
+    suboptions:
+        snapshot_id:
+            description: The ID of the snapshot. Each snapshot receives a unique identifier when it is created.
+            type: str
+            returned: always
+            sample: snap-01234567
+        volume_id:
+            description: The ID of the volume that was used to create the snapshot.
+            type: str
+            returned: always
+            sample: vol-01234567
+        state:
+            description: The snapshot state (completed, pending or error).
+            type: str
+            returned: always
+            sample: completed
+        state_message:
+            description: Encrypted Amazon EBS snapshots are copied asynchronously. If a snapshot copy operation fails (for example, if the proper
+                         AWS Key Management Service (AWS KMS) permissions are not obtained) this field displays error state details to help you diagnose why the
+                         error occurred.
+            type: str
+            returned: always
+            sample:
+        start_time:
+            description: The time stamp when the snapshot was initiated.
+            type: str
+            returned: always
+            sample: "2015-02-12T02:14:02+00:00"
+        progress:
+            description: The progress of the snapshot, as a percentage.
+            type: str
+            returned: always
+            sample: "100%"
+        owner_id:
+            description: The AWS account ID of the EBS snapshot owner.
+            type: str
+            returned: always
+            sample: "099720109477"
+        description:
+            description: The description for the snapshot.
+            type: str
+            returned: always
+            sample: "My important backup"
+        volume_size:
+            description: The size of the volume, in GiB.
+            type: int
+            returned: always
+            sample: 8
+        owner_alias:
+            description: The AWS account alias (for example, amazon, self) or AWS account ID that owns the snapshot.
+            type: str
+            returned: always
+            sample: "033440102211"
+        tags:
+            description: Any tags assigned to the snapshot.
+            type: dict
+            returned: always
+            sample: "{ 'my_tag_key': 'my_tag_value' }"
+        encrypted:
+            description: Indicates whether the snapshot is encrypted.
+            type: bool
+            returned: always
+            sample: "True"
+        kms_key_id:
+            description: The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) that was used to \
+            protect the volume encryption key for the parent volume.
+            type: str
+            returned: always
+            sample: "74c9742a-a1b2-45cb-b3fe-abcdef123456"
+        data_encryption_key_id:
+            description: The data encryption key identifier for the snapshot. This value is a unique identifier that \
+            corresponds to the data encryption key that was used to encrypt the original volume or snapshot copy.
+            type: str
+            returned: always
+            sample: "arn:aws:kms:ap-southeast-2:012345678900:key/74c9742a-a1b2-45cb-b3fe-abcdef123456"
+next_token:
+    description:
+    - Contains the value returned from a previous paginated request where C(max_results) was used and the results exceeded the value of that parameter.
+    - This value is null when there are no more results to return.
     type: str
-    returned: always
-    sample: snap-01234567
-volume_id:
-    description: The ID of the volume that was used to create the snapshot.
-    type: str
-    returned: always
-    sample: vol-01234567
-state:
-    description: The snapshot state (completed, pending or error).
-    type: str
-    returned: always
-    sample: completed
-state_message:
-    description: Encrypted Amazon EBS snapshots are copied asynchronously. If a snapshot copy operation fails (for example, if the proper
-                 AWS Key Management Service (AWS KMS) permissions are not obtained) this field displays error state details to help you diagnose why the
-                 error occurred.
-    type: str
-    returned: always
-    sample:
-start_time:
-    description: The time stamp when the snapshot was initiated.
-    type: str
-    returned: always
-    sample: "2015-02-12T02:14:02+00:00"
-progress:
-    description: The progress of the snapshot, as a percentage.
-    type: str
-    returned: always
-    sample: "100%"
-owner_id:
-    description: The AWS account ID of the EBS snapshot owner.
-    type: str
-    returned: always
-    sample: "099720109477"
-description:
-    description: The description for the snapshot.
-    type: str
-    returned: always
-    sample: "My important backup"
-volume_size:
-    description: The size of the volume, in GiB.
-    type: int
-    returned: always
-    sample: 8
-owner_alias:
-    description: The AWS account alias (for example, amazon, self) or AWS account ID that owns the snapshot.
-    type: str
-    returned: always
-    sample: "033440102211"
-tags:
-    description: Any tags assigned to the snapshot.
-    type: dict
-    returned: always
-    sample: "{ 'my_tag_key': 'my_tag_value' }"
-encrypted:
-    description: Indicates whether the snapshot is encrypted.
-    type: bool
-    returned: always
-    sample: "True"
-kms_key_id:
-    description: The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) that was used to \
-    protect the volume encryption key for the parent volume.
-    type: str
-    returned: always
-    sample: "74c9742a-a1b2-45cb-b3fe-abcdef123456"
-data_encryption_key_id:
-    description: The data encryption key identifier for the snapshot. This value is a unique identifier that \
-    corresponds to the data encryption key that was used to encrypt the original volume or snapshot copy.
-    type: str
-    returned: always
-    sample: "arn:aws:kms:ap-southeast-2:012345678900:key/74c9742a-a1b2-45cb-b3fe-abcdef123456"
-
 '''
 
 try:
@@ -194,12 +222,20 @@ def list_ec2_snapshots(connection, module):
     owner_ids = [str(owner_id) for owner_id in module.params.get("owner_ids")]
     restorable_by_user_ids = [str(user_id) for user_id in module.params.get("restorable_by_user_ids")]
     filters = ansible_dict_to_boto3_filter_list(module.params.get("filters"))
+    max_results = module.params.get('max_results')
+    next_token = module.params.get('next_token')
+    optional_param = {}
+    if max_results:
+        optional_param['MaxResults'] = max_results
+    if next_token:
+        optional_param['NextToken'] = next_token
 
     try:
         snapshots = connection.describe_snapshots(
             aws_retry=True,
             SnapshotIds=snapshot_ids, OwnerIds=owner_ids,
-            RestorableByUserIds=restorable_by_user_ids, Filters=filters)
+            RestorableByUserIds=restorable_by_user_ids, Filters=filters,
+            **optional_param)
     except is_boto3_error_code('InvalidSnapshot.NotFound') as e:
         if len(snapshot_ids) > 1:
             module.warn("Some of your snapshots may exist, but %s" % str(e))
@@ -207,6 +243,7 @@ def list_ec2_snapshots(connection, module):
     except ClientError as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg='Failed to describe snapshots')
 
+    result = {}
     # Turn the boto3 result in to ansible_friendly_snaked_names
     snaked_snapshots = []
     for snapshot in snapshots['Snapshots']:
@@ -217,7 +254,12 @@ def list_ec2_snapshots(connection, module):
         if 'tags' in snapshot:
             snapshot['tags'] = boto3_tag_list_to_ansible_dict(snapshot['tags'], 'key', 'value')
 
-    module.exit_json(snapshots=snaked_snapshots)
+    result['snapshots'] = snaked_snapshots
+
+    if snapshots.get('NextToken'):
+        result.update(camel_dict_to_snake_dict({'NextToken': snapshots.get('NextToken')}))
+
+    module.exit_json(**result)
 
 
 def main():
@@ -226,13 +268,17 @@ def main():
         snapshot_ids=dict(default=[], type='list', elements='str'),
         owner_ids=dict(default=[], type='list', elements='str'),
         restorable_by_user_ids=dict(default=[], type='list', elements='str'),
-        filters=dict(default={}, type='dict')
+        filters=dict(default={}, type='dict'),
+        max_results=dict(type='int'),
+        next_token=dict(type='str')
     )
 
     module = AnsibleAWSModule(
         argument_spec=argument_spec,
         mutually_exclusive=[
-            ['snapshot_ids', 'owner_ids', 'restorable_by_user_ids', 'filters']
+            ['snapshot_ids', 'owner_ids', 'restorable_by_user_ids', 'filters'],
+            ['snapshot_ids', 'max_results'],
+            ['snapshot_ids', 'next_token']
         ],
         supports_check_mode=True
     )

--- a/tests/integration/targets/ec2_snapshot/tasks/main.yml
+++ b/tests/integration/targets/ec2_snapshot/tasks/main.yml
@@ -217,6 +217,61 @@
         that:
           - info_result.snapshots| length == 3
 
+    # check that snapshot_ids and max_results are mutually exclusive
+    - name: Get info about all snapshots in paginated mode
+      ec2_snapshot_info:
+        snapshot_ids:
+          - '{{ tagged_snapshot_id }}'
+        max_results: 1
+      ignore_errors: true
+      register: info_result
+
+    - name: assert that operation failed
+      assert:
+        that:
+          - info_result is failed
+
+    # check that snapshot_ids and next_token are mutually exclusive
+    - name: Get info about all snapshots in paginated mode
+      ec2_snapshot_info:
+        snapshot_ids:
+          - '{{ tagged_snapshot_id }}'
+        next_token: 'random_value_token'
+      ignore_errors: true
+      register: info_result
+
+    - name: assert that operation failed
+      assert:
+        that:
+          - info_result is failed
+
+    # max_results and next_token option
+    - name: Get info about all snapshots in paginated mode
+      ec2_snapshot_info:
+        filters:
+          "tag:Name": '{{ resource_prefix }}'
+        max_results: 1
+      register: info_result
+
+    - assert:
+        that:
+          - info_result.snapshots | length == 1
+          - info_result.next_token is defined
+
+    # Retrieve snapshots using next_token value returned previously
+    - name: Get info about all snapshots using next_token
+      ec2_snapshot_info:
+        filters:
+          "tag:Name": '{{ resource_prefix }}'
+        next_token: "{{ info_result.next_token }}"
+      register: info_result
+
+    - assert:
+        that:
+          - info_result.snapshots | length == 2
+          - info_result.next_token is defined
+
+    # delete the tagged snapshot
     - name: Delete the tagged snapshot
       ec2_snapshot:
         state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
add new options ``max_results`` and ``next_token`` to read snapshot in paginated mode
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
#312 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_snapshot_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
the following task will limit the number of snapshot returned in output
```
- name: limit snapshot to 50
  ec2_snapshot_info:
     max_results: 50
  register: snapshot_result

- name: read next 100 elements
  ec2_snapshot_info:
     max_results: 50
     next_token: "{{ snapshot_result.next_token }}"

```
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
