### PR TITLE
Correct changelog data from 1.4.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -40,6 +40,14 @@ Bugfixes
 - ec2_vol - create or update now preserves the existing tags, including Name (https://github.com/ansible-collections/amazon.aws/issues/229)
 - ec2_vol - fix exception when platform information isn't available (https://github.com/ansible-collections/amazon.aws/issues/305).
 
+v1.4.1
+======
+
+Minor Changes
+-------------
+
+- module_utils - the ipaddress module utility has been vendored into this collection. This eliminates the collection dependency on ansible.netcommon (which had removed the library in its 2.0 release). The ipaddress library is provided for internal use in this collection only. (https://github.com/ansible-collections/amazon.aws/issues/273)-
+
 v1.4.0
 ======
 
@@ -52,7 +60,6 @@ Minor Changes
 - aws_secret - add ``bypath`` functionality (https://github.com/ansible-collections/amazon.aws/pull/192).
 - ec2_key - add AWSRetry decorator to automatically retry on common temporary failures (https://github.com/ansible-collections/amazon.aws/pull/213).
 - ec2_vol - Add support for gp3 volumes and support for modifying existing volumes (https://github.com/ansible-collections/amazon.aws/issues/55).
-- module_utils - the ipaddress module utility has been vendored into this collection.  This eliminates the collection dependency on ansible.netcommon (which had removed the library in its 2.0 release).  The ipaddress library is provided for internal use in this collection only. (https://github.com/ansible-collections/amazon.aws/issues/273)-
 - module_utils/elbv2 - add logic to compare_rules to suit Values list nested within dicts unique to each field type. Fixes issue (https://github.com/ansible-collections/amazon.aws/issues/187)
 - various AWS plugins and module_utils - Cleanup unused imports (https://github.com/ansible-collections/amazon.aws/pull/217).
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -214,10 +214,6 @@ releases:
         failures (https://github.com/ansible-collections/amazon.aws/pull/213).
       - ec2_vol - Add support for gp3 volumes and support for modifying existing volumes
         (https://github.com/ansible-collections/amazon.aws/issues/55).
-      - module_utils - the ipaddress module utility has been vendored into this collection.  This
-        eliminates the collection dependency on ansible.netcommon (which had removed
-        the library in its 2.0 release).  The ipaddress library is provided for internal
-        use in this collection only. (https://github.com/ansible-collections/amazon.aws/issues/273)-
       - module_utils/elbv2 - add logic to compare_rules to suit Values list nested
         within dicts unique to each field type. Fixes issue (https://github.com/ansible-collections/amazon.aws/issues/187)
       - various AWS plugins and module_utils - Cleanup unused imports (https://github.com/ansible-collections/amazon.aws/pull/217).
@@ -231,6 +227,15 @@ releases:
     - 237_replace_inverse_ec2_aws_filter.yaml
     - 241_ec2_vol-returns-an-up-to-date-tag-dict-of-the-volume.yaml
     - 25-aws_ec2-hostname-options-concatenation.yaml
+    release_date: '2021-02-05'
+  1.4.1:
+    changes:
+      minor_changes:
+      - module_utils - the ipaddress module utility has been vendored into this collection.  This
+        eliminates the collection dependency on ansible.netcommon (which had removed
+        the library in its 2.0 release).  The ipaddress library is provided for internal
+        use in this collection only. (https://github.com/ansible-collections/amazon.aws/issues/273)-
+    fragments:
     - 273-vendor-ipaddress-utility.yml
     release_date: '2021-03-05'
   1.5.0:


### PR DESCRIPTION
##### SUMMARY
Changelog entry for release 1.4.1 was appended to 1.4.0 section, move the data to the correct place in the files.

Fixes: #329 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
CHANGELOG.rst

##### ADDITIONAL INFORMATION
Will also need to be backported to stable-1.5
