### PR TITLE
Remove reference to 'boto' from s3_bucket failure

### DIFF
--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -963,7 +963,7 @@ def main():
     s3_client = get_s3_client(module, aws_connect_kwargs, location, ceph, s3_url)
 
     if s3_client is None:  # this should never happen
-        module.fail_json(msg='Unknown error, failed to create s3 connection, no information from boto.')
+        module.fail_json(msg='Unknown error, failed to create s3 connection, no information available.')
 
     state = module.params.get("state")
     encryption = module.params.get("encryption")


### PR DESCRIPTION
##### SUMMARY

Remove reference to 'boto' from s3_bucket failure: it's not using boto.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

s3_bucket

##### ADDITIONAL INFORMATION
