### PR TITLE
Add waiter config for rds_instance_available

### DIFF
--- a/changelogs/fragments/625-rds-waiters-update.yml
+++ b/changelogs/fragments/625-rds-waiters-update.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_utils/waiters Add db_instance_available RDS waiter config (https://github.com/ansible-collections/amazon.aws/pull/625).

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -146,6 +146,7 @@ def wait_for_instance_status(client, module, db_instance_id, waiter_name):
     waiter_expected_status = {
         'db_instance_deleted': 'deleted',
         'db_instance_stopped': 'stopped',
+        'db_instance_available': 'available',
     }
     expected_status = waiter_expected_status.get(waiter_name, 'available')
     if expected_status == 'available':
@@ -154,6 +155,7 @@ def wait_for_instance_status(client, module, db_instance_id, waiter_name):
         extra_retry_codes = []
     for attempt_to_wait in range(0, 10):
         try:
+            sleep(10) # This seems to help limit failures from the waiter itself
             wait(client, db_instance_id, waiter_name, extra_retry_codes)
             break
         except WaiterError as e:

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -155,8 +155,6 @@ def wait_for_instance_status(client, module, db_instance_id, waiter_name):
         extra_retry_codes = []
     for attempt_to_wait in range(0, 10):
         try:
-            # This seems to help limit failures from the waiter itself
-            sleep(10)
             wait(client, db_instance_id, waiter_name, extra_retry_codes)
             break
         except WaiterError as e:

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -155,7 +155,8 @@ def wait_for_instance_status(client, module, db_instance_id, waiter_name):
         extra_retry_codes = []
     for attempt_to_wait in range(0, 10):
         try:
-            sleep(10) # This seems to help limit failures from the waiter itself
+            # This seems to help limit failures from the waiter itself
+            sleep(10)
             wait(client, db_instance_id, waiter_name, extra_retry_codes)
             break
         except WaiterError as e:

--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -581,6 +581,24 @@ elb_data = {
 rds_data = {
     "version": 2,
     "waiters": {
+        "DBInstanceAvailable": {
+            "delay": 20,
+            "maxAttempts": 60,
+            "operation": "DescribeDBInstances",
+            "acceptors": [
+                {
+                    "state": "success",
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].DBInstanceStatus",
+                    "expected": "available"
+                },
+                {
+                    "state": "retry",
+                    "matcher": "error",
+                    "expected": "DBInstanceNotFoundFault"
+                }
+            ]
+        },
         "DBInstanceStopped": {
             "delay": 20,
             "maxAttempts": 60,
@@ -901,6 +919,12 @@ waiters_by_name = {
         elb_model('LoadBalancerDeleted'),
         core_waiter.NormalizedOperationMethod(
             elb.describe_load_balancers
+        )),
+    ('RDS', 'db_instance_available'): lambda rds: core_waiter.Waiter(
+        'db_instance_available',
+        rds_model('DBInstanceAvailable'),
+        core_waiter.NormalizedOperationMethod(
+            rds.describe_db_instances
         )),
     ('RDS', 'db_instance_stopped'): lambda rds: core_waiter.Waiter(
         'db_instance_stopped',

--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -582,8 +582,8 @@ rds_data = {
     "version": 2,
     "waiters": {
         "DBInstanceAvailable": {
-            "delay": 20,
-            "maxAttempts": 60,
+            "delay": 60,
+            "maxAttempts": 120,
             "operation": "DescribeDBInstances",
             "acceptors": [
                 {


### PR DESCRIPTION
##### SUMMARY
Currently rarely from time to time on RDS instance creation with `community.aws.rds_instance` I see the following error:
```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: botocore.exceptions.WaiterError: Waiter DBInstanceAvailable failed: Waiter encountered a terminal failure state
fatal: [vpc_security_groups]: FAILED! => {"boto3_version": "1.16.0", "botocore_version": "1.19.0", "changed": false, "msg": "Error while waiting for DB instance ansible-test-44f5e4d5a14a to be available: Waiter DBInstanceAvailable failed: Waiter encountered a terminal failure state", "resource_actions": ["rds:DescribeDBInstances", "rds:ListTagsForResource"]}
```

This can be re-produced intermittently by running the `community.aws.rds_instance` integration tests.

I think what is missing is the extra waiter configuration.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
waiters.py

##### ADDITIONAL INFORMATION
The `rds_instance` tests are slow and currently disabled but can be run with:
```
ansible-test integration --docker centos8 -v rds_instance --allow-disabled
```
