### PR TITLE
Prevent CI to be run for whole collection

### DIFF
--- a/tests/integration/targets/legacy_missing_tests/README.md
+++ b/tests/integration/targets/legacy_missing_tests/README.md
@@ -1,0 +1,5 @@
+## Fake integration suite
+
+This is a fake integration suite including an aliases file listing every module name with missing integration tests (some of them are covered by units). 
+
+This fake suite is necessary for the new CI ansible-test-splitter behaviour. Namely, if one of the modules (listed in the aliases file) without a test suite is modified, the CI is run for the entire collection since the ansible-test-splitter won't find any target match. This fake integration suite helps handle this situation by avoiding running the CI for the whole collection. Furthermore, since the modules listed in the aliases file are marked as disabled, tests are automatically skipped.

--- a/tests/integration/targets/legacy_missing_tests/aliases
+++ b/tests/integration/targets/legacy_missing_tests/aliases
@@ -1,0 +1,10 @@
+disabled
+
+# Lookup plugins
+aws_ssm  # covered by unit tests
+aws_service_ip_range
+aws_secret  # covered by unit tests
+aws_account_attribute
+
+# Callback plugin 
+aws_resource_actions 

--- a/tests/integration/targets/legacy_missing_tests/aliases
+++ b/tests/integration/targets/legacy_missing_tests/aliases
@@ -2,9 +2,6 @@ disabled
 
 # Lookup plugins
 aws_ssm  # covered by unit tests
-aws_service_ip_range
-aws_secret  # covered by unit tests
-aws_account_attribute
 
 # Callback plugin 
 aws_resource_actions 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add a fake integration suite including an aliases file listing every module name with missing integration tests.
This fake suite is necessary for the new CI ansible-test-splitter behaviour. If one of the modules (listed in the aliases file) without a test suite is modified, the CI is run for the entire collection since the ansible-test-splitter won't find any target match. This fake integration suite helps handle this situation by avoiding running the CI for the whole collection. Furthermore, since the modules listed in the aliases file are marked as disabled, tests are automatically skipped.

Track Issue: https://github.com/ansible-collections/amazon.aws/issues/729

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
