### PR TITLE
rds module_util - add retry_code to get_rds_method_attributes and add functionality for copying snapshot

### DIFF
--- a/changelogs/fragments/776-module_util_rds-add-extra-retry-codes-refactor.yml
+++ b/changelogs/fragments/776-module_util_rds-add-extra-retry-codes-refactor.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - module.utils.rds - add retry_codes to get_rds_method_attribute return data to use in call_method and add unit tests (https://github.com/ansible-collections/amazon.aws/pull/776).
+  - module.utils.rds - refactor to utilize get_rds_method_attribute return data (https://github.com/ansible-collections/amazon.aws/pull/776).
+
+bugfixes:
+  - module.utils.rds - Catch InvalidDBSecurityGroupStateFault when modifying a db instance (https://github.com/ansible-collections/amazon.aws/pull/776).

--- a/changelogs/fragments/776-module_util_rds-catch-extra-error-code.yml
+++ b/changelogs/fragments/776-module_util_rds-catch-extra-error-code.yml
@@ -1,6 +1,0 @@
-minor_changes:
-  - module.utils.rds - add retry_codes to get_rds_method_attribute return data to use in call_method (https://github.com/ansible-collections/amazon.aws/pull/776).
-  - module.utils.rds - add/update unit tests to reflect these changes and remove some unused code (https://github.com/ansible-collections/amazon.aws/pull/776).
-
-bugfixes:
-  - module.utils.rds - Catch InvalidDBSecurityGroupStateFault when modifying a db instance (https://github.com/ansible-collections/amazon.aws/pull/776).

--- a/changelogs/fragments/776-module_util_rds-catch-extra-error-code.yml
+++ b/changelogs/fragments/776-module_util_rds-catch-extra-error-code.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module.utils.rds - Catch InvalidDBSecurityGroupStateFault when modifying db instance's security groups (https://github.com/ansible-collections/amazon.aws/pull/776).

--- a/changelogs/fragments/776-module_util_rds-catch-extra-error-code.yml
+++ b/changelogs/fragments/776-module_util_rds-catch-extra-error-code.yml
@@ -1,2 +1,6 @@
+minor_changes:
+  - module.utils.rds - add retry_codes to get_rds_method_attribute return data to use in call_method (https://github.com/ansible-collections/amazon.aws/pull/776).
+  - module.utils.rds - add/update unit tests to reflect these changes and remove some unused code (https://github.com/ansible-collections/amazon.aws/pull/776).
+
 bugfixes:
-  - module.utils.rds - Catch InvalidDBSecurityGroupStateFault when modifying db instance's security groups (https://github.com/ansible-collections/amazon.aws/pull/776).
+  - module.utils.rds - Catch InvalidDBSecurityGroupStateFault when modifying a db instance (https://github.com/ansible-collections/amazon.aws/pull/776).

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -43,7 +43,7 @@ snapshot_cluster_method_names = [
 
 snapshot_instance_method_names = [
     'create_db_snapshot', 'delete_db_snapshot', 'add_tags_to_resource', 'remove_tags_from_resource',
-    'list_tags_for_resource'
+    'copy_db_snapshot', 'list_tags_for_resource'
 ]
 
 

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -163,7 +163,8 @@ def call_method(client, module, method_name, parameters):
                 # check if instance is in an available state first, if possible
                 if wait:
                     wait_for_status(client, module, module.params['db_instance_identifier'], 'modify_db_instance')
-                result = AWSRetry.jittered_backoff(catch_extra_error_codes=['InvalidDBInstanceState'])(method)(**parameters)
+                error_codes = ['InvalidDBInstanceState', 'InvalidDBSecurityGroupState']
+                result = AWSRetry.jittered_backoff(catch_extra_error_codes=error_codes)(method)(**parameters)
             elif method_name == 'modify_db_cluster':
                 # check if cluster is in an available state first, if possible
                 if wait:

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -223,7 +223,7 @@ def wait_for_instance_status(client, module, db_instance_id, waiter_name):
         except ValueError:
             # using a waiter in module_utils/waiters.py
             waiter = get_waiter(client, waiter_name)
-        waiter.wait(DBInstanceIdentifier=db_instance_id)
+        waiter.wait(WaiterConfig={'Delay': 60, 'MaxAttempts': 60}, DBInstanceIdentifier=db_instance_id)
 
     waiter_expected_status = {
         'db_instance_deleted': 'deleted',

--- a/tests/unit/module_utils/test_rds.py
+++ b/tests/unit/module_utils/test_rds.py
@@ -186,7 +186,7 @@ def test__wait_for_cluster_snapshot_status_failed(input, expected):
                     name="fake_method",
                     waiter="",
                     operation_description="fake method",
-                    resource = '',
+                    resource='',
                     retry_codes=[]
                 )
             ),

--- a/tests/unit/module_utils/test_rds.py
+++ b/tests/unit/module_utils/test_rds.py
@@ -430,6 +430,24 @@ def test__get_rds_method_attribute_instance(method_name, params, expected, error
             ),
         ),
         (
+            "copy_db_snapshot",
+            {
+                "source_db_snapshot_identifier": "test",
+                "db_snapshot_identifier": "test-copy"
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="copy_db_snapshot",
+                    waiter="db_snapshot_available",
+                    operation_description="copy DB snapshot",
+                    cluster=False,
+                    instance=False,
+                    snapshot=True,
+                    retry_codes=['InvalidDBSnapshotState']
+                )
+            ),
+        ),
+        (
             "list_tags_for_resource",
             {
                 "db_snapshot_identifier": "test",

--- a/tests/unit/module_utils/test_rds.py
+++ b/tests/unit/module_utils/test_rds.py
@@ -75,12 +75,294 @@ def test__wait_for_snapshot_status_failed(input, expected):
     module.fail_json_aws.assert_called_once
     module.fail_json_aws.call_args[1]["msg"] == expected
 
+@pytest.mark.parametrize(
+    "method_name, params, expected, error",
+    [
+        (
+            "delete_db_cluster",
+            {
+                "new_db_cluster_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="delete_db_cluster",
+                    waiter="cluster_deleted",
+                    operation_description="delete DB cluster",
+                    cluster=True,
+                    instance=False,
+                    snapshot=False,
+                    retry_codes=['InvalidDBClusterState']
+                )
+            ),
+        ),
+        (
+            "create_db_cluster",
+            {
+                "new_db_cluster_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="create_db_cluster",
+                    waiter="cluster_available",
+                    operation_description="create DB cluster",
+                    cluster=True,
+                    instance=False,
+                    snapshot=False,
+                    retry_codes=['InvalidDBClusterState']
+                )
+            ),
+        ),
+        (
+            "restore_db_cluster_from_snapshot",
+            {
+                "new_db_cluster_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="restore_db_cluster_from_snapshot",
+                    waiter="cluster_available",
+                    operation_description="restore DB cluster from snapshot",
+                    cluster=True,
+                    instance=False,
+                    snapshot=False,
+                    retry_codes=['InvalidDBClusterSnapshotState']
+                )
+            ),
+        ),
+        (
+            "modify_db_cluster",
+            {
+                "new_db_cluster_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="modify_db_cluster",
+                    waiter="cluster_available",
+                    operation_description="modify DB cluster",
+                    cluster=True,
+                    instance=False,
+                    snapshot=False,
+                    retry_codes=['InvalidDBClusterState']
+                )
+            ),
+        ),
+        (
+            "list_tags_for_resource",
+            {
+                "new_db_cluster_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="list_tags_for_resource",
+                    waiter="cluster_available",
+                    operation_description="list tags for resource",
+                    cluster=True,
+                    instance=False,
+                    snapshot=False,
+                    retry_codes=['InvalidDBClusterState']
+                )
+            ),
+        ),
+        (
+            "fake_method",
+            {
+                "db_cluster_snapshot_identifier": "test",
+            },
+            *error(
+                NotImplementedError,
+                match="method fake_method hasn't been added to the list of accepted methods to use a waiter in module_utils/rds.py",
+            ),
+        ),
+    ],
+)
+def test__get_rds_method_attribute_cluster(method_name, params, expected, error):
+    module = MagicMock()
+    module.params = params
+    with error:
+        assert rds.get_rds_method_attribute(method_name, module) == expected
 
 @pytest.mark.parametrize(
-    "input, expected, error",
+    "method_name, params, expected, error",
+    [
+        (
+            "delete_db_instance",
+            {
+                "new_db_instance_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="delete_db_instance",
+                    waiter="db_instance_deleted",
+                    operation_description="delete DB instance",
+                    cluster=False,
+                    instance=True,
+                    snapshot=False,
+                    retry_codes=['InvalidDBInstanceState', 'InvalidDBSecurityGroupState']
+                )
+            ),
+        ),
+        (
+            "create_db_instance",
+            {
+                "new_db_instance_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="create_db_instance",
+                    waiter="db_instance_available",
+                    operation_description="create DB instance",
+                    cluster=False,
+                    instance=True,
+                    snapshot=False,
+                    retry_codes=['InvalidDBInstanceState', 'InvalidDBSecurityGroupState']
+                )
+            ),
+        ),
+        (
+            "stop_db_instance",
+            {
+                "new_db_instance_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="stop_db_instance",
+                    waiter="db_instance_stopped",
+                    operation_description="stop DB instance",
+                    cluster=False,
+                    instance=True,
+                    snapshot=False,
+                    retry_codes=['InvalidDBInstanceState', 'InvalidDBSecurityGroupState']
+                )
+            ),
+        ),
+        (
+            "promote_read_replica",
+            {
+                "new_db_instance_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="promote_read_replica",
+                    waiter="read_replica_promoted",
+                    operation_description="promote read replica",
+                    cluster=False,
+                    instance=True,
+                    snapshot=False,
+                    retry_codes=['InvalidDBInstanceState', 'InvalidDBSecurityGroupState']
+                )
+            ),
+        ),
+        (
+            "restore_db_instance_from_db_snapshot",
+            {
+                "new_db_instance_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="restore_db_instance_from_db_snapshot",
+                    waiter="db_instance_available",
+                    operation_description="restore DB instance from DB snapshot",
+                    cluster=False,
+                    instance=True,
+                    snapshot=False,
+                    retry_codes=['InvalidDBSnapshotState']
+                )
+            ),
+        ),
+        (
+            "modify_db_instance",
+            {
+                "new_db_instance_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="modify_db_instance",
+                    waiter="db_instance_available",
+                    operation_description="modify DB instance",
+                    cluster=False,
+                    instance=True,
+                    snapshot=False,
+                    retry_codes=['InvalidDBInstanceState', 'InvalidDBSecurityGroupState']
+                )
+            ),
+        ),
+        (
+            "add_role_to_db_instance",
+            {
+                "new_db_instance_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="add_role_to_db_instance",
+                    waiter="role_associated",
+                    operation_description="add role to DB instance",
+                    cluster=False,
+                    instance=True,
+                    snapshot=False,
+                    retry_codes=['InvalidDBInstanceState', 'InvalidDBSecurityGroupState']
+                )
+            ),
+        ),
+        (
+            "remove_role_from_db_instance",
+            {
+                "new_db_instance_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="remove_role_from_db_instance",
+                    waiter="role_disassociated",
+                    operation_description="remove role from DB instance",
+                    cluster=False,
+                    instance=True,
+                    snapshot=False,
+                    retry_codes=['InvalidDBInstanceState', 'InvalidDBSecurityGroupState']
+                )
+            ),
+        ),
+        (
+            "list_tags_for_resource",
+            {
+                "new_db_instance_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="list_tags_for_resource",
+                    waiter="db_instance_available",
+                    operation_description="list tags for resource",
+                    cluster=False,
+                    instance=True,
+                    snapshot=False,
+                    retry_codes=['InvalidDBInstanceState', 'InvalidDBSecurityGroupState']
+                )
+            ),
+        ),
+        (
+            "fake_method",
+            {
+                "db_instance_snapshot_identifier": "test",
+            },
+            *error(
+                NotImplementedError,
+                match="method fake_method hasn't been added to the list of accepted methods to use a waiter in module_utils/rds.py",
+            ),
+        ),
+    ],
+)
+def test__get_rds_method_attribute_instance(method_name, params, expected, error):
+    module = MagicMock()
+    module.params = params
+    with error:
+        assert rds.get_rds_method_attribute(method_name, module) == expected
+
+@pytest.mark.parametrize(
+    "method_name, params, expected, error",
     [
         (
             "delete_db_snapshot",
+            {
+                "db_snapshot_identifier": "test",
+            },
             *expected(
                 rds.Boto3ClientMethod(
                     name="delete_db_snapshot",
@@ -89,11 +371,15 @@ def test__wait_for_snapshot_status_failed(input, expected):
                     cluster=False,
                     instance=False,
                     snapshot=True,
+                    retry_codes=['InvalidDBSnapshotState']
                 )
             ),
         ),
         (
             "create_db_snapshot",
+            {
+                "db_snapshot_identifier": "test",
+            },
             *expected(
                 rds.Boto3ClientMethod(
                     name="create_db_snapshot",
@@ -102,11 +388,32 @@ def test__wait_for_snapshot_status_failed(input, expected):
                     cluster=False,
                     instance=False,
                     snapshot=True,
+                    retry_codes=['InvalidDBInstanceState']
+                )
+            ),
+        ),
+        (
+            "list_tags_for_resource",
+            {
+                "db_snapshot_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="list_tags_for_resource",
+                    waiter="db_snapshot_available",
+                    operation_description="list tags for resource",
+                    cluster=False,
+                    instance=False,
+                    snapshot=True,
+                    retry_codes=['InvalidDBSnapshotState']
                 )
             ),
         ),
         (
             "delete_db_cluster_snapshot",
+            {
+                "db_cluster_snapshot_identifier": "test",
+            },
             *expected(
                 rds.Boto3ClientMethod(
                     name="delete_db_cluster_snapshot",
@@ -115,11 +422,15 @@ def test__wait_for_snapshot_status_failed(input, expected):
                     cluster=False,
                     instance=False,
                     snapshot=True,
+                    retry_codes=['InvalidDBClusterSnapshotState']
                 )
             ),
         ),
         (
             "create_db_cluster_snapshot",
+            {
+                "db_cluster_snapshot_identifier": "test",
+            },
             *expected(
                 rds.Boto3ClientMethod(
                     name="create_db_cluster_snapshot",
@@ -128,11 +439,32 @@ def test__wait_for_snapshot_status_failed(input, expected):
                     cluster=False,
                     instance=False,
                     snapshot=True,
+                    retry_codes=['InvalidDBClusterState']
+                )
+            ),
+        ),
+        (
+            "list_tags_for_resource",
+            {
+                "db_cluster_snapshot_identifier": "test",
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="list_tags_for_resource",
+                    waiter="db_cluster_snapshot_available",
+                    operation_description="list tags for resource",
+                    cluster=False,
+                    instance=False,
+                    snapshot=True,
+                    retry_codes=['InvalidDBClusterSnapshotState']
                 )
             ),
         ),
         (
             "fake_method",
+            {
+                "db_cluster_snapshot_identifier": "test",
+            },
             *error(
                 NotImplementedError,
                 match="method fake_method hasn't been added to the list of accepted methods to use a waiter in module_utils/rds.py",
@@ -140,9 +472,11 @@ def test__wait_for_snapshot_status_failed(input, expected):
         ),
     ],
 )
-def test__get_rds_method_attribute(input, expected, error):
+def test__get_rds_method_attribute_snapshot(method_name, params, expected, error):
+    module = MagicMock()
+    module.params = params
     with error:
-        assert rds.get_rds_method_attribute(input, MagicMock()) == expected
+        assert rds.get_rds_method_attribute(method_name, module) == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/module_utils/test_rds.py
+++ b/tests/unit/module_utils/test_rds.py
@@ -75,6 +75,7 @@ def test__wait_for_snapshot_status_failed(input, expected):
     module.fail_json_aws.assert_called_once
     module.fail_json_aws.call_args[1]["msg"] == expected
 
+
 @pytest.mark.parametrize(
     "method_name, params, expected, error",
     [
@@ -166,7 +167,24 @@ def test__wait_for_snapshot_status_failed(input, expected):
         (
             "fake_method",
             {
-                "db_cluster_snapshot_identifier": "test",
+                "wait": False
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="fake_method",
+                    waiter="",
+                    operation_description="fake method",
+                    cluster=False,
+                    instance=False,
+                    snapshot=False,
+                    retry_codes=[]
+                )
+            ),
+        ),
+        (
+            "fake_method",
+            {
+                "wait": True
             },
             *error(
                 NotImplementedError,
@@ -180,6 +198,7 @@ def test__get_rds_method_attribute_cluster(method_name, params, expected, error)
     module.params = params
     with error:
         assert rds.get_rds_method_attribute(method_name, module) == expected
+
 
 @pytest.mark.parametrize(
     "method_name, params, expected, error",
@@ -340,7 +359,24 @@ def test__get_rds_method_attribute_cluster(method_name, params, expected, error)
         (
             "fake_method",
             {
-                "db_instance_snapshot_identifier": "test",
+                "wait": False
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="fake_method",
+                    waiter="",
+                    operation_description="fake method",
+                    cluster=False,
+                    instance=False,
+                    snapshot=False,
+                    retry_codes=[]
+                )
+            ),
+        ),
+        (
+            "fake_method",
+            {
+                "wait": True
             },
             *error(
                 NotImplementedError,
@@ -354,6 +390,7 @@ def test__get_rds_method_attribute_instance(method_name, params, expected, error
     module.params = params
     with error:
         assert rds.get_rds_method_attribute(method_name, module) == expected
+
 
 @pytest.mark.parametrize(
     "method_name, params, expected, error",
@@ -463,7 +500,24 @@ def test__get_rds_method_attribute_instance(method_name, params, expected, error
         (
             "fake_method",
             {
-                "db_cluster_snapshot_identifier": "test",
+                "wait": False
+            },
+            *expected(
+                rds.Boto3ClientMethod(
+                    name="fake_method",
+                    waiter="",
+                    operation_description="fake method",
+                    cluster=False,
+                    instance=False,
+                    snapshot=False,
+                    retry_codes=[]
+                )
+            ),
+        ),
+        (
+            "fake_method",
+            {
+                "wait": True
             },
             *error(
                 NotImplementedError,


### PR DESCRIPTION
##### SUMMARY
- catch InvalidDBSecurityGroupStateFault when modifying db
- add retry_codes to return data from get_rds_method_attribute, and add unit tests to cover
- add functionality for `copy_db_snapshot` 
- refactor to utilize the return values of get_rds_method_attribute

##### ISSUE TYPE
- Feature Pull Request
- Bugfix Pull Request

##### COMPONENT NAME
rds

##### ADDITIONAL INFORMATION
- Ran into the InvalidDBSecurityGroupStateFault error running integration tests for community.aws.rds_instance

There is quite a bit of refactoring here so I wanted to explain why I made the changes I did:
- there were many instances of calling get_rds_method_attribute to retrieve certain values (waiter, retry_codes, which RDS resource), so I tried to remove the duplicate calls and use the return values already retrieved from the initial call.
- split wait_for_snapshot_status into wait_for_instance_snapshot_status and wait_for_cluster_snapshot_status, as they have different identifiers (they are also broken up in get_final_identifier)

The initial goal here was simply to add retry_codes as a return value of get_rds_method_attribute and add `copy_db_snapshot` as a valid method, but working through that uncovered some bugs and just general redundancies, so I felt these were necessary changes.
