### PR TITLE
Mark ec2_vpc_subnet and ec2_eni as not slow

### DIFF
--- a/tests/integration/targets/ec2_eni/aliases
+++ b/tests/integration/targets/ec2_eni/aliases
@@ -1,3 +1,2 @@
 cloud/aws
-slow
 ec2_eni_info

--- a/tests/integration/targets/ec2_vpc_subnet/aliases
+++ b/tests/integration/targets/ec2_vpc_subnet/aliases
@@ -1,4 +1,2 @@
-slow
-
 cloud/aws
 ec2_vpc_subnet_info


### PR DESCRIPTION
##### SUMMARY
10 minutes as the cutoff for "slow" may have been too aggressive; we don't have enough Zuul jobs to split into when running a complete CI run (such as when testing module utils).

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
CI

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
