### PR TITLE
s3: raise an error if the bucket name is not correct

### DIFF
--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -323,6 +323,7 @@ from ..module_utils.ec2 import get_aws_connection_info
 from ..module_utils.s3 import HAS_MD5
 from ..module_utils.s3 import calculate_etag
 from ..module_utils.s3 import calculate_etag_content
+from ..module_utils.s3 import validate_bucket_name
 
 IGNORE_S3_DROP_IN_EXCEPTIONS = ['XNotImplemented', 'NotImplemented']
 
@@ -730,6 +731,8 @@ def main():
 
     object_canned_acl = ["private", "public-read", "public-read-write", "aws-exec-read", "authenticated-read", "bucket-owner-read", "bucket-owner-full-control"]
     bucket_canned_acl = ["private", "public-read", "public-read-write", "authenticated-read"]
+
+    validate_bucket_name(module, bucket)
 
     if overwrite not in ['always', 'never', 'different']:
         if module.boolean(overwrite):

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -226,6 +226,7 @@ from ..module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ..module_utils.ec2 import compare_policies
 from ..module_utils.ec2 import get_aws_connection_info
 from ..module_utils.ec2 import snake_dict_to_camel_dict
+from ..module_utils.s3 import validate_bucket_name
 
 
 def create_or_update_bucket(s3_client, module, location):
@@ -825,6 +826,7 @@ def main():
     )
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+    validate_bucket_name(module, module.params["name"])
 
     if region in ('us-east-1', '', None):
         # default to US Standard region

--- a/tests/integration/targets/aws_s3/tasks/main.yml
+++ b/tests/integration/targets/aws_s3/tasks/main.yml
@@ -30,6 +30,17 @@
           - result is failed
           - "result.msg != 'MODULE FAILURE'"
 
+    - name: test create bucket with an invalid name
+      aws_s3:
+        bucket: "{{ bucket_name }}-"
+        mode: create
+      register: result
+      ignore_errors: yes
+
+    - assert:
+        that:
+          - result is failed
+
     - name: test create bucket
       aws_s3:
         bucket: "{{ bucket_name }}"
@@ -658,6 +669,6 @@
 
     - name: delete the dot bucket
       aws_s3:
-        bucket: "{{ bucket_name + '.bucket' }}"
+        bucket: "{{ bucket_name | hash('md5') + '.bucket' }}"
         mode: delete
       ignore_errors: yes

--- a/tests/unit/module_utils/test_s3.py
+++ b/tests/unit/module_utils/test_s3.py
@@ -1,0 +1,40 @@
+#
+# (c) 2021 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.amazon.aws.tests.unit.compat.mock import MagicMock
+import ansible_collections.amazon.aws.plugins.module_utils.s3 as s3
+
+
+def test_validate_bucket_name():
+    module = MagicMock()
+
+    assert s3.validate_bucket_name(module, "docexamplebucket1") is True
+    assert not module.fail_json.called
+    assert s3.validate_bucket_name(module, "log-delivery-march-2020") is True
+    assert not module.fail_json.called
+    assert s3.validate_bucket_name(module, "my-hosted-content") is True
+    assert not module.fail_json.called
+
+    assert s3.validate_bucket_name(module, "docexamplewebsite.com") is True
+    assert not module.fail_json.called
+    assert s3.validate_bucket_name(module, "www.docexamplewebsite.com") is True
+    assert not module.fail_json.called
+    assert s3.validate_bucket_name(module, "my.example.s3.bucket") is True
+    assert not module.fail_json.called
+
+    module.fail_json.reset_mock()
+    s3.validate_bucket_name(module, "doc_example_bucket")
+    assert module.fail_json.called
+
+    module.fail_json.reset_mock()
+    s3.validate_bucket_name(module, "DocExampleBucket")
+    assert module.fail_json.called
+    module.fail_json.reset_mock()
+    s3.validate_bucket_name(module, "doc-example-bucket-")
+    assert module.fail_json.called


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/345

Ensure the name of the bucket does not go above 63 characters.

See: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html