### PR TITLE
Migrate ec2 instance modules

### DIFF
--- a/changelogs/fragments/migrate_ec2_instance.yml
+++ b/changelogs/fragments/migrate_ec2_instance.yml
@@ -1,0 +1,3 @@
+major_changes:
+  - ec2_instance - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should be updated to use ``amazon.aws.ec2_instance``.
+  - ec2_instance_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should be updated to use ``amazon.aws.ec2_instance_info``.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -33,6 +33,8 @@ action_groups:
   - ec2_eni_info
   - ec2_group
   - ec2_group_info
+  - ec2_instance
+  - ec2_instance_info
   - ec2_key
   - ec2_snapshot
   - ec2_snapshot_info

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -120,7 +120,7 @@ options:
   vpc_subnet_id:
     description:
       - The subnet ID in which to launch the instance (VPC)
-        If none is provided, M(community.aws.ec2_instance) will chose the default zone of the default VPC.
+        If none is provided, M(amazon.aws.ec2_instance) will chose the default zone of the default VPC.
     aliases: ['subnet_id']
     type: str
   network:
@@ -287,19 +287,19 @@ EXAMPLES = '''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 
 - name: Terminate every running instance in a region. Use with EXTREME caution.
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     state: absent
     filters:
       instance-state-name: running
 
 - name: restart a particular instance by its ID
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     state: restarted
     instance_ids:
       - i-12345678
 
 - name: start an instance with a public IP address
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: "public-compute-instance"
     key_name: "prod-ssh-key"
     vpc_subnet_id: subnet-5ca1ab1e
@@ -312,7 +312,7 @@ EXAMPLES = '''
       Environment: Testing
 
 - name: start an instance and Add EBS
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: "public-withebs-instance"
     vpc_subnet_id: subnet-5ca1ab1e
     instance_type: t2.micro
@@ -325,7 +325,7 @@ EXAMPLES = '''
           delete_on_termination: true
 
 - name: start an instance with a cpu_options
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: "public-cpuoption-instance"
     vpc_subnet_id: subnet-5ca1ab1e
     tags:
@@ -340,7 +340,7 @@ EXAMPLES = '''
         threads_per_core: 1
 
 - name: start an instance and have it begin a Tower callback on boot
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: "tower-callback-test"
     key_name: "prod-ssh-key"
     vpc_subnet_id: subnet-5ca1ab1e
@@ -358,7 +358,7 @@ EXAMPLES = '''
       SomeThing: "A value"
 
 - name: start an instance with ENI (An existing ENI ID is required)
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: "public-eni-instance"
     key_name: "prod-ssh-key"
     vpc_subnet_id: subnet-5ca1ab1e
@@ -375,7 +375,7 @@ EXAMPLES = '''
     image_id: ami-123456
 
 - name: add second ENI interface
-  community.aws.ec2_instance:
+  amazon.aws.ec2_instance:
     name: "public-eni-instance"
     network:
       interfaces:

--- a/plugins/modules/ec2_instance_facts.py
+++ b/plugins/modules/ec2_instance_facts.py
@@ -1,0 +1,1 @@
+ec2_instance_info.py

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -51,30 +51,30 @@ EXAMPLES = r'''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 
 - name: Gather information about all instances
-  community.aws.ec2_instance_info:
+  amazon.aws.ec2_instance_info:
 
 - name: Gather information about all instances in AZ ap-southeast-2a
-  community.aws.ec2_instance_info:
+  amazon.aws.ec2_instance_info:
     filters:
       availability-zone: ap-southeast-2a
 
 - name: Gather information about a particular instance using ID
-  community.aws.ec2_instance_info:
+  amazon.aws.ec2_instance_info:
     instance_ids:
       - i-12345678
 
 - name: Gather information about any instance with a tag key Name and value Example
-  community.aws.ec2_instance_info:
+  amazon.aws.ec2_instance_info:
     filters:
       "tag:Name": Example
 
 - name: Gather information about any instance in states "shutting-down", "stopping", "stopped"
-  community.aws.ec2_instance_info:
+  amazon.aws.ec2_instance_info:
     filters:
       instance-state-name: [ "shutting-down", "stopping", "stopped" ]
 
 - name: Gather information about any instance with Name beginning with RHEL and an uptime of at least 60 minutes
-  community.aws.ec2_instance_info:
+  amazon.aws.ec2_instance_info:
     region: "{{ ec2_region }}"
     uptime: 60
     filters:
@@ -577,7 +577,7 @@ def main():
         supports_check_mode=True,
     )
     if module._name == 'ec2_instance_facts':
-        module.deprecate("The 'ec2_instance_facts' module has been renamed to 'ec2_instance_info'", date='2021-12-01', collection_name='community.aws')
+        module.deprecate("The 'ec2_instance_facts' module has been renamed to 'ec2_instance_info'", date='2021-12-01', collection_name='amazon.aws')
 
     try:
         connection = module.client('ec2')

--- a/tests/integration/targets/ec2_instance/aliases
+++ b/tests/integration/targets/ec2_instance/aliases
@@ -1,4 +1,2 @@
 cloud/aws
-shippable/aws/group3
-
 ec2_instance_info

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/defaults/main.yml
@@ -12,3 +12,5 @@ subnet_a_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.32.0/24'
 subnet_a_startswith: '10.{{ 256 | random(seed=vpc_seed) }}.32.'
 subnet_b_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.33.0/24'
 subnet_b_startswith: '10.{{ 256 | random(seed=vpc_seed) }}.33.'
+first_iam_role: "ansible-test-sts-{{ resource_prefix | hash('md5') }}-test-policy"
+second_iam_role: "ansible-test-sts-{{ resource_prefix | hash('md5') }}-test-policy-2"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/iam_instance_role.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/iam_instance_role.yml
@@ -2,7 +2,7 @@
   - name: "Create IAM role for test"
     iam_role:
       state: present
-      name: "ansible-test-sts-{{ resource_prefix }}-test-policy"
+      name: '{{ first_iam_role }}'
       assume_role_policy_document: "{{ lookup('file','assume-role-policy.json') }}"
       create_instance_profile: yes
       managed_policy:
@@ -12,7 +12,7 @@
   - name: "Create second IAM role for test"
     iam_role:
       state: present
-      name: "ansible-test-sts-{{ resource_prefix }}-test-policy-2"
+      name: '{{ second_iam_role }}'
       assume_role_policy_document: "{{ lookup('file','assume-role-policy.json') }}"
       create_instance_profile: yes
       managed_policy:
@@ -119,8 +119,8 @@
       managed_policy:
       - AmazonEC2ContainerServiceRole
     loop:
-      - "ansible-test-sts-{{ resource_prefix }}-test-policy"
-      - "ansible-test-sts-{{ resource_prefix }}-test-policy-2"
+      - '{{ first_iam_role }}'
+      - '{{ second_iam_role }}'
     register: removed
     until: removed is not failed
     ignore_errors: yes

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/main.yml
@@ -30,7 +30,7 @@
           # don't support any configuration of the delay between retries.
           max_attempts: 20
   collections:
-    - amazon.aws
+    - community.aws
   block:
     - debug:
         msg: "{{ inventory_hostname }} start: {{ lookup('pipe','date') }}"

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -16,3 +16,4 @@ plugins/modules/ec2_vpc_subnet_info.py pylint:ansible-deprecated-no-version  # W
 plugins/module_utils/compat/_ipaddress.py no-assert  # Vendored library
 plugins/module_utils/compat/_ipaddress.py no-unicode-literals  # Vendored library
 plugins/module_utils/ec2.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2_instance_info.py pylint:ansible-deprecated-no-version # We use dates for deprecations, Ansible 2.9 only supports this for compatability


### PR DESCRIPTION
##### SUMMARY
Moves ec2_instance and ec2_instance_info from community.aws to amazon.aws via git patch.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
ec2_instance
ec2_instance_info

##### ADDITIONAL INFORMATION
This is the first time we're doing this, git history should be preserved but Github may want to squash.  I don't love the idea of directly committing to origin to get around that.  ETA: I should be able to do a manual merge from the cli though?

Migration was done via:

```
COLLECTIONS_PATH/community/aws$ git log --pretty=email --patch-with-stat --reverse --full-index --binary -- tests/integration/targets/ec2_instance/ plugins/modules/ec2_instance.py plugins/modules/ec2_instance_info.py > /tmp/patch`

COLLECTIONS_PATH/amazon/aws$ git am < /tmp/patch
```
then adding the _facts.py symlink and sed'ing the FQCNs.
A PR will follow to remove the modules from community.aws after this has merged.