### PR TITLE
aws_az_info remove aws_az_facts alias

### DIFF
--- a/changelogs/fragments/57613-facts.yml
+++ b/changelogs/fragments/57613-facts.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- aws_az_info - the module alias ``aws_az_facts`` was deprecated in Ansible 2.9 and has now been removed (https://github.com/ansible-collections/amazon.aws/pull/832).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,7 +1,6 @@
 requires_ansible: '>=2.9.10'
 action_groups:
   aws:
-  - aws_az_facts
   - aws_az_info
   - aws_caller_info
   - aws_s3

--- a/plugins/modules/aws_az_facts.py
+++ b/plugins/modules/aws_az_facts.py
@@ -1,1 +1,0 @@
-aws_az_info.py

--- a/plugins/modules/aws_az_info.py
+++ b/plugins/modules/aws_az_info.py
@@ -84,8 +84,6 @@ def main():
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
-    if module._name == 'aws_az_facts':
-        module.deprecate("The 'aws_az_facts' module has been renamed to 'aws_az_info'", date='2022-06-01', collection_name='amazon.aws')
 
     connection = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,5 +1,4 @@
 plugins/module_utils/botocore.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/aws_az_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_tag.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vol.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vpc_dhcp_option.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability


### PR DESCRIPTION
##### SUMMARY

The aws_az_facts alias was deprecated in Ansible 2.9 remove it as previously announced.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

aws_az_info

##### ADDITIONAL INFORMATION

See also https://github.com/ansible/ansible/pull/57613
