### PR TITLE
ec2_instance: add missing metadata_options parameters

### DIFF
--- a/changelogs/fragments/715-ec2-instance-metadata-options.yml
+++ b/changelogs/fragments/715-ec2-instance-metadata-options.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ec2_instance - Add missing ``metadata_options`` parameters (https://github.com/ansible-collections/amazon.aws/pull/715).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -321,6 +321,29 @@ options:
         choices: [optional, required]
         default: optional
         type: str
+      http_put_response_hop_limit:
+        version_added: 3.2.0
+        type: int
+        description: >
+          The desired HTTP PUT response hop limit for instance metadata requests.
+          The larger the number, the further instance metadata requests can travel.
+        default: 1
+      http_protocol_ipv6:
+        version_added: 3.2.0
+        type: str
+        description: >
+          - Wether the instance metadata endpoint is available via IPv6 (C(enabled)) or not (C(disabled)).
+          - Requires botocore >= 1.21.29
+        choices: [enabled, disabled]
+        default: 'disabled'
+      instance_metadata_tags:
+        version_added: 3.2.0
+        type: str
+        description:
+          - Wether the instance tags are availble (C(enabled)) via metadata endpoint or not (C(disabled)).
+          - Requires botocore >= 1.23.30
+        choices: [enabled, disabled]
+        default: 'disabled'
 
 extends_documentation_fragment:
 - amazon.aws.aws
@@ -1268,6 +1291,25 @@ def build_top_level_options(params):
             'metadata_options').get('http_endpoint')
         spec['MetadataOptions']['HttpTokens'] = params.get(
             'metadata_options').get('http_tokens')
+        spec['MetadataOptions']['HttpPutResponseHopLimit'] = params.get(
+            'metadata_options').get('http_put_response_hop_limit')
+
+        if not module.botocore_at_least('1.23.30'):
+            # fail only if enabled is requested
+            if params.get('metadata_options').get('instance_metadata_tags') == 'enabled':
+                module.require_botocore_at_least('1.23.30', reason='to set instance_metadata_tags')
+        else:
+            spec['MetadataOptions']['InstanceMetadataTags'] = params.get(
+                'metadata_options').get('instance_metadata_tags')
+
+        if not module.botocore_at_least('1.21.29'):
+            # fail only if enabled is requested
+            if params.get('metadata_options').get('http_protocol_ipv6') == 'enabled':
+                module.require_botocore_at_least('1.21.29', reason='to set http_protocol_ipv6')
+        else:
+            spec['MetadataOptions']['HttpProtocolIpv6'] = params.get(
+                'metadata_options').get('http_protocol_ipv6')
+
     return spec
 
 
@@ -1954,9 +1996,16 @@ def main():
         instance_ids=dict(default=[], type='list', elements='str'),
         network=dict(default=None, type='dict'),
         volumes=dict(default=None, type='list', elements='dict'),
-        metadata_options=dict(type='dict', options=dict(
-            http_endpoint=dict(type='str', choices=['enabled', 'disabled'], default='enabled'),
-            http_tokens=dict(type='str', choices=['optional', 'required'], default='optional'))),
+        metadata_options=dict(
+            type='dict',
+            options=dict(
+                http_endpoint=dict(choices=['enabled', 'disabled'], default='enabled'),
+                http_put_response_hop_limit=dict(type='int', default=1),
+                http_tokens=dict(choices=['optional', 'required'], default='optional'),
+                http_protocol_ipv6=dict(choices=['disabled', 'enabled'], default='disabled'),
+                instance_metadata_tags=dict(choices=['disabled', 'enabled'], default='disabled'),
+            )
+        ),
     )
     # running/present are synonyms
     # as are terminated/absent

--- a/tests/integration/targets/ec2_instance/meta/main.yml
+++ b/tests/integration/targets/ec2_instance/meta/main.yml
@@ -2,3 +2,6 @@
 dependencies:
 - role: prepare_tests
 - role: setup_ec2_facts
+- role: setup_botocore_pip
+  vars:
+    boto3_version: "1.20.30"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/meta/main.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/meta/main.yml
@@ -1,8 +1,5 @@
 dependencies:
 - role: prepare_tests
 - role: setup_ec2_facts
-- role: setup_botocore_pip
-  vars:
-    boto3_version: "1.20.30"
 collections:
 - amazon.aws

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/meta/main.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/meta/main.yml
@@ -1,5 +1,8 @@
 dependencies:
 - role: prepare_tests
 - role: setup_ec2_facts
+- role: setup_botocore_pip
+  vars:
+    boto3_version: "1.20.30"
 collections:
 - amazon.aws

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
@@ -1,5 +1,34 @@
-- block:
-  - name: "create t3.nano instance with metadata_options"
+- name: test with boto3 version that does not support instance_metadata_tags
+  block:
+  - name: "fail create t3.nano instance with metadata_options"
+    ec2_instance:
+      state: present
+      name: "{{ resource_prefix }}-test-t3nano-enabled-required"
+      image_id: "{{ ec2_ami_id }}"
+      tags:
+        TestId: "{{ ec2_instance_tag_TestId }}"
+      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+      instance_type: t3.nano
+      metadata_options:
+          http_endpoint: enabled
+          http_tokens: required
+          instance_metadata_tags: enabled
+      wait: false
+    ignore_errors: yes
+    register: instance_creation
+
+  - name: verify fail instance with metadata_options because insufficient boto3 requirements
+    assert:
+      that:
+        - instance_creation is failed
+        - instance_creation is not changed
+        - "'This is required to set instance_metadata_tags' in instance_creation.msg"
+
+- name: test with boto3 version that supports instance_metadata_tags
+  vars:
+    ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+  block:
+  - name: "fail create t3.nano instance with metadata_options"
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-t3nano-enabled-required"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
@@ -28,7 +28,7 @@
   vars:
     ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
   block:
-  - name: "fail create t3.nano instance with metadata_options"
+  - name: "create t3.nano instance with metadata_options"
     ec2_instance:
       state: present
       name: "{{ resource_prefix }}-test-t3nano-enabled-required"

--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/metadata_options.yml
@@ -11,6 +11,7 @@
       metadata_options:
           http_endpoint: enabled
           http_tokens: required
+          instance_metadata_tags: enabled
       wait: false
     register: instance_creation
 
@@ -21,6 +22,7 @@
         - instance_creation is changed
         - "'{{ instance_creation.spec.MetadataOptions.HttpEndpoint }}' == 'enabled'"
         - "'{{ instance_creation.spec.MetadataOptions.HttpTokens }}' == 'required'"
+        - "'{{ instance_creation.spec.MetadataOptions.InstanceMetadataTags }}' == 'enabled'"
 
   - name: "modify metadata_options on existing instance"
     ec2_instance:


### PR DESCRIPTION
##### SUMMARY
add missing metadata_options parameter
* http_put_response_hop_limit
* http_protocol_ipv6
* instance_metadata_tags

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME
ec2_instance


