### PR TITLE
Add note to use FQCN on Ansible versions <1.10

### DIFF
--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -39,6 +39,8 @@ DOCUMENTATION = '''
         iam_role_arn:
           description: The ARN of the IAM role to assume to perform the inventory lookup. You should still provide
               AWS credentials with enough privilege to perform the AssumeRole action.
+    note:
+        Ansible versions prior to 2.10 should use the fully qualified plugin name 'amazon.aws.aws_rds'.
     extends_documentation_fragment:
     - inventory_cache
     - constructed


### PR DESCRIPTION
##### SUMMARY
Updates aws_rds inventory module documentation to add a note for uses of Ansible versions prior to 1.10 to use the fully qualified collection name to avoid issues with role assumption (Addresses #415 )

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
aws_rds