### PR TITLE
`ec2_vpc_igw`: fix NoneType error (#695)

### DIFF
--- a/changelogs/fragments/695-ec2_vpc_igw-fix-nonetype-with-paginator.yml
+++ b/changelogs/fragments/695-ec2_vpc_igw-fix-nonetype-with-paginator.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_vpc_igw - use paginator for describe internet gateways and add retry to fix NoneType object is not subscriptable error (https://github.com/ansible-collections/amazon.aws/pull/695).


### PR DESCRIPTION
`ec2_vpc_igw`: fix NoneType error

SUMMARY

use paginator for describe internet gateways and add retry_codes='InvalidInternetGatewayID.NotFound' (thanks @alinabuzachis)
Fixes #647

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
ec2_vpc_igw
ADDITIONAL INFORMATION

previously added InternetGatewayAttached waiter but problem still persists (#691)

Reviewed-by: Abhijeet Kasurde <None>
Reviewed-by: Jill R <None>
(cherry picked from commit 1965b0531421879c16631d2ba461f8d43a085cc6)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
