### PR TITLE
ec2_vol/test: gives more time to convert vol to gp3

### DIFF
--- a/tests/integration/targets/ec2_vol/tasks/main.yml
+++ b/tests/integration/targets/ec2_vol/tasks/main.yml
@@ -510,7 +510,7 @@
         volume_type: gp3
         modify_volume: yes
       register: changed_gp3_volume
-      retries: 3
+      retries: 10
       delay: 3
       until: not changed_gp3_volume.failed
       # retry because ebs change is to slow


### PR DESCRIPTION
We give 9s to convert the volumne to gp3, in some cases this is not
enough.
Closes: https://github.com/ansible-collections/amazon.aws/issues/738
