### PR TITLE
ec2_vol - remove deprecated state=list

### DIFF
--- a/changelogs/fragments/108-ec2_vol-state-list-remove.yml
+++ b/changelogs/fragments/108-ec2_vol-state-list-remove.yml
@@ -1,0 +1,2 @@
+removed_features:
+- ec2_vol - the previously deprecated state ``list`` has been removed.  To list volumes the ``ec2_vol_info`` module can be used (https://github.com/ansible-collections/amazon.aws/pull/828).

--- a/tests/integration/targets/ec2_vol/tasks/main.yml
+++ b/tests/integration/targets/ec2_vol/tasks/main.yml
@@ -413,19 +413,6 @@
           - attach_new_vol_from_snapshot_result.volume.attachment_set[0].status in ['attached', 'attaching']
           - attach_new_vol_from_snapshot_result.volume.attachment_set[0].instance_id == test_instance.instance_ids[0]
 
-    - name: list volumes attached to instance
-      ec2_vol:
-        instance: "{{ test_instance.instance_ids[0] }}"
-        state: list
-      register: inst_vols
-
-    - name: check task return attributes
-      assert:
-        that:
-          - not inst_vols.changed
-          - "'volumes' in inst_vols"
-          - inst_vols.volumes | length == 4
-
     - name: get info on ebs volumes
       ec2_vol_info:
       register: ec2_vol_info

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,2 +1,1 @@
 plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
-plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,2 +1,1 @@
 plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
-plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,2 +1,1 @@
 plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
-plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,2 +1,1 @@
 plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
-plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,2 +1,1 @@
 plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022
-plugins/modules/ec2_vol.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,7 +1,6 @@
 plugins/module_utils/botocore.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/aws_az_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_tag.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_vol.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vpc_dhcp_option.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vpc_igw_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vpc_endpoint.py pylint:ansible-deprecated-no-version


### PR DESCRIPTION
##### SUMMARY

Remove the deprecated state `list` from ec2_vol.  This functionality has been moved to the ec2_vol_info module.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vol

##### ADDITIONAL INFORMATION

See also: #108 