### PR TITLE
Don't emit warning when VPC has IPv6 CIDR associated

### DIFF
--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -456,11 +456,7 @@ def main():
                 except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                     module.fail_json_aws(e, "Unable to associate CIDR {0}.".format(ipv6_cidr))
         if ipv6_cidr:
-            if 'Ipv6CidrBlockAssociationSet' in vpc_obj.keys():
-                module.warn("Only one IPv6 CIDR is permitted per VPC, {0} already has CIDR {1}".format(
-                    vpc_id,
-                    vpc_obj['Ipv6CidrBlockAssociationSet'][0]['Ipv6CidrBlock']))
-            else:
+            if 'Ipv6CidrBlockAssociationSet' not in vpc_obj.keys():
                 try:
                     connection.associate_vpc_cidr_block(AmazonProvidedIpv6CidrBlock=ipv6_cidr, VpcId=vpc_id, aws_retry=True)
                     changed = True

--- a/tests/integration/targets/ec2_vpc_net/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_net/tasks/main.yml
@@ -205,7 +205,6 @@
     - name: Assert no changes made
       assert:
         that:
-          - '"Only one IPv6 CIDR is permitted per VPC, {{ result.vpc.id }} already has CIDR {{ vpc_1_ipv6_cidr }}" in result.warnings'
           - result is not changed
           - vpc_info.vpcs | length == 1
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Setting `ipv6_cidr: yes` on an `ec2_vpc_net` task will create a VPC with an associated IPv6 CIDR. Running the same task again will result in no changes as the VPC will already contain an IPv6 CIDR (i.e. idempotence).
But the task will now raise a warning every time:
```
[WARNING]: Only one IPv6 CIDR is permitted per VPC, vpc-01d8cfbcb7c00bbd4 already has CIDR 2a05:d014:c53:d00::/56
```
This warning is unnecessary because what happens is actually expected, i.e. "the right thing": idempotence.
So, the warning should be removed.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vpc_net