### PR TITLE
Fix/support envvars for lookup aws ssm

### DIFF
--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -273,7 +273,7 @@ class LookupModule(LookupBase):
                 self._display.warning('Skipping, did not find SSM parameter path %s' % term)
 
         return paramlist
-    
+
     def fail_json(self, msg, **kwargs):
         raise AnsibleError(msg)
 

--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -146,6 +146,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_er
 
 display = Display()
 
+
 class LookupModule(LookupBase):
     def run(self, terms, variables=None, boto_profile=None, aws_profile=None,
             aws_secret_key=None, aws_access_key=None, aws_security_token=None, region=None,
@@ -181,40 +182,43 @@ class LookupModule(LookupBase):
         ssm_dict = {}
 
         self.params = variables
-        cli_region, cli_endpoint, cli_boto_params = get_aws_connection_info(self,boto3=True)
-        
+
+        cli_region, cli_endpoint, cli_boto_params = get_aws_connection_info(self, boto3=True)
+
         if region:
-          cli_region = region
-        
+            cli_region = region
+
         if endpoint:
-          cli_endpoint = endpoint
+            cli_endpoint = endpoint
 
         # For backward  compatibility
         if aws_access_key:
-          cli_boto_params.update({'aws_access_key_id': aws_access_key})
+            cli_boto_params.update({'aws_access_key_id': aws_access_key})
         if aws_secret_key:
-          cli_boto_params.update({'aws_secret_access_key': aws_secret_key})
+            cli_boto_params.update({'aws_secret_access_key': aws_secret_key})
         if aws_security_token:
-          cli_boto_params.update({'aws_session_token': aws_security_token})
+            cli_boto_params.update({'aws_session_token': aws_security_token})
         if boto_profile:
-          cli_boto_params.update({'profile_name': boto_profile})
+            cli_boto_params.update({'profile_name': boto_profile})
         if aws_profile:
-          cli_boto_params.update({'profile_name': aws_profile})
-        
+            cli_boto_params.update({'profile_name': aws_profile})
+
         cli_boto_params.update(dict(
-          conn_type='client', resource='ssm', region=cli_region, endpoint=cli_endpoint
+            conn_type='client',
+            resource='ssm',
+            region=cli_region,
+            endpoint=cli_endpoint,
         ))
 
         try:
-          client = boto3_conn(module=self,**cli_boto_params )
+            client = boto3_conn(module=self, **cli_boto_params)
         except (
-          botocore.exceptions.ProfileNotFound, 
-          botocore.exceptions.PartialCredentialsError,
-          botocore.exceptions.ClientError,
-          botocore.exceptions.ParamValidationError,
-          ):
-          display.vv("WWWWW")
-          raise AnsibleError("Insufficient credentials found.")
+            botocore.exceptions.ProfileNotFound,
+            botocore.exceptions.PartialCredentialsError,
+            botocore.exceptions.ClientError,
+            botocore.exceptions.ParamValidationError,
+        ):
+            raise AnsibleError("Insufficient credentials found.")
 
         ssm_dict['WithDecryption'] = decrypt
 

--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -204,7 +204,7 @@ class LookupModule(LookupBase):
         cli_boto_params.update(dict(
           conn_type='client', resource='ssm', region=cli_region, endpoint=cli_endpoint
         ))
-        
+
         try:
           client = boto3_conn(module=self,**cli_boto_params )
         except (

--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -70,6 +70,7 @@ options:
   endpoint:
     description: Use a custom endpoint when connecting to SSM service
     type: string
+    version_added: 3.4.0
 extends_documentation_fragment:
 - amazon.aws.aws_boto3
 '''

--- a/tests/unit/plugins/lookup/test_aws_ssm.py
+++ b/tests/unit/plugins/lookup/test_aws_ssm.py
@@ -121,15 +121,15 @@ def test_lookup_variable(mocker):
     assert(len(retval) == 1)
     assert(retval[0] == "simplevalue")
     boto3_client_double.assert_called_with(
-        'ssm', 
-        region_name='eu-west-1', 
+        'ssm',
+        region_name='eu-west-1',
         aws_access_key_id='notakey',
-        aws_secret_access_key="notasecret", 
+        aws_secret_access_key="notasecret",
         aws_session_token=None,
         endpoint_url=None,
         config=ANY,
         verify=None,
-        )
+    )
 
 
 def test_path_lookup_variable(mocker):
@@ -150,13 +150,13 @@ def test_path_lookup_variable(mocker):
     assert(retval[0]["/testpath/won"] == "simple_value_won")
     assert(retval[0]["/testpath/too"] == "simple_value_too")
     boto3_client_double.assert_called_with(
-        'ssm', 
-        region_name='eu-west-1', 
+        'ssm',
+        region_name='eu-west-1',
         aws_access_key_id='notakey',
-        aws_secret_access_key="notasecret", 
-        aws_session_token=None, 
+        aws_secret_access_key="notasecret",
+        aws_session_token=None,
         endpoint_url=None,
-        config=ANY, 
+        config=ANY,
         verify=None,
         )
     get_paginator_fn.assert_called_with('get_parameters_by_path')

--- a/tests/unit/plugins/lookup/test_aws_ssm.py
+++ b/tests/unit/plugins/lookup/test_aws_ssm.py
@@ -158,7 +158,7 @@ def test_path_lookup_variable(mocker):
         endpoint_url=None,
         config=ANY,
         verify=None,
-        )
+    )
     get_paginator_fn.assert_called_with('get_parameters_by_path')
     paginator.paginate.assert_called_with(Path="/testpath", Recursive=True, WithDecryption=True)
     paginator.paginate.return_value.build_full_result.assert_called_with()

--- a/tests/unit/plugins/lookup/test_aws_ssm.py
+++ b/tests/unit/plugins/lookup/test_aws_ssm.py
@@ -18,6 +18,7 @@
 
 # Make coding more python3-ish
 from __future__ import (absolute_import, division, print_function)
+from unittest.mock import ANY
 __metaclass__ = type
 
 import pytest
@@ -119,8 +120,16 @@ def test_lookup_variable(mocker):
     assert(isinstance(retval, list))
     assert(len(retval) == 1)
     assert(retval[0] == "simplevalue")
-    boto3_client_double.assert_called_with('ssm', 'eu-west-1', aws_access_key_id='notakey',
-                                           aws_secret_access_key="notasecret", aws_session_token=None)
+    boto3_client_double.assert_called_with(
+        'ssm', 
+        region_name='eu-west-1', 
+        aws_access_key_id='notakey',
+        aws_secret_access_key="notasecret", 
+        aws_session_token=None,
+        endpoint_url=None,
+        config=ANY,
+        verify=None,
+        )
 
 
 def test_path_lookup_variable(mocker):
@@ -140,8 +149,16 @@ def test_path_lookup_variable(mocker):
     retval = lookup.run(["/testpath"], {}, **args)
     assert(retval[0]["/testpath/won"] == "simple_value_won")
     assert(retval[0]["/testpath/too"] == "simple_value_too")
-    boto3_client_double.assert_called_with('ssm', 'eu-west-1', aws_access_key_id='notakey',
-                                           aws_secret_access_key="notasecret", aws_session_token=None)
+    boto3_client_double.assert_called_with(
+        'ssm', 
+        region_name='eu-west-1', 
+        aws_access_key_id='notakey',
+        aws_secret_access_key="notasecret", 
+        aws_session_token=None, 
+        endpoint_url=None,
+        config=ANY, 
+        verify=None,
+        )
     get_paginator_fn.assert_called_with('get_parameters_by_path')
     paginator.paginate.assert_called_with(Path="/testpath", Recursive=True, WithDecryption=True)
     paginator.paginate.return_value.build_full_result.assert_called_with()


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1424
##### SUMMARY

Working on support in `lookup` plugin `amazon.aws.aws_ssm` for `endpoint` parameters, as well of tradional environment variable for client configuration (`AWS_PROFILE`, `AWS_ACCESS_KEY_ID`, ...).

This should fixes #519 

Depends-On: https://github.com/ansible-collections/amazon.aws/pull/728

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`aws_ssm`

##### ADDITIONAL INFORMATION

It seems `LookupModule` cannot benefit from `AnsibleAWSModule` (it expect several methods/params, I am not familiar enough with Python and Ansible to sort it out) ; so this PR uses `boto3_conn` and `get_aws_connection_info` defined in `utils.ec2`.

This is a simple snippet how it can be used:
```yaml
- name: Load env
  collections:
  - amazon.aws
  gather_facts: no
  hosts: localhost
  connection: local
  vars:
    my_env: "{{ lookup('amazon.aws.aws_ssm', 'status', endpoint='http://localhost:4566') }}"
  tasks:
    - name: show the env
      debug:
        msg: "{{ my_env }}"

```

Command line test:
```bash
ANSIBLE_COLLECTIONS_PATHS=${ANSIBLE_HOME}/collections ansible-playbook test.yml
```

Output:
```
PLAY [Load env] *************************************************************************************************************************************************************************************************************************************************************

TASK [show the env] *********************************************************************************************************************************************************************************************************************************************************
ok: [localhost] => {
    "msg": "INIT"
}

PLAY RECAP ******************************************************************************************************************************************************************************************************************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=0    skipped=0    rescued=0    ignored=0   
```

Another test with envars:
```bash
AWS_ACCESS_KEY_ID='foo' AWS_ACCESS_SECRET_KEY='bar' AWS_URL='http://localhost:4566' ANSIBLE_COLLECTIONS_PATHS=${ANSIBLE_HOME}/collections ansible-playbook test.yml
```
where we remove the `endpoint` from `lookup`:
```yaml
- name: Load env
  collections:
  - amazon.aws
  gather_facts: no
  hosts: localhost
  connection: local
  vars:
    my_env: "{{ lookup('amazon.aws.aws_ssm', 'status') }}"
  tasks:
    - name: show the env
      debug:
        msg: "{{ my_env }}"
```


(provides same output)

