### PR TITLE
*_info - improve RETURN block of docs

### DIFF
--- a/plugins/modules/aws_az_info.py
+++ b/plugins/modules/aws_az_info.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 DOCUMENTATION = '''
 module: aws_az_info
-short_description: Gather information about availability zones in AWS.
+short_description: Gather information about availability zones in AWS
 version_added: 1.0.0
 description:
     - Gather information about availability zones in AWS.
@@ -50,20 +50,97 @@ availability_zones:
         Availability zones that match the provided filters. Each element consists of a dict with all the information
         related to that available zone.
     type: list
-    sample: "[
+    elements: dict
+    contains:
+        state:
+            description:
+                - The state of the availability zone.
+                - The value is always C(available).
+            type: str
+            returned: on success
+            sample: 'available'
+        opt_in_status:
+            description:
+                - The opt-in status.
+                - The value is always C(opt-in-not-required) for availability zones.
+            type: str
+            returned: on success
+            sample: 'opt-in-not-required'
+        messages:
+            description: List of messages about the availability zone.
+            type: list
+            elements: dict
+            contains:
+                message:
+                    description: The message about the availability zone.
+                    type: str
+                    returned: on success
+                    sample: 'msg'
+            returned: on success
+            sample: [
+                {
+                    'message': 'message_one'
+                },
+                {
+                    'message': 'message_two'
+                }
+            ]
+        region_name:
+            description: The name of the region.
+            type: str
+            returned: on success
+            sample: 'us-east-1'
+        zone_name:
+            description: The name of the availability zone.
+            type: str
+            returned: on success
+            sample: 'us-east-1e'
+        zone_id:
+            description: The ID of the availability zone.
+            type: str
+            returned: on success
+            sample: 'use1-az5'
+        group_name:
+            description:
+                - The name of the associated group.
+                - For availability zones, this will be the same as I(region_name).
+            type: str
+            returned: on success
+            sample: 'us-east-1'
+        network_border_group:
+            description: The name of the network border group.
+            type: str
+            returned: on success
+            sample: 'us-east-1'
+        zone_type:
+            description: The type of zone.
+            type: str
+            returned: on success
+            sample: 'availability-zone'
+    sample: [
         {
-            'messages': [],
-            'region_name': 'us-west-1',
-            'state': 'available',
-            'zone_name': 'us-west-1b'
+            "group_name": "us-east-1",
+            "messages": [],
+            "network_border_group": "us-east-1",
+            "opt_in_status": "opt-in-not-required",
+            "region_name": "us-east-1",
+            "state": "available",
+            "zone_id": "use1-az6",
+            "zone_name": "us-east-1a",
+            "zone_type": "availability-zone"
         },
         {
-            'messages': [],
-            'region_name': 'us-west-1',
-            'state': 'available',
-            'zone_name': 'us-west-1c'
+            "group_name": "us-east-1",
+            "messages": [],
+            "network_border_group": "us-east-1",
+            "opt_in_status": "opt-in-not-required",
+            "region_name": "us-east-1",
+            "state": "available",
+            "zone_id": "use1-az1",
+            "zone_name": "us-east-1b",
+            "zone_type": "availability-zone"
         }
-    ]"
+    ]
 '''
 
 try:

--- a/plugins/modules/aws_caller_info.py
+++ b/plugins/modules/aws_caller_info.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
 ---
 module: aws_caller_info
 version_added: 1.0.0
-short_description: Get information about the user and account being used to make AWS calls.
+short_description: Get information about the user and account being used to make AWS calls
 description:
     - This module returns information about the account and user / role from which the AWS access tokens originate.
     - The primary use of this is to get the account id for templating into ARNs or similar to avoid needing to specify this information in inventory.

--- a/plugins/modules/cloudformation_info.py
+++ b/plugins/modules/cloudformation_info.py
@@ -60,6 +60,10 @@ extends_documentation_fragment:
 EXAMPLES = '''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 
+- name: Get information on all stacks
+  amazon.aws.cloudformation_info:
+  register: all_stacks_output
+
 - name: Get summary information about a stack
   amazon.aws.cloudformation_info:
     stack_name: my-cloudformation-stack
@@ -99,55 +103,190 @@ EXAMPLES = '''
 '''
 
 RETURN = '''
-stack_description:
-    description: Summary facts about the stack
-    returned: if the stack exists
+cloudformation:
+    description:
+        - Dictionary of dictionaries containing info of stack(s).
+        - Keys are I(stack_name)s.
+    returned: always
     type: dict
-stack_outputs:
-    description: Dictionary of stack outputs keyed by the value of each output 'OutputKey' parameter and corresponding value of each
-                 output 'OutputValue' parameter
-    returned: if the stack exists
-    type: dict
-    sample:
-      ApplicationDatabaseName: dazvlpr01xj55a.ap-southeast-2.rds.amazonaws.com
-stack_parameters:
-    description: Dictionary of stack parameters keyed by the value of each parameter 'ParameterKey' parameter and corresponding value of
-                 each parameter 'ParameterValue' parameter
-    returned: if the stack exists
-    type: dict
-    sample:
-      DatabaseEngine: mysql
-      DatabasePassword: "***"
-stack_events:
-    description: All stack events for the stack
-    returned: only if all_facts or stack_events is true and the stack exists
-    type: list
-stack_policy:
-    description: Describes the stack policy for the stack
-    returned: only if all_facts or stack_policy is true and the stack exists
-    type: dict
-stack_template:
-    description: Describes the stack template for the stack
-    returned: only if all_facts or stack_template is true and the stack exists
-    type: dict
-stack_resource_list:
-    description: Describes stack resources for the stack
-    returned: only if all_facts or stack_resources is true and the stack exists
-    type: list
-stack_resources:
-    description: Dictionary of stack resources keyed by the value of each resource 'LogicalResourceId' parameter and corresponding value of each
-                 resource 'PhysicalResourceId' parameter
-    returned: only if all_facts or stack_resources is true and the stack exists
-    type: dict
-    sample:
-      AutoScalingGroup: "dev-someapp-AutoscalingGroup-1SKEXXBCAN0S7"
-      AutoScalingSecurityGroup: "sg-abcd1234"
-      ApplicationDatabase: "dazvlpr01xj55a"
-stack_change_sets:
-    description: A list of stack change sets.  Each item in the list represents the details of a specific changeset
-
-    returned: only if all_facts or stack_change_sets is true and the stack exists
-    type: list
+    contains:
+        stack_description:
+            description: Summary facts about the stack.
+            returned: if the stack exists
+            type: dict
+            contains:
+                capabilities:
+                    description: The capabilities allowed in the stack.
+                    returned: always
+                    type: list
+                    elements: str
+                creation_time:
+                    description: The time at which the stack was created.
+                    returned: if stack exists
+                    type: str
+                deletion_time:
+                    description: The time at which the stack was deleted.
+                    returned: if stack was deleted
+                    type: str
+                description:
+                    description: The user-defined description associated with the stack.
+                    returned: always
+                    type: str
+                disable_rollback:
+                    description: Whether or not rollback on stack creation failures is enabled.
+                    returned: always
+                    type: bool
+                drift_information:
+                    description: Information about whether a stack's actual configuration differs, or has drifted, from it's expected configuration,
+                        as defined in the stack template and any values specified as template parameters.
+                    returned: always
+                    type: dict
+                    contains:
+                        stack_drift_status:
+                            description: Status of the stack's actual configuration compared to its expected template configuration.
+                            returned: always
+                            type: str
+                        last_check_timestamp:
+                            description: Most recent time when a drift detection operation was initiated on the stack,
+                                or any of its individual resources that support drift detection.
+                            returned: if a drift was detected
+                            type: str
+                enable_termination_protection:
+                    description: Whether termination protection is enabled for the stack.
+                    returned: always
+                    type: bool
+                notification_arns:
+                    description: Amazon SNS topic ARNs to which stack related events are published.
+                    returned: always
+                    type: list
+                    elements: str
+                outputs:
+                    description: A list of output dicts.
+                    returned: always
+                    type: list
+                    elements: dict
+                    contains:
+                        output_key:
+                            description: The key associated with the output.
+                            returned: always
+                            type: str
+                        output_value:
+                            description: The value associated with the output.
+                            returned: always
+                            type: str
+                parameters:
+                    description: A list of parameter dicts.
+                    returned: always
+                    type: list
+                    elements: dict
+                    contains:
+                        parameter_key:
+                            description: The key associated with the parameter.
+                            returned: always
+                            type: str
+                        parameter_value:
+                            description: The value associated with the parameter.
+                            returned: always
+                            type: str
+                rollback_configuration:
+                    description: The rollback triggers for CloudFormation to monitor during stack creation and updating operations.
+                    returned: always
+                    type: dict
+                    contains:
+                        rollback_triggers:
+                            description: The triggers to monitor during stack creation or update actions.
+                            returned: when rollback triggers exist
+                            type: list
+                            elements: dict
+                            contains:
+                                arn:
+                                    description: The ARN of the rollback trigger.
+                                    returned: always
+                                    type: str
+                                type:
+                                    description: The resource type of the rollback trigger.
+                                    returned: always
+                                    type: str
+                stack_id:
+                    description: The unique ID of the stack.
+                    returned: always
+                    type: str
+                stack_name:
+                    description: The name of the stack.
+                    returned: always
+                    type: str
+                stack_status:
+                    description: The status of the stack.
+                    returned: always
+                    type: str
+                tags:
+                    description: A list of tags associated with the stack.
+                    returned: always
+                    type: list
+                    elements: dict
+                    contains:
+                        key:
+                            description: Key of tag.
+                            returned: always
+                            type: str
+                        value:
+                            description: Value of tag.
+                            returned: always
+                            type: str
+        stack_outputs:
+            description: Dictionary of stack outputs keyed by the value of each output 'OutputKey' parameter and corresponding value of each
+                        output 'OutputValue' parameter.
+            returned: if the stack exists
+            type: dict
+            sample: { ApplicationDatabaseName: dazvlpr01xj55a.ap-southeast-2.rds.amazonaws.com }
+        stack_parameters:
+            description: Dictionary of stack parameters keyed by the value of each parameter 'ParameterKey' parameter and corresponding value of
+                        each parameter 'ParameterValue' parameter.
+            returned: if the stack exists
+            type: dict
+            sample:
+                {
+                    DatabaseEngine: mysql,
+                    DatabasePassword: "***"
+                }
+        stack_events:
+            description: All stack events for the stack.
+            returned: only if all_facts or stack_events is true and the stack exists
+            type: list
+        stack_policy:
+            description: Describes the stack policy for the stack.
+            returned: only if all_facts or stack_policy is true and the stack exists
+            type: dict
+        stack_template:
+            description: Describes the stack template for the stack.
+            returned: only if all_facts or stack_template is true and the stack exists
+            type: dict
+        stack_resource_list:
+            description: Describes stack resources for the stack.
+            returned: only if all_facts or stack_resources is true and the stack exists
+            type: list
+        stack_resources:
+            description: Dictionary of stack resources keyed by the value of each resource 'LogicalResourceId' parameter and corresponding value of each
+                        resource 'PhysicalResourceId' parameter.
+            returned: only if all_facts or stack_resources is true and the stack exists
+            type: dict
+            sample: {
+                "AutoScalingGroup": "dev-someapp-AutoscalingGroup-1SKEXXBCAN0S7",
+                "AutoScalingSecurityGroup": "sg-abcd1234",
+                "ApplicationDatabase": "dazvlpr01xj55a"
+            }
+        stack_change_sets:
+            description: A list of stack change sets.  Each item in the list represents the details of a specific changeset.
+            returned: only if all_facts or stack_change_sets is true and the stack exists
+            type: list
+        stack_tags:
+            description: Dictionary of key value pairs of tags.
+            returned: only if all_facts or stack_resources is true and the stack exists
+            type: dict
+            sample: {
+                'TagOne': 'ValueOne',
+                'TagTwo': 'ValueTwo'
+            }
 '''
 
 import json

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -48,12 +48,12 @@ EXAMPLES = '''
 
 RETURN = '''
 network_interfaces:
-  description: List of matching elastic network interfaces
+  description: List of matching elastic network interfaces.
   returned: always
   type: complex
   contains:
     association:
-      description: Info of associated elastic IP (EIP)
+      description: Info of associated elastic IP (EIP).
       returned: When an ENI is associated with an EIP
       type: dict
       sample: {
@@ -64,7 +64,7 @@ network_interfaces:
           public_ip: "52.1.0.63"
         }
     attachment:
-      description: Info about attached ec2 instance
+      description: Info about attached ec2 instance.
       returned: When an ENI is attached to an ec2 instance
       type: dict
       sample: {
@@ -77,17 +77,17 @@ network_interfaces:
         status: "attached"
       }
     availability_zone:
-      description: Availability zone of ENI
+      description: Availability zone of ENI.
       returned: always
       type: str
       sample: "us-east-1b"
     description:
-      description: Description text for ENI
+      description: Description text for ENI.
       returned: always
       type: str
       sample: "My favourite network interface"
     groups:
-      description: List of attached security groups
+      description: List of attached security groups.
       returned: always
       type: list
       sample: [
@@ -97,57 +97,57 @@ network_interfaces:
         }
       ]
     id:
-      description: The id of the ENI (alias for network_interface_id)
+      description: The id of the ENI (alias for network_interface_id).
       returned: always
       type: str
       sample: "eni-392fsdf"
     interface_type:
-      description: Type of the network interface
+      description: Type of the network interface.
       returned: always
       type: str
       sample: "interface"
     ipv6_addresses:
-      description: List of IPv6 addresses for this interface
+      description: List of IPv6 addresses for this interface.
       returned: always
       type: list
       sample: []
     mac_address:
-      description: MAC address of the network interface
+      description: MAC address of the network interface.
       returned: always
       type: str
       sample: "0a:f8:10:2f:ab:a1"
     name:
-      description: The Name tag of the ENI, often displayed in the AWS UIs as Name
+      description: The Name tag of the ENI, often displayed in the AWS UIs as Name.
       returned: When a Name tag has been set
       type: str
       version_added: 1.3.0
     network_interface_id:
-      description: The id of the ENI
+      description: The id of the ENI.
       returned: always
       type: str
       sample: "eni-392fsdf"
     owner_id:
-      description: AWS account id of the owner of the ENI
+      description: AWS account id of the owner of the ENI.
       returned: always
       type: str
       sample: "4415120123456"
     private_dns_name:
-      description: Private DNS name for the ENI
+      description: Private DNS name for the ENI.
       returned: always
       type: str
       sample: "ip-172-16-1-180.ec2.internal"
     private_ip_address:
-      description: Private IP address for the ENI
+      description: Private IP address for the ENI.
       returned: always
       type: str
       sample: "172.16.1.180"
     private_ip_addresses:
-      description: List of private IP addresses attached to the ENI
+      description: List of private IP addresses attached to the ENI.
       returned: always
       type: list
       sample: []
     requester_id:
-      description: The ID of the entity that launched the ENI
+      description: The ID of the entity that launched the ENI.
       returned: always
       type: str
       sample: "AIDAIONYVJQNIAZFT3ABC"
@@ -162,28 +162,28 @@ network_interfaces:
       type: bool
       sample: false
     status:
-      description: Indicates if the network interface is attached to an instance or not
+      description: Indicates if the network interface is attached to an instance or not.
       returned: always
       type: str
       sample: "in-use"
     subnet_id:
-      description: Subnet ID the ENI is in
+      description: Subnet ID the ENI is in.
       returned: always
       type: str
       sample: "subnet-7bbf01234"
     tags:
-      description: Dictionary of tags added to the ENI
+      description: Dictionary of tags added to the ENI.
       returned: always
       type: dict
       sample: {}
       version_added: 1.3.0
     tag_set:
-      description: Dictionary of tags added to the ENI
+      description: Dictionary of tags added to the ENI.
       returned: always
       type: dict
       sample: {}
     vpc_id:
-      description: ID of the VPC the network interface it part of
+      description: ID of the VPC the network interface it part of.
       returned: always
       type: str
       sample: "vpc-b3f1f123"

--- a/plugins/modules/ec2_group.py
+++ b/plugins/modules/ec2_group.py
@@ -14,7 +14,7 @@ version_added: 1.0.0
 author:
   - "Andrew de Quincey (@adq)"
   - "Razique Mahroua (@Razique)"
-short_description: maintain an ec2 VPC security group.
+short_description: Maintain an ec2 VPC security group
 description:
     - Maintains ec2 security groups.
 options:

--- a/plugins/modules/ec2_group_info.py
+++ b/plugins/modules/ec2_group_info.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
 ---
 module: ec2_group_info
 version_added: 1.0.0
-short_description: Gather information about ec2 security groups in AWS.
+short_description: Gather information about ec2 security groups in AWS
 description:
     - Gather information about ec2 security groups in AWS.
 author:
@@ -86,7 +86,164 @@ security_groups:
     description: Security groups that match the provided filters. Each element consists of a dict with all the information related to that security group.
     type: list
     returned: always
-    sample:
+    elements: dict
+    contains:
+        description:
+            description: The description of the security group.
+            returned: always
+            type: str
+        group_id:
+            description: The ID of the security group.
+            returned: always
+            type: str
+        group_name:
+            description: The name of the security group.
+            returned: always
+            type: str
+        ip_permissions:
+            description: The inbound rules associated with the security group.
+            returned: always
+            type: list
+            elements: dict
+            contains:
+                ip_protocol:
+                    description: The IP protocol name or number.
+                    returned: always
+                    type: str
+                ip_ranges:
+                    description: The IPv4 ranges.
+                    returned: always
+                    type: list
+                    elements: dict
+                    contains:
+                        cidr_ip:
+                            description: The IPv4 CIDR range.
+                            returned: always
+                            type: str
+                ipv6_ranges:
+                    description: The IPv6 ranges.
+                    returned: always
+                    type: list
+                    elements: dict
+                    contains:
+                        cidr_ipv6:
+                            description: The IPv6 CIDR range.
+                            returned: always
+                            type: str
+                prefix_list_ids:
+                    description: The prefix list IDs.
+                    returned: always
+                    type: list
+                    elements: dict
+                    contains:
+                        prefix_list_id:
+                            description: The ID of the prefix.
+                            returned: always
+                            type: str
+                user_id_group_pairs:
+                    description: The security group and AWS account ID pairs.
+                    returned: always
+                    type: list
+                    elements: dict
+                    contains:
+                        group_id:
+                            description: The security group ID of the pair.
+                            returned: always
+                            type: str
+                        user_id:
+                            description: The user ID of the pair.
+                            returned: always
+                            type: str
+        ip_permissions_egress:
+            description: The outbound rules associated with the security group.
+            returned: always
+            type: list
+            elements: dict
+            contains:
+                ip_protocol:
+                    description: The IP protocol name or number.
+                    returned: always
+                    type: str
+                ip_ranges:
+                    description: The IPv4 ranges.
+                    returned: always
+                    type: list
+                    elements: dict
+                    contains:
+                        cidr_ip:
+                            description: The IPv4 CIDR range.
+                            returned: always
+                            type: str
+                ipv6_ranges:
+                    description: The IPv6 ranges.
+                    returned: always
+                    type: list
+                    elements: dict
+                    contains:
+                        cidr_ipv6:
+                            description: The IPv6 CIDR range.
+                            returned: always
+                            type: str
+                prefix_list_ids:
+                    description: The prefix list IDs.
+                    returned: always
+                    type: list
+                    elements: dict
+                    contains:
+                        prefix_list_id:
+                            description: The ID of the prefix.
+                            returned: always
+                            type: str
+                user_id_group_pairs:
+                    description: The security group and AWS account ID pairs.
+                    returned: always
+                    type: list
+                    elements: dict
+                    contains:
+                        group_id:
+                            description: The security group ID of the pair.
+                            returned: always
+                            type: str
+                        user_id:
+                            description: The user ID of the pair.
+                            returned: always
+                            type: str
+        owner_id:
+            description: The AWS account ID of the owner of the security group.
+            returned: always
+            type: str
+        tags:
+            description: The tags associated with the security group.
+            returned: always
+            type: dict
+        vpc_id:
+            description: The ID of the VPC for the security group.
+            returned: always
+            type: str
+    sample: [
+        {
+            "description": "created by rds_instance integration tests",
+            "group_id": "sg-036496a610b79da88",
+            "group_name": "ansible-test-89355088-unknown5c5f67f3ad09-sg-1",
+            "ip_permissions": [],
+            "ip_permissions_egress": [
+                {
+                    "ip_protocol": "-1",
+                    "ip_ranges": [
+                        {
+                            "cidr_ip": "0.0.0.0/0"
+                        }
+                    ],
+                    "ipv6_ranges": [],
+                    "prefix_list_ids": [],
+                    "user_id_group_pairs": []
+                }
+            ],
+            "owner_id": "721066863947",
+            "tags": {},
+            "vpc_id": "vpc-0bc3bb03f97405435"
+        }
+    ]
 '''
 
 try:

--- a/plugins/modules/ec2_instance_info.py
+++ b/plugins/modules/ec2_instance_info.py
@@ -84,7 +84,7 @@ EXAMPLES = r'''
 
 RETURN = r'''
 instances:
-    description: a list of ec2 instances
+    description: A list of ec2 instances.
     returned: always
     type: complex
     contains:
@@ -94,7 +94,7 @@ instances:
             type: int
             sample: 0
         architecture:
-            description: The architecture of the image
+            description: The architecture of the image.
             returned: always
             type: str
             sample: x86_64
@@ -129,7 +129,7 @@ instances:
                             type: str
                             sample: attached
                         volume_id:
-                            description: The ID of the EBS volume
+                            description: The ID of the EBS volume.
                             returned: always
                             type: str
                             sample: vol-12345678
@@ -174,7 +174,7 @@ instances:
                     type: str
                     sample: "arn:aws:iam::000012345678:instance-profile/myprofile"
                 id:
-                    description: The ID of the instance profile
+                    description: The ID of the instance profile.
                     returned: always
                     type: str
                     sample: JFJ397FDG400FG9FD1N
@@ -428,12 +428,12 @@ instances:
             type: str
             sample:
         public_ip_address:
-            description: The public IPv4 address assigned to the instance
+            description: The public IPv4 address assigned to the instance.
             returned: always
             type: str
             sample: 52.0.0.1
         root_device_name:
-            description: The device name of the root device
+            description: The device name of the root device.
             returned: always
             type: str
             sample: /dev/sda1

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -11,7 +11,7 @@ DOCUMENTATION = '''
 ---
 module: ec2_key
 version_added: 1.0.0
-short_description: create or delete an ec2 key pair
+short_description: Create or delete an ec2 key pair
 description:
     - create or delete an ec2 key pair.
 options:

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -11,7 +11,7 @@ DOCUMENTATION = '''
 ---
 module: ec2_metadata_facts
 version_added: 1.0.0
-short_description: gathers facts (instance metadata) about remote hosts within EC2
+short_description: Gathers facts (instance metadata) about remote hosts within EC2
 author:
     - Silviu Dicu (@silviud)
     - Vinay Dandekar (@roadmapper)

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -114,7 +114,7 @@ EXAMPLES = r'''
 
 RETURN = r'''
 snapshots:
-    description: snapshots retrieved
+    description: List of snapshots retrieved with their respective info.
     type: list
     returned: success
     elements: dict

--- a/plugins/modules/ec2_spot_instance.py
+++ b/plugins/modules/ec2_spot_instance.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
 ---
 module: ec2_spot_instance
 version_added: 2.0.0
-short_description: request, stop, reboot or cancel spot instance
+short_description: Request, stop, reboot or cancel spot instance
 description:
     - Creates or cancels spot instance requests.
 author:

--- a/plugins/modules/ec2_spot_instance_info.py
+++ b/plugins/modules/ec2_spot_instance_info.py
@@ -71,7 +71,7 @@ spot_request:
         create_time:
             description: The date and time when the Spot Instance request was created.
             returned: always
-            type: datetime
+            type: str
         instance_id:
             description: The instance ID, if an instance has been launched to fulfill the Spot Instance request.
             returned: when instance exists
@@ -175,7 +175,7 @@ spot_request:
                 update_time:
                     description: The date and time of the most recent status update in UTC format.
                     returned: always
-                    type: datetime
+                    type: str
         tags:
             description: List of tags associated with the resource.
             returned: always
@@ -189,7 +189,7 @@ spot_request:
                 value:
                     description: The value of the tag.
                     returned: always
-                    type:
+                    type: str
         type:
             description: The Spot Instance request type.
             returned: always
@@ -197,7 +197,7 @@ spot_request:
         valid_until:
             description: The end date of the request in UTC format.
             returned: always
-            type: datetime
+            type: str
     sample: {
         "create_time": "2021-09-01T21:05:57+00:00",
         "instance_id": "i-08877936b801ac475",

--- a/plugins/modules/ec2_spot_instance_info.py
+++ b/plugins/modules/ec2_spot_instance_info.py
@@ -65,7 +65,139 @@ RETURN = '''
 spot_request:
     description:  The gathered information about specified spot instance requests.
     returned: when success
-    type: dict
+    type: list
+    elements: dict
+    contains:
+        create_time:
+            description: The date and time when the Spot Instance request was created.
+            returned: always
+            type: datetime
+        instance_id:
+            description: The instance ID, if an instance has been launched to fulfill the Spot Instance request.
+            returned: when instance exists
+            type: str
+        instance_interruption_behavior:
+            description: The behavior when a Spot Instance is interruped.
+            returned: always
+            type: str
+        launch_specification:
+            description: Additional information for launching instances.
+            returned: always
+            type: dict
+            contains:
+                ebs_optimized:
+                    description: Indicates whether the instance is optimized for EBS I/O.
+                    returned: always
+                    type: bool
+                image_id:
+                    description: The ID of the AMI.
+                    returned: always
+                    type: str
+                instance_type:
+                    description: The instance type.
+                    returned: always
+                    type: str
+                key_name:
+                    description: The name of the key pair.
+                    returned: always
+                    type: str
+                monitoring:
+                    description: Described the monitoring of an instance.
+                    returned: always
+                    type: dict
+                    contains:
+                        enabled:
+                            description: Indicated whether detailed monitoring is enabled.
+                            returned: always
+                            type: bool
+                placement:
+                    description: The placement information for the instance.
+                    returned: always
+                    type: dict
+                    contains:
+                        availability_zone:
+                            description: The name of the availability zone.
+                            returned: always
+                            type: str
+                security_groups:
+                    description: List of security groups.
+                    returned: always
+                    type: list
+                    elements: dict
+                    contains:
+                        group_id:
+                            description: The ID of the security group.
+                            returned: always
+                            type: str
+                        group_name:
+                            description: The name of the security group.
+                            returned: always
+                            type: str
+                subnet_id:
+                    description: The ID of the subnet.
+                    returned: when creating a network interface when launching an instance
+                    type: str
+        launched_availability_zone:
+            description: The availability zone in which the request is launched.
+            returned: always
+            type: str
+        product_description:
+            description: The product description associated with the Spot Instance.
+            returned: always
+            type: str
+        spot_instance_request_id:
+            description: The ID of the Spot Instance request.
+            returned: always
+            type: str
+        spot_price:
+            description: The maximum price per hour that you are willing to pay for a Spot Instance.
+            returned: always
+            type: str
+        state:
+            description: The state of the Spot Instance request.
+            returned: always
+            type: str
+        status:
+            description: Extra information about the status of the Spot Instance request.
+            returned: always
+            type: dict
+            contains:
+                code:
+                    description:
+                        - The status code.
+                        - See https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-request-status.html#spot-instance-request-status-understand for codes.
+                    returned: always
+                    type: str
+                message:
+                    description: The description of the status code.
+                    returned: always
+                    type: str
+                update_time:
+                    description: The date and time of the most recent status update in UTC format.
+                    returned: always
+                    type: datetime
+        tags:
+            description: List of tags associated with the resource.
+            returned: always
+            type: list
+            elements: dict
+            contains:
+                key:
+                    description: The key of the tag.
+                    returned: always
+                    type: str
+                value:
+                    description: The value of the tag.
+                    returned: always
+                    type:
+        type:
+            description: The Spot Instance request type.
+            returned: always
+            type: str
+        valid_until:
+            description: The end date of the request in UTC format.
+            returned: always
+            type: datetime
     sample: {
         "create_time": "2021-09-01T21:05:57+00:00",
         "instance_id": "i-08877936b801ac475",

--- a/plugins/modules/ec2_tag.py
+++ b/plugins/modules/ec2_tag.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
 ---
 module: ec2_tag
 version_added: 1.0.0
-short_description: create and remove tags on ec2 resources
+short_description: Create and remove tags on ec2 resources
 description:
     - Creates, modifies and removes tags for any EC2 resource.
     - Resources are referenced by their resource id (for example, an instance being i-XXXXXXX, a VPC being vpc-XXXXXXX).

--- a/plugins/modules/ec2_tag_info.py
+++ b/plugins/modules/ec2_tag_info.py
@@ -10,7 +10,7 @@ DOCUMENTATION = '''
 ---
 module: ec2_tag_info
 version_added: 1.0.0
-short_description: list tags on ec2 resources
+short_description: List tags on ec2 resources
 description:
     - Lists tags for any EC2 resource.
     - Resources are referenced by their resource id (e.g. an instance being i-XXXXXXX, a vpc being vpc-XXXXXX).

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -99,7 +99,7 @@ dhcp_options:
               - '{"key": "ntp-servers", "values": [{"value": "10.0.0.2" , "value": "10.0.1.2"}]}'
               - '{"key": "netbios-name-servers", "values": [{value": "10.0.0.1"}, {"value": "10.0.1.1" }]}'
         dhcp_options_id:
-            description: The aws resource id of the primary DCHP options set created or found.
+            description: The aws resource id of the primary DHCP options set created or found.
             type: str
             sample: "dopt-0955331de6a20dd07"
         owner_id:

--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -71,19 +71,35 @@ EXAMPLES = '''
 
 RETURN = '''
 dhcp_options:
-    description: The DHCP options created, associated or found
+    description: The DHCP options created, associated or found.
     returned: always
     type: list
     elements: dict
     contains:
         dhcp_configurations:
-            description: The DHCP configuration for the option set
+            description: The DHCP configuration for the option set.
             type: list
+            elements: dict
+            contains:
+                key:
+                    description: The name of a DHCP option.
+                    returned: always
+                    type: str
+                values:
+                    description: List of values for the DHCP option.
+                    returned: always
+                    type: list
+                    elements: dict
+                    contains:
+                        value:
+                            description: The attribute value. This value is case-sensitive.
+                            returned: always
+                            type: str
             sample:
               - '{"key": "ntp-servers", "values": [{"value": "10.0.0.2" , "value": "10.0.1.2"}]}'
               - '{"key": "netbios-name-servers", "values": [{value": "10.0.0.1"}, {"value": "10.0.1.1" }]}'
         dhcp_options_id:
-            description: The aws resource id of the primary DCHP options set created or found
+            description: The aws resource id of the primary DCHP options set created or found.
             type: str
             sample: "dopt-0955331de6a20dd07"
         owner_id:
@@ -91,8 +107,9 @@ dhcp_options:
             type: str
             sample: 012345678912
         tags:
-            description: The tags to be applied to a DHCP options set
+            description: The tags to be applied to a DHCP options set.
             type: list
+            elements: dict
             sample:
               - '{"Key": "CreatedBy", "Value": "ansible-test"}'
               - '{"Key": "Collection", "Value": "amazon.aws"}'
@@ -100,6 +117,7 @@ dhcp_config:
     description: The boto2-style DHCP options created, associated or found. Provided for consistency with ec2_vpc_dhcp_option's C(dhcp_config).
     returned: always
     type: list
+    elements: dict
     contains:
       domain-name-servers:
         description: The IP addresses of up to four domain name servers, or AmazonProvidedDNS.
@@ -109,7 +127,7 @@ dhcp_config:
           - 10.0.0.1
           - 10.0.1.1
       domain-name:
-        description: The domain name for hosts in the DHCP option sets
+        description: The domain name for hosts in the DHCP option sets.
         returned: when available
         type: list
         sample:
@@ -134,7 +152,7 @@ dhcp_config:
         type: str
         sample: 2
 changed:
-    description: True if listing the dhcp options succeeds
+    description: True if listing the dhcp options succeeds.
     type: bool
     returned: always
 '''

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 module: ec2_vpc_endpoint_info
-short_description: Retrieves AWS VPC endpoints details using AWS methods.
+short_description: Retrieves AWS VPC endpoints details using AWS methods
 version_added: 1.0.0
 description:
   - Gets various details related to AWS VPC endpoints.
@@ -81,9 +81,10 @@ EXAMPLES = r'''
 
 RETURN = r'''
 service_names:
-  description: AWS VPC endpoint service names
+  description: AWS VPC endpoint service names.
   returned: I(query) is C(services)
   type: list
+  elements: str
   sample:
     service_names:
     - com.amazonaws.ap-southeast-2.s3
@@ -93,6 +94,95 @@ vpc_endpoints:
       policy_document, route_table_ids, service_name, state, vpc_endpoint_id, vpc_id.
   returned: I(query) is C(endpoints)
   type: list
+  elements: dict
+  contains:
+    creation_timestamp:
+      description: The date and time that the endpoint was created.
+      returned: always
+      type: str
+    dns_entries:
+      description: List of DNS entires for the endpoint.
+      returned: always
+      type: list
+      elements: dict
+      contains:
+        dns_name:
+          description: The DNS name.
+          returned: always
+          type: str
+        hosted_zone_id:
+          description: The ID of the private hosted zone.
+          returned: always
+          type: str
+    groups:
+      description: List of security groups associated with the network interface.
+      returned: always
+      type: list
+      elements: dict
+      contains:
+        group_id:
+          description: The ID of the security group.
+          returned: always
+          type: str
+        group_name:
+          description: The name of the security group.
+          returned: always
+          type: str
+    network_interface_ids:
+      description: List of network interfaces for the endpoint.
+      returned: always
+      type: list
+      elements: str
+    owner_id:
+      description: The ID of the AWS account that owns the endpoint.
+      returned: always
+      type: str
+    policy_document:
+      description: The policy document associated with the endpoint.
+      returned: always
+      type: str
+    private_dns_enabled:
+      description: Indicates whether the VPC is associated with a private hosted zone.
+      returned: always
+      type: bool
+    requester_managed:
+      description: Indicated whether the endpoint is being managed by its service.
+      returned: always
+      type: bool
+    route_table_ids:
+      description: List of route table IDs associated with the endpoint.
+      returned: always
+      type: list
+      elements: str
+    service_name:
+      description: The name of the service to which the endpoint is associated.
+      returned: always
+      type: str
+    state:
+      description: The state of the endpoint.
+      returned: always
+      type: str
+    subnet_ids:
+      description: List of subnets associated with the endpoint.
+      returned: always
+      type: str
+    tags:
+      description: List of tags associated with the endpoint.
+      returned: always
+      type: list
+      elements: dict
+    vpc_endpoint_id:
+      description: The ID of the endpoint.
+      returned: always
+      type: str
+    vpc_endpoint_type:
+      description: The type of endpoint.
+      returned: always
+      type: str
+    vpc_id:
+      description: The ID of the VPC.
+      returned: always
+      type: str
   sample:
     vpc_endpoints:
     - creation_timestamp: "2017-02-16T11:06:48+00:00"

--- a/plugins/modules/ec2_vpc_endpoint_service_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_service_info.py
@@ -7,7 +7,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 module: ec2_vpc_endpoint_service_info
-short_description: retrieves AWS VPC endpoint service details
+short_description: Retrieves AWS VPC endpoint service details
 version_added: 1.5.0
 description:
   - Gets details related to AWS VPC Endpoint Services.

--- a/plugins/modules/ec2_vpc_igw_info.py
+++ b/plugins/modules/ec2_vpc_igw_info.py
@@ -75,12 +75,12 @@ internet_gateways:
     type: complex
     contains:
         attachments:
-            description: Any VPCs attached to the internet gateway
+            description: Any VPCs attached to the internet gateway.
             returned: I(state=present)
             type: complex
             contains:
                 state:
-                    description: The current state of the attachment
+                    description: The current state of the attachment.
                     returned: I(state=present)
                     type: str
                     sample: available
@@ -90,12 +90,12 @@ internet_gateways:
                     type: str
                     sample: vpc-02123b67
         internet_gateway_id:
-            description: The ID of the internet gateway
+            description: The ID of the internet gateway.
             returned: I(state=present)
             type: str
             sample: igw-2123634d
         tags:
-            description: Any tags assigned to the internet gateway
+            description: Any tags assigned to the internet gateway.
             returned: I(state=present)
             type: dict
             sample:

--- a/plugins/modules/ec2_vpc_nat_gateway.py
+++ b/plugins/modules/ec2_vpc_nat_gateway.py
@@ -10,7 +10,7 @@ DOCUMENTATION = r'''
 ---
 module: ec2_vpc_nat_gateway
 version_added: 1.0.0
-short_description: Manage AWS VPC NAT Gateways.
+short_description: Manage AWS VPC NAT Gateways
 description:
   - Ensure the state of AWS VPC NAT Gateways based on their id, allocation and subnet ids.
 options:

--- a/plugins/modules/ec2_vpc_nat_gateway_info.py
+++ b/plugins/modules/ec2_vpc_nat_gateway_info.py
@@ -8,7 +8,7 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 module: ec2_vpc_nat_gateway_info
-short_description: Retrieves AWS VPC Managed Nat Gateway details using AWS methods.
+short_description: Retrieves AWS VPC Managed Nat Gateway details using AWS methods
 version_added: 1.0.0
 description:
   - Gets various details related to AWS VPC Managed Nat Gateways
@@ -67,74 +67,74 @@ EXAMPLES = r'''
 
 RETURN = r'''
 changed:
-  description: True if listing the internet gateways succeeds
+  description: True if listing the internet gateways succeeds.
   type: bool
   returned: always
   sample: false
 result:
   description:
     - The result of the describe, converted to ansible snake case style.
-    - See also U(http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_nat_gateways)
+    - See also U(http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_nat_gateways).
   returned: suceess
   type: list
   contains:
     create_time:
-        description: The date and time the NAT gateway was created
+        description: The date and time the NAT gateway was created.
         returned: always
         type: str
         sample: "2021-03-11T22:43:25+00:00"
     delete_time:
-        description: The date and time the NAT gateway was deleted
+        description: The date and time the NAT gateway was deleted.
         returned: when the NAT gateway has been deleted
         type: str
         sample: "2021-03-11T22:43:25+00:00"
     nat_gateway_addresses:
-        description: List containing a dictionary with the IP addresses and network interface associated with the NAT gateway
+        description: List containing a dictionary with the IP addresses and network interface associated with the NAT gateway.
         returned: always
         type: dict
         contains:
             allocation_id:
-                description: The allocation ID of the Elastic IP address that's associated with the NAT gateway
+                description: The allocation ID of the Elastic IP address that's associated with the NAT gateway.
                 returned: always
                 type: str
                 sample: eipalloc-0853e66a40803da76
             network_interface_id:
-                description: The ID of the network interface associated with the NAT gateway
+                description: The ID of the network interface associated with the NAT gateway.
                 returned: always
                 type: str
                 sample: eni-0a37acdbe306c661c
             private_ip:
-                description: The private IP address associated with the Elastic IP address
+                description: The private IP address associated with the Elastic IP address.
                 returned: always
                 type: str
                 sample: 10.0.238.227
             public_ip:
-                description: The Elastic IP address associated with the NAT gateway
+                description: The Elastic IP address associated with the NAT gateway.
                 returned: always
                 type: str
                 sample: 34.204.123.52
     nat_gateway_id:
-        description: The ID of the NAT gateway
+        description: The ID of the NAT gateway.
         returned: always
         type: str
         sample: nat-0c242a2397acf6173
     state:
-        description: state of the NAT gateway
+        description: state of the NAT gateway.
         returned: always
         type: str
         sample: available
     subnet_id:
-        description: The ID of the subnet in which the NAT gateway is located
+        description: The ID of the subnet in which the NAT gateway is located.
         returned: always
         type: str
         sample: subnet-098c447465d4344f9
     vpc_id:
-        description: The ID of the VPC in which the NAT gateway is located
+        description: The ID of the VPC in which the NAT gateway is located.
         returned: always
         type: str
         sample: vpc-02f37f48438ab7d4c
     tags:
-        description: Tags applied to the NAT gateway
+        description: Tags applied to the NAT gateway.
         returned: always
         type: dict
         sample:

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -59,7 +59,7 @@ vpcs:
             returned: always
             type: str
         vpc_id:
-            description: The ID of the VPC .
+            description: The ID of the VPC.
             returned: always
             type: str
         state:
@@ -104,7 +104,7 @@ vpcs:
             type: complex
             contains:
                 association_id:
-                    description: The association ID
+                    description: The association ID.
                     returned: always
                     type: str
                 cidr_block:
@@ -126,7 +126,7 @@ vpcs:
             type: complex
             contains:
                 association_id:
-                    description: The association ID
+                    description: The association ID.
                     returned: always
                     type: str
                 ipv6_cidr_block:

--- a/plugins/modules/ec2_vpc_route_table_info.py
+++ b/plugins/modules/ec2_vpc_route_table_info.py
@@ -53,136 +53,136 @@ EXAMPLES = r'''
 RETURN = r'''
 route_tables:
   description:
-    - A list of dictionarys describing route tables
-    - See also U(https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_route_tables)
+    - A list of dictionarys describing route tables.
+    - See also U(https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_route_tables).
   returned: always
   type: complex
   contains:
     associations:
-      description: List of associations between the route table and one or more subnets or a gateway
+      description: List of associations between the route table and one or more subnets or a gateway.
       returned: always
       type: complex
       contains:
         association_state:
-          description: The state of the association
+          description: The state of the association.
           returned: always
           type: complex
           contains:
             state:
-              description: The state of the association
+              description: The state of the association.
               returned: always
               type: str
               sample: associated
             state_message:
-              description: Additional information about the state of the association
+              description: Additional information about the state of the association.
               returned: when available
               type: str
               sample: 'Creating association'
         gateway_id:
-          description: ID of the internet gateway or virtual private gateway
+          description: ID of the internet gateway or virtual private gateway.
           returned: when route table is a gateway route table
           type: str
           sample: igw-03312309
         main:
-          description: Whether this is the main route table
+          description: Whether this is the main route table.
           returned: always
           type: bool
           sample: false
         route_table_association_id:
-          description: ID of association between route table and subnet
+          description: ID of association between route table and subnet.
           returned: always
           type: str
           sample: rtbassoc-ab47cfc3
         route_table_id:
-          description: ID of the route table
+          description: ID of the route table.
           returned: always
           type: str
           sample: rtb-bf779ed7
         subnet_id:
-          description: ID of the subnet
+          description: ID of the subnet.
           returned: when route table is a subnet route table
           type: str
           sample: subnet-82055af9
     id:
-      description: ID of the route table (same as route_table_id for backwards compatibility)
+      description: ID of the route table (same as route_table_id for backwards compatibility).
       returned: always
       type: str
       sample: rtb-bf779ed7
     owner_id:
-      description: ID of the account which owns the route table
+      description: ID of the account which owns the route table.
       returned: always
       type: str
       sample: '012345678912'
     propagating_vgws:
-      description: List of Virtual Private Gateways propagating routes
+      description: List of Virtual Private Gateways propagating routes.
       returned: always
       type: list
       sample: []
     route_table_id:
-      description: ID of the route table
+      description: ID of the route table.
       returned: always
       type: str
       sample: rtb-bf779ed7
     routes:
-      description: List of routes in the route table
+      description: List of routes in the route table.
       returned: always
       type: complex
       contains:
         destination_cidr_block:
-          description: CIDR block of destination
+          description: CIDR block of destination.
           returned: always
           type: str
           sample: 10.228.228.0/22
         gateway_id:
-          description: ID of the gateway
+          description: ID of the gateway.
           returned: when gateway is local or internet gateway
           type: str
           sample: local
         instance_id:
           description:
             - ID of a NAT instance.
-            - Empty unless the route is via an EC2 instance
+            - Empty unless the route is via an EC2 instance.
           returned: always
           type: str
           sample: i-abcd123456789
         instance_owner_id:
           description:
-            - AWS account owning the NAT instance
-            - Empty unless the route is via an EC2 instance
+            - AWS account owning the NAT instance.
+            - Empty unless the route is via an EC2 instance.
           returned: always
           type: str
           sample: 123456789012
         network_interface_id:
           description:
-            - The ID of the network interface
-            - Empty unless the route is via an EC2 instance
+            - The ID of the network interface.
+            - Empty unless the route is via an EC2 instance.
           returned: always
           type: str
           sample: 123456789012
         nat_gateway_id:
-          description: ID of the NAT gateway
-          returned: when the route is via a NAT gateway
+          description: ID of the NAT gateway.
+          returned: when the route is via a NAT gateway.
           type: str
           sample: local
         origin:
-          description: mechanism through which the route is in the table
+          description: mechanism through which the route is in the table.
           returned: always
           type: str
           sample: CreateRouteTable
         state:
-          description: state of the route
+          description: state of the route.
           returned: always
           type: str
           sample: active
     tags:
-      description: Tags applied to the route table
+      description: Tags applied to the route table.
       returned: always
       type: dict
       sample:
         Name: Public route table
         Public: 'true'
     vpc_id:
-      description: ID for the VPC in which the route lives
+      description: ID for the VPC in which the route lives.
       returned: always
       type: str
       sample: vpc-6e2d2407

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -14,7 +14,7 @@ description:
   - Creates, updates or destroys an Amazon Elastic Load Balancer (ELB).
   - This module was renamed from C(amazon.aws.ec2_elb_lb) to M(amazon.aws.elb_classic_lb) in version
     2.1.0 of the amazon.aws collection.
-short_description: creates, updates or destroys an Amazon ELB.
+short_description: Creates, updates or destroys an Amazon ELB
 author:
   - "Jim Dalton (@jsdalton)"
   - "Mark Chappell (@tremble)"

--- a/tests/integration/targets/cloudformation/tasks/main.yml
+++ b/tests/integration/targets/cloudformation/tasks/main.yml
@@ -123,6 +123,15 @@
           - "'stack_outputs' in cf_stack and 'InstanceId' in cf_stack.stack_outputs"
           - "'stack_resources' in cf_stack"
 
+    - name: get all stacks details
+      cloudformation_info:
+      register: all_stacks_info
+
+    - name: assert all stacks info
+      assert:
+        that:
+          - all_stacks_info | length > 0
+
     - name: get stack details
       cloudformation_info:
         stack_name: "{{ stack_name }}"

--- a/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
@@ -72,7 +72,7 @@
   # Minimal check_mode with _info
   - name: Fetch Endpoints in check_mode
     ec2_vpc_endpoint_info:
-      query: endpoints
+      # query: endpoints
     register: endpoint_info
     check_mode: true
   - name: Assert success
@@ -84,49 +84,49 @@
       - endpoint_info is successful
       - '"vpc_endpoints" in endpoint_info'
 
-  - name: Fetch Services in check_mode
-    ec2_vpc_endpoint_info:
-      query: services
-    register: endpoint_info
-    check_mode: true
-  - name: Assert success
-    assert:
-      that:
-      - endpoint_info is successful
-      - '"service_names" in endpoint_info'
-        # This is just 2 arbitrary AWS services that should (generally) be
-        # available.  The actual list will vary over time and between regions
-      - endpoint_service_a in endpoint_info.service_names
-      - endpoint_service_b in endpoint_info.service_names
+#   - name: Fetch Services in check_mode
+#     ec2_vpc_endpoint_info:
+#       query: services
+#     register: endpoint_info
+#     check_mode: true
+#   - name: Assert success
+#     assert:
+#       that:
+#       - endpoint_info is successful
+#       - '"service_names" in endpoint_info'
+#         # This is just 2 arbitrary AWS services that should (generally) be
+#         # available.  The actual list will vary over time and between regions
+#       - endpoint_service_a in endpoint_info.service_names
+#       - endpoint_service_b in endpoint_info.service_names
 
-  # Fetch services without check mode
-  # Note: Filters not supported on services via this module, this is all we can test for now
-  - name: Fetch Services
-    ec2_vpc_endpoint_info:
-      query: services
-    register: endpoint_info
-  - name: Assert success
-    assert:
-      that:
-      - endpoint_info is successful
-      - '"service_names" in endpoint_info'
-        # This is just 2 arbitrary AWS services that should (generally) be
-        # available.  The actual list will vary over time and between regions
-      - endpoint_service_a in endpoint_info.service_names
-      - endpoint_service_b in endpoint_info.service_names
+#   # Fetch services without check mode
+#   # Note: Filters not supported on services via this module, this is all we can test for now
+#   - name: Fetch Services
+#     ec2_vpc_endpoint_info:
+#       query: services
+#     register: endpoint_info
+#   - name: Assert success
+#     assert:
+#       that:
+#       - endpoint_info is successful
+#       - '"service_names" in endpoint_info'
+#         # This is just 2 arbitrary AWS services that should (generally) be
+#         # available.  The actual list will vary over time and between regions
+#       - endpoint_service_a in endpoint_info.service_names
+#       - endpoint_service_b in endpoint_info.service_names
 
-  # Attempt to create an endpoint
-  - name: Create minimal endpoint (check mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-    register: create_endpoint_check
-    check_mode: true
-  - name: Assert changed
-    assert:
-      that:
-      - create_endpoint_check is changed
+#   # Attempt to create an endpoint
+#   - name: Create minimal endpoint (check mode)
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       service: '{{ endpoint_service_a }}'
+#     register: create_endpoint_check
+#     check_mode: true
+#   - name: Assert changed
+#     assert:
+#       that:
+#       - create_endpoint_check is changed
 
   - name: Create minimal endpoint
     ec2_vpc_endpoint:
@@ -168,7 +168,7 @@
   # Pull info about the endpoints
   - name: Fetch Endpoints (all)
     ec2_vpc_endpoint_info:
-      query: endpoints
+      # query: endpoints
     register: endpoint_info
   - name: Assert success
     assert:
@@ -201,603 +201,603 @@
     vars:
       first_endpoint: '{{ endpoint_info.vpc_endpoints[0] }}'
 
-  - name: Fetch Endpoints (targetted by ID)
-    ec2_vpc_endpoint_info:
-      query: endpoints
-      vpc_endpoint_ids: '{{ endpoint_id }}'
-    register: endpoint_info
-  - name: Assert success
-    assert:
-      that:
-      - endpoint_info is successful
-      - '"vpc_endpoints" in endpoint_info'
-      - '"creation_timestamp" in first_endpoint'
-      - '"policy_document" in first_endpoint'
-      - '"route_table_ids" in first_endpoint'
-      - first_endpoint.route_table_ids | length == 0
-      - '"service_name" in first_endpoint'
-      - first_endpoint.service_name == endpoint_service_a
-      - '"state" in first_endpoint'
-      - first_endpoint.state == "available"
-      - '"vpc_endpoint_id" in first_endpoint'
-      - first_endpoint.vpc_endpoint_id == endpoint_id
-      - '"vpc_id" in first_endpoint'
-      - first_endpoint.vpc_id == vpc_id
-        # Not yet documented, but returned
-      - '"dns_entries" in first_endpoint'
-      - '"groups" in first_endpoint'
-      - '"network_interface_ids" in first_endpoint'
-      - '"owner_id" in first_endpoint'
-      - '"private_dns_enabled" in first_endpoint'
-      - first_endpoint.private_dns_enabled == False
-      - '"requester_managed" in first_endpoint'
-      - first_endpoint.requester_managed == False
-      - '"subnet_ids" in first_endpoint'
-      - '"tags" in first_endpoint'
-      - '"vpc_endpoint_type" in first_endpoint'
-    vars:
-      first_endpoint: '{{ endpoint_info.vpc_endpoints[0] }}'
+#   - name: Fetch Endpoints (targetted by ID)
+#     ec2_vpc_endpoint_info:
+#       query: endpoints
+#       vpc_endpoint_ids: '{{ endpoint_id }}'
+#     register: endpoint_info
+#   - name: Assert success
+#     assert:
+#       that:
+#       - endpoint_info is successful
+#       - '"vpc_endpoints" in endpoint_info'
+#       - '"creation_timestamp" in first_endpoint'
+#       - '"policy_document" in first_endpoint'
+#       - '"route_table_ids" in first_endpoint'
+#       - first_endpoint.route_table_ids | length == 0
+#       - '"service_name" in first_endpoint'
+#       - first_endpoint.service_name == endpoint_service_a
+#       - '"state" in first_endpoint'
+#       - first_endpoint.state == "available"
+#       - '"vpc_endpoint_id" in first_endpoint'
+#       - first_endpoint.vpc_endpoint_id == endpoint_id
+#       - '"vpc_id" in first_endpoint'
+#       - first_endpoint.vpc_id == vpc_id
+#         # Not yet documented, but returned
+#       - '"dns_entries" in first_endpoint'
+#       - '"groups" in first_endpoint'
+#       - '"network_interface_ids" in first_endpoint'
+#       - '"owner_id" in first_endpoint'
+#       - '"private_dns_enabled" in first_endpoint'
+#       - first_endpoint.private_dns_enabled == False
+#       - '"requester_managed" in first_endpoint'
+#       - first_endpoint.requester_managed == False
+#       - '"subnet_ids" in first_endpoint'
+#       - '"tags" in first_endpoint'
+#       - '"vpc_endpoint_type" in first_endpoint'
+#     vars:
+#       first_endpoint: '{{ endpoint_info.vpc_endpoints[0] }}'
 
-  - name: Fetch Endpoints (targetted by VPC)
-    ec2_vpc_endpoint_info:
-      query: endpoints
-      filters:
-        vpc-id:
-        - '{{ vpc_id }}'
-    register: endpoint_info
-  - name: Assert success
-    assert:
-      that:
-      - endpoint_info is successful
-      - '"vpc_endpoints" in endpoint_info'
-      - '"creation_timestamp" in first_endpoint'
-      - '"policy_document" in first_endpoint'
-      - '"route_table_ids" in first_endpoint'
-      - '"service_name" in first_endpoint'
-      - first_endpoint.service_name == endpoint_service_a
-      - '"state" in first_endpoint'
-      - first_endpoint.state == "available"
-      - '"vpc_endpoint_id" in first_endpoint'
-      - first_endpoint.vpc_endpoint_id == endpoint_id
-      - '"vpc_id" in first_endpoint'
-      - first_endpoint.vpc_id == vpc_id
-        # Not yet documented, but returned
-      - '"dns_entries" in first_endpoint'
-      - '"groups" in first_endpoint'
-      - '"network_interface_ids" in first_endpoint'
-      - '"owner_id" in first_endpoint'
-      - '"private_dns_enabled" in first_endpoint'
-      - first_endpoint.private_dns_enabled == False
-      - '"requester_managed" in first_endpoint'
-      - first_endpoint.requester_managed == False
-      - '"subnet_ids" in first_endpoint'
-      - '"tags" in first_endpoint'
-      - '"vpc_endpoint_type" in first_endpoint'
-    vars:
-      first_endpoint: '{{ endpoint_info.vpc_endpoints[0] }}'
-
-
-  # matches on parameters without explicitly passing the endpoint ID
-  - name: Create minimal endpoint - idempotency (check mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-    register: create_endpoint_idem_check
-    check_mode: true
-  - assert:
-      that:
-      - create_endpoint_idem_check is not changed
-
-  - name: Create minimal endpoint - idempotency
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-    register: create_endpoint_idem
-  - assert:
-      that:
-      - create_endpoint_idem is not changed
-
-  - name: Delete minimal endpoint by ID (check_mode)
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ endpoint_id }}'
-    check_mode: true
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is changed
+#   - name: Fetch Endpoints (targetted by VPC)
+#     ec2_vpc_endpoint_info:
+#       query: endpoints
+#       filters:
+#         vpc-id:
+#         - '{{ vpc_id }}'
+#     register: endpoint_info
+#   - name: Assert success
+#     assert:
+#       that:
+#       - endpoint_info is successful
+#       - '"vpc_endpoints" in endpoint_info'
+#       - '"creation_timestamp" in first_endpoint'
+#       - '"policy_document" in first_endpoint'
+#       - '"route_table_ids" in first_endpoint'
+#       - '"service_name" in first_endpoint'
+#       - first_endpoint.service_name == endpoint_service_a
+#       - '"state" in first_endpoint'
+#       - first_endpoint.state == "available"
+#       - '"vpc_endpoint_id" in first_endpoint'
+#       - first_endpoint.vpc_endpoint_id == endpoint_id
+#       - '"vpc_id" in first_endpoint'
+#       - first_endpoint.vpc_id == vpc_id
+#         # Not yet documented, but returned
+#       - '"dns_entries" in first_endpoint'
+#       - '"groups" in first_endpoint'
+#       - '"network_interface_ids" in first_endpoint'
+#       - '"owner_id" in first_endpoint'
+#       - '"private_dns_enabled" in first_endpoint'
+#       - first_endpoint.private_dns_enabled == False
+#       - '"requester_managed" in first_endpoint'
+#       - first_endpoint.requester_managed == False
+#       - '"subnet_ids" in first_endpoint'
+#       - '"tags" in first_endpoint'
+#       - '"vpc_endpoint_type" in first_endpoint'
+#     vars:
+#       first_endpoint: '{{ endpoint_info.vpc_endpoints[0] }}'
 
 
-  - name: Delete minimal endpoint by ID
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ endpoint_id }}'
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is changed
+#   # matches on parameters without explicitly passing the endpoint ID
+#   - name: Create minimal endpoint - idempotency (check mode)
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       service: '{{ endpoint_service_a }}'
+#     register: create_endpoint_idem_check
+#     check_mode: true
+#   - assert:
+#       that:
+#       - create_endpoint_idem_check is not changed
 
-  - name: Delete minimal endpoint by ID - idempotency (check_mode)
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ endpoint_id }}'
-    check_mode: true
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is not changed
+#   - name: Create minimal endpoint - idempotency
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       service: '{{ endpoint_service_a }}'
+#     register: create_endpoint_idem
+#   - assert:
+#       that:
+#       - create_endpoint_idem is not changed
 
-  - name: Delete minimal endpoint by ID - idempotency
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ endpoint_id }}'
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is not changed
+#   - name: Delete minimal endpoint by ID (check_mode)
+#     ec2_vpc_endpoint:
+#       state: absent
+#       vpc_endpoint_id: '{{ endpoint_id }}'
+#     check_mode: true
+#     register: endpoint_delete_check
+#   - assert:
+#       that:
+#       - endpoint_delete_check is changed
 
-  - name: Fetch Endpoints by ID (expect failed)
-    ec2_vpc_endpoint_info:
-      query: endpoints
-      vpc_endpoint_ids: '{{ endpoint_id }}'
-    ignore_errors: true
-    register: endpoint_info
-  - name: Assert endpoint does not exist
-    assert:
-      that:
-      - endpoint_info is successful
-      - '"does not exist" in endpoint_info.msg'
-      - endpoint_info.vpc_endpoints | length == 0
 
-  # Attempt to create an endpoint with a route table
-  - name: Create an endpoint with route table (check mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_empty_id }}'
-    register: create_endpoint_check
-    check_mode: true
-  - name: Assert changed
-    assert:
-      that:
-      - create_endpoint_check is changed
+#   - name: Delete minimal endpoint by ID
+#     ec2_vpc_endpoint:
+#       state: absent
+#       vpc_endpoint_id: '{{ endpoint_id }}'
+#     register: endpoint_delete_check
+#   - assert:
+#       that:
+#       - endpoint_delete_check is changed
 
-  - name: Create an endpoint with route table
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_empty_id }}'
-      wait: true
-    register: create_rtb_endpoint
-  - name: Check standard return values
-    assert:
-      that:
-      - create_rtb_endpoint is changed
-      - '"result" in create_rtb_endpoint'
-      - '"creation_timestamp" in create_rtb_endpoint.result'
-      - '"dns_entries" in create_rtb_endpoint.result'
-      - '"groups" in create_rtb_endpoint.result'
-      - '"network_interface_ids" in create_rtb_endpoint.result'
-      - '"owner_id" in create_rtb_endpoint.result'
-      - '"policy_document" in create_rtb_endpoint.result'
-      - '"private_dns_enabled" in create_rtb_endpoint.result'
-      - '"route_table_ids" in create_rtb_endpoint.result'
-      - create_rtb_endpoint.result.route_table_ids | length == 1
-      - create_rtb_endpoint.result.route_table_ids[0] == '{{ rtb_empty_id }}'
-      - create_rtb_endpoint.result.private_dns_enabled == False
-      - '"requester_managed" in create_rtb_endpoint.result'
-      - create_rtb_endpoint.result.requester_managed == False
-      - '"service_name" in create_rtb_endpoint.result'
-      - create_rtb_endpoint.result.service_name == endpoint_service_a
-      - '"state" in create_endpoint.result'
-      - create_rtb_endpoint.result.state == "available"
-      - '"vpc_endpoint_id" in create_rtb_endpoint.result'
-      - create_rtb_endpoint.result.vpc_endpoint_id.startswith("vpce-")
-      - '"vpc_endpoint_type" in create_rtb_endpoint.result'
-      - create_rtb_endpoint.result.vpc_endpoint_type == "Gateway"
-      - '"vpc_id" in create_rtb_endpoint.result'
-      - create_rtb_endpoint.result.vpc_id == vpc_id
+#   - name: Delete minimal endpoint by ID - idempotency (check_mode)
+#     ec2_vpc_endpoint:
+#       state: absent
+#       vpc_endpoint_id: '{{ endpoint_id }}'
+#     check_mode: true
+#     register: endpoint_delete_check
+#   - assert:
+#       that:
+#       - endpoint_delete_check is not changed
 
-  - name: Save Endpoint info in a fact
-    set_fact:
-      rtb_endpoint_id: '{{ create_rtb_endpoint.result.vpc_endpoint_id }}'
+#   - name: Delete minimal endpoint by ID - idempotency
+#     ec2_vpc_endpoint:
+#       state: absent
+#       vpc_endpoint_id: '{{ endpoint_id }}'
+#     register: endpoint_delete_check
+#   - assert:
+#       that:
+#       - endpoint_delete_check is not changed
 
-  - name: Create an endpoint with route table - idempotency (check mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_empty_id }}'
-    register: create_endpoint_check
-    check_mode: true
-  - name: Assert changed
-    assert:
-      that:
-      - create_endpoint_check is not changed
+#   - name: Fetch Endpoints by ID (expect failed)
+#     ec2_vpc_endpoint_info:
+#       query: endpoints
+#       vpc_endpoint_ids: '{{ endpoint_id }}'
+#     ignore_errors: true
+#     register: endpoint_info
+#   - name: Assert endpoint does not exist
+#     assert:
+#       that:
+#       - endpoint_info is successful
+#       - '"does not exist" in endpoint_info.msg'
+#       - endpoint_info.vpc_endpoints | length == 0
 
-  - name: Create an endpoint with route table - idempotency
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_empty_id }}'
-    register: create_endpoint_check
-    check_mode: true
-  - name: Assert changed
-    assert:
-      that:
-      - create_endpoint_check is not changed
+#   # Attempt to create an endpoint with a route table
+#   - name: Create an endpoint with route table (check mode)
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       service: '{{ endpoint_service_a }}'
+#       route_table_ids:
+#       - '{{ rtb_empty_id }}'
+#     register: create_endpoint_check
+#     check_mode: true
+#   - name: Assert changed
+#     assert:
+#       that:
+#       - create_endpoint_check is changed
 
-# # Endpoint modifications are not yet supported by the module
-#  # A Change the route table for the endpoint
-#  - name: Change the route table for the endpoint (check_mode)
-#    ec2_vpc_endpoint:
-#      state: present
-#      vpc_id: '{{ vpc_id }}'
-#      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
-#      service: '{{ endpoint_service_a }}'
-#      route_table_ids:
-#        - '{{ rtb_igw_id }}'
-#    check_mode: True
-#    register: check_two_rtbs_endpoint
-#
-#  - name: Assert second route table would be added
-#    assert:
-#      that:
-#        - check_two_rtbs_endpoint.changed
-#
-#  - name: Change the route table for the endpoint
-#    ec2_vpc_endpoint:
-#      state: present
-#      vpc_id: '{{ vpc_id }}'
-#      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
-#      service: '{{ endpoint_service_a }}'
-#      route_table_ids:
-#        - '{{ rtb_igw_id }}'
-#    register: two_rtbs_endpoint
-#
-#  - name: Assert second route table would be added
-#    assert:
-#      that:
-#        - check_two_rtbs_endpoint.changed
-#        - two_rtbs_endpoint.result.route_table_ids | length == 1
-#        - two_rtbs_endpoint.result.route_table_ids[0] == '{{ rtb_igw_id }}'
-#
-#  - name: Change the route table for the endpoint - idempotency (check_mode)
-#    ec2_vpc_endpoint:
-#      state: present
-#      vpc_id: '{{ vpc_id }}'
-#      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
-#      service: '{{ endpoint_service_a }}'
-#      route_table_ids:
-#        - '{{ rtb_igw_id }}'
-#    check_mode: True
-#    register: check_two_rtbs_endpoint
-#
-#  - name: Assert route table would not change
-#    assert:
-#      that:
-#        - not check_two_rtbs_endpoint.changed
-#
-#  - name: Change the route table for the endpoint - idempotency
-#    ec2_vpc_endpoint:
-#      state: present
-#      vpc_id: '{{ vpc_id }}'
-#      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
-#      service: '{{ endpoint_service_a }}'
-#      route_table_ids:
-#        - '{{ rtb_igw_id }}'
-#    register: two_rtbs_endpoint
-#
-#  - name: Assert route table would not change
-#    assert:
-#      that:
-#        - not check_two_rtbs_endpoint.changed
+#   - name: Create an endpoint with route table
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       service: '{{ endpoint_service_a }}'
+#       route_table_ids:
+#       - '{{ rtb_empty_id }}'
+#       wait: true
+#     register: create_rtb_endpoint
+#   - name: Check standard return values
+#     assert:
+#       that:
+#       - create_rtb_endpoint is changed
+#       - '"result" in create_rtb_endpoint'
+#       - '"creation_timestamp" in create_rtb_endpoint.result'
+#       - '"dns_entries" in create_rtb_endpoint.result'
+#       - '"groups" in create_rtb_endpoint.result'
+#       - '"network_interface_ids" in create_rtb_endpoint.result'
+#       - '"owner_id" in create_rtb_endpoint.result'
+#       - '"policy_document" in create_rtb_endpoint.result'
+#       - '"private_dns_enabled" in create_rtb_endpoint.result'
+#       - '"route_table_ids" in create_rtb_endpoint.result'
+#       - create_rtb_endpoint.result.route_table_ids | length == 1
+#       - create_rtb_endpoint.result.route_table_ids[0] == '{{ rtb_empty_id }}'
+#       - create_rtb_endpoint.result.private_dns_enabled == False
+#       - '"requester_managed" in create_rtb_endpoint.result'
+#       - create_rtb_endpoint.result.requester_managed == False
+#       - '"service_name" in create_rtb_endpoint.result'
+#       - create_rtb_endpoint.result.service_name == endpoint_service_a
+#       - '"state" in create_endpoint.result'
+#       - create_rtb_endpoint.result.state == "available"
+#       - '"vpc_endpoint_id" in create_rtb_endpoint.result'
+#       - create_rtb_endpoint.result.vpc_endpoint_id.startswith("vpce-")
+#       - '"vpc_endpoint_type" in create_rtb_endpoint.result'
+#       - create_rtb_endpoint.result.vpc_endpoint_type == "Gateway"
+#       - '"vpc_id" in create_rtb_endpoint.result'
+#       - create_rtb_endpoint.result.vpc_id == vpc_id
 
-  - name: Tag the endpoint (check_mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_empty_id }}'
-      tags:
-        camelCase: helloWorld
-        PascalCase: HelloWorld
-        snake_case: hello_world
-        Title Case: Hello World
-        lowercase spaced: hello world
-    check_mode: true
-    register: check_tag_vpc_endpoint
+#   - name: Save Endpoint info in a fact
+#     set_fact:
+#       rtb_endpoint_id: '{{ create_rtb_endpoint.result.vpc_endpoint_id }}'
 
-  - name: Assert tags would have changed
-    assert:
-      that:
-      - check_tag_vpc_endpoint.changed
+#   - name: Create an endpoint with route table - idempotency (check mode)
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       service: '{{ endpoint_service_a }}'
+#       route_table_ids:
+#       - '{{ rtb_empty_id }}'
+#     register: create_endpoint_check
+#     check_mode: true
+#   - name: Assert changed
+#     assert:
+#       that:
+#       - create_endpoint_check is not changed
 
-  - name: Tag the endpoint
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_igw_id }}'
-      tags:
-        testPrefix: '{{ resource_prefix }}'
-        camelCase: helloWorld
-        PascalCase: HelloWorld
-        snake_case: hello_world
-        Title Case: Hello World
-        lowercase spaced: hello world
-    register: tag_vpc_endpoint
+#   - name: Create an endpoint with route table - idempotency
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       service: '{{ endpoint_service_a }}'
+#       route_table_ids:
+#       - '{{ rtb_empty_id }}'
+#     register: create_endpoint_check
+#     check_mode: true
+#   - name: Assert changed
+#     assert:
+#       that:
+#       - create_endpoint_check is not changed
 
-  - name: Assert tags are successful
-    assert:
-      that:
-      - tag_vpc_endpoint.changed
-      - tag_vpc_endpoint.result.tags | length == 6
-      - endpoint_tags["testPrefix"] == resource_prefix
-      - endpoint_tags["camelCase"] == "helloWorld"
-      - endpoint_tags["PascalCase"] == "HelloWorld"
-      - endpoint_tags["snake_case"] == "hello_world"
-      - endpoint_tags["Title Case"] == "Hello World"
-      - endpoint_tags["lowercase spaced"] == "hello world"
-    vars:
-      endpoint_tags: "{{ tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
-        \ value_name='Value') }}"
+# # # Endpoint modifications are not yet supported by the module
+# #  # A Change the route table for the endpoint
+# #  - name: Change the route table for the endpoint (check_mode)
+# #    ec2_vpc_endpoint:
+# #      state: present
+# #      vpc_id: '{{ vpc_id }}'
+# #      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+# #      service: '{{ endpoint_service_a }}'
+# #      route_table_ids:
+# #        - '{{ rtb_igw_id }}'
+# #    check_mode: True
+# #    register: check_two_rtbs_endpoint
+# #
+# #  - name: Assert second route table would be added
+# #    assert:
+# #      that:
+# #        - check_two_rtbs_endpoint.changed
+# #
+# #  - name: Change the route table for the endpoint
+# #    ec2_vpc_endpoint:
+# #      state: present
+# #      vpc_id: '{{ vpc_id }}'
+# #      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+# #      service: '{{ endpoint_service_a }}'
+# #      route_table_ids:
+# #        - '{{ rtb_igw_id }}'
+# #    register: two_rtbs_endpoint
+# #
+# #  - name: Assert second route table would be added
+# #    assert:
+# #      that:
+# #        - check_two_rtbs_endpoint.changed
+# #        - two_rtbs_endpoint.result.route_table_ids | length == 1
+# #        - two_rtbs_endpoint.result.route_table_ids[0] == '{{ rtb_igw_id }}'
+# #
+# #  - name: Change the route table for the endpoint - idempotency (check_mode)
+# #    ec2_vpc_endpoint:
+# #      state: present
+# #      vpc_id: '{{ vpc_id }}'
+# #      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+# #      service: '{{ endpoint_service_a }}'
+# #      route_table_ids:
+# #        - '{{ rtb_igw_id }}'
+# #    check_mode: True
+# #    register: check_two_rtbs_endpoint
+# #
+# #  - name: Assert route table would not change
+# #    assert:
+# #      that:
+# #        - not check_two_rtbs_endpoint.changed
+# #
+# #  - name: Change the route table for the endpoint - idempotency
+# #    ec2_vpc_endpoint:
+# #      state: present
+# #      vpc_id: '{{ vpc_id }}'
+# #      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+# #      service: '{{ endpoint_service_a }}'
+# #      route_table_ids:
+# #        - '{{ rtb_igw_id }}'
+# #    register: two_rtbs_endpoint
+# #
+# #  - name: Assert route table would not change
+# #    assert:
+# #      that:
+# #        - not check_two_rtbs_endpoint.changed
 
-  - name: Query by tag
-    ec2_vpc_endpoint_info:
-      query: endpoints
-      filters:
-        tag:testPrefix:
-        - '{{ resource_prefix }}'
-    register: tag_result
+#   - name: Tag the endpoint (check_mode)
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+#       service: '{{ endpoint_service_a }}'
+#       route_table_ids:
+#       - '{{ rtb_empty_id }}'
+#       tags:
+#         camelCase: helloWorld
+#         PascalCase: HelloWorld
+#         snake_case: hello_world
+#         Title Case: Hello World
+#         lowercase spaced: hello world
+#     check_mode: true
+#     register: check_tag_vpc_endpoint
 
-  - name: Assert tag lookup found endpoint
-    assert:
-      that:
-      - tag_result is successful
-      - '"vpc_endpoints" in tag_result'
-      - first_endpoint.vpc_endpoint_id == rtb_endpoint_id
-    vars:
-      first_endpoint: '{{ tag_result.vpc_endpoints[0] }}'
+#   - name: Assert tags would have changed
+#     assert:
+#       that:
+#       - check_tag_vpc_endpoint.changed
 
-  - name: Tag the endpoint - idempotency (check_mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_igw_id }}'
-      tags:
-        testPrefix: '{{ resource_prefix }}'
-        camelCase: helloWorld
-        PascalCase: HelloWorld
-        snake_case: hello_world
-        Title Case: Hello World
-        lowercase spaced: hello world
-    register: tag_vpc_endpoint_again
+#   - name: Tag the endpoint
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+#       service: '{{ endpoint_service_a }}'
+#       route_table_ids:
+#       - '{{ rtb_igw_id }}'
+#       tags:
+#         testPrefix: '{{ resource_prefix }}'
+#         camelCase: helloWorld
+#         PascalCase: HelloWorld
+#         snake_case: hello_world
+#         Title Case: Hello World
+#         lowercase spaced: hello world
+#     register: tag_vpc_endpoint
 
-  - name: Assert tags would not change
-    assert:
-      that:
-      - not tag_vpc_endpoint_again.changed
+#   - name: Assert tags are successful
+#     assert:
+#       that:
+#       - tag_vpc_endpoint.changed
+#       - tag_vpc_endpoint.result.tags | length == 6
+#       - endpoint_tags["testPrefix"] == resource_prefix
+#       - endpoint_tags["camelCase"] == "helloWorld"
+#       - endpoint_tags["PascalCase"] == "HelloWorld"
+#       - endpoint_tags["snake_case"] == "hello_world"
+#       - endpoint_tags["Title Case"] == "Hello World"
+#       - endpoint_tags["lowercase spaced"] == "hello world"
+#     vars:
+#       endpoint_tags: "{{ tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
+#         \ value_name='Value') }}"
 
-  - name: Tag the endpoint - idempotency
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_igw_id }}'
-      tags:
-        testPrefix: '{{ resource_prefix }}'
-        camelCase: helloWorld
-        PascalCase: HelloWorld
-        snake_case: hello_world
-        Title Case: Hello World
-        lowercase spaced: hello world
-    register: tag_vpc_endpoint_again
+#   - name: Query by tag
+#     ec2_vpc_endpoint_info:
+#       query: endpoints
+#       filters:
+#         tag:testPrefix:
+#         - '{{ resource_prefix }}'
+#     register: tag_result
 
-  - name: Assert tags would not change
-    assert:
-      that:
-      - not tag_vpc_endpoint_again.changed
+#   - name: Assert tag lookup found endpoint
+#     assert:
+#       that:
+#       - tag_result is successful
+#       - '"vpc_endpoints" in tag_result'
+#       - first_endpoint.vpc_endpoint_id == rtb_endpoint_id
+#     vars:
+#       first_endpoint: '{{ tag_result.vpc_endpoints[0] }}'
 
-  - name: Add a tag (check_mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_igw_id }}'
-      tags:
-        new_tag: ANewTag
-    check_mode: true
-    register: check_tag_vpc_endpoint
+#   - name: Tag the endpoint - idempotency (check_mode)
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+#       service: '{{ endpoint_service_a }}'
+#       route_table_ids:
+#       - '{{ rtb_igw_id }}'
+#       tags:
+#         testPrefix: '{{ resource_prefix }}'
+#         camelCase: helloWorld
+#         PascalCase: HelloWorld
+#         snake_case: hello_world
+#         Title Case: Hello World
+#         lowercase spaced: hello world
+#     register: tag_vpc_endpoint_again
 
-  - name: Assert tags would have changed
-    assert:
-      that:
-      - check_tag_vpc_endpoint.changed
+#   - name: Assert tags would not change
+#     assert:
+#       that:
+#       - not tag_vpc_endpoint_again.changed
 
-  - name: Add a tag (purge_tags=False)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_igw_id }}'
-      tags:
-        new_tag: ANewTag
-    register: add_tag_vpc_endpoint
+#   - name: Tag the endpoint - idempotency
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+#       service: '{{ endpoint_service_a }}'
+#       route_table_ids:
+#       - '{{ rtb_igw_id }}'
+#       tags:
+#         testPrefix: '{{ resource_prefix }}'
+#         camelCase: helloWorld
+#         PascalCase: HelloWorld
+#         snake_case: hello_world
+#         Title Case: Hello World
+#         lowercase spaced: hello world
+#     register: tag_vpc_endpoint_again
 
-  - name: Assert tags changed
-    assert:
-      that:
-      - add_tag_vpc_endpoint.changed
-      - add_tag_vpc_endpoint.result.tags | length == 7
-      - endpoint_tags["testPrefix"] == resource_prefix
-      - endpoint_tags["camelCase"] == "helloWorld"
-      - endpoint_tags["PascalCase"] == "HelloWorld"
-      - endpoint_tags["snake_case"] == "hello_world"
-      - endpoint_tags["Title Case"] == "Hello World"
-      - endpoint_tags["lowercase spaced"] == "hello world"
-      - endpoint_tags["new_tag"] == "ANewTag"
-    vars:
-      endpoint_tags: "{{ add_tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
-        \ value_name='Value') }}"
+#   - name: Assert tags would not change
+#     assert:
+#       that:
+#       - not tag_vpc_endpoint_again.changed
 
-  - name: Add a tag (purge_tags=True)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_igw_id }}'
-      tags:
-        another_new_tag: AnotherNewTag
-      purge_tags: true
-    register: purge_tag_vpc_endpoint
+#   - name: Add a tag (check_mode)
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+#       service: '{{ endpoint_service_a }}'
+#       route_table_ids:
+#       - '{{ rtb_igw_id }}'
+#       tags:
+#         new_tag: ANewTag
+#     check_mode: true
+#     register: check_tag_vpc_endpoint
 
-  - name: Assert tags changed
-    assert:
-      that:
-      - purge_tag_vpc_endpoint.changed
-      - purge_tag_vpc_endpoint.result.tags | length == 1
-      - endpoint_tags["another_new_tag"] == "AnotherNewTag"
-    vars:
-      endpoint_tags: "{{ purge_tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
-        \ value_name='Value') }}"
+#   - name: Assert tags would have changed
+#     assert:
+#       that:
+#       - check_tag_vpc_endpoint.changed
 
-  - name: Delete minimal route table (no routes)
-    ec2_vpc_route_table:
-      state: absent
-      lookup: id
-      route_table_id: '{{ rtb_empty_id }}'
-    register: rtb_delete
-  - assert:
-      that:
-      - rtb_delete is changed
+#   - name: Add a tag (purge_tags=False)
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+#       service: '{{ endpoint_service_a }}'
+#       route_table_ids:
+#       - '{{ rtb_igw_id }}'
+#       tags:
+#         new_tag: ANewTag
+#     register: add_tag_vpc_endpoint
 
-  - name: Delete minimal route table (IGW route)
-    ec2_vpc_route_table:
-      state: absent
-      lookup: id
-      route_table_id: '{{ rtb_igw_id }}'
-  - assert:
-      that:
-      - rtb_delete is changed
+#   - name: Assert tags changed
+#     assert:
+#       that:
+#       - add_tag_vpc_endpoint.changed
+#       - add_tag_vpc_endpoint.result.tags | length == 7
+#       - endpoint_tags["testPrefix"] == resource_prefix
+#       - endpoint_tags["camelCase"] == "helloWorld"
+#       - endpoint_tags["PascalCase"] == "HelloWorld"
+#       - endpoint_tags["snake_case"] == "hello_world"
+#       - endpoint_tags["Title Case"] == "Hello World"
+#       - endpoint_tags["lowercase spaced"] == "hello world"
+#       - endpoint_tags["new_tag"] == "ANewTag"
+#     vars:
+#       endpoint_tags: "{{ add_tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
+#         \ value_name='Value') }}"
 
-  - name: Delete route table endpoint by ID
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is changed
+#   - name: Add a tag (purge_tags=True)
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+#       service: '{{ endpoint_service_a }}'
+#       route_table_ids:
+#       - '{{ rtb_igw_id }}'
+#       tags:
+#         another_new_tag: AnotherNewTag
+#       purge_tags: true
+#     register: purge_tag_vpc_endpoint
 
-  - name: Delete minimal endpoint by ID - idempotency (check_mode)
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-    check_mode: true
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is not changed
+#   - name: Assert tags changed
+#     assert:
+#       that:
+#       - purge_tag_vpc_endpoint.changed
+#       - purge_tag_vpc_endpoint.result.tags | length == 1
+#       - endpoint_tags["another_new_tag"] == "AnotherNewTag"
+#     vars:
+#       endpoint_tags: "{{ purge_tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
+#         \ value_name='Value') }}"
 
-  - name: Delete endpoint by ID - idempotency
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ endpoint_id }}'
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is not changed
+#   - name: Delete minimal route table (no routes)
+#     ec2_vpc_route_table:
+#       state: absent
+#       lookup: id
+#       route_table_id: '{{ rtb_empty_id }}'
+#     register: rtb_delete
+#   - assert:
+#       that:
+#       - rtb_delete is changed
 
-  - name: Create interface endpoint
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-      vpc_endpoint_type: Interface
-    register: create_interface_endpoint
-  - name: Check that the interface endpoint was created properly
-    assert:
-      that:
-      - create_interface_endpoint is changed
-      - create_interface_endpoint.result.vpc_endpoint_type == "Interface"
-  - name: Delete interface endpoint
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ create_interface_endpoint.result.vpc_endpoint_id }}'
-    register: interface_endpoint_delete_check
-  - assert:
-      that:
-      - interface_endpoint_delete_check is changed
+#   - name: Delete minimal route table (IGW route)
+#     ec2_vpc_route_table:
+#       state: absent
+#       lookup: id
+#       route_table_id: '{{ rtb_igw_id }}'
+#   - assert:
+#       that:
+#       - rtb_delete is changed
 
-  - name: Create a subnet
-    ec2_vpc_subnet:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      az: "{{ aws_region}}a"
-      cidr: "{{ vpc_cidr }}"
-    register: interface_endpoint_create_subnet_check
+#   - name: Delete route table endpoint by ID
+#     ec2_vpc_endpoint:
+#       state: absent
+#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+#     register: endpoint_delete_check
+#   - assert:
+#       that:
+#       - endpoint_delete_check is changed
 
-  - name: Create a security group
-    ec2_group:
-      name: securitygroup-prodext
-      description: "security group for Ansible interface endpoint"
-      state: present
-      vpc_id: "{{ vpc.vpc.id }}"
-      rules:
-        - proto: tcp
-          from_port: 1
-          to_port: 65535
-          cidr_ip: 0.0.0.0/0
-    register: interface_endpoint_create_sg_check
+#   - name: Delete minimal endpoint by ID - idempotency (check_mode)
+#     ec2_vpc_endpoint:
+#       state: absent
+#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+#     check_mode: true
+#     register: endpoint_delete_check
+#   - assert:
+#       that:
+#       - endpoint_delete_check is not changed
 
-  - name: Create interface endpoint attached to a subnet
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-      vpc_endpoint_type: Interface
-      vpc_endpoint_subnets: "{{ interface_endpoint_create_subnet_check.subnet.id') }}"
-      vpc_endpoint_security_groups: "{{ interface_endpoint_create_sg_check.group_id }}"
-    register: create_interface_endpoint_with_sg_subnets
-  - name: Check that the interface endpoint was created properly
-    assert:
-      that:
-        - create_interface_endpoint_with_sg_subnets is changed
-        - create_interface_endpoint_with_sg_subnets.result.vpc_endpoint_type == "Interface"
+#   - name: Delete endpoint by ID - idempotency
+#     ec2_vpc_endpoint:
+#       state: absent
+#       vpc_endpoint_id: '{{ endpoint_id }}'
+#     register: endpoint_delete_check
+#   - assert:
+#       that:
+#       - endpoint_delete_check is not changed
 
-  - name: Delete interface endpoint
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: "{{ create_interface_endpoint_with_sg_subnets.result.vpc_endpoint_id }}"
-    register: create_interface_endpoint_with_sg_subnets_delete_check
-  - assert:
-      that:
-        - create_interface_endpoint_with_sg_subnets_delete_check is changed
+#   - name: Create interface endpoint
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       service: '{{ endpoint_service_a }}'
+#       vpc_endpoint_type: Interface
+#     register: create_interface_endpoint
+#   - name: Check that the interface endpoint was created properly
+#     assert:
+#       that:
+#       - create_interface_endpoint is changed
+#       - create_interface_endpoint.result.vpc_endpoint_type == "Interface"
+#   - name: Delete interface endpoint
+#     ec2_vpc_endpoint:
+#       state: absent
+#       vpc_endpoint_id: '{{ create_interface_endpoint.result.vpc_endpoint_id }}'
+#     register: interface_endpoint_delete_check
+#   - assert:
+#       that:
+#       - interface_endpoint_delete_check is changed
+
+#   - name: Create a subnet
+#     ec2_vpc_subnet:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       az: "{{ aws_region}}a"
+#       cidr: "{{ vpc_cidr }}"
+#     register: interface_endpoint_create_subnet_check
+
+#   - name: Create a security group
+#     ec2_group:
+#       name: securitygroup-prodext
+#       description: "security group for Ansible interface endpoint"
+#       state: present
+#       vpc_id: "{{ vpc.vpc.id }}"
+#       rules:
+#         - proto: tcp
+#           from_port: 1
+#           to_port: 65535
+#           cidr_ip: 0.0.0.0/0
+#     register: interface_endpoint_create_sg_check
+
+#   - name: Create interface endpoint attached to a subnet
+#     ec2_vpc_endpoint:
+#       state: present
+#       vpc_id: '{{ vpc_id }}'
+#       service: '{{ endpoint_service_a }}'
+#       vpc_endpoint_type: Interface
+#       vpc_endpoint_subnets: "{{ interface_endpoint_create_subnet_check.subnet.id') }}"
+#       vpc_endpoint_security_groups: "{{ interface_endpoint_create_sg_check.group_id }}"
+#     register: create_interface_endpoint_with_sg_subnets
+#   - name: Check that the interface endpoint was created properly
+#     assert:
+#       that:
+#         - create_interface_endpoint_with_sg_subnets is changed
+#         - create_interface_endpoint_with_sg_subnets.result.vpc_endpoint_type == "Interface"
+
+#   - name: Delete interface endpoint
+#     ec2_vpc_endpoint:
+#       state: absent
+#       vpc_endpoint_id: "{{ create_interface_endpoint_with_sg_subnets.result.vpc_endpoint_id }}"
+#     register: create_interface_endpoint_with_sg_subnets_delete_check
+#   - assert:
+#       that:
+#         - create_interface_endpoint_with_sg_subnets_delete_check is changed
 
   # ============================================================
   # BEGIN POST-TEST CLEANUP

--- a/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
@@ -72,7 +72,7 @@
   # Minimal check_mode with _info
   - name: Fetch Endpoints in check_mode
     ec2_vpc_endpoint_info:
-      # query: endpoints
+      query: endpoints
     register: endpoint_info
     check_mode: true
   - name: Assert success
@@ -84,49 +84,49 @@
       - endpoint_info is successful
       - '"vpc_endpoints" in endpoint_info'
 
-#   - name: Fetch Services in check_mode
-#     ec2_vpc_endpoint_info:
-#       query: services
-#     register: endpoint_info
-#     check_mode: true
-#   - name: Assert success
-#     assert:
-#       that:
-#       - endpoint_info is successful
-#       - '"service_names" in endpoint_info'
-#         # This is just 2 arbitrary AWS services that should (generally) be
-#         # available.  The actual list will vary over time and between regions
-#       - endpoint_service_a in endpoint_info.service_names
-#       - endpoint_service_b in endpoint_info.service_names
+  - name: Fetch Services in check_mode
+    ec2_vpc_endpoint_info:
+      query: services
+    register: endpoint_info
+    check_mode: true
+  - name: Assert success
+    assert:
+      that:
+      - endpoint_info is successful
+      - '"service_names" in endpoint_info'
+        # This is just 2 arbitrary AWS services that should (generally) be
+        # available.  The actual list will vary over time and between regions
+      - endpoint_service_a in endpoint_info.service_names
+      - endpoint_service_b in endpoint_info.service_names
 
-#   # Fetch services without check mode
-#   # Note: Filters not supported on services via this module, this is all we can test for now
-#   - name: Fetch Services
-#     ec2_vpc_endpoint_info:
-#       query: services
-#     register: endpoint_info
-#   - name: Assert success
-#     assert:
-#       that:
-#       - endpoint_info is successful
-#       - '"service_names" in endpoint_info'
-#         # This is just 2 arbitrary AWS services that should (generally) be
-#         # available.  The actual list will vary over time and between regions
-#       - endpoint_service_a in endpoint_info.service_names
-#       - endpoint_service_b in endpoint_info.service_names
+  # Fetch services without check mode
+  # Note: Filters not supported on services via this module, this is all we can test for now
+  - name: Fetch Services
+    ec2_vpc_endpoint_info:
+      query: services
+    register: endpoint_info
+  - name: Assert success
+    assert:
+      that:
+      - endpoint_info is successful
+      - '"service_names" in endpoint_info'
+        # This is just 2 arbitrary AWS services that should (generally) be
+        # available.  The actual list will vary over time and between regions
+      - endpoint_service_a in endpoint_info.service_names
+      - endpoint_service_b in endpoint_info.service_names
 
-#   # Attempt to create an endpoint
-#   - name: Create minimal endpoint (check mode)
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       service: '{{ endpoint_service_a }}'
-#     register: create_endpoint_check
-#     check_mode: true
-#   - name: Assert changed
-#     assert:
-#       that:
-#       - create_endpoint_check is changed
+  # Attempt to create an endpoint
+  - name: Create minimal endpoint (check mode)
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      service: '{{ endpoint_service_a }}'
+    register: create_endpoint_check
+    check_mode: true
+  - name: Assert changed
+    assert:
+      that:
+      - create_endpoint_check is changed
 
   - name: Create minimal endpoint
     ec2_vpc_endpoint:
@@ -168,7 +168,7 @@
   # Pull info about the endpoints
   - name: Fetch Endpoints (all)
     ec2_vpc_endpoint_info:
-      # query: endpoints
+      query: endpoints
     register: endpoint_info
   - name: Assert success
     assert:
@@ -201,603 +201,603 @@
     vars:
       first_endpoint: '{{ endpoint_info.vpc_endpoints[0] }}'
 
-#   - name: Fetch Endpoints (targetted by ID)
-#     ec2_vpc_endpoint_info:
-#       query: endpoints
-#       vpc_endpoint_ids: '{{ endpoint_id }}'
-#     register: endpoint_info
-#   - name: Assert success
-#     assert:
-#       that:
-#       - endpoint_info is successful
-#       - '"vpc_endpoints" in endpoint_info'
-#       - '"creation_timestamp" in first_endpoint'
-#       - '"policy_document" in first_endpoint'
-#       - '"route_table_ids" in first_endpoint'
-#       - first_endpoint.route_table_ids | length == 0
-#       - '"service_name" in first_endpoint'
-#       - first_endpoint.service_name == endpoint_service_a
-#       - '"state" in first_endpoint'
-#       - first_endpoint.state == "available"
-#       - '"vpc_endpoint_id" in first_endpoint'
-#       - first_endpoint.vpc_endpoint_id == endpoint_id
-#       - '"vpc_id" in first_endpoint'
-#       - first_endpoint.vpc_id == vpc_id
-#         # Not yet documented, but returned
-#       - '"dns_entries" in first_endpoint'
-#       - '"groups" in first_endpoint'
-#       - '"network_interface_ids" in first_endpoint'
-#       - '"owner_id" in first_endpoint'
-#       - '"private_dns_enabled" in first_endpoint'
-#       - first_endpoint.private_dns_enabled == False
-#       - '"requester_managed" in first_endpoint'
-#       - first_endpoint.requester_managed == False
-#       - '"subnet_ids" in first_endpoint'
-#       - '"tags" in first_endpoint'
-#       - '"vpc_endpoint_type" in first_endpoint'
-#     vars:
-#       first_endpoint: '{{ endpoint_info.vpc_endpoints[0] }}'
+  - name: Fetch Endpoints (targetted by ID)
+    ec2_vpc_endpoint_info:
+      query: endpoints
+      vpc_endpoint_ids: '{{ endpoint_id }}'
+    register: endpoint_info
+  - name: Assert success
+    assert:
+      that:
+      - endpoint_info is successful
+      - '"vpc_endpoints" in endpoint_info'
+      - '"creation_timestamp" in first_endpoint'
+      - '"policy_document" in first_endpoint'
+      - '"route_table_ids" in first_endpoint'
+      - first_endpoint.route_table_ids | length == 0
+      - '"service_name" in first_endpoint'
+      - first_endpoint.service_name == endpoint_service_a
+      - '"state" in first_endpoint'
+      - first_endpoint.state == "available"
+      - '"vpc_endpoint_id" in first_endpoint'
+      - first_endpoint.vpc_endpoint_id == endpoint_id
+      - '"vpc_id" in first_endpoint'
+      - first_endpoint.vpc_id == vpc_id
+        # Not yet documented, but returned
+      - '"dns_entries" in first_endpoint'
+      - '"groups" in first_endpoint'
+      - '"network_interface_ids" in first_endpoint'
+      - '"owner_id" in first_endpoint'
+      - '"private_dns_enabled" in first_endpoint'
+      - first_endpoint.private_dns_enabled == False
+      - '"requester_managed" in first_endpoint'
+      - first_endpoint.requester_managed == False
+      - '"subnet_ids" in first_endpoint'
+      - '"tags" in first_endpoint'
+      - '"vpc_endpoint_type" in first_endpoint'
+    vars:
+      first_endpoint: '{{ endpoint_info.vpc_endpoints[0] }}'
 
-#   - name: Fetch Endpoints (targetted by VPC)
-#     ec2_vpc_endpoint_info:
-#       query: endpoints
-#       filters:
-#         vpc-id:
-#         - '{{ vpc_id }}'
-#     register: endpoint_info
-#   - name: Assert success
-#     assert:
-#       that:
-#       - endpoint_info is successful
-#       - '"vpc_endpoints" in endpoint_info'
-#       - '"creation_timestamp" in first_endpoint'
-#       - '"policy_document" in first_endpoint'
-#       - '"route_table_ids" in first_endpoint'
-#       - '"service_name" in first_endpoint'
-#       - first_endpoint.service_name == endpoint_service_a
-#       - '"state" in first_endpoint'
-#       - first_endpoint.state == "available"
-#       - '"vpc_endpoint_id" in first_endpoint'
-#       - first_endpoint.vpc_endpoint_id == endpoint_id
-#       - '"vpc_id" in first_endpoint'
-#       - first_endpoint.vpc_id == vpc_id
-#         # Not yet documented, but returned
-#       - '"dns_entries" in first_endpoint'
-#       - '"groups" in first_endpoint'
-#       - '"network_interface_ids" in first_endpoint'
-#       - '"owner_id" in first_endpoint'
-#       - '"private_dns_enabled" in first_endpoint'
-#       - first_endpoint.private_dns_enabled == False
-#       - '"requester_managed" in first_endpoint'
-#       - first_endpoint.requester_managed == False
-#       - '"subnet_ids" in first_endpoint'
-#       - '"tags" in first_endpoint'
-#       - '"vpc_endpoint_type" in first_endpoint'
-#     vars:
-#       first_endpoint: '{{ endpoint_info.vpc_endpoints[0] }}'
-
-
-#   # matches on parameters without explicitly passing the endpoint ID
-#   - name: Create minimal endpoint - idempotency (check mode)
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       service: '{{ endpoint_service_a }}'
-#     register: create_endpoint_idem_check
-#     check_mode: true
-#   - assert:
-#       that:
-#       - create_endpoint_idem_check is not changed
-
-#   - name: Create minimal endpoint - idempotency
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       service: '{{ endpoint_service_a }}'
-#     register: create_endpoint_idem
-#   - assert:
-#       that:
-#       - create_endpoint_idem is not changed
-
-#   - name: Delete minimal endpoint by ID (check_mode)
-#     ec2_vpc_endpoint:
-#       state: absent
-#       vpc_endpoint_id: '{{ endpoint_id }}'
-#     check_mode: true
-#     register: endpoint_delete_check
-#   - assert:
-#       that:
-#       - endpoint_delete_check is changed
+  - name: Fetch Endpoints (targetted by VPC)
+    ec2_vpc_endpoint_info:
+      query: endpoints
+      filters:
+        vpc-id:
+        - '{{ vpc_id }}'
+    register: endpoint_info
+  - name: Assert success
+    assert:
+      that:
+      - endpoint_info is successful
+      - '"vpc_endpoints" in endpoint_info'
+      - '"creation_timestamp" in first_endpoint'
+      - '"policy_document" in first_endpoint'
+      - '"route_table_ids" in first_endpoint'
+      - '"service_name" in first_endpoint'
+      - first_endpoint.service_name == endpoint_service_a
+      - '"state" in first_endpoint'
+      - first_endpoint.state == "available"
+      - '"vpc_endpoint_id" in first_endpoint'
+      - first_endpoint.vpc_endpoint_id == endpoint_id
+      - '"vpc_id" in first_endpoint'
+      - first_endpoint.vpc_id == vpc_id
+        # Not yet documented, but returned
+      - '"dns_entries" in first_endpoint'
+      - '"groups" in first_endpoint'
+      - '"network_interface_ids" in first_endpoint'
+      - '"owner_id" in first_endpoint'
+      - '"private_dns_enabled" in first_endpoint'
+      - first_endpoint.private_dns_enabled == False
+      - '"requester_managed" in first_endpoint'
+      - first_endpoint.requester_managed == False
+      - '"subnet_ids" in first_endpoint'
+      - '"tags" in first_endpoint'
+      - '"vpc_endpoint_type" in first_endpoint'
+    vars:
+      first_endpoint: '{{ endpoint_info.vpc_endpoints[0] }}'
 
 
-#   - name: Delete minimal endpoint by ID
-#     ec2_vpc_endpoint:
-#       state: absent
-#       vpc_endpoint_id: '{{ endpoint_id }}'
-#     register: endpoint_delete_check
-#   - assert:
-#       that:
-#       - endpoint_delete_check is changed
+  # matches on parameters without explicitly passing the endpoint ID
+  - name: Create minimal endpoint - idempotency (check mode)
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      service: '{{ endpoint_service_a }}'
+    register: create_endpoint_idem_check
+    check_mode: true
+  - assert:
+      that:
+      - create_endpoint_idem_check is not changed
 
-#   - name: Delete minimal endpoint by ID - idempotency (check_mode)
-#     ec2_vpc_endpoint:
-#       state: absent
-#       vpc_endpoint_id: '{{ endpoint_id }}'
-#     check_mode: true
-#     register: endpoint_delete_check
-#   - assert:
-#       that:
-#       - endpoint_delete_check is not changed
+  - name: Create minimal endpoint - idempotency
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      service: '{{ endpoint_service_a }}'
+    register: create_endpoint_idem
+  - assert:
+      that:
+      - create_endpoint_idem is not changed
 
-#   - name: Delete minimal endpoint by ID - idempotency
-#     ec2_vpc_endpoint:
-#       state: absent
-#       vpc_endpoint_id: '{{ endpoint_id }}'
-#     register: endpoint_delete_check
-#   - assert:
-#       that:
-#       - endpoint_delete_check is not changed
+  - name: Delete minimal endpoint by ID (check_mode)
+    ec2_vpc_endpoint:
+      state: absent
+      vpc_endpoint_id: '{{ endpoint_id }}'
+    check_mode: true
+    register: endpoint_delete_check
+  - assert:
+      that:
+      - endpoint_delete_check is changed
 
-#   - name: Fetch Endpoints by ID (expect failed)
-#     ec2_vpc_endpoint_info:
-#       query: endpoints
-#       vpc_endpoint_ids: '{{ endpoint_id }}'
-#     ignore_errors: true
-#     register: endpoint_info
-#   - name: Assert endpoint does not exist
-#     assert:
-#       that:
-#       - endpoint_info is successful
-#       - '"does not exist" in endpoint_info.msg'
-#       - endpoint_info.vpc_endpoints | length == 0
 
-#   # Attempt to create an endpoint with a route table
-#   - name: Create an endpoint with route table (check mode)
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       service: '{{ endpoint_service_a }}'
-#       route_table_ids:
-#       - '{{ rtb_empty_id }}'
-#     register: create_endpoint_check
-#     check_mode: true
-#   - name: Assert changed
-#     assert:
-#       that:
-#       - create_endpoint_check is changed
+  - name: Delete minimal endpoint by ID
+    ec2_vpc_endpoint:
+      state: absent
+      vpc_endpoint_id: '{{ endpoint_id }}'
+    register: endpoint_delete_check
+  - assert:
+      that:
+      - endpoint_delete_check is changed
 
-#   - name: Create an endpoint with route table
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       service: '{{ endpoint_service_a }}'
-#       route_table_ids:
-#       - '{{ rtb_empty_id }}'
-#       wait: true
-#     register: create_rtb_endpoint
-#   - name: Check standard return values
-#     assert:
-#       that:
-#       - create_rtb_endpoint is changed
-#       - '"result" in create_rtb_endpoint'
-#       - '"creation_timestamp" in create_rtb_endpoint.result'
-#       - '"dns_entries" in create_rtb_endpoint.result'
-#       - '"groups" in create_rtb_endpoint.result'
-#       - '"network_interface_ids" in create_rtb_endpoint.result'
-#       - '"owner_id" in create_rtb_endpoint.result'
-#       - '"policy_document" in create_rtb_endpoint.result'
-#       - '"private_dns_enabled" in create_rtb_endpoint.result'
-#       - '"route_table_ids" in create_rtb_endpoint.result'
-#       - create_rtb_endpoint.result.route_table_ids | length == 1
-#       - create_rtb_endpoint.result.route_table_ids[0] == '{{ rtb_empty_id }}'
-#       - create_rtb_endpoint.result.private_dns_enabled == False
-#       - '"requester_managed" in create_rtb_endpoint.result'
-#       - create_rtb_endpoint.result.requester_managed == False
-#       - '"service_name" in create_rtb_endpoint.result'
-#       - create_rtb_endpoint.result.service_name == endpoint_service_a
-#       - '"state" in create_endpoint.result'
-#       - create_rtb_endpoint.result.state == "available"
-#       - '"vpc_endpoint_id" in create_rtb_endpoint.result'
-#       - create_rtb_endpoint.result.vpc_endpoint_id.startswith("vpce-")
-#       - '"vpc_endpoint_type" in create_rtb_endpoint.result'
-#       - create_rtb_endpoint.result.vpc_endpoint_type == "Gateway"
-#       - '"vpc_id" in create_rtb_endpoint.result'
-#       - create_rtb_endpoint.result.vpc_id == vpc_id
+  - name: Delete minimal endpoint by ID - idempotency (check_mode)
+    ec2_vpc_endpoint:
+      state: absent
+      vpc_endpoint_id: '{{ endpoint_id }}'
+    check_mode: true
+    register: endpoint_delete_check
+  - assert:
+      that:
+      - endpoint_delete_check is not changed
 
-#   - name: Save Endpoint info in a fact
-#     set_fact:
-#       rtb_endpoint_id: '{{ create_rtb_endpoint.result.vpc_endpoint_id }}'
+  - name: Delete minimal endpoint by ID - idempotency
+    ec2_vpc_endpoint:
+      state: absent
+      vpc_endpoint_id: '{{ endpoint_id }}'
+    register: endpoint_delete_check
+  - assert:
+      that:
+      - endpoint_delete_check is not changed
 
-#   - name: Create an endpoint with route table - idempotency (check mode)
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       service: '{{ endpoint_service_a }}'
-#       route_table_ids:
-#       - '{{ rtb_empty_id }}'
-#     register: create_endpoint_check
-#     check_mode: true
-#   - name: Assert changed
-#     assert:
-#       that:
-#       - create_endpoint_check is not changed
+  - name: Fetch Endpoints by ID (expect failed)
+    ec2_vpc_endpoint_info:
+      query: endpoints
+      vpc_endpoint_ids: '{{ endpoint_id }}'
+    ignore_errors: true
+    register: endpoint_info
+  - name: Assert endpoint does not exist
+    assert:
+      that:
+      - endpoint_info is successful
+      - '"does not exist" in endpoint_info.msg'
+      - endpoint_info.vpc_endpoints | length == 0
 
-#   - name: Create an endpoint with route table - idempotency
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       service: '{{ endpoint_service_a }}'
-#       route_table_ids:
-#       - '{{ rtb_empty_id }}'
-#     register: create_endpoint_check
-#     check_mode: true
-#   - name: Assert changed
-#     assert:
-#       that:
-#       - create_endpoint_check is not changed
+  # Attempt to create an endpoint with a route table
+  - name: Create an endpoint with route table (check mode)
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      service: '{{ endpoint_service_a }}'
+      route_table_ids:
+      - '{{ rtb_empty_id }}'
+    register: create_endpoint_check
+    check_mode: true
+  - name: Assert changed
+    assert:
+      that:
+      - create_endpoint_check is changed
 
-# # # Endpoint modifications are not yet supported by the module
-# #  # A Change the route table for the endpoint
-# #  - name: Change the route table for the endpoint (check_mode)
-# #    ec2_vpc_endpoint:
-# #      state: present
-# #      vpc_id: '{{ vpc_id }}'
-# #      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
-# #      service: '{{ endpoint_service_a }}'
-# #      route_table_ids:
-# #        - '{{ rtb_igw_id }}'
-# #    check_mode: True
-# #    register: check_two_rtbs_endpoint
-# #
-# #  - name: Assert second route table would be added
-# #    assert:
-# #      that:
-# #        - check_two_rtbs_endpoint.changed
-# #
-# #  - name: Change the route table for the endpoint
-# #    ec2_vpc_endpoint:
-# #      state: present
-# #      vpc_id: '{{ vpc_id }}'
-# #      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
-# #      service: '{{ endpoint_service_a }}'
-# #      route_table_ids:
-# #        - '{{ rtb_igw_id }}'
-# #    register: two_rtbs_endpoint
-# #
-# #  - name: Assert second route table would be added
-# #    assert:
-# #      that:
-# #        - check_two_rtbs_endpoint.changed
-# #        - two_rtbs_endpoint.result.route_table_ids | length == 1
-# #        - two_rtbs_endpoint.result.route_table_ids[0] == '{{ rtb_igw_id }}'
-# #
-# #  - name: Change the route table for the endpoint - idempotency (check_mode)
-# #    ec2_vpc_endpoint:
-# #      state: present
-# #      vpc_id: '{{ vpc_id }}'
-# #      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
-# #      service: '{{ endpoint_service_a }}'
-# #      route_table_ids:
-# #        - '{{ rtb_igw_id }}'
-# #    check_mode: True
-# #    register: check_two_rtbs_endpoint
-# #
-# #  - name: Assert route table would not change
-# #    assert:
-# #      that:
-# #        - not check_two_rtbs_endpoint.changed
-# #
-# #  - name: Change the route table for the endpoint - idempotency
-# #    ec2_vpc_endpoint:
-# #      state: present
-# #      vpc_id: '{{ vpc_id }}'
-# #      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
-# #      service: '{{ endpoint_service_a }}'
-# #      route_table_ids:
-# #        - '{{ rtb_igw_id }}'
-# #    register: two_rtbs_endpoint
-# #
-# #  - name: Assert route table would not change
-# #    assert:
-# #      that:
-# #        - not check_two_rtbs_endpoint.changed
+  - name: Create an endpoint with route table
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      service: '{{ endpoint_service_a }}'
+      route_table_ids:
+      - '{{ rtb_empty_id }}'
+      wait: true
+    register: create_rtb_endpoint
+  - name: Check standard return values
+    assert:
+      that:
+      - create_rtb_endpoint is changed
+      - '"result" in create_rtb_endpoint'
+      - '"creation_timestamp" in create_rtb_endpoint.result'
+      - '"dns_entries" in create_rtb_endpoint.result'
+      - '"groups" in create_rtb_endpoint.result'
+      - '"network_interface_ids" in create_rtb_endpoint.result'
+      - '"owner_id" in create_rtb_endpoint.result'
+      - '"policy_document" in create_rtb_endpoint.result'
+      - '"private_dns_enabled" in create_rtb_endpoint.result'
+      - '"route_table_ids" in create_rtb_endpoint.result'
+      - create_rtb_endpoint.result.route_table_ids | length == 1
+      - create_rtb_endpoint.result.route_table_ids[0] == '{{ rtb_empty_id }}'
+      - create_rtb_endpoint.result.private_dns_enabled == False
+      - '"requester_managed" in create_rtb_endpoint.result'
+      - create_rtb_endpoint.result.requester_managed == False
+      - '"service_name" in create_rtb_endpoint.result'
+      - create_rtb_endpoint.result.service_name == endpoint_service_a
+      - '"state" in create_endpoint.result'
+      - create_rtb_endpoint.result.state == "available"
+      - '"vpc_endpoint_id" in create_rtb_endpoint.result'
+      - create_rtb_endpoint.result.vpc_endpoint_id.startswith("vpce-")
+      - '"vpc_endpoint_type" in create_rtb_endpoint.result'
+      - create_rtb_endpoint.result.vpc_endpoint_type == "Gateway"
+      - '"vpc_id" in create_rtb_endpoint.result'
+      - create_rtb_endpoint.result.vpc_id == vpc_id
 
-#   - name: Tag the endpoint (check_mode)
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-#       service: '{{ endpoint_service_a }}'
-#       route_table_ids:
-#       - '{{ rtb_empty_id }}'
-#       tags:
-#         camelCase: helloWorld
-#         PascalCase: HelloWorld
-#         snake_case: hello_world
-#         Title Case: Hello World
-#         lowercase spaced: hello world
-#     check_mode: true
-#     register: check_tag_vpc_endpoint
+  - name: Save Endpoint info in a fact
+    set_fact:
+      rtb_endpoint_id: '{{ create_rtb_endpoint.result.vpc_endpoint_id }}'
 
-#   - name: Assert tags would have changed
-#     assert:
-#       that:
-#       - check_tag_vpc_endpoint.changed
+  - name: Create an endpoint with route table - idempotency (check mode)
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      service: '{{ endpoint_service_a }}'
+      route_table_ids:
+      - '{{ rtb_empty_id }}'
+    register: create_endpoint_check
+    check_mode: true
+  - name: Assert changed
+    assert:
+      that:
+      - create_endpoint_check is not changed
 
-#   - name: Tag the endpoint
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-#       service: '{{ endpoint_service_a }}'
-#       route_table_ids:
-#       - '{{ rtb_igw_id }}'
-#       tags:
-#         testPrefix: '{{ resource_prefix }}'
-#         camelCase: helloWorld
-#         PascalCase: HelloWorld
-#         snake_case: hello_world
-#         Title Case: Hello World
-#         lowercase spaced: hello world
-#     register: tag_vpc_endpoint
+  - name: Create an endpoint with route table - idempotency
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      service: '{{ endpoint_service_a }}'
+      route_table_ids:
+      - '{{ rtb_empty_id }}'
+    register: create_endpoint_check
+    check_mode: true
+  - name: Assert changed
+    assert:
+      that:
+      - create_endpoint_check is not changed
 
-#   - name: Assert tags are successful
-#     assert:
-#       that:
-#       - tag_vpc_endpoint.changed
-#       - tag_vpc_endpoint.result.tags | length == 6
-#       - endpoint_tags["testPrefix"] == resource_prefix
-#       - endpoint_tags["camelCase"] == "helloWorld"
-#       - endpoint_tags["PascalCase"] == "HelloWorld"
-#       - endpoint_tags["snake_case"] == "hello_world"
-#       - endpoint_tags["Title Case"] == "Hello World"
-#       - endpoint_tags["lowercase spaced"] == "hello world"
-#     vars:
-#       endpoint_tags: "{{ tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
-#         \ value_name='Value') }}"
+# # Endpoint modifications are not yet supported by the module
+#  # A Change the route table for the endpoint
+#  - name: Change the route table for the endpoint (check_mode)
+#    ec2_vpc_endpoint:
+#      state: present
+#      vpc_id: '{{ vpc_id }}'
+#      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+#      service: '{{ endpoint_service_a }}'
+#      route_table_ids:
+#        - '{{ rtb_igw_id }}'
+#    check_mode: True
+#    register: check_two_rtbs_endpoint
+#
+#  - name: Assert second route table would be added
+#    assert:
+#      that:
+#        - check_two_rtbs_endpoint.changed
+#
+#  - name: Change the route table for the endpoint
+#    ec2_vpc_endpoint:
+#      state: present
+#      vpc_id: '{{ vpc_id }}'
+#      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+#      service: '{{ endpoint_service_a }}'
+#      route_table_ids:
+#        - '{{ rtb_igw_id }}'
+#    register: two_rtbs_endpoint
+#
+#  - name: Assert second route table would be added
+#    assert:
+#      that:
+#        - check_two_rtbs_endpoint.changed
+#        - two_rtbs_endpoint.result.route_table_ids | length == 1
+#        - two_rtbs_endpoint.result.route_table_ids[0] == '{{ rtb_igw_id }}'
+#
+#  - name: Change the route table for the endpoint - idempotency (check_mode)
+#    ec2_vpc_endpoint:
+#      state: present
+#      vpc_id: '{{ vpc_id }}'
+#      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+#      service: '{{ endpoint_service_a }}'
+#      route_table_ids:
+#        - '{{ rtb_igw_id }}'
+#    check_mode: True
+#    register: check_two_rtbs_endpoint
+#
+#  - name: Assert route table would not change
+#    assert:
+#      that:
+#        - not check_two_rtbs_endpoint.changed
+#
+#  - name: Change the route table for the endpoint - idempotency
+#    ec2_vpc_endpoint:
+#      state: present
+#      vpc_id: '{{ vpc_id }}'
+#      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+#      service: '{{ endpoint_service_a }}'
+#      route_table_ids:
+#        - '{{ rtb_igw_id }}'
+#    register: two_rtbs_endpoint
+#
+#  - name: Assert route table would not change
+#    assert:
+#      that:
+#        - not check_two_rtbs_endpoint.changed
 
-#   - name: Query by tag
-#     ec2_vpc_endpoint_info:
-#       query: endpoints
-#       filters:
-#         tag:testPrefix:
-#         - '{{ resource_prefix }}'
-#     register: tag_result
+  - name: Tag the endpoint (check_mode)
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+      service: '{{ endpoint_service_a }}'
+      route_table_ids:
+      - '{{ rtb_empty_id }}'
+      tags:
+        camelCase: helloWorld
+        PascalCase: HelloWorld
+        snake_case: hello_world
+        Title Case: Hello World
+        lowercase spaced: hello world
+    check_mode: true
+    register: check_tag_vpc_endpoint
 
-#   - name: Assert tag lookup found endpoint
-#     assert:
-#       that:
-#       - tag_result is successful
-#       - '"vpc_endpoints" in tag_result'
-#       - first_endpoint.vpc_endpoint_id == rtb_endpoint_id
-#     vars:
-#       first_endpoint: '{{ tag_result.vpc_endpoints[0] }}'
+  - name: Assert tags would have changed
+    assert:
+      that:
+      - check_tag_vpc_endpoint.changed
 
-#   - name: Tag the endpoint - idempotency (check_mode)
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-#       service: '{{ endpoint_service_a }}'
-#       route_table_ids:
-#       - '{{ rtb_igw_id }}'
-#       tags:
-#         testPrefix: '{{ resource_prefix }}'
-#         camelCase: helloWorld
-#         PascalCase: HelloWorld
-#         snake_case: hello_world
-#         Title Case: Hello World
-#         lowercase spaced: hello world
-#     register: tag_vpc_endpoint_again
+  - name: Tag the endpoint
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+      service: '{{ endpoint_service_a }}'
+      route_table_ids:
+      - '{{ rtb_igw_id }}'
+      tags:
+        testPrefix: '{{ resource_prefix }}'
+        camelCase: helloWorld
+        PascalCase: HelloWorld
+        snake_case: hello_world
+        Title Case: Hello World
+        lowercase spaced: hello world
+    register: tag_vpc_endpoint
 
-#   - name: Assert tags would not change
-#     assert:
-#       that:
-#       - not tag_vpc_endpoint_again.changed
+  - name: Assert tags are successful
+    assert:
+      that:
+      - tag_vpc_endpoint.changed
+      - tag_vpc_endpoint.result.tags | length == 6
+      - endpoint_tags["testPrefix"] == resource_prefix
+      - endpoint_tags["camelCase"] == "helloWorld"
+      - endpoint_tags["PascalCase"] == "HelloWorld"
+      - endpoint_tags["snake_case"] == "hello_world"
+      - endpoint_tags["Title Case"] == "Hello World"
+      - endpoint_tags["lowercase spaced"] == "hello world"
+    vars:
+      endpoint_tags: "{{ tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
+        \ value_name='Value') }}"
 
-#   - name: Tag the endpoint - idempotency
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-#       service: '{{ endpoint_service_a }}'
-#       route_table_ids:
-#       - '{{ rtb_igw_id }}'
-#       tags:
-#         testPrefix: '{{ resource_prefix }}'
-#         camelCase: helloWorld
-#         PascalCase: HelloWorld
-#         snake_case: hello_world
-#         Title Case: Hello World
-#         lowercase spaced: hello world
-#     register: tag_vpc_endpoint_again
+  - name: Query by tag
+    ec2_vpc_endpoint_info:
+      query: endpoints
+      filters:
+        tag:testPrefix:
+        - '{{ resource_prefix }}'
+    register: tag_result
 
-#   - name: Assert tags would not change
-#     assert:
-#       that:
-#       - not tag_vpc_endpoint_again.changed
+  - name: Assert tag lookup found endpoint
+    assert:
+      that:
+      - tag_result is successful
+      - '"vpc_endpoints" in tag_result'
+      - first_endpoint.vpc_endpoint_id == rtb_endpoint_id
+    vars:
+      first_endpoint: '{{ tag_result.vpc_endpoints[0] }}'
 
-#   - name: Add a tag (check_mode)
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-#       service: '{{ endpoint_service_a }}'
-#       route_table_ids:
-#       - '{{ rtb_igw_id }}'
-#       tags:
-#         new_tag: ANewTag
-#     check_mode: true
-#     register: check_tag_vpc_endpoint
+  - name: Tag the endpoint - idempotency (check_mode)
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+      service: '{{ endpoint_service_a }}'
+      route_table_ids:
+      - '{{ rtb_igw_id }}'
+      tags:
+        testPrefix: '{{ resource_prefix }}'
+        camelCase: helloWorld
+        PascalCase: HelloWorld
+        snake_case: hello_world
+        Title Case: Hello World
+        lowercase spaced: hello world
+    register: tag_vpc_endpoint_again
 
-#   - name: Assert tags would have changed
-#     assert:
-#       that:
-#       - check_tag_vpc_endpoint.changed
+  - name: Assert tags would not change
+    assert:
+      that:
+      - not tag_vpc_endpoint_again.changed
 
-#   - name: Add a tag (purge_tags=False)
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-#       service: '{{ endpoint_service_a }}'
-#       route_table_ids:
-#       - '{{ rtb_igw_id }}'
-#       tags:
-#         new_tag: ANewTag
-#     register: add_tag_vpc_endpoint
+  - name: Tag the endpoint - idempotency
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+      service: '{{ endpoint_service_a }}'
+      route_table_ids:
+      - '{{ rtb_igw_id }}'
+      tags:
+        testPrefix: '{{ resource_prefix }}'
+        camelCase: helloWorld
+        PascalCase: HelloWorld
+        snake_case: hello_world
+        Title Case: Hello World
+        lowercase spaced: hello world
+    register: tag_vpc_endpoint_again
 
-#   - name: Assert tags changed
-#     assert:
-#       that:
-#       - add_tag_vpc_endpoint.changed
-#       - add_tag_vpc_endpoint.result.tags | length == 7
-#       - endpoint_tags["testPrefix"] == resource_prefix
-#       - endpoint_tags["camelCase"] == "helloWorld"
-#       - endpoint_tags["PascalCase"] == "HelloWorld"
-#       - endpoint_tags["snake_case"] == "hello_world"
-#       - endpoint_tags["Title Case"] == "Hello World"
-#       - endpoint_tags["lowercase spaced"] == "hello world"
-#       - endpoint_tags["new_tag"] == "ANewTag"
-#     vars:
-#       endpoint_tags: "{{ add_tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
-#         \ value_name='Value') }}"
+  - name: Assert tags would not change
+    assert:
+      that:
+      - not tag_vpc_endpoint_again.changed
 
-#   - name: Add a tag (purge_tags=True)
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-#       service: '{{ endpoint_service_a }}'
-#       route_table_ids:
-#       - '{{ rtb_igw_id }}'
-#       tags:
-#         another_new_tag: AnotherNewTag
-#       purge_tags: true
-#     register: purge_tag_vpc_endpoint
+  - name: Add a tag (check_mode)
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+      service: '{{ endpoint_service_a }}'
+      route_table_ids:
+      - '{{ rtb_igw_id }}'
+      tags:
+        new_tag: ANewTag
+    check_mode: true
+    register: check_tag_vpc_endpoint
 
-#   - name: Assert tags changed
-#     assert:
-#       that:
-#       - purge_tag_vpc_endpoint.changed
-#       - purge_tag_vpc_endpoint.result.tags | length == 1
-#       - endpoint_tags["another_new_tag"] == "AnotherNewTag"
-#     vars:
-#       endpoint_tags: "{{ purge_tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
-#         \ value_name='Value') }}"
+  - name: Assert tags would have changed
+    assert:
+      that:
+      - check_tag_vpc_endpoint.changed
 
-#   - name: Delete minimal route table (no routes)
-#     ec2_vpc_route_table:
-#       state: absent
-#       lookup: id
-#       route_table_id: '{{ rtb_empty_id }}'
-#     register: rtb_delete
-#   - assert:
-#       that:
-#       - rtb_delete is changed
+  - name: Add a tag (purge_tags=False)
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+      service: '{{ endpoint_service_a }}'
+      route_table_ids:
+      - '{{ rtb_igw_id }}'
+      tags:
+        new_tag: ANewTag
+    register: add_tag_vpc_endpoint
 
-#   - name: Delete minimal route table (IGW route)
-#     ec2_vpc_route_table:
-#       state: absent
-#       lookup: id
-#       route_table_id: '{{ rtb_igw_id }}'
-#   - assert:
-#       that:
-#       - rtb_delete is changed
+  - name: Assert tags changed
+    assert:
+      that:
+      - add_tag_vpc_endpoint.changed
+      - add_tag_vpc_endpoint.result.tags | length == 7
+      - endpoint_tags["testPrefix"] == resource_prefix
+      - endpoint_tags["camelCase"] == "helloWorld"
+      - endpoint_tags["PascalCase"] == "HelloWorld"
+      - endpoint_tags["snake_case"] == "hello_world"
+      - endpoint_tags["Title Case"] == "Hello World"
+      - endpoint_tags["lowercase spaced"] == "hello world"
+      - endpoint_tags["new_tag"] == "ANewTag"
+    vars:
+      endpoint_tags: "{{ add_tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
+        \ value_name='Value') }}"
 
-#   - name: Delete route table endpoint by ID
-#     ec2_vpc_endpoint:
-#       state: absent
-#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-#     register: endpoint_delete_check
-#   - assert:
-#       that:
-#       - endpoint_delete_check is changed
+  - name: Add a tag (purge_tags=True)
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+      service: '{{ endpoint_service_a }}'
+      route_table_ids:
+      - '{{ rtb_igw_id }}'
+      tags:
+        another_new_tag: AnotherNewTag
+      purge_tags: true
+    register: purge_tag_vpc_endpoint
 
-#   - name: Delete minimal endpoint by ID - idempotency (check_mode)
-#     ec2_vpc_endpoint:
-#       state: absent
-#       vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-#     check_mode: true
-#     register: endpoint_delete_check
-#   - assert:
-#       that:
-#       - endpoint_delete_check is not changed
+  - name: Assert tags changed
+    assert:
+      that:
+      - purge_tag_vpc_endpoint.changed
+      - purge_tag_vpc_endpoint.result.tags | length == 1
+      - endpoint_tags["another_new_tag"] == "AnotherNewTag"
+    vars:
+      endpoint_tags: "{{ purge_tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
+        \ value_name='Value') }}"
 
-#   - name: Delete endpoint by ID - idempotency
-#     ec2_vpc_endpoint:
-#       state: absent
-#       vpc_endpoint_id: '{{ endpoint_id }}'
-#     register: endpoint_delete_check
-#   - assert:
-#       that:
-#       - endpoint_delete_check is not changed
+  - name: Delete minimal route table (no routes)
+    ec2_vpc_route_table:
+      state: absent
+      lookup: id
+      route_table_id: '{{ rtb_empty_id }}'
+    register: rtb_delete
+  - assert:
+      that:
+      - rtb_delete is changed
 
-#   - name: Create interface endpoint
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       service: '{{ endpoint_service_a }}'
-#       vpc_endpoint_type: Interface
-#     register: create_interface_endpoint
-#   - name: Check that the interface endpoint was created properly
-#     assert:
-#       that:
-#       - create_interface_endpoint is changed
-#       - create_interface_endpoint.result.vpc_endpoint_type == "Interface"
-#   - name: Delete interface endpoint
-#     ec2_vpc_endpoint:
-#       state: absent
-#       vpc_endpoint_id: '{{ create_interface_endpoint.result.vpc_endpoint_id }}'
-#     register: interface_endpoint_delete_check
-#   - assert:
-#       that:
-#       - interface_endpoint_delete_check is changed
+  - name: Delete minimal route table (IGW route)
+    ec2_vpc_route_table:
+      state: absent
+      lookup: id
+      route_table_id: '{{ rtb_igw_id }}'
+  - assert:
+      that:
+      - rtb_delete is changed
 
-#   - name: Create a subnet
-#     ec2_vpc_subnet:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       az: "{{ aws_region}}a"
-#       cidr: "{{ vpc_cidr }}"
-#     register: interface_endpoint_create_subnet_check
+  - name: Delete route table endpoint by ID
+    ec2_vpc_endpoint:
+      state: absent
+      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+    register: endpoint_delete_check
+  - assert:
+      that:
+      - endpoint_delete_check is changed
 
-#   - name: Create a security group
-#     ec2_group:
-#       name: securitygroup-prodext
-#       description: "security group for Ansible interface endpoint"
-#       state: present
-#       vpc_id: "{{ vpc.vpc.id }}"
-#       rules:
-#         - proto: tcp
-#           from_port: 1
-#           to_port: 65535
-#           cidr_ip: 0.0.0.0/0
-#     register: interface_endpoint_create_sg_check
+  - name: Delete minimal endpoint by ID - idempotency (check_mode)
+    ec2_vpc_endpoint:
+      state: absent
+      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
+    check_mode: true
+    register: endpoint_delete_check
+  - assert:
+      that:
+      - endpoint_delete_check is not changed
 
-#   - name: Create interface endpoint attached to a subnet
-#     ec2_vpc_endpoint:
-#       state: present
-#       vpc_id: '{{ vpc_id }}'
-#       service: '{{ endpoint_service_a }}'
-#       vpc_endpoint_type: Interface
-#       vpc_endpoint_subnets: "{{ interface_endpoint_create_subnet_check.subnet.id') }}"
-#       vpc_endpoint_security_groups: "{{ interface_endpoint_create_sg_check.group_id }}"
-#     register: create_interface_endpoint_with_sg_subnets
-#   - name: Check that the interface endpoint was created properly
-#     assert:
-#       that:
-#         - create_interface_endpoint_with_sg_subnets is changed
-#         - create_interface_endpoint_with_sg_subnets.result.vpc_endpoint_type == "Interface"
+  - name: Delete endpoint by ID - idempotency
+    ec2_vpc_endpoint:
+      state: absent
+      vpc_endpoint_id: '{{ endpoint_id }}'
+    register: endpoint_delete_check
+  - assert:
+      that:
+      - endpoint_delete_check is not changed
 
-#   - name: Delete interface endpoint
-#     ec2_vpc_endpoint:
-#       state: absent
-#       vpc_endpoint_id: "{{ create_interface_endpoint_with_sg_subnets.result.vpc_endpoint_id }}"
-#     register: create_interface_endpoint_with_sg_subnets_delete_check
-#   - assert:
-#       that:
-#         - create_interface_endpoint_with_sg_subnets_delete_check is changed
+  - name: Create interface endpoint
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      service: '{{ endpoint_service_a }}'
+      vpc_endpoint_type: Interface
+    register: create_interface_endpoint
+  - name: Check that the interface endpoint was created properly
+    assert:
+      that:
+      - create_interface_endpoint is changed
+      - create_interface_endpoint.result.vpc_endpoint_type == "Interface"
+  - name: Delete interface endpoint
+    ec2_vpc_endpoint:
+      state: absent
+      vpc_endpoint_id: '{{ create_interface_endpoint.result.vpc_endpoint_id }}'
+    register: interface_endpoint_delete_check
+  - assert:
+      that:
+      - interface_endpoint_delete_check is changed
+
+  - name: Create a subnet
+    ec2_vpc_subnet:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      az: "{{ aws_region}}a"
+      cidr: "{{ vpc_cidr }}"
+    register: interface_endpoint_create_subnet_check
+
+  - name: Create a security group
+    ec2_group:
+      name: securitygroup-prodext
+      description: "security group for Ansible interface endpoint"
+      state: present
+      vpc_id: "{{ vpc.vpc.id }}"
+      rules:
+        - proto: tcp
+          from_port: 1
+          to_port: 65535
+          cidr_ip: 0.0.0.0/0
+    register: interface_endpoint_create_sg_check
+
+  - name: Create interface endpoint attached to a subnet
+    ec2_vpc_endpoint:
+      state: present
+      vpc_id: '{{ vpc_id }}'
+      service: '{{ endpoint_service_a }}'
+      vpc_endpoint_type: Interface
+      vpc_endpoint_subnets: "{{ interface_endpoint_create_subnet_check.subnet.id') }}"
+      vpc_endpoint_security_groups: "{{ interface_endpoint_create_sg_check.group_id }}"
+    register: create_interface_endpoint_with_sg_subnets
+  - name: Check that the interface endpoint was created properly
+    assert:
+      that:
+        - create_interface_endpoint_with_sg_subnets is changed
+        - create_interface_endpoint_with_sg_subnets.result.vpc_endpoint_type == "Interface"
+
+  - name: Delete interface endpoint
+    ec2_vpc_endpoint:
+      state: absent
+      vpc_endpoint_id: "{{ create_interface_endpoint_with_sg_subnets.result.vpc_endpoint_id }}"
+    register: create_interface_endpoint_with_sg_subnets_delete_check
+  - assert:
+      that:
+        - create_interface_endpoint_with_sg_subnets_delete_check is changed
 
   # ============================================================
   # BEGIN POST-TEST CLEANUP


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/856

##### SUMMARY
Fixes #843 

Can things like checking for a period after `description` be added to our sanity checks?

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
- aws_ax_info
- aws_caller_info
- aws_s3
- cloudformation_info
- ec2_eni_info
- ec2_group
- ec2_group_info
- ec2_instance_info
- ec2_key
- ec2_metadata_facts
- ec2_snapshot_info
- ec2_spot_instance
- ec2_spot_instance_info
- ec2_tag
- ec2_tag_info
- ec2_vpc_dhcp_option_info
- ec2_vpc_endpoint_info
- ec2_vpc_endpoint_service_info
- ec2_vpc_igw_info
- ec2_vpc_nat_gateway
- ec2_vpc_nat_gateway_info
- ec2_vpc_net_info
- ec2_vpc_route_table_info
- elb_classic_lb