### PR TITLE
Wait for instance to start before attempting to attach a volume

### DIFF
--- a/tests/integration/targets/ec2_vol/aliases
+++ b/tests/integration/targets/ec2_vol/aliases
@@ -1,4 +1,2 @@
-slow
-
 cloud/aws
 ec2_vol_info

--- a/tests/integration/targets/ec2_vol/tasks/main.yml
+++ b/tests/integration/targets/ec2_vol/tasks/main.yml
@@ -31,6 +31,36 @@
         az: '{{ availability_zone }}'
       register: testing_subnet
 
+    - name: create an ec2 instance
+      ec2_instance:
+        name: "{{ instance_name }}"
+        vpc_subnet_id: "{{ testing_subnet.subnet.id }}"
+        instance_type: t3.nano
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          ResourcePrefix: "{{ resource_prefix }}"
+      register: test_instance
+
+    - name: check task return attributes
+      assert:
+        that:
+          - test_instance.changed
+
+    - name: create another ec2 instance
+      ec2_instance:
+        name: "{{ instance_name }}-2"
+        vpc_subnet_id: "{{ testing_subnet.subnet.id }}"
+        instance_type: t3.nano
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          ResourcePrefix: "{{ resource_prefix }}"
+      register: test_instance_2
+
+    - name: check task return attributes
+      assert:
+        that:
+          - test_instance_2.changed
+
     # # ==== ec2_vol tests ===============================================
 
     - name: create a volume (validate module defaults)
@@ -134,20 +164,12 @@
           - volume3.changed
           - "volume3.volume.snapshot_id ==  vol1_snapshot.snapshot_id"
 
-    - name: create an ec2 instance
+    - name: Wait for instance to start
       ec2_instance:
         name: "{{ instance_name }}"
-        vpc_subnet_id: "{{ testing_subnet.subnet.id }}"
-        instance_type: t3.nano
+        state: running
         image_id: "{{ ec2_ami_id }}"
-        tags:
-          ResourcePrefix: "{{ resource_prefix }}"
-      register: test_instance
-
-    - name: check task return attributes
-      assert:
-        that:
-          - test_instance.changed
+        wait: True
 
     - name: attach existing volume to an instance
       ec2_vol:
@@ -668,20 +690,12 @@
         delete_on_termination: no
       register: vol_attach_result
 
-    - name: create another ec2 instance
+    - name: Wait for instance to start
       ec2_instance:
         name: "{{ instance_name }}-2"
-        vpc_subnet_id: "{{ testing_subnet.subnet.id }}"
-        instance_type: t3.nano
+        state: running
         image_id: "{{ ec2_ami_id }}"
-        tags:
-          ResourcePrefix: "{{ resource_prefix }}"
-      register: test_instance_2
-
-    - name: check task return attributes
-      assert:
-        that:
-          - test_instance_2.changed
+        wait: True
 
     - name: attach existing volume to second instance
       ec2_vol:
@@ -721,6 +735,7 @@
         instance_ids:
           - "{{ item }}"
         state: terminated
+        wait: True
       with_items:
         - "{{ test_instance.instance_ids[0] }}"
         - "{{ test_instance_2.instance_ids[0] }}"


### PR DESCRIPTION
##### SUMMARY
Following #481 ec2_vol tests failed because the instances hadn't finished starting before trying to attach

```
botocore.exceptions.ClientError: An error occurred (IncorrectState) when calling the AttachVolume operation: Instance 'i-0d740b81c23f11a4c' is not 'running'.
```

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_vol

##### ADDITIONAL INFORMATION

https://7860a9269d0955476c03-81788054a9528b940bcdbd064c8a3746.ssl.cf1.rackcdn.com/488/b02aebad5940f5500e4ccb93c093bc00339b2426/check/ansible-test-cloud-integration-aws-py36_1/110bed5/job-output.txt