### PR TITLE
Fix on_denied and on_missing bugs

### DIFF
--- a/changelogs/fragments/617-aws_ssm-on_missing-and-on-denied-now-default-to-error.yml
+++ b/changelogs/fragments/617-aws_ssm-on_missing-and-on-denied-now-default-to-error.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- aws_ssm - on_denied and on_missing now both default to error, for consistency with both aws_secret and the base Lookup class (https://github.com/ansible-collections/amazon.aws/issues/617).

--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -24,13 +24,13 @@ description:
     parameters. Hierarchies start with a forward slash and end with the parameter name. Up to
     5 layers may be specified.
   - If looking up an explicitly listed parameter by name which does not exist then the lookup
-    will generate an error.  You can use the ```default``` filter to give a default value in
-    this case but must set the ```on_missing``` parameter to ```skip``` or ```warn```.  You must
+    will generate an error. You can use the ```default``` filter to give a default value in
+    this case but must set the ```on_missing``` parameter to ```skip``` or ```warn```. You must
     also set the second parameter of the ```default``` filter to ```true``` (see examples below).
   - When looking up a path for parameters under it a dictionary will be returned for each path.
     If there is no parameter under that path then the lookup will generate an error.
   - If the lookup fails due to lack of permissions or due to an AWS client error then the aws_ssm
-    will generate an error.  If you want to continue in this case then you will have to set up
+    will generate an error. If you want to continue in this case then you will have to set up
     two ansible tasks, one which sets a variable and ignores failures and one which uses the value
     of that variable with a default.  See the examples below.
 

--- a/tests/unit/plugins/lookup/test_aws_ssm.py
+++ b/tests/unit/plugins/lookup/test_aws_ssm.py
@@ -252,7 +252,7 @@ def test_skip_on_missing_variable(mocker):
     boto3_double.Session.return_value.client.return_value.get_parameter.side_effect = mock_get_parameter
 
     missing_credentials = copy(dummy_credentials)
-    missing_credentials['on_missing'] = "warn"
+    missing_credentials['on_missing'] = "skip"
     mocker.patch.object(boto3, 'session', boto3_double)
     retval = lookup.run(["missing_variable"], {}, **missing_credentials)
     assert(isinstance(retval, list))
@@ -313,7 +313,7 @@ def test_skip_on_denied_variable(mocker):
     boto3_double.Session.return_value.client.return_value.get_parameter.side_effect = mock_get_parameter
 
     denied_credentials = copy(dummy_credentials)
-    denied_credentials['on_denied'] = "warn"
+    denied_credentials['on_denied'] = "skip"
     mocker.patch.object(boto3, 'session', boto3_double)
     retval = lookup.run(["denied_variable"], {}, **denied_credentials)
     assert(isinstance(retval, list))


### PR DESCRIPTION
##### SUMMARY

This pull request:
- Changes the default value of `on_denied` to be `error`, so that it agrees with what is stated in the documentation.
- Changes the default value of `on_missing` to be `error`, and updates the documentation to explain this.

Fixes #617.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_ssm lookup
