### PR TITLE
Tagging - deprecate defaults of purge_tags=False

### DIFF
--- a/changelogs/fragments/846-tagging-deprecate.yml
+++ b/changelogs/fragments/846-tagging-deprecate.yml
@@ -1,0 +1,6 @@
+deprecated_features:
+- ec2_ami - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
+- ec2_key - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
+- ec2_vol - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
+- ec2_vpc_endpoint - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
+- ec2_vpc_route_table - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/844

##### SUMMARY

The simple cases where we want to deprecate purge_tags=False

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/ec2_ami.py
plugins/modules/ec2_key.py
plugins/modules/ec2_vol.py
plugins/modules/ec2_vpc_endpoint.py
plugins/modules/ec2_vpc_route_table.py

##### ADDITIONAL INFORMATION
