### PR TITLE
Install ec2_eni test requirements

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,3 +4,5 @@ mock
 pytest-xdist
 # We should avoid these two modules with py3
 pytest-mock
+# Needed for ansible.netcommon.ipaddr in tests
+netaddr


### PR DESCRIPTION
##### SUMMARY
ansible.netcommon needs the netaddr python package to be installed in the test env, add this to test-requirements.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
ec2_eni