### PR TITLE
Backport - Fixup / ignore new pylint 2.9.3 issues

### DIFF
--- a/changelogs/fragments/460-pylint.yml
+++ b/changelogs/fragments/460-pylint.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_instance - remove unnecessary raise when exiting with a failure (https://github.com/ansible-collections/amazon.aws/pull/460).

--- a/tests/integration/targets/ec2_vol/aliases
+++ b/tests/integration/targets/ec2_vol/aliases
@@ -1,3 +1,5 @@
+slow
+
 cloud/aws
-shippable/aws/group3
+
 ec2_vol_info

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,3 +1,5 @@
+plugins/inventory/aws_ec2.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
+plugins/modules/ec2_group.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
 plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
 plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
 plugins/module_utils/compat/_ipaddress.py no-assert  # Vendored library

--- a/tests/unit/mock/loader.py
+++ b/tests/unit/mock/loader.py
@@ -46,12 +46,12 @@ class DictDataLoader(DataLoader):
 
     # TODO: the real _get_file_contents returns a bytestring, so we actually convert the
     #       unicode/text it's created with to utf-8
-    def _get_file_contents(self, path):
-        path = to_text(path)
-        if path in self._file_mapping:
-            return (to_bytes(self._file_mapping[path]), False)
+    def _get_file_contents(self, file_name):
+        file_name = to_text(file_name)
+        if file_name in self._file_mapping:
+            return (to_bytes(self._file_mapping[file_name]), False)
         else:
-            raise AnsibleParserError("file not found: %s" % path)
+            raise AnsibleParserError("file not found: %s" % file_name)
 
     def path_exists(self, path):
         path = to_text(path)

--- a/tests/unit/module_utils/test_elbv2.py
+++ b/tests/unit/module_utils/test_elbv2.py
@@ -7,7 +7,7 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-import ansible_collections.amazon.aws.plugins.module_utils.elbv2 as elbv2
+from ansible_collections.amazon.aws.plugins.module_utils import elbv2
 from ansible_collections.amazon.aws.tests.unit.compat import unittest
 from ansible_collections.amazon.aws.tests.unit.compat.mock import MagicMock
 


### PR DESCRIPTION
##### SUMMARY

The containers have been updated to include a new version of pylint ( ansible-collections/overview#45 )
fixup arguments-renamed
ignore pylint:use-a-generator (an easy fix but not worth blocking gating)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tests/unit/mock/loader.py
tests/unit/module_utils/test_elbv2.py

##### ADDITIONAL INFORMATION

Backport of #460 
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1097