### PR TITLE
ec2_ami - Tag the image on creation when creating an image from an instance

### DIFF
--- a/changelogs/551-ec2_ami-tag-on-create.yml
+++ b/changelogs/551-ec2_ami-tag-on-create.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_ami - when creating an AMI from an instance pass the tagging options at creation time (https://github.com/ansible-collections/amazon.aws/pull/551).


### PR DESCRIPTION
##### SUMMARY

Tagging an instance during creation avoids the need to make an additional "tag" call on an untagged resource.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_ami

##### ADDITIONAL INFORMATION

fixes: #550 