### PR TITLE
ec2_instance: wait on instance state, rather than status check

### DIFF
--- a/changelogs/fragments/481-ec2_instance-wait_sanity.yml
+++ b/changelogs/fragments/481-ec2_instance-wait_sanity.yml
@@ -1,8 +1,10 @@
 breaking_changes:
 - >-
-  ec2_instance - if plays require the old behavior of ``ec2_instance``, waiting for
-  EC2 instance monitoring status to become ``OK`` when launching a new instance,
-  the action will need to specify ``state: started`` (https://github.com/ansible-collections/amazon.aws/pull/481).
+  ec2_instance - instance wait for state behaviour has changed.  If plays
+  require the old behavior of waiting for the instance monitoring status to
+  become ``OK`` when launching a new instance, the action will need to specify
+  ``state: started``
+  (https://github.com/ansible-collections/amazon.aws/pull/481).
 bugfixes:
 - >-
   ec2_instance - ``ec2_instance`` was waiting on EC2 instance monitoring status

--- a/changelogs/fragments/481-ec2_instance-wait_sanity.yml
+++ b/changelogs/fragments/481-ec2_instance-wait_sanity.yml
@@ -1,0 +1,11 @@
+breaking_changes:
+- >-
+  ec2_instance - if plays require the old behavior of ``ec2_instance``, waiting for
+  EC2 instance monitoring status to become ``OK`` when launching a new instance,
+  the action will need to specify ``state: started`` (https://github.com/ansible-collections/amazon.aws/pull/481).
+bugfixes:
+- >-
+  ec2_instance - ``ec2_instance`` was waiting on EC2 instance monitoring status
+  to be ``OK`` when launching a new instance. This could cause a play to wait
+  multiple minutes for AWS's monitoring to complete status checks
+  (https://github.com/ansible-collections/amazon.aws/pull/481).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1293,8 +1293,8 @@ def build_run_instance_spec(params, ec2):
     return spec
 
 
-def await_instances(ids, desired_module_state='present'):
-    if not module.params.get('wait', True):
+def await_instances(ids, desired_module_state='present', force_wait=False):
+    if not module.params.get('wait', True) and not force_wait:
         # the user asked not to wait for anything
         return
 
@@ -1732,6 +1732,10 @@ def ensure_present(existing_matches, changed, ec2, desired_module_state):
         instance_response = run_instances(ec2, **instance_spec)
         instances = instance_response['Instances']
         instance_ids = [i['InstanceId'] for i in instances]
+
+        # Wait for instances to exist in the EC2 API before
+        # attempting to modify them
+        await_instances(instance_ids, desired_module_state='present', force_wait=True)
 
         for ins in instances:
             # Wait for instances to exist (don't check state)

--- a/tests/integration/targets/ec2_instance/aliases
+++ b/tests/integration/targets/ec2_instance/aliases
@@ -1,4 +1,5 @@
-disabled
+# Takes about 10-15 minutes
+slow
+
 cloud/aws
 ec2_instance_info
-slow

--- a/tests/integration/targets/ec2_instance/inventory
+++ b/tests/integration/targets/ec2_instance/inventory
@@ -1,5 +1,6 @@
 [tests]
-# Sorted fastest to slowest
+checkmode_tests
+termination_protection
 ebs_optimized
 block_devices
 cpu_options
@@ -8,9 +9,7 @@ default_vpc_tests
 external_resource_attach
 instance_no_wait
 iam_instance_role
-termination_protection
 tags_and_vpc_settings
-checkmode_tests
 security_group
 state_config_updates
 

--- a/tests/integration/targets/ec2_instance/main.yml
+++ b/tests/integration/targets/ec2_instance/main.yml
@@ -35,6 +35,6 @@
 - hosts: all
   gather_facts: no
   strategy: free
-  #serial: 10
+  serial: 3
   roles:
     - ec2_instance

--- a/tests/integration/targets/ec2_instance/main.yml
+++ b/tests/integration/targets/ec2_instance/main.yml
@@ -21,9 +21,6 @@
     block:
     - include_role:
         name: 'ec2_instance'
-        tasks_from: find_ami.yml
-    - include_role:
-        name: 'ec2_instance'
         tasks_from: env_setup.yml
     rescue:
     - include_role:

--- a/tests/integration/targets/ec2_instance/meta/main.yml
+++ b/tests/integration/targets/ec2_instance/meta/main.yml
@@ -1,3 +1,3 @@
 dependencies:
-  - prepare_tests
-  - setup_ec2_facts
+- prepare_tests
+- setup_ec2_facts

--- a/tests/integration/targets/ec2_instance/meta/main.yml
+++ b/tests/integration/targets/ec2_instance/meta/main.yml
@@ -1,4 +1,3 @@
 dependencies:
   - prepare_tests
-  - setup_ec2
-  - setup_remote_tmp_dir
+  - setup_ec2_facts

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/defaults/main.yml
@@ -3,15 +3,18 @@
 ec2_instance_owner: 'integration-run-{{ resource_prefix }}'
 ec2_instance_type: 't3.micro'
 ec2_instance_tag_TestId: '{{ resource_prefix }}-{{ inventory_hostname }}'
-ec2_ami_name: 'amzn2-ami-hvm-2.*-x86_64-gp2'
 
 vpc_name: '{{ resource_prefix }}-vpc'
 vpc_seed: '{{ resource_prefix }}'
 vpc_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.0.0/16'
+
+subnet_a_az: '{{ ec2_availability_zone_names[0] }}'
 subnet_a_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.32.0/24'
 subnet_a_startswith: '10.{{ 256 | random(seed=vpc_seed) }}.32.'
+subnet_b_az: '{{ ec2_availability_zone_names[1] }}'
 subnet_b_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.33.0/24'
 subnet_b_startswith: '10.{{ 256 | random(seed=vpc_seed) }}.33.'
+
 first_iam_role: "ansible-test-sts-{{ resource_prefix | hash('md5') }}-test-policy"
 second_iam_role: "ansible-test-sts-{{ resource_prefix | hash('md5') }}-test-policy-2"
 # Zuul resource prefixes are very long, and IAM roles can only be 64 characters

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/meta/main.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/meta/main.yml
@@ -1,5 +1,5 @@
 dependencies:
   - prepare_tests
-  - setup_ec2
+  - setup_ec2_facts
 collections:
   - amazon.aws

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/meta/main.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/meta/main.yml
@@ -1,5 +1,5 @@
 dependencies:
-  - prepare_tests
-  - setup_ec2_facts
+- prepare_tests
+- setup_ec2_facts
 collections:
-  - amazon.aws
+- amazon.aws

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/block_devices.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/block_devices.yml
@@ -3,7 +3,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-ebs-vols"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
       volumes:
       - device_name: /dev/sdb
@@ -35,7 +35,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-ebs-vols-checkmode"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
       volumes:
       - device_name: /dev/sdb
@@ -71,12 +71,12 @@
     ec2_instance:
       state: absent
       instance_ids: "{{ block_device_instances.instance_ids }}"
-  
+
   - name: "New instance with an extra block device - gp3 volume_type and throughput"
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-ebs-vols-gp3"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
       volumes:
       - device_name: /dev/sdb

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/block_devices.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/block_devices.yml
@@ -1,7 +1,7 @@
 - block:
   - name: "New instance with an extra block device"
     ec2_instance:
-      state: present
+      state: running
       name: "{{ resource_prefix }}-test-ebs-vols"
       image_id: "{{ ec2_ami_id }}"
       vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
@@ -77,7 +77,7 @@
 
   - name: "New instance with an extra block device - gp3 volume_type and throughput"
     ec2_instance:
-      state: present
+      state: running
       name: "{{ resource_prefix }}-test-ebs-vols-gp3"
       image_id: "{{ ec2_ami_id }}"
       vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/block_devices.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/block_devices.yml
@@ -52,7 +52,6 @@
     ec2_instance_info:
       filters:
         "tag:Name": "{{ resource_prefix }}-test-ebs-vols"
-        "instance-state-name": "running"
     register: presented_instance_fact
 
   - name: "fact checkmode ec2 instance"
@@ -61,10 +60,14 @@
         "tag:Name": "{{ resource_prefix }}-test-ebs-vols-checkmode"
     register: checkmode_instance_fact
 
-  - name: "Confirm whether the check mode is working normally."
+  - name: "Confirm instance was created without check mode"
     assert:
       that:
         - "{{ presented_instance_fact.instances | length }} > 0"
+
+  - name: "Confirm instance was not created with check mode"
+    assert:
+      that:
         - "{{ checkmode_instance_fact.instances | length }} == 0"
 
   - name: "Terminate instances"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/checkmode_tests.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/checkmode_tests.yml
@@ -63,7 +63,7 @@
   - name: "Verify that it was not stopped."
     assert:
       that:
-        - '"{{ confirm_checkmode_stopinstance_fact.instances[0].state.name }}" != "stopped"'
+        - confirm_checkmode_stopinstance_fact.instances[0].state.name not in ["stopped", "stopping"]
 
   - name: "Stop instance."
     ec2_instance:
@@ -73,9 +73,8 @@
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
         TestTag: "Some Value"
+      wait: true
     register: instance_stop
-    until: not instance_stop.failed
-    retries: 10
 
   - name: "fact stopped ec2 instance"
     ec2_instance_info:
@@ -86,7 +85,7 @@
   - name: "Verify that it was stopped."
     assert:
       that:
-        - '"{{ confirm_stopinstance_fact.instances[0].state.name }}" in ["stopped", "stopping"]'
+        - confirm_stopinstance_fact.instances[0].state.name  in ["stopped", "stopping"]
 
   - name: "Running instance in check mode."
     ec2_instance:
@@ -158,6 +157,7 @@
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
         TestTag: "Some Value"
+      wait: True
     check_mode: yes
 
   - name: "fact ec2 instance"
@@ -179,6 +179,7 @@
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
         TestTag: "Some Value"
+      wait: True
 
   - name: "fact ec2 instance"
     ec2_instance_info:

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/checkmode_tests.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/checkmode_tests.yml
@@ -3,7 +3,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-checkmode-comparison"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       security_groups: "{{ sg.group_id }}"
       instance_type: "{{ ec2_instance_type }}"
       vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
@@ -17,7 +17,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-checkmode-comparison-checkmode"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       security_groups: "{{ sg.group_id }}"
       instance_type: "{{ ec2_instance_type }}"
       vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/cpu_options.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/cpu_options.yml
@@ -3,7 +3,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-t3nano-1-threads-per-core"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
@@ -24,7 +24,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-t3nano-1-threads-per-core"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
@@ -55,7 +55,7 @@
   - name: "create t3.nano instance with cpu_options(check mode)"
     ec2_instance:
       name: "{{ resource_prefix }}-test-t3nano-1-threads-per-core-checkmode"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/cpu_options.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/cpu_options.yml
@@ -11,7 +11,7 @@
       cpu_options:
           core_count: 1
           threads_per_core: 1
-      wait: false
+      wait: true
     register: instance_creation
 
   - name: "instance with cpu_options created with the right options"
@@ -32,7 +32,7 @@
       cpu_options:
           core_count: 1
           threads_per_core: 2
-      wait: false
+      wait: true
     register: cpu_options_update
     ignore_errors: yes
 
@@ -54,6 +54,7 @@
 
   - name: "create t3.nano instance with cpu_options(check mode)"
     ec2_instance:
+      state: running
       name: "{{ resource_prefix }}-test-t3nano-1-threads-per-core-checkmode"
       image_id: "{{ ec2_ami_id }}"
       tags:
@@ -63,6 +64,7 @@
       cpu_options:
           core_count: 1
           threads_per_core: 1
+      wait: true
     check_mode: yes
 
   - name: "fact checkmode ec2 instance"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/default_vpc_tests.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/default_vpc_tests.yml
@@ -3,7 +3,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-default-vpc"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       security_group: "default"
@@ -15,7 +15,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-default-vpc-checkmode"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       security_group: "default"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/ebs_optimized.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/ebs_optimized.yml
@@ -3,7 +3,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-ebs-optimized-instance-in-vpc"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       security_groups: "{{ sg.group_id }}"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/env_cleanup.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/env_cleanup.yml
@@ -17,6 +17,7 @@
   ec2_eni:
     state: absent
     eni_id: "{{ item.id }}"
+  register: removed
   until: removed is not failed
   with_items: "{{ enis.network_interfaces }}"
   ignore_errors: yes

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/env_cleanup.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/env_cleanup.yml
@@ -44,32 +44,6 @@
   ignore_errors: yes
   retries: 10
 
-- name: "remove routing rules"
-  ec2_vpc_route_table:
-    state: absent
-    vpc_id: "{{ testing_vpc.vpc.id }}"
-    tags:
-      created: "{{ resource_prefix }}-route"
-    routes:
-      - dest: 0.0.0.0/0
-        gateway_id: "{{ igw.gateway_id }}"
-    subnets:
-      - "{{ testing_subnet_a.subnet.id }}"
-      - "{{ testing_subnet_b.subnet.id }}"
-  register: removed
-  until: removed is not failed
-  ignore_errors: yes
-  retries: 10
-
-- name: "remove internet gateway"
-  ec2_vpc_igw:
-    state: absent
-    vpc_id: "{{ testing_vpc.vpc.id }}"
-  register: removed
-  until: removed is not failed
-  ignore_errors: yes
-  retries: 10
-
 - name: "remove subnet A"
   ec2_vpc_subnet:
     state: absent

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/env_setup.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/env_setup.yml
@@ -1,17 +1,5 @@
 - run_once: '{{ setup_run_once | default("no") | bool }}'
   block:
-  - name: "fetch AZ availability"
-    aws_az_info:
-    register: az_info
-  - name: "Assert that we have multiple AZs available to us"
-    assert:
-      that: az_info.availability_zones | length >= 2
-
-  - name: "pick AZs"
-    set_fact:
-      subnet_a_az: '{{ az_info.availability_zones[0].zone_name }}'
-      subnet_b_az: '{{ az_info.availability_zones[1].zone_name }}'
-
   - name: "Create VPC for use in testing"
     ec2_vpc_net:
       state: present
@@ -77,7 +65,7 @@
           to_port: 80
           cidr_ip: 0.0.0.0/0
     register: sg
-  
+
   - name: "create secondary security group with the vpc"
     ec2_group:
       name: "{{ resource_prefix }}-sg-2"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/env_setup.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/env_setup.yml
@@ -10,12 +10,6 @@
       tenancy: default
     register: testing_vpc
 
-  - name: "Create internet gateway for use in testing"
-    ec2_vpc_igw:
-      state: present
-      vpc_id: "{{ testing_vpc.vpc.id }}"
-    register: igw
-
   - name: "Create default subnet in zone A"
     ec2_vpc_subnet:
       state: present
@@ -35,19 +29,6 @@
       resource_tags:
         Name: "{{ resource_prefix }}-subnet-b"
     register: testing_subnet_b
-
-  - name: "create routing rules"
-    ec2_vpc_route_table:
-      state: present
-      vpc_id: "{{ testing_vpc.vpc.id }}"
-      tags:
-        created: "{{ resource_prefix }}-route"
-      routes:
-        - dest: 0.0.0.0/0
-          gateway_id: "{{ igw.gateway_id }}"
-      subnets:
-        - "{{ testing_subnet_a.subnet.id }}"
-        - "{{ testing_subnet_b.subnet.id }}"
 
   - name: "create a security group with the vpc"
     ec2_group:

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/external_resource_attach.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/external_resource_attach.yml
@@ -35,7 +35,7 @@
       network:
         interfaces:
           - id: "{{ eni_a.interface.id }}"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       availability_zone: '{{ subnet_b_az }}'
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
@@ -62,7 +62,7 @@
         interfaces:
           - id: "{{ eni_a.interface.id }}"
           - id: "{{ eni_b.interface.id }}"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       instance_type: "{{ ec2_instance_type }}"
@@ -80,7 +80,7 @@
       network:
         interfaces:
           - id: "{{ eni_c.interface.id }}"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       availability_zone: '{{ subnet_b_az }}'
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/iam_instance_role.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/iam_instance_role.yml
@@ -28,7 +28,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-instance-role"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       security_groups: "{{ sg.group_id }}"
       instance_type: "{{ ec2_instance_type }}"
       instance_role: "ansible-test-sts-{{ unique_id }}-test-policy"
@@ -45,7 +45,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-instance-role-checkmode"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       security_groups: "{{ sg.group_id }}"
       instance_type: "{{ ec2_instance_type }}"
       instance_role: "{{ iam_role.arn.replace(':role/', ':instance-profile/') }}"
@@ -76,7 +76,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-instance-role"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       security_groups: "{{ sg.group_id }}"
       instance_type: "{{ ec2_instance_type }}"
       instance_role: "{{ iam_role_2.arn.replace(':role/', ':instance-profile/') }}"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/instance_no_wait.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/instance_no_wait.yml
@@ -3,7 +3,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-no-wait"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
@@ -23,7 +23,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-no-wait-checkmode"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
@@ -3,7 +3,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-t3nano-enabled-required"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
@@ -26,7 +26,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-t3nano-enabled-required"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/security_group.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/security_group.yml
@@ -2,7 +2,7 @@
   - name: "New instance with 2 security groups"
     ec2_instance:
       name: "{{ resource_prefix }}-test-security-groups"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
       tags:
         TestId: "{{ resource_prefix }}"
@@ -16,7 +16,7 @@
   - name: "Recreate same instance with 2 security groups ( Idempotency )"
     ec2_instance:
       name: "{{ resource_prefix }}-test-security-groups"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
       tags:
         TestId: "{{ resource_prefix }}"
@@ -39,7 +39,7 @@
   - name: "Remove secondary security group from instance"
     ec2_instance:
       name: "{{ resource_prefix }}-test-security-groups"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
       tags:
         TestId: "{{ resource_prefix }}"
@@ -60,7 +60,7 @@
   - name: "Add secondary security group to instance"
     ec2_instance:
       name: "{{ resource_prefix }}-test-security-groups"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
       tags:
         TestId: "{{ resource_prefix }}"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/state_config_updates.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/state_config_updates.yml
@@ -7,7 +7,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-state-param-changes"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       security_groups: "{{ sg.group_id }}"
@@ -31,7 +31,7 @@
     ec2_instance:
       state: running
       name: "{{ resource_prefix }}-test-state-param-changes"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       security_groups: "{{ sg2.group_id }}"
@@ -56,7 +56,7 @@
     ec2_instance:
       state: stopped
       name: "{{ resource_prefix }}-test-state-param-changes"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       security_groups: "{{ sg.group_id }}"
@@ -81,7 +81,7 @@
     ec2_instance:
       state: stopped
       name: "{{ resource_prefix }}-test-state-param-changes"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       security_groups: "{{ sg2.group_id }}"
@@ -104,7 +104,7 @@
     ec2_instance:
       state: running
       name: "{{ resource_prefix }}-test-state-param-changes"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       security_groups: "{{ sg.group_id }}"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/state_config_updates.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/state_config_updates.yml
@@ -5,7 +5,7 @@
 - block:
   - name: "Make instance with sg and termination protection enabled"
     ec2_instance:
-      state: present
+      state: running
       name: "{{ resource_prefix }}-test-state-param-changes"
       image_id: "{{ ec2_ami_id }}"
       tags:
@@ -111,6 +111,7 @@
       vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
       termination_protection: False
       instance_type: "{{ ec2_instance_type }}"
+      wait: True
     register: change_params_start_result
 
   - assert:
@@ -120,8 +121,8 @@
         - '"instances" in change_params_start_result'
         - '"instance_ids" in change_params_start_result'
         - '"changes" in change_params_start_result'
-        - '"reboot_success" in change_params_start_result'
-        - '"reboot_failed" in change_params_start_result'
+        - '"start_success" in change_params_start_result'
+        - '"start_failed" in change_params_start_result'
         - change_params_start_result.instances[0].security_groups[0].group_id == "{{ sg.group_id }}"
         - change_params_start_result.changes[0].DisableApiTermination.Value == False
 

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/tags_and_vpc_settings.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/tags_and_vpc_settings.yml
@@ -3,7 +3,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       user_data: |
         #cloud-config
         package_upgrade: true
@@ -23,7 +23,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-basic-vpc-create-checkmode"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       user_data: |
         #cloud-config
         package_upgrade: true
@@ -42,7 +42,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       user_data: |
         #cloud-config
         package_upgrade: true
@@ -86,7 +86,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
         Another: thing
@@ -108,7 +108,7 @@
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       purge_tags: true
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/termination_protection.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/termination_protection.yml
@@ -17,8 +17,8 @@
     - name: Check the returned value for the earlier task
       assert:
         that:
-          - "{{ create_instance_check_mode_results.changed }}"
-          - "{{ create_instance_check_mode_results.spec.DisableApiTermination }}"
+          - create_instance_check_mode_results is changed
+          - create_instance_check_mode_results.spec.DisableApiTermination == True
 
     - name: Create instance with termination protection
       ec2_instance:
@@ -80,7 +80,7 @@
     - name: Check the returned value for the earlier task
       assert:
         that:
-          - "{{ not create_instance_check_mode_results.changed }}"
+          - create_instance_check_mode_results is not changed
 
     - name: Create instance with termination protection (idempotent)
       ec2_instance:

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/termination_protection.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/termination_protection.yml
@@ -2,7 +2,7 @@
     - name: Create instance with termination protection (check mode)
       ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         tags:
           TestId: "{{ resource_prefix }}"
         security_groups: "{{ sg.group_id }}"
@@ -23,7 +23,7 @@
     - name: Create instance with termination protection
       ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         tags:
           TestId: "{{ resource_prefix }}"
         security_groups: "{{ sg.group_id }}"
@@ -65,7 +65,7 @@
     - name: Create instance with termination protection (check mode) (idempotent)
       ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         tags:
           TestId: "{{ resource_prefix }}"
         security_groups: "{{ sg.group_id }}"
@@ -85,7 +85,7 @@
     - name: Create instance with termination protection (idempotent)
       ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         tags:
           TestId: "{{ resource_prefix }}"
         security_groups: "{{ sg.group_id }}"
@@ -113,7 +113,7 @@
     - name: Set termination protection to false (check_mode)
       ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         tags:
           TestId: "{{ resource_prefix }}"
         termination_protection: false
@@ -147,7 +147,7 @@
     - name: Set termination protection to false
       ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         tags:
           TestId: "{{ resource_prefix }}"
         termination_protection: false
@@ -180,7 +180,7 @@
     - name: Set termination protection to false (idempotent)
       ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         tags:
           TestId: "{{ resource_prefix }}"
         termination_protection: false
@@ -196,7 +196,7 @@
     - name: Set termination protection to true
       ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         tags:
           TestId: "{{ resource_prefix }}"
         termination_protection: true
@@ -213,7 +213,7 @@
     - name: Set termination protection to true (idempotent)
       ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         tags:
           TestId: "{{ resource_prefix }}"
         termination_protection: true
@@ -229,7 +229,7 @@
     - name: Set termination protection to false (so we can terminate instance)
       ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
-        image_id: "{{ ec2_ami_image }}"
+        image_id: "{{ ec2_ami_id }}"
         tags:
           TestId: "{{ resource_prefix }}"
         termination_protection: false

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/uptime.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/uptime.yml
@@ -4,7 +4,7 @@
     ec2_instance:
       name: "{{ resource_prefix }}-test-uptime"
       region: "{{ ec2_region }}"
-      image_id: "{{ ec2_ami_image }}"
+      image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
       vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"

--- a/tests/integration/targets/setup_ec2_facts/tasks/main.yml
+++ b/tests/integration/targets/setup_ec2_facts/tasks/main.yml
@@ -15,6 +15,7 @@
       security_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
 
+  run_once: True
   block:
   # ============================================================
 


### PR DESCRIPTION
Attempt to revive https://github.com/ansible-collections/community.aws/pull/461

(Thanks @overhacked)

##### SUMMARY

The `await_instances()` function was calling `module.client('ec2').get_waiter('instance_status_ok')` by default, which causes boto3 to wait on the `DescribeInstanceStatus` api to return "Ok". The status API is linked to [EC2's instance status checks](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/monitoring-system-instance-status-check.html#reporting_status), which lag the instance's real state by 3-5 minutes.

It's unlikely that most Ansible users who set `wait: true` want their playbooks to delay until EC2's status checks catch up. The more efficient approach is to use `wait_for` or `wait_for_connection`. What is useful, however, is to wait the short period of time necessary for EC2 to move an instance from `pending` to `running`.

Before this change, the `ec2_instance` module would wait for an "Ok" status check for newly-created instances *before* waiting for any other state change. This change makes the default `state: present` wait for `instance_exists`, and `state: running` wait for `instance_running`. `state: started` (previously just an alias for `state: running`) now will wait for `instance_status_ok` if `wait: true`.

The only, IMHO unlikely, scenario that this is a breaking change for is if an Ansible user had combined `state: present/running/started` and `wait: true` and is actually depending on the play to halt until EC2's status checks return OK. Based on my own informal survey of playbooks on GitHub, I did not see anyone using `ec2_instance` in this way. Most playbooks follow `ec2_instance` with `wait_for` or `wait_for_connection`.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_instance

##### ADDITIONAL INFORMATION