### PR TITLE
Add aliases to the security_token param (#655)

### DIFF
--- a/changelogs/fragments/655-aws_ec2-aws_rds-add-support-for-hostvars_prefix-and-hostvars_suffix.yml
+++ b/changelogs/fragments/655-aws_ec2-aws_rds-add-support-for-hostvars_prefix-and-hostvars_suffix.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- module_utils - add new aliases ``aws_session_token`` and ``session_token`` to the ``security_token`` paramater to be more in-line with the boto SDK (https://github.com/ansible-collections/amazon.aws/pull/631).

--- a/plugins/doc_fragments/aws.py
+++ b/plugins/doc_fragments/aws.py
@@ -48,8 +48,9 @@ options:
       - If I(profile) is set this parameter is ignored.
       - Passing the I(security_token) and I(profile) options at the same time has been deprecated
         and the options will be made mutually exclusive after 2022-06-01.
+      - Aliases I(aws_session_token) and I(session_token) have been added in version 3.2.0.
     type: str
-    aliases: [ aws_security_token, access_token ]
+    aliases: [ aws_session_token, session_token, aws_security_token, access_token ]
   aws_ca_bundle:
     description:
       - "The location of a CA Bundle to use when validating SSL certificates."

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -193,7 +193,7 @@ def aws_common_argument_spec():
         ec2_url=dict(aliases=['aws_endpoint_url', 'endpoint_url']),
         aws_access_key=dict(aliases=['ec2_access_key', 'access_key'], no_log=False),
         aws_secret_key=dict(aliases=['ec2_secret_key', 'secret_key'], no_log=True),
-        security_token=dict(aliases=['access_token', 'aws_security_token'], no_log=True),
+        security_token=dict(aliases=['access_token', 'aws_security_token', 'session_token', 'aws_session_token'], no_log=True),
         validate_certs=dict(default=True, type='bool'),
         aws_ca_bundle=dict(type='path'),
         profile=dict(aliases=['aws_profile']),


### PR DESCRIPTION
Add aliases to the security_token param

SUMMARY
This pull request adds two aliases to the security_token param to make it more in-line with the correct AWS terminology ("session token") - the Boto SDK even refers to it this way.
ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
AWS Common Argument Spec / _aws_common_argument_spec()

Reviewed-by: Alina Buzachis <None>
Reviewed-by: Abhijeet Kasurde <None>
(cherry picked from commit cc21c0f0476f2d418add43c515b5fd5aa12745d1)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
