### PR TITLE
feat: Add S3 bucket owner enforcement

### DIFF
--- a/changelogs/fragments/694-s3_bucket-owner_enforcement.yml
+++ b/changelogs/fragments/694-s3_bucket-owner_enforcement.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - s3_bucket - Add support for enforced bucket owner object ownership.
+  - s3_bucket - Add support for enforced bucket owner object ownership (https://github.com/ansible-collections/amazon.aws/pull/694).

--- a/changelogs/fragments/694-s3_bucket-owner_enforcement.yml
+++ b/changelogs/fragments/694-s3_bucket-owner_enforcement.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - s3_bucket - Add support for enforced bucket owner object ownership.

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -133,6 +133,7 @@ options:
       - C(ObjectWriter) - The uploading account will own the object
         if the object is uploaded with the bucket-owner-full-control canned ACL.
       - This option cannot be used together with a I(delete_object_ownership) definition.
+      - C(BucketOwnerEnforced) has been added in version 3.2.0.
     choices: [ 'BucketOwnerEnforced', 'BucketOwnerPreferred', 'ObjectWriter' ]
     type: str
     version_added: 2.0.0

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -124,12 +124,16 @@ options:
   object_ownership:
     description:
       - Allow bucket's ownership controls.
+      - C(BucketOwnerEnforced) - ACLs are disabled and no longer affect access permissions to your
+        bucket. Requests to set or update ACLs fail. However, requests to read ACLs are supported.
+        Bucket owner has full ownership and control.
+Object writer no longer has full ownership and control.
       - C(BucketOwnerPreferred) - Objects uploaded to the bucket change ownership to the bucket owner
         if the objects are uploaded with the bucket-owner-full-control canned ACL.
       - C(ObjectWriter) - The uploading account will own the object
         if the object is uploaded with the bucket-owner-full-control canned ACL.
       - This option cannot be used together with a I(delete_object_ownership) definition.
-    choices: [ 'BucketOwnerPreferred', 'ObjectWriter' ]
+    choices: [ 'BucketOwnerEnforced', 'BucketOwnerPreferred', 'ObjectWriter' ]
     type: str
     version_added: 2.0.0
   delete_object_ownership:
@@ -1016,7 +1020,7 @@ def main():
             block_public_policy=dict(type='bool', default=False),
             restrict_public_buckets=dict(type='bool', default=False))),
         delete_public_access=dict(type='bool', default=False),
-        object_ownership=dict(type='str', choices=['BucketOwnerPreferred', 'ObjectWriter']),
+        object_ownership=dict(type='str', choices=['BucketOwnerEnforced', 'BucketOwnerPreferred', 'ObjectWriter']),
         delete_object_ownership=dict(type='bool', default=False),
         acl=dict(type='str', choices=['private', 'public-read', 'public-read-write', 'authenticated-read']),
         validate_bucket_name=dict(type='bool', default=True),

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -126,8 +126,8 @@ options:
       - Allow bucket's ownership controls.
       - C(BucketOwnerEnforced) - ACLs are disabled and no longer affect access permissions to your
         bucket. Requests to set or update ACLs fail. However, requests to read ACLs are supported.
-        Bucket owner has full ownership and control.
-Object writer no longer has full ownership and control.
+        Bucket owner has full ownership and control. Object writer no longer has full ownership and
+        control.
       - C(BucketOwnerPreferred) - Objects uploaded to the bucket change ownership to the bucket owner
         if the objects are uploaded with the bucket-owner-full-control canned ACL.
       - C(ObjectWriter) - The uploading account will own the object

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
@@ -51,7 +51,7 @@
           - output.object_ownership
           - output.object_ownership == 'ObjectWriter'
 
-    - name: 'update s3 bucket ownership controls'
+    - name: 'update s3 bucket ownership preferred controls'
       s3_bucket:
         name: '{{ local_bucket_name }}'
         state: present
@@ -64,7 +64,7 @@
           - output.object_ownership
           - output.object_ownership == 'BucketOwnerPreferred'
 
-    - name: 'test idempotency update s3 bucket ownership controls'
+    - name: 'test idempotency update s3 bucket ownership preferred controls'
       s3_bucket:
         name: '{{ local_bucket_name }}'
         state: present
@@ -76,6 +76,32 @@
           - output.changed is false
           - output.object_ownership
           - output.object_ownership == 'BucketOwnerPreferred'
+
+    - name: 'update s3 bucket ownership enforced controls'
+      s3_bucket:
+        name: '{{ local_bucket_name }}'
+        state: present
+        object_ownership: BucketOwnerEnforced
+      register: output
+
+    - assert:
+        that:
+          - output.changed
+          - output.object_ownership
+          - output.object_ownership == 'BucketOwnerEnforced'
+
+    - name: 'test idempotency update s3 bucket ownership preferred controls'
+      s3_bucket:
+        name: '{{ local_bucket_name }}'
+        state: present
+        object_ownership: BucketOwnerEnforced
+      register: output
+
+    - assert:
+        that:
+          - output.changed is false
+          - output.object_ownership
+          - output.object_ownership == 'BucketOwnerEnforced'
 
     - name: 'delete s3 bucket ownership controls'
       s3_bucket:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
AWS finally supports the ability to enforce object ownership such that the owner of the bucket owns all objects. This adds support for that.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
s3_bucket

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
---
  - hosts: localhost
    tasks:
      - s3_bucket:
          name: tyler-test-123
          state: present

      - s3_bucket:
          name: tyler-test-123
          object_ownership: BucketOwnerEnforced
          state: present

      - s3_bucket:
          name: tyler-test-123
          state: absent

      - s3_bucket:
          name: tyler-test-123
          object_ownership: BucketOwnerEnforced
          state: present

      - s3_bucket:
          name: tyler-test-123
          state: absent
```
