### PR TITLE
ec2_key - remove unused wait and wait_timeout parameters

### DIFF
--- a/changelogs/fragments/64230-ec2_key-remove-unused.yml
+++ b/changelogs/fragments/64230-ec2_key-remove-unused.yml
@@ -1,0 +1,3 @@
+removed_features:
+- ec2_key - the ``wait`` option had no effect, was deprecated in release 1.0.0, and has now been removed (https://github.com/ansible-collections/amazon.aws/pull/830).
+- ec2_key - the ``wait_timeout`` option had no effect, was deprecated in release 1.0.0, and has now been removed (https://github.com/ansible-collections/amazon.aws/pull/830).

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -38,15 +38,6 @@ options:
     choices: [ present, absent ]
     default: 'present'
     type: str
-  wait:
-    description:
-      - This option has no effect since version 2.5 and will be removed after 2022-06-01.
-    type: bool
-  wait_timeout:
-    description:
-      - This option has no effect since version 2.5 and will be removed after 2022-06-01.
-    type: int
-    required: false
   tags:
     description:
       - A dictionary of tags to set on the key pair.
@@ -325,8 +316,6 @@ def main():
         tags=dict(type='dict'),
         purge_tags=dict(type='bool', default=False),
         key_type=dict(type='str', choices=['rsa', 'ed25519']),
-        wait=dict(type='bool', removed_at_date='2022-06-01', removed_from_collection='amazon.aws'),
-        wait_timeout=dict(type='int', removed_at_date='2022-06-01', removed_from_collection='amazon.aws')
     )
 
     module = AnsibleAWSModule(


### PR DESCRIPTION
##### SUMMARY

Remove unused `wait` and `wait_timeout` parameters from the ec2_key module.  These have had no effect since Ansible 2.5 and were deprecated in release 1.0.0.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_key

##### ADDITIONAL INFORMATION

See also: https://github.com/ansible/ansible/pull/64230