### PR TITLE
ipv4, ipv6, ipsubnet have moved from ansible.netcommon to ansible.utils

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -8,7 +8,7 @@ mock
 pytest-xdist
 # We should avoid these two modules with py3
 pytest-mock
-# Needed for ansible.netcommon.ipaddr in tests
+# Needed for ansible.utils.ipaddr in tests
 netaddr
 # Sometimes needed where we don't have features we need in modules
 awscli

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -3,7 +3,7 @@ boto
 boto3
 botocore
 
-# netaddr is needed for ansible.netcommon.ipv6
+# netaddr is needed for ansible.utils.ipv6
 netaddr
 virtualenv
 # Sometimes needed where we don't have features we need in modules

--- a/tests/integration/targets/ec2_eni/tasks/main.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/main.yaml
@@ -7,7 +7,7 @@
       region: "{{ aws_region }}"
 
   collections:
-  - ansible.netcommon
+  - ansible.utils
   - community.aws
 
   block:

--- a/tests/integration/targets/ec2_eni/tasks/test_eni_basic_creation.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/test_eni_basic_creation.yaml
@@ -70,7 +70,7 @@
       - _interface_0.private_dns_name is string
       - _interface_0.private_dns_name.endswith("ec2.internal")
       - '"private_ip_address" in _interface_0'
-      - _interface_0.private_ip_address | ansible.netcommon.ipaddr
+      - _interface_0.private_ip_address | ansible.utils.ipaddr
       - _interface_0.private_ip_address == ip_1
       - '"private_ip_addresses" in _interface_0'
       - _interface_0.private_ip_addresses | length == 1
@@ -178,7 +178,7 @@
       - _interface_0.private_dns_name is string
       - _interface_0.private_dns_name.endswith("ec2.internal")
       - '"private_ip_address" in _interface_0'
-      - _interface_0.private_ip_address | ansible.netcommon.ipaddr
+      - _interface_0.private_ip_address | ansible.utils.ipaddr
       - _interface_0.private_ip_address == ip_5
       - '"private_ip_addresses" in _interface_0'
       - _interface_0.private_ip_addresses | length == 1

--- a/tests/integration/targets/ec2_vpc_net/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_net/tasks/main.yml
@@ -92,7 +92,7 @@
           - '"instance_tenancy" in result.vpc'
           - result.vpc.ipv6_cidr_block_association_set | length == 1
           - result.vpc.ipv6_cidr_block_association_set[0].association_id.startswith("vpc-cidr-assoc-")
-          - result.vpc.ipv6_cidr_block_association_set[0].ipv6_cidr_block | ansible.netcommon.ipv6
+          - result.vpc.ipv6_cidr_block_association_set[0].ipv6_cidr_block | ansible.utils.ipv6
           - result.vpc.ipv6_cidr_block_association_set[0].ipv6_cidr_block_state.state in ["associated", "associating"]
           - '"is_default" in result.vpc'
           - '"state" in result.vpc'
@@ -136,7 +136,7 @@
           - '"instance_tenancy" in result.vpc'
           - result.vpc.ipv6_cidr_block_association_set | length == 1
           - result.vpc.ipv6_cidr_block_association_set[0].association_id.startswith("vpc-cidr-assoc-")
-          - result.vpc.ipv6_cidr_block_association_set[0].ipv6_cidr_block | ansible.netcommon.ipv6
+          - result.vpc.ipv6_cidr_block_association_set[0].ipv6_cidr_block | ansible.utils.ipv6
           - result.vpc.ipv6_cidr_block_association_set[0].ipv6_cidr_block_state.state in ["associated", "associating"]
           - '"is_default" in result.vpc'
           - '"state" in result.vpc'

--- a/tests/integration/targets/lookup_aws_service_ip_ranges/tasks/main.yaml
+++ b/tests/integration/targets/lookup_aws_service_ip_ranges/tasks/main.yaml
@@ -20,12 +20,12 @@
       - want_list is iterable
       - want_list is not string
       - want_list | length > 1
-      - want_list[0] | ansible.netcommon.ipv4
+      - want_list[0] | ansible.utils.ipv4
       - want_ipv6_list is defined
       - want_ipv6_list is iterable
       - want_ipv6_list is not string
       - want_ipv6_list | length > 1
-      - want_ipv6_list[0] | ansible.netcommon.ipv6
+      - want_ipv6_list[0] | ansible.utils.ipv6
 
 
 - name: lookup range with service
@@ -40,12 +40,12 @@
       - s3_ips is iterable
       - s3_ips is not string
       - s3_ips | length > 1
-      - s3_ips[0] | ansible.netcommon.ipv4
+      - s3_ips[0] | ansible.utils.ipv4
       - s3_ipv6s is defined
       - s3_ipv6s is iterable
       - s3_ipv6s is not string
       - s3_ipv6s | length > 1
-      - s3_ipv6s[0] | ansible.netcommon.ipv6
+      - s3_ipv6s[0] | ansible.utils.ipv6
 
 - name: lookup range with a different service
   set_fact:
@@ -59,12 +59,12 @@
       - route53_ips is iterable
       - route53_ips is not string
       - route53_ips | length > 1
-      - route53_ips[0] | ansible.netcommon.ipv4
+      - route53_ips[0] | ansible.utils.ipv4
       - route53_ipv6s is defined
       - route53_ipv6s is iterable
       - route53_ipv6s is not string
       - route53_ipv6s | length > 1
-      - route53_ipv6s[0] | ansible.netcommon.ipv6
+      - route53_ipv6s[0] | ansible.utils.ipv6
 
 
 - name: assert that service IPV4s and IPV6s do not overlap
@@ -88,12 +88,12 @@
       - us_east_1_ips is iterable
       - us_east_1_ips is not string
       - us_east_1_ips | length > 1
-      - us_east_1_ips[0] | ansible.netcommon.ipv4
+      - us_east_1_ips[0] | ansible.utils.ipv4
       - us_east_1_ipv6s is defined
       - us_east_1_ipv6s is iterable
       - us_east_1_ipv6s is not string
       - us_east_1_ipv6s | length > 1
-      - us_east_1_ipv6s[0] | ansible.netcommon.ipv6
+      - us_east_1_ipv6s[0] | ansible.utils.ipv6
 
 - name: lookup range with a different region
   set_fact:
@@ -107,12 +107,12 @@
       - eu_central_1_ips is iterable
       - eu_central_1_ips is not string
       - eu_central_1_ips | length > 1
-      - eu_central_1_ips[0] | ansible.netcommon.ipv4
+      - eu_central_1_ips[0] | ansible.utils.ipv4
       - eu_central_1_ipv6s is defined
       - eu_central_1_ipv6s is iterable
       - eu_central_1_ipv6s is not string
       - eu_central_1_ipv6s | length > 1
-      - eu_central_1_ipv6s[0] | ansible.netcommon.ipv6
+      - eu_central_1_ipv6s[0] | ansible.utils.ipv6
 
 - name: assert that regional IPs don't overlap
   assert:
@@ -132,12 +132,12 @@
       - s3_us_ips is iterable
       - s3_us_ips is not string
       - s3_us_ips | length > 1
-      - s3_us_ips[0] | ansible.netcommon.ipv4
+      - s3_us_ips[0] | ansible.utils.ipv4
       - s3_us_ipv6s is defined
       - s3_us_ipv6s is iterable
       - s3_us_ipv6s is not string
       - s3_us_ipv6s | length > 1
-      - s3_us_ipv6s[0] | ansible.netcommon.ipv6
+      - s3_us_ipv6s[0] | ansible.utils.ipv6
 
 - name: assert that the regional service IPs are a subset of the regional IPs and service IPs.
   assert:

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,4 +1,4 @@
 integration_tests_dependencies:
 - ansible.windows
-- ansible.netcommon  # ipv6 filter
+- ansible.utils  # ipv6 filter
 unit_tests_dependencies: []


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This is a maintenance task to migrate from ansible.netcommon to ansible.utils. I was trying to fix an issue in that module, but I was told the functions have moved to ansible.utils. See https://github.com/ansible-collections/ansible.netcommon/pull/362#issuecomment-1020049600

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Existing integration tests that use the ansible.netcommon module. No module uses netcommon, only integration tests.

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
