### PR TITLE
ec2_vol - support changing from volume without IOPS to one with IOPS

### DIFF
--- a/changelogs/fragments/626-ec2_vol-iops-when-source-does-not-have-iops.yml
+++ b/changelogs/fragments/626-ec2_vol-iops-when-source-does-not-have-iops.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ec2_vol - changing a volume from a type that does not support IOPS (like ``standard``) to a type that does (like ``gp3``) fails (https://github.com/ansible-collections/amazon.aws/issues/626).

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -388,8 +388,8 @@ def update_volume(module, ec2_conn, volume):
 
         iops_changed = False
         target_iops = module.params.get('iops')
+        original_iops = volume.get('iops')
         if target_iops:
-            original_iops = volume['iops']
             if target_iops != original_iops:
                 iops_changed = True
                 req_obj['Iops'] = target_iops
@@ -401,7 +401,7 @@ def update_volume(module, ec2_conn, volume):
             # otherwise, the default iops value is applied.
             if type_changed and target_type == 'gp3':
                 if (
-                    (volume['iops'] and (int(volume['iops']) < 3000 or int(volume['iops']) > 16000)) or not volume['iops']
+                    (original_iops and (int(original_iops) < 3000 or int(original_iops) > 16000)) or not original_iops
                 ):
                     req_obj['Iops'] = 3000
                     iops_changed = True

--- a/tests/integration/targets/ec2_vol/tasks/main.yml
+++ b/tests/integration/targets/ec2_vol/tasks/main.yml
@@ -286,7 +286,7 @@
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdh
         volume_size: 1
-        volume_type: gp2
+        volume_type: standard
         name: '{{ resource_prefix }} - sdh'
         tags:
           "lowercase spaced": 'hello cruel world'
@@ -316,7 +316,7 @@
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdh
         volume_size: 1
-        volume_type: gp2
+        volume_type: standard
         tags:
           ResourcePrefix: "{{ resource_prefix }}"
       check_mode: true
@@ -332,7 +332,7 @@
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdh
         volume_size: 1
-        volume_type: gp2
+        volume_type: standard
         tags:
           ResourcePrefix: "{{ resource_prefix }}"
       register: new_vol_attach_result_idem
@@ -350,7 +350,7 @@
         id: "{{ new_vol_attach_result.volume.id }}"
         device_name: /dev/sdh
         volume_size: 1
-        volume_type: gp2
+        volume_type: standard
         tags:
           "lowercase spaced": 'hello cruel world ❤️'
           "Title Case": 'Hello Cruel World ❤️'
@@ -370,7 +370,7 @@
           - "'size' in new_vol_attach_result.volume"
           - new_vol_attach_result.volume.size == 1
           - "'volume_type' in new_vol_attach_result"
-          - new_vol_attach_result.volume_type == 'gp2'
+          - new_vol_attach_result.volume_type == 'standard'
           - "'tags' in new_vol_attach_result.volume"
           - (new_vol_attach_result.volume.tags | length) == 6
           - new_vol_attach_result.volume.tags["lowercase spaced"] == 'hello cruel world ❤️'


### PR DESCRIPTION
`ec2_vol` - support changing from volume without IOPS to one with IOPS

Backport of PR #627 as merged into main (a9b9bd1) to stable-3 as well (it was originally only backported to stable-2).
SUMMARY

Fixes #626
Changing from standard volume type to gp3 failed when the module was trying to read the "original" IOPS value from the existing volume, since it doesn't have one.
See the linked issue for detailed description.

ISSUE TYPE


Bugfix Pull Request

COMPONENT NAME

ec2_vol
ADDITIONAL INFORMATION



N/A

Reviewed-by: Jill R <None>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
