### PR TITLE
For consistency - add empty dependencies file to targets with no current meta data

### DIFF
--- a/tests/integration/targets/setup_botocore_pip/meta/main.yml
+++ b/tests/integration/targets/setup_botocore_pip/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/setup_ec2_facts/meta/main.yml
+++ b/tests/integration/targets/setup_ec2_facts/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/setup_remote_tmp_dir/meta/main.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/setup_sshkey/meta/main.yml
+++ b/tests/integration/targets/setup_sshkey/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []


### PR DESCRIPTION
##### SUMMARY

add empty dependencies file to targets with no current meta data

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tests/integration/targets/

##### ADDITIONAL INFORMATION

Split off from #784 to try and avoid issues with ansible-test-splitter