### PR TITLE
Fix versioned parameters

### DIFF
--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -223,6 +223,7 @@ class LookupModule(LookupBase):
                                                     tag_value_key_name="Value")
             for i in terms:
                 if i.split(':', 1)[0] in params:
+                    i = i.split(':', 1)[0]
                     ret.append(params[i])
                 elif i in response['InvalidParameters']:
                     ret.append(None)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes an issue where a versioned parameter in the list causes a KeyError.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ssm.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Problem:
If you request a versioned parameter using the lookup function, you get an unhandled exception. This is because although we are checking for just the name of the parameter (by using .split), when we add it to the list we are returning, we use the name as-is for the index lookup.

```
session = boto3.Session()
ssm = session.client('ssm')
ssm_dict["Names"] = ['/path/to/parameter:1']
response = ssm.get_parameters(**ssm_dict)
params = boto3_tag_list_to_ansible_dict(response['Parameters'], tag_name_key_name="Name",
                                                                    tag_value_key_name="Value")
for i in ['/path/to/parameter:1']:
  if i.split(':', 1)[0] in params:
    print(params[i])

Traceback (most recent call last):
  File "<stdin>", line 3, in <module>
KeyError: '/path/to/parameter:1'
```

To solve this problem, we need to set `i` to the value without the version identifier. This works regardless of whether the parameter is versioned or not.

Solution:
```
session = boto3.Session()
ssm = session.client('ssm')
ssm_dict["Names"] = ['/path/to/parameter:1']
response = ssm.get_parameters(**ssm_dict)
params = boto3_tag_list_to_ansible_dict(response['Parameters'], tag_name_key_name="Name",
                                                                    tag_value_key_name="Value")
for i in ['/path/to/parameter:1']:
  if i.split(':', 1)[0] in params:
    i = i.split(':', 1)[0]
    print(params[i])

PARAMETER VALUE IS PRINTED HERE
```
<!--- Paste verbatim command output below, e.g. before and after your change -->
See Above:
```paste below

```
