### PR TITLE
ec2_instance/test: ability to import_role the ec2_instance target

### DIFF
--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/main.yml
@@ -30,6 +30,7 @@
           # don't support any configuration of the delay between retries.
           max_attempts: 20
   collections:
+    - amazon.aws
     - community.aws
   block:
     - debug:


### PR DESCRIPTION
Ensre the embedded ec2_instance role can look up for mode in the amazon.aws
collection.

e.g: https://dbbf67233059c7d506cb-2e57d9c82077eebb09071ca136168dfe.ssl.cf2.rackcdn.com/1510/78ed972ece54255fcd2b6371aec90b2a62be068f/check/downstream-ee-amazon-aws-ec2_instance/bcce114/job-output.txt
