### PR TITLE
For consistency - add empty dependencies file to targets with no current meta data

### DIFF
--- a/tests/integration/targets/aws_caller_info/meta/main.yml
+++ b/tests/integration/targets/aws_caller_info/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/ec2_vpc_dhcp_option/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_dhcp_option/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/ec2_vpc_endpoint/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/ec2_vpc_igw/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_igw/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/ec2_vpc_nat_gateway/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_nat_gateway/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/inventory_aws_ec2/meta/main.yml
+++ b/tests/integration/targets/inventory_aws_ec2/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/inventory_aws_rds/meta/main.yml
+++ b/tests/integration/targets/inventory_aws_rds/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/legacy_missing_tests/meta/main.yml
+++ b/tests/integration/targets/legacy_missing_tests/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/lookup_aws_account_attribute/meta/main.yml
+++ b/tests/integration/targets/lookup_aws_account_attribute/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/lookup_aws_secret/meta/main.yml
+++ b/tests/integration/targets/lookup_aws_secret/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/lookup_aws_service_ip_ranges/meta/main.yml
+++ b/tests/integration/targets/lookup_aws_service_ip_ranges/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []


### PR DESCRIPTION
##### SUMMARY

add empty dependencies file to targets with no current meta data

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tests/integration/targets/

##### ADDITIONAL INFORMATION

Split off from #784 to try and avoid issues with ansible-test-splitter

#784 has been approved so I'm just going to let this gate