### PR TITLE
ec2_instance: Fix launch template condition, handle launch template - default value for instance_type

### DIFF
--- a/changelogs/fragments/587-ec2_instance-default-instance-type-launch-template.yml
+++ b/changelogs/fragments/587-ec2_instance-default-instance-type-launch-template.yml
@@ -1,3 +1,6 @@
 bugfixes:
   - ec2_instance - Add a condition to handle default ```instance_type``` value
     for fix breaking on instance creation with launch template (https://github.com/ansible-collections/amazon.aws/pull/587).
+deprecated_features:
+  - ec2_instance - The default value for ```instance_type``` has been deprecated,
+    in the future release you must set an instance_type or a launch_template".

--- a/changelogs/fragments/587-ec2_instance-default-instance-type-launch-template.yml
+++ b/changelogs/fragments/587-ec2_instance-default-instance-type-launch-template.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - ec2_instance - Add a condition to handle default ```instance_type``` value
+    for fix breaking on instance creation with launch template (https://github.com/ansible-collections/amazon.aws/pull/587).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1972,6 +1972,10 @@ def main():
         ],
         supports_check_mode=True
     )
+
+    if not module.params.get('instance_type') and not module.params.get('launch_template'):
+        module.deprecate("Default value instance_type has been deprecated, in the future you must set an instance_type or a launch_template",
+                         date='2023-01-01', collection_name='amazon.aws')
     result = dict()
 
     if module.params.get('network'):

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -9,3 +9,4 @@ plugins/modules/ec2_vpc_dhcp_option.py pylint:ansible-deprecated-no-version  # W
 plugins/modules/ec2_vpc_igw_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vpc_endpoint.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_vpc_endpoint_info.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2_instance.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The ```launch_template``` option in ```ec2_instance``` has a broken condition.
Also the ```launch_template``` option defaults the ```instance_type``` to ```t2.micro``` if not specified and ignores the ```instance_type``` specified in the ```launch_template``` as said in the issue #451.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes 
- #451
- #462 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
```ec2_instance```

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
The change does not break existing functionality as tested by the integration test run locally.
Related to the condition fix in community.aws: https://github.com/ansible-collections/community.aws/pull/111
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Ran the following playbook to verify the change.
```
# create a launch template called "test-launch-template" 
    - name: create test launch template
      community.aws.ec2_launch_template:
        template_name: test-launch-template
        image_id: ami-002068ed284xxxxxx
        instance_type: t3a.small
        network_interfaces:
          - associate_public_ip_address: no
            delete_on_termination: yes
            device_index: 0
            groups:
              - sg-xxxxxxxxxxxxxxxxxx
            subnet_id: subnet-xxxxxxxxxxxxxxxxxx
        region: us-east-2
        block_device_mappings:
          - device_name: /dev/sdb
            ebs:
              volume_size: 5
              volume_type: gp3
              delete_on_termination: true
              encrypted: yes
          - device_name: /dev/sdc
            ebs:
              volume_size: 2
              volume_type: gp2
              delete_on_termination: true
              encrypted: no
        tags:
          ssome: tags

# launch a ec2 instance using launch template created earlier - launches t3a.small instance as expected
    - name: test launch template usage
      ec2_instance:
        wait: yes
        name: "test-instance-mk-t3a.small"
        launch_template:
          name: test-launch-template
        vpc_subnet_id: subnet-xxxxxxxxxxxxxxxxxx

# launch ec2 instance using launch template created earlier - override instance type to be launch to t3.xlarge
    - name: test launch template usage - override instance type
      ec2_instance:
        wait: yes
        name: "test-instance-mk-t3.xlarge"
        instance_type: t3.xlarge
        launch_template:
          name: test-launch-template
        vpc_subnet_id: subnet-xxxxxxxxxxxxxxxxxx
```
