### PR TITLE
ec2_instance: metadata_options version_added increased

### DIFF
--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -333,7 +333,7 @@ options:
           The larger the number, the further instance metadata requests can travel.
         default: 1
       http_protocol_ipv6:
-        version_added: 3.4.0
+        version_added: 4.0.0
         type: str
         description: >
           - Wether the instance metadata endpoint is available via IPv6 (C(enabled)) or not (C(disabled)).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -326,7 +326,7 @@ options:
         default: optional
         type: str
       http_put_response_hop_limit:
-        version_added: 3.4.0
+        version_added: 4.0.0
         type: int
         description: >
           The desired HTTP PUT response hop limit for instance metadata requests.

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -326,14 +326,14 @@ options:
         default: optional
         type: str
       http_put_response_hop_limit:
-        version_added: 3.3.0
+        version_added: 3.4.0
         type: int
         description: >
           The desired HTTP PUT response hop limit for instance metadata requests.
           The larger the number, the further instance metadata requests can travel.
         default: 1
       http_protocol_ipv6:
-        version_added: 3.3.0
+        version_added: 3.4.0
         type: str
         description: >
           - Wether the instance metadata endpoint is available via IPv6 (C(enabled)) or not (C(disabled)).
@@ -341,7 +341,7 @@ options:
         choices: [enabled, disabled]
         default: 'disabled'
       instance_metadata_tags:
-        version_added: 3.3.0
+        version_added: 3.4.0
         type: str
         description:
           - Wether the instance tags are availble (C(enabled)) via metadata endpoint or not (C(disabled)).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -341,7 +341,7 @@ options:
         choices: [enabled, disabled]
         default: 'disabled'
       instance_metadata_tags:
-        version_added: 3.4.0
+        version_added: 4.0.0
         type: str
         description:
           - Wether the instance tags are availble (C(enabled)) via metadata endpoint or not (C(disabled)).


### PR DESCRIPTION
##### SUMMARY
After CI troubles in the past, we've forget to backport this feature.

* incr from 3.2.0 to 3.3.0 https://github.com/ansible-collections/amazon.aws/pull/763
  * failed backport 3 PR for 3.2.0 release https://github.com/ansible-collections/amazon.aws/pull/721 
* initial implementation for 3.2.0 https://github.com/ansible-collections/amazon.aws/pull/715

therefore no changelog fragment is necessary.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
