### PR TITLE
Fix for Issue #560  Add example for searching volumes by EC2 instance ID

### DIFF
--- a/docs/amazon.aws.ec2_vol_info_module.rst
+++ b/docs/amazon.aws.ec2_vol_info_module.rst
@@ -277,7 +277,6 @@ Examples
     # register information to `volumes` variable
     # Replaces functionality of `amazon.aws.ec2_vol` - `state: list`
     - name: get volume(s) info from EC2 Instance
-      delegate_to: localhost
       amazon.aws.ec2_vol_info:
         filters:
           attachment.instance-id: "i-000111222333"

--- a/docs/amazon.aws.ec2_vol_info_module.rst
+++ b/docs/amazon.aws.ec2_vol_info_module.rst
@@ -273,6 +273,17 @@ Examples
         filters:
           attachment.status: attached
 
+    # Gather information about all volumes related to an EC2 Instance
+    # register information to `volumes` variable
+    # Replaces functionality of `amazon.aws.ec2_vol` - `state: list`
+    - name: get volume(s) info from EC2 Instance
+      delegate_to: localhost
+      amazon.aws.ec2_vol_info:
+        filters:
+          attachment.instance-id: "i-000111222333"
+        region: "us-east-1"
+      register: volumes
+
 
 
 Return Values


### PR DESCRIPTION
##### SUMMARY

Add example for Searching volumes based on EC2 Instance ID - "state: list" functionality from ec2_vol

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

ec2_vol_info

##### ADDITIONAL INFORMATION

fixes: #560