### PR TITLE
Deprecate Camel- and Upper- case aliases

### DIFF
--- a/changelogs/fragments/795-deprecate-aliases.yml
+++ b/changelogs/fragments/795-deprecate-aliases.yml
@@ -3,3 +3,6 @@ deprecated_features:
 - aws_s3 - The ``S3_URL`` alias for the s3_url option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
 - ec2_vpc_dhcp_option_info - The ``DryRun`` alias for the dry_run option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
 - ec2_vpc_dhcp_option_info - The ``DhcpOptionIds`` alias for the dhcp_option_ids option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
+- ec2_ami - The ``DeviceName`` alias for the device_name option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
+- ec2_ami - The ``VirtualName`` alias for the virtual_name option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
+- ec2_ami - The ``NoDevice`` alias for the no_device option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).

--- a/changelogs/fragments/795-deprecate-aliases.yml
+++ b/changelogs/fragments/795-deprecate-aliases.yml
@@ -1,3 +1,5 @@
 deprecated_features:
 - s3_bucket - The ``S3_URL`` alias for the s3_url option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
 - aws_s3 - The ``S3_URL`` alias for the s3_url option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
+- ec2_vpc_dhcp_option_info - The ``DryRun`` alias for the dry_run option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
+- ec2_vpc_dhcp_option_info - The ``DhcpOptionIds`` alias for the dhcp_option_ids option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).

--- a/changelogs/fragments/795-deprecate-aliases.yml
+++ b/changelogs/fragments/795-deprecate-aliases.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+- s3_bucket - The ``S3_URL`` alias for the s3_url option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
+- aws_s3 - The ``S3_URL`` alias for the s3_url option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).

--- a/plugins/modules/aws_s3.py
+++ b/plugins/modules/aws_s3.py
@@ -121,6 +121,8 @@ options:
   s3_url:
     description:
       - S3 URL endpoint for usage with Ceph, Eucalyptus and fakes3 etc. Otherwise assumes AWS.
+      - The S3_URL alias for this option has been deprecated and will be removed
+        in release 5.0.0.
     aliases: [ S3_URL ]
     type: str
   dualstack:
@@ -925,7 +927,7 @@ def main():
         overwrite=dict(aliases=['force'], default='always'),
         prefix=dict(default=""),
         retries=dict(aliases=['retry'], type='int', default=0),
-        s3_url=dict(aliases=['S3_URL']),
+        s3_url=dict(aliases=['S3_URL'], deprecated_aliases=[dict(name='S3_URL', version='5.0.0', collection_name='amazon.aws')]),
         dualstack=dict(default='no', type='bool'),
         rgw=dict(default='no', type='bool'),
         src=dict(type='path'),

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -80,6 +80,8 @@ options:
           type: str
           description:
           - The device name. For example C(/dev/sda).
+          - The C(DeviceName) alias had been deprecated and will be removed in
+            release 5.0.0.
           required: yes
           aliases: ['DeviceName']
         virtual_name:
@@ -87,13 +89,15 @@ options:
           description:
           - The virtual name for the device.
           - See the AWS documentation for more detail U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html).
-          - Alias C(VirtualName) has been deprecated and will be removed after 2022-06-01.
+          - The C(VirtualName) alias has been deprecated and will be removed in
+            release 5.0.0.
           aliases: ['VirtualName']
         no_device:
           type: bool
           description:
           - Suppresses the specified device included in the block device mapping of the AMI.
-          - Alias C(NoDevice) has been deprecated and will be removed after 2022-06-01.
+          - The C(NoDevice) alias has been deprecated and will be removed in
+            release 5.0.0.
           aliases: ['NoDevice']
         volume_type:
           type: str
@@ -707,13 +711,15 @@ def rename_item_if_exists(dict_object, attribute, new_attribute, child_node=None
 
 def main():
     mapping_options = dict(
-        device_name=dict(type='str', aliases=['DeviceName'], required=True),
+        device_name=dict(
+            type='str', aliases=['DeviceName'], required=True,
+            deprecated_aliases=[dict(name='DeviceName', version='5.0.0', collection_name='amazon.aws')]),
         virtual_name=dict(
             type='str', aliases=['VirtualName'],
-            deprecated_aliases=[dict(name='VirtualName', date='2022-06-01', collection_name='amazon.aws')]),
+            deprecated_aliases=[dict(name='VirtualName', version='5.0.0', collection_name='amazon.aws')]),
         no_device=dict(
             type='bool', aliases=['NoDevice'],
-            deprecated_aliases=[dict(name='NoDevice', date='2022-06-01', collection_name='amazon.aws')]),
+            deprecated_aliases=[dict(name='NoDevice', version='5.0.0', collection_name='amazon.aws')]),
         volume_type=dict(type='str'),
         delete_on_termination=dict(type='bool'),
         snapshot_id=dict(type='str'),

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -23,6 +23,8 @@ options:
   dhcp_options_ids:
     description:
       - Get details of specific DHCP Option IDs.
+      - The C(DhcpOptionIds) alias has been deprecated and will be removed in
+        release 5.0.0.
     aliases: ['DhcpOptionIds']
     type: list
     elements: str
@@ -30,6 +32,8 @@ options:
     description:
       - Checks whether you have the required permissions to view the DHCP
         Options.
+      - The C(DryRun) alias has been deprecated and will be removed in
+        release 5.0.0.
     aliases: ['DryRun']
     type: bool
     default: false
@@ -178,8 +182,12 @@ def list_dhcp_options(client, module):
 def main():
     argument_spec = dict(
         filters=dict(type='dict', default={}),
-        dry_run=dict(type='bool', default=False, aliases=['DryRun']),
-        dhcp_options_ids=dict(type='list', elements='str', aliases=['DhcpOptionIds'])
+        dry_run=dict(
+            type='bool', default=False, aliases=['DryRun'],
+            deprecated_aliases=[dict(name='DryRun', version='5.0.0', collection_name='amazon.aws')]),
+        dhcp_options_ids=dict(
+            type='list', elements='str', aliases=['DhcpOptionIds'],
+            deprecated_aliases=[dict(name='DhcpOptionIds', version='5.0.0', collection_name='amazon.aws')]),
     )
 
     module = AnsibleAWSModule(

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -48,6 +48,8 @@ options:
       - S3 URL endpoint for usage with DigitalOcean, Ceph, Eucalyptus and FakeS3 etc.
       - Assumes AWS if not specified.
       - For Walrus, use FQDN of the endpoint without scheme nor path.
+      - The S3_URL alias for this option has been deprecated and will be removed
+        in release 5.0.0.
     aliases: [ S3_URL ]
     type: str
   ceph:
@@ -1007,7 +1009,7 @@ def main():
         policy=dict(type='json'),
         name=dict(required=True),
         requester_pays=dict(type='bool'),
-        s3_url=dict(aliases=['S3_URL']),
+        s3_url=dict(aliases=['S3_URL'], deprecated_aliases=[dict(name='S3_URL', version='5.0.0', collection_name='amazon.aws')]),
         state=dict(default='present', choices=['present', 'absent']),
         tags=dict(type='dict'),
         purge_tags=dict(type='bool', default=True),


### PR DESCRIPTION
##### SUMMARY

Clean up aliases.

S3_URL is a quirk from the very early code base and wasn't cleaned up when the [original cleanup was done](https://github.com/ansible/ansible/pull/3894) (in 2014!) 
The CamelCase parameters were originally for compatibility.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

s3_bucket
aws_s3
ec2_vpc_dhcp_option_info aliases
ec2_ami

##### ADDITIONAL INFORMATION

S3_URL is causing linting issues with the docs:
`  /home/runner/work/_temp/docsbuild/rst/collections/amazon/aws/aws_s3_module.rst:1478: WARNING: Duplicate explicit target name: "ansible_collections.amazon.aws.aws_s3_module__parameter-s3_url".`
