### PR TITLE
ec2_vol: backport fix incorrectly returned changed result

### DIFF
--- a/changelogs/fragments/486-ec2_vol_fixed_returned_changed_var.yml
+++ b/changelogs/fragments/486-ec2_vol_fixed_returned_changed_var.yml
@@ -1,0 +1,6 @@
+bugfixes:
+- >-
+  ec2_vol - Fixes ``changed`` status when ``modify_volume`` is used, but no new 
+  disk is being attached.  The module incorrectly reported that no change had 
+  occurred even when disks had been modified (iops, throughput, type, etc.).
+  (https://github.com/ansible-collections/amazon.aws/issues/482).

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -483,7 +483,7 @@ def attach_volume(module, ec2_conn, volume_dict, instance_dict, device_name):
                                                  InstanceId=instance_dict['instance_id'],
                                                  VolumeId=volume_dict['volume_id'])
 
-        waiter = ec2_conn.get_waiter('volume_available')
+        waiter = ec2_conn.get_waiter('volume_in_use')
         waiter.wait(VolumeIds=[attach_response['VolumeId']])
         changed = True
 

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -483,7 +483,7 @@ def attach_volume(module, ec2_conn, volume_dict, instance_dict, device_name):
                                                  InstanceId=instance_dict['instance_id'],
                                                  VolumeId=volume_dict['volume_id'])
 
-        waiter = ec2_conn.get_waiter('volume_in_use')
+        waiter = ec2_conn.get_waiter('volume_available')
         waiter.wait(VolumeIds=[attach_response['VolumeId']])
         changed = True
 

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -740,7 +740,7 @@ def main():
         final_tags, tags_changed = ensure_tags(module, ec2_conn, volume['volume_id'], 'volume', tags, module.params.get('purge_tags'))
 
         if detach_vol_flag:
-            volume, changed = detach_volume(module, ec2_conn, volume_dict=volume)
+            volume, attach_changed = detach_volume(module, ec2_conn, volume_dict=volume)
         elif inst is not None:
             volume, vol_attached = attach_volume(module, ec2_conn, volume_dict=volume, instance_dict=inst, device_name=device_name)
 

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -749,7 +749,7 @@ def main():
         # Add device, volume_id and volume_type parameters separately to maintain backward compatibility
         volume_info = get_volume_info(volume, tags=final_tags)
 
-        if tags_changed or vol_attached:
+        if tags_changed or attach_changed:
             changed = True
 
         module.exit_json(changed=changed, volume=volume_info, device=volume_info['attachment_set']['device'],

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -742,12 +742,12 @@ def main():
         if detach_vol_flag:
             volume, changed = detach_volume(module, ec2_conn, volume_dict=volume)
         elif inst is not None:
-            volume, changed = attach_volume(module, ec2_conn, volume_dict=volume, instance_dict=inst, device_name=device_name)
+            volume, vol_attached = attach_volume(module, ec2_conn, volume_dict=volume, instance_dict=inst, device_name=device_name)
 
         # Add device, volume_id and volume_type parameters separately to maintain backward compatibility
         volume_info = get_volume_info(volume, tags=final_tags)
 
-        if tags_changed:
+        if tags_changed or vol_attached:
             changed = True
 
         module.exit_json(changed=changed, volume=volume_info, device=volume_info['attachment_set']['device'],

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -742,7 +742,9 @@ def main():
         if detach_vol_flag:
             volume, attach_changed = detach_volume(module, ec2_conn, volume_dict=volume)
         elif inst is not None:
-            volume, vol_attached = attach_volume(module, ec2_conn, volume_dict=volume, instance_dict=inst, device_name=device_name)
+            volume, attach_changed = attach_volume(module, ec2_conn, volume_dict=volume, instance_dict=inst, device_name=device_name)
+        else:
+            attach_changed = False
 
         # Add device, volume_id and volume_type parameters separately to maintain backward compatibility
         volume_info = get_volume_info(volume, tags=final_tags)

--- a/tests/integration/targets/ec2_vol/tasks/tests.yml
+++ b/tests/integration/targets/ec2_vol/tasks/tests.yml
@@ -330,29 +330,6 @@
         that:
           - ec2_vol_info.volumes | length == 4
 
-    - name: detach volume from the instance
-      ec2_vol:
-        id: "{{ new_vol_attach_result.volume_id }}"
-        instance: ""
-      register: new_vol_attach_result
-
-    - name: check task return attributes
-      assert:
-        that:
-          - new_vol_attach_result.changed
-          - new_vol_attach_result.volume.status == 'available'
-
-    - name: detach volume from the instance (idempotent)
-      ec2_vol:
-        id: "{{ new_vol_attach_result.volume_id }}"
-        instance: ""
-      register: new_vol_attach_result_idem
-
-    - name: check task return attributes
-      assert:
-        that:
-          - not new_vol_attach_result_idem.changed
-
     - name: must not change because of missing parameter modify_volume
       ec2_vol:
         id: "{{ new_vol_attach_result.volume_id }}"
@@ -414,7 +391,30 @@
           - v.type == 'gp3'
       vars:
         v: "{{ verify_gp3_change.volumes[0] }}"
+        
+    - name: detach volume from the instance
+      ec2_vol:
+        id: "{{ new_vol_attach_result.volume_id }}"
+        instance: ""
+      register: new_vol_attach_result
 
+    - name: check task return attributes
+      assert:
+        that:
+          - new_vol_attach_result.changed
+          - new_vol_attach_result.volume.status == 'available'
+
+    - name: detach volume from the instance (idempotent)
+      ec2_vol:
+        id: "{{ new_vol_attach_result.volume_id }}"
+        instance: ""
+      register: new_vol_attach_result_idem
+
+    - name: check task return attributes
+      assert:
+        that:
+          - not new_vol_attach_result_idem.changed
+          
     - name: delete volume
       ec2_vol:
         id: "{{ volume2.volume_id }}"

--- a/tests/integration/targets/ec2_vol/tasks/tests.yml
+++ b/tests/integration/targets/ec2_vol/tasks/tests.yml
@@ -203,7 +203,7 @@
       assert:
         that:
           - "not vol_attach_result.changed"
-          - "vol_attach_result.volume.attachment_set.status == 'attached'"
+          - vol_attach_result.volume.attachment_set.status in ['attached', 'attaching']
 
     - name: attach a new volume to an instance
       ec2_vol:


### PR DESCRIPTION
##### SUMMARY

**Backport version of #483**

When `modify_volume` is used but no new disk is being attached, the module incorrectly reports that no change has occurred even when disks have been modified (iops, throughput, type, etc.). This is due to the attach function overwriting the changed variable even if no disks are attached.

Fixes #482 

The integration test has been fixed so that when the gp3 modifications are tested, the volume is already in an attached state (previously detached) when reporting back `changed`. The detach tests are moved further down now, allowing this case to be properly covered by the existing assert:

https://github.com/ansible-collections/amazon.aws/blob/e8df91778ee808bfbfa7008c855a3bda92bf4c01/tests/integration/targets/ec2_vol/tasks/tests.yml#L384-L387

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ec2_vol



Depends-On: https://github.com/ansible-collections/amazon.aws/pull/491