### PR TITLE
aws_s3: Add latest choice on overwrite parameter

### DIFF
--- a/changelogs/fragments/595-aws_s3-add-latest-choice-on-overwrite-parameter.yml
+++ b/changelogs/fragments/595-aws_s3-add-latest-choice-on-overwrite-parameter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- aws_s3 - add latest choice on overwrite parameter to get latest object on S3
+- aws_s3 - add latest choice on ``overwrite`` parameter to get latest object on S3 (https://github.com/ansible-collections/amazon.aws/pull/595).

--- a/changelogs/fragments/595-aws_s3-add-latest-choice-on-overwrite-parameter.yml
+++ b/changelogs/fragments/595-aws_s3-add-latest-choice-on-overwrite-parameter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- aws_s3 - add latest choice on overwrite parameter to get latest object on S3

--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -427,7 +427,7 @@ def get_s3_last_modified_timestamp(s3, bucket, obj, version=version):
     return s3_head_object['LastModified'].timestamp()
 
 
-def is_local_object_latest(module, s3, bucket, obj, version=None, local_file=None, content=None):
+def is_local_object_latest(module, s3, bucket, obj, version=None, local_file=None):
     s3_last_modified = get_s3_last_modified_timestamp(s3, bucket, obj, version)
     if os.path.exists(local_file) is False:
         return False

--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -423,8 +423,13 @@ def get_etag(s3, bucket, obj, version=None):
 
 
 def get_s3_last_modified_timestamp(s3, bucket, obj, version=None):
-    s3_head_object = s3.head_object(Bucket=bucket, Key=obj, VersionId=version)
-    return s3_head_object['LastModified'].timestamp()
+    if version:
+        key_check = s3.head_object(Bucket=bucket, Key=obj, VersionId=version)
+    else:
+        key_check = s3.head_object(Bucket=bucket, Key=obj)
+    if not key_check:
+        return None
+    return key_check['LastModified'].timestamp()
 
 
 def is_local_object_latest(module, s3, bucket, obj, version=None, local_file=None):

--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -1032,7 +1032,7 @@ def main():
                 module.exit_json(msg="Local object already exists and overwrite is disabled.", changed=False)
             if overwrite == 'different' and etag_compare(module, s3, bucket, obj, version=version, local_file=dest):
                 module.exit_json(msg="Local and remote object are identical, ignoring. Use overwrite=always parameter to force.", changed=False)
-            if overwrite == 'latest' and is_local_object_latest(module, s3, bucket, obj, version=version, lodal_file=dest):
+            if overwrite == 'latest' and is_local_object_latest(module, s3, bucket, obj, version=version, local_file=dest):
                 module.exit_json(msg="Local object is latest, ignoreing. Use overwrite=always parameter to force.", changed=False)
 
         try:

--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -108,7 +108,7 @@ options:
       - When this is set to C(different) the MD5 sum of the local file is compared with the 'ETag' of the object/key in S3.
         The ETag may or may not be an MD5 digest of the object data. See the ETag response header here
         U(https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html).
-      - (C(GET) mode only): When this is set to C(latest) the last modified timestamp of local file is compared with the 'LastModified' of the object/key in S3.
+      - (C(GET) mode only) When this is set to C(latest) the last modified timestamp of local file is compared with the 'LastModified' of the object/key in S3.
     default: 'always'
     aliases: ['force']
     type: str

--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -428,7 +428,7 @@ def get_s3_last_modified_timestamp(s3, bucket, obj, version=version):
 
 
 def is_local_object_latest(module, s3, bucket, obj, version=None, local_file=None, content=None):
-    s3_last_modified = get_s3_last_modified_timestamp(s3, bucket, obj, version=version)
+    s3_last_modified = get_s3_last_modified_timestamp(s3, bucket, obj, version)
     if os.path.exists(local_file) is False:
         return False
     else:

--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -422,7 +422,7 @@ def get_etag(s3, bucket, obj, version=None):
     return key_check['ETag']
 
 
-def get_s3_last_modified_timestamp(s3, bucket, obj, version=version):
+def get_s3_last_modified_timestamp(s3, bucket, obj, version=None):
     s3_head_object = s3.head_object(Bucket=bucket, Key=obj, VersionId=version)
     return s3_head_object['LastModified'].timestamp()
 

--- a/tests/integration/targets/aws_s3/tasks/main.yml
+++ b/tests/integration/targets/aws_s3/tasks/main.yml
@@ -273,6 +273,39 @@
         that:
           - result is changed
 
+    - name: test get with overwrite=latest and identical files
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: get
+        dest: "{{ tmpdir.path }}/download.txt"
+        object: delete.txt
+        overwrite: latest
+      retries: 3
+      delay: 3
+      register: result
+
+    - assert:
+        that:
+          - result is not changed
+
+    - name: modify mtime for local file to past
+      shell: touch -mt 197001010900.00 "{{ tmpdir.path }}/download.txt"
+
+    - name: test get with overwrite=latest and files that mtimes are different
+      aws_s3:
+        bucket: "{{ bucket_name }}"
+        mode: get
+        dest: "{{ tmpdir.path }}/download.txt"
+        object: delete.txt
+        overwrite: latest
+      retries: 3
+      delay: 3
+      register: result
+
+    - assert:
+        that:
+          - result is changed
+
     - name: test geturl of the object
       aws_s3:
         bucket: "{{ bucket_name }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds `latest` choice on `overwrite` parameter to get remote object only when it's the latest. If a local object is the latest, or local and remote objects have identical last-modified timestamps, overwriting is ignored.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`aws_s3`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Motivation: when using the `different` choice, getting a large sized object takes few minutes whether local and remote objects are identical or not because of MD5 calculation.

<!--- Paste verbatim command output below, e.g. before and after your change -->