### PR TITLE
ec2_vpc_igw: fix 'NoneType' object is not subscriptable

### DIFF
--- a/plugins/modules/ec2_vpc_igw.py
+++ b/plugins/modules/ec2_vpc_igw.py
@@ -217,7 +217,8 @@ class AnsibleEc2Igw():
             self._connection, self._module, igw['internet_gateway_id'],
             resource_type='internet-gateway', tags=tags, purge_tags=purge_tags
         )
-        igw_info = self.get_igw_info(self.get_matching_igw(vpc_id), vpc_id)
+        igw = self.get_matching_igw(vpc_id)
+        igw_info = self.get_igw_info(igw, vpc_id)
         self._results.update(igw_info)
 
         return self._results


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ec2_vpc_igw: fix 'NoneType' object is not subscriptable

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vpc_igw

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
