### PR TITLE
Add debugging info to ENI tests

### DIFF
--- a/tests/integration/targets/ec2_eni/tasks/main.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/main.yaml
@@ -96,6 +96,11 @@
     include_tasks: ./test_deletion.yaml
 
   always:
+    # ============================================================
+      # Some test problems are caused by "eventual consistency"
+      # describe the ENIs in the account so we can see what's happening
+      - name: Describe ENIs in account
+        ec2_eni_info: {}
 
     # ============================================================
       - name: remove the network interfaces


### PR DESCRIPTION
##### SUMMARY

We're seeing some flakes, describe the ENIs before we nuke them to try and see where the issue might be.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_eni

##### ADDITIONAL INFORMATION

Example failure: waiter timeout:
https://ebf5fd30c6ae7bcc0e77-bb555a5b613b25366f4ba04980cee756.ssl.cf1.rackcdn.com/488/2808477252b5339f2f1af24f1658f756c8b3b931/check/ansible-test-cloud-integration-aws-py36_1/975c9cb/job-output.txt
