### PR TITLE
Improve doc to show support for IPv6 CIDR block

### DIFF
--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -74,7 +74,7 @@ options:
     elements: str
   tags:
     description: >
-      A dictionary of resource tags of the form: C({ tag1: value1, tag2: value2 }). Tags are
+      A dictionary of resource tags of the form: blockC({ tag1: value1, tag2: value2 }). Tags are
       used to uniquely identify route tables within a VPC when the route_table_id is not supplied.
     aliases: [ "resource_tags" ]
     type: dict

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -48,18 +48,13 @@ options:
     type: str
   routes:
     description:
-        - >
-          List of routes in the route table.
-        - >
-          Routes are specified as dicts containing the keys 'dest' and one of 'gateway_id',
-          'instance_id', 'network_interface_id', or 'vpc_peering_connection_id'.
-        - >
-          The value of 'dest' is used for the destination match. It may be a IPv4 CIDR block
+        - List of routes in the route table.
+        - Routes are specified as dicts containing the keys C(dest) and one of C(gateway_id),
+          C(instance_id), C(network_interface_id), or C(vpc_peering_connection_id).
+        - The value of C(dest) is used for the destination match. It may be a IPv4 CIDR block
           or a IPv6 CIDR block.
-        - >
-          If 'gateway_id' is specified, you can refer to the VPC's IGW by using the value 'igw'.
-        - >
-          Routes are required for present states.
+        - If I(gateway_id) is specified, you can refer to the VPC's IGW by using the value C(igw).
+        - Routes are required for present states.
     type: list
     elements: dict
   state:

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -74,7 +74,7 @@ options:
     elements: str
   tags:
     description: >
-      A dictionary of resource tags of the form: blockC({ tag1: value1, tag2: value2 }). Tags are
+      A dictionary of resource tags of the form: C({ tag1: value1, tag2: value2 }). Tags are
       used to uniquely identify route tables within a VPC when the route_table_id is not supplied.
     aliases: [ "resource_tags" ]
     type: dict

--- a/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -514,7 +514,7 @@
       lookup: id
       purge_tags: yes
       tags:
-        Name: Public routeroute_spec table
+        Name: Public route table
         Updated: new_tag
     check_mode: true
     register: check_mode_results


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

1. Improve doc to show IPv6 CIDR blocks are supported.
2. Add example with IPv6 CIDR block.
3. Add missing attribute to return values.
4. Remove duplicate assertions in integration tests.
5. Add tests for IPv6 subnets in integration tests.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vpc_route_table

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

1. While testing IPv6 in this module, I discovered the `ipsubnet` filter does not work if the prefix length has a fairly high value such as `/120`.
    1. I was running an integration test with a /120 subnet in this PR, but the `ipsubnet` call never returns and uses 100% CPU. I changed the value to a /64 subnet so this PR can pass.
    2. The `ipsubnet` issue needs to be fixed in ansible.netcommon and the netaddr package. I've created a unit test to reproduce the problem: https://github.com/ansible-collections/ansible.netcommon/pull/362
2. The integration tests in this PR depend on #631 for the VPC configuration.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
