### PR TITLE
inventory_aws_ec2/test: switch to ec2_instance

### DIFF
--- a/tests/integration/targets/inventory_aws_ec2/playbooks/populate_cache.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/populate_cache.yml
@@ -28,16 +28,12 @@
         # Create new host, add it to inventory and then terminate it without updating the cache
 
         - name: create a new host
-          ec2:
-            image: '{{ image_id }}'
-            exact_count: 1
-            count_tag:
-              Name: '{{ resource_prefix }}'
-            instance_tags:
-              Name: '{{ resource_prefix }}'
+          ec2_instance:
+            image_id: '{{ image_id }}'
+            name: '{{ resource_prefix }}'
             instance_type: t2.micro
-            wait: yes
-            group_id: '{{ sg_id }}'
+            wait: no
+            security_groups: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
           register: setup_instance
 
@@ -46,14 +42,12 @@
       always:
 
         - name: remove setup ec2 instance
-          ec2:
+          ec2_instance:
             instance_type: t2.micro
             instance_ids: '{{ setup_instance.instance_ids }}'
             state: absent
-            wait: yes
-            instance_tags:
-              Name: '{{ resource_prefix }}'
-            group_id: '{{ sg_id }}'
+            name: '{{ resource_prefix }}'
+            security_groups: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
           ignore_errors: yes
           when: setup_instance is defined

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/setup.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/setup.yml
@@ -5,7 +5,7 @@
       owner-id: '125523088429'
       virtualization-type: hvm
       root-device-type: ebs
-      name: 'Fedora-Atomic-27*'
+      name: 'Fedora-Cloud-Base-34-1.2.x86_64*'
   register: fedora_images
 
 - set_fact:

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory.yml
@@ -27,17 +27,13 @@
         # Create new host, refresh inventory, remove host, refresh inventory
 
         - name: create a new host
-          ec2:
-            image: '{{ image_id }}'
-            exact_count: 1
-            count_tag:
-              Name: '{{ resource_prefix }}'
-            instance_tags:
-              Name: '{{ resource_prefix }}'
+          ec2_instance:
+            image_id: '{{ image_id }}'
+            name: '{{ resource_prefix }}'
             instance_type: t2.micro
-            wait: yes
-            group_id: '{{ sg_id }}'
+            security_groups: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
+            wait: no
           register: setup_instance
 
         - meta: refresh_inventory
@@ -50,14 +46,12 @@
               - "groups.aws_ec2.0 == '{{ resource_prefix }}'"
 
         - name: remove setup ec2 instance
-          ec2:
+          ec2_instance:
             instance_type: t2.micro
             instance_ids: '{{ setup_instance.instance_ids }}'
             state: absent
-            wait: yes
-            instance_tags:
-              Name: '{{ resource_prefix }}'
-            group_id: '{{ sg_id }}'
+            name: '{{ resource_prefix }}'
+            security_groups: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
 
         - meta: refresh_inventory
@@ -71,14 +65,12 @@
       always:
 
         - name: remove setup ec2 instance
-          ec2:
+          ec2_instance:
             instance_type: t2.micro
             instance_ids: '{{ setup_instance.instance_ids }}'
             state: absent
-            wait: yes
-            instance_tags:
-              Name: '{{ resource_prefix }}'
-            group_id: '{{ sg_id }}'
+            name: '{{ resource_prefix }}'
+            security_groups: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
           ignore_errors: yes
           when: setup_instance is defined

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_concatenation.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_concatenation.yml
@@ -18,18 +18,15 @@
 
         # Create new host, refresh inventory
         - name: create a new host
-          ec2:
-            image: '{{ image_id }}'
-            exact_count: 1
-            count_tag:
-              Name: '{{ resource_prefix }}'
-            instance_tags:
-              Name: '{{ resource_prefix }}'
+          ec2_instance:
+            image_id: '{{ image_id }}'
+            name: '{{ resource_prefix }}'
+            tags:
               OtherTag: value
             instance_type: t2.micro
-            wait: yes
-            group_id: '{{ sg_id }}'
+            security_groups: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
+            wait: no
           register: setup_instance
 
         - meta: refresh_inventory
@@ -46,14 +43,12 @@
       always:
 
         - name: remove setup ec2 instance
-          ec2:
+          ec2_instance:
             instance_type: t2.micro
             instance_ids: '{{ setup_instance.instance_ids }}'
             state: absent
-            wait: yes
-            instance_tags:
-              Name: '{{ resource_prefix }}'
-            group_id: "{{ sg_id }}"
+            name: '{{ resource_prefix }}'
+            security_groups: "{{ sg_id }}"
             vpc_subnet_id: "{{ subnet_id }}"
           ignore_errors: yes
           when: setup_instance is defined

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml
@@ -20,19 +20,16 @@
         # Create new host, refresh inventory
 
         - name: create a new host
-          ec2:
-            image: '{{ image_id }}'
-            exact_count: 1
-            count_tag:
-              Name: '{{ resource_prefix }}'
-            instance_tags:
-              Name: '{{ resource_prefix }}'
+          ec2_instance:
+            image_id: '{{ image_id }}'
+            name: '{{ resource_prefix }}'
+            tags:
               tag1: value1
               tag2: value2
             instance_type: t2.micro
-            wait: yes
-            group_id: '{{ sg_id }}'
+            security_groups: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
+            wait: no
           register: setup_instance
 
         - meta: refresh_inventory
@@ -59,14 +56,12 @@
       always:
 
         - name: remove setup ec2 instance
-          ec2:
+          ec2_instance:
             instance_type: t2.micro
             instance_ids: '{{ setup_instance.instance_ids }}'
             state: absent
-            wait: yes
-            instance_tags:
-              Name: '{{ resource_prefix }}'
-            group_id: "{{ sg_id }}"
+            name: '{{ resource_prefix }}'
+            security_groups: "{{ sg_id }}"
             vpc_subnet_id: "{{ subnet_id }}"
           ignore_errors: yes
           when: setup_instance is defined

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_include_or_exclude_filters.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_include_or_exclude_filters.yml
@@ -19,48 +19,39 @@
 
         # Create new host, refresh inventory
         - name: create a new host (1/3)
-          ec2:
-            image: '{{ image_id }}'
-            exact_count: 1
-            count_tag:
-              Name: '{{ resource_prefix }}_1'
-            instance_tags:
-              Name: '{{ resource_prefix }}_1'
+          ec2_instance:
+            image_id: '{{ image_id }}'
+            name: '{{ resource_prefix }}_1'
+            tags:
               tag_instance1: foo
             instance_type: t2.micro
-            wait: yes
-            group_id: '{{ sg_id }}'
+            security_groups: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
+            wait: no
           register: setup_instance_1
 
         - name: create a new host (2/3)
-          ec2:
-            image: '{{ image_id }}'
-            exact_count: 1
-            count_tag:
-              Name: '{{ resource_prefix }}_2'
-            instance_tags:
-              Name: '{{ resource_prefix }}_2'
+          ec2_instance:
+            image_id: '{{ image_id }}'
+            name: '{{ resource_prefix }}_2'
+            tags:
               tag_instance2: bar
             instance_type: t2.micro
-            wait: yes
-            group_id: '{{ sg_id }}'
+            security_groups: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
+            wait: no
           register: setup_instance_2
 
         - name: create a new host (3/3)
-          ec2:
-            image: '{{ image_id }}'
-            exact_count: 1
-            count_tag:
-              Name: '{{ resource_prefix }}_3'
-            instance_tags:
-              Name: '{{ resource_prefix }}_3'
+          ec2_instance:
+            image_id: '{{ image_id }}'
+            name: '{{ resource_prefix }}_3'
+            tags:
               tag_instance2: bar
             instance_type: t2.micro
-            wait: yes
-            group_id: '{{ sg_id }}'
+            security_groups: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
+            wait: no
           register: setup_instance_3
 
         - meta: refresh_inventory
@@ -77,40 +68,34 @@
       always:
 
         - name: remove setup ec2 instance (1/3)
-          ec2:
+          ec2_instance:
             instance_type: t2.micro
             instance_ids: '{{ setup_instance_1.instance_ids }}'
             state: absent
-            wait: yes
-            instance_tags:
-              Name: '{{ resource_prefix }}'
-            group_id: "{{ sg_id }}"
+            name: '{{ resource_prefix }}_1'
+            security_groups: "{{ sg_id }}"
             vpc_subnet_id: "{{ subnet_id }}"
           ignore_errors: yes
           when: setup_instance_1 is defined
 
         - name: remove setup ec2 instance (2/3)
-          ec2:
+          ec2_instance:
             instance_type: t2.micro
             instance_ids: '{{ setup_instance_2.instance_ids }}'
             state: absent
-            wait: yes
-            instance_tags:
-              Name: '{{ resource_prefix }}'
-            group_id: "{{ sg_id }}"
+            name: '{{ resource_prefix }}_2'
+            security_groups: "{{ sg_id }}"
             vpc_subnet_id: "{{ subnet_id }}"
           ignore_errors: yes
           when: setup_instance_2 is defined
 
         - name: remove setup ec2 instance (3/3)
-          ec2:
+          ec2_instance:
             instance_type: t2.micro
             instance_ids: '{{ setup_instance_3.instance_ids }}'
             state: absent
-            wait: yes
-            instance_tags:
-              Name: '{{ resource_prefix }}'
-            group_id: "{{ sg_id }}"
+            name: '{{ resource_prefix }}_3'
+            security_groups: "{{ sg_id }}"
             vpc_subnet_id: "{{ subnet_id }}"
           ignore_errors: yes
           when: setup_instance_3 is defined

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_use_contrib_script_keys.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_use_contrib_script_keys.yml
@@ -18,18 +18,15 @@
 
         # Create new host, refresh inventory
         - name: create a new host
-          ec2:
-            image: '{{ image_id }}'
-            exact_count: 1
-            count_tag:
-              Name: '{{ resource_prefix }}:/aa'
-            instance_tags:
-              Name: '{{ resource_prefix }}:/aa'
+          ec2_instance:
+            image_id: '{{ image_id }}'
+            name: '{{ resource_prefix }}:/aa'
+            tags:
               OtherTag: value
             instance_type: t2.micro
-            wait: yes
-            group_id: '{{ sg_id }}'
+            security_groups: '{{ sg_id }}'
             vpc_subnet_id: '{{ subnet_id }}'
+            wait: no
           register: setup_instance
 
         - meta: refresh_inventory
@@ -47,14 +44,12 @@
       always:
 
         - name: remove setup ec2 instance
-          ec2:
+          ec2_instance:
             instance_type: t2.micro
             instance_ids: '{{ setup_instance.instance_ids }}'
             state: absent
-            wait: yes
-            instance_tags:
-              Name: '{{ resource_prefix }}'
-            group_id: "{{ sg_id }}"
+            name: '{{ resource_prefix }}'
+            security_groups: "{{ sg_id }}"
             vpc_subnet_id: "{{ subnet_id }}"
           ignore_errors: yes
           when: setup_instance is defined

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_refresh_inventory.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_refresh_inventory.yml
@@ -13,17 +13,14 @@
           - "not groups.aws_ec2"
 
     - name: create a new host
-      ec2:
-        image: "{{ images[aws_region] }}"
+      ec2_instance:
+        image_id: "{{ images[aws_region] }}"
         exact_count: 1
-        count_tag:
-          Name: '{{ resource_prefix }}'
-        instance_tags:
-          Name: '{{ resource_prefix }}'
+        name: '{{ resource_prefix }}'
         instance_type: t2.micro
-        wait: yes
-        group_id: '{{ setup_sg.group_id }}'
+        security_groups: '{{ setup_sg.security_groups }}'
         vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
+        wait: no
       register: setup_instance
 
     - meta: refresh_inventory
@@ -36,14 +33,12 @@
           - "groups.aws_ec2.0 == '{{ resource_prefix }}'"
 
     - name: remove setup ec2 instance
-      ec2:
+      ec2_instance:
         instance_type: t2.micro
         instance_ids: '{{ setup_instance.instance_ids }}'
         state: absent
-        wait: yes
-        instance_tags:
-          Name: '{{ resource_prefix }}'
-        group_id: '{{ setup_sg.group_id }}'
+        name: '{{ resource_prefix }}'
+        security_groups: '{{ setup_sg.security_groups }}'
         vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
 
     - meta: refresh_inventory
@@ -56,13 +51,11 @@
 
   always:
     - name: remove setup ec2 instance
-      ec2:
+      ec2_instance:
         instance_type: t2.micro
         instance_ids: '{{ setup_instance.instance_ids }}'
         state: absent
-        wait: yes
-        instance_tags:
-          Name: '{{ resource_prefix }}'
-        group_id: '{{ setup_sg.group_id }}'
+        name: '{{ resource_prefix }}'
+        security_groups: '{{ setup_sg.security_groups }}'
         vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
       ignore_errors: yes


### PR DESCRIPTION
##### SUMMARY

- Migrate the inventory_aws_ec2 tests from ec2 to ec2_instance.
- Also, properly clean up all the resources during the test


##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME

inventory_aws_ec2