### PR TITLE
Add support for ipv6 addresses

### DIFF
--- a/changelogs/fragments/430-add_support_for_ipv6_addresses.yml
+++ b/changelogs/fragments/430-add_support_for_ipv6_addresses.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - aws_service_ip_ranges - add new option ``ipv6_prefixes``
+    to get only IPV6 addresses and prefixes for Amazon services
+    (https://github.com/ansible-collections/amazon.aws/pull/430)

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -42,10 +42,15 @@ _raw:
   description: comma-separated list of CIDR ranges
 """
 
-
 import json
-import netaddr
+try:
+    import netaddr
+except ImportError as imp_exc:
+    NETADDR_LIBRARY_IMPORT_ERROR = imp_exc
+else:
+    NETADDR_LIBRARY_IMPORT_ERROR = None
 
+from ansible.module_utils.six import raise_from
 from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.urllib.error import URLError
@@ -60,20 +65,10 @@ def valid_cidr(ip_address):
     """
     Validate IP address
     """
-    try:
-        netaddr.IPNetwork(ip_address)
-    except netaddr.core.AddrFormatError as e:
-        raise AnsibleError("Not a valid IP address: %s" % e)
-    cidr = ip_address.split('/')
-    if (len(cidr) <= 1 or cidr[1] == ''):
-        return False
-    return True
-
-
-def valid_cidr(ip_address):
-    """
-    Validate IP address
-    """
+    if NETADDR_LIBRARY_IMPORT_ERROR:
+        raise_from(
+        AnsibleError('netaddr must be installed to use this plugin'),
+        NETADDR_LIBRARY_IMPORT_ERROR)
     try:
         netaddr.IPNetwork(ip_address)
     except netaddr.core.AddrFormatError as e:

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -72,12 +72,12 @@ def valid_cidr(Ip):
 
 class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
-        if "ipv6_prefix" in kwargs["ipv6_prefix"] is False:
-            prefixes_label = "prefixes"
-            ip_prefix_label = "ip_prefix"
-        else:
+        if "ipv6_prefix" in kwargs and kwargs["ipv6_prefix"]:
             prefixes_label = "ipv6_prefixes"
             ip_prefix_label = "ipv6_prefix"
+        else:
+            prefixes_label = "prefixes"
+            ip_prefix_label = "ip_prefix"
 
         try:
             resp = open_url('https://ip-ranges.amazonaws.com/ip-ranges.json')

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -44,6 +44,7 @@ _raw:
 
 
 import json
+import netaddr
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves.urllib.error import HTTPError
@@ -53,6 +54,20 @@ from ansible.module_utils.urls import ConnectionError
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.urls import SSLValidationError
 from ansible.plugins.lookup import LookupBase
+
+def valid_cidr(Ip):
+    """
+    Validate IP address
+    """
+    try:
+        netaddr.IPNetwork(Ip)
+    except netaddr.core.AddrFormatError as e:
+        raise AnsibleError("Not a valid IP address" %e)
+        return False
+    cidr = Ip.split('/')
+    if (len(cidr) <= 1 or cidr[1] == ''):
+        return False
+    return True
 
 
 class LookupModule(LookupBase):
@@ -87,4 +102,9 @@ class LookupModule(LookupBase):
             service = str.upper(kwargs['service'])
             amazon_response = (item for item in amazon_response if item['service'] == service)
 
-        return [item[ip_prefix_label] for item in amazon_response]
+            iprange = [item[ip_prefix_label] for item in amazon_response]
+            for i in iprange:
+                if not valid_cidr(i):
+                    raise AnsibleError("Invalid Ip address: %s" % i)
+                return True
+            return iprange

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -20,8 +20,8 @@ options:
   region:
     description: 'The AWS region to narrow the ranges to. Examples: us-east-1, eu-west-2, ap-southeast-1'
   ipv6_prefixes:
-    description: 'Return only ipv6 addresses. Option: ipv6_prefixes=True'
-    version_added: 2.0.0
+    description: 'When I(ipv6_prefixes=True) the lookup will return ipv6 addresses instead of ipv4 addresses'
+    version_added: 2.1.0
 '''
 
 EXAMPLES = """

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -85,5 +85,5 @@ class LookupModule(LookupBase):
         if 'service' in kwargs:
             service = str.upper(kwargs['service'])
             amazon_response = (item for item in amazon_response if item['service'] == service)
-            iprange = [item[ip_prefix_label] for item in amazon_response]
-            return iprange
+        iprange = [item[ip_prefix_label] for item in amazon_response]
+        return iprange

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -53,6 +53,20 @@ from ansible.module_utils.urls import open_url
 from ansible.module_utils.urls import SSLValidationError
 from ansible.plugins.lookup import LookupBase
 
+def valid_cidr(Ip):
+    """
+    Validate IP address
+    """
+    try:
+        netaddr.IPNetwork(Ip)
+    except netaddr.core.AddrFormatError as e:
+        raise AnsibleError("Not a valid IP address" %e)
+        return False
+    cidr = Ip.split('/')
+    if (len(cidr) <= 1 or cidr[1] == ''):
+        return False
+    return True
+
 
 def valid_cidr(ip_address):
     """

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -43,14 +43,7 @@ _raw:
 """
 
 import json
-try:
-    import netaddr
-except ImportError as imp_exc:
-    NETADDR_LIBRARY_IMPORT_ERROR = imp_exc
-else:
-    NETADDR_LIBRARY_IMPORT_ERROR = None
 
-from ansible.module_utils.six import raise_from
 from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.urllib.error import URLError
@@ -59,24 +52,6 @@ from ansible.module_utils.urls import ConnectionError
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.urls import SSLValidationError
 from ansible.plugins.lookup import LookupBase
-
-
-def valid_cidr(ip_address):
-    """
-    Validate IP address
-    """
-    if NETADDR_LIBRARY_IMPORT_ERROR:
-        raise_from(
-            AnsibleError('netaddr must be installed to use this plugin'),
-            NETADDR_LIBRARY_IMPORT_ERROR)
-    try:
-        netaddr.IPNetwork(ip_address)
-    except netaddr.core.AddrFormatError as e:
-        raise AnsibleError("Not a valid IP address: %s" % e)
-    cidr = ip_address.split('/')
-    if (len(cidr) <= 1 or cidr[1] == ''):
-        return False
-    return True
 
 
 class LookupModule(LookupBase):
@@ -112,8 +87,4 @@ class LookupModule(LookupBase):
             amazon_response = (item for item in amazon_response if item['service'] == service)
 
             iprange = [item[ip_prefix_label] for item in amazon_response]
-            for i in iprange:
-                if not valid_cidr(i):
-                    raise AnsibleError("Invalid Ip address: %s" % i)
-                return True
             return iprange

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -19,8 +19,8 @@ options:
     description: 'The service to filter ranges by. Options: EC2, S3, CLOUDFRONT, CODEbUILD, ROUTE53, ROUTE53_HEALTHCHECKS'
   region:
     description: 'The AWS region to narrow the ranges to. Examples: us-east-1, eu-west-2, ap-southeast-1'
-  ipv6_prefix:
-    description: 'Return only ipv6 addresses. Option: ipv6_prefix=True'
+  ipv6_prefixes:
+    description: 'Return only ipv6 addresses. Option: ipv6_prefixes=True'
 '''
 
 EXAMPLES = """

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -19,6 +19,8 @@ options:
     description: 'The service to filter ranges by. Options: EC2, S3, CLOUDFRONT, CODEbUILD, ROUTE53, ROUTE53_HEALTHCHECKS'
   region:
     description: 'The AWS region to narrow the ranges to. Examples: us-east-1, eu-west-2, ap-southeast-1'
+  ipv6_prefix:
+    description: 'Return only ipv6 addresses. Option: ipv6_prefix=True'
 '''
 
 EXAMPLES = """
@@ -55,9 +57,16 @@ from ansible.plugins.lookup import LookupBase
 
 class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
+        if "ipv6_prefix" in kwargs["ipv6_prefix"] is False:
+            prefixes_label = "prefixes"
+            ip_prefix_label = "ip_prefix"
+        else:
+            prefixes_label = "ipv6_prefixes"
+            ip_prefix_label = "ipv6_prefix"
+
         try:
             resp = open_url('https://ip-ranges.amazonaws.com/ip-ranges.json')
-            amazon_response = json.load(resp)['prefixes']
+            amazon_response = json.load(resp)[prefixes_label]
         except getattr(json.decoder, 'JSONDecodeError', ValueError) as e:
             # on Python 3+, json.decoder.JSONDecodeError is raised for bad
             # JSON. On 2.x it's a ValueError
@@ -78,4 +87,4 @@ class LookupModule(LookupBase):
             service = str.upper(kwargs['service'])
             amazon_response = (item for item in amazon_response if item['service'] == service)
 
-        return [item['ip_prefix'] for item in amazon_response]
+        return [item[ip_prefix_label] for item in amazon_response]

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -55,6 +55,20 @@ from ansible.module_utils.urls import open_url
 from ansible.module_utils.urls import SSLValidationError
 from ansible.plugins.lookup import LookupBase
 
+def valid_cidr(Ip):
+    """
+    Validate IP address
+    """
+    try:
+        netaddr.IPNetwork(Ip)
+    except netaddr.core.AddrFormatError as e:
+        raise AnsibleError("Not a valid IP address" %e)
+        return False
+    cidr = Ip.split('/')
+    if (len(cidr) <= 1 or cidr[1] == ''):
+        return False
+    return True
+
 
 def valid_cidr(ip_address):
     """

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -54,33 +54,6 @@ from ansible.module_utils.urls import SSLValidationError
 from ansible.plugins.lookup import LookupBase
 
 
-def valid_cidr(ip_address):
-    """
-    Validate IP address
-    """
-    try:
-        netaddr.IPNetwork(ip_address)
-    except netaddr.core.AddrFormatError as e:
-        raise AnsibleError("Not a valid IP address: %s" % e)
-    cidr = ip_address.split('/')
-    if (len(cidr) <= 1 or cidr[1] == ''):
-        return False
-    return True
-
-
-def valid_cidr(ip_address):
-    """
-    Validate IP address
-    """
-    try:
-        netaddr.IPNetwork(ip_address)
-    except netaddr.core.AddrFormatError as e:
-        raise AnsibleError("Not a valid IP address: %s" % e)
-    cidr = ip_address.split('/')
-    if (len(cidr) <= 1 or cidr[1] == ''):
-        return False
-    return True
-
 
 class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -43,7 +43,6 @@ _raw:
 """
 
 import json
-import netaddr
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves.urllib.error import HTTPError

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -53,16 +53,16 @@ from ansible.module_utils.urls import open_url
 from ansible.module_utils.urls import SSLValidationError
 from ansible.plugins.lookup import LookupBase
 
-def valid_cidr(Ip):
+
+def valid_cidr(ip_address):
     """
     Validate IP address
     """
     try:
-        netaddr.IPNetwork(Ip)
+        netaddr.IPNetwork(ip_address)
     except netaddr.core.AddrFormatError as e:
-        raise AnsibleError("Not a valid IP address" %e)
-        return False
-    cidr = Ip.split('/')
+        raise AnsibleError("Not a valid IP address: %s" % e)
+    cidr = ip_address.split('/')
     if (len(cidr) <= 1 or cidr[1] == ''):
         return False
     return True

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -55,16 +55,16 @@ from ansible.module_utils.urls import open_url
 from ansible.module_utils.urls import SSLValidationError
 from ansible.plugins.lookup import LookupBase
 
-def valid_cidr(Ip):
+
+def valid_cidr(ip_address):
     """
     Validate IP address
     """
     try:
-        netaddr.IPNetwork(Ip)
+        netaddr.IPNetwork(ip_address)
     except netaddr.core.AddrFormatError as e:
-        raise AnsibleError("Not a valid IP address" %e)
-        return False
-    cidr = Ip.split('/')
+        raise AnsibleError("Not a valid IP address: %s" % e)
+    cidr = ip_address.split('/')
     if (len(cidr) <= 1 or cidr[1] == ''):
         return False
     return True

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -21,6 +21,7 @@ options:
     description: 'The AWS region to narrow the ranges to. Examples: us-east-1, eu-west-2, ap-southeast-1'
   ipv6_prefixes:
     description: 'Return only ipv6 addresses. Option: ipv6_prefixes=True'
+    version_added: 2.0.0
 '''
 
 EXAMPLES = """

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -67,8 +67,8 @@ def valid_cidr(ip_address):
     """
     if NETADDR_LIBRARY_IMPORT_ERROR:
         raise_from(
-        AnsibleError('netaddr must be installed to use this plugin'),
-        NETADDR_LIBRARY_IMPORT_ERROR)
+            AnsibleError('netaddr must be installed to use this plugin'),
+            NETADDR_LIBRARY_IMPORT_ERROR)
     try:
         netaddr.IPNetwork(ip_address)
     except netaddr.core.AddrFormatError as e:
@@ -81,7 +81,7 @@ def valid_cidr(ip_address):
 
 class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
-        if "ipv6_prefix" in kwargs and kwargs["ipv6_prefix"]:
+        if "ipv6_prefixes" in kwargs and kwargs["ipv6_prefixes"]:
             prefixes_label = "ipv6_prefixes"
             ip_prefix_label = "ipv6_prefix"
         else:

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -43,6 +43,7 @@ _raw:
 """
 
 import json
+import netaddr
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.six.moves.urllib.error import HTTPError
@@ -52,6 +53,20 @@ from ansible.module_utils.urls import ConnectionError
 from ansible.module_utils.urls import open_url
 from ansible.module_utils.urls import SSLValidationError
 from ansible.plugins.lookup import LookupBase
+
+def valid_cidr(Ip):
+    """
+    Validate IP address
+    """
+    try:
+        netaddr.IPNetwork(Ip)
+    except netaddr.core.AddrFormatError as e:
+        raise AnsibleError("Not a valid IP address" %e)
+        return False
+    cidr = Ip.split('/')
+    if (len(cidr) <= 1 or cidr[1] == ''):
+        return False
+    return True
 
 
 class LookupModule(LookupBase):

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -54,7 +54,6 @@ from ansible.module_utils.urls import SSLValidationError
 from ansible.plugins.lookup import LookupBase
 
 
-
 class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
         if "ipv6_prefixes" in kwargs and kwargs["ipv6_prefixes"]:

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -85,6 +85,5 @@ class LookupModule(LookupBase):
         if 'service' in kwargs:
             service = str.upper(kwargs['service'])
             amazon_response = (item for item in amazon_response if item['service'] == service)
-
             iprange = [item[ip_prefix_label] for item in amazon_response]
             return iprange

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 boto>=2.49.0
 botocore>=1.16.0
 boto3>=1.13.0
+netaddr>=0.8.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 boto>=2.49.0
 botocore>=1.16.0
 boto3>=1.13.0
-netaddr>=0.8.0

--- a/tests/integration/targets/lookup_aws_service_ip_ranges/tasks/main.yaml
+++ b/tests/integration/targets/lookup_aws_service_ip_ranges/tasks/main.yaml
@@ -1,5 +1,6 @@
 - name: lookup range with no arguments
-  set_fact:    no_params: "{{ lookup('amazon.aws.aws_service_ip_ranges') }}"
+  set_fact:
+    no_params: "{{ lookup('amazon.aws.aws_service_ip_ranges') }}"
 
 - name: assert that we're returned a single string
   assert:

--- a/tests/integration/targets/lookup_aws_service_ip_ranges/tasks/main.yaml
+++ b/tests/integration/targets/lookup_aws_service_ip_ranges/tasks/main.yaml
@@ -1,6 +1,5 @@
 - name: lookup range with no arguments
-  set_fact:
-    no_params: "{{ lookup('amazon.aws.aws_service_ip_ranges') }}"
+  set_fact:    no_params: "{{ lookup('amazon.aws.aws_service_ip_ranges') }}"
 
 - name: assert that we're returned a single string
   assert:
@@ -11,6 +10,7 @@
 - name: lookup range with wantlist
   set_fact:
     want_list: "{{ lookup('amazon.aws.aws_service_ip_ranges', wantlist=True) }}"
+    want_ipv6_list: "{ lookup('amazon.aws.aws_service_ip_ranges', wantlist=True, ipv6_prefixes=True) }}"
 
 - name: assert that we're returned a list
   assert:
@@ -20,10 +20,17 @@
       - want_list is not string
       - want_list | length > 1
       - want_list[0] | ansible.netcommon.ipv4
+      - want_ipv6_list is defined
+      - want_ipv6_list is iterable
+      - want_ipv6_list is not string
+      - want_ipv6_list | length > 1
+      - want_ipv6_list[0] | ansible.netcommon.ipv6
+
 
 - name: lookup range with service
   set_fact:
     s3_ips: "{{ lookup('amazon.aws.aws_service_ip_ranges', service='S3', wantlist=True) }}"
+    s3_ipv6s: "{{ lookup('amazon.aws.aws_service_ip_ranges', service='S3', wantlist=True, ipv6_prefixes=True) }}"
 
 - name: assert that we're returned a list
   assert:
@@ -33,10 +40,16 @@
       - s3_ips is not string
       - s3_ips | length > 1
       - s3_ips[0] | ansible.netcommon.ipv4
+      - s3_ipv6s is defined
+      - s3_ipv6s is iterable
+      - s3_ipv6s is not string
+      - s3_ipv6s | length > 1
+      - s3_ipsv6s[0] | ansible.netcommon.ipv6
 
 - name: lookup range with a different service
   set_fact:
     route53_ips: "{{ lookup('amazon.aws.aws_service_ip_ranges', service='ROUTE53_HEALTHCHECKS', wantlist=True) }}"
+    route53_ipv6s: "{{ lookup('amazon.aws.aws_service_ip_ranges', service='ROUTE53_HEALTHCHECKS', wantlist=True, ipv6_prefixes=True) }}"
 
 - name: assert that we're returned a list
   assert:
@@ -46,15 +59,26 @@
       - route53_ips is not string
       - route53_ips | length > 1
       - route53_ips[0] | ansible.netcommon.ipv4
+      - route53_ipv6s is defined
+      - route53_ipv6s is iterable
+      - route53_ipv6s is not string
+      - route53_ipv6s | length > 1
+      - route53_ipv6s[0] | ansible.netcommon.ipv6
 
-- name: assert that service IPs don't overlap
+
+- name: assert that service IPV4s and IPV6s do not overlap
   assert:
     that:
       - route53_ips | intersect(s3_ips) | length == 0
+      - route53_ipv6s | intersect(s3_ipv6s) | length == 0
 
 - name: lookup range with region
   set_fact:
     us_east_1_ips: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='us-east-1', wantlist=True) }}"
+
+- name: lookup IPV6 range with region
+  set_fact:
+    us_east_1_ipv6s: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='us-east-1', wantlist=True, ipv6_prefixes=True) }}"
 
 - name: assert that we're returned a list
   assert:
@@ -64,10 +88,16 @@
       - us_east_1_ips is not string
       - us_east_1_ips | length > 1
       - us_east_1_ips[0] | ansible.netcommon.ipv4
+      - us_east_1_ipv6s is defined
+      - us_east_1_ipv6s is iterable
+      - us_east_1_ipv6s is not string
+      - us_east_1_ipv6s | length > 1
+      - us_east_1_ipv6s[0] | ansible.netcommon.ipv6
 
 - name: lookup range with a different region
   set_fact:
     eu_central_1_ips: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='eu-central-1', wantlist=True) }}"
+    eu_central_1_ipv6s: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='eu-central-1', wantlist=True, ipv6_prefixes=True) }}"
 
 - name: assert that we're returned a list
   assert:
@@ -77,15 +107,24 @@
       - eu_central_1_ips is not string
       - eu_central_1_ips | length > 1
       - eu_central_1_ips[0] | ansible.netcommon.ipv4
+      - eu_central_1_ipv6s is defined
+      - eu_central_1_ipv6s is iterable
+      - eu_central_1_ipv6s is not string
+      - eu_central_1_ipv6s | length > 1
+      - eu_central_1_ipv6s[0] | ansible.netcommon.ipv6
 
 - name: assert that regional IPs don't overlap
   assert:
     that:
       - eu_central_1_ips | intersect(us_east_1_ips) | length == 0
+      - eu_central_1_ipv6s | intersect(us_east_1_ipv6s) | length == 0
+
 
 - name: lookup range with service and region
   set_fact:
     s3_us_ips: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='us-east-1', service='S3', wantlist=True) }}"
+    s3_us_ipv6s: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='us-east-1', service='S3', wantlist=True, ipv6_prefixes=True) }}"
+
 
 - name: assert that we're returned a list
   assert:
@@ -95,9 +134,16 @@
       - s3_us_ips is not string
       - s3_us_ips | length > 1
       - s3_us_ips[0] | ansible.netcommon.ipv4
+      - s3_us_ipv6s is defined
+      - s3_us_ipv6s is iterable
+      - s3_us_ipv6s is not string
+      - s3_us_ipv6s | length > 1
+      - s3_us_ipv6s[0] | ansible.netcommon.ipv6
 
 - name: assert that the regional service IPs are a subset of the regional IPs and service IPs.
   assert:
     that:
       - ( s3_us_ips | intersect(us_east_1_ips) | length ) == ( s3_us_ips | length )
       - ( s3_us_ips | intersect(s3_ips) | length ) == ( s3_us_ips | length )
+      - ( s3_us_ipv6s | intersect(us_east_1_ipv6s) | length ) == ( s3_us_ipv6s | length )
+      - ( s3_us_ipv6s | intersect(s3_ipv6s) | length ) == ( s3_us_ipv6s | length )

--- a/tests/integration/targets/lookup_aws_service_ip_ranges/tasks/main.yaml
+++ b/tests/integration/targets/lookup_aws_service_ip_ranges/tasks/main.yaml
@@ -44,7 +44,7 @@
       - s3_ipv6s is iterable
       - s3_ipv6s is not string
       - s3_ipv6s | length > 1
-      - s3_ipsv6s[0] | ansible.netcommon.ipv6
+      - s3_ipv6s[0] | ansible.netcommon.ipv6
 
 - name: lookup range with a different service
   set_fact:

--- a/tests/integration/targets/lookup_aws_service_ip_ranges/tasks/main.yaml
+++ b/tests/integration/targets/lookup_aws_service_ip_ranges/tasks/main.yaml
@@ -11,7 +11,7 @@
 - name: lookup range with wantlist
   set_fact:
     want_list: "{{ lookup('amazon.aws.aws_service_ip_ranges', wantlist=True) }}"
-    want_ipv6_list: "{ lookup('amazon.aws.aws_service_ip_ranges', wantlist=True, ipv6_prefixes=True) }}"
+    want_ipv6_list: "{{ lookup('amazon.aws.aws_service_ip_ranges', wantlist=True, ipv6_prefixes=True) }}"
 
 - name: assert that we're returned a list
   assert:
@@ -120,12 +120,10 @@
       - eu_central_1_ips | intersect(us_east_1_ips) | length == 0
       - eu_central_1_ipv6s | intersect(us_east_1_ipv6s) | length == 0
 
-
 - name: lookup range with service and region
   set_fact:
     s3_us_ips: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='us-east-1', service='S3', wantlist=True) }}"
     s3_us_ipv6s: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='us-east-1', service='S3', wantlist=True, ipv6_prefixes=True) }}"
-
 
 - name: assert that we're returned a list
   assert:


### PR DESCRIPTION
##### SUMMARY
Allow amazon.aws.aws_service_ip_ranges to return only IPv6 addresses with setting ipv6_prefixes=True

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
amazon.aws.aws_service_ip_ranges 

##### ADDITIONAL INFORMATION

<!--- Paste verbatim command output below, e.g. before and after your change -->
```
vars:
  rt53_ranges: "{{ lookup('aws_service_ip_ranges', region='us-west-2', service='ROUTE53_HEALTHCHECKS', ipv6_prefix=True, wantlist=True) }}"
tasks:

- name: "use list return option and iterate as a loop"
  debug: msg="{% for x in rt53_ranges %}{{ x }} {% endfor %}"
# "2600:1f14:7ff:f800::/56,2600:1f14:fff:f800::/56"
```

Closes #438 