### PR TITLE
tests: disable ec2_instance for now

### DIFF
--- a/tests/integration/targets/ec2_instance/aliases
+++ b/tests/integration/targets/ec2_instance/aliases
@@ -1,2 +1,3 @@
+disabled
 cloud/aws
 ec2_instance_info


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1005

##### SUMMARY

Disable ec2_instance until we land:
- https://github.com/ansible-collections/amazon.aws/pull/411
- https://github.com/ansible-collections/amazon.aws/pull/406
and figure out how to improve the reliabilty of the test.

e.g of failure: https://890aa13aa78f6724352d-5fecf071b6e8bbf9bfb6df76861c0c6d.ssl.cf1.rackcdn.com/406/8f3c9c688f226433b44c0f21c738cf79190f49f4/check/ansible-test-cloud-integration-aws-py36_1/131d33e/job-output.txt


<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Reques

##### COMPONENT NAME

tests