### PR TITLE
Add tests/config.yml to tell recent versions of ansible-test we don't support Python<3.6

### DIFF
--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,0 +1,2 @@
+modules:
+    python_requires: '>=3.6'


### PR DESCRIPTION
##### SUMMARY

(Ansible 2.12) ansible-test now has a config file that lets us limit tests to those relevant to Python>=3.6

Add this to simplify things.

Unfortunately this hasn't been (and likely won't be) backported to older versions of Ansible, so there's a little while before we can drop the python 2.x compatability code, but this gets us started.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tests/sanity

##### ADDITIONAL INFORMATION
