### PR TITLE
Handle ResourceNotFoundException while iterating certificates

### DIFF
--- a/changelogs/fragments/646-acm-resource-not-found.yml
+++ b/changelogs/fragments/646-acm-resource-not-found.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- >-
+  aws_acm - No longer raising ResourceNotFound exception while retrieving ACM certificates.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

The module/utils/acm.py was not correctly handling deletion of certificates. While iterating over a list of certificates, the `get_certificate` function was making API calls to obtain more information about the certificates, but some certificates may be deleted while iterating.

Fixes #622 

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
acm.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->

Wow, it seems many tests are very flaky. I'm attempting to fix an issue in ACM, but problems occur elsewhere. Not to mention I raised this PR to fix #622, which was discovered while working on https://github.com/ansible-collections/community.aws/pull/870. And I discovered other issues as well, and so it looks like it's not possible to make any progress without going down a tree of bug fixes.

```
TypeError: 'NoneType' object is not subscriptable
fatal: [testhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"<stdin>\", line 121, in <module>\n  File \"<stdin>\", line 113, in _ansiballz_main\n  File \"<stdin>\", line 61, in invoke_module\n  File \"/usr/lib64/python3.8/runpy.py\", line 207, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib64/python3.8/runpy.py\", line 97, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib64/python3.8/runpy.py\", line 87, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_ec2_vpc_igw_payload_g4o1kl_r/ansible_ec2_vpc_igw_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vpc_igw.py\", line 248, in <module>\n  File \"/tmp/ansible_ec2_vpc_igw_payload_g4o1kl_r/ansible_ec2_vpc_igw_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vpc_igw.py\", line 242, in main\n  File \"/tmp/ansible_ec2_vpc_igw_payload_g4o1kl_r/ansible_ec2_vpc_igw_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vpc_igw.py\", line 132, in process\n  File \"/tmp/ansible_ec2_vpc_igw_payload_g4o1kl_r/ansible_ec2_vpc_igw_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vpc_igw.py\", line 220, in ensure_igw_present\n  File \"/tmp/ansible_ec2_vpc_igw_payload_g4o1kl_r/ansible_ec2_vpc_igw_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vpc_igw.py\", line 158, in get_igw_info\nTypeError: 'NoneType' object is not subscriptable\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}
