### PR TITLE
stable-1.5 - Add sanity ignores for 2.12, 2.13 and 2.14

### DIFF
--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -6,18 +6,18 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: ec2_snapshot_info
 version_added: 1.0.0
-short_description: Gather information about ec2 volume snapshots in AWS
+short_description: Gathers information about EC2 volume snapshots in AWS
 description:
     - Gather information about ec2 volume snapshots in AWS.
     - This module was called C(ec2_snapshot_facts) before Ansible 2.9. The usage did not change.
 requirements: [ boto3 ]
 author:
-    - "Rob White (@wimnat)"
-    - Aubin Bikouo (@abikouo)
+  - Rob White (@wimnat)
+  - Aubin Bikouo (@abikouo)
 options:
   snapshot_ids:
     description:
@@ -72,12 +72,11 @@ notes:
     the account use the filter 'owner-id'.
 
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-
+  - amazon.aws.ec2
+  - amazon.aws.aws
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 
 # Gather information about all snapshots, including public ones
@@ -115,7 +114,7 @@ EXAMPLES = '''
 
 '''
 
-RETURN = '''
+RETURN = r'''
 snapshots:
     description: snapshots retrieved
     type: list
@@ -138,9 +137,10 @@ snapshots:
             returned: always
             sample: completed
         state_message:
-            description: Encrypted Amazon EBS snapshots are copied asynchronously. If a snapshot copy operation fails (for example, if the proper
-                         AWS Key Management Service (AWS KMS) permissions are not obtained) this field displays error state details to help you diagnose why the
-                         error occurred.
+            description:
+              - Encrypted Amazon EBS snapshots are copied asynchronously. If a snapshot copy operation fails (for example, if the proper
+                AWS Key Management Service (AWS KMS) permissions are not obtained) this field displays error state details to help you diagnose why the
+                error occurred.
             type: str
             returned: always
             sample:
@@ -185,14 +185,16 @@ snapshots:
             returned: always
             sample: "True"
         kms_key_id:
-            description: The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) that was used to \
-            protect the volume encryption key for the parent volume.
+            description:
+              - The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) that was used to
+                protect the volume encryption key for the parent volume.
             type: str
             returned: always
             sample: "74c9742a-a1b2-45cb-b3fe-abcdef123456"
         data_encryption_key_id:
-            description: The data encryption key identifier for the snapshot. This value is a unique identifier that \
-            corresponds to the data encryption key that was used to encrypt the original volume or snapshot copy.
+            description:
+              - The data encryption key identifier for the snapshot. This value is a unique identifier that
+                corresponds to the data encryption key that was used to encrypt the original volume or snapshot copy.
             type: str
             returned: always
             sample: "arn:aws:kms:ap-southeast-2:012345678900:key/74c9742a-a1b2-45cb-b3fe-abcdef123456"

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,4 +1,13 @@
+plugins/callback/aws_resource_actions.py validate-modules:invalid-documentation  # Branch accepting security fixes only
 plugins/inventory/aws_ec2.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
+plugins/inventory/aws_ec2.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/inventory/aws_ec2.py validate-modules:parameter-list-no-elements  # Branch accepting security fixes only
+plugins/inventory/aws_rds.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/inventory/aws_rds.py validate-modules:parameter-list-no-elements  # Branch accepting security fixes only
+plugins/lookup/aws_account_attribute.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/lookup/aws_secret.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/lookup/aws_service_ip_ranges.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/lookup/aws_ssm.py validate-modules:invalid-documentation  # Branch accepting security fixes only
 plugins/modules/ec2_group.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
 plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
 plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,4 +1,13 @@
+plugins/callback/aws_resource_actions.py validate-modules:invalid-documentation  # Branch accepting security fixes only
 plugins/inventory/aws_ec2.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
+plugins/inventory/aws_ec2.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/inventory/aws_ec2.py validate-modules:parameter-list-no-elements  # Branch accepting security fixes only
+plugins/inventory/aws_rds.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/inventory/aws_rds.py validate-modules:parameter-list-no-elements  # Branch accepting security fixes only
+plugins/lookup/aws_account_attribute.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/lookup/aws_secret.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/lookup/aws_service_ip_ranges.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/lookup/aws_ssm.py validate-modules:invalid-documentation  # Branch accepting security fixes only
 plugins/modules/ec2_group.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
 plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
 plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,4 +1,13 @@
+plugins/callback/aws_resource_actions.py validate-modules:invalid-documentation  # Branch accepting security fixes only
 plugins/inventory/aws_ec2.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
+plugins/inventory/aws_ec2.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/inventory/aws_ec2.py validate-modules:parameter-list-no-elements  # Branch accepting security fixes only
+plugins/inventory/aws_rds.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/inventory/aws_rds.py validate-modules:parameter-list-no-elements  # Branch accepting security fixes only
+plugins/lookup/aws_account_attribute.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/lookup/aws_secret.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/lookup/aws_service_ip_ranges.py validate-modules:invalid-documentation  # Branch accepting security fixes only
+plugins/lookup/aws_ssm.py validate-modules:invalid-documentation  # Branch accepting security fixes only
 plugins/modules/ec2_group.py pylint:use-a-generator # (new test) Should be an easy fix but not worth blocking gating
 plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
 plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022


### PR DESCRIPTION
##### SUMMARY

Add sanity ignore entries, stable 1.5 is primarily security fixes only

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/modules/ec2_snapshot_info.py
tests/sanity/ignore-2.12.txt
tests/sanity/ignore-2.13.txt
tests/sanity/ignore-2.14.txt

##### ADDITIONAL INFORMATION
