### PR TITLE
Bump botocore to 1.18.0 prior to 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ As the AWS SDK for Python (Boto3 and Botocore) has [ceased supporting Python 2.7
 
 Starting with the 2.0.0 releases of amazon.aws and community.aws, it is generally the collection's policy to support the versions of `botocore` and `boto3` that were released 12 months prior to the most recent major collection release, following semantic versioning (for example, 2.0.0, 3.0.0).
 
-Version 2.0.0 of this collection supports `boto3 >= 1.13.0` and `botocore >= 1.16.0`
+Version 2.0.0 of this collection supports `boto3 >= 1.15.0` and `botocore >= 1.18.0`
 
 ## Included content
 

--- a/changelogs/fragments/442-boto3-minimums.yml
+++ b/changelogs/fragments/442-boto3-minimums.yml
@@ -1,7 +1,7 @@
 major_changes:
-- amazon.aws collection - The amazon.aws collection has dropped support for ``botocore<1.16.0`` and ``boto3<1.13.0``.
+- amazon.aws collection - The amazon.aws collection has dropped support for ``botocore<1.18.0`` and ``boto3<1.15.0``.
   Most modules will continue to work with older versions of the AWS SDK, however compatability with older versions of the SDK is not guaranteed and will not be tested.
-  When using older versions of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/442).
+  When using older versions of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/502).
 minor_changes:
 - aws_s3 - Tests for compatability with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
 - cloudformation - Tests for compatability with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).

--- a/plugins/doc_fragments/aws.py
+++ b/plugins/doc_fragments/aws.py
@@ -77,8 +77,8 @@ options:
     type: dict
 requirements:
   - python >= 3.6
-  - boto3 >= 1.13.0
-  - botocore >= 1.16.0
+  - boto3 >= 1.15.0
+  - botocore >= 1.18.0
 notes:
   - If parameters are not set within the module, the following
     environment variables can be used in decreasing order of precedence

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -10,7 +10,7 @@ author:
 requirements:
   - python >= 3.6
   - boto3
-  - botocore >= 1.16.0
+  - botocore >= 1.18.0
 extends_documentation_fragment:
 - amazon.aws.aws_credentials
 - amazon.aws.aws_region

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -11,7 +11,7 @@ author:
 requirements:
   - python >= 3.6
   - boto3
-  - botocore >= 1.16.0
+  - botocore >= 1.18.0
 extends_documentation_fragment:
 - amazon.aws.aws_credentials
 - amazon.aws.aws_region

--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -16,7 +16,7 @@ author:
 requirements:
   - python >= 3.6
   - boto3
-  - botocore >= 1.16.0
+  - botocore >= 1.18.0
 short_description: Get the value for a SSM parameter or all parameters under a path.
 description:
   - Get the value for an Amazon Simple Systems Manager parameter or a hierarchy of parameters.

--- a/plugins/module_utils/core.py
+++ b/plugins/module_utils/core.py
@@ -126,11 +126,11 @@ class AnsibleAWSModule(object):
                 self._module.fail_json(
                     msg=missing_required_lib('botocore or boto3'))
             current_versions = self._gather_versions()
-            if not self.botocore_at_least('1.16.0'):
-                self.warn('botocore < 1.16.0 is not supported or tested.'
+            if not self.botocore_at_least('1.18.0'):
+                self.warn('botocore < 1.18.0 is not supported or tested.'
                           '  Some features may not work.')
-            if not self.boto3_at_least("1.13.0"):
-                self.warn('boto3 < 1.13.0 is not supported or tested.'
+            if not self.boto3_at_least("1.15.0"):
+                self.warn('boto3 < 1.15.0 is not supported or tested.'
                           '  Some features may not work.')
 
         self.check_mode = self._module.check_mode

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 boto>=2.49.0
-botocore>=1.16.0
-boto3>=1.13.0
+botocore>=1.18.0
+boto3>=1.15.0

--- a/tests/integration/targets/setup_botocore_pip/defaults/main.yml
+++ b/tests/integration/targets/setup_botocore_pip/defaults/main.yml
@@ -1,2 +1,2 @@
-default_botocore_version: '1.16.0'
-default_boto3_version: '1.13.0'
+default_botocore_version: '1.18.0'
+default_boto3_version: '1.15.0'

--- a/tests/unit/module_utils/core/ansible_aws_module/test_minimal_versions.py
+++ b/tests/unit/module_utils/core/ansible_aws_module/test_minimal_versions.py
@@ -20,10 +20,10 @@ class TestMinimalVersions(object):
     # Prepare some data for use in our testing
     # ========================================================
     def setup_method(self):
-        self.MINIMAL_BOTO3 = '1.13.0'
-        self.MINIMAL_BOTOCORE = '1.16.0'
-        self.OLD_BOTO3 = '1.12.999'
-        self.OLD_BOTOCORE = '1.15.999'
+        self.MINIMAL_BOTO3 = '1.15.0'
+        self.MINIMAL_BOTOCORE = '1.18.0'
+        self.OLD_BOTO3 = '1.14.999'
+        self.OLD_BOTOCORE = '1.17.999'
 
     # ========================================================
     #   Test we don't warn when using valid versions

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -1,2 +1,2 @@
-boto3>=1.13.0
+boto3>=1.15.0
 placebo


### PR DESCRIPTION
##### SUMMARY

We delayed, so bonus, we get to bump botocore and boto3 a little

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME


##### ADDITIONAL INFORMATION

boto3 1.15.0:
Thu Sep 17 18:12:25 2020

botocore 1.18.0:
Thu Sep 17 18:12:33 2020