### PR TITLE
Add support for icmp_type and icmp_code parameters (close #628)

### DIFF
--- a/docs/amazon.aws.ec2_group_module.rst
+++ b/docs/amazon.aws.ec2_group_module.rst
@@ -8,7 +8,7 @@ amazon.aws.ec2_group
 **maintain an ec2 VPC security group.**
 
 
-Version added: 1.0.0
+Version added: 1.1.0
 
 .. contents::
    :local:
@@ -358,6 +358,24 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>icmp_type</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">integer</span>
+                    </div>
+                </td>
+                <td>
+                </td>
+                <td>
+                        <div>When using <code>proto: icmp</code> or <code>code: icmpv6</code> parameter, allows you to specify the ICMP type to use.</div>
+                        <div>The option is mutually exclusive with the <code>from_port</code> parameter.</div>
+                        <div>See the list of available ICMP types from the <a href="https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml">IANA website</a></div>
+                </td>
+            </tr>
+            <tr>
+                    <td class="elbow-placeholder"></td>
+                <td colspan="1">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>group_desc</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -455,7 +473,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                    <td class="elbow-placeholder"></td>
+                <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>to_port</b>
@@ -464,6 +482,24 @@ Parameters
                         <span style="color: purple">integer</span>
                     </div>
                 </td>
+                <tr>
+                   <td class="elbow-placeholder"></td>
+                    <td colspan="1">
+                        <div class="ansibleOptionAnchor" id="parameter-"></div>
+                        <b>icmp_code</b>
+                        <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                        <div style="font-size: small">
+                            <span style="color: purple">integer</span>
+                        </div>
+                    </td>
+                    <td>
+                    </td>
+                    <td>
+                            <div>When using <code>proto: icmp</code> or <code>proto: icmpv6</code> parameter, allows you to specify the ICMP code to use.</div>
+                            <div>The option is mutually exclusive with the <code>to_port</code> parameter.</div>
+                            <div>See the list of available ICMP codes from the <a href="https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml">IANA website</a></div>
+                    </td>
+                </tr>
                 <td>
                 </td>
                 <td>
@@ -783,6 +819,19 @@ Examples
             cidr_ip: 0.0.0.0/0
             rule_desc: allow all on port 80
 
+    - name: example using ICMP type and code
+      amazon.aws.ec2_group:
+        name: "{{ name }}"
+        description: sg for ICMP
+        vpc_id: vpc-xxxxxxxx
+        profile: "{{ aws_profile }}"
+        region: us-east-1
+        rules:
+          - proto: icmp
+            icmp_type: 3
+            icmp_code: 1
+            cidr_ip: 0.0.0.0/0
+
     - name: example ec2 group
       amazon.aws.ec2_group:
         name: example
@@ -1048,3 +1097,4 @@ Authors
 ~~~~~~~
 
 - Andrew de Quincey (@adq)
+- Razique Mahroua (@razique)

--- a/docs/amazon.aws.ec2_group_module.rst
+++ b/docs/amazon.aws.ec2_group_module.rst
@@ -8,7 +8,7 @@ amazon.aws.ec2_group
 **maintain an ec2 VPC security group.**
 
 
-Version added: 1.1.0
+Version added: 1.0.0
 
 .. contents::
    :local:
@@ -358,24 +358,6 @@ Parameters
                     <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
-                    <b>icmp_type</b>
-                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                    <div style="font-size: small">
-                        <span style="color: purple">integer</span>
-                    </div>
-                </td>
-                <td>
-                </td>
-                <td>
-                        <div>When using <code>proto: icmp</code> or <code>code: icmpv6</code> parameter, allows you to specify the ICMP type to use.</div>
-                        <div>The option is mutually exclusive with the <code>from_port</code> parameter.</div>
-                        <div>See the list of available ICMP types from the <a href="https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml">IANA website</a></div>
-                </td>
-            </tr>
-            <tr>
-                    <td class="elbow-placeholder"></td>
-                <td colspan="1">
-                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>group_desc</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -473,7 +455,7 @@ Parameters
                 </td>
             </tr>
             <tr>
-                <td class="elbow-placeholder"></td>
+                    <td class="elbow-placeholder"></td>
                 <td colspan="1">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>to_port</b>
@@ -482,24 +464,6 @@ Parameters
                         <span style="color: purple">integer</span>
                     </div>
                 </td>
-                <tr>
-                   <td class="elbow-placeholder"></td>
-                    <td colspan="1">
-                        <div class="ansibleOptionAnchor" id="parameter-"></div>
-                        <b>icmp_code</b>
-                        <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
-                        <div style="font-size: small">
-                            <span style="color: purple">integer</span>
-                        </div>
-                    </td>
-                    <td>
-                    </td>
-                    <td>
-                            <div>When using <code>proto: icmp</code> or <code>proto: icmpv6</code> parameter, allows you to specify the ICMP code to use.</div>
-                            <div>The option is mutually exclusive with the <code>to_port</code> parameter.</div>
-                            <div>See the list of available ICMP codes from the <a href="https://www.iana.org/assignments/icmp-parameters/icmp-parameters.xhtml">IANA website</a></div>
-                    </td>
-                </tr>
                 <td>
                 </td>
                 <td>
@@ -819,19 +783,6 @@ Examples
             cidr_ip: 0.0.0.0/0
             rule_desc: allow all on port 80
 
-    - name: example using ICMP type and code
-      amazon.aws.ec2_group:
-        name: "{{ name }}"
-        description: sg for ICMP
-        vpc_id: vpc-xxxxxxxx
-        profile: "{{ aws_profile }}"
-        region: us-east-1
-        rules:
-          - proto: icmp
-            icmp_type: 3
-            icmp_code: 1
-            cidr_ip: 0.0.0.0/0
-
     - name: example ec2 group
       amazon.aws.ec2_group:
         name: example
@@ -1097,4 +1048,3 @@ Authors
 ~~~~~~~
 
 - Andrew de Quincey (@adq)
-- Razique Mahroua (@razique)

--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -10,7 +10,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ec2_group
-version_added: 1.1.0
+version_added: 1.0.0
 author:
   - "Andrew de Quincey (@adq)"
   - "Razique Mahroua (@Razique)"

--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -111,16 +111,18 @@ options:
             - A value can be between C(0) to C(65535).
             - A value of C(-1) indicates all ports (only supported when I(proto=icmp)).
         icmp_type:
+          version_added: 3.3.0
           type: int
           description:
-          - When using I(proto=icmp) or I(proto=icmpv6), allows you to
-          - specify the ICMP type to use. The option is mutually exclusive with I(from_port).
+          - When using C(proto: icmp) or C(proto: icmpv6), allows you to
+          - specify the ICMP type to use. The option is mutually exclusive with C(from_port).
           - A value of C(-1) indicates all ICMP types.
         icmp_code:
+          version_added: 3.3.0
           type: int
           description:
-          - When using I(proto=icmp) or I(proto=icmpv6), allows you to specify
-          - the ICMP code to use. The option is mutually exclusive with I(to_port).
+          - When using C(proto: icmp) or C(proto: icmpv6), allows you to specify
+          - the ICMP code to use. The option is mutually exclusive with C(to_port).
           - A value of C(-1) indicates all ICMP codes.
         rule_desc:
             type: str
@@ -178,8 +180,8 @@ options:
             description:
             - The IP protocol name (C(tcp), C(udp), C(icmp), C(icmpv6)) or
             - number (U(https://en.wikipedia.org/wiki/List_of_IP_protocol_numbers))
-            - When using a I(proto=icmp) or I(proto=icmpv6), you can pass the
-              I(icmp_type) and I(icmp_code) parameters instead of I(from_port) and I(to_port).
+            - When using a C(proto: icmp) or C(proto: icmpv6), you can pass the
+            - C(icmp_type) and C(icmp_code) parameters instead of C(from_port) and C(to_port).
         from_port:
             type: int
             description:
@@ -193,12 +195,14 @@ options:
             - A value can be between C(0) to C(65535).
             - A value of C(-1) indicates all ports (only supported when I(proto=icmp)).
         icmp_type:
+          version_added: 3.3.0
           type: int
           description:
           - When using C(proto: icmp) or C(proto: icmpv6), allows you to specify
           - the ICMP type to use. The option is mutually exclusive with from_port.
           - A value of C(-1) indicates all ICMP types.
         icmp_code:
+          version_added: 3.3.0
           type: int
           description:
           - When using C(proto: icmp) or C(proto: icmpv6), allows you to specify

--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -96,8 +96,9 @@ options:
             description:
             - The IP protocol name (C(tcp), C(udp), C(icmp), C(icmpv6)) or
             - number (U(https://en.wikipedia.org/wiki/List_of_IP_protocol_numbers))
-            - When using a protocol of ICMP, you can pass the C(icmp_type)
-            - and C(icmp_code) parameters instead of C(from_port) and C(to_port).
+            - When using C(icmp) or C(icmpv6) as the protocol, you can pass
+            - the C(icmp_type) and C(icmp_code) parameters instead of
+            - C(from_port) and C(to_port).
         from_port:
             type: int
             description:
@@ -114,14 +115,14 @@ options:
           version_added: 3.3.0
           type: int
           description:
-          - When using C(proto: icmp) or C(proto: icmpv6), allows you to
+          - When using C(icmp) or C(icmpv6) as the protocol, allows you to
           - specify the ICMP type to use. The option is mutually exclusive with C(from_port).
           - A value of C(-1) indicates all ICMP types.
         icmp_code:
           version_added: 3.3.0
           type: int
           description:
-          - When using C(proto: icmp) or C(proto: icmpv6), allows you to specify
+          - When using C(icmp) or C(icmpv6) as the protocol, allows you to specify
           - the ICMP code to use. The option is mutually exclusive with C(to_port).
           - A value of C(-1) indicates all ICMP codes.
         rule_desc:
@@ -180,7 +181,7 @@ options:
             description:
             - The IP protocol name (C(tcp), C(udp), C(icmp), C(icmpv6)) or
             - number (U(https://en.wikipedia.org/wiki/List_of_IP_protocol_numbers))
-            - When using a C(proto: icmp) or C(proto: icmpv6), you can pass the
+            - When using C(icmp) or C(icmpv6) as the protocol, you can pass the
             - C(icmp_type) and C(icmp_code) parameters instead of C(from_port) and C(to_port).
         from_port:
             type: int
@@ -198,14 +199,14 @@ options:
           version_added: 3.3.0
           type: int
           description:
-          - When using C(proto: icmp) or C(proto: icmpv6), allows you to specify
-          - the ICMP type to use. The option is mutually exclusive with from_port.
+          - When using C(icmp) or C(icmpv6) as the protocol, allows you to specify
+          - the ICMP type to use. The option is mutually exclusive with C(from_port).
           - A value of C(-1) indicates all ICMP types.
         icmp_code:
           version_added: 3.3.0
           type: int
           description:
-          - When using C(proto: icmp) or C(proto: icmpv6), allows you to specify
+          - When using C(icmp) or C(icmpv6) as the protocol, allows you to specify
           - the ICMP code to use. The option is mutually exclusive with C(to_port).
           - A value of C(-1) indicates all ICMP codes.
         rule_desc:

--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -120,7 +120,7 @@ options:
           type: int
           description:
           - When using I(proto=icmp) or I(proto=icmpv6), allows you to specify
-          - the ICMP code to use. The option is mutually exclusive with C(to_port).
+          - the ICMP code to use. The option is mutually exclusive with I(to_port).
           - A value of C(-1) indicates all ICMP codes.
         rule_desc:
             type: str

--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -113,7 +113,7 @@ options:
         icmp_type:
           type: int
           description:
-          - When using C(proto: icmp) or C(proto: icmpv6), allows you to
+          - When using I(proto=icmp) or I(proto=icmpv6), allows you to
           - specify the ICMP type to use. The option is mutually exclusive with C(from_port).
           - A value of C(-1) indicates all ICMP types.
         icmp_code:

--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -119,7 +119,7 @@ options:
         icmp_code:
           type: int
           description:
-          - When using C(proto: icmp) or C(proto: icmpv6), allows you to specify
+          - When using I(proto=icmp) or I(proto=icmpv6), allows you to specify
           - the ICMP code to use. The option is mutually exclusive with C(to_port).
           - A value of C(-1) indicates all ICMP codes.
         rule_desc:

--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -178,8 +178,8 @@ options:
             description:
             - The IP protocol name (C(tcp), C(udp), C(icmp), C(icmpv6)) or
             - number (U(https://en.wikipedia.org/wiki/List_of_IP_protocol_numbers))
-            - When using a C(proto: icmp) or C(proto: icmpv6), you can pass the
-            - C(icmp_type) and C(icmp_code) parameters instead of C(from_port) and C(to_port).
+            - When using a I(proto=icmp) or I(proto=icmpv6), you can pass the
+              I(icmp_type) and I(icmp_code) parameters instead of I(from_port) and I(to_port).
         from_port:
             type: int
             description:

--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -114,7 +114,7 @@ options:
           type: int
           description:
           - When using I(proto=icmp) or I(proto=icmpv6), allows you to
-          - specify the ICMP type to use. The option is mutually exclusive with C(from_port).
+          - specify the ICMP type to use. The option is mutually exclusive with I(from_port).
           - A value of C(-1) indicates all ICMP types.
         icmp_code:
           type: int

--- a/tests/integration/targets/ec2_group/tasks/icmp_verbs.yml
+++ b/tests/integration/targets/ec2_group/tasks/icmp_verbs.yml
@@ -1,0 +1,191 @@
+---
+- block:
+    # ============================================================
+    - name: Create simple rule using icmp verbs
+      ec2_group:
+        name: '{{ec2_group_name}}-icmp-1'
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        description: '{{ec2_group_description}}'
+        rules:
+          - proto: "icmp"
+            icmp_type: 3
+            icmp_code: 8
+            cidr_ip:
+              - 10.0.0.0/8
+              - 172.16.40.10/32
+        state: present
+      register: result
+
+    - name: Retrieve security group info
+      ec2_group_info:
+        filters:
+          group-name: '{{ ec2_group_name }}-icmp-1'
+      register: result_1
+
+    - assert:
+        that:
+          - result is changed
+          - result_1.security_groups is defined
+          - (result_1.security_groups|first).group_name == '{{ ec2_group_name }}-icmp-1'
+          - (result_1.security_groups|first).ip_permissions[0].ip_protocol == "icmp"
+
+    - name: Create ipv6 rule using icmp verbs
+      ec2_group:
+        name: '{{ec2_group_name}}-icmp-2'
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        description: '{{ec2_group_description}}'
+        rules:
+          - proto: "icmpv6"
+            icmp_type: 1
+            icmp_code: 4
+            cidr_ipv6: "64:ff9b::/96"
+        state: present
+      register: result
+
+    - name: Retrieve security group info
+      ec2_group_info:
+        filters:
+          group-name: '{{ ec2_group_name }}-icmp-2'
+      register: result_1
+
+    - assert:
+        that:
+          - result is changed
+          - result_1.security_groups is defined
+          - (result_1.security_groups|first).group_name == '{{ ec2_group_name }}-icmp-2'
+          - (result_1.security_groups|first).ip_permissions[0].ip_protocol == "icmpv6"
+
+
+    - name: Create rule using security group referencing
+      ec2_group:
+        name: '{{ec2_group_name}}-icmp-3'
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        description: '{{ec2_group_description}}'
+        rules:
+          - proto: "icmp"
+            icmp_type: 5
+            icmp_code: 1
+            group_name: '{{ec2_group_name}}-auto-create-2'
+            group_desc: "sg-group-referencing"
+        state: present
+      register: result
+
+    - name: Retrieve security group info
+      ec2_group_info:
+        filters:
+          group-name: '{{ ec2_group_name }}-icmp-3'
+      register: result_1
+
+    - assert:
+        that:
+          - result is changed
+          - (result_1.security_groups | first).ip_permissions[0].user_id_group_pairs is defined
+
+    - name: Create list rule using 0 as icmp_type
+      ec2_group:
+        name: '{{ec2_group_name}}-icmp-4'
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        description: '{{ec2_group_description}}'
+        rules:
+          - proto: icmp
+            icmp_type: 0
+            icmp_code: 1
+            cidr_ip:
+              - 10.0.0.0/8
+              - 172.16.40.10/32
+          - proto: "tcp"
+            from_port: 80
+            to_port: 80
+            cidr_ip: 172.16.40.10/32
+        state: present
+      register: result
+
+    - name: Retrieve security group info
+      ec2_group_info:
+        filters:
+          group-name: '{{ ec2_group_name }}-icmp-4'
+      register: result_1
+
+    - assert:
+        that:
+          - result is changed
+          - (result_1.security_groups | first).ip_permissions | length == 2
+    # ============================================================
+
+    # ============================================================
+    - name: Create a group with non-ICMP protocol
+      ec2_group:
+        name: '{{ec2_group_name}}-icmp-4'
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        description: '{{ec2_group_description}}'
+        rules:
+        - proto: "tcp"
+          icmp_type: 0
+          icmp_code: 1
+          cidr_ip:
+            - 10.0.0.0/8
+            - 172.16.40.10/32
+        state: present
+      register: result
+      ignore_errors: true
+
+    - name: assert that group creation fails when proto != icmp with icmp parameters
+      assert:
+        that:
+          - result is failed
+
+    - name: Create a group with conflicting parameters
+      ec2_group:
+        name: '{{ec2_group_name}}-icmp-4'
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        description: '{{ec2_group_description}}'
+        rules:
+          - proto: icmp
+            from_port: 5
+            to_port: 1
+            icmp_type: 0
+            icmp_code: 1
+            cidr_ip:
+              - 10.0.0.0/8
+              - 172.16.40.10/32
+        state: present
+      register: result
+      ignore_errors: true
+
+    - name: assert that group creation fails when using conflicting parameters
+      assert:
+        that:
+          - result is failed
+
+    - name: Create a group with missing icmp parameters
+      ec2_group:
+        name: '{{ec2_group_name}}-icmp-4'
+        vpc_id: '{{ vpc_result.vpc.id }}'
+        description: '{{ec2_group_description}}'
+        rules:
+        - proto: "tcp"
+          icmp_type: 0
+          cidr_ip:
+            - 10.0.0.0/8
+            - 172.16.40.10/32
+        state: present
+      register: result
+      ignore_errors: true
+
+    - name: assert that group creation fails when missing icmp parameters
+      assert:
+        that:
+          - result is failed
+
+  always:
+    - name: tidy up egress rule test security group
+      ec2_group:
+        name: '{{ec2_group_name}}-auto-create-{{ item }}'
+        state: absent
+        vpc_id: '{{ vpc_result.vpc.id }}'
+      ignore_errors: yes
+      with_items:
+        - 1
+        - 2
+        - 3
+        - 4

--- a/tests/integration/targets/ec2_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_group/tasks/main.yml
@@ -62,6 +62,7 @@
     - include: ./numeric_protos.yml
     - include: ./rule_group_create.yml
     - include: ./egress_tests.yml
+    - include: ./icmp_verbs.yml
     - include: ./data_validation.yml
     - include: ./multi_nested_target.yml
     - include: ./group_info.yml


### PR DESCRIPTION
##### SUMMARY
This pull request add support for new `icmp_type` and `icmp_code` parameters with `proto: icmp` or `proto: icmpv6`. This initial suggestion was aimed at closing the inconsistency when the meaning of `from_port` and `to_port` would change based on the protocol type.

Fixes #628 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ec2_group`

