### PR TITLE
Formally start the ec2 deprecation process

### DIFF
--- a/changelogs/fragments/424-deprecate-ec2.yml
+++ b/changelogs/fragments/424-deprecate-ec2.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+- ec2 - the boto based ``ec2`` module has been deprecated in favour of the boto3 based ``ec2_instance`` module.
+  The ``ec2`` module will be removed in release 4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/424).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -72,6 +72,13 @@ plugin_routing:
             The cloudformation_info module returns the same information, but
             not as ansible_facts.  See the module documentation for more
             information.
+    ec2:
+      deprecation:
+        removal_version: 4.0.0
+        warning_text: >-
+            The ec2 module is based upon a deprecated version of the AWS SDKs
+            and is deprecated in favor of the ec2_instance module.
+            Please update your tasks.
     ec2_ami_facts:
       deprecation:
         removal_date: 2021-12-01

--- a/plugins/modules/ec2.py
+++ b/plugins/modules/ec2.py
@@ -11,6 +11,10 @@ DOCUMENTATION = '''
 module: ec2
 version_added: 1.0.0
 short_description: create, terminate, start or stop an instance in ec2
+deprecated:
+  removed_in: 4.0.0
+  why: The ec2 module is based upon a deprecated version of the AWS SDK.
+  alternative: Use M(ec2_instance).
 description:
     - Creates or terminates ec2 instances.
     - >
@@ -1958,6 +1962,9 @@ def main():
             ['network_interfaces', 'vpc_subnet_id'],
         ],
     )
+
+    module.deprecate("The 'ec2' module has been deprecated and replaced by the 'ec2_instance' module'",
+                     version='4.0.0', collection_name='amazon.aws')
 
     if module.params.get('group') and module.params.get('group_id'):
         module.deprecate(

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -89,6 +89,8 @@ plugins/modules/ec2.py import-3.6!skip
 plugins/modules/ec2.py import-3.7!skip
 plugins/modules/ec2.py metaclass-boilerplate!skip
 plugins/modules/ec2.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2.py validate-modules:deprecation-mismatch  # Ansible 2.9 docs don't support deprecation properly
+plugins/modules/ec2.py validate-modules:invalid-documentation  # Ansible 2.9 docs don't support deprecation properly
 plugins/modules/ec2_ami.py compile-2.6!skip
 plugins/modules/ec2_ami.py compile-2.7!skip
 plugins/modules/ec2_ami.py compile-3.5!skip


### PR DESCRIPTION
##### SUMMARY

The ec2 module is based upon the deprecated `boto` (not `boto3`/`botocore`) SDK and most functionality has been replaced by the ec2_instance module.

Formally start the deprecation process and give it 2 major releases.

For practical purposes the ec2 module has a number of limitations (things like not supporting all regions) and we're still getting bugs filed against it for quirky behaviour that's fixed in ec2_instance.  By formally starting the deprecation process we can move most folks over to ec2_instance where possible and avoid trying to support 2 modules at the same time.

The major missing feature with the ec2_instance module is spot instances.  Support for spot instances is underway in https://github.com/ansible-collections/amazon.aws/pull/407

Should spot instance support not be available by 3.0.0 we can always extend the deprecation period.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2

##### ADDITIONAL INFORMATION
