### PR TITLE
ec2_vpc_igw: fix 'NoneType' object is not subscriptable (#691)

### DIFF
--- a/changelogs/fragments/691-ec2_vpc_igw-fix-null-igw-error.yml
+++ b/changelogs/fragments/691-ec2_vpc_igw-fix-null-igw-error.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_vpc_igw - fix 'NoneType' object is not subscriptable error (https://github.com/ansible-collections/amazon.aws/pull/691).

--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -54,6 +54,24 @@ ec2_data = {
                 },
             ]
         },
+        "InternetGatewayAttached": {
+            "operation": "DescribeInternetGateways",
+            "delay": 5,
+            "maxAttempts": 40,
+            "acceptors": [
+                {
+                    "expected": "available",
+                    "matcher": "pathAll",
+                    "state": "success",
+                    "argument": "InternetGateways[].Attachments[].State"
+                },
+                {
+                    "matcher": "error",
+                    "expected": "InvalidInternetGatewayID.NotFound",
+                    "state": "retry"
+                },
+            ]
+        },
         "NetworkInterfaceAttached": {
             "operation": "DescribeNetworkInterfaces",
             "delay": 5,
@@ -713,6 +731,12 @@ waiters_by_name = {
     ('EC2', 'internet_gateway_exists'): lambda ec2: core_waiter.Waiter(
         'internet_gateway_exists',
         ec2_model('InternetGatewayExists'),
+        core_waiter.NormalizedOperationMethod(
+            ec2.describe_internet_gateways
+        )),
+    ('EC2', 'internet_gateway_attached'): lambda ec2: core_waiter.Waiter(
+        'internet_gateway_attached',
+        ec2_model('InternetGatewayAttached'),
         core_waiter.NormalizedOperationMethod(
             ec2.describe_internet_gateways
         )),

--- a/plugins/modules/ec2_vpc_igw.py
+++ b/plugins/modules/ec2_vpc_igw.py
@@ -207,6 +207,11 @@ class AnsibleEc2Igw():
                     InternetGatewayId=igw['internet_gateway_id'],
                     VpcId=vpc_id
                 )
+
+                # Ensure the gateway is attached before proceeding
+                waiter = get_waiter(self._connection, 'internet_gateway_attached')
+                waiter.wait(InternetGatewayIds=[igw['internet_gateway_id']])
+
                 self._results['changed'] = True
             except botocore.exceptions.WaiterError as e:
                 self._module.fail_json_aws(e, msg="No Internet Gateway exists.")


### PR DESCRIPTION
Manual backport to stable-2: ec2_vpc_igw: fix 'NoneType' object is not subscriptable

Depends-On: ansible/ansible-zuul-jobs#1368
SUMMARY
Add "InternetGatewayAttached" waiter
Fixes #647
ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
ec2_vpc_igw

Reviewed-by: Alina Buzachis <None>
Reviewed-by: Joseph Torcasso <None>
Reviewed-by: Jill R <None>
Reviewed-by: Abhijeet Kasurde <None>
(cherry picked from commit 8cc9397fb931057f93ab36b0f06b7cf218891a68)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
