### PR TITLE
Remove deprecated "facts" aliases

### DIFF
--- a/changelogs/fragments/remove_deprecated_facts.yml
+++ b/changelogs/fragments/remove_deprecated_facts.yml
@@ -1,0 +1,16 @@
+breaking_changes:
+  - aws_caller_facts - Remove deprecated ``aws_caller_facts`` alias.  Please use ``aws_caller_info`` instead.
+  - cloudformation_facts - Remove deprecated ``cloudformation_facts`` alias.  Please use ``cloudformation_info`` instead.
+  - ec2_ami_facts - Remove deprecated ``ec2_ami_facts`` alias.  Please use ``ec2_ami_info`` instead.
+  - ec2_eni_facts - Remove deprecated ``ec2_eni_facts`` alias.  Please use ``ec2_eni_info`` instead.
+  - ec2_group_facts - Remove deprecated ``ec2_group_facts`` alias.  Please use ``ec2_group_info`` instead.
+  - ec2_instance_facts - Remove deprecated ``ec2_instance_facts`` alias.  Please use ``ec2_instance_info`` instead.
+  - ec2_snapshot_facts - Remove deprecated ``ec2_snapshot_facts`` alias.  Please use ``ec2_snapshot_info`` instead.
+  - ec2_vol_facts - Remove deprecated ``ec2_vol_facts`` alias.  Please use ``ec2_vol_info`` instead.
+  - ec2_vpc_dhcp_option_facts - Remove deprecated ``ec2_vpc_dhcp_option_facts`` alias.  Please use ``ec2_vpc_dhcp_option_info`` instead.
+  - ec2_vpc_endpoint_facts - Remove deprecated ``ec2_vpc_endpoint_facts`` alias.  Please use ``ec2_vpc_endpoint_info`` instead.
+  - ec2_vpc_igw_facts - Remove deprecated ``ec2_vpc_igw_facts`` alias.  Please use ``ec2_vpc_igw_info`` instead.
+  - ec2_vpc_nat_gateway_facts - Remove deprecated ``ec2_vpc_nat_gateway_facts`` alias.  Please use ``ec2_vpc_nat_gateway_info`` instead.
+  - ec2_vpc_net_facts - Remove deprecated ``ec2_vpc_net_facts`` alias.  Please use ``ec2_vpc_net_info`` instead.
+  - ec2_vpc_route_table_facts - Remove deprecated ``ec2_vpc_route_table_facts`` alias.  Please use ``ec2_vpc_route_table_info`` instead.
+  - ec2_vpc_subnet_facts - Remove deprecated ``ec2_vpc_subnet_facts`` alias.  Please use ``ec2_vpc_subnet_info`` instead.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -3,63 +3,47 @@ action_groups:
   aws:
   - aws_az_facts
   - aws_az_info
-  - aws_caller_facts
   - aws_caller_info
   - aws_s3
   - aws_s3
   - aws_secret
   - cloudformation
-  - cloudformation_facts
   - cloudformation_info
-  - cloudfront_facts
   - ec2
   - ec2
   - ec2
   - ec2_ami
-  - ec2_ami_facts
   - ec2_ami_info
   - ec2_elb_lb
   - ec2_eni
-  - ec2_eni_facts
   - ec2_eni_info
   - ec2_group
-  - ec2_group_facts
   - ec2_group_info
   - ec2_instance
-  - ec2_instance_facts
   - ec2_instance_info
   - ec2_key
   - ec2_snapshot
-  - ec2_snapshot_facts
   - ec2_snapshot_info
   - ec2_spot_instance
   - ec2_spot_instance_info
   - ec2_tag
   - ec2_tag_info
   - ec2_vol
-  - ec2_vol_facts
   - ec2_vol_info
   - ec2_vpc_dhcp_option
-  - ec2_vpc_dhcp_option_facts
   - ec2_vpc_dhcp_option_info
   - ec2_vpc_endpoint
-  - ec2_vpc_endpoint_facts
   - ec2_vpc_endpoint_info
   - ec2_vpc_endpoint_service_info
   - ec2_vpc_igw
-  - ec2_vpc_igw_facts
   - ec2_vpc_igw_info
   - ec2_vpc_nat_gateway
-  - ec2_vpc_nat_gateway_facts
   - ec2_vpc_nat_gateway_info
   - ec2_vpc_net
-  - ec2_vpc_net_facts
   - ec2_vpc_net_info
   - ec2_vpc_route_table
-  - ec2_vpc_route_table_facts
   - ec2_vpc_route_table_info
   - ec2_vpc_subnet
-  - ec2_vpc_subnet_facts
   - ec2_vpc_subnet_info
   - elb_classic_lb
   - iam
@@ -73,32 +57,12 @@ plugin_routing:
         warning_text: >-
           aws_az_facts was renamed in Ansible 2.9 to aws_az_info.
           Please update your tasks.
-    aws_caller_facts:
-      deprecation:
-        removal_date: 2021-12-01
-        warning_text: >-
-          aws_caller_facts was renamed in Ansible 2.9 to aws_caller_info.
-          Please update your tasks.
-    cloudformation_facts:
-      deprecation:
-        removal_date: 2021-12-01
-        warning_text: >-
-          cloudformation_facts has been deprecated and will be removed.
-          The cloudformation_info module returns the same information, but
-          not as ansible_facts.  See the module documentation for more
-          information.
     ec2:
       deprecation:
         removal_version: 4.0.0
         warning_text: >-
           The ec2 module is based upon a deprecated version of the AWS SDKs
           and is deprecated in favor of the ec2_instance module.
-          Please update your tasks.
-    ec2_ami_facts:
-      deprecation:
-        removal_date: 2021-12-01
-        warning_text: >-
-          ec2_ami_facts was renamed in Ansible 2.9 to ec2_ami_info.
           Please update your tasks.
     ec2_elb_lb:
       redirect: amazon.aws.elb_classic_lb
@@ -107,66 +71,4 @@ plugin_routing:
         removal_date: 2021-12-01
         warning_text: >-
           ec2_eni_facts was renamed in Ansible 2.9 to ec2_eni_info.
-          Please update your tasks.
-    ec2_group_facts:
-      deprecation:
-        removal_date: 2021-12-01
-        warning_text: >-
-          ec2_group_facts was renamed in Ansible 2.9 to ec2_group_info.
-          Please update your tasks.
-    ec2_snapshot_facts:
-      deprecation:
-        removal_date: 2021-12-01
-        warning_text: >-
-          ec2_snapshot_facts was renamed in Ansible 2.9 to ec2_snapshot_info.
-          Please update your tasks.
-    ec2_vol_facts:
-      deprecation:
-        removal_date: 2021-12-01
-        warning_text: >-
-          ec2_vol_facts was renamed in Ansible 2.9 to ec2_vol_info.
-          Please update your tasks.
-    ec2_vpc_dhcp_option_facts:
-      deprecation:
-        removal_date: 2021-12-01
-        warning_text: >-
-          ec2_vpc_dhcp_option_facts was renamed in Ansible 2.9 to
-          ec2_vpc_dhcp_option_info.  Please update your tasks.
-    ec2_vpc_net_facts:
-      deprecation:
-        removal_date: 2021-12-01
-        warning_text: >-
-          ec2_vpc_net_facts was renamed in Ansible 2.9 to ec2_vpc_net_info.
-          Please update your tasks.
-    ec2_vpc_subnet_facts:
-      deprecation:
-        removal_date: 2021-12-01
-        warning_text: >-
-          ec2_vpc_subnet_facts was renamed in Ansible 2.9 to
-          ec2_vpc_subnet_info.  Please update your tasks.
-    ec2_vpc_endpoint_facts:
-      deprecation:
-        removal_date: 2021-12-01
-        warning_text: >-
-          ec2_vpc_endpoint_facts was renamed in Ansible 2.9 to
-          ec2_vpc_endpoint_info.
-    ec2_vpc_igw_facts:
-      deprecation:
-        removal_date: 2021-12-01
-        warning_text: >-
-            ec2_vpc_igw_facts was renamed in Ansible 2.9 to ec2_vpc_igw_info.
-            Please update your tasks.
-    ec2_vpc_route_table_facts:
-      deprecation:
-        removal_date: 2021-12-01
-        warning_text: >-
-            ec2_vpc_route_table_facts was renamed in Ansible 2.9 to
-            ec2_vpc_route_table_info.
-            Please update your tasks.
-    ec2_vpc_nat_gateway_facts:
-      deprecation:
-        removal_date: 2021-12-01
-        warning_text: >-
-          ec2_vpc_nat_gateway_facts was renamed in Ansible 2.9 to
-          ec2_vpc_nat_gateway_info.
           Please update your tasks.

--- a/plugins/modules/aws_caller_facts.py
+++ b/plugins/modules/aws_caller_facts.py
@@ -1,1 +1,0 @@
-aws_caller_info.py

--- a/plugins/modules/aws_caller_info.py
+++ b/plugins/modules/aws_caller_info.py
@@ -14,7 +14,6 @@ short_description: Get information about the user and account being used to make
 description:
     - This module returns information about the account and user / role from which the AWS access tokens originate.
     - The primary use of this is to get the account id for templating into ARNs or similar to avoid needing to specify this information in inventory.
-    - This module was called M(amazon.aws.aws_caller_facts) before Ansible 2.9. The usage did not change.
 
 author:
     - Ed Costello (@orthanc)
@@ -75,8 +74,6 @@ def main():
         argument_spec={},
         supports_check_mode=True,
     )
-    if module._name == 'aws_caller_facts':
-        module.deprecate("The 'aws_caller_facts' module has been renamed to 'aws_caller_info'", date='2021-12-01', collection_name='amazon.aws')
 
     client = module.client('sts', retry_decorator=AWSRetry.jittered_backoff())
 

--- a/plugins/modules/cloudformation_facts.py
+++ b/plugins/modules/cloudformation_facts.py
@@ -1,1 +1,0 @@
-cloudformation_info.py

--- a/plugins/modules/cloudformation_info.py
+++ b/plugins/modules/cloudformation_info.py
@@ -309,6 +309,12 @@ def main():
         if all_facts or module.params.get('stack_change_sets'):
             facts['stack_change_sets'] = service_mgr.describe_stack_change_sets(stack_name)
 
+        result['cloudformation'][stack_name] = camel_dict_to_snake_dict(facts, ignore_list=('stack_outputs',
+                                                                                            'stack_parameters',
+                                                                                            'stack_policy',
+                                                                                            'stack_resources',
+                                                                                            'stack_tags',
+                                                                                            'stack_template'))
     module.exit_json(changed=False, **result)
 
 

--- a/plugins/modules/ec2_ami_facts.py
+++ b/plugins/modules/ec2_ami_facts.py
@@ -1,1 +1,0 @@
-ec2_ami_info.py

--- a/plugins/modules/ec2_ami_info.py
+++ b/plugins/modules/ec2_ami_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Gather information about ec2 AMIs
 description:
   - Gather information about ec2 AMIs
-  - This module was called C(amazon.aws.ec2_ami_facts) before Ansible 2.9. The usage did not change.
 author:
   - Prasad Katti (@prasadkatti)
 options:
@@ -274,8 +273,6 @@ def main():
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
-    if module._module._name == 'ec2_ami_facts':
-        module._module.deprecate("The 'ec2_ami_facts' module has been renamed to 'ec2_ami_info'", date='2021-12-01', collection_name='amazon.aws')
 
     ec2_client = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 

--- a/plugins/modules/ec2_eni_facts.py
+++ b/plugins/modules/ec2_eni_facts.py
@@ -1,1 +1,0 @@
-ec2_eni_info.py

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Gather information about ec2 ENI interfaces in AWS
 description:
     - Gather information about ec2 ENI interfaces in AWS.
-    - This module was called C(ec2_eni_facts) before Ansible 2.9. The usage did not change.
 author: "Rob White (@wimnat)"
 options:
   eni_id:
@@ -285,8 +284,6 @@ def main():
     ]
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
-    if module._name == 'ec2_eni_facts':
-        module.deprecate("The 'ec2_eni_facts' module has been renamed to 'ec2_eni_info'", date='2021-12-01', collection_name='amazon.aws')
 
     connection = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 

--- a/plugins/modules/ec2_group_facts.py
+++ b/plugins/modules/ec2_group_facts.py
@@ -1,1 +1,0 @@
-ec2_group_info.py

--- a/plugins/modules/ec2_group_info.py
+++ b/plugins/modules/ec2_group_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Gather information about ec2 security groups in AWS.
 description:
     - Gather information about ec2 security groups in AWS.
-    - This module was called C(amazon.aws.ec2_group_facts) before Ansible 2.9. The usage did not change.
 author:
 - Henrique Rodrigues (@Sodki)
 options:
@@ -109,8 +108,6 @@ def main():
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
-    if module._name == 'ec2_group_facts':
-        module.deprecate("The 'ec2_group_facts' module has been renamed to 'ec2_group_info'", date='2021-12-01', collection_name='amazon.aws')
 
     connection = module.client('ec2', AWSRetry.jittered_backoff())
 

--- a/plugins/modules/ec2_instance_facts.py
+++ b/plugins/modules/ec2_instance_facts.py
@@ -1,1 +1,0 @@
-ec2_instance_info.py

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Gather information about ec2 instances in AWS
 description:
     - Gather information about ec2 instances in AWS
-    - This module was called C(ec2_instance_facts) before Ansible 2.9. The usage did not change.
 author:
   - Michael Schuett (@michaeljs1990)
   - Rob White (@wimnat)
@@ -575,8 +574,6 @@ def main():
         ],
         supports_check_mode=True,
     )
-    if module._name == 'ec2_instance_facts':
-        module.deprecate("The 'ec2_instance_facts' module has been renamed to 'ec2_instance_info'", date='2021-12-01', collection_name='amazon.aws')
 
     try:
         connection = module.client('ec2')

--- a/plugins/modules/ec2_snapshot_facts.py
+++ b/plugins/modules/ec2_snapshot_facts.py
@@ -1,1 +1,0 @@
-ec2_snapshot_info.py

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Gather information about ec2 volume snapshots in AWS
 description:
     - Gather information about ec2 volume snapshots in AWS.
-    - This module was called C(ec2_snapshot_facts) before Ansible 2.9. The usage did not change.
 author:
     - "Rob White (@wimnat)"
     - Aubin Bikouo (@abikouo)
@@ -283,8 +282,6 @@ def main():
         ],
         supports_check_mode=True
     )
-    if module._name == 'ec2_snapshot_facts':
-        module.deprecate("The 'ec2_snapshot_facts' module has been renamed to 'ec2_snapshot_info'", date='2021-12-01', collection_name='amazon.aws')
 
     connection = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 

--- a/plugins/modules/ec2_vol_facts.py
+++ b/plugins/modules/ec2_vol_facts.py
@@ -1,1 +1,0 @@
-ec2_vol_info.py

--- a/plugins/modules/ec2_vol_info.py
+++ b/plugins/modules/ec2_vol_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Gather information about ec2 volumes in AWS
 description:
     - Gather information about ec2 volumes in AWS.
-    - This module was called C(ec2_vol_facts) before Ansible 2.9. The usage did not change.
 author: "Rob White (@wimnat)"
 options:
   filters:
@@ -205,8 +204,6 @@ def main():
     argument_spec = dict(filters=dict(default={}, type='dict'))
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
-    if module._name == 'ec2_vol_facts':
-        module.deprecate("The 'ec2_vol_facts' module has been renamed to 'ec2_vol_info'", date='2021-12-01', collection_name='amazon.aws')
 
     connection = module.client('ec2')
 

--- a/plugins/modules/ec2_vpc_dhcp_option_facts.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_facts.py
@@ -1,1 +1,0 @@
-ec2_vpc_dhcp_option_info.py

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Gather information about dhcp options sets in AWS
 description:
     - Gather information about dhcp options sets in AWS.
-    - This module was called C(ec2_vpc_dhcp_option_facts) before Ansible 2.9. The usage did not change.
 author: "Nick Aslanidis (@naslanidis)"
 options:
   filters:
@@ -187,9 +186,6 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True
     )
-    if module._name == 'ec2_vpc_dhcp_option_facts':
-        module.deprecate("The 'ec2_vpc_dhcp_option_facts' module has been renamed to 'ec2_vpc_dhcp_option_info'",
-                         date='2021-12-01', collection_name='amazon.aws')
 
     client = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 

--- a/plugins/modules/ec2_vpc_endpoint_facts.py
+++ b/plugins/modules/ec2_vpc_endpoint_facts.py
@@ -1,1 +1,0 @@
-ec2_vpc_endpoint_info.py

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -11,7 +11,6 @@ short_description: Retrieves AWS VPC endpoints details using AWS methods.
 version_added: 1.0.0
 description:
   - Gets various details related to AWS VPC endpoints.
-  - This module was called C(ec2_vpc_endpoint_facts) before Ansible 2.9. The usage did not change.
 options:
   query:
     description:
@@ -170,8 +169,6 @@ def main():
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
-    if module._name == 'ec2_vpc_endpoint_facts':
-        module.deprecate("The 'ec2_vpc_endpoint_facts' module has been renamed to 'ec2_vpc_endpoint_info'", date='2021-12-01', collection_name='amazon.aws')
 
     # Validate Requirements
     try:

--- a/plugins/modules/ec2_vpc_igw_facts.py
+++ b/plugins/modules/ec2_vpc_igw_facts.py
@@ -1,1 +1,0 @@
-ec2_vpc_igw_info.py

--- a/plugins/modules/ec2_vpc_igw_info.py
+++ b/plugins/modules/ec2_vpc_igw_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Gather information about internet gateways in AWS
 description:
     - Gather information about internet gateways in AWS.
-    - This module was called C(ec2_vpc_igw_facts) before Ansible 2.9. The usage did not change.
 author: "Nick Aslanidis (@naslanidis)"
 options:
   filters:
@@ -159,8 +158,6 @@ def main():
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
-    if module._name == 'ec2_vpc_igw_facts':
-        module.deprecate("The 'ec2_vpc_igw_facts' module has been renamed to 'ec2_vpc_igw_info'", date='2021-12-01', collection_name='amazon.aws')
 
     if module.params.get('convert_tags') is None:
         module.deprecate('This module currently returns boto3 style tags by default.  '

--- a/plugins/modules/ec2_vpc_nat_gateway_facts.py
+++ b/plugins/modules/ec2_vpc_nat_gateway_facts.py
@@ -1,1 +1,0 @@
-ec2_vpc_nat_gateway_info.py

--- a/plugins/modules/ec2_vpc_nat_gateway_info.py
+++ b/plugins/modules/ec2_vpc_nat_gateway_info.py
@@ -12,7 +12,6 @@ short_description: Retrieves AWS VPC Managed Nat Gateway details using AWS metho
 version_added: 1.0.0
 description:
   - Gets various details related to AWS VPC Managed Nat Gateways
-  - This module was called C(ec2_vpc_nat_gateway_facts) before Ansible 2.9. The usage did not change.
 options:
   nat_gateway_ids:
     description:
@@ -200,9 +199,6 @@ def main():
 
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               supports_check_mode=True,)
-    if module._name == 'ec2_vpc_nat_gateway_facts':
-        module.deprecate("The 'ec2_vpc_nat_gateway_facts' module has been renamed to 'ec2_vpc_nat_gateway_info'",
-                         date='2021-12-01', collection_name='amazon.aws')
 
     try:
         connection = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())

--- a/plugins/modules/ec2_vpc_net_facts.py
+++ b/plugins/modules/ec2_vpc_net_facts.py
@@ -1,1 +1,0 @@
-ec2_vpc_net_info.py

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Gather information about ec2 VPCs in AWS
 description:
     - Gather information about ec2 VPCs in AWS
-    - This module was called C(ec2_vpc_net_facts) before Ansible 2.9. The usage did not change.
 author: "Rob White (@wimnat)"
 options:
   vpc_ids:
@@ -253,8 +252,6 @@ def main():
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
-    if module._name == 'ec2_vpc_net_facts':
-        module.deprecate("The 'ec2_vpc_net_facts' module has been renamed to 'ec2_vpc_net_info'", date='2021-12-01', collection_name='amazon.aws')
 
     connection = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff(retries=10))
 

--- a/plugins/modules/ec2_vpc_route_table_facts.py
+++ b/plugins/modules/ec2_vpc_route_table_facts.py
@@ -1,1 +1,0 @@
-ec2_vpc_route_table_info.py

--- a/plugins/modules/ec2_vpc_route_table_info.py
+++ b/plugins/modules/ec2_vpc_route_table_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Gather information about ec2 VPC route tables in AWS
 description:
     - Gather information about ec2 VPC route tables in AWS
-    - This module was called C(ec2_vpc_route_table_facts) before Ansible 2.9. The usage did not change.
 author:
 - "Rob White (@wimnat)"
 - "Mark Chappell (@tremble)"
@@ -270,9 +269,6 @@ def main():
 
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               supports_check_mode=True)
-    if module._name == 'ec2_vpc_route_table_facts':
-        module.deprecate("The 'ec2_vpc_route_table_facts' module has been renamed to 'ec2_vpc_route_table_info'",
-                         date='2021-12-01', collection_name='amazon.aws')
 
     connection = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff(retries=10))
 

--- a/plugins/modules/ec2_vpc_subnet_facts.py
+++ b/plugins/modules/ec2_vpc_subnet_facts.py
@@ -1,1 +1,0 @@
-ec2_vpc_subnet_info.py

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -13,7 +13,6 @@ version_added: 1.0.0
 short_description: Gather information about ec2 VPC subnets in AWS
 description:
     - Gather information about ec2 VPC subnets in AWS
-    - This module was called C(ec2_vpc_subnet_facts) before Ansible 2.9. The usage did not change.
 author: "Rob White (@wimnat)"
 options:
   subnet_ids:
@@ -214,8 +213,6 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True
     )
-    if module._name == 'ec2_vpc_subnet_facts':
-        module.deprecate("The 'ec2_vpc_subnet_facts' module has been renamed to 'ec2_vpc_subnet_info'", date='2021-12-01', collection_name='amazon.aws')
 
     connection = module.client('ec2')
 

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,24 +1,11 @@
 plugins/module_utils/ec2.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/aws_az_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/aws_caller_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/cloudformation_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2.py validate-modules:deprecation-mismatch  # Ansible 2.9 docs don't support deprecation properly
 plugins/modules/ec2.py validate-modules:invalid-documentation  # Ansible 2.9 docs don't support deprecation properly
-plugins/modules/ec2_ami_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_eni_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_group_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_instance_info.py pylint:ansible-deprecated-no-version # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_snapshot_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_tag.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vol.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_vol_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vpc_dhcp_option.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_vpc_dhcp_option_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vpc_igw_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_vpc_net_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_vpc_route_table_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_vpc_subnet_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vpc_endpoint.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_vpc_endpoint_info.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2_vpc_nat_gateway_info.py pylint:ansible-deprecated-no-version


### PR DESCRIPTION
##### SUMMARY

Modules named "facts.py" that do not return ansible_facts were renamed to "info.py" in 2.9. Remove these aliases now that the deprecation period is over.

This PR should be included in 3.0.0 of the collection.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
*_facts.py

##### ADDITIONAL INFORMATION
aws_az_facts.py has a deprecation date of 2022-06, so has not been removed.
