### PR TITLE
docs - Remove references to old (unsupported) versions of Ansible

### DIFF
--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -63,9 +63,16 @@ options:
     type: dict
   mode:
     description:
-      - Switches the module behaviour between C(PUT) (upload), C(GET) (download), C(geturl) (return download URL, Ansible 1.3+),
-        C(getstr) (download object as string (1.3+)), C(list) (list keys, Ansible 2.0+), C(create) (bucket), C(delete) (bucket),
-        delobj (delete object, Ansible 2.0+) and C(copy) object that is already stored in another (bucket).
+      - Switches the module behaviour between
+      - 'C(PUT): upload'
+      - 'C(GET): download'
+      - 'C(geturl): return download URL'
+      - 'C(getstr): download object as string'
+      - 'C(list): list keys'
+      - 'C(create): create bucket'
+      - 'C(delete): delete bucket'
+      - 'C(delobj): delete object'
+      - 'C(copy): copy object that is already stored in another bucket'
     required: true
     choices: ['get', 'put', 'delete', 'create', 'geturl', 'getstr', 'delobj', 'list', 'copy']
     type: str

--- a/plugins/modules/ec2.py
+++ b/plugins/modules/ec2.py
@@ -174,7 +174,7 @@ options:
     type: str
   state:
     description:
-      - Create, terminate, start, stop or restart instances. The state 'restarted' was added in Ansible 2.2.
+      - Create, terminate, start, stop or restart instances.
       - When I(state=absent), I(instance_ids) is required.
       - When I(state=running), I(state=stopped) or I(state=restarted) then either I(instance_ids) or I(instance_tags) is required.
     default: 'present'

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -154,7 +154,6 @@ EXAMPLES = '''
 # Example: Launch an instance and then add a volume if not already attached
 #   * Volume will be created with the given name if not already created.
 #   * Nothing will happen if the volume is already attached.
-#   * Requires Ansible 2.0
 
 - amazon.aws.ec2:
     keypair: "{{ keypair }}"


### PR DESCRIPTION
##### SUMMARY

We've carried entries in our module docs about version info from long prior to Ansible 2.9 and the creation of this collection.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/modules/aws_s3.py
plugins/modules/ec2.py
plugins/modules/ec2_vol.py

##### ADDITIONAL INFORMATION
