### PR TITLE
[WIP] elb_classic_lb: fix return value _format_listener method to include SSLCertificateId

### DIFF
--- a/changelogs/fragments/860-elb_classic_lb-create-https-listeners.yml
+++ b/changelogs/fragments/860-elb_classic_lb-create-https-listeners.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- elb_classic_lb - modify the return value of _format_listeners method to resolve a failure creating https listeners (https://github.com/ansible-collections/amazon.aws/pull/860).

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -890,7 +890,7 @@ class ElbManager(object):
         if ssl_id:
             formatted_listener['SSLCertificateId'] = ssl_id
 
-        return snake_dict_to_camel_dict(listener, True)
+        return formatted_listener
 
     def _format_healthcheck_target(self):
         """Compose target string from healthcheck parameters"""


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #686.

Current [return value of _format_listener method](https://github.com/ansible-collections/amazon.aws/blob/main/plugins/modules/elb_classic_lb.py#L893) does not include `SSLCertificateId` even if it is provided in the playbook, causing the failure as reported in above mentioned issue.
Sample return value:
```
{'InstancePort': 8080, 'InstanceProtocol': 'HTTP', 'LoadBalancerPort': 443, 'Protocol': 'HTTPS'}
```

This can be fixed by modifying the return value of _format_listener method to [formatted_listener](https://github.com/ansible-collections/amazon.aws/blob/main/plugins/modules/elb_classic_lb.py#L889-L891), which includes `SSLCertificateId` if provided in the playbook.
Sample return Value:
```
{'InstancePort': 8080, 'InstanceProtocol': 'HTTP', 'LoadBalancerPort': 443, 
'Protocol': 'HTTPS', 'SSLCertificateId': 'arn:aws:acm:us-east-1:1234...'}
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
elb_classic_lb