### PR TITLE
Add constraints.txt and requirements.txt for unit/integration tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
-boto>=2.49.0
+# When updating the minimal requirements please also update
+# - tests/unit/constraints.txt
+# - tests/integration/constraints.txt
+# - tests/integration/targets/setup_botocore_pip
 botocore>=1.18.0
 boto3>=1.15.0
+# Final released version
+boto>=2.49.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,7 @@
+botocore
+boto3
+boto
+
 coverage==4.5.4
 placebo
 mock

--- a/tests/integration/constraints.txt
+++ b/tests/integration/constraints.txt
@@ -1,0 +1,7 @@
+# Specifically run tests against the oldest versions that we support
+boto3==1.15.0
+botocore==1.18.0
+
+# AWS CLI has `botocore==` dependencies, provide the one that matches botocore
+# to avoid needing to download over a years worth of awscli wheels.
+awscli==1.18.141

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -1,3 +1,8 @@
+# Our code is based on the AWS SDKs
+boto
+boto3
+botocore
+
 # netaddr is needed for ansible.netcommon.ipv6
 netaddr
 virtualenv

--- a/tests/integration/targets/ec2_ami/aliases
+++ b/tests/integration/targets/ec2_ami/aliases
@@ -1,3 +1,5 @@
-cloud/aws
+# duration: 15
 slow
+
+cloud/aws
 ec2_ami_info

--- a/tests/integration/targets/ec2_instance/aliases
+++ b/tests/integration/targets/ec2_instance/aliases
@@ -1,4 +1,4 @@
-# Takes about 10-15 minutes
+# duration: 25
 slow
 
 cloud/aws

--- a/tests/integration/targets/ec2_vpc_subnet/aliases
+++ b/tests/integration/targets/ec2_vpc_subnet/aliases
@@ -1,4 +1,2 @@
-slow
-
 cloud/aws
 ec2_vpc_subnet_info

--- a/tests/unit/constraints.txt
+++ b/tests/unit/constraints.txt
@@ -1,0 +1,7 @@
+# Specifically run tests against the oldest versions that we support
+boto3==1.15.0
+botocore==1.18.0
+
+# AWS CLI has `botocore==` dependencies, provide the one that matches botocore
+# to avoid needing to download over a years worth of awscli wheels.
+awscli==1.18.141

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,2 +1,6 @@
-boto3>=1.15.0
+# Our code is based on the AWS SDKs
+botocore
+boto3
+boto
+
 placebo


### PR DESCRIPTION
##### SUMMARY

Now that we state that we support specific minimum versions of the AWS SDKs, make sure we base our unit/integration tests against them such that modules need to explicitly test/request newer versions of the SDKs.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tests/integration
tests/unit

##### ADDITIONAL INFORMATION

Once merged into amazon.aws we should merge this into community.aws


Depends-On: https://github.com/ansible-collections/amazon.aws/pull/453
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/454
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/450
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/496

See also: https://github.com/ansible/ansible-zuul-jobs/pull/991