### PR TITLE
Cleanup unused imports (again)

### DIFF
--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -205,7 +205,6 @@ from ansible.plugins.inventory import BaseInventoryPlugin
 from ansible.plugins.inventory import Cacheable
 from ansible.plugins.inventory import Constructable
 from ansible.template import Templar
-from ansible.utils.display import Display
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import HAS_BOTO3
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list

--- a/plugins/modules/ec2_tag.py
+++ b/plugins/modules/ec2_tag.py
@@ -113,15 +113,7 @@ removed_tags:
   type: dict
 '''
 
-try:
-    from botocore.exceptions import BotoCoreError, ClientError
-except ImportError:
-    pass    # Handled by AnsibleAWSModule
-
 from ..module_utils.core import AnsibleAWSModule
-from ..module_utils.ec2 import AWSRetry
-from ..module_utils.ec2 import ansible_dict_to_boto3_tag_list
-from ..module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ..module_utils.ec2 import compare_aws_tags
 from ..module_utils.ec2 import describe_ec2_tags
 from ..module_utils.ec2 import ensure_ec2_tags

--- a/plugins/modules/ec2_tag_info.py
+++ b/plugins/modules/ec2_tag_info.py
@@ -51,11 +51,6 @@ tags:
   type: dict
 '''
 
-try:
-    from botocore.exceptions import BotoCoreError, ClientError
-except Exception:
-    pass    # Handled by AnsibleAWSModule
-
 from ..module_utils.core import AnsibleAWSModule
 from ..module_utils.ec2 import describe_ec2_tags
 

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -261,8 +261,6 @@ from ..module_utils.core import AnsibleAWSModule
 from ..module_utils.ec2 import camel_dict_to_snake_dict
 from ..module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ..module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ..module_utils.ec2 import ansible_dict_to_boto3_tag_list
-from ..module_utils.ec2 import compare_aws_tags
 from ..module_utils.ec2 import describe_ec2_tags
 from ..module_utils.ec2 import ensure_ec2_tags
 from ..module_utils.ec2 import AWSRetry

--- a/plugins/modules/ec2_vpc_subnet.py
+++ b/plugins/modules/ec2_vpc_subnet.py
@@ -215,10 +215,7 @@ from ansible.module_utils.common.dict_transformations import camel_dict_to_snake
 from ..module_utils.core import AnsibleAWSModule
 from ..module_utils.ec2 import AWSRetry
 from ..module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ..module_utils.ec2 import ansible_dict_to_boto3_tag_list
 from ..module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ..module_utils.ec2 import compare_aws_tags
-from ..module_utils.ec2 import describe_ec2_tags
 from ..module_utils.ec2 import ensure_ec2_tags
 from ..module_utils.waiters import get_waiter
 

--- a/tests/unit/module_utils/core/test_normalize_boto3_result.py
+++ b/tests/unit/module_utils/core/test_normalize_boto3_result.py
@@ -2,7 +2,6 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 import pytest
-import datetime
 from dateutil import parser as date_parser
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import normalize_boto3_result

--- a/tests/unit/plugins/modules/test_ec2_vpc_dhcp_option.py
+++ b/tests/unit/plugins/modules/test_ec2_vpc_dhcp_option.py
@@ -6,10 +6,9 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify
+# Magic...  Incorrectly identified by pylint as unused
+from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify  # pylint: disable=unused-import
 from ansible_collections.amazon.aws.tests.unit.compat.mock import patch
-from ansible_collections.amazon.aws.tests.unit.plugins.modules.utils import set_module_args
-from ansible_collections.amazon.aws.tests.unit.plugins.modules.utils import AnsibleExitJson
 
 from ansible_collections.amazon.aws.plugins.modules import ec2_vpc_dhcp_option as dhcp_module
 from ansible_collections.amazon.aws.tests.unit.plugins.modules.utils import ModuleTestCase


### PR DESCRIPTION
##### SUMMARY

When moving the tagging code into shared module_utils code I forgot to go back and prune the import

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/inventory/aws_ec2.py
plugins/modules/ec2_tag.py
plugins/modules/ec2_tag_info.py
plugins/modules/ec2_vol.py
plugins/modules/ec2_vpc_subnet.py
tests/unit/module_utils/core/test_normalize_boto3_result.py
tests/unit/plugins/modules/test_ec2_vpc_dhcp_option.py

##### ADDITIONAL INFORMATION