### PR TITLE
ec2_eni: Fix idempotency when security_groups is specified

### DIFF
--- a/changelogs/fragments/337-ec2_eni-fix-idempotency-security-groups.yml
+++ b/changelogs/fragments/337-ec2_eni-fix-idempotency-security-groups.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- ec2_eni - fix idempotency when ``security_groups`` is specified (https://github.com/ansible-collections/amazon.aws/pull/337).

--- a/changelogs/fragments/337-ec2_eni-fix-idempotency-security-groups.yml
+++ b/changelogs/fragments/337-ec2_eni-fix-idempotency-security-groups.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- ec2_eni - fix idempotency when ``security_groups`` is specified (https://github.com/ansible-collections/amazon.aws/pull/337).
+- ec2_eni - fix idempotency when ``security_groups`` attribute is specified (https://github.com/ansible-collections/amazon.aws/pull/337).

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -769,7 +769,7 @@ def get_sec_group_list(groups):
     # Build list of remote security groups
     remote_security_groups = []
     for group in groups:
-        remote_security_groups.append(group["GroupId"].encode())
+        remote_security_groups.append(group["GroupId"])
 
     return remote_security_groups
 

--- a/tests/integration/targets/ec2_eni/tasks/main.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/main.yaml
@@ -7,6 +7,7 @@
       region: "{{ aws_region }}"
 
   collections:
+  - ansible.netcommon
   - community.aws
 
   block:

--- a/tests/integration/targets/ec2_eni/tasks/test_eni_basic_creation.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/test_eni_basic_creation.yaml
@@ -57,7 +57,7 @@
       - _interface_0.private_dns_name is string
       - _interface_0.private_dns_name.endswith("ec2.internal")
       - '"private_ip_address" in _interface_0'
-      - _interface_0.private_ip_address | ipaddr()
+      - _interface_0.private_ip_address | ansible.netcommon.ipaddr()
       - _interface_0.private_ip_address == ip_1
       - '"private_ip_addresses" in _interface_0'
       - _interface_0.private_ip_addresses | length == 1
@@ -152,7 +152,7 @@
       - _interface_0.private_dns_name is string
       - _interface_0.private_dns_name.endswith("ec2.internal")
       - '"private_ip_address" in _interface_0'
-      - _interface_0.private_ip_address | ipaddr()
+      - _interface_0.private_ip_address | ansible.netcommon.ipaddr()
       - _interface_0.private_ip_address == ip_5
       - '"private_ip_addresses" in _interface_0'
       - _interface_0.private_ip_addresses | length == 1

--- a/tests/integration/targets/ec2_eni/tasks/test_eni_basic_creation.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/test_eni_basic_creation.yaml
@@ -57,7 +57,7 @@
       - _interface_0.private_dns_name is string
       - _interface_0.private_dns_name.endswith("ec2.internal")
       - '"private_ip_address" in _interface_0'
-      - _interface_0.private_ip_address | ansible.netcommon.ipaddr()
+      - _interface_0.private_ip_address | ansible.netcommon.ipaddr
       - _interface_0.private_ip_address == ip_1
       - '"private_ip_addresses" in _interface_0'
       - _interface_0.private_ip_addresses | length == 1
@@ -152,7 +152,7 @@
       - _interface_0.private_dns_name is string
       - _interface_0.private_dns_name.endswith("ec2.internal")
       - '"private_ip_address" in _interface_0'
-      - _interface_0.private_ip_address | ansible.netcommon.ipaddr()
+      - _interface_0.private_ip_address | ansible.netcommon.ipaddr
       - _interface_0.private_ip_address == ip_5
       - '"private_ip_addresses" in _interface_0'
       - _interface_0.private_ip_addresses | length == 1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
If `security_groups` attribute is specified - module always returns `Changed` = `True`.

Fixes #255.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_eni

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Example:

```
- amazon.aws.ec2_eni:
    name: my-eni
    security_groups:
      - my-sg
    subnet_id: subnet-123456
```

Will always return `Changed` = `True`.