### PR TITLE
ec2_vpc_endpoint: improve documentation to provide details about route_table_ids

### DIFF
--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -115,6 +115,7 @@ options:
       - List of one or more route table ids to attach to the endpoint. A route
         is added to the route table with the destination of the endpoint if
         provided.
+      - Route table ids are only valid for gateway type endpoints.
     required: false
     type: list
     elements: str

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -310,6 +310,9 @@ def create_vpc_endpoint(client, module):
     params['VpcEndpointType'] = module.params.get('vpc_endpoint_type')
     params['ServiceName'] = module.params.get('service')
 
+    if module.params.get('vpc_endpoint_type') != 'Gateway' and module.params.get('route_table_ids'):
+        module.fail_json(msg="Route table IDs are only supported for Gateway type VPC Endpoint.")
+
     if module.check_mode:
         changed = True
         result = 'Would have created VPC Endpoint if not in check mode'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Modify documentation to specify that while creating VPC endpoint using ```ec2_vpc_endpoint```, route table IDs are only valid for ```gateway``` type endpoints.
As specified in the API doc:
```
RouteTableIds (list) --
(Gateway endpoint) One or more route table IDs.
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #576 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vpc_endpoint
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
API Doc: https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.create_vpc_endpoint
<!--- Paste verbatim command output below, e.g. before and after your change -->
