### PR TITLE
ec2_spot_instance cleanup imports

### DIFF
--- a/plugins/modules/ec2_spot_instance.py
+++ b/plugins/modules/ec2_spot_instance.py
@@ -398,8 +398,9 @@ cancelled_spot_request:
     type: str
     sample: 'Spot requests with IDs: sir-1234abcd have been cancelled'
 '''
-import time
-import datetime
+# TODO: add support for datetime-based parameters
+# import datetime
+# import time
 
 try:
     import botocore


### PR DESCRIPTION
##### SUMMARY

Remove unused import, they're there for a future TODO

While ansible-test ignores unused imports they're still a minor code smell and cleaning them up avoids potential issues in the future.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_spot_instance

##### ADDITIONAL INFORMATION