### PR TITLE
ec2_eni - Increase timeout when waiting for ENIs to detach

### DIFF
--- a/changelogs/fragments/501-ec2_eni-timeout.yml
+++ b/changelogs/fragments/501-ec2_eni-timeout.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_eni - timeout increased when waiting for ENIs to finish detaching (https://github.com/ansible-collections/amazon.aws/pull/501).

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -684,9 +684,12 @@ def detach_eni(connection, eni, module):
         connection.detach_network_interface(
             aws_retry=True,
             AttachmentId=eni["Attachment"]["AttachmentId"],
-            Force=force_detach
+            Force=force_detach,
         )
-        get_waiter(connection, 'network_interface_available').wait(NetworkInterfaceIds=[eni_id])
+        get_waiter(connection, 'network_interface_available').wait(
+            NetworkInterfaceIds=[eni_id],
+            WaiterConfig={'Delay': 5, 'MaxAttempts': 80},
+        )
         return True
 
     return False

--- a/tests/integration/targets/ec2_eni/aliases
+++ b/tests/integration/targets/ec2_eni/aliases
@@ -1,3 +1,4 @@
+unstable
+
 cloud/aws
-slow
 ec2_eni_info


### PR DESCRIPTION
##### SUMMARY

Increase timeout when waiting for ENIs to detach

https://796bc2ffb2f08daedb4f-dfd1c589d70cb07166ffb8939d1c9bb5.ssl.cf2.rackcdn.com/500/50b47988590728b63925dd979fc5a83a15e40a06/gate/ansible-test-cloud-integration-aws-py36_0/4c3a4d5/job-output.txt

Logs show that the ENI was in the 'detaching' state, implying that our default 40*5 second retries were insufficient

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_eni

##### ADDITIONAL INFORMATION

Logs show that the ENI had entered a 'detaching' state:

```
2021-09-14 11:44:06.593046 | fedora-34 |         {
2021-09-14 11:44:06.593054 | fedora-34 |             "attachment": {
2021-09-14 11:44:06.593061 | fedora-34 |                 "attach_time": "2021-09-14T11:40:16+00:00",
2021-09-14 11:44:06.593069 | fedora-34 |                 "attachment_id": "eni-attach-09bb047d2f0f5f293",
2021-09-14 11:44:06.593100 | fedora-34 |                 "delete_on_termination": false,
2021-09-14 11:44:06.593110 | fedora-34 |                 "device_index": 1,
2021-09-14 11:44:06.593118 | fedora-34 |                 "instance_id": "i-0db09d037e72f7e33",
2021-09-14 11:44:06.593127 | fedora-34 |                 "instance_owner_id": "966509639900",
2021-09-14 11:44:06.593135 | fedora-34 |                 "network_card_index": 0,
2021-09-14 11:44:06.593143 | fedora-34 |                 "status": "detaching"
2021-09-14 11:44:06.593151 | fedora-34 |             },
2021-09-14 11:44:06.593160 | fedora-34 |             "availability_zone": "us-east-1a",
2021-09-14 11:44:06.593168 | fedora-34 |             "description": "",
2021-09-14 11:44:06.593176 | fedora-34 |             "groups": [
2021-09-14 11:44:06.593184 | fedora-34 |                 {
2021-09-14 11:44:06.593193 | fedora-34 |                     "group_id": "sg-0e140a452ed923a71",
2021-09-14 11:44:06.593201 | fedora-34 |                     "group_name": "default"
2021-09-14 11:44:06.593209 | fedora-34 |                 }
2021-09-14 11:44:06.593217 | fedora-34 |             ],
2021-09-14 11:44:06.593226 | fedora-34 |             "id": "eni-0a4e0246ce3fe9245",
2021-09-14 11:44:06.593234 | fedora-34 |             "interface_type": "interface",
2021-09-14 11:44:06.593242 | fedora-34 |             "ipv6_addresses": [],
2021-09-14 11:44:06.593250 | fedora-34 |             "mac_address": "12:fe:a9:4f:34:c7",
2021-09-14 11:44:06.593258 | fedora-34 |             "network_interface_id": "eni-0a4e0246ce3fe9245",
2021-09-14 11:44:06.593266 | fedora-34 |             "owner_id": "966509639900",
2021-09-14 11:44:06.593275 | fedora-34 |             "private_dns_name": "ip-10-254-241-132.ec2.internal",
2021-09-14 11:44:06.593283 | fedora-34 |             "private_ip_address": "10.254.241.132",
2021-09-14 11:44:06.593291 | fedora-34 |             "private_ip_addresses": [
2021-09-14 11:44:06.593306 | fedora-34 |                 {
2021-09-14 11:44:06.593315 | fedora-34 |                     "primary": true,
2021-09-14 11:44:06.593337 | fedora-34 |                     "private_dns_name": "ip-10-254-241-132.ec2.internal",
2021-09-14 11:44:06.593345 | fedora-34 |                     "private_ip_address": "10.254.241.132"
2021-09-14 11:44:06.593353 | fedora-34 |                 }
2021-09-14 11:44:06.593361 | fedora-34 |             ],
2021-09-14 11:44:06.593370 | fedora-34 |             "requester_id": "AROAIUOWG2JZBBCEMK7M2:dev=remote=zuul-cloud",
2021-09-14 11:44:06.593378 | fedora-34 |             "requester_managed": false,
2021-09-14 11:44:06.593399 | fedora-34 |             "source_dest_check": true,
2021-09-14 11:44:06.593407 | fedora-34 |             "status": "in-use",
2021-09-14 11:44:06.593414 | fedora-34 |             "subnet_id": "subnet-09d5010acb57dfa83",
2021-09-14 11:44:06.593422 | fedora-34 |             "tag_set": {},
2021-09-14 11:44:06.593429 | fedora-34 |             "tags": {},
2021-09-14 11:44:06.593437 | fedora-34 |             "vpc_id": "vpc-0b9f195f029ca4f69"
2021-09-14 11:44:06.593458 | fedora-34 |         },
```

Amazon are sometimes just 'slow', if our tests show a 30% failure rate, then better to wait longer, this is probably hitting users.