### PR TITLE
Create extra snapshots for ec2_snapshot_info test - minimum max_results is 5

### DIFF
--- a/tests/integration/targets/ec2_snapshot/tasks/main.yml
+++ b/tests/integration/targets/ec2_snapshot/tasks/main.yml
@@ -178,10 +178,9 @@
 #        that:
 #          - result is changed
 
-    #  Wait at least 15 seconds between concurrent volume snapshots.
-    - name: Prevent SnapshotCreationPerVolumeRateExceeded errors
+    - name: Pause to avoid SnapshotCreationPerVolumeRateExceeded
       pause:
-        seconds: 15
+        seconds: 20
 
     - name: Take snapshot and tag it
       ec2_snapshot:
@@ -217,12 +216,30 @@
         that:
           - info_result.snapshots| length == 3
 
+    - name: Pause to avoid SnapshotCreationPerVolumeRateExceeded
+      pause:
+        seconds: 20
+
+    - ec2_snapshot:
+        volume_id: '{{ volume_id }}'
+        snapshot_tags:
+          ResourcePrefix: '{{ resource_prefix }}'
+      loop: '{{ range(1, 6, 1) | list }}'
+      loop_control:
+        # Anything under 15 will trigger SnapshotCreationPerVolumeRateExceeded
+        pause: 20
+        label: "Generate extra snapshots - {{ item }}"
+
+    - name: Pause to allow creation to finish
+      pause:
+        minutes: 2
+
     # check that snapshot_ids and max_results are mutually exclusive
     - name: Check that max_results and snapshot_ids are mutually exclusive
       ec2_snapshot_info:
         snapshot_ids:
           - '{{ tagged_snapshot_id }}'
-        max_results: 1
+        max_results: 5
       ignore_errors: true
       register: info_result
 
@@ -250,12 +267,12 @@
       ec2_snapshot_info:
         filters:
           "tag:Name": '{{ resource_prefix }}'
-        max_results: 1
+        max_results: 5
       register: info_result
 
     - assert:
         that:
-          - info_result.snapshots | length == 1
+          - info_result.snapshots | length == 5
           - info_result.next_token_id is defined
 
     # Pagination : 2nd request
@@ -268,8 +285,7 @@
 
     - assert:
         that:
-          - info_result.snapshots | length == 2
-          - info_result.next_token_id is defined
+          - info_result.snapshots | length == 3
 
     # delete the tagged snapshot
     - name: Delete the tagged snapshot
@@ -285,7 +301,7 @@
 
     - assert:
         that:
-          - info_result.snapshots| length == 2
+          - info_result.snapshots| length == 7
           - '"{{ tagged_snapshot_id }}" not in "{{ info_result| community.general.json_query("snapshots[].snapshot_id") }}"'
 
     - name: Delete snapshots


### PR DESCRIPTION
This is a partial backport of PR https://github.com/ansible-collections/amazon.aws/pull/356 as merged into main (https://github.com/ansible-collections/amazon.aws/commit/b7087f46044bcee279b490a32a57ef0138a753c5).

##### SUMMARY

Fixes a bug in the integration test

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_snapshot_info

##### ADDITIONAL INFORMATION
