### PR TITLE
ec2_vol: backport - set iops even if unchanged for boto req

### DIFF
--- a/changelogs/fragments/608-ec2_vol-set-iops-even-if-unchanged-for-boto-req.yml
+++ b/changelogs/fragments/608-ec2_vol-set-iops-even-if-unchanged-for-boto-req.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- >-
+  ec2_vol - Sets the Iops value in req_obj even if the iops value
+  has not changed, to allow modifying volume types that require
+  passing an iops value to boto. (https://github.com/ansible-collections/amazon.aws/pull/608)

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -373,6 +373,8 @@ def update_volume(module, ec2_conn, volume):
             if target_iops != original_iops:
                 iops_changed = True
                 req_obj['Iops'] = target_iops
+            else:
+                req_obj['Iops'] = original_iops
         else:
             # If no IOPS value is specified and there was a volume_type update to gp3,
             # the existing value is retained, unless a volume type is modified that supports different values,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Set the iops value in `req_obj` even if the target iops is the same as the existing. This is a required parameter for boto's modify_volume. Fixes #605 

Main PR is #606 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
ec2_vol
