### PR TITLE
aws_s3: simplify the template check

### DIFF
--- a/tests/integration/targets/aws_s3/tasks/main.yml
+++ b/tests/integration/targets/aws_s3/tasks/main.yml
@@ -666,7 +666,7 @@
         bucket: "{{ bucket_name }}"
         object: put-template.txt
         mode: put
-        content: "{{ lookup('template', 'templates/put-template.txt.j2') }}"
+        content: "{{ lookup('template', 'templates/put-template.txt.j2')|replace('\n', '') }}"
       register: result
 
     - assert:
@@ -682,7 +682,7 @@
 
     - assert:
         that:
-          - result.contents == "{{ lookup('template', 'templates/put-template.txt.j2') }}"
+          - result.contents == "template:test template"
 
     # at present, there is no lookup that can process binary data, so we use slurp instead
     - slurp:


### PR DESCRIPTION
Don't compare strings with \n character. This triggers errors like this:

```
fatal: [testhost]: FAILED! => {
    "msg": "The conditional check 'result.contents == \"template:\ntest template\n\"' failed. The error was: Invalid conditional detected: EOL while scanning string literal (<unknown>, line 1)"
}
```
