### PR TITLE
elb_classic_lb - Remove deprecated ec2_elb fact

### DIFF
--- a/changelogs/fragments/552-elb_classic_lb-fact-remove.yml
+++ b/changelogs/fragments/552-elb_classic_lb-fact-remove.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- elb_classic_lb - the ``ec2_elb`` fact has been removed (https://github.com/ansible-collections/amazon.aws/pull/827).

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -289,8 +289,8 @@ options:
     version_added: 2.1.0
 
 notes:
-- The ec2_elb fact currently set by this module has been deprecated and will no
-  longer be set after release 4.0.0 of the collection.
+- The ec2_elb fact previously set by this module was deprecated in release 2.1.0 and since release
+  4.0.0 is no longer set.
 
 extends_documentation_fragment:
 - amazon.aws.aws
@@ -2147,10 +2147,7 @@ def main():
         elb = elb_man.get_info()
         ec2_result = dict(elb=elb)
 
-    ansible_facts = {'ec2_elb': 'info'}
-
     module.exit_json(
-        ansible_facts=ansible_facts,
         changed=elb_man.changed,
         **ec2_result,
     )


### PR DESCRIPTION
##### SUMMARY

Remove previously deprecated `ec2_elb` fact from elb_classic_lb this only every returned the value 'info'.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

elb_classic_lb

##### ADDITIONAL INFORMATION

See also #552 and #377 for some of the history.