### PR TITLE
ec2_instance - raise an error when missing permission to stop instance

### DIFF
--- a/changelogs/fragments/756-ec2_instance-raise-an-error-when-missing-permission.yml
+++ b/changelogs/fragments/756-ec2_instance-raise-an-error-when-missing-permission.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_instance - raise an error when missing permission to stop instance when ``state`` is set to ``rebooted``` (https://github.com/ansible-collections/amazon.aws/pull/671).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1598,6 +1598,13 @@ def ensure_instance_state(desired_module_state):
             filters=module.params.get('filters'),
             desired_module_state='stopped',
         )
+
+        if failed:
+            module.fail_json(
+                msg="Unable to stop instances: {0}".format(failure_reason),
+                stop_success=list(_changed),
+                stop_failed=failed)
+
         changed |= bool(len(_changed))
         _changed, failed, instances, failure_reason = change_instance_state(
             filters=module.params.get('filters'),
@@ -1794,7 +1801,7 @@ def handle_existing(existing_matches, state):
     )
 
     state_results = ensure_instance_state(state)
-
+    alter_config_result['changed'] |= state_results.pop('changed', False)
     result = {**state_results, **alter_config_result}
 
     return result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #671 
When missing permission to stop an instance, the module quietly exists instead of raising an error.
This PR fixes that.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance