### PR TITLE
In integration tests use a common AMI rather than hard coded per test

### DIFF
--- a/tests/integration/targets/ec2_spot_instance/meta/main.yml
+++ b/tests/integration/targets/ec2_spot_instance/meta/main.yml
@@ -1,4 +1,2 @@
 dependencies:
-  - prepare_tests
-  - setup_ec2
   - setup_ec2_facts

--- a/tests/integration/targets/ec2_spot_instance/tasks/main.yaml
+++ b/tests/integration/targets/ec2_spot_instance/tasks/main.yaml
@@ -51,14 +51,6 @@
       vpc_id: "{{ vpc_result.vpc.id }}"
     register: vpc_sg_result
 
-  - name: Get a list of images
-    ec2_ami_info:
-      filters:
-        owner-alias: amazon
-        name: "amzn2-ami-minimal-hvm-*"
-        description: "Amazon Linux 2 AMI *"
-    register: images_info
-
   - name: create a new ec2 key pair
     ec2_key:
       name: "{{ resource_prefix }}-keypair"
@@ -68,7 +60,6 @@
       vpc_id: "{{ vpc_result.vpc.id }}"
       vpc_subnet_id: "{{ vpc_subnet_result.subnet.id }}"
       vpc_sg_id: "{{ vpc_sg_result.group_id }}"
-      image_id: "{{ images_info.images | sort(attribute='creation_date') | reverse | first | json_query('image_id') }}"
 
   # ============================================================
 
@@ -76,7 +67,7 @@
   - name: Create simple spot instance request
     ec2_spot_instance:
       launch_specification:
-        image_id: "{{ image_id }}"
+        image_id: "{{ ec2_ami_id }}"
         key_name: "{{ resource_prefix }}-keypair"
         instance_type: "t2.medium"
         subnet_id: "{{ vpc_subnet_result.subnet.id }}"
@@ -106,7 +97,7 @@
   - name: Create spot request with more complex options
     ec2_spot_instance:
       launch_specification:
-        image_id: "{{ image_id }}"
+        image_id: "{{ ec2_ami_id }}"
         key_name: "{{ resource_prefix }}-keypair"
         instance_type: "t2.medium"
         block_device_mappings:
@@ -197,7 +188,7 @@
   - name: Create spot instance request (check_mode)
     ec2_spot_instance:
       launch_specification:
-        image_id: "{{ image_id }}"
+        image_id: "{{ ec2_ami_id }}"
         key_name: "{{ resource_prefix }}-keypair"
         instance_type: "t2.medium"
         subnet_id: "{{ vpc_subnet_result.subnet.id }}"

--- a/tests/integration/targets/elb_classic_lb/tasks/setup_instances.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/setup_instances.yml
@@ -1,16 +1,8 @@
 ---
-- name: Get a list of images
-  ec2_ami_info:
-    filters:
-      owner-alias: amazon
-      name: "amzn2-ami-minimal-hvm-*"
-      description: "Amazon Linux 2 AMI *"
-  register: images_info
-
 - name: Create instance a
   ec2_instance:
     name: "ansible-test-{{ tiny_prefix }}-elb-a"
-    image_id: "{{ images_info.images | sort(attribute='creation_date') | reverse | first | json_query('image_id') }}"
+    image_id: "{{ ec2_ami_id }}"
     vpc_subnet_id: "{{ subnet_a }}"
     instance_type: t2.micro
     wait: false
@@ -20,7 +12,7 @@
 - name: Create instance b
   ec2_instance:
     name: "ansible-test-{{ tiny_prefix }}-elb-b"
-    image_id: "{{ images_info.images | sort(attribute='creation_date') | reverse | first | json_query('image_id') }}"
+    image_id: "{{ ec2_ami_id }}"
     vpc_subnet_id: "{{ subnet_b }}"
     instance_type: t2.micro
     wait: false


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1498

##### SUMMARY

Rather than hard coding the AMIs on a per-test basis, use a common AMI defined in setup_ec2_facts

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_spot_instance
elb_classic_lb

##### ADDITIONAL INFORMATION

This doesn't touch the ec2_ami integration tests as this would be something of a circular dependency