### PR TITLE
test/s3: keep the bucket name length under control (<63 characters)

### DIFF
--- a/tests/integration/targets/aws_s3/tasks/main.yml
+++ b/tests/integration/targets/aws_s3/tasks/main.yml
@@ -444,7 +444,7 @@
 
     - name: test create a bucket with a dot in the name
       aws_s3:
-        bucket: "{{ bucket_name + '.bucket' }}"
+        bucket: "{{ bucket_name | hash('md5') + '.bucket' }}"
         mode: create
       register: result
 
@@ -454,7 +454,7 @@
 
     - name: test delete a bucket with a dot in the name
       aws_s3:
-        bucket: "{{ bucket_name + '.bucket' }}"
+        bucket: "{{ bucket_name | hash('md5') + '.bucket' }}"
         mode: delete
       register: result
 
@@ -464,7 +464,7 @@
 
     - name: test delete a nonexistent bucket
       aws_s3:
-        bucket: "{{ bucket_name + '.bucket' }}"
+        bucket: "{{ bucket_name | hash('md5') + '.bucket' }}"
         mode: delete
       register: result
 

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/defaults/main.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-bucket_name: '{{ resource_prefix }}-{{ inventory_hostname | regex_replace("_","-") }}'
+bucket_name: '{{ resource_prefix }}'


### PR DESCRIPTION
The bucket_name variable length is 63 or below. If we add a prefix we
can generate an invalid bucket name.

See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html