### PR TITLE
Don't check aws_az_info 'zone_type' it's only returned when botocore >= 1.17.18

### DIFF
--- a/tests/integration/targets/aws_az_info/tasks/main.yml
+++ b/tests/integration/targets/aws_az_info/tasks/main.yml
@@ -26,7 +26,8 @@
       - '"state" in first_az'
       - '"zone_id" in first_az'
       - '"zone_name" in first_az'
-      - '"zone_type" in first_az'
+      # botocore >= 1.17.18
+      #- '"zone_type" in first_az'
 
   - name: 'List available AZs in current Region - check_mode'
     aws_az_info:
@@ -48,7 +49,8 @@
       - '"state" in first_az'
       - '"zone_id" in first_az'
       - '"zone_name" in first_az'
-      - '"zone_type" in first_az'
+      # botocore >= 1.17.18
+      #- '"zone_type" in first_az'
 
 
   # Be specific - aws_region isn't guaranteed to be any specific value
@@ -72,7 +74,8 @@
       - '"state" in first_az'
       - '"zone_id" in first_az'
       - '"zone_name" in first_az'
-      - '"zone_type" in first_az'
+      # botocore >= 1.17.18
+      #- '"zone_type" in first_az'
       - first_az.group_name.startswith('us-east-1')
       - first_az.network_border_group.startswith('us-east-1')
       - first_az.region_name == 'us-east-1'
@@ -80,7 +83,8 @@
       - not first_az.zone_id == "use1-az"
       - first_az.zone_name.startswith('us-east-1')
       - not first_az.zone_name == 'us-east-1'
-      - first_az.zone_type == 'availability-zone'
+      # botocore >= 1.17.18
+      #- first_az.zone_type == 'availability-zone'
 
   - name: 'Filter Available AZs in us-west-2 using - ("zone-name")'
     aws_az_info:
@@ -105,7 +109,8 @@
       - '"state" in first_az'
       - '"zone_id" in first_az'
       - '"zone_name" in first_az'
-      - '"zone_type" in first_az'
+      # botocore >= 1.17.18
+      #- '"zone_type" in first_az'
       - first_az.group_name == 'us-west-2'
       - first_az.network_border_group == 'us-west-2'
       - first_az.region_name == 'us-west-2'
@@ -113,7 +118,8 @@
       - first_az.zone_id.startswith('usw2-az')
       - not first_az.zone_id == 'usw2-az'
       - first_az.zone_name == 'us-west-2c'
-      - first_az.zone_type == 'availability-zone'
+      # botocore >= 1.17.18
+      #- first_az.zone_type == 'availability-zone'
 
   - name: 'Filter Available AZs in eu-central-1 using _ ("zone_name")'
     aws_az_info:
@@ -138,7 +144,8 @@
       - '"state" in first_az'
       - '"zone_id" in first_az'
       - '"zone_name" in first_az'
-      - '"zone_type" in first_az'
+      # botocore >= 1.17.18
+      #- '"zone_type" in first_az'
       - first_az.group_name == 'eu-central-1'
       - first_az.network_border_group == 'eu-central-1'
       - first_az.region_name == 'eu-central-1'
@@ -146,7 +153,8 @@
       - first_az.zone_id.startswith('euc1-az')
       - not first_az.zone_id == "euc1-az"
       - first_az.zone_name == 'eu-central-1b'
-      - first_az.zone_type == 'availability-zone'
+      # botocore >= 1.17.18
+      #- first_az.zone_type == 'availability-zone'
 
   - name: 'Filter Available AZs in eu-west-2 using _ and - ("zone_name" and "zone-name") : _ wins '
     aws_az_info:
@@ -172,7 +180,8 @@
       - '"state" in first_az'
       - '"zone_id" in first_az'
       - '"zone_name" in first_az'
-      - '"zone_type" in first_az'
+      # botocore >= 1.17.18
+      #- '"zone_type" in first_az'
       - first_az.group_name == 'eu-west-2'
       - first_az.network_border_group == 'eu-west-2'
       - first_az.region_name == 'eu-west-2'
@@ -180,4 +189,5 @@
       - first_az.zone_id.startswith('euw2-az')
       - not first_az.zone_id == "euw2-az"
       - first_az.zone_name == 'eu-west-2c'
-      - first_az.zone_type == 'availability-zone'
+      # botocore >= 1.17.18
+      #- first_az.zone_type == 'availability-zone'


### PR DESCRIPTION
##### SUMMARY

AWS 'zone_type' info is only returned when botocore >= 1.17.18.  Since we don't document what's returned we can get away with not testing this until the next botocore bump.

##### ISSUE TYPE

- Tests Pull Request

##### COMPONENT NAME

aws_az_info

##### ADDITIONAL INFORMATION

Depends-On: https://github.com/ansible-collections/amazon.aws/pull/460