### PR TITLE
Add EKS Fargate Profile waiters

### DIFF
--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -497,7 +497,7 @@ eks_data = {
                 {
                     "state": "retry",
                     "matcher": "error",
-                    "expected" : "ResourceNotFoundException"
+                    "expected": "ResourceNotFoundException"
                 }
             ]
         },
@@ -515,7 +515,7 @@ eks_data = {
                 {
                     "state": "success",
                     "matcher": "error",
-                    "expected" : "ResourceNotFoundException"
+                    "expected": "ResourceNotFoundException"
                 }
             ]
         }
@@ -910,16 +910,16 @@ waiters_by_name = {
             eks.describe_cluster
         )),
     ('EKS', 'fargate_profile_active'): lambda eks: core_waiter.Waiter(
-            'fargate_profile_active',
-            eks_model('FargateProfileActive'),
-            core_waiter.NormalizedOperationMethod(
-                eks.describe_fargate_profile
+        'fargate_profile_active',
+        eks_model('FargateProfileActive'),
+        core_waiter.NormalizedOperationMethod(
+            eks.describe_fargate_profile
         )),
     ('EKS', 'fargate_profile_deleted'): lambda eks: core_waiter.Waiter(
-            'fargate_profile_deleted',
-            eks_model('FargateProfileDeleted'),
-            core_waiter.NormalizedOperationMethod(
-                eks.describe_fargate_profile
+        'fargate_profile_deleted',
+        eks_model('FargateProfileDeleted'),
+        core_waiter.NormalizedOperationMethod(
+            eks.describe_fargate_profile
         )),
     ('ElasticLoadBalancing', 'any_instance_in_service'): lambda elb: core_waiter.Waiter(
         'any_instance_in_service',

--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -482,6 +482,42 @@ eks_data = {
                     "expected": "ResourceNotFoundException"
                 }
             ]
+        },
+        "FargateProfileActive": {
+            "delay": 20,
+            "maxAttempts": 30,
+            "operation": "DescribeFargateProfile",
+            "acceptors": [
+                {
+                    "state": "success",
+                    "matcher": "path",
+                    "argument": "fargateProfile.status",
+                    "expected": "ACTIVE"
+                },
+                {
+                    "state": "retry",
+                    "matcher": "error",
+                    "expected" : "ResourceNotFoundException"
+                }
+            ]
+        },
+        "FargateProfileDeleted": {
+            "delay": 20,
+            "maxAttempts": 30,
+            "operation": "DescribeFargateProfile",
+            "acceptors": [
+                {
+                    "state": "retry",
+                    "matcher": "path",
+                    "argument": "fargateProfile.status == 'DELETING'",
+                    "expected": True
+                },
+                {
+                    "state": "success",
+                    "matcher": "error",
+                    "expected" : "ResourceNotFoundException"
+                }
+            ]
         }
     }
 }
@@ -872,6 +908,18 @@ waiters_by_name = {
         eks_model('ClusterDeleted'),
         core_waiter.NormalizedOperationMethod(
             eks.describe_cluster
+        )),
+    ('EKS', 'fargate_profile_active'): lambda eks: core_waiter.Waiter(
+            'fargate_profile_active',
+            eks_model('FargateProfileActive'),
+            core_waiter.NormalizedOperationMethod(
+                eks.describe_fargate_profile
+        )),
+    ('EKS', 'fargate_profile_deleted'): lambda eks: core_waiter.Waiter(
+            'fargate_profile_deleted',
+            eks_model('FargateProfileDeleted'),
+            core_waiter.NormalizedOperationMethod(
+                eks.describe_fargate_profile
         )),
     ('ElasticLoadBalancing', 'any_instance_in_service'): lambda elb: core_waiter.Waiter(
         'any_instance_in_service',


### PR DESCRIPTION
##### SUMMARY

Add waiters for eks fargate profile to manage deleted and created states. 
A PR will be done in community.aws to add a new module to manage the eks_fargate_profile resource that uses these waiters.

New module PR: [ansible-collections/community.aws#942](https://github.com/ansible-collections/community.aws/pull/942)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

waiter.py
