### PR TITLE
s3_bucket/test: use one bucket per scenario

### DIFF
--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/complex.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/complex.yml
@@ -1,8 +1,10 @@
 ---
 - block:
+    - set_fact:
+        local_bucket_name: "{{ bucket_name | hash('md5')}}complex"
     - name: 'Create more complex s3_bucket'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: "{{ local_bucket_name }}"
         state: present
         policy: "{{ lookup('template','policy.json') }}"
         requester_pays: yes
@@ -15,7 +17,7 @@
     - assert:
         that:
           - output is changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.requester_pays
           - output.versioning.MfaDelete == 'Disabled'
           - output.versioning.Versioning == 'Enabled'
@@ -24,7 +26,7 @@
           - output.policy.Statement[0].Action == 's3:GetObject'
           - output.policy.Statement[0].Effect == 'Allow'
           - output.policy.Statement[0].Principal == '*'
-          - output.policy.Statement[0].Resource == 'arn:aws:s3:::{{ bucket_name }}/*'
+          - output.policy.Statement[0].Resource == 'arn:aws:s3:::{{ local_bucket_name }}/*'
           - output.policy.Statement[0].Sid == 'AddPerm'
 
     # ============================================================
@@ -36,7 +38,7 @@
 
     - name: 'Try to update the same complex s3_bucket'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         policy: "{{ lookup('template','policy.json') }}"
         requester_pays: yes
@@ -49,7 +51,7 @@
     - assert:
         that:
           - output is not changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.requester_pays
           - output.versioning.MfaDelete == 'Disabled'
           - output.versioning.Versioning == 'Enabled'
@@ -58,13 +60,13 @@
           - output.policy.Statement[0].Action == 's3:GetObject'
           - output.policy.Statement[0].Effect == 'Allow'
           - output.policy.Statement[0].Principal == '*'
-          - output.policy.Statement[0].Resource == 'arn:aws:s3:::{{ bucket_name }}/*'
+          - output.policy.Statement[0].Resource == 'arn:aws:s3:::{{ local_bucket_name }}/*'
           - output.policy.Statement[0].Sid == 'AddPerm'
 
     # ============================================================
     - name: 'Update bucket policy on complex bucket'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         policy: "{{ lookup('template','policy-updated.json') }}"
         requester_pays: yes
@@ -80,7 +82,7 @@
           - output.policy.Statement[0].Action == 's3:GetObject'
           - output.policy.Statement[0].Effect == 'Deny'
           - output.policy.Statement[0].Principal.AWS == '*'
-          - output.policy.Statement[0].Resource == 'arn:aws:s3:::{{ bucket_name }}/*'
+          - output.policy.Statement[0].Resource == 'arn:aws:s3:::{{ local_bucket_name }}/*'
           - output.policy.Statement[0].Sid == 'AddPerm'
 
     # ============================================================
@@ -92,7 +94,7 @@
 
     - name: Update attributes for s3_bucket
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         policy: "{{ lookup('template','policy.json') }}"
         requester_pays: no
@@ -105,7 +107,7 @@
     - assert:
         that:
           - output is changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - not output.requester_pays
           - output.versioning.MfaDelete == 'Disabled'
           - output.versioning.Versioning in ['Suspended', 'Disabled']
@@ -114,12 +116,12 @@
           - output.policy.Statement[0].Action == 's3:GetObject'
           - output.policy.Statement[0].Effect == 'Allow'
           - output.policy.Statement[0].Principal == '*'
-          - output.policy.Statement[0].Resource == 'arn:aws:s3:::{{ bucket_name }}/*'
+          - output.policy.Statement[0].Resource == 'arn:aws:s3:::{{ local_bucket_name }}/*'
           - output.policy.Statement[0].Sid == 'AddPerm'
 
     - name: 'Delete complex test bucket'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       register: output
 
@@ -129,7 +131,7 @@
 
     - name: 'Re-delete complex test bucket'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       register: output
 
@@ -141,6 +143,6 @@
   always:
     - name: 'Ensure all buckets are deleted'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       ignore_errors: yes

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/dotted.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/dotted.yml
@@ -2,20 +2,21 @@
 - block:
     - name: 'Ensure bucket_name contains a .'
       set_fact:
-        bucket_name: '{{ bucket_name }}.something'
+        local_bucket_name: "{{ bucket_name | hash('md5')}}.dotted"
+
 
     # ============================================================
     #
     - name: 'Create bucket with dot in name'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
       register: output
 
     - assert:
         that:
           - output is changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
 
 
     # ============================================================
@@ -27,7 +28,7 @@
 
     - name: 'Delete s3_bucket with dot in name'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       register: output
 
@@ -37,7 +38,7 @@
 
     - name: 'Re-delete s3_bucket with dot in name'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       register: output
 
@@ -49,6 +50,6 @@
   always:
     - name: 'Ensure all buckets are deleted'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       ignore_errors: yes

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_kms.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_kms.yml
@@ -6,18 +6,19 @@
       security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-
+    - set_fact:
+        local_bucket_name: "{{ bucket_name | hash('md5')}}e-kms"
     # ============================================================
 
     - name: 'Create a simple bucket'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
       register: output
 
     - name: 'Enable aws:kms encryption with KMS master key'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         encryption: "aws:kms"
       register: output
@@ -30,7 +31,7 @@
 
     - name: 'Re-enable aws:kms encryption with KMS master key (idempotent)'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         encryption: "aws:kms"
       register: output
@@ -45,7 +46,7 @@
 
     - name: Disable encryption from bucket
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         encryption: "none"
       register: output
@@ -57,7 +58,7 @@
 
     - name: Disable encryption from bucket
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         encryption: "none"
       register: output
@@ -71,7 +72,7 @@
 
     - name: Delete encryption test s3 bucket
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       register: output
 
@@ -83,6 +84,6 @@
   always:
     - name: Ensure all buckets are deleted
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       ignore_errors: yes

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_sse.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_sse.yml
@@ -6,18 +6,19 @@
       security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-
+    - set_fact:
+        local_bucket_name: "{{ bucket_name | hash('md5')}}e-sse"
     # ============================================================
 
     - name: 'Create a simple bucket'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
       register: output
 
     - name: 'Enable AES256 encryption'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         encryption: 'AES256'
       register: output
@@ -30,7 +31,7 @@
 
     - name: 'Re-enable AES256 encryption (idempotency)'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         encryption: 'AES256'
       register: output
@@ -45,7 +46,7 @@
 
     - name: Disable encryption from bucket
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         encryption: "none"
       register: output
@@ -57,7 +58,7 @@
 
     - name: Disable encryption from bucket
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         encryption: "none"
       register: output
@@ -71,7 +72,7 @@
 
     - name: Delete encryption test s3 bucket
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       register: output
 
@@ -83,6 +84,6 @@
   always:
     - name: Ensure all buckets are deleted
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       ignore_errors: yes

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/missing.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/missing.yml
@@ -1,6 +1,8 @@
 ---
 - name: 'Attempt to delete non-existent buckets'
   block:
+    - set_fact:
+        local_bucket_name: "{{ bucket_name | hash('md5')}}-missing"
     # ============================================================
     #
     # While in theory the 'simple' test case covers this there are
@@ -8,7 +10,7 @@
     #
     - name: 'Delete non-existstent s3_bucket (never created)'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       register: output
 
@@ -21,6 +23,6 @@
   always:
     - name: 'Ensure all buckets are deleted'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       ignore_errors: yes

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/public_access.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/public_access.yml
@@ -6,12 +6,13 @@
       security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-
+    - set_fact:
+        local_bucket_name: "{{ bucket_name | hash('md5')}}-public"
     # ============================================================
 
     - name: 'Create a simple bucket with public access block configuration'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         public_access:
           block_public_acls: true
@@ -31,7 +32,7 @@
 
     - name: 'Re-configure public access block configuration'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         public_access:
           block_public_acls: true
@@ -51,7 +52,7 @@
 
     - name: 'Re-configure public access block configuration (idempotency)'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         public_access:
           block_public_acls: true
@@ -71,7 +72,7 @@
 
     - name: 'Delete public access block configuration'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         delete_public_access: true
       register: output
@@ -83,7 +84,7 @@
 
     - name: 'Delete public access block configuration (idempotency)'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         delete_public_access: true
       register: output
@@ -97,7 +98,7 @@
 
     - name: Delete testing s3 bucket
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       register: output
 
@@ -109,6 +110,6 @@
   always:
     - name: Ensure all buckets are deleted
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       ignore_errors: yes

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/simple.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/simple.yml
@@ -1,12 +1,14 @@
 ---
 - name: 'Run simple tests'
   block:
+    - set_fact:
+        local_bucket_name: "{{ bucket_name | hash('md5')}}-simple"
     # Note: s3_bucket doesn't support check_mode
 
     # ============================================================
     - name: 'Create a simple s3_bucket'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
       register: output
 
@@ -14,14 +16,14 @@
         that:
           - output is success
           - output is changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - not output.requester_pays
           - output.public_access is undefined
 
     # ============================================================
     - name: 'Try to update the simple bucket with the same values'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
       register: output
 
@@ -29,13 +31,13 @@
         that:
           - output is success
           - output is not changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - not output.requester_pays
 
     # ============================================================
     - name: 'Delete the simple s3_bucket'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       register: output
 
@@ -47,7 +49,7 @@
     # ============================================================
     - name: 'Re-delete the simple s3_bucket (idempotency)'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       register: output
 
@@ -60,6 +62,6 @@
   always:
     - name: 'Ensure all buckets are deleted'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       ignore_errors: yes

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/tags.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/tags.yml
@@ -1,24 +1,25 @@
 ---
 - name: 'Run tagging tests'
   block:
-
+    - set_fact:
+        local_bucket_name: "{{ bucket_name | hash('md5')}}-tags"
     # ============================================================
     - name: 'Create simple s3_bucket for testing tagging'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
       register: output
 
     - assert:
         that:
           - output.changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
 
     # ============================================================
 
     - name: 'Add tags to s3 bucket'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         tags:
           example: tag1
@@ -28,13 +29,13 @@
     - assert:
         that:
           - output.changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.tags.example == 'tag1'
           - output.tags.another == 'tag2'
 
     - name: 'Re-Add tags to s3 bucket'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         tags:
           example: tag1
@@ -44,7 +45,7 @@
     - assert:
         that:
           - output is not changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.tags.example == 'tag1'
           - output.tags.another == 'tag2'
 
@@ -52,7 +53,7 @@
 
     - name: Remove a tag from an s3_bucket
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         tags:
           example: tag1
@@ -61,13 +62,13 @@
     - assert:
         that:
           - output.changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.tags.example == 'tag1'
           - "'another' not in output.tags"
 
     - name: Re-remove the tag from an s3_bucket
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         tags:
           example: tag1
@@ -76,7 +77,7 @@
     - assert:
         that:
           - output is not changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.tags.example == 'tag1'
           - "'another' not in output.tags"
 
@@ -91,7 +92,7 @@
 
     - name: 'Add a tag for s3_bucket with purge_tags False'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         purge_tags: no
         tags:
@@ -101,13 +102,13 @@
     - assert:
         that:
           - output.changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.tags.example == 'tag1'
           - output.tags.anewtag == 'here'
 
     - name: 'Re-add a tag for s3_bucket with purge_tags False'
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         purge_tags: no
         tags:
@@ -117,7 +118,7 @@
     - assert:
         that:
           - output is not changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.tags.example == 'tag1'
           - output.tags.anewtag == 'here'
 
@@ -132,7 +133,7 @@
 
     - name: Update a tag for s3_bucket with purge_tags False
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         purge_tags: no
         tags:
@@ -142,13 +143,13 @@
     - assert:
         that:
           - output.changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.tags.example == 'tag1'
           - output.tags.anewtag == 'next'
 
     - name: Re-update a tag for s3_bucket with purge_tags False
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         purge_tags: no
         tags:
@@ -158,7 +159,7 @@
     - assert:
         that:
           - output is not changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.tags.example == 'tag1'
           - output.tags.anewtag == 'next'
 
@@ -173,7 +174,7 @@
 
     - name: Pass empty tags dict for s3_bucket with purge_tags False
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         purge_tags: no
         tags: {}
@@ -182,7 +183,7 @@
     - assert:
         that:
           - output is not changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.tags.example == 'tag1'
           - output.tags.anewtag == 'next'
 
@@ -197,21 +198,21 @@
 
     - name: Do not specify any tag to ensure previous tags are not removed
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
       register: output
 
     - assert:
         that:
           - not output.changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.tags.example == 'tag1'
 
     # ============================================================
 
     - name: Remove all tags
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         tags: {}
       register: output
@@ -219,12 +220,12 @@
     - assert:
         that:
           - output.changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.tags == {}
 
     - name: Re-remove all tags
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: present
         tags: {}
       register: output
@@ -232,14 +233,14 @@
     - assert:
         that:
           - output is not changed
-          - output.name == '{{ bucket_name }}'
+          - output.name == '{{ local_bucket_name }}'
           - output.tags == {}
 
     # ============================================================
 
     - name: Delete bucket
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       register: output
 
@@ -251,6 +252,6 @@
   always:
     - name: Ensure all buckets are deleted
       s3_bucket:
-        name: '{{ bucket_name }}'
+        name: '{{ local_bucket_name }}'
         state: absent
       ignore_errors: yes

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/templates/policy-updated.json
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/templates/policy-updated.json
@@ -6,7 +6,7 @@
       "Effect":"Deny",
       "Principal": {"AWS": "*"},
       "Action":["s3:GetObject"],
-      "Resource":["arn:aws:s3:::{{bucket_name}}/*"]
+      "Resource":["arn:aws:s3:::{{local_bucket_name}}/*"]
     }
   ]
 }

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/templates/policy.json
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/templates/policy.json
@@ -6,7 +6,7 @@
       "Effect":"Allow",
       "Principal": "*",
       "Action":["s3:GetObject"],
-      "Resource":["arn:aws:s3:::{{bucket_name}}/*"]
+      "Resource":["arn:aws:s3:::{{local_bucket_name}}/*"]
     }
   ]
 }


### PR DESCRIPTION
To speed up the execution, we run all the tests in parallel. This commit
ensures each playbook uses a different bucket, this to avoid any
unexpected side-effect.