### PR TITLE
rds module_util - fix check_mode and idempotence bugs and support adding/removing IAM roles

### DIFF
--- a/changelogs/fragments/714-module_util_rds-support-iam-roles-add-waiters.yml
+++ b/changelogs/fragments/714-module_util_rds-support-iam-roles-add-waiters.yml
@@ -1,4 +1,4 @@
 minor_changes:
-  - module_utils.rds - Add support and unit tests for addition/removal of IAM roles to/from a db instance in module_utils.elbv2 with waiters (https://github.com/ansible-collections/amazon.aws/pull/714).
+  - module_utils.rds - Add support and unit tests for addition/removal of IAM roles to/from a db instance in module_utils.rds with waiters (https://github.com/ansible-collections/amazon.aws/pull/714).
 bugfixes:
   - module.utils.rds - Add waiter for promoting read replica to fix idempotency issue (https://github.com/ansible-collections/amazon.aws/pull/714).

--- a/changelogs/fragments/714-module_util_rds-support-iam-roles-add-waiters.yml
+++ b/changelogs/fragments/714-module_util_rds-support-iam-roles-add-waiters.yml
@@ -1,2 +1,4 @@
 minor_changes:
   - module_utils.rds - Add support and unit tests for addition/removal of IAM roles to/from a db instance in module_utils.elbv2 with waiters (https://github.com/ansible-collections/amazon.aws/pull/714).
+bugfixes:
+  - module.utils.rds - Add waiter for promoting read replica to fix idempotency issue (https://github.com/ansible-collections/amazon.aws/pull/714).

--- a/changelogs/fragments/714-module_util_rds-support-iam-roles.yml
+++ b/changelogs/fragments/714-module_util_rds-support-iam-roles.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module_utils.rds - Add support for addition/removal of IAM roles to/from a db instance in module_utils.elbv2 with waiters (https://github.com/ansible-collections/amazon.aws/pull/714).

--- a/changelogs/fragments/714-module_util_rds-support-iam-roles.yml
+++ b/changelogs/fragments/714-module_util_rds-support-iam-roles.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - module_utils.rds - Add support for addition/removal of IAM roles to/from a db instance in module_utils.elbv2 with waiters (https://github.com/ansible-collections/amazon.aws/pull/714).
+  - module_utils.rds - Add support and unit tests for addition/removal of IAM roles to/from a db instance in module_utils.elbv2 with waiters (https://github.com/ansible-collections/amazon.aws/pull/714).

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -318,29 +318,9 @@ def compare_iam_roles(existing_roles, target_roles, purge_roles):
             roles_to_add (list): List of IAM roles to add
             roles_to_delete (list): List of IAM roles to delete
     '''
-    if target_roles is None:
-        target_roles = []
-    roles_to_add = []
-    roles_to_remove = []
-    for target_role in target_roles:
-        found = False
-        for existing_role in existing_roles:
-            if target_role['role_arn'] == existing_role['role_arn'] and target_role['feature_name'] == existing_role['feature_name']:
-                found = True
-                break
-        if not found:
-            roles_to_add.append(target_role)
-
-    if purge_roles:
-        for existing_role in existing_roles:
-            found = False
-            for target_role in target_roles:
-                if target_role['role_arn'] == existing_role['role_arn'] and target_role['feature_name'] == existing_role['feature_name']:
-                    found = True
-                    break
-            if not found:
-                roles_to_remove.append(existing_role)
-
+    existing_roles = [dict((k, v) for k, v in role.items() if k != 'status') for role in existing_roles]
+    roles_to_add = [role for role in target_roles if role not in existing_roles]
+    roles_to_remove = [role for role in existing_roles if role not in target_roles] if purge_roles else []
     return roles_to_add, roles_to_remove
 
 

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -350,8 +350,8 @@ def update_iam_roles(client, module, instance_id, roles_to_add, roles_to_remove)
 
         Parameters:
             client: RDS client
-            module: AWSModule
-            instance_id: DB's instance ID
+            module: AnsibleAWSModule
+            instance_id (str): DB's instance ID
             roles_to_add (list): List of IAM roles to add
             roles_to_delete (list): List of IAM roles to delete
 

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -13,7 +13,6 @@ except ImportError:
     pass
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 
 from .ec2 import AWSRetry
@@ -314,6 +313,8 @@ def ensure_tags(client, module, resource_arn, existing_tags, tags, purge_tags):
 
 
 def compare_iam_roles(existing_roles, target_roles, purge_roles):
+    if target_roles is None:
+        target_roles = []
     roles_to_add = []
     roles_to_remove = []
     for target_role in target_roles:
@@ -338,11 +339,7 @@ def compare_iam_roles(existing_roles, target_roles, purge_roles):
     return roles_to_add, roles_to_remove
 
 
-def ensure_iam_roles(client, module, instance_id, existing_roles, target_roles, purge_iam_roles):
-    if target_roles is None:
-        target_roles = []
-    roles_to_add, roles_to_remove = compare_iam_roles(existing_roles, target_roles, purge_iam_roles)
-    changed = bool(roles_to_add or roles_to_remove)
+def update_iam_roles(client, module, instance_id, roles_to_add, roles_to_remove):
     for role in roles_to_remove:
         params = {'DBInstanceIdentifier': instance_id,
                   'RoleArn': role['role_arn'],

--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -685,6 +685,50 @@ rds_data = {
                 }
             ]
         },
+        "RoleAssociated": {
+            "delay": 5,
+            "maxAttempts": 40,
+            "operation": "DescribeDBInstances",
+            "acceptors": [
+                {
+                    "state": "success",
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].AssociatedRoles[].Status",
+                    "expected": "ACTIVE"
+                },
+                {
+                    "state": "retry",
+                    "matcher": "pathAny",
+                    "argument": "DBInstances[].AssociatedRoles[].Status",
+                    "expected": "PENDING"
+                }
+            ]
+        },
+        "RoleDisassociated": {
+            "delay": 5,
+            "maxAttempts": 40,
+            "operation": "DescribeDBInstances",
+            "acceptors": [
+                {
+                    "state": "success",
+                    "matcher": "pathAll",
+                    "argument": "DBInstances[].AssociatedRoles[].Status",
+                    "expected": "ACTIVE"
+                },
+                {
+                    "state": "retry",
+                    "matcher": "pathAny",
+                    "argument": "DBInstances[].AssociatedRoles[].Status",
+                    "expected": "PENDING"
+                },
+                {
+                    "state": "success",
+                    "matcher": "path",
+                    "argument": "length(DBInstances[].AssociatedRoles[]) == `0`",
+                    "expected": True
+                },
+            ]
+        }
     }
 }
 
@@ -992,6 +1036,18 @@ waiters_by_name = {
         rds_model('DBClusterDeleted'),
         core_waiter.NormalizedOperationMethod(
             rds.describe_db_clusters
+        )),
+    ('RDS', 'role_associated'): lambda rds: core_waiter.Waiter(
+        'role_associated',
+        rds_model('RoleAssociated'),
+        core_waiter.NormalizedOperationMethod(
+            rds.describe_db_instances
+        )),
+    ('RDS', 'role_disassociated'): lambda rds: core_waiter.Waiter(
+        'role_disassociated',
+        rds_model('RoleDisassociated'),
+        core_waiter.NormalizedOperationMethod(
+            rds.describe_db_instances
         )),
     ('Route53', 'resource_record_sets_changed'): lambda route53: core_waiter.Waiter(
         'resource_record_sets_changed',

--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -685,6 +685,25 @@ rds_data = {
                 }
             ]
         },
+        "ReadReplicaPromoted": {
+            "delay": 5,
+            "maxAttempts": 40,
+            "operation": "DescribeDBInstances",
+            "acceptors": [
+                {
+                    "state": "success",
+                    "matcher": "path",
+                    "argument": "length(DBInstances[].StatusInfos) == `0`",
+                    "expected": True
+                },
+                {
+                    "state": "retry",
+                    "matcher": "pathAny",
+                    "argument": "DBInstances[].StatusInfos[].Status",
+                    "expected": "replicating"
+                }
+            ]
+        },
         "RoleAssociated": {
             "delay": 5,
             "maxAttempts": 40,
@@ -1036,6 +1055,12 @@ waiters_by_name = {
         rds_model('DBClusterDeleted'),
         core_waiter.NormalizedOperationMethod(
             rds.describe_db_clusters
+        )),
+    ('RDS', 'read_replica_promoted'): lambda rds: core_waiter.Waiter(
+        'read_replica_promoted',
+        rds_model('ReadReplicaPromoted'),
+        core_waiter.NormalizedOperationMethod(
+            rds.describe_db_instances
         )),
     ('RDS', 'role_associated'): lambda rds: core_waiter.Waiter(
         'role_associated',

--- a/tests/unit/module_utils/test_rds.py
+++ b/tests/unit/module_utils/test_rds.py
@@ -7,9 +7,9 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible_collections.amazon.aws.tests.unit.compat.mock import MagicMock
 from ansible_collections.amazon.aws.plugins.module_utils import rds
-
+from ansible_collections.amazon.aws.tests.unit.compat import unittest
+from ansible_collections.amazon.aws.tests.unit.compat.mock import MagicMock
 
 from contextlib import nullcontext
 import pytest
@@ -308,3 +308,81 @@ def test__handle_errors_failed(method_name, exception, expected, error):
         rds.handle_errors(module, exception, method_name, {"Engine": "fake_engine"})
         module.fail_json_aws.assert_called_once
         module.fail_json_aws.call_args[1]["msg"] == expected
+
+
+class RdsUtils(unittest.TestCase):
+
+    # ========================================================
+    # Setup some initial data that we can use within our tests
+    # ========================================================
+    def setUp(self):
+        self.target_role_list = [
+            {
+                'role_arn': 'role_won',
+                'feature_name': 's3Export'
+            },
+            {
+                'role_arn': 'role_too',
+                'feature_name': 'Lambda'
+            },
+            {
+                'role_arn': 'role_thrie',
+                'feature_name': 's3Import'
+            }
+        ]
+
+    # ========================================================
+    #   rds.compare_iam_roles
+    # ========================================================
+
+    def test_compare_iam_roles_equal(self):
+        existing_list = self.target_role_list
+        roles_to_add, roles_to_delete = rds.compare_iam_roles(existing_list, self.target_role_list, purge_roles=False)
+        self.assertEqual([], roles_to_add)
+        self.assertEqual([], roles_to_delete)
+        roles_to_add, roles_to_delete = rds.compare_iam_roles(existing_list, self.target_role_list, purge_roles=True)
+        self.assertEqual([], roles_to_add)
+        self.assertEqual([], roles_to_delete)
+
+    def test_compare_iam_roles_empty_arr_existing(self):
+        roles_to_add, roles_to_delete = rds.compare_iam_roles([], self.target_role_list, purge_roles=False)
+        self.assertEqual(self.target_role_list, roles_to_add)
+        self.assertEqual([], roles_to_delete)
+        roles_to_add, roles_to_delete = rds.compare_iam_roles([], self.target_role_list, purge_roles=True)
+        self.assertEqual(self.target_role_list, roles_to_add)
+        self.assertEqual([], roles_to_delete)
+
+    def test_compare_iam_roles_empty_arr_target(self):
+        existing_list = self.target_role_list
+        roles_to_add, roles_to_delete = rds.compare_iam_roles(existing_list, [], purge_roles=False)
+        self.assertEqual([], roles_to_add)
+        self.assertEqual([], roles_to_delete)
+        roles_to_add, roles_to_delete = rds.compare_iam_roles(existing_list, [], purge_roles=True)
+        self.assertEqual([], roles_to_add)
+        self.assertEqual(self.target_role_list, roles_to_delete)
+
+    def test_compare_iam_roles_different(self):
+        existing_list = [
+            {
+                'role_arn': 'role_wonn',
+                'feature_name': 's3Export'
+            }]
+        roles_to_add, roles_to_delete = rds.compare_iam_roles(existing_list, self.target_role_list, purge_roles=False)
+        self.assertEqual(self.target_role_list, roles_to_add)
+        self.assertEqual([], roles_to_delete)
+        roles_to_add, roles_to_delete = rds.compare_iam_roles(existing_list, self.target_role_list, purge_roles=True)
+        self.assertEqual(self.target_role_list, roles_to_add)
+        self.assertEqual(existing_list, roles_to_delete)
+
+        existing_list = self.target_role_list.copy()
+        self.target_role_list = [
+            {
+                'role_arn': 'role_wonn',
+                'feature_name': 's3Export'
+            }]
+        roles_to_add, roles_to_delete = rds.compare_iam_roles(existing_list, self.target_role_list, purge_roles=False)
+        self.assertEqual(self.target_role_list, roles_to_add)
+        self.assertEqual([], roles_to_delete)
+        roles_to_add, roles_to_delete = rds.compare_iam_roles(existing_list, self.target_role_list, purge_roles=True)
+        self.assertEqual(self.target_role_list, roles_to_add)
+        self.assertEqual(existing_list, roles_to_delete)

--- a/tests/unit/module_utils/test_rds.py
+++ b/tests/unit/module_utils/test_rds.py
@@ -285,14 +285,6 @@ def test__handle_errors(method_name, exception, expected):
             ),
         ),
         (
-            "create_db_instance",
-            build_exception("create_db_instance", code="InvalidParameterValue"),
-            *expected(
-                "DB engine fake_engine should be one of aurora, aurora-mysql, aurora-postgresql, mariadb, mysql, oracle-ee, oracle-se, oracle-se1, "
-                + "oracle-se2, postgres, sqlserver-ee, sqlserver-ex, sqlserver-se, sqlserver-web"
-            ),
-        ),
-        (
             "create_db_cluster",
             build_exception("create_db_cluster", code="InvalidParameterValue"),
             *expected(


### PR DESCRIPTION
##### SUMMARY
- Add waiter for promoting read replica to fix idempotence bug in community.aws integration testing
- Support modifying IAM roles to a db instance for https://github.com/ansible-collections/community.aws/pull/1002
- Add necessary waiters for both adding and removing an IAM role
- compare and ensure iam_roles methods for idempotency
- unit & integration tests for coverage (integration tests in community.aws PR)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
- module_util/rds
- community.aws.rds_instance

##### ADDITIONAL INFORMATION
Refs:
- (adding role) https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/add-role-to-db-instance.html
- (removing role) https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/remove-role-from-db-instance.html
- (waiters) https://awscli.amazonaws.com/v2/documentation/api/latest/reference/rds/describe-db-instances.html
