### PR TITLE
[3.0.0] Add deprecation notice for boto support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,13 @@ PEP440 is the schema used to describe the versions of Ansible.
 
 As the AWS SDK for Python (Boto3 and Botocore) has [ceased supporting Python 2.7](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-python-2-7-in-aws-sdk-for-python-and-aws-cli-v1/), this collection requires Python 3.6 or greater.
 
+## AWS SDK version compatibility
+
 Starting with the 2.0.0 releases of amazon.aws and community.aws, it is generally the collection's policy to support the versions of `botocore` and `boto3` that were released 12 months prior to the most recent major collection release, following semantic versioning (for example, 2.0.0, 3.0.0).
 
 Version 2.0.0 of this collection supports `boto3 >= 1.15.0` and `botocore >= 1.18.0`
+
+Support for the original AWS SDK `boto` has been deprecated and the module_utils library code to support it will be removed in release 4.0.0.
 
 ## Included content
 

--- a/changelogs/fragments/575-deprecate-boto.yml
+++ b/changelogs/fragments/575-deprecate-boto.yml
@@ -1,0 +1,5 @@
+deprecated_features:
+- module_utils - support for the original AWS SDK `boto` has been deprecated in favour of the `boto3`/`botocore` SDK.
+  All `boto` based modules have either been deprecated or migrated to `botocore`, and the remaining support code in module_utils will be removed in release 4.0.0 of the amazon.aws collection.
+  Any modules outside of the amazon.aws and community.aws collections based on the `boto` library will need to be migrated to the `boto3`/`botocore` libraries
+  (https://github.com/ansible-collections/amazon.aws/pull/575).


### PR DESCRIPTION
##### SUMMARY

The last of our boto modules have either been migrated to boto3/botocore or are deprecated and slated for removal in release 4.0.0.  Add a deprecation notice for the boto support code in module_utils.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

module_utils/

##### ADDITIONAL INFORMATION

```
$ grep -rl 'boto\.' */aws/{plugins,scripts}/ | grep '\.py'
amazon/aws/plugins/doc_fragments/aws.py
amazon/aws/plugins/module_utils/ec2.py
amazon/aws/plugins/modules/ec2.py
community/aws/plugins/modules/ec2_elb_info.py
community/aws/plugins/modules/iam.py
community/aws/plugins/modules/rds.py
community/aws/scripts/inventory/ec2.py
```

- amazon.aws.ec2 module - deprecated - `removed_in: 4.0.0`
- community.aws.ec2_elb_info module - deprecated - `removed_in: 3.0.0`
- community.aws.iam module - deprecated - `removed_in: 3.0.0`
- community.aws.rds module - deprecated - `removed_in: 3.0.0`
- ec2 inventory script - deprecated