### PR TITLE
Use hash of hostname for s3_bucket's bucket name

### DIFF
--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/defaults/main.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-bucket_name: '{{ resource_prefix }}-{{ inventory_hostname | regex_replace("_","-") }}'
+bucket_name: '{{ resource_prefix| hash("md5") }}-{{ inventory_hostname | regex_replace("_","-") }}'


### PR DESCRIPTION
##### SUMMARY
Zuul CI hostnames cause bucket names in tests to exceed S3's allowable 63 characters

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/integration/targets/s3_bucket/roles/s3_bucket/defaults/main.yml

##### ADDITIONAL INFORMATION
For example: 
https://4b2ae1954e8e64a484dc-1b1d0bfad31e0b3f9500a4be3dccc5f5.ssl.cf2.rackcdn.com/311/6f131890a25a1399b229b959eb33f33d89671f0f/check/ansible-test-cloud-integration-aws-py36/614888e/job-output.html#l1773
`ansible-test-11129663-centos-8-1vcpu-limestone-us-dfw-1-0001381.something`
