### PR TITLE
Disable broken integration test - lookup_aws_account_attribute

### DIFF
--- a/tests/integration/targets/lookup_aws_account_attribute/aliases
+++ b/tests/integration/targets/lookup_aws_account_attribute/aliases
@@ -1,1 +1,2 @@
+disabled
 cloud/aws


### PR DESCRIPTION
##### SUMMARY

After going through the joys of bisecting recent changes https://github.com/ansible/ansible/pull/75587 appears to have broken the test when running 'wantlist=False'

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

aws_account_attribute

##### ADDITIONAL INFORMATION

```
TASK [lookup_aws_account_attribute : Fetch all account attributes (wantlist=False)] *******************************************************************************************************************************
task path: /root/ansible_collections/amazon/aws/tests/output/.tmp/integration/lookup_aws_account_attribute-bjtiq49h-ÅÑŚÌβŁÈ/tests/integration/targets/lookup_aws_account_attribute/tasks/main.yaml:50
The full traceback is:
Traceback (most recent call last):
  File "/root/ansible/lib/ansible/executor/task_executor.py", line 503, in _execute
    self._task.post_validate(templar=templar)
  File "/root/ansible/lib/ansible/playbook/task.py", line 283, in post_validate
    super(Task, self).post_validate(templar)
  File "/root/ansible/lib/ansible/playbook/base.py", line 650, in post_validate
    value = templar.template(getattr(self, name))
  File "/root/ansible/lib/ansible/template/__init__.py", line 874, in template
    d[k] = self.template(
  File "/root/ansible/lib/ansible/template/__init__.py", line 842, in template
    result = self.do_template(
  File "/root/ansible/lib/ansible/template/__init__.py", line 1101, in do_template
    res = ansible_concat(rf, convert_data, myenv.variable_start_string)
  File "/root/ansible/lib/ansible/template/native_helpers.py", line 60, in ansible_concat
    head = list(islice(nodes, 2))
  File "<template>", line 13, in root
  File "/usr/lib/python3.10/dist-packages/jinja2/runtime.py", line 349, in call
    return __obj(*args, **kwargs)
  File "/root/ansible/lib/ansible/template/__init__.py", line 1013, in _lookup
    if isinstance(ran[0], NativeJinjaText):
KeyError: 0
fatal: [testhost]: FAILED! => {
    "changed": false
}
```