### PR TITLE
ec2_metadata_facts - tests - Wait for instance to reach running state before trying to SSH into it.

### DIFF
--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -3,3 +3,5 @@ netaddr
 virtualenv
 # Sometimes needed where we don't have features we need in modules
 awscli
+# Used for comparing SSH Public keys to the Amazon fingerprints
+pycrypto

--- a/tests/integration/targets/ec2_metadata_facts/aliases
+++ b/tests/integration/targets/ec2_metadata_facts/aliases
@@ -1,2 +1,6 @@
+# We're dependent on AWS actually starting up the instances in a timely manner.
+# This doesn't always happen...
+unstable
+
 non_local
 cloud/aws

--- a/tests/integration/targets/ec2_metadata_facts/meta/main.yml
+++ b/tests/integration/targets/ec2_metadata_facts/meta/main.yml
@@ -1,0 +1,4 @@
+dependencies:
+- prepare_tests
+- setup_ec2_facts
+- setup_sshkey

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -16,23 +16,16 @@
     vpc_seed: '{{ resource_prefix }}'
     vpc_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.0.0/16'
     subnet_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.32.0/24'
-    ec2_ami_name: 'amzn2-ami-hvm-2.*-x86_64-gp2'
-    sshkey_file: '{{ resource_prefix }}_key'
 
   tasks:
 
-  - name: Create an ssh key
-    shell: echo 'y' | ssh-keygen -P '' -f ../{{ sshkey_file }}
+  - include_role:
+      name: '../setup_sshkey'
+  - include_role:
+      name: '../setup_ec2_facts'
 
-  - name: Get available AZs
-    aws_az_info:
-      filters:
-        region-name: "{{ aws_region }}"
-    register: az_info
-
-  - name: Pick an AZ
-    set_fact:
-      availability_zone: "{{ az_info['availability_zones'][0]['zone_name'] }}"
+  - set_fact:
+      availability_zone: '{{ ec2_availability_zone_names[0] }}'
 
   # ============================================================
   - name: create a VPC
@@ -97,17 +90,9 @@
   - name: Create a key
     ec2_key:
       name: '{{ resource_prefix }}'
-      key_material: "{{ lookup('file', '../' ~ sshkey_file ~ '.pub') }}"
+      key_material: '{{ key_material }}'
       state: present
     register: ec2_key_result
-
-  - name: Get a list of images
-    ec2_ami_info:
-      filters:
-        owner-alias: amazon
-        name: "amzn2-ami-minimal-hvm-*"
-        description: "Amazon Linux 2 AMI *"
-    register: images_info
 
   - name: Set facts to simplify use of extra resources
     set_fact:
@@ -115,21 +100,21 @@
       vpc_sg_id: "{{ vpc_sg_result.group_id }}"
       vpc_igw_id: "{{ igw_result.gateway_id }}"
       vpc_route_table_id: "{{ public_route_table.route_table.id }}"
-      image_id: "{{ images_info.images | sort(attribute='creation_date') | reverse | first | json_query('image_id') }}"
       ec2_key_name: "{{ ec2_key_result.key.name }}"
 
   - name: Create an instance to test with
     ec2_instance:
+      state: running
       name: "{{ resource_prefix }}-ec2-metadata-facts"
-      image_id: "{{ image_id }}"
+      image_id: "{{ ec2_ami_id }}"
       vpc_subnet_id: "{{ vpc_subnet_id }}"
       security_group: "{{ vpc_sg_id }}"
       instance_type: t2.micro
       key_name: "{{ ec2_key_name }}"
       network:
         assign_public_ip: true
-      wait: true
-      wait_timeout: 300
+        delete_on_termination: true
+      wait: True
     register: ec2_instance
 
   - set_fact:
@@ -139,3 +124,8 @@
     template:
       src: ../templates/inventory.j2
       dest: ../inventory
+
+  - wait_for:
+      port: 22
+      host: '{{ ec2_instance.instances[0].public_ip_address }}'
+      timeout: 300

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -115,6 +115,7 @@
         assign_public_ip: true
         delete_on_termination: true
       wait: True
+
     register: ec2_instance
 
   - set_fact:
@@ -128,4 +129,4 @@
   - wait_for:
       port: 22
       host: '{{ ec2_instance.instances[0].public_ip_address }}'
-      timeout: 300
+      timeout: 1200

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/teardown.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/teardown.yml
@@ -22,19 +22,14 @@
       wait: True
     ignore_errors: true
     retries: 5
+    register: remove
+    until: remove is successful
 
   - name: remove ssh key
     ec2_key:
       name: "{{ ec2_key_name }}"
       state: absent
     ignore_errors: true
-
-  - name: remove the security group
-    ec2_group:
-      group_id: "{{ vpc_sg_id }}"
-      state: absent
-    ignore_errors: true
-    retries: 5
 
   - name: remove the public route table
     ec2_vpc_route_table:
@@ -44,6 +39,26 @@
       state: absent
     ignore_errors: true
     retries: 5
+    register: remove
+    until: remove is successful
+
+  - name: remove the internet gateway
+    ec2_vpc_igw:
+      vpc_id: "{{ vpc_id }}"
+      state: absent
+    ignore_errors: true
+    retries: 5
+    register: remove
+    until: remove is successful
+
+  - name: remove the security group
+    ec2_group:
+      group_id: "{{ vpc_sg_id }}"
+      state: absent
+    ignore_errors: true
+    retries: 5
+    register: remove
+    until: remove is successful
 
   - name: remove the subnet
     ec2_vpc_subnet:
@@ -53,13 +68,8 @@
       state: absent
     ignore_errors: true
     retries: 5
-
-  - name: remove the internet gateway
-    ec2_vpc_igw:
-      vpc_id: "{{ vpc_id }}"
-      state: absent
-    ignore_errors: true
-    retries: 5
+    register: remove
+    until: remove is successful
 
   - name: remove the VPC
     ec2_vpc_net:
@@ -68,3 +78,5 @@
       state: absent
     ignore_errors: true
     retries: 5
+    register: remove
+    until: remove is successful

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
@@ -6,11 +6,11 @@
     wait_for_connection:
 
   - amazon.aws.ec2_metadata_facts:
-  
+
   - name: Assert initial metadata for the instance
     assert:
       that:
         - ansible_ec2_ami_id == image_id
-        - ansible_ec2_placement_availability_zone == "{{ availability_zone }}"
+        - ansible_ec2_placement_availability_zone == availability_zone
         - ansible_ec2_security_groups == "{{ resource_prefix }}-sg"
         - ansible_ec2_user_data == "None"

--- a/tests/integration/targets/ec2_metadata_facts/templates/inventory.j2
+++ b/tests/integration/targets/ec2_metadata_facts/templates/inventory.j2
@@ -2,8 +2,8 @@
 "{{ ec2_instance.instances[0].public_ip_address }}"
 
 [testhost:vars]
-ansible_user=ec2-user
-ansible_ssh_private_key_file="{{ sshkey_file }}"
+ansible_user={{ ec2_ami_ssh_user }}
+ansible_ssh_private_key_file="{{ sshkey }}"
 ansible_python_interpreter=/usr/bin/env python
 
 [all:vars]
@@ -16,5 +16,5 @@ vpc_igw="{{ vpc_igw_id }}"
 vpc_route_table_id="{{ vpc_route_table_id }}"
 ec2_key_name="{{ ec2_key_name }}"
 availability_zone="{{ availability_zone }}"
-image_id="{{ image_id }}"
+image_id="{{ ec2_ami_id }}"
 ec2_instance_id="{{ ec2_instance_id }}"

--- a/tests/integration/targets/setup_ec2_facts/defaults/main.yml
+++ b/tests/integration/targets/setup_ec2_facts/defaults/main.yml
@@ -1,2 +1,3 @@
 ec2_ami_name: 'Fedora-Cloud-Base-*.x86_64*'
 ec2_ami_owner_id: '125523088429'
+ec2_ami_ssh_user: 'fedora'

--- a/tests/integration/targets/setup_ec2_facts/tasks/main.yml
+++ b/tests/integration/targets/setup_ec2_facts/tasks/main.yml
@@ -50,3 +50,4 @@
       ec2_ami_id: '{{ latest_image.image_id }}'
       ec2_ami_details: '{{ latest_image }}'
       ec2_ami_root_disk: '{{ latest_image.block_device_mappings[0].device_name }}'
+      ec2_ami_ssh_user: '{{ ec2_ami_ssh_user }}'

--- a/tests/integration/targets/setup_sshkey/tasks/main.yml
+++ b/tests/integration/targets/setup_sshkey/tasks/main.yml
@@ -61,8 +61,10 @@
 
 - name: set facts for future roles
   set_fact:
+    # Public SSH keys (OpenSSH format)
     key_material: "{{ lookup('file', sshkey_pub) }}"
     another_key_material: "{{ lookup('file', another_sshkey_pub) }}"
+    # AWS 'fingerprint' (md5digest)
     fingerprint: '{{ fingerprint.stdout }}'
     another_fingerprint: '{{ another_fingerprint.stdout }}'
   tags:


### PR DESCRIPTION
##### SUMMARY

ec2_metadata_facts has been flaking since the ec2_instance change - make sure we wait for the instance to reach "running" and for SSH to be accepting connections  before we start trying to SSH into it.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_metadata_facts

##### ADDITIONAL INFORMATION
