### PR TITLE
Add the ability to disable the validate_bucket_name check

### DIFF
--- a/changelogs/fragments/615-s3-validate_bucket_name.yml
+++ b/changelogs/fragments/615-s3-validate_bucket_name.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - aws_s3 - Add `validate_bucket_name` option, to control bucket name validation.
+  - s3_bucket - Add `validate_bucket_name` option, to control bucket name validation.

--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -197,6 +197,14 @@ options:
         type: str
         description:
         - version ID of the source object.
+  validate_bucket_name:
+    description:
+      - Whether the bucket name should be validated to conform to AWS S3 naming rules.
+      - On by default, this may be disabled for S3 backends that do not enforce these rules.
+      - See https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+    type: bool
+    version_added: 3.1.0
+    default: True
 author:
     - "Lester Wade (@lwade)"
     - "Sloane Hertel (@s-hertel)"
@@ -928,6 +936,7 @@ def main():
         tags=dict(type='dict'),
         purge_tags=dict(type='bool', default=True),
         copy_src=dict(type='dict', options=dict(bucket=dict(required=True), object=dict(required=True), version_id=dict())),
+        validate_bucket_name=dict(type='bool', default=True),
     )
     module = AnsibleAWSModule(
         argument_spec=argument_spec,
@@ -965,7 +974,8 @@ def main():
     object_canned_acl = ["private", "public-read", "public-read-write", "aws-exec-read", "authenticated-read", "bucket-owner-read", "bucket-owner-full-control"]
     bucket_canned_acl = ["private", "public-read", "public-read-write", "authenticated-read"]
 
-    validate_bucket_name(module, bucket)
+    if module.params.get('validate_bucket_name'):
+        validate_bucket_name(module, bucket)
 
     if overwrite not in ['always', 'never', 'different', 'latest']:
         if module.boolean(overwrite):

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -147,6 +147,14 @@ options:
     choices: [ 'private', 'public-read', 'public-read-write', 'authenticated-read' ]
     type: str
     version_added: 3.1.0
+  validate_bucket_name:
+    description:
+      - Whether the bucket name should be validated to conform to AWS S3 naming rules.
+      - On by default, this may be disabled for S3 backends that do not enforce these rules.
+      - See https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+    type: bool
+    version_added: 3.1.0
+    default: True
 
 extends_documentation_fragment:
 - amazon.aws.aws
@@ -1011,6 +1019,7 @@ def main():
         object_ownership=dict(type='str', choices=['BucketOwnerPreferred', 'ObjectWriter']),
         delete_object_ownership=dict(type='bool', default=False),
         acl=dict(type='str', choices=['private', 'public-read', 'public-read-write', 'authenticated-read']),
+        validate_bucket_name=dict(type='bool', default=True),
     )
 
     required_by = dict(
@@ -1027,7 +1036,9 @@ def main():
     )
 
     region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
-    validate_bucket_name(module, module.params["name"])
+
+    if module.params.get('validate_bucket_name'):
+        validate_bucket_name(module, module.params["name"])
 
     if region in ('us-east-1', '', None):
         # default to US Standard region


### PR DESCRIPTION
The AWS bucket naming rules are not necessarily enforced on all S3 implementations. Where the rules are not enforced, the validation can now be disabled (it is still on by default).

Resolves #593.