### PR TITLE
Update ec2_instance.py

### DIFF
--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -451,10 +451,10 @@ EXAMPLES = '''
     image_id: ami-123456
     exact_count: 5
     region: us-east-2
+    vpc_subnet_id: subnet-0123456
     network:
       assign_public_ip: yes
       security_group: default
-      vpc_subnet_id: subnet-0123456
     tags:
       foo: bar
 


### PR DESCRIPTION


##### SUMMARY
vpc_subnet_id is not configurable under the network key, just tried a copy of the example and got this error->

```
TASK [manage_ec2_instances : Create EC2 instances for ansible node (control node)] **********************************************************************************************************
fatal: [localhost]: FAILED! => changed=false
  msg: No default subnet could be found - you must include a VPC subnet ID (vpc_subnet_id parameter) to create an instance
```

changing to match other examples

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
ec2_instance 

##### ADDITIONAL INFORMATION
n/a, only see one bad example here