### PR TITLE
ec2_key : Fix tests

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,4 @@
+# Needed by the ec2_key integration tests (generating EC2 format fingerprint)
+openssl [test platform:rpm]
+gcc [test platform:rpm]
+python3-devel [test platform:rpm]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,3 +8,5 @@ pytest-mock
 netaddr
 # Sometimes needed where we don't have features we need in modules
 awscli
+# Used for comparing SSH Public keys to the Amazon fingerprints
+pycrypto

--- a/tests/integration/targets/ec2_key/aliases
+++ b/tests/integration/targets/ec2_key/aliases
@@ -2,6 +2,4 @@
 # We need either the openssl binary, pycrpto, or a compiler on the Py36 and Py38
 # Zuul nodes
 # https://github.com/ansible-collections/amazon.aws/issues/428
-disabled
-
 cloud/aws

--- a/tests/integration/targets/setup_sshkey/files/ec2-fingerprint.py
+++ b/tests/integration/targets/setup_sshkey/files/ec2-fingerprint.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+"""
+Reads an OpenSSH Public key and spits out the 'AWS' MD5 sum
+The equivalent of
+
+ssh-keygen -f id_rsa.pub -e -m PKCS8 | openssl pkey -pubin -outform DER | openssl md5 -c | cut -f 2 -d ' '
+
+(but without needing the OpenSSL CLI)
+"""
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+import hashlib
+import sys
+from Crypto.PublicKey import RSA
+
+if len(sys.argv) == 0:
+    ssh_public_key = "id_rsa.pub"
+else:
+    ssh_public_key = sys.argv[1]
+
+with open(ssh_public_key, 'r') as key_fh:
+    data = key_fh.read()
+
+# Convert from SSH format to DER format
+public_key = RSA.importKey(data).exportKey('DER')
+md5digest = hashlib.md5(public_key).hexdigest()
+# Format the md5sum into the normal format
+pairs = zip(md5digest[::2], md5digest[1::2])
+md5string = ":".join(["".join(pair) for pair in pairs])
+
+print(md5string)

--- a/tests/integration/targets/setup_sshkey/tasks/main.yml
+++ b/tests/integration/targets/setup_sshkey/tasks/main.yml
@@ -15,48 +15,55 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
-- name: ensure openssl cli is available
-  package:
-    name: openssl
-    state: present
+- name: create a temp dir
+  tempfile:
+    state: directory
+  register: sshkey_dir
   tags:
     - prepare
 
-- name: create a temp file
-  tempfile:
-    state: file
-  register: sshkey_file
+- name: ensure script is available
+  copy:
+    src: ec2-fingerprint.py
+    dest: '{{ sshkey_dir.path }}/ec2-fingerprint.py'
+    mode: 0700
   tags:
     - prepare
+
+- name: Set location of SSH keys
+  set_fact:
+    sshkey: '{{ sshkey_dir.path }}/key_one'
+    another_sshkey: '{{ sshkey_dir.path }}/key_two'
+    sshkey_pub: '{{ sshkey_dir.path }}/key_one.pub'
+    another_sshkey_pub: '{{ sshkey_dir.path }}/key_two.pub'
 
 - name: generate sshkey
-  shell: echo 'y' | ssh-keygen -P '' -f {{ sshkey_file.path }}
-  tags:
-    - prepare
-
-- name: create another temp file
-  tempfile:
-    state: file
-  register: another_sshkey_file
-  tags:
-    - prepare
-
-- name: generate another_sshkey
-  shell: echo 'y' | ssh-keygen -P '' -f {{ another_sshkey_file.path }}
+  shell: echo 'y' | ssh-keygen -P '' -f '{{ sshkey }}'
   tags:
     - prepare
 
 - name: record fingerprint
-  shell: openssl rsa -in {{ sshkey_file.path }} -pubout -outform DER 2>/dev/null | openssl md5 -c
+  shell: '{{ sshkey_dir.path }}/ec2-fingerprint.py {{ sshkey_pub }}'
   register: fingerprint
+  tags:
+    - prepare
+
+- name: generate another_sshkey
+  shell: echo 'y' | ssh-keygen -P '' -f {{ another_sshkey }}
+  tags:
+    - prepare
+
+- name: record another fingerprint
+  shell: '{{ sshkey_dir.path }}/ec2-fingerprint.py {{ another_sshkey_pub }}'
+  register: another_fingerprint
   tags:
     - prepare
 
 - name: set facts for future roles
   set_fact:
-    sshkey: '{{ sshkey_file.path }}'
-    key_material: "{{ lookup('file', sshkey_file.path ~ '.pub') }}"
-    another_key_material: "{{ lookup('file', another_sshkey_file.path ~ '.pub') }}"
-    fingerprint: '{{ fingerprint.stdout.split()[1] }}'
+    key_material: "{{ lookup('file', sshkey_pub) }}"
+    another_key_material: "{{ lookup('file', another_sshkey_pub) }}"
+    fingerprint: '{{ fingerprint.stdout }}'
+    another_fingerprint: '{{ another_fingerprint.stdout }}'
   tags:
     - prepare

--- a/tests/integration/targets/setup_sshkey/tasks/main.yml
+++ b/tests/integration/targets/setup_sshkey/tasks/main.yml
@@ -15,6 +15,13 @@
 # You should have received a copy of the GNU General Public License
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
+- name: ensure openssl cli is available
+  package:
+    name: openssl
+    state: present
+  tags:
+    - prepare
+
 - name: create a temp file
   tempfile:
     state: file


### PR DESCRIPTION
##### SUMMARY

The Zuul nodes don't have OpenSSL installed on them, this breaks the generation of the fingerprints

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_key

##### ADDITIONAL INFORMATION

https://dashboard.zuul.ansible.com/t/ansible/build/d79dcec2e3024558800bba5fd6917505/log/job-output.txt

```
"stderr": "/bin/sh: line 1: openssl: command not found"
```

Depends-on: https://github.com/ansible-collections/amazon.aws/pull/460