### PR TITLE
Add strawman for ISSUE_TEMPLATES form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,161 @@
+---
+name: Bug report
+description: Create a report to help us improve
+
+body:
+- type: markdown
+  attributes:
+    value: |
+      ⚠
+      Verify first that your issue is not [already reported on GitHub][issue search].
+      Where possible also test if the latest release and main branch are affected too.
+      *Complete **all** sections as described, this form is processed automatically.*
+
+      [issue search]: https://github.com/ansible-collections/amazon.aws/search?q=is%3Aissue&type=issues
+
+- type: textarea
+  attributes:
+    label: Summary
+    description: |
+      Explain the problem briefly below.
+    placeholder: >-
+      When I try to do X with the collection from the main branch on GitHub, Y
+      breaks in a way Z under the env E. Here are all the details I know
+      about this problem...
+  validations:
+    required: true
+
+- type: dropdown
+  attributes:
+    label: Issue Type
+    # FIXME: Once GitHub allows defining the default choice, update this
+    options:
+    - Bug Report
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    # For smaller collections we could use a multi-select and hardcode the list
+    # May generate this list via GitHub action and walking files under https://github.com/ansible-collections/community.general/tree/main/plugins
+    # Select from list, filter as you type (`mysql` would only show the 3 mysql components)
+    # OR freeform - doesn't seem to be supported in adaptivecards
+    label: Component Name
+    description: >-
+      Write the short name of the module or plugin below,
+      *use your best guess if unsure*.
+    placeholder: ec2_instance, ec2_security_group
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Ansible Version
+    description: >-
+      Paste verbatim output from `ansible --version` between
+      tripple backticks.
+    value: |
+      ```console (paste below)
+      $ ansible --version
+
+      ```
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Collection Versions
+    description: >-
+      Paste verbatim output from `ansible-galaxy collection list` between
+      tripple backticks.
+    value: |
+      ```console (paste below)
+      $ ansible-galaxy collection list
+      ```
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: AWS SDK versions
+    description: >-
+      The AWS modules depend heavily on the Amazon AWS SDKs which are regularly updated.
+      Paste verbatim output from `pip show boto boto3 botocore` between quotes
+    value: |
+      ```console (paste below)
+      $ pip show boto boto3 botocore
+      ```
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Configuration
+    description: >-
+      If this issue has an example piece of YAML that can help to reproduce this problem, please provide it.
+      This can be a piece of YAML from, e.g., an automation, script, scene or configuration.
+
+      Paste verbatim output from `ansible-config dump --only-changed` between quotes
+    value: |
+      ```console (paste below)
+      $ ansible-config dump --only-changed
+
+      ```
+
+- type: textarea
+  attributes:
+    label: OS / Environment
+    description: >-
+      Provide all relevant information below, e.g. target OS versions,
+      network device firmware, etc.
+    placeholder: RHEL 8, CentOS Stream etc.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Steps to Reproduce
+    description: |
+      Describe exactly how to reproduce the problem, using a minimal test-case. It would *really* help us understand your problem if you could also paste any playbooks, configs and commands you used.
+
+      **HINT:** You can paste https://gist.github.com links for larger files.
+    value: |
+      <!--- Paste example playbooks or commands between quotes below -->
+      ```yaml (paste below)
+
+      ```
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Expected Results
+    description: >-
+      Describe what you expected to happen when running the steps above.
+    placeholder: >-
+      I expected X to happen because I assumed Y.
+      that it did not.
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Actual Results
+    description: |
+      Describe what actually happened. If possible run with extra verbosity (`-vvvv`).
+
+      Paste verbatim command output between quotes.
+    value: |
+      ```console (paste below)
+
+      ```
+
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: |
+      Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
+    options:
+    - label: I agree to follow the Ansible Code of Conduct
+      required: true
+...

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -1,0 +1,130 @@
+---
+name: Documentation Report
+description: Ask us about docs
+# NOTE: issue body is enabled to allow screenshots
+
+body:
+- type: markdown
+  attributes:
+    value: |
+      ⚠
+      Verify first that your issue is not [already reported on GitHub][issue search].
+      Where possible also test if the latest release and main branch are affected too.
+      *Complete **all** sections as described, this form is processed automatically.*
+
+      [issue search]: https://github.com/ansible-collections/amazon.aws/search?q=is%3Aissue&type=issues
+
+- type: textarea
+  attributes:
+    label: Summary
+    description: |
+      Explain the problem briefly below, add suggestions to wording or structure.
+
+      **HINT:** Did you know the documentation has an `Edit on GitHub` link on every page?
+    placeholder: >-
+      I was reading the Collection documentation of version X and I'm having
+      problems understanding Y. It would be very helpful if that got
+      rephrased as Z.
+  validations:
+    required: true
+
+- type: dropdown
+  attributes:
+    label: Issue Type
+    # FIXME: Once GitHub allows defining the default choice, update this
+    options:
+    - Documentation Report
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    # For smaller collections we could use a multi-select and hardcode the list
+    # May generate this list via GitHub action and walking files under https://github.com/ansible-collections/community.general/tree/main/plugins
+    # Select from list, filter as you type (`mysql` would only show the 3 mysql components)
+    # OR freeform - doesn't seem to be supported in adaptivecards
+    label: Component Name
+    description: >-
+      Write the short name of the rst file, module, plugin or task below,
+      *use your best guess if unsure*.
+    placeholder: ec2_instance, ec2_security_group
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Ansible Version
+    description: >-
+      Paste verbatim output from `ansible --version` between
+      tripple backticks.
+    value: |
+      ```console (paste below)
+      $ ansible --version
+
+      ```
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Collection Versions
+    description: >-
+      Paste verbatim output from `ansible-galaxy collection list` between
+      tripple backticks.
+    value: |
+      ```console (paste below)
+      $ ansible-galaxy collection list
+      ```
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Configuration
+    description: >-
+      If this issue has an example piece of YAML that can help to reproduce this problem, please provide it.
+      This can be a piece of YAML from, e.g., an automation, script, scene or configuration.
+
+      Paste verbatim output from `ansible-config dump --only-changed` between quotes
+    value: |
+      ```console (paste below)
+      $ ansible-config dump --only-changed
+
+      ```
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: OS / Environment
+    description: >-
+      Provide all relevant information below, e.g. OS version,
+      browser, etc.
+    placeholder: RHEL 8, Firefox etc.
+  validations:
+    required: false
+
+- type: textarea
+  attributes:
+    label: Additional Information
+    description: |
+      Describe how this improves the documentation, e.g. before/after situation or screenshots.
+
+      **Tip:** It's not possible to upload the screenshot via this field directly but you can use the last textarea in this form to attach them.
+
+      **HINT:** You can paste https://gist.github.com links for larger files.
+    placeholder: >-
+      When the improvement is applied, it makes it more straightforward
+      to understand X.
+  validations:
+    required: false
+
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: |
+      Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
+    options:
+    - label: I agree to follow the Ansible Code of Conduct
+      required: true
+...

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,74 @@
+---
+name: Feature request
+description: Suggest an idea for this project
+
+body:
+- type: markdown
+  attributes:
+    value: |
+      ⚠
+      Verify first that your issue is not [already reported on GitHub][issue search].
+      Where possible also test if the latest release and main branch are affected too.
+      *Complete **all** sections as described, this form is processed automatically.*
+
+      [issue search]: https://github.com/ansible-collections/amazon.aws/search?q=is%3Aissue&type=issues
+
+- type: textarea
+  attributes:
+    label: Summary
+    description: |
+      Describe the new feature/improvement briefly below.
+    placeholder: >-
+      I am trying to do X with the collection from the main branch on GitHub and
+      I think that implementing a feature Y would be very helpful for me and
+      every other user of amazon.aws because of Z.
+  validations:
+    required: true
+
+- type: dropdown
+  attributes:
+    label: Issue Type
+    # FIXME: Once GitHub allows defining the default choice, update this
+    options:
+    - Feature Idea
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    # For smaller collections we could use a multi-select and hardcode the list
+    # May generate this list via GitHub action and walking files under https://github.com/ansible-collections/community.general/tree/main/plugins
+    # Select from list, filter as you type (`mysql` would only show the 3 mysql components)
+    # OR freeform - doesn't seem to be supported in adaptivecards
+    label: Component Name
+    description: >-
+      Write the short name of the module or plugin below,
+      *use your best guess if unsure*.
+    placeholder: ec2_instance, ec2_security_group
+  validations:
+    required: true
+
+- type: textarea
+  attributes:
+    label: Additional Information
+    description: |
+      Describe how the feature would be used, why it is needed and what it would solve.
+
+      **HINT:** You can paste https://gist.github.com links for larger files.
+    value: |
+      <!--- Paste example playbooks or commands between quotes below -->
+      ```yaml (paste below)
+
+      ```
+  validations:
+    required: false
+
+- type: checkboxes
+  attributes:
+    label: Code of Conduct
+    description: |
+      Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
+    options:
+    - label: I agree to follow the Ansible Code of Conduct
+      required: true
+...


### PR DESCRIPTION
##### SUMMARY

We've had a number of issues posted recently without the templates.  This results in maintainers needing to guess to fill in the blanks.  Use forms rather than the default template to make it harder to skip things like examples.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
.github/

##### ADDITIONAL INFORMATION

