### PR TITLE
Update dev guidelines - add return values guidelines

### DIFF
--- a/docs/docsite/rst/dev_guidelines.rst
+++ b/docs/docsite/rst/dev_guidelines.rst
@@ -551,11 +551,18 @@ of a dict.  This is particularly useful for tags, where keys are case-sensitive.
 
 .. code-block:: python
 
-   # Make a call to AWS
-   result = connection.aws_call()
+    # Make a call to AWS
+    resource = connection.aws_call()
 
-   # Return the result to the user without modifying tags
-   module.exit_json(changed=True, **camel_dict_to_snake_dict(result, ignore_list=['Tags']))
+    # Convert resource response to snake_case
+    snaked_resource = camel_dict_to_snake_dict(resource, ignore_list=['Tags'])
+
+    # Return the resource details to the user without modifying tags
+    module.exit_json(changed=True, some_resource=snaked_resource)
+
+Note: The returned key representing the details of the specific resource (``some_resource`` above)
+should be a sensible approximation of the resource name.  For example, ``volume`` for ``ec2_vol``,
+``volumes`` for ``ec2_vol_info``.
 
 Tags
 ----

--- a/docs/docsite/rst/dev_guidelines.rst
+++ b/docs/docsite/rst/dev_guidelines.rst
@@ -547,8 +547,7 @@ You should use this helper function and avoid changing the names of values retur
 E.g. if boto3 returns a value called 'SecretAccessKey' do not change it to 'AccessKey'.
 
 There is an optional parameter, ``ignore_list``, which is used to avoid converting a sub-tree
-of a dict.  This is particularly important for tags, where keys are case-sensitive.  We
-convert the 'Tags' key but nothing below.
+of a dict.  This is particularly useful for tags, where keys are case-sensitive.
 
 .. code-block:: python
 

--- a/docs/docsite/rst/dev_guidelines.rst
+++ b/docs/docsite/rst/dev_guidelines.rst
@@ -556,6 +556,79 @@ E.g. if boto3 returns a value called 'SecretAccessKey' do not change it to 'Acce
 
 .. _ansible_collections.amazon.aws.docsite.dev_policies:
 
+Info modules
+------------
+
+Info modules that can return information on multiple resources should return a singular value representing a list of dictionaries,
+with each dictionary containing information about that particular resource (i.e. ``security_groups`` in ``ec2_group_info``).
+In cases where the _info module only returns information on a singular resource (i.e. ``ec2_tag_info``),
+a singular dictionary should be returned as opposed to a list of dictionaries.
+In cases where the _info module returns no instances, and empty list '[]' should be returned.
+Keys in the returned dictionaries should follow the guidelines above and use snake_case.
+If a return value can be used as a parameter for its corresponding main module, the key should match either
+the parameter name itself, or an alias of that parameter. The following is an example of improper usage of an info module with its respective main module:
+
+.. code-block:: yaml
+
+    "security_groups": [
+        {
+            "description": "Created by ansible integration tests",
+            "group_id": "sg-050dba5c3520cba71",
+            "group_name": "ansible-test-87988625-unknown5c5f67f3ad09-icmp-1",
+            "ip_permissions": [
+                {
+                    "from_port": 3,
+                    "ip_protocol": "icmp",
+                    "ip_ranges": [
+                        {
+                            "cidr_ip": "172.16.40.10/32"
+                        },
+                        {
+                            "cidr_ip": "10.0.0.0/8"
+                        }
+                    ],
+                    "ipv6_ranges": [],
+                    "prefix_list_ids": [],
+                    "to_port": 8,
+                    "user_id_group_pairs": []
+                }
+            ],
+            "ip_permissions_egress": [
+                {
+                    "ip_protocol": "-1",
+                    "ip_ranges": [
+                        {
+                            "cidr_ip": "0.0.0.0/0"
+                        }
+                    ],
+                    "ipv6_ranges": [],
+                    "prefix_list_ids": [],
+                    "user_id_group_pairs": []
+                }
+            ],
+            "owner_id": "721066863947",
+            "tags": {},
+            "vpc_id": "vpc-0cbc2380a326b8a0d"
+        }
+    ]
+
+The output above is what was returned by the ``ec2_group_info`` module. It correctly returns a list of dictionaries called ``security_groups``; however,
+the parameter names do not match those of the ``ec2_group`` module. ``ec2_group`` requires ``name``, meanwhile this returns ``group_name``.
+
+Deprecating return values
+-------------------------
+
+If changes need to be made to current return values, the new/"correct" keys should be returned **in addition to** the existing keys to preserve
+compability with existing playbooks. A deprecation should be added to the return values being replaced, initially placed 2 years out.
+For example:
+
+.. code-block:: python
+
+    # Deprecate old `iam_user` return key to be replaced by `user` introduced on 2022-05-01
+    module.deprecate("The 'iam_user' return key is deprecated and will be replaced by 'user'. Both values are returned for now.",
+                     date='2024-05-01', collection_name='community.aws')
+
+
 Dealing with IAM JSON policy
 ============================
 

--- a/docs/docsite/rst/dev_guidelines.rst
+++ b/docs/docsite/rst/dev_guidelines.rst
@@ -539,9 +539,9 @@ When you make a call using boto3, you will probably get back some useful informa
 should return in the module.  As well as information related to the call itself, you will also have
 some response metadata.  It is OK to return this to the user as well as they may find it useful.
 
-Boto3 commonly returns all keys CamelCased.  Ansible follows Python standards for variable names and uses
-snake_case.  There is a commonly used helper function ``ansible.module_utils.common.dict_transformations.camel_dict_to_snake_dict``
-that allows you to easily convert the boto3 response to snake_case.
+Boto3 returns most keys in CamelCase.  Ansible adopts python standards for naming variables and usage.
+There is a useful helper function called ``camel_dict_to_snake_dict`` that allows for an easy conversion
+of the boto3 response to snake_case.  It resides in ``module_utils/common/dict_transformations``.
 
 You should use this helper function and avoid changing the names of values returned by Boto3.
 E.g. if boto3 returns a value called 'SecretAccessKey' do not change it to 'AccessKey'.

--- a/docs/docsite/rst/dev_guidelines.rst
+++ b/docs/docsite/rst/dev_guidelines.rst
@@ -539,8 +539,8 @@ When you make a call using boto3, you will probably get back some useful informa
 should return in the module.  As well as information related to the call itself, you will also have
 some response metadata.  It is OK to return this to the user as well as they may find it useful.
 
-Boto3 returns all values CamelCased.  Ansible follows Python standards for variable names and uses
-snake_case.  There is a helper function in module_utils/ec2.py called ``camel_dict_to_snake_dict``
+Boto3 commonly returns all keys CamelCased.  Ansible follows Python standards for variable names and uses
+snake_case.  There is a commonly used helper function ``ansible.module_utils.common.dict_transformations.camel_dict_to_snake_dict``
 that allows you to easily convert the boto3 response to snake_case.
 
 You should use this helper function and avoid changing the names of values returned by Boto3.
@@ -562,7 +562,7 @@ Tags
 ----
 
 Tags should be returned as a dictionary of key: value pairs, with each key being the tag's
-key and value being the tag's value.  It should be noted, however, that boto3 returns tags
+key and value being the tag's value.  It should be noted, however, that boto3 often returns tags
 as a list of dictionaries.
 
 There is a helper function in module_utils/ec2.py called ``boto3_tag_list_to_ansible_dict``
@@ -596,7 +596,7 @@ In cases where the _info module only returns information on a singular resource
 (i.e. ``ec2_tag_info``), a singular dictionary should be returned as opposed to a list
 of dictionaries.
 
-In cases where the _info module returns no instances, and empty list '[]' should be returned.
+In cases where the _info module returns no instances, an empty list '[]' should be returned.
 
 Keys in the returned dictionaries should follow the guidelines above and use snake_case.
 If a return value can be used as a parameter for its corresponding main module, the key should


### PR DESCRIPTION
##### SUMMARY
As discussed in the last working group meeting. Updating the guidelines to create standards for what _info modules should return.

Items addressed:
- more info on how to return tags using `boto3_tag_list_to_ansible_dict`
- info modules should return list of dicts
- how to deprecate keys

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
docs/docsite/rst/dev_guidelines.rst