### PR TITLE
tests: ec2_eni, ec2_instance and ec2_ami are slow

### DIFF
--- a/tests/integration/targets/ec2_ami/aliases
+++ b/tests/integration/targets/ec2_ami/aliases
@@ -1,2 +1,3 @@
 cloud/aws
+slow
 ec2_ami_info

--- a/tests/integration/targets/ec2_eni/aliases
+++ b/tests/integration/targets/ec2_eni/aliases
@@ -1,2 +1,3 @@
 cloud/aws
+slow
 ec2_eni_info

--- a/tests/integration/targets/ec2_instance/aliases
+++ b/tests/integration/targets/ec2_instance/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 ec2_instance_info
+slow


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1005

The two tests often last more than 10 minutes. This is enough to break
the balance an trigger timeout in the CI.