### PR TITLE
Fix broken links to modules which don't exist any more

### DIFF
--- a/plugins/modules/aws_az_info.py
+++ b/plugins/modules/aws_az_info.py
@@ -12,7 +12,6 @@ short_description: Gather information about availability zones in AWS
 version_added: 1.0.0
 description:
     - Gather information about availability zones in AWS.
-    - This module was called M(amazon.aws.aws_az_facts) before Ansible 2.9. The usage did not change.
 author: 'Henrique Rodrigues (@Sodki)'
 options:
   filters:

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -15,8 +15,8 @@ description:
   - Create and manage AWS EC2 instances.
   - >
     Note: This module does not support creating
-    L(EC2 Spot instances,https://aws.amazon.com/ec2/spot/). The M(amazon.aws.ec2) module
-    can create and manage spot instances.
+    L(EC2 Spot instances,https://aws.amazon.com/ec2/spot/).
+  - The M(amazon.aws.ec2_spot_instance) module can create and manage spot instances.
 author:
   - Ryan Scott Brown (@ryansb)
 options:


### PR DESCRIPTION
##### SUMMARY

The ec2 module no longer exists, and we don't call out the other Ansible 2.9 fact -> info renames any more (That was 4 major releases ago!)

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/modules/aws_az_info.py
plugins/modules/ec2_instance.py

##### ADDITIONAL INFORMATION
