### PR TITLE
EC2_instance: add support for controlling metadata options

### DIFF
--- a/changelogs/fragments/414-ec2_instance-support-controlling-metadata-options.yml
+++ b/changelogs/fragments/414-ec2_instance-support-controlling-metadata-options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_instance - Add support for controlling metadata options (https://github.com/ansible-collections/amazon.aws/pull/414)

--- a/changelogs/fragments/414-ec2_instance-support-controlling-metadata-options.yml
+++ b/changelogs/fragments/414-ec2_instance-support-controlling-metadata-options.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- ec2_instance - Add support for controlling metadata options (https://github.com/ansible-collections/amazon.aws/pull/414)
+- ec2_instance - add support for controlling metadata options (https://github.com/ansible-collections/amazon.aws/pull/414).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1195,6 +1195,12 @@ def build_top_level_options(params):
         spec['CpuOptions'] = {}
         spec['CpuOptions']['ThreadsPerCore'] = params.get('cpu_options').get('threads_per_core')
         spec['CpuOptions']['CoreCount'] = params.get('cpu_options').get('core_count')
+    if params.get('metadata_options'):
+        spec['MetadataOptions'] = {}
+        spec['MetadataOptions']['HttpEndpoint'] = params.get(
+            'metadata_options').get('metadata_accessible')
+        spec['MetadataOptions']['HttpTokens'] = 'optional' if params.get(
+            'metadata_options').get('metadata_version') == 'v1 and v2' else 'required'
     return spec
 
 
@@ -1737,6 +1743,7 @@ def main():
         instance_ids=dict(default=[], type='list', elements='str'),
         network=dict(default=None, type='dict'),
         volumes=dict(default=None, type='list', elements='dict'),
+        metadata_options=dict(type='dict', options=dict(metadata_accessible=dict(type='str', choices=['enabled', 'disabled'], default='enabled'), metadata_version=dict(type='str', choices=['v1 and v2', 'v2'], default='v1 and v2'))),
     )
     # running/present are synonyms
     # as are terminated/absent

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -280,7 +280,7 @@ options:
     description:
       - Modify the metadata options for the instance.
       - See U(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for more information.
-      - The two suboptions http_endpoint and http_tokens are supported.
+      - The two suboptions I(http_endpoint) and I(http_tokens) are supported.
     type: dict
     version_added: 2.0.0
     suboptions:
@@ -1233,7 +1233,7 @@ def build_top_level_options(params):
         spec['MetadataOptions'] = {}
         spec['MetadataOptions']['HttpEndpoint'] = params.get(
             'metadata_options').get('http_endpoint')
-        spec['MetadataOptions']['HttpTokens'] =  params.get(
+        spec['MetadataOptions']['HttpTokens'] = params.get(
             'metadata_options').get('http_tokens')
     return spec
 

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -288,6 +288,7 @@ options:
         - Enables or disables the HTTP metadata endpoint on instances, default state is enabled.
         - If specified a value of disabled, metadata of the instance will not be accessible.
         choices: [enabled, disabled]
+        default: enabled
         type: str
       metadata_version:
         description:
@@ -295,6 +296,7 @@ options:
         - If the state is v1 and v2 (optional), instance metadata can be retrieved with or without a signed token header on request.
         - If the state is v2 (required), a signed token header must be sent with any instance metadata retrieval requests.
         choices: [v1 and v2, v2]
+        default: v1 and v2
         type: str
 
 extends_documentation_fragment:
@@ -405,17 +407,17 @@ EXAMPLES = '''
     tags:
       Env: "eni_on"
     instance_type: t2.micro
-- name: start an instance with a metadata options
-    amazon.aws.ec2_instance:
-      name: "public-metadataoption-instance"
-      vpc_subnet_id: subnet-5calable
-      instance_type: t3.small
-      image_id: ami-123456
-      tags:
-        Environment: Testing
-      metadata_options:
-        metadata_accessible: enabled
-        metadata_version: v1 and v2
+- name: start an instance with metadata options
+  amazon.aws.ec2_instance:
+    name: "public-metadataoptions-instance"
+    vpc_subnet_id: subnet-5calable
+    instance_type: t3.small
+    image_id: ami-123456
+    tags:
+      Environment: Testing
+    metadata_options:
+      metadata_accessible: enabled
+      metadata_version: v1 and v2
 '''
 
 RETURN = '''
@@ -1774,7 +1776,9 @@ def main():
         instance_ids=dict(default=[], type='list', elements='str'),
         network=dict(default=None, type='dict'),
         volumes=dict(default=None, type='list', elements='dict'),
-        metadata_options=dict(type='dict', options=dict(metadata_accessible=dict(type='str', choices=['enabled', 'disabled'], default='enabled'), metadata_version=dict(type='str', choices=['v1 and v2', 'v2'], default='v1 and v2'))),
+        metadata_options=dict(type='dict', options=dict(
+            metadata_accessible=dict(type='str', choices=['enabled', 'disabled'], default='enabled'),
+            metadata_version=dict(type='str', choices=['v1 and v2', 'v2'], default='v1 and v2'))),
     )
     # running/present are synonyms
     # as are terminated/absent

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -280,23 +280,24 @@ options:
     description:
       - Modify the metadata options for the instance.
       - See U(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for more information.
-      - The two suboptions metadata_accessible and metadata_version are supported.
+      - The two suboptions http_endpoint and http_tokens are supported.
     type: dict
+    version_added: 2.0.0
     suboptions:
-      metadata_accessible:
+      http_endpoint:
         description:
         - Enables or disables the HTTP metadata endpoint on instances, default state is enabled.
         - If specified a value of disabled, metadata of the instance will not be accessible.
         choices: [enabled, disabled]
         default: enabled
         type: str
-      metadata_version:
+      http_tokens:
         description:
-        - Set the state of token usage for instance metadata requests, default state is v1 and v2 (optional).
-        - If the state is v1 and v2 (optional), instance metadata can be retrieved with or without a signed token header on request.
-        - If the state is v2 (required), a signed token header must be sent with any instance metadata retrieval requests.
-        choices: [v1 and v2, v2]
-        default: v1 and v2
+        - Set the state of token usage for instance metadata requests, default state is optional (optional).
+        - If the state is optional (v1 and v2), instance metadata can be retrieved with or without a signed token header on request.
+        - If the state is required (v2), a signed token header must be sent with any instance metadata retrieval requests.
+        choices: [optional, required]
+        default: optional
         type: str
 
 extends_documentation_fragment:
@@ -416,8 +417,8 @@ EXAMPLES = '''
     tags:
       Environment: Testing
     metadata_options:
-      metadata_accessible: enabled
-      metadata_version: v1 and v2
+      http_endpoint: enabled
+      http_tokens: optional
 '''
 
 RETURN = '''
@@ -1231,9 +1232,9 @@ def build_top_level_options(params):
     if params.get('metadata_options'):
         spec['MetadataOptions'] = {}
         spec['MetadataOptions']['HttpEndpoint'] = params.get(
-            'metadata_options').get('metadata_accessible')
-        spec['MetadataOptions']['HttpTokens'] = 'optional' if params.get(
-            'metadata_options').get('metadata_version') == 'v1 and v2' else 'required'
+            'metadata_options').get('http_endpoint')
+        spec['MetadataOptions']['HttpTokens'] =  params.get(
+            'metadata_options').get('http_tokens')
     return spec
 
 
@@ -1777,8 +1778,8 @@ def main():
         network=dict(default=None, type='dict'),
         volumes=dict(default=None, type='list', elements='dict'),
         metadata_options=dict(type='dict', options=dict(
-            metadata_accessible=dict(type='str', choices=['enabled', 'disabled'], default='enabled'),
-            metadata_version=dict(type='str', choices=['v1 and v2', 'v2'], default='v1 and v2'))),
+            http_endpoint=dict(type='str', choices=['enabled', 'disabled'], default='enabled'),
+            http_tokens=dict(type='str', choices=['optional', 'required'], default='optional'))),
     )
     # running/present are synonyms
     # as are terminated/absent

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -293,7 +293,7 @@ options:
         type: str
       http_tokens:
         description:
-        - Set the state of token usage for instance metadata requests, default state is optional (optional).
+        - Set the state of token usage for instance metadata requests, default state is optional.
         - If the state is optional (v1 and v2), instance metadata can be retrieved with or without a signed token header on request.
         - If the state is required (v2), a signed token header must be sent with any instance metadata retrieval requests.
         choices: [optional, required]

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -276,6 +276,26 @@ options:
     description:
       - The placement group that needs to be assigned to the instance
     type: str
+  metadata_options:
+    description:
+      - Modify the metadata options for the instance.
+      - See U(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html) for more information.
+      - The two suboptions metadata_accessible and metadata_version are supported.
+    type: dict
+    suboptions:
+      metadata_accessible:
+        description:
+        - Enables or disables the HTTP metadata endpoint on instances, default state is enabled.
+        - If specified a value of disabled, metadata of the instance will not be accessible.
+        choices: [enabled, disabled]
+        type: str
+      metadata_version:
+        description:
+        - Set the state of token usage for instance metadata requests, default state is v1 and v2 (optional).
+        - If the state is v1 and v2 (optional), instance metadata can be retrieved with or without a signed token header on request.
+        - If the state is v2 (required), a signed token header must be sent with any instance metadata retrieval requests.
+        choices: [v1 and v2, v2]
+        type: str
 
 extends_documentation_fragment:
 - amazon.aws.aws
@@ -385,6 +405,17 @@ EXAMPLES = '''
     tags:
       Env: "eni_on"
     instance_type: t2.micro
+- name: start an instance with a metadata options
+    amazon.aws.ec2_instance:
+      name: "public-metadataoption-instance"
+      vpc_subnet_id: subnet-5calable
+      instance_type: t3.small
+      image_id: ami-123456
+      tags:
+        Environment: Testing
+      metadata_options:
+        metadata_accessible: enabled
+        metadata_version: v1 and v2
 '''
 
 RETURN = '''

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -286,14 +286,14 @@ options:
     suboptions:
       http_endpoint:
         description:
-        - Enables or disables the HTTP metadata endpoint on instances, default state is enabled.
+        - Enables or disables the HTTP metadata endpoint on instances.
         - If specified a value of disabled, metadata of the instance will not be accessible.
         choices: [enabled, disabled]
         default: enabled
         type: str
       http_tokens:
         description:
-        - Set the state of token usage for instance metadata requests, default state is optional.
+        - Set the state of token usage for instance metadata requests.
         - If the state is optional (v1 and v2), instance metadata can be retrieved with or without a signed token header on request.
         - If the state is required (v2), a signed token header must be sent with any instance metadata retrieval requests.
         choices: [optional, required]

--- a/tests/integration/targets/ec2_instance/inventory
+++ b/tests/integration/targets/ec2_instance/inventory
@@ -4,6 +4,7 @@ version_fail_wrapper
 ebs_optimized
 block_devices
 cpu_options
+metadata_options
 default_vpc_tests
 external_resource_attach
 instance_no_wait

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
@@ -49,8 +49,8 @@
         - metadata_options_update is not changed
         - "{{ presented_instance_fact.instances | length }} > 0"
         - "'{{ presented_instance_fact.instances.0.state.name }}' in ['running','pending']"
-        - "{{ presented_instance_fact.instances.0.metadata_options.http_endpoint }} == 'enabled'"
-        - "{{ presented_instance_fact.instances.0.metadata_options.http_tokens }} == 'required'"
+        - "'{{ presented_instance_fact.instances.0.metadata_options.http_endpoint }}' == 'enabled'"
+        - "'{{ presented_instance_fact.instances.0.metadata_options.http_tokens }}' == 'required'"
 
   always:
   - name: "Terminate metadata_options instances"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
@@ -9,8 +9,8 @@
       vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
       instance_type: t3.nano
       metadata_options:
-          metadata_accessible: enabled
-          metadata_version: v2
+          http_endpoint: enabled
+          http_tokens: required
       wait: false
     register: instance_creation
 
@@ -30,8 +30,8 @@
       vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
       instance_type: t3.nano
       metadata_options:
-          metadata_accessible: enabled
-          metadata_version: v1 and v2
+          http_endpoint: enabled
+          http_tokens: optional
       wait: false
     register: metadata_options_update
     ignore_errors: yes

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
@@ -19,6 +19,8 @@
       that:
         - instance_creation is success
         - instance_creation is changed
+        - "'{{ instance_creation.spec.MetadataOptions.HttpEndpoint }}' == 'enabled'"
+        - "'{{ instance_creation.spec.MetadataOptions.HttpTokens }}' == 'required'"
 
   - name: "modify metadata_options on existing instance"
     ec2_instance:

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
@@ -1,0 +1,62 @@
+- block:
+  - name: "create t3.nano instance with metadata_options"
+    ec2_instance:
+      state: present
+      name: "{{ resource_prefix }}-test-t3nano-enabled-required"
+      image_id: "{{ ec2_ami_image }}"
+      tags:
+        TestId: "{{ ec2_instance_tag_TestId }}"
+      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+      instance_type: t3.nano
+      metadata_options:
+          metadata_accessible: enabled
+          metadata_version: v2
+      wait: false
+    register: instance_creation
+
+  - name: "instance with metadata_options created with the right options"
+    assert:
+      that:
+        - instance_creation is success
+        - instance_creation is changed
+
+  - name: "modify metadata_options on existing instance"
+    ec2_instance:
+      state: present
+      name: "{{ resource_prefix }}-test-t3nano-enabled-required"
+      image_id: "{{ ec2_ami_image }}"
+      tags:
+        TestId: "{{ ec2_instance_tag_TestId }}"
+      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+      instance_type: t3.nano
+      metadata_options:
+          metadata_accessible: enabled
+          metadata_version: v1 and v2
+      wait: false
+    register: metadata_options_update
+    ignore_errors: yes
+
+  - name: "fact presented ec2 instance"
+    ec2_instance_info:
+      filters:
+        "tag:Name": "{{ resource_prefix }}-test-t3nano-enabled-required"
+    register: presented_instance_fact
+
+  - name: "modify metadata_options has no effect on existing instance"
+    assert:
+      that:
+        - metadata_options_update is success
+        - metadata_options_update is not changed
+        - "{{ presented_instance_fact.instances | length }} > 0"
+        - "'{{ presented_instance_fact.instances.0.state.name }}' in ['running','pending']"
+        - "{{ presented_instance_fact.instances.0.metadata_options.http_endpoint }} == 'enabled'"
+        - "{{ presented_instance_fact.instances.0.metadata_options.http_tokens }} == 'required'"
+
+  always:
+  - name: "Terminate metadata_options instances"
+    ec2_instance:
+      state: absent
+      filters:
+        "tag:TestId": "{{ ec2_instance_tag_TestId }}"
+      wait: yes
+    ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Adding support for controlling the metadata options, 'Metadata Accessible' and 'Metadata Version' in amazon.aws.ec2_instance. 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #399 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
amazon.aws.ec2_instance
