### PR TITLE
setup_botocore_pip: create tempdir in /var/tmp

### DIFF
--- a/tests/integration/targets/setup_botocore_pip/tasks/main.yml
+++ b/tests/integration/targets/setup_botocore_pip/tasks/main.yml
@@ -4,6 +4,7 @@
 
 - name: 'Create temporary directory for pip environment'
   tempfile:
+    path: /var/tmp
     state: directory
     prefix: botocore
     suffix: .test


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1418
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/739
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/739
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/740

/tmp is based on ramfs and is not suitable for large files.
/var/tmp should be used instead.

See: https://fedoraproject.org/wiki/Features/tmp-on-tmpfs
