### PR TITLE
do not include {} boto filter by default

### DIFF
--- a/changelogs/fragments/include_filters_with_filter.yaml
+++ b/changelogs/fragments/include_filters_with_filter.yaml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- "inventory - ``include_filters`` won't be ignored anymore if ``filters`` is not set (https://github.com/ansible-collections/amazon.aws/pull/456)."
+- "inventory - ``include_filters`` won't be ignored anymore if ``filters`` is not set (https://github.com/ansible-collections/amazon.aws/issues/457)."

--- a/changelogs/fragments/include_filters_with_filter.yaml
+++ b/changelogs/fragments/include_filters_with_filter.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "inventory - ``include_filters`` won't be ignored anymore if ``filters`` is not set (https://github.com/ansible-collections/amazon.aws/pull/456)."

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -693,6 +693,16 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.display.debug("aws_ec2 inventory filename must end with 'aws_ec2.yml' or 'aws_ec2.yaml'")
         return False
 
+
+    def build_include_filters(self):
+        if self.get_option('filters'):
+            return [self.get_option('filters')] + self.get_option('include_filters')
+        elif self.get_option('include_filters'):
+            return self.get_option('include_filters')
+        else:  # no filter
+            return [{}]
+
+
     def parse(self, inventory, loader, path, cache=True):
 
         super(InventoryModule, self).parse(inventory, loader, path)
@@ -709,7 +719,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         # get user specifications
         regions = self.get_option('regions')
-        include_filters = [self.get_option('filters')] if self.get_option('filters') else [] + self.get_option('include_filters')
+        include_filters = self.build_include_filters()
         exclude_filters = self.get_option('exclude_filters')
         hostnames = self.get_option('hostnames')
         strict_permissions = self.get_option('strict_permissions')

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -693,7 +693,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         self.display.debug("aws_ec2 inventory filename must end with 'aws_ec2.yml' or 'aws_ec2.yaml'")
         return False
 
-
     def build_include_filters(self):
         if self.get_option('filters'):
             return [self.get_option('filters')] + self.get_option('include_filters')
@@ -701,7 +700,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             return self.get_option('include_filters')
         else:  # no filter
             return [{}]
-
 
     def parse(self, inventory, loader, path, cache=True):
 

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -709,7 +709,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         # get user specifications
         regions = self.get_option('regions')
-        include_filters = [self.get_option('filters')] + self.get_option('include_filters')
+        include_filters = [self.get_option('filters')] if self.get_option('filters') else [] + self.get_option('include_filters')
         exclude_filters = self.get_option('exclude_filters')
         hostnames = self.get_option('hostnames')
         strict_permissions = self.get_option('strict_permissions')

--- a/tests/unit/plugins/inventory/test_aws_ec2.py
+++ b/tests/unit/plugins/inventory/test_aws_ec2.py
@@ -192,3 +192,45 @@ def test_insufficient_credentials(inventory):
 
 def test_verify_file_bad_config(inventory):
     assert inventory.verify_file('not_aws_config.yml') is False
+
+
+def test_insufficient_credentials(inventory):
+    inventory._options = {
+        'aws_access_key': None,
+        'aws_secret_key': None,
+        'aws_security_token': None,
+        'aws_profile': None,
+        'iam_role_arn': None
+    }
+    with pytest.raises(AnsibleError) as error_message:
+        loader = DataLoader()
+        inventory._set_credentials(loader)
+        assert "Insufficient credentials found" in error_message
+
+
+def test_include_filters_with_no_filter(inventory):
+    inventory._options = {
+        'filters': {},
+        'include_filters': [],
+    }
+    print(inventory.build_include_filters())
+    assert inventory.build_include_filters() == [{}]
+
+
+def test_include_filters_with_include_filters_only(inventory):
+    inventory._options = {
+        'filters': {},
+        'include_filters': [{"foo": "bar"}],
+    }
+    assert inventory.build_include_filters() == [{"foo": "bar"}]
+
+
+def test_include_filters_with_filter_and_include_filters(inventory):
+    inventory._options = {
+        'filters': {"from_filter": 1},
+        'include_filters': [{"from_include_filter": "bar"}],
+    }
+    print(inventory.build_include_filters())
+    assert inventory.build_include_filters() == [
+        {"from_filter": 1},
+        {"from_include_filter": "bar"}]

--- a/tests/unit/plugins/inventory/test_aws_ec2.py
+++ b/tests/unit/plugins/inventory/test_aws_ec2.py
@@ -194,20 +194,6 @@ def test_verify_file_bad_config(inventory):
     assert inventory.verify_file('not_aws_config.yml') is False
 
 
-def test_insufficient_credentials(inventory):
-    inventory._options = {
-        'aws_access_key': None,
-        'aws_secret_key': None,
-        'aws_security_token': None,
-        'aws_profile': None,
-        'iam_role_arn': None
-    }
-    with pytest.raises(AnsibleError) as error_message:
-        loader = DataLoader()
-        inventory._set_credentials(loader)
-        assert "Insufficient credentials found" in error_message
-
-
 def test_include_filters_with_no_filter(inventory):
     inventory._options = {
         'filters': {},


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/480

* When no filter: specified, do not include an empty dict in the list of
boto filters because it effectively matches any host.

Closes: #457
Closes: #452

##### ISSUE TYPE

- Bugfix Pull Request