### PR TITLE
ARN: Add Support for the aws/aws-managed 'account' special cases

### DIFF
--- a/plugins/module_utils/arn.py
+++ b/plugins/module_utils/arn.py
@@ -31,7 +31,7 @@ def parse_aws_arn(arn):
     The specific formats depend on the resource.
     The ARNs for some resources omit the Region, the account ID, or both the Region and the account ID.
     """
-    m = re.search(r"arn:(aws(-([a-z\-]+))?):([\w-]+):([a-z0-9\-]*):(\d*):(.*)", arn)
+    m = re.search(r"arn:(aws(-([a-z\-]+))?):([\w-]+):([a-z0-9\-]*):(\d*|aws|aws-managed):(.*)", arn)
     if m is None:
         return None
     result = dict()

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -261,13 +261,13 @@ volume:
 
 import time
 
+from ..module_utils.arn import is_outpost_arn
 from ..module_utils.core import AnsibleAWSModule
 from ..module_utils.ec2 import camel_dict_to_snake_dict
 from ..module_utils.ec2 import boto3_tag_list_to_ansible_dict
 from ..module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ..module_utils.ec2 import describe_ec2_tags
 from ..module_utils.ec2 import ensure_ec2_tags
-from ..module_utils.ec2 import is_outposts_arn
 from ..module_utils.ec2 import AWSRetry
 from ..module_utils.core import is_boto3_error_code
 from ..module_utils.tagging import boto3_tag_specifications
@@ -502,7 +502,7 @@ def create_volume(module, ec2_conn, zone):
                 additional_params['MultiAttachEnabled'] = True
 
             if outpost_arn:
-                if is_outposts_arn(outpost_arn):
+                if is_outpost_arn(outpost_arn):
                     additional_params['OutpostArn'] = outpost_arn
                 else:
                     module.fail_json('OutpostArn does not match the pattern specified in API specifications.')

--- a/tests/unit/module_utils/test_arn.py
+++ b/tests/unit/module_utils/test_arn.py
@@ -32,30 +32,45 @@ arn_bad_values = [
 
 arn_good_values = [
     # Play about with partition name in valid ways
-    dict(partition='aws', service='outpost', region='us-east-1', account_id='123456789012', resource='outpost/op-1234567890abcdef0'),
-    dict(partition='aws-gov', service='outpost', region='us-gov-east-1', account_id='123456789012', resource='outpost/op-1234567890abcdef0'),
-    dict(partition='aws-cn', service='outpost', region='us-east-1', account_id='123456789012', resource='outpost/op-1234567890abcdef0'),
+    dict(partition='aws', service='outpost', region='us-east-1', account_id='123456789012',
+         resource='outpost/op-1234567890abcdef0'),
+    dict(partition='aws-gov', service='outpost', region='us-gov-east-1', account_id='123456789012',
+         resource='outpost/op-1234567890abcdef0'),
+    dict(partition='aws-cn', service='outpost', region='us-east-1', account_id='123456789012',
+         resource='outpost/op-1234567890abcdef0'),
     # Start the account ID with 0s, it's a 12 digit *string*, if someone treats
     # it as an integer the leading 0s can disappear.
-    dict(partition='aws-cn', service='outpost', region='us-east-1', account_id='000123000123', resource='outpost/op-1234567890abcdef0'),
+    dict(partition='aws-cn', service='outpost', region='us-east-1', account_id='000123000123',
+         resource='outpost/op-1234567890abcdef0'),
     # S3 doesn't "need" region/account_id as bucket names are globally unique
     dict(partition='aws', service='s3', region='', account_id='', resource='bucket/object'),
     # IAM is a 'global' service, so the ARNs don't have regions
-    dict(partition='aws', service='iam', region='', account_id='123456789012', resource='policy/foo/bar/PolicyName'),
-    dict(partition='aws', service='iam', region='', account_id='123456789012', resource='instance-profile/ExampleProfile'),
+    dict(partition='aws', service='iam', region='', account_id='123456789012',
+         resource='policy/foo/bar/PolicyName'),
+    dict(partition='aws', service='iam', region='', account_id='123456789012',
+         resource='instance-profile/ExampleProfile'),
     dict(partition='aws', service='iam', region='', account_id='123456789012', resource='root'),
     # Some examples with different regions
-    dict(partition='aws', service='sqs', region='eu-west-3', account_id='123456789012', resource='example-queue'),
-    dict(partition='aws', service='sqs', region='us-gov-east-1', account_id='123456789012', resource='example-queue'),
-    dict(partition='aws', service='sqs', region='sa-east-1', account_id='123456789012', resource='example-queue'),
-    dict(partition='aws', service='sqs', region='ap-northeast-2', account_id='123456789012', resource='example-queue'),
-    dict(partition='aws', service='sqs', region='ca-central-1', account_id='123456789012', resource='example-queue'),
+    dict(partition='aws', service='sqs', region='eu-west-3', account_id='123456789012',
+         resource='example-queue'),
+    dict(partition='aws', service='sqs', region='us-gov-east-1', account_id='123456789012',
+         resource='example-queue'),
+    dict(partition='aws', service='sqs', region='sa-east-1', account_id='123456789012',
+         resource='example-queue'),
+    dict(partition='aws', service='sqs', region='ap-northeast-2', account_id='123456789012',
+         resource='example-queue'),
+    dict(partition='aws', service='sqs', region='ca-central-1', account_id='123456789012',
+         resource='example-queue'),
     # Some more unusual service names
-    dict(partition='aws', service='network-firewall', region='us-east-1', account_id='123456789012', resource='stateful-rulegroup/ExampleDomainList'),
-    dict(partition='aws', service='resource-groups', region='us-east-1', account_id='123456789012', resource='group/group-name'),
+    dict(partition='aws', service='network-firewall', region='us-east-1', account_id='123456789012',
+         resource='stateful-rulegroup/ExampleDomainList'),
+    dict(partition='aws', service='resource-groups', region='us-east-1', account_id='123456789012',
+         resource='group/group-name'),
     # A special case for resources AWS curate
-    dict(partition='aws', service='network-firewall', region='us-east-1', account_id='aws-managed', resource='stateful-rulegroup/BotNetCommandAndControlDomainsActionOrder'),
-    dict(partition='aws', service='iam', region='', account_id='aws', resource='policy/AWSDirectConnectReadOnlyAccess'),
+    dict(partition='aws', service='network-firewall', region='us-east-1', account_id='aws-managed',
+         resource='stateful-rulegroup/BotNetCommandAndControlDomainsActionOrder'),
+    dict(partition='aws', service='iam', region='', account_id='aws',
+         resource='policy/AWSDirectConnectReadOnlyAccess'),
 ]
 
 

--- a/tests/unit/module_utils/test_arn.py
+++ b/tests/unit/module_utils/test_arn.py
@@ -27,6 +27,7 @@ arn_bad_values = [
     ("arn:aws:outpost:us east 1:123456789012:outpost/op-1234567890abcdef0"),
     ("invalid:aws:outpost:us-east-1:123456789012:outpost/op-1234567890abcdef0"),
     ("arn:junk:outpost:us-east-1:123456789012:outpost/op-1234567890abcdef0"),
+    ("arn:aws:outpost:us-east-1:junk:outpost/op-1234567890abcdef0"),
 ]
 
 arn_good_values = [
@@ -52,6 +53,9 @@ arn_good_values = [
     # Some more unusual service names
     dict(partition='aws', service='network-firewall', region='us-east-1', account_id='123456789012', resource='stateful-rulegroup/ExampleDomainList'),
     dict(partition='aws', service='resource-groups', region='us-east-1', account_id='123456789012', resource='group/group-name'),
+    # A special case for resources AWS curate
+    dict(partition='aws', service='network-firewall', region='us-east-1', account_id='aws-managed', resource='stateful-rulegroup/BotNetCommandAndControlDomainsActionOrder'),
+    dict(partition='aws', service='iam', region='', account_id='aws', resource='policy/AWSDirectConnectReadOnlyAccess'),
 ]
 
 


### PR DESCRIPTION
##### SUMMARY

AWS has a couple of special cases for accounts in ARNs where they're named instead of just numbers.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/arn.py

##### ADDITIONAL INFORMATION

This code isn't part of a release yet, no need for a changelog