### PR TITLE
DNM Ensure the correct dhcp_option is deleted

### DIFF
--- a/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml
@@ -314,7 +314,7 @@
 
   - name: delete it for the next test
     ec2_vpc_dhcp_option:
-      dhcp_options_id: "{{ new_dhcp_options_id }}"
+      dhcp_options_id: "{{ original_dhcp_options_id }}"
       state: absent
 
   # Create a DHCP option set that inherits from the default set overwrites a default and deletes the old set
@@ -946,3 +946,4 @@
       name: "{{ resource_prefix }}"
       cidr_block: "{{ vpc_cidr }}"
       state: absent
+    


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ec2_vpc_dhcp_option: Ensure the correct dhcp_option is deleted
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vpc_dhcp_option

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below


22:31:37.641494 \| controller \| TASK [ec2_vpc_dhcp_option : verify the original set was deleted] ***************
--
10887 | 2022-01-31 22:31:37.641604 \| controller \| task path: /home/zuul/.ansible/collections/ansible_collections/amazon/aws/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml:388
10888 | 2022-01-31 22:31:37.662668 \| controller \| Using module file /home/zuul/.ansible/collections/ansible_collections/amazon/aws/plugins/modules/ec2_vpc_dhcp_option_info.py
10889 | 2022-01-31 22:31:37.663003 \| controller \| Pipelining is enabled.
10890 | 2022-01-31 22:31:37.663179 \| controller \| <testhost> ESTABLISH LOCAL CONNECTION FOR USER: zuul
10891 | 2022-01-31 22:31:37.663298 \| controller \| <testhost> EXEC /bin/sh -c 'ANSIBLE_DEBUG_BOTOCORE_LOGS=True /home/zuul/venv/bin/python && sleep 0'
10892 | 2022-01-31 22:31:38.422950 \| controller \| ok: [testhost] => {
10893 | 2022-01-31 22:31:38.422981 \| controller \|     "changed": false,
10894 | 2022-01-31 22:31:38.422985 \| controller \|     "dhcp_config": [
10895 | 2022-01-31 22:31:38.422988 \| controller \|         {
10896 | 2022-01-31 22:31:38.422991 \| controller \|             "domain-name": [
10897 | 2022-01-31 22:31:38.422994 \| controller \|                 "ec2.internal"
10898 | 2022-01-31 22:31:38.422998 \| controller \|             ],
10899 | 2022-01-31 22:31:38.423001 \| controller \|             "domain-name-servers": [
10900 | 2022-01-31 22:31:38.423004 \| controller \|                 "AmazonProvidedDNS"
10901 | 2022-01-31 22:31:38.423007 \| controller \|             ]
10902 | 2022-01-31 22:31:38.423010 \| controller \|         }
10903 | 2022-01-31 22:31:38.423013 \| controller \|     ],
10904 | 2022-01-31 22:31:38.423016 \| controller \|     "dhcp_options": [
10905 | 2022-01-31 22:31:38.423019 \| controller \|         {
10906 | 2022-01-31 22:31:38.423022 \| controller \|             "dhcp_configurations": [
10907 | 2022-01-31 22:31:38.423025 \| controller \|                 {
10908 | 2022-01-31 22:31:38.423028 \| controller \|                     "key": "domain-name",
10909 | 2022-01-31 22:31:38.423031 \| controller \|                     "values": [
10910 | 2022-01-31 22:31:38.423034 \| controller \|                         {
10911 | 2022-01-31 22:31:38.423037 \| controller \|                             "value": "ec2.internal"
10912 | 2022-01-31 22:31:38.423040 \| controller \|                         }
10913 | 2022-01-31 22:31:38.423043 \| controller \|                     ]
10914 | 2022-01-31 22:31:38.423046 \| controller \|                 },
10915 | 2022-01-31 22:31:38.423048 \| controller \|                 {
10916 | 2022-01-31 22:31:38.423051 \| controller \|                     "key": "domain-name-servers",
10917 | 2022-01-31 22:31:38.423054 \| controller \|                     "values": [
10918 | 2022-01-31 22:31:38.423057 \| controller \|                         {
10919 | 2022-01-31 22:31:38.423060 \| controller \|                             "value": "AmazonProvidedDNS"
10920 | 2022-01-31 22:31:38.423063 \| controller \|                         }
10921 | 2022-01-31 22:31:38.423066 \| controller \|                     ]
10922 | 2022-01-31 22:31:38.423069 \| controller \|                 }
10923 | 2022-01-31 22:31:38.423072 \| controller \|             ],
10924 | 2022-01-31 22:31:38.423075 \| controller \|             "dhcp_options_id": "dopt-04dc907510266ba59",
10925 | 2022-01-31 22:31:38.423078 \| controller \|             "tags": {
10926 | 2022-01-31 22:31:38.423081 \| controller \|                 "Name": "ansible-test-40315108-node-0002039155"
10927 | 2022-01-31 22:31:38.423084 \| controller \|             }
10928 | 2022-01-31 22:31:38.423087 \| controller \|         }
10929 | 2022-01-31 22:31:38.423090 \| controller \|     ],
10930 | 2022-01-31 22:31:38.423092 \| controller \|     "invocation": {
10931 | 2022-01-31 22:31:38.423095 \| controller \|         "module_args": {
10932 | 2022-01-31 22:31:38.423098 \| controller \|             "aws_access_key": "ASIA6CCDWXDOP6KB4SCY",
10933 | 2022-01-31 22:31:38.423101 \| controller \|             "aws_ca_bundle": null,
10934 | 2022-01-31 22:31:38.423104 \| controller \|             "aws_config": null,
10935 | 2022-01-31 22:31:38.423112 \| controller \|             "aws_secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
10936 | 2022-01-31 22:31:38.423115 \| controller \|             "debug_botocore_endpoint_logs": true,
10937 | 2022-01-31 22:31:38.423118 \| controller \|             "dhcp_options_ids": [
10938 | 2022-01-31 22:31:38.423121 \| controller \|                 "dopt-04dc907510266ba59"
10939 | 2022-01-31 22:31:38.423124 \| controller \|             ],
10940 | 2022-01-31 22:31:38.423127 \| controller \|             "dry_run": false,
10941 | 2022-01-31 22:31:38.423130 \| controller \|             "ec2_url": null,
10942 | 2022-01-31 22:31:38.423133 \| controller \|             "filters": {},
10943 | 2022-01-31 22:31:38.423136 \| controller \|             "profile": null,
10944 | 2022-01-31 22:31:38.423139 \| controller \|             "region": "us-east-1",
10945 | 2022-01-31 22:31:38.423142 \| controller \|             "security_token": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
10946 | 2022-01-31 22:31:38.423145 \| controller \|             "validate_certs": true
10947 | 2022-01-31 22:31:38.423148 \| controller \|         }
10948 | 2022-01-31 22:31:38.423150 \| controller \|     },
10949 | 2022-01-31 22:31:38.423153 \| controller \|     "resource_actions": [
10950 | 2022-01-31 22:31:38.423156 \| controller \|         "ec2:DescribeDhcpOptions"
10951 | 2022-01-31 22:31:38.423159 \| controller \|     ]
10952 | 2022-01-31 22:31:38.423162 \| controller \| }
10953 | 2022-01-31 22:31:38.430433 \| controller \|
10954 | 2022-01-31 22:31:38.430447 \| controller \| TASK [ec2_vpc_dhcp_option : assert] ********************************************
10955 | 2022-01-31 22:31:38.430561 \| controller \| task path: /home/zuul/.ansible/collections/ansible_collections/amazon/aws/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml:394
10956 | 2022-01-31 22:31:38.454948 \| controller \| fatal: [testhost]: FAILED! => {
10957 | 2022-01-31 22:31:38.454978 \| controller \|     "assertion": "dhcp_options.failed",
10958 | 2022-01-31 22:31:38.454983 \| controller \|     "changed": false,
10959 | 2022-01-31 22:31:38.454986 \| controller \|     "evaluated_to": false,
10960 | 2022-01-31 22:31:38.454989 \| controller \|     "msg": "Assertion failed"
10961 | 2022-01-31 22:31:38.454992 \| controller \| }


```
