### PR TITLE
Bring changelog changes of amazon.aws 3.1.0 from stable-3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,37 @@ community.aws Release Notes
 .. contents:: Topics
 
 
+v3.1.0
+======
+
+Minor Changes
+-------------
+
+- add new parameters hostvars_prefix and hostvars_suffix for inventory plugins aws_ec2 and aws_rds (https://github.com/ansible-collections/amazon.aws/issues/535).
+- aws_s3 - Add ``validate_bucket_name`` option, to control bucket name validation (https://github.com/ansible-collections/amazon.aws/pull/615).
+- aws_s3 - add latest choice on ``overwrite`` parameter to get latest object on S3 (https://github.com/ansible-collections/amazon.aws/pull/595).
+- ec2_vol - add support for OutpostArn param (https://github.com/ansible-collections/amazon.aws/pull/597).
+- ec2_vol - tag volume on creation (https://github.com/ansible-collections/amazon.aws/pull/603).
+- ec2_vpc_route_table - add support for IPv6 in creating route tables (https://github.com/ansible-collections/amazon.aws/pull/601).
+- s3_bucket - Add ``validate_bucket_name`` option, to control bucket name validation (https://github.com/ansible-collections/amazon.aws/pull/615).
+
+Deprecated Features
+-------------------
+
+- ec2_instance - The default value for ```instance_type``` has been deprecated, in the future release you must set an instance_type or a launch_template (https://github.com/ansible-collections/amazon.aws/pull/587).
+
+Bugfixes
+--------
+
+- Various modules and plugins - use vendored version of ``distutils.version`` instead of the deprecated Python standard library ``distutils`` (https://github.com/ansible-collections/amazon.aws/pull/599).
+- aws_acm - No longer raising ResourceNotFound exception while retrieving ACM certificates.
+- aws_s3 - fix exception raised when using module to copy from source to destination and key is missing from source (https://github.com/ansible-collections/amazon.aws/issues/602).
+- ec2_instance - Add a condition to handle default ```instance_type``` value for fix breaking on instance creation with launch template (https://github.com/ansible-collections/amazon.aws/pull/587).
+- ec2_key - add support for ED25519 key type (https://github.com/ansible-collections/amazon.aws/issues/572).
+- ec2_vol - Sets the Iops value in req_obj even if the iops value has not changed, to allow modifying volume types that require passing an iops value to boto. (https://github.com/ansible-collections/amazon.aws/pull/606)
+- elb_classic_lb - handle security_group_ids when providing security_group_names and fix broken tasks in integration test (https://github.com/ansible-collections/amazon.aws/pull/592).
+- s3_bucket - Enable the management of bucket-level ACLs (https://github.com/ansible-collections/amazon.aws/issues/573).
+
 v3.0.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -649,3 +649,52 @@ releases:
     - 575-deprecate-boto.yml
     - remove_deprecated_facts.yml
     release_date: '2021-12-06'
+  3.1.0:
+    changes:
+      bugfixes:
+      - Various modules and plugins - use vendored version of ``distutils.version``
+        instead of the deprecated Python standard library ``distutils`` (https://github.com/ansible-collections/amazon.aws/pull/599).
+      - aws_acm - No longer raising ResourceNotFound exception while retrieving ACM
+        certificates.
+      - aws_s3 - fix exception raised when using module to copy from source to destination
+        and key is missing from source (https://github.com/ansible-collections/amazon.aws/issues/602).
+      - ec2_instance - Add a condition to handle default ```instance_type``` value
+        for fix breaking on instance creation with launch template (https://github.com/ansible-collections/amazon.aws/pull/587).
+      - ec2_key - add support for ED25519 key type (https://github.com/ansible-collections/amazon.aws/issues/572).
+      - ec2_vol - Sets the Iops value in req_obj even if the iops value has not changed,
+        to allow modifying volume types that require passing an iops value to boto.
+        (https://github.com/ansible-collections/amazon.aws/pull/606)
+      - elb_classic_lb - handle security_group_ids when providing security_group_names
+        and fix broken tasks in integration test (https://github.com/ansible-collections/amazon.aws/pull/592).
+      - s3_bucket - Enable the management of bucket-level ACLs (https://github.com/ansible-collections/amazon.aws/issues/573).
+      deprecated_features:
+      - ec2_instance - The default value for ```instance_type``` has been deprecated,
+        in the future release you must set an instance_type or a launch_template (https://github.com/ansible-collections/amazon.aws/pull/587).
+      minor_changes:
+      - add new parameters hostvars_prefix and hostvars_suffix for inventory plugins
+        aws_ec2 and aws_rds (https://github.com/ansible-collections/amazon.aws/issues/535).
+      - aws_s3 - Add ``validate_bucket_name`` option, to control bucket name validation
+        (https://github.com/ansible-collections/amazon.aws/pull/615).
+      - aws_s3 - add latest choice on ``overwrite`` parameter to get latest object
+        on S3 (https://github.com/ansible-collections/amazon.aws/pull/595).
+      - ec2_vol - add support for OutpostArn param (https://github.com/ansible-collections/amazon.aws/pull/597).
+      - ec2_vol - tag volume on creation (https://github.com/ansible-collections/amazon.aws/pull/603).
+      - ec2_vpc_route_table - add support for IPv6 in creating route tables (https://github.com/ansible-collections/amazon.aws/pull/601).
+      - s3_bucket - Add ``validate_bucket_name`` option, to control bucket name validation
+        (https://github.com/ansible-collections/amazon.aws/pull/615).
+    fragments:
+    - 587-ec2_instance-default-instance-type-launch-template.yml
+    - 592-elb_classic_lb-handle-sg-ids-fix-tests.yml
+    - 593-aws_s3-fix-copy-when-missing-key.yml
+    - 595-aws_s3-add-latest-choice-on-overwrite-parameter.yml
+    - 597-ec2_vol-add-outpostarn-support.yml
+    - 601-ec2_vpc_route_table-ipv6-support.yml
+    - 603-ec2_vol-add-tags-on-creation.yml
+    - 606-ec2_vol-set-iops-even-if-unchanged-for-boto-req.yml
+    - 611-s3_bucket-add-support-for-acl.yml
+    - 614-ec2_key-add-support-for-ed25519-key-type.yml
+    - 615-s3-validate_bucket_name.yml
+    - 619-aws_ec2-aws_rds-add-support-for-hostvars_prefix-and-hostvars_suffix.yml
+    - 646-acm-resource-not-found.yml
+    - disutils.version.yml
+    release_date: '2022-02-10'

--- a/changelogs/fragments/592-elb_classic_lb-handle-sg-ids-fix-tests.yml
+++ b/changelogs/fragments/592-elb_classic_lb-handle-sg-ids-fix-tests.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- elb_classic_lb - handle security_group_ids when providing security_group_names and fix broken tasks in integration test (https://github.com/ansible-collections/amazon.aws/pull/592).

--- a/changelogs/fragments/593-aws_s3-fix-copy-when-missing-key.yml
+++ b/changelogs/fragments/593-aws_s3-fix-copy-when-missing-key.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- aws_s3 - fix exception raised when using module to copy from source to destination and key is missing from source (https://github.com/ansible-collections/amazon.aws/issues/602).

--- a/changelogs/fragments/595-aws_s3-add-latest-choice-on-overwrite-parameter.yml
+++ b/changelogs/fragments/595-aws_s3-add-latest-choice-on-overwrite-parameter.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- aws_s3 - add latest choice on ``overwrite`` parameter to get latest object on S3 (https://github.com/ansible-collections/amazon.aws/pull/595).

--- a/changelogs/fragments/597-ec2_vol-add-outpostarn-support.yml
+++ b/changelogs/fragments/597-ec2_vol-add-outpostarn-support.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - ec2_vol - add support for OutpostArn param (https://github.com/ansible-collections/amazon.aws/pull/597).

--- a/changelogs/fragments/601-ec2_vpc_route_table-ipv6-support.yml
+++ b/changelogs/fragments/601-ec2_vpc_route_table-ipv6-support.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- ec2_vpc_route_table - add support for IPv6 in creating route tables (https://github.com/ansible-collections/amazon.aws/pull/601).

--- a/changelogs/fragments/603-ec2_vol-add-tags-on-creation.yml
+++ b/changelogs/fragments/603-ec2_vol-add-tags-on-creation.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - ec2_vol - tag volume on creation (https://github.com/ansible-collections/amazon.aws/pull/603).

--- a/changelogs/fragments/606-ec2_vol-set-iops-even-if-unchanged-for-boto-req.yml
+++ b/changelogs/fragments/606-ec2_vol-set-iops-even-if-unchanged-for-boto-req.yml
@@ -1,5 +1,0 @@
-bugfixes:
-- >-
-  ec2_vol - Sets the Iops value in req_obj even if the iops value
-  has not changed, to allow modifying volume types that require
-  passing an iops value to boto. (https://github.com/ansible-collections/amazon.aws/pull/606)

--- a/changelogs/fragments/611-s3_bucket-add-support-for-acl.yml
+++ b/changelogs/fragments/611-s3_bucket-add-support-for-acl.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- s3_bucket - Enable the management of bucket-level ACLs (https://github.com/ansible-collections/amazon.aws/issues/573).

--- a/changelogs/fragments/614-ec2_key-add-support-for-ed25519-key-type.yml
+++ b/changelogs/fragments/614-ec2_key-add-support-for-ed25519-key-type.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- ec2_key - add support for ED25519 key type (https://github.com/ansible-collections/amazon.aws/issues/572).

--- a/changelogs/fragments/619-aws_ec2-aws_rds-add-support-for-hostvars_prefix-and-hostvars_suffix.yml
+++ b/changelogs/fragments/619-aws_ec2-aws_rds-add-support-for-hostvars_prefix-and-hostvars_suffix.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- add new parameters hostvars_prefix and hostvars_suffix for inventory plugins aws_ec2 and aws_rds (https://github.com/ansible-collections/amazon.aws/issues/535).

--- a/changelogs/fragments/646-acm-resource-not-found.yml
+++ b/changelogs/fragments/646-acm-resource-not-found.yml
@@ -1,3 +1,0 @@
-bugfixes:
-- >-
-  aws_acm - No longer raising ResourceNotFound exception while retrieving ACM certificates.

--- a/changelogs/fragments/disutils.version.yml
+++ b/changelogs/fragments/disutils.version.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - "Various modules and plugins - use vendored version of ``distutils.version`` instead of the deprecated Python standard library ``distutils`` (https://github.com/ansible-collections/amazon.aws/pull/599)."

--- a/docs/amazon.aws.aws_az_info_module.rst
+++ b/docs/amazon.aws.aws_az_info_module.rst
@@ -27,8 +27,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.aws_caller_info_module.rst
+++ b/docs/amazon.aws.aws_caller_info_module.rst
@@ -27,8 +27,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.aws_ec2_inventory.rst
+++ b/docs/amazon.aws.aws_ec2_inventory.rst
@@ -17,7 +17,7 @@ amazon.aws.aws_ec2
 Synopsis
 --------
 - Get inventory hosts from Amazon Web Services EC2.
-- Uses a YAML configuration file that ends with ``aws_ec2.(yml|yaml``).
+- Uses a YAML configuration file that ends with ``aws_ec2.{yml|yaml}``.
 
 
 
@@ -337,6 +337,42 @@ Parameters
                         <div>A list in order of precedence for hostname variables.</div>
                         <div>You can use the options specified in <a href='http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options'>http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options</a>.</div>
                         <div>To use tags as hostnames use the syntax tag:Name=Value to use the hostname Name_Value, or tag:Name to use the value of the Name tag.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostvars_prefix</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                    </td>
+                <td>
+                        <div>The prefix for host variables names coming from AWS.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostvars_suffix</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                    </td>
+                <td>
+                        <div>The suffix for host variables names coming from AWS.</div>
                 </td>
             </tr>
             <tr>
@@ -716,6 +752,12 @@ Examples
       ansible_host: public_dns_name
     groups:
       libvpc: vpc_id == 'vpc-####'
+    # Define prefix and suffix for host variables coming from AWS.
+    plugin: aws_ec2
+    regions:
+      - us-east-1
+    hostvars_prefix: 'aws_'
+    hostvars_suffix: '_ec2'
 
 
 

--- a/docs/amazon.aws.aws_rds_inventory.rst
+++ b/docs/amazon.aws.aws_rds_inventory.rst
@@ -300,6 +300,42 @@ Parameters
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostvars_prefix</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                    </td>
+                <td>
+                        <div>The prefix for host variables names coming from AWS.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>hostvars_suffix</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>
+                </td>
+                    <td>
+                    </td>
+                <td>
+                        <div>The suffix for host variables names coming from AWS.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>iam_role_arn</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -504,6 +540,8 @@ Examples
         prefix: rds
       - key: tags
       - key: region
+    hostvars_prefix: aws_
+    hostvars_suffix: _rds
 
 
 

--- a/docs/amazon.aws.aws_s3_module.rst
+++ b/docs/amazon.aws.aws_s3_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters
@@ -515,10 +515,11 @@ Parameters
                 </td>
                 <td>
                         <div>Force overwrite either locally on the filesystem or remotely with the object/key. Used with <code>PUT</code> and <code>GET</code> operations.</div>
-                        <div>Must be a Boolean, <code>always</code>, <code>never</code> or <code>different</code>.</div>
+                        <div>Must be a Boolean, <code>always</code>, <code>never</code>, <code>different</code> or <code>latest</code>.</div>
                         <div><code>true</code> is the same as <code>always</code>.</div>
                         <div><code>false</code> is equal to <code>never</code>.</div>
                         <div>When this is set to <code>different</code> the MD5 sum of the local file is compared with the &#x27;ETag&#x27; of the object/key in S3. The ETag may or may not be an MD5 digest of the object data. See the ETag response header here <a href='https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html'>https://docs.aws.amazon.com/AmazonS3/latest/API/RESTCommonResponseHeaders.html</a>.</div>
+                        <div>(<code>GET</code> mode only) When this is set to <code>latest</code> the last modified timestamp of local file is compared with the &#x27;LastModified&#x27; of the object/key in S3.</div>
                         <div style="font-size: small; color: darkgreen"><br/>aliases: force</div>
                 </td>
             </tr>
@@ -709,6 +710,28 @@ Parameters
                 </td>
                 <td>
                         <div>Tags dict to apply to the S3 object.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_bucket_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Whether the bucket name should be validated to conform to AWS S3 naming rules.</div>
+                        <div>On by default, this may be disabled for S3 backends that do not enforce these rules.</div>
+                        <div>See https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html</div>
                 </td>
             </tr>
             <tr>

--- a/docs/amazon.aws.cloudformation_info_module.rst
+++ b/docs/amazon.aws.cloudformation_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.cloudformation_module.rst
+++ b/docs/amazon.aws.cloudformation_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_ami_info_module.rst
+++ b/docs/amazon.aws.ec2_ami_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_ami_module.rst
+++ b/docs/amazon.aws.ec2_ami_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_eni_info_module.rst
+++ b/docs/amazon.aws.ec2_eni_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_eni_module.rst
+++ b/docs/amazon.aws.ec2_eni_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_group_info_module.rst
+++ b/docs/amazon.aws.ec2_group_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_group_module.rst
+++ b/docs/amazon.aws.ec2_group_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_instance_info_module.rst
+++ b/docs/amazon.aws.ec2_instance_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_instance_module.rst
+++ b/docs/amazon.aws.ec2_instance_module.rst
@@ -28,8 +28,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters
@@ -472,10 +472,10 @@ Parameters
                     </div>
                 </td>
                 <td>
-                        <b>Default:</b><br/><div style="color: blue">"t2.micro"</div>
                 </td>
                 <td>
                         <div>Instance type to use for the instance, see <a href='https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html'>https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html</a> Only required when instance is not already present.</div>
+                        <div>If not specified, t2.micro will be used.</div>
                 </td>
             </tr>
             <tr>
@@ -1353,10 +1353,10 @@ Examples
         image_id: ami-123456
         exact_count: 5
         region: us-east-2
+        vpc_subnet_id: subnet-0123456
         network:
           assign_public_ip: yes
           security_group: default
-          vpc_subnet_id: subnet-0123456
         tags:
           foo: bar
 

--- a/docs/amazon.aws.ec2_key_module.rst
+++ b/docs/amazon.aws.ec2_key_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters
@@ -178,6 +178,30 @@ Parameters
                 </td>
                 <td>
                         <div>Public key material.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>key_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>rsa</li>
+                                    <li>ed25519</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The type of key pair to create.</div>
+                        <div>Note that ED25519 keys are not supported for Windows instances, EC2 Instance Connect, and EC2 Serial Console.</div>
+                        <div>By default Amazon will create an RSA key.</div>
+                        <div>Mutually exclusive with parameter <em>key_material</em>.</div>
+                        <div>Requires at least botocore version 1.21.23.</div>
                 </td>
             </tr>
             <tr>
@@ -391,6 +415,11 @@ Examples
         name: my_keypair
         key_material: "{{ lookup('file', '/path/to/public_key/id_rsa.pub') }}"
 
+    - name: Create ED25519 key pair
+      amazon.aws.ec2_key:
+        name: my_keypair
+        key_type: ed25519
+
     # try creating a key pair with the name of an already existing keypair
     # but don't overwrite it even if the key is different (force=false)
     - name: try creating a key pair with name of an already existing keypair
@@ -538,6 +567,25 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
                     <br/>
                         <div style="font-size: smaller"><b>Sample:</b></div>
                         <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">{&quot;my_key&quot;: &quot;my value&quot;}</div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder">&nbsp;</td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>type</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>when a new keypair is created by AWS</td>
+                <td>
+                            <div>type of a newly created keypair</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">rsa</div>
                 </td>
             </tr>
 

--- a/docs/amazon.aws.ec2_module.rst
+++ b/docs/amazon.aws.ec2_module.rst
@@ -35,8 +35,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - boto
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 - python >= 2.6
 - python >= 3.6
 

--- a/docs/amazon.aws.ec2_snapshot_info_module.rst
+++ b/docs/amazon.aws.ec2_snapshot_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_snapshot_module.rst
+++ b/docs/amazon.aws.ec2_snapshot_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_spot_instance_info_module.rst
+++ b/docs/amazon.aws.ec2_spot_instance_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_spot_instance_module.rst
+++ b/docs/amazon.aws.ec2_spot_instance_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_tag_info_module.rst
+++ b/docs/amazon.aws.ec2_tag_info_module.rst
@@ -28,8 +28,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_tag_module.rst
+++ b/docs/amazon.aws.ec2_tag_module.rst
@@ -28,8 +28,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vol_info_module.rst
+++ b/docs/amazon.aws.ec2_vol_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vol_module.rst
+++ b/docs/amazon.aws.ec2_vol_module.rst
@@ -27,8 +27,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters
@@ -315,6 +315,23 @@ Parameters
                 </td>
                 <td>
                         <div>Volume Name tag if you wish to attach an existing volume (requires instance)</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>outpost_arn</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>The Amazon Resource Name (ARN) of the Outpost.</div>
+                        <div>If set, allows to create volume in an Outpost.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/amazon.aws.ec2_vpc_dhcp_option_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_dhcp_option_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_dhcp_option_module.rst
+++ b/docs/amazon.aws.ec2_vpc_dhcp_option_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_endpoint_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_endpoint_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_endpoint_module.rst
+++ b/docs/amazon.aws.ec2_vpc_endpoint_module.rst
@@ -28,8 +28,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters
@@ -264,6 +264,7 @@ Parameters
                 </td>
                 <td>
                         <div>List of one or more route table ids to attach to the endpoint. A route is added to the route table with the destination of the endpoint if provided.</div>
+                        <div>Route table ids are only valid for gateway type endpoints.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/amazon.aws.ec2_vpc_endpoint_service_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_endpoint_service_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_igw_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_igw_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_igw_module.rst
+++ b/docs/amazon.aws.ec2_vpc_igw_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_nat_gateway_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_nat_gateway_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_nat_gateway_module.rst
+++ b/docs/amazon.aws.ec2_vpc_nat_gateway_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_net_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_net_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_net_module.rst
+++ b/docs/amazon.aws.ec2_vpc_net_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_route_table_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_route_table_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_route_table_module.rst
+++ b/docs/amazon.aws.ec2_vpc_route_table_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_subnet_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_subnet_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_subnet_module.rst
+++ b/docs/amazon.aws.ec2_vpc_subnet_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.elb_classic_lb_module.rst
+++ b/docs/amazon.aws.elb_classic_lb_module.rst
@@ -27,8 +27,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters

--- a/docs/amazon.aws.s3_bucket_module.rst
+++ b/docs/amazon.aws.s3_bucket_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.15.0
-- botocore >= 1.18.0
+- boto3 >= 1.16.0
+- botocore >= 1.19.0
 
 
 Parameters
@@ -41,6 +41,29 @@ Parameters
             <th>Choices/<font color="blue">Defaults</font></th>
             <th width="100%">Comments</th>
         </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>acl</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">string</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>private</li>
+                                    <li>public-read</li>
+                                    <li>public-read-write</li>
+                                    <li>authenticated-read</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>The canned ACL to apply to the bucket.</div>
+                        <div>If your bucket uses the bucket owner enforced setting for S3 Object Ownership, ACLs are disabled and no longer affect permissions.</div>
+                </td>
+            </tr>
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
@@ -557,6 +580,28 @@ Parameters
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>validate_bucket_name</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 3.1.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Whether the bucket name should be validated to conform to AWS S3 naming rules.</div>
+                        <div>On by default, this may be disabled for S3 backends that do not enforce these rules.</div>
+                        <div>See https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>validate_certs</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -701,6 +746,12 @@ Examples
         state: present
         policy: "null"
 
+    # This example grants public-read to everyone on bucket using ACL
+    - amazon.aws.s3_bucket:
+        name: mys3bucket
+        state: present
+        acl: public-read
+
 
 
 Return Values
@@ -715,6 +766,23 @@ Common return values are documented `here <https://docs.ansible.com/ansible/late
             <th>Returned</th>
             <th width="100%">Description</th>
         </tr>
+            <tr>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="return-"></div>
+                    <b>acl</b>
+                    <a class="ansibleOptionLink" href="#return-" title="Permalink to this return value"></a>
+                    <div style="font-size: small">
+                      <span style="color: purple">dictionary</span>
+                    </div>
+                </td>
+                <td><em>state=present</em></td>
+                <td>
+                            <div>S3 bucket&#x27;s canned ACL.</div>
+                    <br/>
+                        <div style="font-size: smaller"><b>Sample:</b></div>
+                        <div style="font-size: smaller; color: blue; word-wrap: break-word; word-break: break-all;">public-read</div>
+                </td>
+            </tr>
             <tr>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="return-"></div>


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Since the prep PR has been merged https://github.com/ansible-collections/amazon.aws/pull/664, let's bring changelog changes of amazon.aws 3.1.0 from stable-3.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

