### PR TITLE
setup_sshkey: drop a dep on Crypto

### DIFF
--- a/tests/integration/targets/ec2_key/tasks/main.yml
+++ b/tests/integration/targets/ec2_key/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 # TODO - name: test 'validate_certs' parameter
 # TODO - name: test creating key pair with another_key_material with force=yes
-# ============================================================
+# =============================================================
 
 - module_defaults:
     group/aws:

--- a/tests/integration/targets/setup_sshkey/files/ec2-fingerprint.py
+++ b/tests/integration/targets/setup_sshkey/files/ec2-fingerprint.py
@@ -8,24 +8,25 @@ ssh-keygen -f id_rsa.pub -e -m PKCS8 | openssl pkey -pubin -outform DER | openss
 (but without needing the OpenSSL CLI)
 """
 
-from __future__ import absolute_import, division, print_function
-__metaclass__ = type
 
 import hashlib
 import sys
-from Crypto.PublicKey import RSA
+from cryptography.hazmat.primitives import serialization
 
 if len(sys.argv) == 0:
     ssh_public_key = "id_rsa.pub"
 else:
     ssh_public_key = sys.argv[1]
 
-with open(ssh_public_key, 'r') as key_fh:
-    data = key_fh.read()
-
-# Convert from SSH format to DER format
-public_key = RSA.importKey(data).exportKey('DER')
-md5digest = hashlib.md5(public_key).hexdigest()
+with open(ssh_public_key, "rb") as key_file:
+    public_key = serialization.load_ssh_public_key(
+        key_file.read(),
+    )
+pub_der = public_key.public_bytes(
+    encoding=serialization.Encoding.DER,
+    format=serialization.PublicFormat.SubjectPublicKeyInfo,
+)
+md5digest = hashlib.md5(pub_der).hexdigest()
 # Format the md5sum into the normal format
 pairs = zip(md5digest[::2], md5digest[1::2])
 md5string = ":".join(["".join(pair) for pair in pairs])


### PR DESCRIPTION
Adjust ec2-fingerprint.py so it use cryptography instead of the
deprecated Crypto library.
