### PR TITLE
Bump version number in galaxy.yml to 5.0.0

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: amazon
 name: aws
-version: 4.0.0
+version: 5.0.0
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)


### PR DESCRIPTION
##### SUMMARY

Bump version number in galaxy.yml from 4.0.0 to 5.0.0 to reflect that stable-4 has now been branched and main will be released as 5.0.0

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

galaxy.yml

##### ADDITIONAL INFORMATION
