### PR TITLE
Mark ec2_group and ec2_snapshot as slow tests

### DIFF
--- a/tests/integration/targets/ec2_group/aliases
+++ b/tests/integration/targets/ec2_group/aliases
@@ -3,5 +3,7 @@
 # https://github.com/ansible-collections/amazon.aws/issues/440
 disabled
 
+slow
+
 cloud/aws
 ec2_group_info

--- a/tests/integration/targets/ec2_snapshot/aliases
+++ b/tests/integration/targets/ec2_snapshot/aliases
@@ -4,5 +4,7 @@
 # https://github.com/ansible-collections/amazon.aws/issues/441
 disabled
 
+slow
+
 cloud/aws
 ec2_snapshot_info

--- a/tests/integration/targets/ec2_vol/aliases
+++ b/tests/integration/targets/ec2_vol/aliases
@@ -1,2 +1,4 @@
+slow
+
 cloud/aws
 ec2_vol_info

--- a/tests/integration/targets/ec2_vpc_subnet/aliases
+++ b/tests/integration/targets/ec2_vpc_subnet/aliases
@@ -1,2 +1,4 @@
+slow
+
 cloud/aws
 ec2_vpc_subnet_info


### PR DESCRIPTION
##### SUMMARY
Mark these tests as slow so they get their own, dedicated job.

WIP as I'm (ab)using this PR to also fix a few other zuul things

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ec2_group, ec2_snapshot

##### ADDITIONAL INFORMATION
From https://github.com/goneri/ci_analytics/blob/main/AWS_TIMEOUTS
```
ci_analytics$ ./AWS_TIMEOUTS 
Looking for AWS jobs that timeouted during the last 72 hours...
🧪 Log URL: https://2d83767e7d0b47cc6467-b552e5dea4fd4e73803214f8adfb6e6e.ssl.cf2.rackcdn.com/414/870c76561d3a91a74b84b7e079206d86ce981577/check/ansible-test-cloud-integration-aws-py36_2/22e2886//job-output.txt
  🎯 ec2_snapshot lasted 1708 seconds, from 02:12:33 to 02:41:02.
 ⌛ All the targets took 0:50:33.111938 to run.
🧪 Log URL: https://34667caf4980e1a898ee-75746687dfc2ac5ed97d146b7085c3b2.ssl.cf5.rackcdn.com/414/900aab708871f9517b57a777400715b76d755879/check/ansible-test-cloud-integration-aws-py36_2/a271b16//job-output.txt
  🎯 ec2_snapshot lasted 1541 seconds, from 00:54:47 to 01:20:29.
 ⌛ All the targets took 0:47:48.584199 to run.
🧪 Log URL: https://437dd30aa6615d2ae5b6-0c148146fa0d08a9a2fa172bb9668f3c.ssl.cf1.rackcdn.com/414/900aab708871f9517b57a777400715b76d755879/check/ansible-test-cloud-integration-aws-py36_2/e12c53e//job-output.txt
 ⌛ All the targets took 0:30:30.997345 to run.
🧪 Log URL: https://45e6dee77ce59d98994f-3af13d43dd38bc19ce7c59853caeabda.ssl.cf2.rackcdn.com/418/8e6e37a8e9b873ec40bd46db7df55953c111cac2/check/ansible-test-cloud-integration-aws-py36_2/57b7a59//job-output.txt
  🎯 ec2_group lasted 1241 seconds, from 20:36:20 to 20:57:01.
 ⌛ All the targets took 0:39:32.194628 to run.
```