### PR TITLE
Doc fix ec2_vol_info

### DIFF
--- a/plugins/modules/ec2_vol_info.py
+++ b/plugins/modules/ec2_vol_info.py
@@ -58,15 +58,18 @@ volumes:
     returned: always
     contains:
         attachment_set:
-            description: Information about the volume attachments.
-            type: dict
-            sample: {
+            description:
+                - Information about the volume attachments.
+                - This was changed in version 2.0.0 from a dictionary to a list of dictionaries.
+            type: list
+            elements: dict
+            sample: [{
                 "attach_time": "2015-10-23T00:22:29.000Z",
                 "deleteOnTermination": "false",
                 "device": "/dev/sdf",
                 "instance_id": "i-8356263c",
                 "status": "attached"
-            }
+            }]
         create_time:
             description: The time stamp when volume creation was initiated.
             type: str


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`attachment_set` has always be returned as a list of dictionaries, but the module documented it as a dictionary instead. Let's fix this documentation mismatch. 
```
"attachment_set": [{
            "attach_time": "2015-10-23T00:22:29.000Z",
            "deleteOnTermination": "false",
            "device": "/dev/sdf",
            "instance_id": "i-8356263c",
            "status": "attached"
        }]
```

Fixes: https://github.com/ansible-collections/amazon.aws/issues/515
 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vol_info
