### PR TITLE
ec2_vpc_igw - convert tags by default

### DIFF
--- a/changelogs/fragments/318-ec2_vpc_igw_info-convert-tags.yml
+++ b/changelogs/fragments/318-ec2_vpc_igw_info-convert-tags.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- ec2_vpc_igw_info - The default value for ``convert_tags`` has been changed to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/835).

--- a/plugins/modules/ec2_vpc_igw_info.py
+++ b/plugins/modules/ec2_vpc_igw_info.py
@@ -28,7 +28,8 @@ options:
   convert_tags:
     description:
       - Convert tags from boto3 format (list of dictionaries) to the standard dictionary format.
-      - This currently defaults to C(False).  The default will be changed to C(True) after 2022-06-22.
+      - Prior to release 4.0.0 this defaulted to C(False).
+    default: True
     type: bool
     version_added: 1.3.0
 extends_documentation_fragment:
@@ -154,16 +155,10 @@ def main():
     argument_spec = dict(
         filters=dict(type='dict', default=dict()),
         internet_gateway_ids=dict(type='list', default=None, elements='str'),
-        convert_tags=dict(type='bool'),
+        convert_tags=dict(type='bool', default=True),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
-
-    if module.params.get('convert_tags') is None:
-        module.deprecate('This module currently returns boto3 style tags by default.  '
-                         'This default has been deprecated and the module will return a simple dictionary in future.  '
-                         'This behaviour can be controlled through the convert_tags parameter.',
-                         date='2021-12-01', collection_name='amazon.aws')
 
     # Validate Requirements
     try:

--- a/tests/integration/targets/ec2_vpc_igw/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_igw/tasks/main.yml
@@ -100,6 +100,7 @@
     ec2_vpc_igw_info:
       filters:
         attachment.vpc-id: '{{ vpc_id }}'
+      convert_tags: false
     register: igw_info
 
   - name: Check standard IGW details
@@ -133,7 +134,6 @@
   - name: Fetch IGW by ID
     ec2_vpc_igw_info:
       internet_gateway_ids: '{{ igw_id }}'
-      convert_tags: yes
     register: igw_info
 
   - name: Check standard IGW details

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -3,7 +3,6 @@ plugins/modules/aws_az_info.py pylint:ansible-deprecated-no-version  # We use da
 plugins/modules/ec2_tag.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vol.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vpc_dhcp_option.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_vpc_igw_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vpc_endpoint.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_vpc_endpoint_info.py pylint:ansible-deprecated-no-version
 plugins/modules/ec2_instance.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability


### PR DESCRIPTION
##### SUMMARY

Updates ec2_vpc_igw so that it return tags as a dictionary by default (instead of the boto3 style list of dictionaries)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vpc_igw

##### ADDITIONAL INFORMATION

See also https://github.com/ansible-collections/community.aws/pull/318