### PR TITLE
Add helper for generating TagSpecification lists and update ec2_instance to use helpers

### DIFF
--- a/changelogs/fragments/527-ec2_instance-tagging.yml
+++ b/changelogs/fragments/527-ec2_instance-tagging.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- ec2_instance - use module_util helpers for tagging (https://github.com/ansible-collections/amazon.aws/pull/527).
+- module_utils.tagging - add new helper to generate TagSpecification lists (https://github.com/ansible-collections/amazon.aws/pull/527).
+- module_utils.ec2 - moved generic tagging helpers into module_utils.tagging (https://github.com/ansible-collections/amazon.aws/pull/527).

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -50,6 +50,10 @@ from ansible.module_utils.common.dict_transformations import camel_dict_to_snake
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict  # pylint: disable=unused-import
 
 from .cloud import CloudRetry
+# Used to live here, moved into ansible_collections.amazon.aws.plugins.module_utils.tagging
+from .tagging import ansible_dict_to_boto3_tag_list
+from .tagging import boto3_tag_list_to_ansible_dict
+from .tagging import compare_aws_tags
 
 BOTO_IMP_ERR = None
 try:
@@ -462,73 +466,6 @@ def ansible_dict_to_boto3_filter_list(filters_dict):
     return filters_list
 
 
-def boto3_tag_list_to_ansible_dict(tags_list, tag_name_key_name=None, tag_value_key_name=None):
-
-    """ Convert a boto3 list of resource tags to a flat dict of key:value pairs
-    Args:
-        tags_list (list): List of dicts representing AWS tags.
-        tag_name_key_name (str): Value to use as the key for all tag keys (useful because boto3 doesn't always use "Key")
-        tag_value_key_name (str): Value to use as the key for all tag values (useful because boto3 doesn't always use "Value")
-    Basic Usage:
-        >>> tags_list = [{'Key': 'MyTagKey', 'Value': 'MyTagValue'}]
-        >>> boto3_tag_list_to_ansible_dict(tags_list)
-        [
-            {
-                'Key': 'MyTagKey',
-                'Value': 'MyTagValue'
-            }
-        ]
-    Returns:
-        Dict: Dict of key:value pairs representing AWS tags
-         {
-            'MyTagKey': 'MyTagValue',
-        }
-    """
-
-    if tag_name_key_name and tag_value_key_name:
-        tag_candidates = {tag_name_key_name: tag_value_key_name}
-    else:
-        tag_candidates = {'key': 'value', 'Key': 'Value'}
-
-    # minio seems to return [{}] as an empty tags_list
-    if not tags_list or not any(tag for tag in tags_list):
-        return {}
-    for k, v in tag_candidates.items():
-        if k in tags_list[0] and v in tags_list[0]:
-            return dict((tag[k], tag[v]) for tag in tags_list)
-    raise ValueError("Couldn't find tag key (candidates %s) in tag list %s" % (str(tag_candidates), str(tags_list)))
-
-
-def ansible_dict_to_boto3_tag_list(tags_dict, tag_name_key_name='Key', tag_value_key_name='Value'):
-
-    """ Convert a flat dict of key:value pairs representing AWS resource tags to a boto3 list of dicts
-    Args:
-        tags_dict (dict): Dict representing AWS resource tags.
-        tag_name_key_name (str): Value to use as the key for all tag keys (useful because boto3 doesn't always use "Key")
-        tag_value_key_name (str): Value to use as the key for all tag values (useful because boto3 doesn't always use "Value")
-    Basic Usage:
-        >>> tags_dict = {'MyTagKey': 'MyTagValue'}
-        >>> ansible_dict_to_boto3_tag_list(tags_dict)
-        {
-            'MyTagKey': 'MyTagValue'
-        }
-    Returns:
-        List: List of dicts containing tag keys and values
-        [
-            {
-                'Key': 'MyTagKey',
-                'Value': 'MyTagValue'
-            }
-        ]
-    """
-
-    tags_list = []
-    for k, v in tags_dict.items():
-        tags_list.append({tag_name_key_name: k, tag_value_key_name: to_native(v)})
-
-    return tags_list
-
-
 def get_ec2_security_group_ids_from_names(sec_group_list, ec2_connection, vpc_id=None, boto3=True):
 
     """ Return list of security group IDs from security group names. Note that security group names are not unique
@@ -778,33 +715,6 @@ def map_complex_type(complex_type, type_map):
     elif type_map:
         return globals()['__builtins__'][type_map](complex_type)
     return new_type
-
-
-def compare_aws_tags(current_tags_dict, new_tags_dict, purge_tags=True):
-    """
-    Compare two dicts of AWS tags. Dicts are expected to of been created using 'boto3_tag_list_to_ansible_dict' helper function.
-    Two dicts are returned - the first is tags to be set, the second is any tags to remove. Since the AWS APIs differ
-    these may not be able to be used out of the box.
-
-    :param current_tags_dict:
-    :param new_tags_dict:
-    :param purge_tags:
-    :return: tag_key_value_pairs_to_set: a dict of key value pairs that need to be set in AWS. If all tags are identical this dict will be empty
-    :return: tag_keys_to_unset: a list of key names (type str) that need to be unset in AWS. If no tags need to be unset this list will be empty
-    """
-
-    tag_key_value_pairs_to_set = {}
-    tag_keys_to_unset = []
-
-    for key in current_tags_dict.keys():
-        if key not in new_tags_dict and purge_tags:
-            tag_keys_to_unset.append(key)
-
-    for key in set(new_tags_dict.keys()) - set(tag_keys_to_unset):
-        if to_text(new_tags_dict[key]) != current_tags_dict.get(key):
-            tag_key_value_pairs_to_set[key] = new_tags_dict[key]
-
-    return tag_key_value_pairs_to_set, tag_keys_to_unset
 
 
 @AWSRetry.jittered_backoff()

--- a/plugins/module_utils/tagging.py
+++ b/plugins/module_utils/tagging.py
@@ -31,6 +31,7 @@ __metaclass__ = type
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils._text import to_text
+from ansible.module_utils.six import string_types
 
 
 def boto3_tag_list_to_ansible_dict(tags_list, tag_name_key_name=None, tag_value_key_name=None):
@@ -98,6 +99,48 @@ def ansible_dict_to_boto3_tag_list(tags_dict, tag_name_key_name='Key', tag_value
         tags_list.append({tag_name_key_name: k, tag_value_key_name: to_native(v)})
 
     return tags_list
+
+
+def boto3_tag_specifications(tags_dict, types=None):
+    """ Converts a list of resource types and a flat dictionary of key:value pairs representing AWS
+    resource tags to a TagSpecification object.
+
+    https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_TagSpecification.html
+
+    Args:
+        tags_dict (dict): Dict representing AWS resource tags.
+        types (list) A list of resource types to be tagged.
+    Basic Usage:
+        >>> tags_dict = {'MyTagKey': 'MyTagValue'}
+        >>> boto3_tag_specifications(tags_dict, ['instance'])
+        [
+            {
+                'ResourceType': 'instance',
+                'Tags': [
+                    {
+                        'Key': 'MyTagKey',
+                        'Value': 'MyTagValue'
+                    }
+                ]
+            }
+        ]
+    Returns:
+        List: List of dictionaries representing an AWS Tag Specification
+    """
+    specifications = list()
+    tag_list = ansible_dict_to_boto3_tag_list(tags_dict)
+
+    if not types:
+        specifications.append(dict(Tags=tag_list))
+        return specifications
+
+    if isinstance(types, string_types):
+        types = [types]
+
+    for type_name in types:
+        specifications.append(dict(ResourceType=type_name, Tags=tag_list))
+
+    return specifications
 
 
 def compare_aws_tags(current_tags_dict, new_tags_dict, purge_tags=True):

--- a/plugins/module_utils/tagging.py
+++ b/plugins/module_utils/tagging.py
@@ -1,0 +1,127 @@
+# This code is part of Ansible, but is an independent component.
+# This particular file snippet, and this file snippet only, is BSD licensed.
+# Modules you write using this snippet, which is embedded dynamically by Ansible
+# still belong to the author of the module, and may assign their own license
+# to the complete work.
+#
+# Copyright (c), Michael DeHaan <michael.dehaan@gmail.com>, 2012-2013
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+#    * Redistributions of source code must retain the above copyright
+#      notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above copyright notice,
+#      this list of conditions and the following disclaimer in the documentation
+#      and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+# ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+# IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+# USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible.module_utils._text import to_native
+from ansible.module_utils._text import to_text
+
+
+def boto3_tag_list_to_ansible_dict(tags_list, tag_name_key_name=None, tag_value_key_name=None):
+
+    """ Convert a boto3 list of resource tags to a flat dict of key:value pairs
+    Args:
+        tags_list (list): List of dicts representing AWS tags.
+        tag_name_key_name (str): Value to use as the key for all tag keys (useful because boto3 doesn't always use "Key")
+        tag_value_key_name (str): Value to use as the key for all tag values (useful because boto3 doesn't always use "Value")
+    Basic Usage:
+        >>> tags_list = [{'Key': 'MyTagKey', 'Value': 'MyTagValue'}]
+        >>> boto3_tag_list_to_ansible_dict(tags_list)
+        [
+            {
+                'Key': 'MyTagKey',
+                'Value': 'MyTagValue'
+            }
+        ]
+    Returns:
+        Dict: Dict of key:value pairs representing AWS tags
+         {
+            'MyTagKey': 'MyTagValue',
+        }
+    """
+
+    if tag_name_key_name and tag_value_key_name:
+        tag_candidates = {tag_name_key_name: tag_value_key_name}
+    else:
+        tag_candidates = {'key': 'value', 'Key': 'Value'}
+
+    # minio seems to return [{}] as an empty tags_list
+    if not tags_list or not any(tag for tag in tags_list):
+        return {}
+    for k, v in tag_candidates.items():
+        if k in tags_list[0] and v in tags_list[0]:
+            return dict((tag[k], tag[v]) for tag in tags_list)
+    raise ValueError("Couldn't find tag key (candidates %s) in tag list %s" % (str(tag_candidates), str(tags_list)))
+
+
+def ansible_dict_to_boto3_tag_list(tags_dict, tag_name_key_name='Key', tag_value_key_name='Value'):
+
+    """ Convert a flat dict of key:value pairs representing AWS resource tags to a boto3 list of dicts
+    Args:
+        tags_dict (dict): Dict representing AWS resource tags.
+        tag_name_key_name (str): Value to use as the key for all tag keys (useful because boto3 doesn't always use "Key")
+        tag_value_key_name (str): Value to use as the key for all tag values (useful because boto3 doesn't always use "Value")
+    Basic Usage:
+        >>> tags_dict = {'MyTagKey': 'MyTagValue'}
+        >>> ansible_dict_to_boto3_tag_list(tags_dict)
+        {
+            'MyTagKey': 'MyTagValue'
+        }
+    Returns:
+        List: List of dicts containing tag keys and values
+        [
+            {
+                'Key': 'MyTagKey',
+                'Value': 'MyTagValue'
+            }
+        ]
+    """
+
+    tags_list = []
+    for k, v in tags_dict.items():
+        tags_list.append({tag_name_key_name: k, tag_value_key_name: to_native(v)})
+
+    return tags_list
+
+
+def compare_aws_tags(current_tags_dict, new_tags_dict, purge_tags=True):
+    """
+    Compare two dicts of AWS tags. Dicts are expected to of been created using 'boto3_tag_list_to_ansible_dict' helper function.
+    Two dicts are returned - the first is tags to be set, the second is any tags to remove. Since the AWS APIs differ
+    these may not be able to be used out of the box.
+
+    :param current_tags_dict:
+    :param new_tags_dict:
+    :param purge_tags:
+    :return: tag_key_value_pairs_to_set: a dict of key value pairs that need to be set in AWS. If all tags are identical this dict will be empty
+    :return: tag_keys_to_unset: a list of key names (type str) that need to be unset in AWS. If no tags need to be unset this list will be empty
+    """
+
+    tag_key_value_pairs_to_set = {}
+    tag_keys_to_unset = []
+
+    for key in current_tags_dict.keys():
+        if key not in new_tags_dict and purge_tags:
+            tag_keys_to_unset.append(key)
+
+    for key in set(new_tags_dict.keys()) - set(tag_keys_to_unset):
+        if to_text(new_tags_dict[key]) != current_tags_dict.get(key):
+            tag_key_value_pairs_to_set[key] = new_tags_dict[key]
+
+    return tag_key_value_pairs_to_set, tag_keys_to_unset

--- a/tests/unit/module_utils/test_ec2.py
+++ b/tests/unit/module_utils/test_ec2.py
@@ -9,9 +9,6 @@ __metaclass__ = type
 import unittest
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import map_complex_type
 
 
@@ -21,24 +18,12 @@ class Ec2Utils(unittest.TestCase):
     # Setup some initial data that we can use within our tests
     # ========================================================
     def setUp(self):
-
-        self.tag_example_boto3_list = [
-            {'Key': 'lowerCamel', 'Value': 'lowerCamelValue'},
-            {'Key': 'UpperCamel', 'Value': 'upperCamelValue'},
-            {'Key': 'Normal case', 'Value': 'Normal Value'},
-            {'Key': 'lower case', 'Value': 'lower case value'}
-        ]
-
-        self.tag_example_dict = {
-            'lowerCamel': 'lowerCamelValue',
-            'UpperCamel': 'upperCamelValue',
-            'Normal case': 'Normal Value',
-            'lower case': 'lower case value'
-        }
+        pass
 
     # ========================================================
     #   ec2.map_complex_type
     # ========================================================
+
     def test_map_complex_type_over_dict(self):
         complex_type = {'minimum_healthy_percent': "75", 'maximum_percent': "150"}
         type_map = {'minimum_healthy_percent': 'int', 'maximum_percent': 'int'}
@@ -91,101 +76,3 @@ class Ec2Utils(unittest.TestCase):
 
         converted_filters_int = ansible_dict_to_boto3_filter_list(filters)
         self.assertEqual(converted_filters_int, filter_list_integer)
-
-    # ========================================================
-    #   ec2.ansible_dict_to_boto3_tag_list
-    # ========================================================
-
-    def test_ansible_dict_to_boto3_tag_list(self):
-        converted_list = ansible_dict_to_boto3_tag_list(self.tag_example_dict)
-        sorted_converted_list = sorted(converted_list, key=lambda i: (i['Key']))
-        sorted_list = sorted(self.tag_example_boto3_list, key=lambda i: (i['Key']))
-        self.assertEqual(sorted_converted_list, sorted_list)
-
-    # ========================================================
-    #   ec2.boto3_tag_list_to_ansible_dict
-    # ========================================================
-
-    def test_boto3_tag_list_to_ansible_dict(self):
-        converted_dict = boto3_tag_list_to_ansible_dict(self.tag_example_boto3_list)
-        self.assertEqual(converted_dict, self.tag_example_dict)
-
-    def test_boto3_tag_list_to_ansible_dict_empty(self):
-        # AWS returns [] when there are no tags
-        self.assertEqual(boto3_tag_list_to_ansible_dict([]), {})
-        # Minio returns [{}] when there are no tags
-        self.assertEqual(boto3_tag_list_to_ansible_dict([{}]), {})
-
-    # ========================================================
-    #   ec2.compare_aws_tags
-    # ========================================================
-
-    def test_compare_aws_tags_equal(self):
-        new_dict = dict(self.tag_example_dict)
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict)
-        self.assertEqual({}, keys_to_set)
-        self.assertEqual([], keys_to_unset)
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=False)
-        self.assertEqual({}, keys_to_set)
-        self.assertEqual([], keys_to_unset)
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=True)
-        self.assertEqual({}, keys_to_set)
-        self.assertEqual([], keys_to_unset)
-
-    def test_compare_aws_tags_removed(self):
-        new_dict = dict(self.tag_example_dict)
-        del new_dict['lowerCamel']
-        del new_dict['Normal case']
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict)
-        self.assertEqual({}, keys_to_set)
-        self.assertEqual(set(['lowerCamel', 'Normal case']), set(keys_to_unset))
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=False)
-        self.assertEqual({}, keys_to_set)
-        self.assertEqual([], keys_to_unset)
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=True)
-        self.assertEqual({}, keys_to_set)
-        self.assertEqual(set(['lowerCamel', 'Normal case']), set(keys_to_unset))
-
-    def test_compare_aws_tags_added(self):
-        new_dict = dict(self.tag_example_dict)
-        new_keys = {'add_me': 'lower case', 'Me too!': 'Contributing'}
-        new_dict.update(new_keys)
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict)
-        self.assertEqual(new_keys, keys_to_set)
-        self.assertEqual([], keys_to_unset)
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=False)
-        self.assertEqual(new_keys, keys_to_set)
-        self.assertEqual([], keys_to_unset)
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=True)
-        self.assertEqual(new_keys, keys_to_set)
-        self.assertEqual([], keys_to_unset)
-
-    def test_compare_aws_tags_changed(self):
-        new_dict = dict(self.tag_example_dict)
-        new_keys = {'UpperCamel': 'anotherCamelValue', 'Normal case': 'normal value'}
-        new_dict.update(new_keys)
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict)
-        self.assertEqual(new_keys, keys_to_set)
-        self.assertEqual([], keys_to_unset)
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=False)
-        self.assertEqual(new_keys, keys_to_set)
-        self.assertEqual([], keys_to_unset)
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=True)
-        self.assertEqual(new_keys, keys_to_set)
-        self.assertEqual([], keys_to_unset)
-
-    def test_compare_aws_tags_complex_update(self):
-        # Adds 'Me too!', Changes 'UpperCamel' and removes 'Normal case'
-        new_dict = dict(self.tag_example_dict)
-        new_keys = {'UpperCamel': 'anotherCamelValue', 'Me too!': 'Contributing'}
-        new_dict.update(new_keys)
-        del new_dict['Normal case']
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict)
-        self.assertEqual(new_keys, keys_to_set)
-        self.assertEqual(['Normal case'], keys_to_unset)
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=False)
-        self.assertEqual(new_keys, keys_to_set)
-        self.assertEqual([], keys_to_unset)
-        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=True)
-        self.assertEqual(new_keys, keys_to_set)
-        self.assertEqual(['Normal case'], keys_to_unset)

--- a/tests/unit/module_utils/test_tagging.py
+++ b/tests/unit/module_utils/test_tagging.py
@@ -1,0 +1,133 @@
+# (c) 2017 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import unittest
+
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
+
+
+class Ec2Utils(unittest.TestCase):
+
+    # ========================================================
+    # Setup some initial data that we can use within our tests
+    # ========================================================
+    def setUp(self):
+
+        self.tag_example_boto3_list = [
+            {'Key': 'lowerCamel', 'Value': 'lowerCamelValue'},
+            {'Key': 'UpperCamel', 'Value': 'upperCamelValue'},
+            {'Key': 'Normal case', 'Value': 'Normal Value'},
+            {'Key': 'lower case', 'Value': 'lower case value'}
+        ]
+
+        self.tag_example_dict = {
+            'lowerCamel': 'lowerCamelValue',
+            'UpperCamel': 'upperCamelValue',
+            'Normal case': 'Normal Value',
+            'lower case': 'lower case value'
+        }
+
+    # ========================================================
+    #   ec2.ansible_dict_to_boto3_tag_list
+    # ========================================================
+
+    def test_ansible_dict_to_boto3_tag_list(self):
+        converted_list = ansible_dict_to_boto3_tag_list(self.tag_example_dict)
+        sorted_converted_list = sorted(converted_list, key=lambda i: (i['Key']))
+        sorted_list = sorted(self.tag_example_boto3_list, key=lambda i: (i['Key']))
+        self.assertEqual(sorted_converted_list, sorted_list)
+
+    # ========================================================
+    #   ec2.boto3_tag_list_to_ansible_dict
+    # ========================================================
+
+    def test_boto3_tag_list_to_ansible_dict(self):
+        converted_dict = boto3_tag_list_to_ansible_dict(self.tag_example_boto3_list)
+        self.assertEqual(converted_dict, self.tag_example_dict)
+
+    def test_boto3_tag_list_to_ansible_dict_empty(self):
+        # AWS returns [] when there are no tags
+        self.assertEqual(boto3_tag_list_to_ansible_dict([]), {})
+        # Minio returns [{}] when there are no tags
+        self.assertEqual(boto3_tag_list_to_ansible_dict([{}]), {})
+
+    # ========================================================
+    #   ec2.compare_aws_tags
+    # ========================================================
+
+    def test_compare_aws_tags_equal(self):
+        new_dict = dict(self.tag_example_dict)
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict)
+        self.assertEqual({}, keys_to_set)
+        self.assertEqual([], keys_to_unset)
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=False)
+        self.assertEqual({}, keys_to_set)
+        self.assertEqual([], keys_to_unset)
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=True)
+        self.assertEqual({}, keys_to_set)
+        self.assertEqual([], keys_to_unset)
+
+    def test_compare_aws_tags_removed(self):
+        new_dict = dict(self.tag_example_dict)
+        del new_dict['lowerCamel']
+        del new_dict['Normal case']
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict)
+        self.assertEqual({}, keys_to_set)
+        self.assertEqual(set(['lowerCamel', 'Normal case']), set(keys_to_unset))
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=False)
+        self.assertEqual({}, keys_to_set)
+        self.assertEqual([], keys_to_unset)
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=True)
+        self.assertEqual({}, keys_to_set)
+        self.assertEqual(set(['lowerCamel', 'Normal case']), set(keys_to_unset))
+
+    def test_compare_aws_tags_added(self):
+        new_dict = dict(self.tag_example_dict)
+        new_keys = {'add_me': 'lower case', 'Me too!': 'Contributing'}
+        new_dict.update(new_keys)
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict)
+        self.assertEqual(new_keys, keys_to_set)
+        self.assertEqual([], keys_to_unset)
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=False)
+        self.assertEqual(new_keys, keys_to_set)
+        self.assertEqual([], keys_to_unset)
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=True)
+        self.assertEqual(new_keys, keys_to_set)
+        self.assertEqual([], keys_to_unset)
+
+    def test_compare_aws_tags_changed(self):
+        new_dict = dict(self.tag_example_dict)
+        new_keys = {'UpperCamel': 'anotherCamelValue', 'Normal case': 'normal value'}
+        new_dict.update(new_keys)
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict)
+        self.assertEqual(new_keys, keys_to_set)
+        self.assertEqual([], keys_to_unset)
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=False)
+        self.assertEqual(new_keys, keys_to_set)
+        self.assertEqual([], keys_to_unset)
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=True)
+        self.assertEqual(new_keys, keys_to_set)
+        self.assertEqual([], keys_to_unset)
+
+    def test_compare_aws_tags_complex_update(self):
+        # Adds 'Me too!', Changes 'UpperCamel' and removes 'Normal case'
+        new_dict = dict(self.tag_example_dict)
+        new_keys = {'UpperCamel': 'anotherCamelValue', 'Me too!': 'Contributing'}
+        new_dict.update(new_keys)
+        del new_dict['Normal case']
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict)
+        self.assertEqual(new_keys, keys_to_set)
+        self.assertEqual(['Normal case'], keys_to_unset)
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=False)
+        self.assertEqual(new_keys, keys_to_set)
+        self.assertEqual([], keys_to_unset)
+        keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=True)
+        self.assertEqual(new_keys, keys_to_set)
+        self.assertEqual(['Normal case'], keys_to_unset)

--- a/tests/unit/module_utils/test_tagging.py
+++ b/tests/unit/module_utils/test_tagging.py
@@ -8,9 +8,9 @@ __metaclass__ = type
 
 import unittest
 
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_tag_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import compare_aws_tags
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import compare_aws_tags
 
 
 class Ec2Utils(unittest.TestCase):


### PR DESCRIPTION
##### SUMMARY

- Moves generic tagging tools into dedicated module_utils.tagging (ensure_ec2_tags is currently EC2 specific and needs some thought to make it more generic)
- Adds boto3_tag_specifications helper to generate TagSpecification lists
- Migrates ec2_instance to the new helper and the ensure_ec2_tags helper.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_instance
plugins/module_utils/ec2.py

##### ADDITIONAL INFORMATION
