### PR TITLE
Move ec2_vol_info example from ec2_vol_info_module.rst to ec2_vol_info.py

### DIFF
--- a/plugins/modules/ec2_vol_info.py
+++ b/plugins/modules/ec2_vol_info.py
@@ -48,6 +48,15 @@ EXAMPLES = '''
     filters:
       attachment.status: attached
 
+# Gather information about all volumes related to an EC2 Instance
+# register information to `volumes` variable
+# Replaces functionality of `amazon.aws.ec2_vol` - `state: list`
+- name: get volume(s) info from EC2 Instance
+  amazon.aws.ec2_vol_info:
+    filters:
+      attachment.instance-id: "i-000111222333"
+  register: volumes
+
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY

#561 put it in the wrong place and release prep overwrites it.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

ec2_vol_info

##### ADDITIONAL INFORMATION