### PR TITLE
Bump release to 4.0.0-dev0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: amazon
 name: aws
-version: 3.0.0
+version: 4.0.0-dev0
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)


### PR DESCRIPTION
##### SUMMARY

Discussed with @jillr on IRC about splitting main and stable sooner rather than later.  stable-3 branch now exists, as such we can start introducing the breaking changes slated for 4.0.0 rather than trying to push them in in the last few days before a release.

Having released amazon.aws 3.0.0 and branched stable-3, bump the release to 4.0.0-dev0

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

galaxy.yml

##### ADDITIONAL INFORMATION

