### PR TITLE
Use tiny_prefix to limit the length of the 'unique' component of ELB name

### DIFF
--- a/tests/integration/targets/ec2_elb_lb/defaults/main.yml
+++ b/tests/integration/targets/ec2_elb_lb/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 # defaults file for ec2_elb_lb
-unique_id: "{{ resource_prefix | hash('md5') | truncate(16, True, '') }}"
-elb_name: 'ansible-test-{{ unique_id }}'
+elb_name: 'ansible-test-{{ tiny_prefix }}'

--- a/tests/integration/targets/ec2_elb_lb/defaults/main.yml
+++ b/tests/integration/targets/ec2_elb_lb/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
-# defaults file for test_ec2_eip
-tag_prefix: '{{resource_prefix}}'
+# defaults file for ec2_elb_lb
+unique_id: "{{ resource_prefix | hash('md5') | truncate(16, True, '') }}"
+elb_name: 'ansible-test-{{ unique_id }}'

--- a/tests/integration/targets/ec2_elb_lb/tasks/main.yml
+++ b/tests/integration/targets/ec2_elb_lb/tasks/main.yml
@@ -37,7 +37,7 @@
 
     - name: Create ELB
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         state: present
         zones:
           - "{{ aws_region }}a"
@@ -98,7 +98,7 @@
 
     - name: Change AZ's
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         state: present
         zones:
           - "{{ aws_region }}c"
@@ -131,7 +131,7 @@
 
     - name: Update AZ's
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         state: present
         zones:
           - "{{ aws_region }}a"
@@ -159,7 +159,7 @@
 
     - name: Purge Listeners
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         state: present
         zones:
           - "{{ aws_region }}a"
@@ -187,7 +187,7 @@
 
     - name: Add Listeners
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         state: present
         zones:
           - "{{ aws_region }}a"
@@ -227,7 +227,7 @@
     # ============================================================
     - name: test with only name (state missing)
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
       register: result
       ignore_errors: true
 
@@ -241,7 +241,7 @@
     # ============================================================
     - name: test invalid region parameter
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         state: present
         region: 'asdf querty 1234'
         zones:
@@ -265,7 +265,7 @@
     # ============================================================
     - name: test no authentication parameters
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         state: present
         aws_access_key: '{{ omit }}'
         aws_secret_key: '{{ omit }}'
@@ -291,7 +291,7 @@
     # ============================================================
     - name: test credentials from environment
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         state: present
         aws_access_key: "{{ omit }}"
         aws_secret_key: "{{ omit }}"
@@ -322,7 +322,7 @@
     # ============================================================
     - name: remove the test load balancer completely
       ec2_elb_lb:
-        name: "{{ tag_prefix }}"
+        name: "{{ elb_name }}"
         state: absent
       register: result
 
@@ -330,5 +330,5 @@
       assert:
         that:
            - 'result.changed'
-           - 'result.elb.name == "{{tag_prefix}}"'
+           - 'result.elb.name == "{{ elb_name }}"'
            - 'result.elb.status == "deleted"'


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1005

##### SUMMARY

Post Zuul migration names can now be much longer which causes problems

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_elb_lb

##### ADDITIONAL INFORMATION

https://14d6523de9e1f2ced925-16d8b6320f45d127d2ef23bdfb3eef13.ssl.cf1.rackcdn.com/404/03f3d6b089206f7c30f4ab80681a015eb4bfe078/check/ansible-test-cloud-integration-aws-py36_0/5487ad2/job-output.txt

```
2021-07-16 19:10:46.097502 | fedora-34 | TASK [ec2_elb_lb : Create ELB] *************************************************
2021-07-16 19:10:46.097756 | fedora-34 | task path: /home/zuul/.ansible/collections/ansible_collections/amazon/aws/tests/integration/targets/ec2_elb_lb/tasks/main.yml:38
2021-07-16 19:10:46.157175 | fedora-34 | <testhost> ESTABLISH LOCAL CONNECTION FOR USER: zuul
2021-07-16 19:10:46.158017 | fedora-34 | <testhost> EXEC /bin/sh -c 'echo ~zuul && sleep 0'
2021-07-16 19:10:46.170693 | fedora-34 | <testhost> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/zuul/.ansible/tmp `"&& mkdir "` echo /home/zuul/.ansible/tmp/ansible-tmp-1626462646.1694572-6660-127468165970653 `" && echo ansible-tmp-1626462646.1694572-6660-127468165970653="` echo /home/zuul/.ansible/tmp/ansible-tmp-1626462646.1694572-6660-127468165970653 `" ) && sleep 0'
2021-07-16 19:10:46.481408 | fedora-34 | Using module file /home/zuul/.ansible/collections/ansible_collections/amazon/aws/plugins/modules/ec2_elb_lb.py
2021-07-16 19:10:46.483101 | fedora-34 | <testhost> PUT /home/zuul/.ansible/tmp/ansible-local-6563_jbynpg5/tmp49ryp_c_ TO /home/zuul/.ansible/tmp/ansible-tmp-1626462646.1694572-6660-127468165970653/AnsiballZ_ec2_elb_lb.py
2021-07-16 19:10:46.484497 | fedora-34 | <testhost> EXEC /bin/sh -c 'chmod u+x /home/zuul/.ansible/tmp/ansible-tmp-1626462646.1694572-6660-127468165970653/ /home/zuul/.ansible/tmp/ansible-tmp-1626462646.1694572-6660-127468165970653/AnsiballZ_ec2_elb_lb.py && sleep 0'
2021-07-16 19:10:46.497710 | fedora-34 | <testhost> EXEC /bin/sh -c 'ANSIBLE_DEBUG_BOTOCORE_LOGS=True /home/zuul/venv/bin/python /home/zuul/.ansible/tmp/ansible-tmp-1626462646.1694572-6660-127468165970653/AnsiballZ_ec2_elb_lb.py && sleep 0'
2021-07-16 19:10:47.937426 | fedora-34 | <testhost> EXEC /bin/sh -c 'rm -f -r /home/zuul/.ansible/tmp/ansible-tmp-1626462646.1694572-6660-127468165970653/ > /dev/null 2>&1 && sleep 0'
2021-07-16 19:10:47.957657 | fedora-34 | The full traceback is:
2021-07-16 19:10:47.957707 | fedora-34 | Traceback (most recent call last):
2021-07-16 19:10:47.957727 | fedora-34 |   File "/home/zuul/.ansible/tmp/ansible-tmp-1626462646.1694572-6660-127468165970653/AnsiballZ_ec2_elb_lb.py", line 114, in <module>
2021-07-16 19:10:47.957741 | fedora-34 |     _ansiballz_main()
2021-07-16 19:10:47.957754 | fedora-34 |   File "/home/zuul/.ansible/tmp/ansible-tmp-1626462646.1694572-6660-127468165970653/AnsiballZ_ec2_elb_lb.py", line 106, in _ansiballz_main
2021-07-16 19:10:47.957766 | fedora-34 |     invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
2021-07-16 19:10:47.957779 | fedora-34 |   File "/home/zuul/.ansible/tmp/ansible-tmp-1626462646.1694572-6660-127468165970653/AnsiballZ_ec2_elb_lb.py", line 55, in invoke_module
2021-07-16 19:10:47.957791 | fedora-34 |     run_name='__main__', alter_sys=True)
2021-07-16 19:10:47.957804 | fedora-34 |   File "/usr/lib64/python3.6/runpy.py", line 205, in run_module
2021-07-16 19:10:47.957816 | fedora-34 |     return _run_module_code(code, init_globals, run_name, mod_spec)
2021-07-16 19:10:47.957829 | fedora-34 |   File "/usr/lib64/python3.6/runpy.py", line 96, in _run_module_code
2021-07-16 19:10:47.957841 | fedora-34 |     mod_name, mod_spec, pkg_name, script_name)
2021-07-16 19:10:47.957853 | fedora-34 |   File "/usr/lib64/python3.6/runpy.py", line 85, in _run_code
2021-07-16 19:10:47.957865 | fedora-34 |     exec(code, run_globals)
2021-07-16 19:10:47.957878 | fedora-34 |   File "/tmp/ansible_ec2_elb_lb_payload_wa_368qa/ansible_ec2_elb_lb_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_elb_lb.py", line 1337, in <module>
2021-07-16 19:10:47.957896 | fedora-34 |   File "/tmp/ansible_ec2_elb_lb_payload_wa_368qa/ansible_ec2_elb_lb_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_elb_lb.py", line 1324, in main
2021-07-16 19:10:47.957910 | fedora-34 |   File "/tmp/ansible_ec2_elb_lb_payload_wa_368qa/ansible_ec2_elb_lb_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_elb_lb.py", line 378, in _do_op
2021-07-16 19:10:47.957922 | fedora-34 |   File "/tmp/ansible_ec2_elb_lb_payload_wa_368qa/ansible_ec2_elb_lb_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_elb_lb.py", line 455, in ensure_ok
2021-07-16 19:10:47.957943 | fedora-34 |   File "/tmp/ansible_ec2_elb_lb_payload_wa_368qa/ansible_ec2_elb_lb_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_elb_lb.py", line 687, in _create_elb
2021-07-16 19:10:47.957957 | fedora-34 |   File "/home/zuul/venv/lib/python3.6/site-packages/boto/ec2/elb/__init__.py", line 242, in create_load_balancer
2021-07-16 19:10:47.957970 | fedora-34 |     params, LoadBalancer)
2021-07-16 19:10:47.957982 | fedora-34 |   File "/home/zuul/venv/lib/python3.6/site-packages/boto/connection.py", line 1208, in get_object
2021-07-16 19:10:47.957995 | fedora-34 |     raise self.ResponseError(response.status, response.reason, body)
2021-07-16 19:10:47.958007 | fedora-34 | boto.exception.BotoServerError: BotoServerError: 400 Bad Request
2021-07-16 19:10:47.958019 | fedora-34 | <ErrorResponse xmlns="http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/">
2021-07-16 19:10:47.958031 | fedora-34 |   <Error>
2021-07-16 19:10:47.958056 | fedora-34 |     <Type>Sender</Type>
2021-07-16 19:10:47.958069 | fedora-34 |     <Code>ValidationError</Code>
2021-07-16 19:10:47.958082 | fedora-34 |     <Message>LoadBalancer name cannot be longer than 32 characters</Message>
2021-07-16 19:10:47.958094 | fedora-34 |   </Error>
2021-07-16 19:10:47.958120 | fedora-34 |   <RequestId>ac18ee90-5355-4abb-93df-99053ff37c41</RequestId>
2021-07-16 19:10:47.958134 | fedora-34 | </ErrorResponse>
2021-07-16 19:10:47.958149 | fedora-34 |
2021-07-16 19:10:47.958162 | fedora-34 | fatal: [testhost]: FAILED! => {
2021-07-16 19:10:47.958175 | fedora-34 |     "changed": false,
2021-07-16 19:10:47.958223 | fedora-34 |     "module_stderr": "Traceback (most recent call last):\n  File \"/home/zuul/.ansible/tmp/ansible-tmp-1626462646.1694572-6660-127468165970653/AnsiballZ_ec2_elb_lb.py\", line 114, in <module>\n    _ansiballz_main()\n  File \"/home/zuul/.ansible/tmp/ansible-tmp-1626462646.1694572-6660-127468165970653/AnsiballZ_ec2_elb_lb.py\", line 106, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/zuul/.ansible/tmp/ansible-tmp-1626462646.1694572-6660-127468165970653/AnsiballZ_ec2_elb_lb.py\", line 55, in invoke_module\n    run_name='__main__', alter_sys=True)\n  File \"/usr/lib64/python3.6/runpy.py\", line 205, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.6/runpy.py\", line 96, in _run_module_code\n    mod_name, mod_spec, pkg_name, script_name)\n  File \"/usr/lib64/python3.6/runpy.py\", line 85, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_ec2_elb_lb_payload_wa_368qa/ansible_ec2_elb_lb_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_elb_lb.py\", line 1337, in <module>\n  File \"/tmp/ansible_ec2_elb_lb_payload_wa_368qa/ansible_ec2_elb_lb_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_elb_lb.py\", line 1324, in main\n  File \"/tmp/ansible_ec2_elb_lb_payload_wa_368qa/ansible_ec2_elb_lb_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_elb_lb.py\", line 378, in _do_op\n  File \"/tmp/ansible_ec2_elb_lb_payload_wa_368qa/ansible_ec2_elb_lb_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_elb_lb.py\", line 455, in ensure_ok\n  File \"/tmp/ansible_ec2_elb_lb_payload_wa_368qa/ansible_ec2_elb_lb_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_elb_lb.py\", line 687, in _create_elb\n  File \"/home/zuul/venv/lib/python3.6/site-packages/boto/ec2/elb/__init__.py\", line 242, in create_load_balancer\n    params, LoadBalancer)\n  File \"/home/zuul/venv/lib/python3.6/site-packages/boto/connection.py\", line 1208, in get_object\n    raise self.ResponseError(response.status, response.reason, body)\nboto.exception.BotoServerError: BotoServerError: 400 Bad Request\n<ErrorResponse xmlns=\"http://elasticloadbalancing.amazonaws.com/doc/2012-06-01/\">\n  <Error>\n    <Type>Sender</Type>\n    <Code>ValidationError</Code>\n    <Message>LoadBalancer name cannot be longer than 32 characters</Message>\n  </Error>\n  <RequestId>ac18ee90-5355-4abb-93df-99053ff37c41</RequestId>\n</ErrorResponse>\n\n",
2021-07-16 19:10:47.958245 | fedora-34 |     "module_stdout": "",
2021-07-16 19:10:47.958259 | fedora-34 |     "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
2021-07-16 19:10:47.958281 | fedora-34 |     "rc": 1
2021-07-16 19:10:47.958295 | fedora-34 | }
```