### PR TITLE
[stable-2] Update plugin docs to explicitly list python, boto3 and botocore version

### DIFF
--- a/plugins/doc_fragments/aws_boto3.py
+++ b/plugins/doc_fragments/aws_boto3.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: (c) 2022,  Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+
+class ModuleDocFragment(object):
+
+    # Minimum requirements for the collection
+    DOCUMENTATION = r'''
+options: {}
+requirements:
+  - python >= 3.6
+  - boto3 >= 1.15.0
+  - botocore >= 1.18.0
+'''

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -7,12 +7,10 @@ __metaclass__ = type
 DOCUMENTATION = '''
     name: aws_ec2
     short_description: EC2 inventory source
-    requirements:
-        - boto3
-        - botocore
     extends_documentation_fragment:
     - inventory_cache
     - constructed
+    - amazon.aws.aws_boto3
     - amazon.aws.aws_credentials
 
     description:

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -44,11 +44,9 @@ DOCUMENTATION = '''
     extends_documentation_fragment:
     - inventory_cache
     - constructed
+    - amazon.aws.aws_boto3
     - amazon.aws.aws_credentials
 
-    requirements:
-        - boto3
-        - botocore
     author: Sloane Hertel (@s-hertel)
 '''
 

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -7,11 +7,8 @@ DOCUMENTATION = '''
 name: aws_account_attribute
 author:
   - Sloane Hertel (@s-hertel) <shertel@redhat.com>
-requirements:
-  - python >= 3.6
-  - boto3
-  - botocore >= 1.18.0
 extends_documentation_fragment:
+- amazon.aws.aws_boto3
 - amazon.aws.aws_credentials
 - amazon.aws.aws_region
 

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -8,11 +8,8 @@ DOCUMENTATION = r'''
 name: aws_secret
 author:
   - Aaron Smith (!UNKNOWN) <ajsmith10381@gmail.com>
-requirements:
-  - python >= 3.6
-  - boto3
-  - botocore >= 1.18.0
 extends_documentation_fragment:
+- amazon.aws.aws_boto3
 - amazon.aws.aws_credentials
 - amazon.aws.aws_region
 

--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -13,10 +13,6 @@ author:
   - Bill Wang (!UNKNOWN) <ozbillwang(at)gmail.com>
   - Marat Bakeev (!UNKNOWN) <hawara(at)gmail.com>
   - Michael De La Rue (!UNKNOWN) <siblemitcom.mddlr@spamgourmet.com>
-requirements:
-  - python >= 3.6
-  - boto3
-  - botocore >= 1.18.0
 short_description: Get the value for a SSM parameter or all parameters under a path.
 description:
   - Get the value for an Amazon Simple Systems Manager parameter or a hierarchy of parameters.
@@ -74,6 +70,8 @@ options:
     type: string
     choices: ['error', 'skip', 'warn']
     version_added: 2.0.0
+extends_documentation_fragment:
+- amazon.aws.aws_boto3
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
Manual backport of https://github.com/ansible-collections/amazon.aws/pull/819

##### SUMMARY

Update plugin docs to explicitly list python, boto3 and botocore version requirements in line with collection requirements.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/inventory/aws_ec2.py
plugins/inventory/aws_rds.py
plugins/lookup/aws_account_attribute.py
plugins/lookup/aws_secret.py
plugins/lookup/aws_ssm.py

##### ADDITIONAL INFORMATION

This is in line with the collection requirements, just trying to make it easier to find.