### PR TITLE
Update ec2_instance find_instances to fix incompatibility with Python 3.8

### DIFF
--- a/changelogs/fragments/709-ec_2_instance-python-3-8-compatibility.yml
+++ b/changelogs/fragments/709-ec_2_instance-python-3-8-compatibility.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - ec2_instance -  ec2_instance module broken in Python 3.8 - dict keys modified during iteration (https://github.com/ansible-collections/amazon.aws/issues/709).
+  - ec2_instance - ec2_instance module broken in Python 3.8 - dict keys modified during iteration (https://github.com/ansible-collections/amazon.aws/issues/709).

--- a/changelogs/fragments/709-ec_2_instance-python-3-8-compatibility.yml
+++ b/changelogs/fragments/709-ec_2_instance-python-3-8-compatibility.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ec2_instance -  ec2_instance module broken in Python 3.8 - dict keys modified during iteration (https://github.com/ansible-collections/amazon.aws/issues/709).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1473,6 +1473,8 @@ def find_instances(ids=None, filters=None):
         for key in list(filters.keys()):
             if not key.startswith("tag:"):
                 sanitized_filters[key.replace("_", "-")] = filters[key]
+            else:
+                sanitized_filters[key] = filters[key]
         params = dict(Filters=ansible_dict_to_boto3_filter_list(sanitized_filters))
 
     try:

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1463,6 +1463,8 @@ def change_network_attachments(instance, params):
 
 def find_instances(ids=None, filters=None):
     paginator = client.get_paginator('describe_instances')
+    sanitized_filters = dict()
+
     if ids:
         params = dict(InstanceIds=ids)
     elif filters is None:
@@ -1470,13 +1472,14 @@ def find_instances(ids=None, filters=None):
     else:
         for key in list(filters.keys()):
             if not key.startswith("tag:"):
-                filters[key.replace("_", "-")] = filters.pop(key)
-        params = dict(Filters=ansible_dict_to_boto3_filter_list(filters))
+                sanitized_filters[key.replace("_", "-")] = filters[key]
+        params = dict(Filters=ansible_dict_to_boto3_filter_list(sanitized_filters))
 
     try:
         results = _describe_instances(**params)
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Could not describe instances")
+
     retval = list(results)
     return retval
 


### PR DESCRIPTION

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Update ec2_instance find_instances to use temporary dict. instead of inline changes. Fixes #709
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`ec2_instance`

##### ADDITIONAL INFORMATION
Current `ec2_module` iterates over a filters dictionary to perform hyphen to underscore substitution while popping keys in the process. This is not compatible with Python 3.8. I have simply created a second dictionary, I can also create a shallow copy via the `copy()` module if the team prefers.
