### PR TITLE
ec2_vol: Limit the scope of new botocore requirements

### DIFF
--- a/changelogs/fragments/346-ec2_vol-boto3-requirements.yml
+++ b/changelogs/fragments/346-ec2_vol-boto3-requirements.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_vol - relax the boto3/botocore requirements and only require botocore 1.19.27 for modifying the ``throughput`` parameter (https://github.com/ansible-collections/amazon.aws/pull/346).

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -570,7 +570,7 @@ def detach_volume(module, ec2_conn, volume_dict):
     return volume_dict, changed
 
 
-def get_volume_info(volume, tags=None):
+def get_volume_info(module, volume, tags=None):
     if not tags:
         tags = boto3_tag_list_to_ansible_dict(volume.get('tags'))
     attachment_data = get_attachment_data(volume)
@@ -684,7 +684,7 @@ def main():
         vols = get_volumes(module, ec2_conn)
 
         for v in vols:
-            returned_volumes.append(get_volume_info(v))
+            returned_volumes.append(get_volume_info(module, v))
 
         module.exit_json(changed=False, volumes=returned_volumes)
 
@@ -751,7 +751,7 @@ def main():
             volume, changed = attach_volume(module, ec2_conn, volume_dict=volume, instance_dict=inst, device_name=device_name)
 
         # Add device, volume_id and volume_type parameters separately to maintain backward compatibility
-        volume_info = get_volume_info(volume, tags=final_tags)
+        volume_info = get_volume_info(module, volume, tags=final_tags)
 
         if tags_changed:
             changed = True


### PR DESCRIPTION
##### SUMMARY

The ec2_vol boto3 migration introduced a dependency on boto3 >= 1.16.33 (Dec 2020).  Limit the scope of this requirement to just the "throughput" parameter and move it to a botocore version (the relevant validation happens in botocore, not boto3)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vol

##### ADDITIONAL INFORMATION