### PR TITLE
Add volume tags key with empty dict and test

### DIFF
--- a/changelogs/fragments/383_ec2_snapshot_tags.yml
+++ b/changelogs/fragments/383_ec2_snapshot_tags.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_snapshot - Fix snapshot issue when capturing a snapshot of a volume without tags (https://github.com/ansible-collections/amazon.aws/pull/383)

--- a/plugins/modules/ec2_snapshot.py
+++ b/plugins/modules/ec2_snapshot.py
@@ -260,7 +260,8 @@ def create_snapshot(module, ec2, description=None, wait=None,
         volume_id = volume['VolumeId']
     else:
         volume = get_volume_by_id(module, ec2, volume_id)
-
+    if 'Tags' not in volume:
+        volume['Tags'] = {}
     if last_snapshot_min_age > 0:
         current_snapshots = get_snapshots_by_volume(module, ec2, volume_id)
         last_snapshot_min_age = last_snapshot_min_age * 60  # Convert to seconds

--- a/tests/integration/targets/ec2_snapshot/tasks/main.yml
+++ b/tests/integration/targets/ec2_snapshot/tasks/main.yml
@@ -52,7 +52,7 @@
         instance_id: '{{ instance.instances[0].instance_id }}'
         device_name: '{{ instance.instances[0].block_device_mappings[0].device_name }}'
 
-#    JR: Check mode not supported
+    #    JR: Check mode not supported
 #    - name: Take snapshot (check mode)
 #      ec2_snapshot:
 #        instance_id: '{{ instance_id }}'
@@ -68,6 +68,12 @@
       ec2_snapshot:
         volume_id: '{{ volume_id }}'
       register: result
+
+    - name: Take a snapshot of the instance with volume
+      ec2_snapshot:
+        instance_id: '{{ instance_id }}'
+        device_name: '{{ instance.instances[0].block_device_mappings[0].device_name }}'
+        state: present
 
     # The Name tag is created automatically as the instance_name; ie the resource_prefix
     - name: Get info about snapshots
@@ -264,10 +270,10 @@
         max_results: 5
       register: info_result
 
-    - assert:
-        that:
-          - info_result.snapshots | length == 5
-          - info_result.next_token_id is defined
+#    - assert:
+#        that:
+#          - info_result.snapshots | length == 5
+#          - info_result.next_token_id is defined
 
     # Pagination : 2nd request
     - name: Get snapshots for a second paginated request
@@ -277,9 +283,9 @@
         next_token_id: "{{ info_result.next_token_id }}"
       register: info_result
 
-    - assert:
-        that:
-          - info_result.snapshots | length == 3
+#    - assert:
+#        that:
+#          - info_result.snapshots | length == 3
 
     # delete the tagged snapshot
     - name: Delete the tagged snapshot

--- a/tests/integration/targets/ec2_snapshot/tasks/main.yml
+++ b/tests/integration/targets/ec2_snapshot/tasks/main.yml
@@ -37,7 +37,8 @@
       register: volume_detached
 
     # Capture snapshot of this detached volume and assert the results
-    - ec2_snapshot:
+    - name: Create a snapshot of detached volume without tags and store results
+      ec2_snapshot:
         volume_id: '{{ volume_detached.volume_id }}'
       register: untagged_snapshot
 
@@ -286,10 +287,10 @@
         max_results: 5
       register: info_result
 
-#    - assert:
-#        that:
-#          - info_result.snapshots | length == 5
-#          - info_result.next_token_id is defined
+    - assert:
+        that:
+          - info_result.snapshots | length == 5
+          - info_result.next_token_id is defined
 
     # Pagination : 2nd request
     - name: Get snapshots for a second paginated request
@@ -299,9 +300,9 @@
         next_token_id: "{{ info_result.next_token_id }}"
       register: info_result
 
-#    - assert:
-#        that:
-#          - info_result.snapshots | length == 3
+    - assert:
+        that:
+          - info_result.snapshots | length == 3
 
     # delete the tagged snapshot
     - name: Delete the tagged snapshot

--- a/tests/integration/targets/ec2_snapshot/tasks/main.yml
+++ b/tests/integration/targets/ec2_snapshot/tasks/main.yml
@@ -25,6 +25,28 @@
 
 
   block:
+    - name: Gather availability zones
+      aws_az_facts:
+      register: azs
+
+    # Create a new volume in detached mode without tags
+    - name: Create a detached volume without tags
+      ec2_vol:
+        volume_size: 1
+        zone: '{{ azs.availability_zones[0].zone_name }}'
+      register: volume_detached
+
+    # Capture snapshot of this detached volume and assert the results
+    - ec2_snapshot:
+        volume_id: '{{ volume_detached.volume_id }}'
+      register: untagged_snapshot
+
+    - assert:
+        that:
+          - untagged_snapshot is changed
+          - untagged_snapshot.snapshots| length == 1
+          - untagged_snapshot.snapshots[0].volume_id == volume_detached.volume_id
+
     - ec2_ami_info:
         owners: amazon
         filters:
@@ -52,7 +74,7 @@
         instance_id: '{{ instance.instances[0].instance_id }}'
         device_name: '{{ instance.instances[0].block_device_mappings[0].device_name }}'
 
-    #    JR: Check mode not supported
+#    JR: Check mode not supported
 #    - name: Take snapshot (check mode)
 #      ec2_snapshot:
 #        instance_id: '{{ instance_id }}'
@@ -68,12 +90,6 @@
       ec2_snapshot:
         volume_id: '{{ volume_id }}'
       register: result
-
-    - name: Take a snapshot of the instance with volume
-      ec2_snapshot:
-        instance_id: '{{ instance_id }}'
-        device_name: '{{ instance.instances[0].block_device_mappings[0].device_name }}'
-        state: present
 
     # The Name tag is created automatically as the instance_name; ie the resource_prefix
     - name: Get info about snapshots
@@ -345,4 +361,16 @@
       ec2_vol:
         id: '{{ volume_id }}'
         state: absent
+      ignore_errors: true
+
+    - name: Delete detached and untagged volume
+      ec2_vol:
+        id: '{{ volume_detached.volume_id}}'
+        state: absent
+      ignore_errors: true
+
+    - name: Delete untagged snapshot
+      ec2_snapshot:
+        state: absent
+        snapshot_id: '{{ untagged_snapshot.snapshot_id }}'
       ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Added 'Tags' key to the dictionary describing volume if isn't present
Fixes: #373
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bug fix Pull Request - ec2_snapshot tagging fails on KeyError #373 

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_snapshot
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
