### PR TITLE
Fix tempfolder path since Fedora uses tmpfs

### DIFF
--- a/tests/integration/targets/aws_s3/tasks/main.yml
+++ b/tests/integration/targets/aws_s3/tasks/main.yml
@@ -19,6 +19,7 @@
     - name: Create temporary directory
       tempfile:
         state: directory
+        path: /var/tmp
       register: tmpdir
 
     - name: Create content


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This is a fix for 

```
2021-12-20 10:36:56.079435 \| fedora-35 \| TASK [aws_s3 : make tempfile 4 GB for linux] ***********************************
--
5391 | 2021-12-20 10:36:56.079637 \| fedora-35 \| task path: /home/zuul/.ansible/collections/ansible_collections/amazon/aws/tests/integration/targets/aws_s3/tasks/main.yml:499
5392 | 2021-12-20 10:36:56.244626 \| fedora-35 \| Using module file /tmp/ansible-test-qyqzaib3/ansible/modules/command.py
5393 | 2021-12-20 10:36:56.244945 \| fedora-35 \| Pipelining is enabled.
5394 | 2021-12-20 10:36:56.245217 \| fedora-35 \| <testhost> ESTABLISH LOCAL CONNECTION FOR USER: zuul
5395 | 2021-12-20 10:36:56.245359 \| fedora-35 \| <testhost> EXEC /bin/sh -c 'ANSIBLE_DEBUG_BOTOCORE_LOGS=True /home/zuul/venv/bin/python && sleep 0'
5396 | 2021-12-20 10:36:57.054748 \| fedora-35 \| fatal: [testhost]: FAILED! => {
5397 | 2021-12-20 10:36:57.054840 \| fedora-35 \|     "changed": true,
5398 | 2021-12-20 10:36:57.054850 \| fedora-35 \|     "cmd": [
5399 | 2021-12-20 10:36:57.054856 \| fedora-35 \|         "dd",
5400 | 2021-12-20 10:36:57.054862 \| fedora-35 \|         "if=/dev/zero",
5401 | 2021-12-20 10:36:57.054868 \| fedora-35 \|         "of=/tmp/ansible.6d71q1je/largefile",
5402 | 2021-12-20 10:36:57.054875 \| fedora-35 \|         "bs=1M",
5403 | 2021-12-20 10:36:57.054880 \| fedora-35 \|         "count=4096"
5404 | 2021-12-20 10:36:57.054886 \| fedora-35 \|     ],
5405 | 2021-12-20 10:36:57.054892 \| fedora-35 \|     "delta": "0:00:00.601860",
5406 | 2021-12-20 10:36:57.054897 \| fedora-35 \|     "end": "2021-12-20 10:36:57.021668",
5407 | 2021-12-20 10:36:57.054903 \| fedora-35 \|     "invocation": {
5408 | 2021-12-20 10:36:57.054909 \| fedora-35 \|         "module_args": {
5409 | 2021-12-20 10:36:57.054915 \| fedora-35 \|             "_raw_params": "dd if=/dev/zero of=/tmp/ansible.6d71q1je/largefile bs=1M count=4096",
5410 | 2021-12-20 10:36:57.054928 \| fedora-35 \|             "_uses_shell": false,
5411 | 2021-12-20 10:36:57.054935 \| fedora-35 \|             "argv": null,
5412 | 2021-12-20 10:36:57.054941 \| fedora-35 \|             "chdir": null,
5413 | 2021-12-20 10:36:57.054947 \| fedora-35 \|             "creates": null,
5414 | 2021-12-20 10:36:57.054953 \| fedora-35 \|             "executable": null,
5415 | 2021-12-20 10:36:57.054960 \| fedora-35 \|             "removes": null,
5416 | 2021-12-20 10:36:57.054966 \| fedora-35 \|             "stdin": null,
5417 | 2021-12-20 10:36:57.054972 \| fedora-35 \|             "stdin_add_newline": true,
5418 | 2021-12-20 10:36:57.054978 \| fedora-35 \|             "strip_empty_ends": true,
5419 | 2021-12-20 10:36:57.054984 \| fedora-35 \|             "warn": false
5420 | 2021-12-20 10:36:57.055001 \| fedora-35 \|         }
5421 | 2021-12-20 10:36:57.055007 \| fedora-35 \|     },
5422 | 2021-12-20 10:36:57.055012 \| fedora-35 \|     "msg": "non-zero return code",
5423 | 2021-12-20 10:36:57.055017 \| fedora-35 \|     "rc": 1,
5424 | 2021-12-20 10:36:57.055023 \| fedora-35 \|     "start": "2021-12-20 10:36:56.419808",
5425 | 2021-12-20 10:36:57.055030 \| fedora-35 \|     "stderr": "dd: error writing '/tmp/ansible.6d71q1je/largefile': No space left on device\n947+0 records in\n946+0 records out\n992100352 bytes (992 MB, 946 MiB) copied, 0.596905 s, 1.7 GB/s",
5426 | 2021-12-20 10:36:57.055037 \| fedora-35 \|     "stderr_lines": [
5427 | 2021-12-20 10:36:57.055043 \| fedora-35 \|         "dd: error writing '/tmp/ansible.6d71q1je/largefile': No space left on device",
5428 | 2021-12-20 10:36:57.055049 \| fedora-35 \|         "947+0 records in",
5429 | 2021-12-20 10:36:57.055054 \| fedora-35 \|         "946+0 records out",
5430 | 2021-12-20 10:36:57.055060 \| fedora-35 \|         "992100352 bytes (992 MB, 946 MiB) copied, 0.596905 s, 1.7 GB/s"
5431 | 2021-12-20 10:36:57.055066 \| fedora-35 \|     ],
5432 | 2021-12-20 10:36:57.055071 \| fedora-35 \|     "stdout": "",
5433 | 2021-12-20 10:36:57.055077 \| fedora-35 \|     "stdout_lines": []
5434 | 2021-12-20 10:36:57.055083 \| fedora-35 \| }
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_s3
