### PR TITLE
[4.0.0] Bump minimum botocore version to 1.20.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ As the AWS SDK for Python (Boto3 and Botocore) has [ceased supporting Python 2.7
 
 Starting with the 2.0.0 releases of amazon.aws and community.aws, it is generally the collection's policy to support the versions of `botocore` and `boto3` that were released 12 months prior to the most recent major collection release, following semantic versioning (for example, 2.0.0, 3.0.0).
 
-Version 3.0.0 of this collection supports `boto3 >= 1.16.0` and `botocore >= 1.19.0`
+Version 4.0.0 of this collection supports `boto3 >= 1.17.0` and `botocore >= 1.20.0`
 
 All support for the original AWS SDK `boto` was removed in release 4.0.0.
 

--- a/changelogs/fragments/release-4--botocore.yml
+++ b/changelogs/fragments/release-4--botocore.yml
@@ -1,0 +1,7 @@
+major_changes:
+- amazon.aws collection - The amazon.aws collection has dropped support for
+  ``botocore<1.20.0`` and ``boto3<1.17.0``. Most modules will continue to work
+  with older versions of the AWS SDK, however compatability with older versions
+  of the SDK is not guaranteed and will not be tested. When using older versions
+  of the SDK a warning will be emitted by Ansible
+  (https://github.com/ansible-collections/amazon.aws/pull/574).

--- a/plugins/doc_fragments/aws.py
+++ b/plugins/doc_fragments/aws.py
@@ -75,8 +75,8 @@ options:
     type: dict
 requirements:
   - python >= 3.6
-  - boto3 >= 1.16.0
-  - botocore >= 1.19.0
+  - boto3 >= 1.17.0
+  - botocore >= 1.20.0
 notes:
   - If parameters are not set within the module, the following
     environment variables can be used in decreasing order of precedence

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -10,7 +10,7 @@ author:
 requirements:
   - python >= 3.6
   - boto3
-  - botocore >= 1.19.0
+  - botocore >= 1.20.0
 extends_documentation_fragment:
 - amazon.aws.aws_credentials
 - amazon.aws.aws_region

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -11,7 +11,7 @@ author:
 requirements:
   - python >= 3.6
   - boto3
-  - botocore >= 1.19.0
+  - botocore >= 1.20.0
 extends_documentation_fragment:
 - amazon.aws.aws_credentials
 - amazon.aws.aws_region

--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -16,7 +16,7 @@ author:
 requirements:
   - python >= 3.6
   - boto3
-  - botocore >= 1.19.0
+  - botocore >= 1.20.0
 short_description: Get the value for a SSM parameter or all parameters under a path.
 description:
   - Get the value for an Amazon Simple Systems Manager parameter or a hierarchy of parameters.

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -125,11 +125,11 @@ class AnsibleAWSModule(object):
                 self._module.fail_json(
                     msg=missing_required_lib('botocore or boto3'))
             current_versions = self._gather_versions()
-            if not self.botocore_at_least('1.19.0'):
-                self.warn('botocore < 1.19.0 is not supported or tested.'
+            if not self.botocore_at_least('1.20.0'):
+                self.warn('botocore < 1.20.0 is not supported or tested.'
                           '  Some features may not work.')
-            if not self.boto3_at_least("1.16.0"):
-                self.warn('boto3 < 1.16.0 is not supported or tested.'
+            if not self.boto3_at_least("1.17.0"):
+                self.warn('boto3 < 1.17.0 is not supported or tested.'
                           '  Some features may not work.')
 
         self.check_mode = self._module.check_mode

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -495,8 +495,7 @@ def create_image(module, connection):
         if instance_id:
             params['InstanceId'] = instance_id
             params['NoReboot'] = no_reboot
-            if tags and module.botocore_at_least('1.19.30'):
-                params['TagSpecifications'] = boto3_tag_specifications(tags, types=['image', 'snapshot'])
+            params['TagSpecifications'] = boto3_tag_specifications(tags, types=['image', 'snapshot'])
             image_id = connection.create_image(aws_retry=True, **params).get('ImageId')
         else:
             if architecture:

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -495,7 +495,9 @@ def create_image(module, connection):
         if instance_id:
             params['InstanceId'] = instance_id
             params['NoReboot'] = no_reboot
-            params['TagSpecifications'] = boto3_tag_specifications(tags, types=['image', 'snapshot'])
+            tag_spec = boto3_tag_specifications(tags, types=['image', 'snapshot'])
+            if tag_spec:
+                params['TagSpecifications'] = tag_spec
             image_id = connection.create_image(aws_retry=True, **params).get('ImageId')
         else:
             if architecture:

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -203,7 +203,6 @@ options:
     - A list of block device mappings, by default this will always use the AMI root device so the volumes option is primarily for adding more storage.
     - A mapping contains the (optional) keys device_name, virtual_name, ebs.volume_type, ebs.volume_size, ebs.kms_key_id,
       ebs.iops, and ebs.delete_on_termination.
-    - Set ebs.throughput value requires botocore>=1.19.27.
     - For more information about each parameter, see U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html).
     type: list
     elements: dict
@@ -987,7 +986,6 @@ def build_volume_spec(params):
                 if not volume['ebs'].get('iops'):
                     volume['ebs']['iops'] = 3000
                 if 'throughput' in volume['ebs']:
-                    module.require_botocore_at_least('1.19.27', reason='to set throughtput value')
                     volume['ebs']['throughput'] = int(volume['ebs']['throughput'])
                 else:
                     volume['ebs']['throughput'] = 125

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -101,7 +101,6 @@ options:
       - Volume throughput in MB/s.
       - This parameter is only valid for gp3 volumes.
       - Valid range is from 125 to 1000.
-      - Requires at least botocore version 1.19.27.
     type: int
     version_added: 1.4.0
   multi_attach:
@@ -450,8 +449,7 @@ def update_volume(module, ec2_conn, volume):
             volume['volume_type'] = response.get('VolumeModification').get('TargetVolumeType')
             volume['iops'] = response.get('VolumeModification').get('TargetIops')
             volume['multi_attach_enabled'] = response.get('VolumeModification').get('TargetMultiAttachEnabled')
-            if module.botocore_at_least("1.19.27"):
-                volume['throughput'] = response.get('VolumeModification').get('TargetThroughput')
+            volume['throughput'] = response.get('VolumeModification').get('TargetThroughput')
 
     return volume, changed
 
@@ -679,8 +677,7 @@ def get_volume_info(module, volume, tags=None):
         'tags': tags
     }
 
-    if module.botocore_at_least("1.19.27"):
-        volume_info['throughput'] = volume.get('throughput')
+    volume_info['throughput'] = volume.get('throughput')
 
     return volume_info
 
@@ -758,9 +755,6 @@ def main():
     if state == 'list':
         module.deprecate(
             'Using the "list" state has been deprecated.  Please use the ec2_vol_info module instead', date='2022-06-01', collection_name='amazon.aws')
-
-    if module.params.get('throughput'):
-        module.require_botocore_at_least('1.19.27', reason='to set the throughput for a volume')
 
     # Ensure we have the zone or can get the zone
     if instance is None and zone is None and state == 'present':

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # - tests/unit/constraints.txt
 # - tests/integration/constraints.txt
 # - tests/integration/targets/setup_botocore_pip
-botocore>=1.19.0
-boto3>=1.16.0
+botocore>=1.20.0
+boto3>=1.17.0

--- a/tests/integration/constraints.txt
+++ b/tests/integration/constraints.txt
@@ -1,7 +1,7 @@
 # Specifically run tests against the oldest versions that we support
-boto3==1.16.0
-botocore==1.19.0
+boto3==1.17.0
+botocore==1.20.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.18.160
+awscli==1.19.0

--- a/tests/integration/targets/ec2_instance/meta/main.yml
+++ b/tests/integration/targets/ec2_instance/meta/main.yml
@@ -1,5 +1,4 @@
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_botocore_pip
 - role: prepare_tests
 - role: setup_ec2_facts

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/block_devices.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/block_devices.yml
@@ -1,8 +1,4 @@
 - block:
-  - include_role:
-      name: setup_botocore_pip
-    vars:
-      botocore_version: '1.19.27'
 
   - name: "New instance with an extra block device"
     ec2_instance:
@@ -98,9 +94,6 @@
       instance_type: "{{ ec2_instance_type }}"
       wait: true
     register: block_device_instances_gp3
-    # Managing Troughput requires botocore >= 1.19.27
-    vars:
-      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
   - assert:
       that:

--- a/tests/integration/targets/ec2_vol/meta/main.yml
+++ b/tests/integration/targets/ec2_vol/meta/main.yml
@@ -1,5 +1,2 @@
 dependencies:
-- role: setup_botocore_pip
-  vars:
-    botocore_version: '1.19.27'
 - role: setup_ec2_facts

--- a/tests/integration/targets/ec2_vol/tasks/main.yml
+++ b/tests/integration/targets/ec2_vol/tasks/main.yml
@@ -504,8 +504,6 @@
           - new_vol_attach_result.volume.tags["Name"] == '{{ resource_prefix }} - sdh'
 
     - name: volume must be from type gp3 (idempotent)
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
       ec2_vol:
         id: "{{ new_vol_attach_result.volume_id }}"
         zone: "{{ availability_zone }}"
@@ -727,8 +725,6 @@
       when: ansible_version.full is version('2.7', '>=')
 
     - name: test create a new gp3 volume
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
       ec2_vol:
         volume_size: 70
         zone: "{{ availability_zone }}"
@@ -760,8 +756,6 @@
           - gp3_volume.volume.tags["ResourcePrefix"] == "{{ resource_prefix }}"
 
     - name: Read volume information to validate throughput
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
       ec2_vol_info:
         filters:
           volume-id: "{{ gp3_volume.volume_id }}"
@@ -779,8 +773,6 @@
         var: vol_facts
 
     - name: Read volume information to validate throughput
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
       ec2_vol_info:
         filters:
           volume-id: "{{ gp3_volume.volume_id }}"
@@ -798,8 +790,6 @@
         var: vol_facts
 
     - name: increase throughput
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
       ec2_vol:
         volume_size: 70
         zone: "{{ availability_zone }}"

--- a/tests/integration/targets/setup_botocore_pip/defaults/main.yml
+++ b/tests/integration/targets/setup_botocore_pip/defaults/main.yml
@@ -1,2 +1,2 @@
-default_botocore_version: '1.19.0'
-default_boto3_version: '1.16.0'
+default_botocore_version: '1.20.0'
+default_boto3_version: '1.17.0'

--- a/tests/unit/constraints.txt
+++ b/tests/unit/constraints.txt
@@ -1,7 +1,7 @@
 # Specifically run tests against the oldest versions that we support
-boto3==1.16.0
-botocore==1.19.0
+boto3==1.17.0
+botocore==1.20.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.18.160
+awscli==1.19.0

--- a/tests/unit/module_utils/core/ansible_aws_module/test_minimal_versions.py
+++ b/tests/unit/module_utils/core/ansible_aws_module/test_minimal_versions.py
@@ -20,10 +20,10 @@ class TestMinimalVersions(object):
     # Prepare some data for use in our testing
     # ========================================================
     def setup_method(self):
-        self.MINIMAL_BOTO3 = '1.16.0'
-        self.MINIMAL_BOTOCORE = '1.19.0'
-        self.OLD_BOTO3 = '1.15.999'
-        self.OLD_BOTOCORE = '1.18.999'
+        self.MINIMAL_BOTO3 = '1.17.0'
+        self.MINIMAL_BOTOCORE = '1.20.0'
+        self.OLD_BOTO3 = '1.16.999'
+        self.OLD_BOTOCORE = '1.19.999'
 
     # ========================================================
     #   Test we don't warn when using valid versions


### PR DESCRIPTION
##### SUMMARY

With the next major version we can bump botocore/boto3 again.  Since 1.20.0 is now over a year old, we can bump the minimum version in preparation for 4.0.0.  CI should still test backports against the relevant versions for the backported release.

1.20.0 was released 2021-02-02.
1.21.0 was released 2021-07-15, hopefully we'll release 4.0.0 before July.

Should we release after mid-July we can always bump again.

(Mentioned in #645)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

requirements.txt

##### ADDITIONAL INFORMATION

```
botocore] $ git show 1.20.0
tag 1.20.0
Tagger: aws-sdk-python-automation <github-aws-sdk-python-automation@amazon.com>
Date:   Tue Feb 2 19:11:44 2021 +0000

Tagging 1.20.0 release.

commit b7d27dc39aea82e22e2c11443fbd02a4904367cd (tag: 1.20.0)
Merge: cc497a593 27ebea65f
Author: aws-sdk-python-automation <github-aws-sdk-python-automation@amazon.com>
Date:   Tue Feb 2 19:11:44 2021 +0000

    Merge branch 'release-1.20.0'
    
    * release-1.20.0:
      Bumping version to 1.20.0
      Update to latest models
      Add changelog for custom endpoints and ARN resources
      Allow custom endpoints when addressing ARN resources
      Add changes for Python 3.4/3.5 removal
      Fall back to Transfer-Encoding 'chunked' if AWSRequest body is not seekable stream
```

```
boto3] $ git show 1.17.0
tag 1.17.0
Tagger: aws-sdk-python-automation <github-aws-sdk-python-automation@amazon.com>
Date:   Tue Feb 2 19:11:35 2021 +0000

Tagging 1.17.0 release.

commit 1a35ed1ab41f967ea43420650075f2693cbbe08b (tag: 1.17.0)
Merge: d77d24f9 35454bc5
Author: aws-sdk-python-automation <github-aws-sdk-python-automation@amazon.com>
Date:   Tue Feb 2 19:11:35 2021 +0000

    Merge branch 'release-1.17.0'
    
    * release-1.17.0:
      Bumping version to 1.17.0
      Add changelog entries from botocore
      Add S3 VPCE examples
      Add changes for Python 3.4/3.5 removal
```