### PR TITLE
ec2_key - support for ED25519 key type

### DIFF
--- a/changelogs/fragments/614-ec2_key-add-support-for-ed25519-key-type.yml
+++ b/changelogs/fragments/614-ec2_key-add-support-for-ed25519-key-type.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_key - add support for ED25519 key type (https://github.com/ansible-collections/amazon.aws/issues/572).

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -165,6 +165,7 @@ key:
       returned: when a new keypair is created by AWS
       type: str
       sample: rsa
+      version_added: 3.1.0
 '''
 
 import uuid

--- a/tests/integration/targets/ec2_key/meta/main.yml
+++ b/tests/integration/targets/ec2_key/meta/main.yml
@@ -2,3 +2,6 @@ dependencies:
   - prepare_tests
   - setup_sshkey
   - setup_ec2
+  - role: setup_botocore_pip
+    vars:
+      botocore_version: '1.21.23'

--- a/tests/integration/targets/ec2_key/tasks/main.yml
+++ b/tests/integration/targets/ec2_key/tasks/main.yml
@@ -388,6 +388,49 @@
            - '"key" in result'
            - 'result.key == None'
 
+    # ============================================================
+    - name: test create ED25519 key pair type with botocore <= 1.21.23
+      ec2_key:
+        name: '{{ ec2_key_name }}'
+        key_type: ed25519
+      ignore_errors: true
+      register: result
+
+    - name: assert that task failed
+      assert:
+        that:
+          - 'result.failed'
+          - '"Failed to import the required Python library (botocore>=1.21.23)" in result.msg'
+          - '"This is required to set the key_type for a keypair" in result.msg'
+
+    - name: test create ED25519 key pair type
+      ec2_key:
+        name: '{{ ec2_key_name }}'
+        key_type: ed25519
+      register: result
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+
+    - name: assert that task succeed
+      assert:
+        that:
+          - 'result.changed'
+          - 'result.key.type == "ed25519"'
+
+    - name: Update key pair type from ED25519 to RSA
+      ec2_key:
+        name: '{{ ec2_key_name }}'
+        key_type: rsa
+      register: result
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+
+    - name: assert that task succeed
+      assert:
+        that:
+          - 'result.changed'
+          - 'result.key.type == "rsa"'
+
   always:
 
     # ============================================================


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ec2_key - add support for ED25519 key type
This parameter requires ``botocore>=1.21.23``

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
``ec2_key``

