### PR TITLE
[aws_s3] Assign keyrtn var before use

### DIFF
--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -827,6 +827,7 @@ def main():
         if src is not None and not path_check(src):
             module.fail_json('Local object "%s" does not exist for PUT operation' % (src))
 
+        keyrtn = None
         if bucketrtn:
             keyrtn = key_check(module, s3, bucket, obj, version=version, validate=validate)
         else:


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/340

##### SUMMARY
keyrtn in `put` mode is only assigned if bucketrtn is not empty/False, but is later checked on any `put` task.

Fixes: #338

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
aws_s3
