### PR TITLE
elb_classic_lb - deprecate the ec2_elb fact

### DIFF
--- a/changelogs/fragments/552-elb_classic_lb-fact.yml
+++ b/changelogs/fragments/552-elb_classic_lb-fact.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+- ec2_classic_lb - setting of the ``ec2_elb`` fact has been deprecated and will be removed in release 4.0.0 of the collection.
+  The module now returns ``elb`` which can be accessed using the register keyword (https://github.com/ansible-collections/amazon.aws/pull/552).

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -288,6 +288,10 @@ options:
     default: true
     version_added: 2.1.0
 
+notes:
+- The ec2_elb fact currently set by this module has been deprecated and will no
+  longer be set after release 4.0.0 of the collection.
+
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2


### PR DESCRIPTION
##### SUMMARY

deprecates the ec2_elb fact in favour of the elb return value.

Split off from #377 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

elb_classic_lb

##### ADDITIONAL INFORMATION

(yes, this module set a fact with the same name, but different content, as the elb_instance module.)