### PR TITLE
aws_ec2: remove py2 compatiblity header

### DIFF
--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -1,9 +1,6 @@
 # Copyright (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
-
 DOCUMENTATION = '''
     name: aws_ec2
     plugin_type: inventory


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/991
