### PR TITLE
parse_aws_arn should accept services with - in the name

### DIFF
--- a/plugins/module_utils/arn.py
+++ b/plugins/module_utils/arn.py
@@ -31,7 +31,7 @@ def parse_aws_arn(arn):
     The specific formats depend on the resource.
     The ARNs for some resources omit the Region, the account ID, or both the Region and the account ID.
     """
-    m = re.search(r"arn:(aws(-([a-z\-]+))?):(\w+):([a-z0-9\-]*):(\d*):(.*)", arn)
+    m = re.search(r"arn:(aws(-([a-z\-]+))?):([\w-]+):([a-z0-9\-]*):(\d*):(.*)", arn)
     if m is None:
         return None
     result = dict()

--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -11,7 +11,6 @@ try:
 except ImportError:
     pass  # caught by HAS_BOTO3
 
-import ansible_collections.amazon.aws.plugins.module_utils.core as aws_core
 from ansible_collections.amazon.aws.plugins.module_utils.modules import _RetryingBotoClientWrapper
 
 

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -905,7 +905,6 @@ instances:
 '''
 
 from collections import namedtuple
-import re
 import string
 import textwrap
 import time

--- a/plugins/modules/ec2_vpc_subnet.py
+++ b/plugins/modules/ec2_vpc_subnet.py
@@ -223,7 +223,7 @@ from ..module_utils.ec2 import AWSRetry
 from ..module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ..module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ..module_utils.ec2 import ensure_ec2_tags
-from ..module_utils.ec2 import is_outposts_arn
+from ..module_utils.arn import is_outpost_arn
 from ..module_utils.waiters import get_waiter
 
 
@@ -287,7 +287,7 @@ def create_subnet(conn, module, vpc_id, cidr, ipv6_cidr=None, outpost_arn=None, 
         params['AvailabilityZone'] = az
 
     if outpost_arn:
-        if is_outposts_arn(outpost_arn):
+        if is_outpost_arn(outpost_arn):
             params['OutpostArn'] = outpost_arn
         else:
             module.fail_json('OutpostArn does not match the pattern specified in API specifications.')

--- a/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -707,6 +707,7 @@
       service: com.amazonaws.{{ aws_region }}.s3
       route_table_ids:
       - '{{ recreate_private_table.route_table.route_table_id }}'
+      wait: True
     register: vpc_endpoint
   - name: purge routes
     ec2_vpc_route_table:

--- a/tests/unit/module_utils/test_arn.py
+++ b/tests/unit/module_utils/test_arn.py
@@ -1,0 +1,73 @@
+# (c) 2022 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+
+__metaclass__ = type
+
+# import unittest
+import pytest
+
+from ansible_collections.amazon.aws.plugins.module_utils.arn import is_outpost_arn
+from ansible_collections.amazon.aws.plugins.module_utils.arn import parse_aws_arn
+
+outpost_arn_test_inputs = [
+    ("arn:aws:outposts:us-east-1:123456789012:outpost/op-1234567890abcdef0", True),
+    ("arn:aws:outposts:us-east-1:123456789012:outpost/op-1234567890abcdef0123", False),
+    ("arn:aws:outpost:us-east-1: 123456789012:outpost/ op-1234567890abcdef0", False),
+    ("ars:aws:outposts:us-east-1: 123456789012:outpost/ op-1234567890abcdef0", False),
+    ("arn:was:outposts:us-east-1: 123456789012:outpost/ op-1234567890abcdef0", False),
+]
+
+arn_bad_values = [
+    ("arn:aws:outpost:us-east-1: 123456789012:outpost/op-1234567890abcdef0"),
+    ("arn:aws:out post:us-east-1:123456789012:outpost/op-1234567890abcdef0"),
+    ("arn:aws:outpost:us east 1:123456789012:outpost/op-1234567890abcdef0"),
+    ("invalid:aws:outpost:us-east-1:123456789012:outpost/op-1234567890abcdef0"),
+    ("arn:junk:outpost:us-east-1:123456789012:outpost/op-1234567890abcdef0"),
+]
+
+arn_good_values = [
+    # Play about with partition name in valid ways
+    dict(partition='aws', service='outpost', region='us-east-1', account_id='123456789012', resource='outpost/op-1234567890abcdef0'),
+    dict(partition='aws-gov', service='outpost', region='us-gov-east-1', account_id='123456789012', resource='outpost/op-1234567890abcdef0'),
+    dict(partition='aws-cn', service='outpost', region='us-east-1', account_id='123456789012', resource='outpost/op-1234567890abcdef0'),
+    # Start the account ID with 0s, it's a 12 digit *string*, if someone treats
+    # it as an integer the leading 0s can disappear.
+    dict(partition='aws-cn', service='outpost', region='us-east-1', account_id='000123000123', resource='outpost/op-1234567890abcdef0'),
+    # S3 doesn't "need" region/account_id as bucket names are globally unique
+    dict(partition='aws', service='s3', region='', account_id='', resource='bucket/object'),
+    # IAM is a 'global' service, so the ARNs don't have regions
+    dict(partition='aws', service='iam', region='', account_id='123456789012', resource='policy/foo/bar/PolicyName'),
+    dict(partition='aws', service='iam', region='', account_id='123456789012', resource='instance-profile/ExampleProfile'),
+    dict(partition='aws', service='iam', region='', account_id='123456789012', resource='root'),
+    # Some examples with different regions
+    dict(partition='aws', service='sqs', region='eu-west-3', account_id='123456789012', resource='example-queue'),
+    dict(partition='aws', service='sqs', region='us-gov-east-1', account_id='123456789012', resource='example-queue'),
+    dict(partition='aws', service='sqs', region='sa-east-1', account_id='123456789012', resource='example-queue'),
+    dict(partition='aws', service='sqs', region='ap-northeast-2', account_id='123456789012', resource='example-queue'),
+    dict(partition='aws', service='sqs', region='ca-central-1', account_id='123456789012', resource='example-queue'),
+    # Some more unusual service names
+    dict(partition='aws', service='network-firewall', region='us-east-1', account_id='123456789012', resource='stateful-rulegroup/ExampleDomainList'),
+    dict(partition='aws', service='resource-groups', region='us-east-1', account_id='123456789012', resource='group/group-name'),
+]
+
+
+@pytest.mark.parametrize("outpost_arn, result", outpost_arn_test_inputs)
+def test_is_outpost_arn(outpost_arn, result):
+    assert is_outpost_arn(outpost_arn) == result
+
+
+@pytest.mark.parametrize("arn", arn_bad_values)
+def test_parse_aws_arn_bad_values(arn):
+    # Make sure we get the expected 'None' for various 'bad' ARNs.
+    assert parse_aws_arn(arn) is None
+
+
+@pytest.mark.parametrize("result", arn_good_values)
+def test_parse_aws_arn_good_values(result):
+    # Something of a cheat, but build the ARN from the result we expect
+    arn = 'arn:{partition}:{service}:{region}:{account_id}:{resource}'.format(**result)
+    assert parse_aws_arn(arn) == result

--- a/tests/unit/module_utils/test_ec2.py
+++ b/tests/unit/module_utils/test_ec2.py
@@ -79,21 +79,3 @@ class Ec2Utils(unittest.TestCase):
 
         converted_filters_int = ansible_dict_to_boto3_filter_list(filters)
         self.assertEqual(converted_filters_int, filter_list_integer)
-
-# ========================================================
-#   ec2.is_outposts_arn
-# ========================================================
-
-
-outpost_arn_test_inputs = [
-    ("arn:aws:outposts:us-east-1:123456789012:outpost/op-1234567890abcdef0", True),
-    ("arn:aws:outposts:us-east-1:123456789012:outpost/op-1234567890abcdef0123", False),
-    ("arn:aws:outpost:us-east-1: 123456789012:outpost/ op-1234567890abcdef0", False),
-    ("ars:aws:outposts:us-east-1: 123456789012:outpost/ op-1234567890abcdef0", False),
-    ("arn:was:outposts:us-east-1: 123456789012:outpost/ op-1234567890abcdef0", False),
-]
-
-
-@pytest.mark.parametrize("outpost_arn, result", outpost_arn_test_inputs)
-def test_is_outposts_arn(outpost_arn, result):
-    assert is_outposts_arn(outpost_arn) == result

--- a/tests/unit/module_utils/test_ec2.py
+++ b/tests/unit/module_utils/test_ec2.py
@@ -5,11 +5,9 @@
 
 from __future__ import (absolute_import, division, print_function)
 
-from plugins.module_utils.ec2 import is_outposts_arn
 __metaclass__ = type
 
 import unittest
-import pytest
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import map_complex_type

--- a/tests/unit/plugins/modules/test_cloudformation.py
+++ b/tests/unit/plugins/modules/test_cloudformation.py
@@ -13,7 +13,6 @@ import pytest
 from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import maybe_sleep, placeboify  # pylint: disable=unused-import
 
 from ansible_collections.amazon.aws.plugins.module_utils.modules import _RetryingBotoClientWrapper
-import ansible_collections.amazon.aws.plugins.module_utils.core as aws_core
 import ansible_collections.amazon.aws.plugins.module_utils.ec2 as aws_ec2
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto_exception


### PR DESCRIPTION
##### SUMMARY

parse_aws_arn currently uses `\w` for service names, there are a couple of services with `-` in the name, which is **not** included by `\w` (`[a-zA-Z0-9_]`)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/module_utils/arn.py

##### ADDITIONAL INFORMATION

Includes net-new unit tests.