### PR TITLE
cloudformation - remove unused template_format parameter

### DIFF
--- a/changelogs/fragments/64368-cloudformation.yml
+++ b/changelogs/fragments/64368-cloudformation.yml
@@ -1,0 +1,2 @@
+removed_features:
+- cloudformation - the ``template_format`` option has been removed. It has been ignored by the module since Ansible 2.3 (https://github.com/ansible-collections/amazon.aws/pull/833).

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -116,11 +116,6 @@ options:
         See the AWS Change Sets docs for more information
         U(https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-cfn-updating-stacks-changesets.html)
     type: str
-  template_format:
-    description:
-    - This parameter is ignored since Ansible 2.3 and will be removed after 2022-06-01.
-    - Templates are now passed raw to CloudFormation regardless of format.
-    type: str
   role_arn:
     description:
     - The role that AWS CloudFormation assumes to create the stack. See the AWS CloudFormation Service Role
@@ -637,7 +632,6 @@ def main():
         create_timeout=dict(default=None, type='int'),
         template_url=dict(default=None, required=False),
         template_body=dict(default=None, required=False),
-        template_format=dict(removed_at_date='2022-06-01', removed_from_collection='amazon.aws'),
         create_changeset=dict(default=False, type='bool'),
         changeset_name=dict(default=None, required=False),
         role_arn=dict(default=None, required=False),


### PR DESCRIPTION
##### SUMMARY

The template_format parameter has been ignored since Ansible 2.3 and deprecated since release 1.0.0.  Remove it.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

cloudformation

##### ADDITIONAL INFORMATION

See also https://github.com/ansible/ansible/pull/64368