### PR TITLE
ec2_ami - ensure tags are propagated to the snapshot(s)

### DIFF
--- a/changelogs/fragments/437-ec2_ami-propagate-tags-to-snapshot.yml
+++ b/changelogs/fragments/437-ec2_ami-propagate-tags-to-snapshot.yml
@@ -1,0 +1,2 @@
+minor_changes:
+   - ec2_ami - ensure tags are propagated to the snapshot(s) when creating an AMI (https://github.com/ansible-collections/amazon.aws/pull/437).

--- a/tests/integration/targets/ec2_ami/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami/tasks/main.yml
@@ -109,6 +109,18 @@
           - "result.changed"
           - "result.image_id.startswith('ami-')"
           - "'Name' in result.tags and result.tags.Name == ec2_ami_name + '_ami'"
+    
+    - name: get related snapshot info and ensure the tags have been propagated
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ result.block_device_mapping['/dev/xvda'].snapshot_id }}"
+      register: snapshot_result
+    
+    - name: ensure the tags have been propagated to the snapshot
+      assert:
+        that:
+          - "'tags' in snapshot_result.snapshots[0]"
+          - "'Name' in snapshot_result.snapshots[0].tags and snapshot_result.snapshots[0].tags.Name == ec2_ami_name + '_ami'"
 
     # ============================================================
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

ec2_ami - ensure tags are propagated to the snapshot(s) when creating an AMI.

Fixes https://github.com/ansible-collections/amazon.aws/issues/368

Using `--tag-specifications` would introduce additional complexity for handling tags within the `ec2_ami` module. A simple approach would be to ensure tags propagation during AMI creation to the snapshot(s) and then edit snapshot(s) tags using the `ec2_tag` module.



##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_ami


