### PR TITLE
ec2_vpc_route_table - support associating internet gateways

### DIFF
--- a/changelogs/fragments/690-ec2_vpc_route_table-associate-igw.yml
+++ b/changelogs/fragments/690-ec2_vpc_route_table-associate-igw.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ec2_vpc_route_table - support associating internet gateways (https://github.com/ansible-collections/amazon.aws/pull/690)
+  - ec2_vpc_route_table - support associating internet gateways (https://github.com/ansible-collections/amazon.aws/pull/690).

--- a/changelogs/fragments/690-ec2_vpc_route_table-associate-igw.yml
+++ b/changelogs/fragments/690-ec2_vpc_route_table-associate-igw.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ec2_vpc_route_table - support associating internet gateways (https://github.com/ansible-collections/amazon.aws/pull/690)

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -439,10 +439,9 @@ def index_of_matching_route(route_spec, routes_to_match):
     for i, route in enumerate(routes_to_match):
         if route_spec_matches_route(route_spec, route):
             return "exact", i
-        if 'Origin' in route_spec and route_spec['Origin'] == 'EnableVgwRoutePropagation':
-            return None
-        if route_spec_matches_route_cidr(route_spec, route):
-            return "replace", i
+        elif 'Origin' in route and route['Origin'] != 'EnableVgwRoutePropagation': # only replace created routes
+            if route_spec_matches_route_cidr(route_spec, route):
+                return "replace", i
 
 
 def ensure_routes(connection=None, module=None, route_table=None, route_specs=None,

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -439,7 +439,7 @@ def index_of_matching_route(route_spec, routes_to_match):
     for i, route in enumerate(routes_to_match):
         if route_spec_matches_route(route_spec, route):
             return "exact", i
-        elif 'Origin' in route and route['Origin'] != 'EnableVgwRoutePropagation': # only replace created routes
+        elif 'Origin' in route and route['Origin'] != 'EnableVgwRoutePropagation':  # only replace created routes
             if route_spec_matches_route_cidr(route_spec, route):
                 return "replace", i
 
@@ -565,6 +565,7 @@ def ensure_subnet_associations(connection=None, module=None, route_table=None, s
                     module.fail_json_aws(e, msg="Couldn't disassociate subnet from route table")
 
     return {'changed': changed}
+
 
 def ensure_gateway_association(connection=None, module=None, route_table=None, gateway_id=None,
                                check_mode=None):

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -21,7 +21,7 @@ options:
   gateway_id:
     description:
     - The ID of the gateway to associate with the route table.
-    - If I(gateway_id) is 'None' or '', gateway will be disassociated with the route table.
+    - If I(gateway_id) is C('None') or C(''), gateway will be disassociated with the route table.
     type: str
     version_added: 3.2.0
   lookup:
@@ -591,7 +591,8 @@ def disassociate_gateway(connection, module, route_table):
     # Subnet associations are handled in its method
     changed = False
     associations_to_delete = [association['RouteTableAssociationId'] for association in route_table['Associations'] if not association['Main']
-                              and association.get('GatewayId') and association['AssociationState']['State'] == 'associated']
+                              and association.get('GatewayId')
+                              and (association['AssociationState']['State'] == 'associated' or association['AssociationState']['State'] == 'associating')]
     for association_id in associations_to_delete:
         changed = True
         if not module.check_mode:
@@ -614,7 +615,8 @@ def associate_gateway(connection, module, route_table, gateway_id):
             for association in table.get('Associations'):
                 if association['Main']:
                     continue
-                if association.get('GatewayId') and association['GatewayId'] == gateway_id and association['AssociationState']['State'] == 'associated':
+                if association.get('GatewayId') and association['GatewayId'] == gateway_id and (association['AssociationState']['State'] == 'associated'
+                                                                                                or association['AssociationState']['State'] == 'associating'):
                     if table['RouteTableId'] == route_table['RouteTableId']:
                         return False
                     elif module.check_mode:

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -546,6 +546,8 @@ def ensure_subnet_association(connection, module, vpc_id, route_table_id, subnet
                     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                         module.fail_json_aws(e, msg="Couldn't disassociate subnet from route table")
 
+    if module.check_mode:
+        return {'changed': True}
     try:
         association_id = connection.associate_route_table(aws_retry=True,
                                                           RouteTableId=route_table_id,
@@ -625,8 +627,8 @@ def ensure_gateway_association(connection, module, route_table, gateway_id, purg
         if not module.check_mode:
             try:
                 connection.associate_route_table(aws_retry=True,
-                                                RouteTableId=route_table['RouteTableId'],
-                                                GatewayId=gateway_id)
+                                                 RouteTableId=route_table['RouteTableId'],
+                                                 GatewayId=gateway_id)
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 module.fail_json_aws(e, msg="Couldn't associate gateway with route table")
         return True

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -591,8 +591,7 @@ def disassociate_gateway(connection, module, route_table):
     # Subnet associations are handled in its method
     changed = False
     associations_to_delete = [association['RouteTableAssociationId'] for association in route_table['Associations'] if not association['Main']
-                              and association.get('GatewayId')
-                              and (association['AssociationState']['State'] == 'associated' or association['AssociationState']['State'] == 'associating')]
+                              and association.get('GatewayId') and association['AssociationState']['State'] in ['associated', 'associating']]
     for association_id in associations_to_delete:
         changed = True
         if not module.check_mode:
@@ -615,8 +614,7 @@ def associate_gateway(connection, module, route_table, gateway_id):
             for association in table.get('Associations'):
                 if association['Main']:
                     continue
-                if association.get('GatewayId') and association['GatewayId'] == gateway_id and (association['AssociationState']['State'] == 'associated'
-                                                                                                or association['AssociationState']['State'] == 'associating'):
+                if association.get('GatewayId', '') == gateway_id and (association['AssociationState']['State'] in ['associated', 'associating']):
                     if table['RouteTableId'] == route_table['RouteTableId']:
                         return False
                     elif module.check_mode:

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -524,7 +524,7 @@ def ensure_subnet_association(connection=None, module=None, vpc_id=None, route_t
                         return {'changed': True}
                     try:
                         connection.disassociate_route_table(
-                            aws_retry=True, AssociationId=a['RouteTableAssociationId'])
+                            aws_retry=True, AssociationId=association['RouteTableAssociationId'])
                     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                         module.fail_json_aws(e, msg="Couldn't disassociate subnet from route table")
 
@@ -589,7 +589,7 @@ def ensure_gateway_association(connection=None, module=None, route_table=None, g
                         return {'changed': True}
                     try:
                         connection.disassociate_route_table(
-                            aws_retry=True, AssociationId=a['RouteTableAssociationId'])
+                            aws_retry=True, AssociationId=association['RouteTableAssociationId'])
                     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                         module.fail_json_aws(e, msg="Couldn't disassociate gateway from route table")
 

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -22,6 +22,7 @@ options:
     description:
     - The ID of the gateway to associate with the route table.
     type: str
+    version_added: 3.2.0
   lookup:
     description: Look up route table by either tags or by route table ID. Non-unique tag lookup will fail.
       If no tags are specified then no lookup for an existing route table is performed and a new
@@ -519,14 +520,13 @@ def ensure_subnet_association(connection=None, module=None, vpc_id=None, route_t
             if association['SubnetId'] == subnet_id:
                 if route_table['RouteTableId'] == route_table_id:
                     return {'changed': False, 'association_id': association['RouteTableAssociationId']}
-                else:
-                    if check_mode:
-                        return {'changed': True}
-                    try:
-                        connection.disassociate_route_table(
-                            aws_retry=True, AssociationId=association['RouteTableAssociationId'])
-                    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                        module.fail_json_aws(e, msg="Couldn't disassociate subnet from route table")
+                if check_mode:
+                    return {'changed': True}
+                try:
+                    connection.disassociate_route_table(
+                        aws_retry=True, AssociationId=association['RouteTableAssociationId'])
+                except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                    module.fail_json_aws(e, msg="Couldn't disassociate subnet from route table")
 
     try:
         association_id = connection.associate_route_table(aws_retry=True,
@@ -584,14 +584,13 @@ def ensure_gateway_association(connection=None, module=None, route_table=None, g
             if association['GatewayId'] == gateway_id:
                 if table['RouteTableId'] == route_table['RouteTableId']:
                     return {'changed': False, 'association_id': association['RouteTableAssociationId']}
-                else:
-                    if check_mode:
-                        return {'changed': True}
-                    try:
-                        connection.disassociate_route_table(
-                            aws_retry=True, AssociationId=association['RouteTableAssociationId'])
-                    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                        module.fail_json_aws(e, msg="Couldn't disassociate gateway from route table")
+                if check_mode:
+                    return {'changed': True}
+                try:
+                    connection.disassociate_route_table(
+                        aws_retry=True, AssociationId=association['RouteTableAssociationId'])
+                except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                    module.fail_json_aws(e, msg="Couldn't disassociate gateway from route table")
 
     try:
         connection.associate_route_table(aws_retry=True,

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -803,7 +803,7 @@ def ensure_route_table_present(connection, module):
 
     if gateway_id or purge_gw:
         gateway_result = ensure_gateway_association(connection=connection, module=module, route_table=route_table,
-                                                gateway_id=gateway_id, purge_gw=purge_gw)
+                                                    gateway_id=gateway_id, purge_gw=purge_gw)
         changed = changed or gateway_result
 
     if changed:

--- a/plugins/modules/ec2_vpc_route_table_info.py
+++ b/plugins/modules/ec2_vpc_route_table_info.py
@@ -59,35 +59,10 @@ route_tables:
   type: complex
   contains:
     associations:
-      description: List of subnets associated with the route table
+      description: List of associations between the route table and one or more subnets or a gateway
       returned: always
       type: complex
       contains:
-        main:
-          description: Whether this is the main route table
-          returned: always
-          type: bool
-          sample: false
-        id:
-          description: ID of association between route table and subnet
-          returned: always
-          type: str
-          sample: rtbassoc-ab47cfc3
-        route_table_association_id:
-          description: ID of association between route table and subnet
-          returned: always
-          type: str
-          sample: rtbassoc-ab47cfc3
-        route_table_id:
-          description: ID of the route table
-          returned: always
-          type: str
-          sample: rtb-bf779ed7
-        subnet_id:
-          description: ID of the subnet
-          returned: always
-          type: str
-          sample: subnet-82055af9
         association_state:
           description: The state of the association
           returned: always
@@ -103,6 +78,31 @@ route_tables:
               returned: when available
               type: str
               sample: 'Creating association'
+        gateway_id:
+          description: ID of the internet gateway or virtual private gateway
+          returned: when route table is a gateway route table
+          type: str
+          sample: igw-03312309
+        main:
+          description: Whether this is the main route table
+          returned: always
+          type: bool
+          sample: false
+        route_table_association_id:
+          description: ID of association between route table and subnet
+          returned: always
+          type: str
+          sample: rtbassoc-ab47cfc3
+        route_table_id:
+          description: ID of the route table
+          returned: always
+          type: str
+          sample: rtb-bf779ed7
+        subnet_id:
+          description: ID of the subnet
+          returned: when route table is a subnet route table
+          type: str
+          sample: subnet-82055af9
     id:
       description: ID of the route table (same as route_table_id for backwards compatibility)
       returned: always

--- a/tests/integration/targets/ec2_vpc_route_table/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 availability_zone_a: '{{ ec2_availability_zone_names[0] }}'
 availability_zone_b: '{{ ec2_availability_zone_names[1] }}'
+vpc_cidr: 10.228.228.0/22

--- a/tests/integration/targets/ec2_vpc_route_table/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 availability_zone_a: '{{ ec2_availability_zone_names[0] }}'
 availability_zone_b: '{{ ec2_availability_zone_names[1] }}'
-vpc_cidr: 10.228.228.0/22
+vpc_cidr: 10.228.224.0/21

--- a/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -1210,25 +1210,6 @@
       routes:
       - dest: "10.228.228.0/24"
         network_interface_id: "{{ eni.interface.id }}"
-      purge_gw: yes
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-
-  - name: Purge gateway
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_gw: yes
       purge_routes: no
     register: create_gateway_table
 
@@ -1253,7 +1234,6 @@
       routes:
       - dest: "10.228.228.0/24"
         network_interface_id: "{{ eni.interface.id }}"
-      purge_gw: yes
       purge_routes: no
     register: create_gateway_table
     check_mode: yes
@@ -1272,7 +1252,6 @@
       routes:
       - dest: "10.228.228.0/24"
         network_interface_id: "{{ eni.interface.id }}"
-      purge_gw: yes
       purge_routes: no
     register: create_gateway_table
 

--- a/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -9,7 +9,7 @@
 
   - name: create VPC
     ec2_vpc_net:
-      cidr_block: 10.228.224.0/21
+      cidr_block: '{{ vpc_cidr }}'
       name: '{{ resource_prefix }}_vpc'
       state: present
     register: vpc
@@ -120,6 +120,7 @@
   - name: create IGW
     ec2_vpc_igw:
       vpc_id: '{{ vpc.vpc.id }}'
+    register: vpc_igw
   - name: create NAT GW
     ec2_vpc_nat_gateway:
       if_exist_do_not_create: yes
@@ -732,10 +733,344 @@
       that:
       - endpoint_details.vpc_endpoints[0].route_table_ids[0] == recreate_private_table.route_table.route_table_id
 
+  # ------------------------------------------------------------------------------------------
+
+  - name: Create gateway route table - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+
+  - name: Create gateway route table
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags and create_gateway_table.route_table.tags['Public']\
+          \ == 'true'"
+        - create_gateway_table.route_table.routes | length == 1
+        - create_gateway_table.route_table.associations | length == 1
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+
+  - name: Create gateway route table (idempotence) - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+
+  - name: Create gateway route table (idempotence)
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags and create_gateway_table.route_table.tags['Public']\
+          \ == 'true'"
+        - create_gateway_table.route_table.routes | length == 1
+        - create_gateway_table.route_table.associations | length == 1
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+
+  # ------------------------------------------------------------------------------------------
+
+  - name: Create ENI for gateway route table
+    ec2_eni:
+      subnet_id: '{{ public_subnets[0] }}'
+    register: eni
+
+  - name: Replace route to gateway route table - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+      routes:
+      - dest: "{{ vpc_cidr }}"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+
+  - name: Replace route to gateway route table
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+      routes:
+      - dest: "{{ vpc_cidr }}"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags and create_gateway_table.route_table.tags['Public']\
+          \ == 'true'"
+        - create_gateway_table.route_table.routes | length == 1
+        - create_gateway_table.route_table.associations | length == 1
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+        - create_gateway_table.route_table.routes[0].destination_cidr_block == vpc_cidr
+        - create_gateway_table.route_table.routes[0].network_interface_id == eni.interface.id
+
+  - name: Replace route to gateway route table (idempotence) - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+      routes:
+      - dest: "{{ vpc_cidr }}"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+
+  - name: Replace route to gateway route table (idempotence)
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+      routes:
+      - dest: "{{ vpc_cidr }}"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags and create_gateway_table.route_table.tags['Public']\
+          \ == 'true'"
+        - create_gateway_table.route_table.routes | length == 1
+        - create_gateway_table.route_table.associations | length == 1
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+        - create_gateway_table.route_table.routes[0].destination_cidr_block == vpc_cidr
+        - create_gateway_table.route_table.routes[0].network_interface_id == eni.interface.id
+
+  # ------------------------------------------------------------------------------------------
+
+  - name: Add route to gateway route table - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+
+  - name: Add route to gateway route table
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags and create_gateway_table.route_table.tags['Public']\
+          \ == 'true'"
+        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.associations | length == 1
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+
+  - name: Add route to gateway route table (idempotence) - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+
+  - name: Add route to gateway route table (idempotence)
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags and create_gateway_table.route_table.tags['Public']\
+          \ == 'true'"
+        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.associations | length == 1
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+
+  # ------------------------------------------------------------------------------------------
+
+  - name: Get route table info
+    ec2_vpc_route_table_info:
+      filters:
+        route-table-id: "{{ create_gateway_table.route_table.id }}"
+    register: rt_info
+
+  - name: Assert route table exists prior to deletion
+    assert:
+      that:
+        - rt_info.route_tables | length == 1
+
+  - name: Delete gateway route table - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      state: absent
+    register: delete_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - delete_gateway_table is changed
+
+  - name: Delete gateway route table
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      state: absent
+    register: delete_gateway_table
+
+  - name: Get route table info
+    ec2_vpc_route_table_info:
+      filters:
+        route-table-id: "{{ create_gateway_table.route_table.id }}"
+    register: rt_info
+
+  - name: Assert route table was deleted
+    assert:
+      that:
+        - delete_gateway_table is changed
+        - rt_info.route_tables | length == 0
+
+  - name: Delete gateway route table (idempotence) - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      state: absent
+    register: delete_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - delete_gateway_table is not changed
+
+  - name: Delete gateway route table (idempotence)
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      state: absent
+    register: delete_gateway_table
+
+  - name: Get route table info
+    ec2_vpc_route_table_info:
+      filters:
+        route-table-id: "{{ create_gateway_table.route_table.id }}"
+    register: rt_info
+
+  - name: Assert route table was deleted
+    assert:
+      that:
+        - delete_gateway_table is not changed
+        - rt_info.route_tables | length == 0
+
   always:
-  #############################################################################
+  # ############################################################################
   # TEAR DOWN STARTS HERE
-  #############################################################################
+  # ############################################################################
   - name: remove the VPC endpoint
     ec2_vpc_endpoint:
       state: absent
@@ -750,6 +1085,7 @@
     with_items:
     - '{{ create_public_table|default() }}'
     - '{{ create_private_table|default() }}'
+    - '{{ create_gateway_table|default() }}'
     when: item and not item.failed
     ignore_errors: yes
   - name: destroy NAT GW
@@ -764,6 +1100,11 @@
     ec2_vpc_igw:
       vpc_id: '{{ vpc.vpc.id }}'
       state: absent
+    ignore_errors: yes
+  - name: destroy ENI
+    ec2_eni:
+      state: absent
+      eni_id: '{{ eni.interface.id }}'
     ignore_errors: yes
   - name: destroy subnets
     ec2_vpc_subnet:

--- a/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -20,7 +20,7 @@
       - vpc.changed
   - name: Assign IPv6 CIDR block to existing VPC, check mode
     ec2_vpc_net:
-      cidr_block: 10.228.224.0/21
+      cidr_block: '{{ vpc_cidr }}'
       name: '{{ resource_prefix }}_vpc'
       ipv6_cidr: true
     check_mode: true
@@ -31,7 +31,7 @@
       - vpc_update.changed
   - name: Assign Amazon-provided IPv6 CIDR block to existing VPC
     ec2_vpc_net:
-      cidr_block: 10.228.224.0/21
+      cidr_block: '{{ vpc_cidr }}'
       name: '{{ resource_prefix }}_vpc'
       ipv6_cidr: true
     register: vpc_update
@@ -187,7 +187,6 @@
       - create_public_table.route_table.id.startswith('rtb-')
       - "'Public' in create_public_table.route_table.tags"
       - create_public_table.route_table.tags['Public'] == 'true'
-      - create_public_table.route_table.routes | length == 1
       - create_public_table.route_table.associations | length == 0
       - create_public_table.route_table.vpc_id == "{{ vpc.vpc.id }}"
       - create_public_table.route_table.propagating_vgws | length == 0
@@ -227,7 +226,6 @@
     assert:
       that:
       - add_routes.changed
-      - add_routes.route_table.routes | length == 3
       - add_routes.route_table.id.startswith('rtb-')
       - "'Public' in add_routes.route_table.tags"
       - add_routes.route_table.tags['Public'] == 'true'
@@ -756,7 +754,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 1
+        - create_gateway_table.route_table.routes | length == 2
         - create_gateway_table.route_table.associations | length == 1
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
         - create_gateway_table.route_table.propagating_vgws | length == 0
@@ -790,7 +788,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 1
+        - create_gateway_table.route_table.routes | length == 2
         - create_gateway_table.route_table.associations | length == 1
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
         - create_gateway_table.route_table.propagating_vgws | length == 0
@@ -839,7 +837,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 1
+        - create_gateway_table.route_table.routes | length == 2
         - create_gateway_table.route_table.associations | length == 1
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
         - create_gateway_table.route_table.propagating_vgws | length == 0
@@ -883,7 +881,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 1
+        - create_gateway_table.route_table.routes | length == 2
         - create_gateway_table.route_table.associations | length == 1
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
         - create_gateway_table.route_table.propagating_vgws | length == 0
@@ -929,7 +927,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.routes | length == 3
         - create_gateway_table.route_table.associations | length == 1
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
         - create_gateway_table.route_table.propagating_vgws | length == 0
@@ -971,7 +969,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.routes | length == 3
         - create_gateway_table.route_table.associations | length == 1
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
         - create_gateway_table.route_table.propagating_vgws | length == 0
@@ -1013,7 +1011,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.routes | length == 3
         - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1 }}"
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
         - create_gateway_table.route_table.propagating_vgws | length == 0
@@ -1057,7 +1055,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.routes | length == 3
         - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0 }}"
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
         - create_gateway_table.route_table.propagating_vgws | length == 0
@@ -1099,7 +1097,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.routes | length == 3
         - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0 }}"
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
         - create_gateway_table.route_table.propagating_vgws | length == 0
@@ -1137,7 +1135,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.routes | length == 3
         - create_gateway_table.route_table.associations | length == 1
         - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1 }}"
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
@@ -1174,7 +1172,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.routes | length == 3
         - create_gateway_table.route_table.associations | length == 1
         - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1 }}"
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
@@ -1219,7 +1217,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.routes | length == 3
         - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0 }}"
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
         - create_gateway_table.route_table.propagating_vgws | length == 0
@@ -1261,7 +1259,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.routes | length == 3
         - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0 }}"
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
         - create_gateway_table.route_table.propagating_vgws | length == 0
@@ -1307,7 +1305,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.routes | length == 3
         - create_gateway_table.route_table.associations | length == 2
         - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1 }}"
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
@@ -1344,7 +1342,7 @@
         - create_gateway_table.route_table.id.startswith('rtb-')
         - "'Public' in create_gateway_table.route_table.tags"
         - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.routes | length == 3
         - create_gateway_table.route_table.associations | length == 2
         - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1 }}"
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id

--- a/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -66,8 +66,8 @@
       vpc_id: '{{ vpc.vpc.id }}'
       state: present
       tags:
-        Public: '{{ item.public|string }}'
-        Name: "{{ (item.public|bool)|ternary('public', 'private') }}-{{ item.zone }}"
+        Public: '{{ item.public | string }}'
+        Name: "{{ (item.public | bool) | ternary('public', 'private') }}-{{ item.zone }}"
     with_items:
     - cidr: 10.228.224.0/24
       zone: '{{ availability_zone_a }}'
@@ -111,12 +111,12 @@
         vpc-id: '{{ vpc.vpc.id }}'
     register: vpc_subnets
   - set_fact:
-      public_subnets: "{{ (vpc_subnets.subnets| selectattr('tags.Public', 'equalto',\
-        \ 'True')| map(attribute='id')| list) }}"
-      public_cidrs: "{{ (vpc_subnets.subnets| selectattr('tags.Public', 'equalto',\
-        \ 'True')| map(attribute='cidr_block')| list) }}"
-      private_subnets: "{{ (vpc_subnets.subnets| selectattr('tags.Public', 'equalto',\
-        \ 'False')| map(attribute='id')| list)  }}"
+      public_subnets: "{{ (vpc_subnets.subnets | selectattr('tags.Public', 'equalto',\
+        \ 'True') | map(attribute='id') | list) }}"
+      public_cidrs: "{{ (vpc_subnets.subnets | selectattr('tags.Public', 'equalto',\
+        \ 'True') | map(attribute='cidr_block') | list) }}"
+      private_subnets: "{{ (vpc_subnets.subnets | selectattr('tags.Public', 'equalto',\
+        \ 'False') | map(attribute='id') | list) }}"
   - name: create IGW
     ec2_vpc_igw:
       vpc_id: '{{ vpc.vpc.id }}'
@@ -152,13 +152,13 @@
       that:
       - create_public_table.changed
       - create_public_table.route_table.id.startswith('rtb-')
-      - "'Public' in create_public_table.route_table.tags and create_public_table.route_table.tags['Public']\
-        \ == 'true'"
-      # One route for IPv4, one route for IPv6
-      - create_public_table.route_table.routes|length == 2
-      - create_public_table.route_table.associations|length == 0
+      - "'Public' in create_public_table.route_table.tags"
+      - create_public_table.route_table.tags['Public'] == 'true'
+      - create_public_table.route_table.associations | length == 0
       - create_public_table.route_table.vpc_id == "{{ vpc.vpc.id }}"
-      - create_public_table.route_table.propagating_vgws|length == 0
+      - create_public_table.route_table.propagating_vgws | length == 0
+      # One route for IPv4, one route for IPv6
+      - create_public_table.route_table.routes | length == 2
 
   - name: CHECK MODE - route table should already exist
     ec2_vpc_route_table:
@@ -185,12 +185,13 @@
       that:
       - not recreate_public_route_table.changed
       - create_public_table.route_table.id.startswith('rtb-')
-      - "'Public' in create_public_table.route_table.tags and create_public_table.route_table.tags['Public']\
-        \ == 'true'"
-      - create_public_table.route_table.routes|length == 2
-      - create_public_table.route_table.associations|length == 0
+      - "'Public' in create_public_table.route_table.tags"
+      - create_public_table.route_table.tags['Public'] == 'true'
+      - create_public_table.route_table.routes | length == 1
+      - create_public_table.route_table.associations | length == 0
       - create_public_table.route_table.vpc_id == "{{ vpc.vpc.id }}"
-      - create_public_table.route_table.propagating_vgws|length == 0
+      - create_public_table.route_table.propagating_vgws | length == 0
+      - create_public_table.route_table.routes | length == 2
 
   - name: CHECK MODE - add route to public route table
     ec2_vpc_route_table:
@@ -226,17 +227,18 @@
     assert:
       that:
       - add_routes.changed
+      - add_routes.route_table.routes | length == 3
+      - add_routes.route_table.id.startswith('rtb-')
+      - "'Public' in add_routes.route_table.tags"
+      - add_routes.route_table.tags['Public'] == 'true'
       # 10.228.224.0/21
       # 0.0.0.0/0
       # ::/0
       # Amazon-provide IPv6 block
-      - add_routes.route_table.routes|length == 4
-      - add_routes.route_table.id.startswith('rtb-')
-      - "'Public' in add_routes.route_table.tags and add_routes.route_table.tags['Public']\
-        \ == 'true'"
-      - add_routes.route_table.associations|length == 0
+      - add_routes.route_table.routes | length == 4
+      - add_routes.route_table.associations | length == 0
       - add_routes.route_table.vpc_id == "{{ vpc.vpc.id }}"
-      - add_routes.route_table.propagating_vgws|length == 0
+      - add_routes.route_table.propagating_vgws | length == 0
 
   - name: CHECK MODE - re-add route to public route table
     ec2_vpc_route_table:
@@ -268,7 +270,7 @@
     assert:
       that:
       - add_routes is not changed
-      - add_routes.route_table.routes|length == 4
+      - add_routes.route_table.routes | length == 4
 
   - name: CHECK MODE - add subnets to public route table
     ec2_vpc_route_table:
@@ -302,18 +304,8 @@
     assert:
       that:
       - add_subnets.changed
-      - add_subnets.route_table.associations|length == 3
+      - add_subnets.route_table.associations | length == 3
 
-  - name: add a route to public route table
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-    register: add_routes
   - name: CHECK MODE - no routes but purge_routes set to false
     ec2_vpc_route_table:
       vpc_id: '{{ vpc.vpc.id }}'
@@ -342,8 +334,8 @@
     assert:
       that:
       - not no_purge_routes.changed
-      - no_purge_routes.route_table.routes|length == 4
-      - no_purge_routes.route_table.associations|length == 3
+      - no_purge_routes.route_table.routes | length == 4
+      - no_purge_routes.route_table.associations | length == 3
 
   - name: rerun with purge_subnets set to false
     ec2_vpc_route_table:
@@ -360,8 +352,8 @@
     assert:
       that:
       - not no_purge_subnets.changed
-      - no_purge_subnets.route_table.routes|length == 4
-      - no_purge_subnets.route_table.associations|length == 3
+      - no_purge_subnets.route_table.routes | length == 4
+      - no_purge_subnets.route_table.associations | length == 3
 
   - name: rerun with purge_tags not set (implicitly false)
     ec2_vpc_route_table:
@@ -377,8 +369,8 @@
     assert:
       that:
       - not no_purge_tags.changed
-      - "'Public' in no_purge_tags.route_table.tags and no_purge_tags.route_table.tags['Public']\
-        \ == 'true'"
+      - "'Public' in no_purge_tags.route_table.tags"
+      - no_purge_tags.route_table.tags['Public'] == 'true'
 
   - name: CHECK MODE - purge subnets
     ec2_vpc_route_table:
@@ -412,7 +404,7 @@
     assert:
       that:
       - purge_subnets.changed
-      - purge_subnets.route_table.associations|length == 0
+      - purge_subnets.route_table.associations | length == 0
       - purge_subnets.route_table.id == create_public_table.route_table.id
 
   - name: CHECK MODE - purge routes
@@ -443,7 +435,7 @@
     assert:
       that:
       - add_subnets_cidr.changed
-      - add_subnets_cidr.route_table.associations|length == 3
+      - add_subnets_cidr.route_table.associations | length == 3
 
   - name: purge subnets added by cidr
     ec2_vpc_route_table:
@@ -459,7 +451,7 @@
     assert:
       that:
       - purge_subnets_cidr.changed
-      - purge_subnets_cidr.route_table.associations|length == 0
+      - purge_subnets_cidr.route_table.associations | length == 0
 
   - name: add subnets by name to public route table
     ec2_vpc_route_table:
@@ -475,7 +467,7 @@
     assert:
       that:
       - add_subnets_name.changed
-      - add_subnets_name.route_table.associations|length == 3
+      - add_subnets_name.route_table.associations | length == 3
 
   - name: purge subnets added by name
     ec2_vpc_route_table:
@@ -491,7 +483,7 @@
     assert:
       that:
       - purge_subnets_name.changed
-      - purge_subnets_name.route_table.associations|length == 0
+      - purge_subnets_name.route_table.associations | length == 0
 
   - name: purge routes
     ec2_vpc_route_table:
@@ -505,7 +497,7 @@
     assert:
       that:
       - purge_routes.changed
-      - purge_routes.route_table.routes|length == 3
+      - purge_routes.route_table.routes | length == 3
       - purge_routes.route_table.id == create_public_table.route_table.id
 
   - name: CHECK MODE - update tags
@@ -538,8 +530,8 @@
     assert:
       that:
       - update_tags.changed
-      - "'Updated' in update_tags.route_table.tags and update_tags.route_table.tags['Updated']\
-        \ == 'new_tag'"
+      - "'Updated' in update_tags.route_table.tags"
+      - update_tags.route_table.tags['Updated'] == 'new_tag'
       - "'Public' not in update_tags.route_table.tags"
 
   - name: create NAT GW
@@ -669,10 +661,10 @@
       that:
       - route_table_info.route_tables | length == 1
       - '"tags" in route_table_info.route_tables[0]'
-      - '"Public" in route_table_info.route_tables[0].tags and route_table_info.route_tables[0].tags["Public"]
-        == "false"'
-      - '"Name" in route_table_info.route_tables[0].tags and route_table_info.route_tables[0].tags["Name"]
-        == "Private route table"'
+      - '"Public" in route_table_info.route_tables[0].tags'
+      - route_table_info.route_tables[0].tags["Public"] == "false"
+      - '"Name" in route_table_info.route_tables[0].tags'
+      - route_table_info.route_tables[0].tags["Name"] == "Private route table"
 
   - name: create NAT GW
     ec2_vpc_nat_gateway:
@@ -762,8 +754,8 @@
       that:
         - create_gateway_table is changed
         - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags and create_gateway_table.route_table.tags['Public']\
-          \ == 'true'"
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
         - create_gateway_table.route_table.routes | length == 1
         - create_gateway_table.route_table.associations | length == 1
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
@@ -796,8 +788,8 @@
       that:
         - create_gateway_table is not changed
         - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags and create_gateway_table.route_table.tags['Public']\
-          \ == 'true'"
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
         - create_gateway_table.route_table.routes | length == 1
         - create_gateway_table.route_table.associations | length == 1
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
@@ -845,8 +837,8 @@
       that:
         - create_gateway_table is changed
         - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags and create_gateway_table.route_table.tags['Public']\
-          \ == 'true'"
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
         - create_gateway_table.route_table.routes | length == 1
         - create_gateway_table.route_table.associations | length == 1
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
@@ -889,8 +881,8 @@
       that:
         - create_gateway_table is not changed
         - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags and create_gateway_table.route_table.tags['Public']\
-          \ == 'true'"
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
         - create_gateway_table.route_table.routes | length == 1
         - create_gateway_table.route_table.associations | length == 1
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
@@ -935,8 +927,8 @@
       that:
         - create_gateway_table is changed
         - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags and create_gateway_table.route_table.tags['Public']\
-          \ == 'true'"
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
         - create_gateway_table.route_table.routes | length == 2
         - create_gateway_table.route_table.associations | length == 1
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
@@ -977,10 +969,384 @@
       that:
         - create_gateway_table is not changed
         - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags and create_gateway_table.route_table.tags['Public']\
-          \ == 'true'"
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
         - create_gateway_table.route_table.routes | length == 2
         - create_gateway_table.route_table.associations | length == 1
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+
+  # ------------------------------------------------------------------------------------------
+
+  - name: Ensure gateway doesn't disassociate when not passed in - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+
+  - name: Ensure gateway doesn't disassociate when not passed in
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
+        - create_gateway_table.route_table.routes | length == 2
+        - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1 }}"
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+
+  # ------------------------------------------------------------------------------------------
+
+  - name: Disassociate gateway when gateway_id is 'None' - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: None
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+
+  - name: Disassociate gateway when gateway_id is 'None'
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: None
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
+        - create_gateway_table.route_table.routes | length == 2
+        - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0 }}"
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+
+  - name: Disassociate gateway when gateway_id is 'None' (idempotence) - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: None
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+
+  - name: Disassociate gateway when gateway_id is 'None' (idempotence)
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: None
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
+        - create_gateway_table.route_table.routes | length == 2
+        - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0 }}"
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+
+  # ------------------------------------------------------------------------------------------
+
+  - name: Associate gateway with route table - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+
+  - name: Associate gateway with route table
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+      purge_routes: no
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
+        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.associations | length == 1
+        - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1 }}"
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+
+  - name: Associate gateway with route table (idempotence) - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+
+  - name: Associate gateway with route table (idempotence)
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vpc_igw.gateway_id }}"
+      purge_routes: no
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
+        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.associations | length == 1
+        - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1 }}"
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+
+  # ------------------------------------------------------------------------------------------
+
+  - name: Disassociate gateway when gateway_id is '' - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: ''
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+
+  - name: Disassociate gateway when gateway_id is ''
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: ''
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
+        - create_gateway_table.route_table.routes | length == 2
+        - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0 }}"
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+
+  - name: Disassociate gateway when gateway_id is '' (idempotence) - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: ''
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+
+  - name: Disassociate gateway when gateway_id is '' (idempotence)
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: ''
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_routes: no
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
+        - create_gateway_table.route_table.routes | length == 2
+        - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0 }}"
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+
+  # ------------------------------------------------------------------------------------------
+
+  - name: Create vgw for gateway route table
+    ec2_vpc_vgw:
+      state: present
+      vpc_id: "{{ vpc.vpc.id }}"
+      type: ipsec.1
+      name: '{{ resource_prefix }}_vpc'
+    register: vgw
+
+  - name: Associate vgw with route table - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vgw.vgw.id }}"
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+
+  - name: Associate vgw with route table
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vgw.vgw.id }}"
+      purge_routes: no
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
+        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.associations | length == 2
+        - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1 }}"
+        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+        - create_gateway_table.route_table.propagating_vgws | length == 0
+
+  - name: Associate vgw with route table (idempotence) - check_mode
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vgw.vgw.id }}"
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+
+  - name: Associate vgw with route table (idempotence)
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      gateway_id: "{{ vgw.vgw.id }}"
+      purge_routes: no
+    register: create_gateway_table
+
+  - assert:
+      that:
+        - create_gateway_table is not changed
+        - create_gateway_table.route_table.id.startswith('rtb-')
+        - "'Public' in create_gateway_table.route_table.tags"
+        - create_gateway_table.route_table.tags['Public'] == 'true'
+        - create_gateway_table.route_table.routes | length == 2
+        - create_gateway_table.route_table.associations | length == 2
+        - "{{ create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1 }}"
         - create_gateway_table.route_table.vpc_id == vpc.vpc.id
         - create_gateway_table.route_table.propagating_vgws | length == 0
 
@@ -1068,18 +1434,24 @@
         - rt_info.route_tables | length == 0
 
   always:
-  # ############################################################################
+  #############################################################################
   # TEAR DOWN STARTS HERE
-  # ############################################################################
+  #############################################################################
+  - name: remove the VPC endpoint
+    ec2_vpc_endpoint:
+      state: absent
+      vpc_endpoint_id: '{{ vpc_endpoint.result.vpc_endpoint_id }}'
+    when: vpc_endpoint is defined
+    ignore_errors: yes
   - name: destroy route tables
     ec2_vpc_route_table:
       route_table_id: '{{ item.route_table.id }}'
       lookup: id
       state: absent
     with_items:
-    - '{{ create_public_table|default() }}'
-    - '{{ create_private_table|default() }}'
-    - '{{ create_gateway_table|default() }}'
+    - '{{ create_public_table | default() }}'
+    - '{{ create_private_table | default() }}'
+    - '{{ create_gateway_table | default() }}'
     when: item and not item.failed
     ignore_errors: yes
   - name: destroy NAT GW
@@ -1094,6 +1466,13 @@
     ec2_vpc_igw:
       vpc_id: '{{ vpc.vpc.id }}'
       state: absent
+    ignore_errors: yes
+  - name: destroy VGW
+    ec2_vpc_vgw:
+      state: absent
+      type: ipsec.1
+      name: '{{ resource_prefix }}_vpc'
+      vpc_id: "{{ vpc.vpc.id }}"
     ignore_errors: yes
   - name: destroy ENI
     ec2_eni:

--- a/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -1210,6 +1210,25 @@
       routes:
       - dest: "10.228.228.0/24"
         network_interface_id: "{{ eni.interface.id }}"
+      purge_gw: yes
+      purge_routes: no
+    register: create_gateway_table
+    check_mode: yes
+
+  - assert:
+      that:
+        - create_gateway_table is changed
+
+  - name: Purge gateway
+    ec2_vpc_route_table:
+      vpc_id: "{{ vpc.vpc.id }}"
+      tags:
+        Public: 'true'
+        Name: Gateway route table
+      routes:
+      - dest: "10.228.228.0/24"
+        network_interface_id: "{{ eni.interface.id }}"
+      purge_gw: yes
       purge_routes: no
     register: create_gateway_table
 
@@ -1234,6 +1253,7 @@
       routes:
       - dest: "10.228.228.0/24"
         network_interface_id: "{{ eni.interface.id }}"
+      purge_gw: yes
       purge_routes: no
     register: create_gateway_table
     check_mode: yes
@@ -1252,6 +1272,7 @@
       routes:
       - dest: "10.228.228.0/24"
         network_interface_id: "{{ eni.interface.id }}"
+      purge_gw: yes
       purge_routes: no
     register: create_gateway_table
 

--- a/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -1071,12 +1071,6 @@
   # ############################################################################
   # TEAR DOWN STARTS HERE
   # ############################################################################
-  - name: remove the VPC endpoint
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ vpc_endpoint.result.vpc_endpoint_id }}'
-    when: vpc_endpoint is defined
-    ignore_errors: yes
   - name: destroy route tables
     ec2_vpc_route_table:
       route_table_id: '{{ item.route_table.id }}'


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1362
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1364

##### SUMMARY
- Update ec2_vpc_route_table to support associating internet gateways per feature request #476 
- Add integration tests
- Fix idempotency issue when associating a subnet with a route table

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_vpc_route_table