### PR TITLE
Adding example of using groups in aws_ec2.py module

### DIFF
--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -192,8 +192,6 @@ exclude_filters:
 # Example using groups to assign the running hosts to a group based on vpc_id
 plugin: aws_ec2
 boto_profile: aws_profile
-# or you could use Jinja as:
-# boto_profile: "{{ lookup('env', 'AWS_PROFILE') | default('aws_profile', true) }}"
 # Populate inventory with instances in these regions
 regions:
   - us-east-2
@@ -203,12 +201,6 @@ filters:
 keyed_groups:
   - prefix: tag
     key: tags
-hostnames:
-  - tag:Name
-  - tag:CustomDNSName
-  - dns-name
-  - public_dns_name
-  - private-ip-address
 compose:
   ansible_host: public_dns_name
 groups:

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -188,6 +188,31 @@ include_filters:
 exclude_filters:
 - tag:Name:
   - 'my_first_tag'
+
+# Example using groups to assign the running hosts to a group based on vpc_id
+plugin: aws_ec2
+boto_profile: aws_profile
+# or you could use Jinja as:
+# boto_profile: "{{ lookup('env', 'AWS_PROFILE') | default('aws_profile', true) }}"
+# Populate inventory with instances in these regions
+regions:
+  - us-east-2
+filters:
+  # All instances with their state as `running`
+  instance-state-name: running
+keyed_groups:
+  - prefix: tag
+    key: tags
+hostnames:
+  - tag:Name
+  - tag:CustomDNSName
+  - dns-name
+  - public_dns_name
+  - private-ip-address
+compose:
+  ansible_host: public_dns_name
+groups:
+  libvpc: vpc_id == 'vpc-####'
 '''
 
 import re


### PR DESCRIPTION
##### SUMMARY
Adding a example of using ```groups``` option to add items from a specific inventory configuration to groups.
Example shows use of ```groups``` to group hosts based on ```vpc id```.

Resolves #412 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_ec2.py