### PR TITLE
increase concurrency of ec2_instance tests

### DIFF
--- a/tests/integration/targets/ec2_instance/main.yml
+++ b/tests/integration/targets/ec2_instance/main.yml
@@ -35,6 +35,6 @@
 - hosts: all
   gather_facts: no
   strategy: free
-  serial: 3
+  serial: 5
   roles:
     - ec2_instance


### PR DESCRIPTION
##### SUMMARY

Looks like the ec2_instance tests were getting stomped on by aws_terminator, try bumping up the concurrency and see if things improve

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

ec2_instance

##### ADDITIONAL INFORMATION

https://dashboard.zuul.ansible.com/t/ansible/builds?job_name=ansible-test-cloud-integration-aws-py36_0&project=ansible-collections%2Famazon.aws&change=495