### PR TITLE
ec2_tag - remove deprecated 'state=list'

### DIFF
--- a/changelogs/fragments/66840-ec2_tag-remove-list.yml
+++ b/changelogs/fragments/66840-ec2_tag-remove-list.yml
@@ -1,0 +1,3 @@
+removed_features:
+- ec2_tag - the previously deprecated state ``list`` has been removed.  To list tags on an EC2 resource the ``ec2_tag_info`` module can be used
+  (https://github.com/ansible-collections/amazon.aws/pull/829).

--- a/plugins/modules/ec2_tag.py
+++ b/plugins/modules/ec2_tag.py
@@ -24,11 +24,12 @@ options:
   state:
     description:
       - Whether the tags should be present or absent on the resource.
-      - The use of I(state=list) to interrogate the tags of an instance has been
-        deprecated and will be removed after 2022-06-01.  The 'list'
-        functionality has been moved to a dedicated module M(amazon.aws.ec2_tag_info).
+      - The use of I(state=list) to interrogate the tags of an instance was
+        deprecated in release 1.0.0 and is no longer available in release 4.0.0.
+        The 'list' functionality has been moved to a dedicated module
+        M(amazon.aws.ec2_tag_info).
     default: present
-    choices: ['present', 'absent', 'list']
+    choices: ['present', 'absent']
     type: str
   tags:
     description:
@@ -125,7 +126,7 @@ def main():
         resource=dict(required=True),
         tags=dict(type='dict'),
         purge_tags=dict(type='bool', default=False),
-        state=dict(default='present', choices=['present', 'absent', 'list']),
+        state=dict(default='present', choices=['present', 'absent']),
     )
     required_if = [('state', 'present', ['tags']), ('state', 'absent', ['tags'])]
 
@@ -141,11 +142,6 @@ def main():
     ec2 = module.client('ec2')
 
     current_tags = describe_ec2_tags(ec2, module, resource)
-
-    if state == 'list':
-        module.deprecate(
-            'Using the "list" state has been deprecated.  Please use the ec2_tag_info module instead', date='2022-06-01', collection_name='amazon.aws')
-        module.exit_json(changed=False, tags=current_tags)
 
     if state == 'absent':
         removed_tags = {}

--- a/tests/integration/targets/ec2_tag/tasks/main.yml
+++ b/tests/integration/targets/ec2_tag/tasks/main.yml
@@ -15,11 +15,6 @@
         zone: "{{ aws_region }}a"
       register: volume
 
-    - name: List the tags on the volume (ec2_tag)
-      ec2_tag:
-        resource: "{{ volume.volume_id }}"
-        state: list
-      register: result
     - name: List the tags on the volume (ec2_tag_info)
       ec2_tag_info:
         resource: "{{ volume.volume_id }}"
@@ -27,8 +22,6 @@
 
     - assert:
         that:
-          - result.tags | length == 1
-          - result.tags.Name == '{{ resource_prefix }} ec2_tag volume'
           - result_info.tags | length == 1
           - result_info.tags.Name == '{{ resource_prefix }} ec2_tag volume'
 

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,1 +1,0 @@
-plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,1 +1,0 @@
-plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,1 +1,0 @@
-plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,1 +1,0 @@
-plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,1 +1,0 @@
-plugins/modules/ec2_tag.py validate-modules:parameter-state-invalid-choice  # Deprecated choice that can't be removed until 2022

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,5 +1,4 @@
-plugins/modules/ec2_tag.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vpc_dhcp_option.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_vpc_endpoint.py pylint:ansible-deprecated-no-version
-plugins/modules/ec2_vpc_endpoint_info.py pylint:ansible-deprecated-no-version
+plugins/modules/ec2_vpc_endpoint.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
+plugins/modules/ec2_vpc_endpoint_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_instance.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability


### PR DESCRIPTION
##### SUMMARY

Remove the deprecated state list from ec2_tag. This functionality has been moved to the ec2_tag_info module.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_tag

##### ADDITIONAL INFORMATION

See also https://github.com/ansible/ansible/pull/66840