### PR TITLE
aws_ec2 add version_added: 1.5.0 (backport to stable-2)

### DIFF
--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -59,6 +59,7 @@ DOCUMENTATION = '''
                 keep the list as short as possible.
           type: list
           default: []
+          version_added: 1.5.0
         exclude_filters:
           description:
               - A list of filters. Any instances matching one of the filters are excluded from the result.
@@ -68,6 +69,7 @@ DOCUMENTATION = '''
                 keep the list as short as possible.
           type: list
           default: []
+          version_added: 1.5.0
         include_extra_api_calls:
           description:
               - Add two additional API calls for every instance to include 'persistent' and 'events' host variables.
@@ -99,6 +101,7 @@ DOCUMENTATION = '''
             - The use of this feature is discouraged and we advise to migrate to the new ``tags`` structure.
           type: bool
           default: False
+          version_added: 1.5.0
 '''
 
 EXAMPLES = '''


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Manual backport of https://github.com/ansible-collections/amazon.aws/pull/858 to stable 2
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_ec2
