### PR TITLE
Add fix to change the no_device parameter value to string 

### DIFF
--- a/changelogs/fragments/386_ec2_ami_no_device.yml
+++ b/changelogs/fragments/386_ec2_ami_no_device.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_ami - Fix ami issue when creating an ami with no_device parameter (https://github.com/ansible-collections/amazon.aws/pull/386)

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -474,6 +474,8 @@ def create_image(module, connection):
                 device = rename_item_if_exists(device, 'iops', 'Iops', 'Ebs')
                 device = rename_item_if_exists(device, 'encrypted', 'Encrypted', 'Ebs')
 
+                # The NoDevice parameter in Boto3 is a string. Empty string omits the device from block device mapping
+                # https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.create_image
                 if 'NoDevice' in device:
                     if device['NoDevice'] is True:
                         device['NoDevice'] = ""

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -457,7 +457,6 @@ def create_image(module, connection):
         }
 
         block_device_mapping = None
-
         # Remove empty values injected by using options
         if device_mapping:
             block_device_mapping = []
@@ -474,6 +473,12 @@ def create_image(module, connection):
                 device = rename_item_if_exists(device, 'volume_size', 'VolumeSize', 'Ebs', attribute_type=int)
                 device = rename_item_if_exists(device, 'iops', 'Iops', 'Ebs')
                 device = rename_item_if_exists(device, 'encrypted', 'Encrypted', 'Ebs')
+
+                if 'NoDevice' in device:
+                    if device['NoDevice'] is True:
+                        device['NoDevice'] = ""
+                    else:
+                        del device['NoDevice']
                 block_device_mapping.append(device)
         if block_device_mapping:
             params['BlockDeviceMappings'] = block_device_mapping

--- a/tests/integration/targets/ec2_ami/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami/tasks/main.yml
@@ -132,6 +132,12 @@
       set_fact:
         ec2_ami_no_device_true_image_id: "{{ result_no_device_true.image_id }}"
 
+    - name: assert that image with no_device option yes has been created
+      assert:
+        that:
+          - "result_no_device_true.changed"
+          - "'/dev/sdf' not in result_no_device_true.block_device_mapping"
+
     - name: create an image from the instance with attached devices with no_device false
       ec2_ami:
         name: '{{ ec2_ami_name }}_no_device_false_ami'
@@ -151,11 +157,11 @@
       set_fact:
         ec2_ami_no_device_false_image_id: "{{ result_no_device_false.image_id }}"
 
-    - name: assert that image with no_device option yes and no_device option no has been created
+    - name: assert that image with no_device option no has been created
       assert:
         that:
-          - "result_no_device_true.changed"
           - "result_no_device_false.changed"
+          - "'/dev/sda1' in result_no_device_false.block_device_mapping"
 
     # ============================================================
 

--- a/tests/integration/targets/ec2_ami/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami/tasks/main.yml
@@ -112,6 +112,53 @@
 
     # ============================================================
 
+    - name: create an image from the instance with attached devices with no_device true
+      ec2_ami:
+        name: '{{ ec2_ami_name }}_no_device_true_ami'
+        instance_id: '{{ setup_instance.instance_ids[0] }}'
+        device_mapping:
+          - device_name: /dev/sda1
+            volume_size: 10
+            delete_on_termination: true
+            volume_type: gp2
+          - device_name: /dev/sdf
+            no_device: yes
+        state: present
+        wait: yes
+        root_device_name: /dev/xvda
+      register: result_no_device_true
+
+    - name: set image id fact for deletion later
+      set_fact:
+        ec2_ami_no_device_true_image_id: "{{ result_no_device_true.image_id }}"
+
+    - name: create an image from the instance with attached devices with no_device false
+      ec2_ami:
+        name: '{{ ec2_ami_name }}_no_device_false_ami'
+        instance_id: '{{ setup_instance.instance_ids[0] }}'
+        device_mapping:
+          - device_name: /dev/sda1
+            volume_size: 10
+            delete_on_termination: true
+            volume_type: gp2
+            no_device: no
+        state: present
+        wait: yes
+        root_device_name: /dev/xvda
+      register: result_no_device_false
+
+    - name: set image id fact for deletion later
+      set_fact:
+        ec2_ami_no_device_false_image_id: "{{ result_no_device_false.image_id }}"
+
+    - name: assert that image with no_device option yes and no_device option no has been created
+      assert:
+        that:
+          - "result_no_device_true.changed"
+          - "result_no_device_false.changed"
+
+    # ============================================================
+
     - name: gather facts about the image created
       ec2_ami_info:
         image_ids: '{{ ec2_ami_image_id }}'
@@ -434,6 +481,20 @@
         state: absent
         image_id: "{{ ec2_ami_image_id }}"
         name: '{{ ec2_ami_name }}_ami'
+        wait: yes
+      ignore_errors: yes
+
+    - name: delete ami
+      ec2_ami:
+        state: absent
+        image_id: "{{ ec2_ami_no_device_true_image_id }}"
+        wait: yes
+      ignore_errors: yes
+
+    - name: delete ami
+      ec2_ami:
+        state: absent
+        image_id: "{{ ec2_ami_no_device_false_image_id }}"
         wait: yes
       ignore_errors: yes
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes the value of no_device parameter from Bool to String for Boto3
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #120 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request - Type error on no_device parameter of ec2_ami module #120

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_ami
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
