### PR TITLE
Yet more sanity cleanup

### DIFF
--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -36,6 +36,7 @@ DOCUMENTATION = '''
               - A list of regions in which to describe EC2 instances.
               - If empty (the default) default this will include all regions, except possibly restricted ones like us-gov-west-1 and cn-north-1.
           type: list
+          elements: str
           default: []
         hostnames:
           description:
@@ -43,6 +44,7 @@ DOCUMENTATION = '''
               - You can use the options specified in U(http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options).
               - To use tags as hostnames use the syntax tag:Name=Value to use the hostname Name_Value, or tag:Name to use the value of the Name tag.
           type: list
+          elements: dict
           default: []
         filters:
           description:
@@ -57,6 +59,7 @@ DOCUMENTATION = '''
               - Every entry in this list triggers a search query. As such, from a performance point of view, it's better to
                 keep the list as short as possible.
           type: list
+          elements: dict
           default: []
         exclude_filters:
           description:
@@ -66,6 +69,7 @@ DOCUMENTATION = '''
               - Every entry in this list triggers a search query. As such, from a performance point of view, it's better to
                 keep the list as short as possible.
           type: list
+          elements: dict
           default: []
         include_extra_api_calls:
           description:

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -32,6 +32,7 @@ DOCUMENTATION = '''
         statuses:
           description: A list of desired states for instances/clusters to be added to inventory. Set to ['all'] as a shorthand to find everything.
           type: list
+          elements: str
           default:
               - creating
               - available

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -157,6 +157,7 @@ options:
         description:
         - a list of ENI IDs (strings) or a list of objects containing the key I(id).
         type: list
+        elements: str
       assign_public_ip:
         description:
         - when true assigns a public IP address to the interface
@@ -169,6 +170,7 @@ options:
         description:
         - a list of IPv6 addresses to assign to the network interface
         type: list
+        elements: str
       source_dest_check:
         description:
         - controls whether source/destination checking is enabled on the interface
@@ -181,6 +183,7 @@ options:
         description:
         - a list of IPv4 addresses to assign to the network interface
         type: list
+        elements: str
       subnet_id:
         description:
         - the subnet to connect the network interface to
@@ -198,6 +201,7 @@ options:
         description:
         - a list of security group IDs to attach to the interface
         type: list
+        elements: str
   volumes:
     description:
     - A list of block device mappings, by default this will always use the AMI root device so the volumes option is primarily for adding more storage.

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -6,16 +6,16 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: ec2_snapshot_info
 version_added: 1.0.0
-short_description: Gather information about ec2 volume snapshots in AWS
+short_description: Gathers information about EC2 volume snapshots in AWS
 description:
-    - Gather information about ec2 volume snapshots in AWS.
+  - Gathers information about EC2 volume snapshots in AWS.
 author:
-    - "Rob White (@wimnat)"
-    - Aubin Bikouo (@abikouo)
+  - Rob White (@wimnat)
+  - Aubin Bikouo (@abikouo)
 options:
   snapshot_ids:
     description:
@@ -70,12 +70,11 @@ notes:
     the account use the filter 'owner-id'.
 
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-
+  - amazon.aws.ec2
+  - amazon.aws.aws
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 
 # Gather information about all snapshots, including public ones
@@ -113,7 +112,7 @@ EXAMPLES = '''
 
 '''
 
-RETURN = '''
+RETURN = r'''
 snapshots:
     description: snapshots retrieved
     type: list

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -136,9 +136,10 @@ snapshots:
             returned: always
             sample: completed
         state_message:
-            description: Encrypted Amazon EBS snapshots are copied asynchronously. If a snapshot copy operation fails (for example, if the proper
-                         AWS Key Management Service (AWS KMS) permissions are not obtained) this field displays error state details to help you diagnose why the
-                         error occurred.
+            description:
+              - Encrypted Amazon EBS snapshots are copied asynchronously. If a snapshot copy operation fails (for example, if the proper
+                AWS Key Management Service (AWS KMS) permissions are not obtained) this field displays error state details to help you diagnose why the
+                error occurred.
             type: str
             returned: always
             sample:
@@ -183,14 +184,16 @@ snapshots:
             returned: always
             sample: "True"
         kms_key_id:
-            description: The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) that was used to \
-            protect the volume encryption key for the parent volume.
+            description:
+              - The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) that was used to
+                protect the volume encryption key for the parent volume.
             type: str
             returned: always
             sample: "74c9742a-a1b2-45cb-b3fe-abcdef123456"
         data_encryption_key_id:
-            description: The data encryption key identifier for the snapshot. This value is a unique identifier that \
-            corresponds to the data encryption key that was used to encrypt the original volume or snapshot copy.
+            description:
+              - The data encryption key identifier for the snapshot. This value is a unique identifier that
+                corresponds to the data encryption key that was used to encrypt the original volume or snapshot copy.
             type: str
             returned: always
             sample: "arn:aws:kms:ap-southeast-2:012345678900:key/74c9742a-a1b2-45cb-b3fe-abcdef123456"


### PR DESCRIPTION
##### SUMMARY

ansible/ansible devel has some more docs sanity tests in the works.  Get ahead of them

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/inventory/aws_ec2.py
plugins/inventory/aws_rds.py
plugins/modules/ec2_instance.py
plugins/modules/ec2_snapshot_info.py

##### ADDITIONAL INFORMATION

```
ERROR: Found 11 validate-modules issue(s) which need to be resolved:
ERROR: plugins/inventory/aws_ec2.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.exclude_filters: Argument defines type as list but elements is not defined for dictionary value @ data['options']['exclude_filters']. Got {'description': ['A list of filters. Any instances matching one of the filters are excluded from the result.', 'The filters from C(exclude_filters) take priority over the C(include_filters) and C(filters) keys', 'Available filters are listed here U(http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options).', "Every entry in this list triggers a search query. As such, from a performance point of view, it's better to keep the list as short as possible."], 'type': 'lis...
ERROR: plugins/inventory/aws_ec2.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.hostnames: Argument defines type as list but elements is not defined for dictionary value @ data['options']['hostnames']. Got {'description': ['A list in order of precedence for hostname variables.', 'You can use the options specified in U(http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options).', 'To use tags as hostnames use the syntax tag:Name=Value to use the hostname Name_Value, or tag:Name to use the value of the Name tag.'], 'type': 'list', 'default': []}
ERROR: plugins/inventory/aws_ec2.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.include_filters: Argument defines type as list but elements is not defined for dictionary value @ data['options']['include_filters']. Got {'description': ['A list of filters. Any instances matching at least one of the filters are included in the result.', 'Available filters are listed here U(http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options).', "Every entry in this list triggers a search query. As such, from a performance point of view, it's better to keep the list as short as possible."], 'type': 'list', 'default': []}
ERROR: plugins/inventory/aws_ec2.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.regions: Argument defines type as list but elements is not defined for dictionary value @ data['options']['regions']. Got {'description': ['A list of regions in which to describe EC2 instances.', 'If empty (the default) default this will include all regions, except possibly restricted ones like us-gov-west-1 and cn-north-1.'], 'type': 'list', 'default': []}
ERROR: plugins/inventory/aws_rds.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.statuses: Argument defines type as list but elements is not defined for dictionary value @ data['options']['statuses']. Got {'description': "A list of desired states for instances/clusters to be added to inventory. Set to ['all'] as a shorthand to find everything.", 'type': 'list', 'default': ['creating', 'available']}
ERROR: plugins/modules/ec2_instance.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.network.suboptions.groups: Argument defines type as list but elements is not defined for dictionary value @ data['options']['network']['suboptions']['groups']. Got {'description': ['a list of security group IDs to attach to the interface'], 'type': 'list'}
ERROR: plugins/modules/ec2_instance.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.network.suboptions.interfaces: Argument defines type as list but elements is not defined for dictionary value @ data['options']['network']['suboptions']['interfaces']. Got {'description': ['a list of ENI IDs (strings) or a list of objects containing the key I(id).'], 'type': 'list'}
ERROR: plugins/modules/ec2_instance.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.network.suboptions.ipv6_addresses: Argument defines type as list but elements is not defined for dictionary value @ data['options']['network']['suboptions']['ipv6_addresses']. Got {'description': ['a list of IPv6 addresses to assign to the network interface'], 'type': 'list'}
ERROR: plugins/modules/ec2_instance.py:0:0: parameter-list-no-elements: DOCUMENTATION.options.network.suboptions.private_ip_addresses: Argument defines type as list but elements is not defined for dictionary value @ data['options']['network']['suboptions']['private_ip_addresses']. Got {'description': ['a list of IPv4 addresses to assign to the network interface'], 'type': 'list'}
ERROR: plugins/modules/ec2_snapshot_info.py:0:0: documentation-error: Unknown DOCUMENTATION error, see TRACE: while scanning a simple key
  in "<unicode string>", line 72, column 13
could not find expected ':'
  in "<unicode string>", line 73, column 13
```