### PR TITLE
aws_s3/test: keep length of name below 63 char

### DIFF
--- a/tests/integration/targets/aws_s3/defaults/main.yml
+++ b/tests/integration/targets/aws_s3/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for s3
 bucket_name: '{{ resource_prefix }}'
-bucket_name_acl: '{{ bucket_name }}-with-acl'
+bucket_name_acl: "{{ resource_prefix | hash('md5') + '-with-acl' }}"

--- a/tests/integration/targets/aws_s3/defaults/main.yml
+++ b/tests/integration/targets/aws_s3/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for s3
-bucket_name: '{{ resource_prefix }}'
-bucket_name_acl: "{{ resource_prefix | hash('md5') + '-with-acl' }}"
+bucket_name: '{{ resource_prefix | hash("md5") }}'
+bucket_name_acl: "{{ bucket_name + '-with-acl' }}"


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/954

To ensure the name of the bucket with ACL is valide we build
the name from the md5 of the `resource_prefix`.