### PR TITLE
ec2_vol tests set botocore requires to == rather than >=

### DIFF
--- a/tests/integration/targets/ec2_vol/tasks/main.yml
+++ b/tests/integration/targets/ec2_vol/tasks/main.yml
@@ -10,8 +10,8 @@
 
 - pip:
     name:
-      - 'boto3>=1.16.33'
-      - 'botocore>=1.13.0'
+      - 'boto3>=1.13.0'
+      - 'botocore==1.19.27'
       - 'coverage<5'
       - 'boto>=2.49.0'
     virtualenv: "{{ virtualenv }}"


### PR DESCRIPTION
##### SUMMARY

We currently use >= which generally means that the latest version of botocore will be pulled in.  Given that we specify it's supposed to work with >= we should test the oldest possible version to ensure that we support at least that version.

##### ISSUE TYPE

- Tests Pull Request

##### COMPONENT NAME

ec2_vol

##### ADDITIONAL INFORMATION

Depends-on: https://github.com/ansible-collections/amazon.aws/pull/460