### PR TITLE
Add version_added: 1.5.0 for exclude_filters, include_filters and use_contrib_script_compatible_ec2_tag_keys

### DIFF
--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -79,6 +79,7 @@ DOCUMENTATION = '''
           type: list
           elements: dict
           default: []
+          version_added: 1.5.0
         exclude_filters:
           description:
               - A list of filters. Any instances matching one of the filters are excluded from the result.
@@ -89,6 +90,7 @@ DOCUMENTATION = '''
           type: list
           elements: dict
           default: []
+          version_added: 1.5.0
         include_extra_api_calls:
           description:
               - Add two additional API calls for every instance to include 'persistent' and 'events' host variables.
@@ -120,6 +122,7 @@ DOCUMENTATION = '''
             - The use of this feature is discouraged and we advise to migrate to the new ``tags`` structure.
           type: bool
           default: False
+          version_added: 1.5.0
         hostvars_prefix:
           description:
             - The prefix for host variables names coming from AWS.


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add version_added: 1.5.0 for `exclude_filters`, `include_filters` and `use_contrib_script_compatible_ec2_tag_keys`

`include_filters` and `exclude_filters` have been added https://github.com/ansible-collections/amazon.aws/pull/328 and released with amazon.aws 1.5.0

`use_contrib_script_compatible_ec2_tag_keys` has been added https://github.com/ansible-collections/amazon.aws/pull/331 and released with  amazon.aws 1.5.0

Let's update the aws_ec2 inventory plugin documentation with this information.
 
This should be a step towards closing this one https://github.com/ansible-collections/amazon.aws/issues/676

aws_ec2 documentation will be enriched with exhaustive examples in an upcoming PR.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_ec2

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
