### PR TITLE
Change Changelog Title from "community.aws" to "amazon.aws"

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,5 @@
 ===========================
-community.aws Release Notes
+amazon.aws Release Notes
 ===========================
 
 .. contents:: Topics

--- a/changelogs/config.yaml
+++ b/changelogs/config.yaml
@@ -25,5 +25,5 @@ sections:
   - Bugfixes
 - - known_issues
   - Known Issues
-title: community.aws
+title: amazon.aws
 trivial_section_name: trivial


### PR DESCRIPTION
##### SUMMARY

[Changelog](https://github.com/ansible-collections/amazon.aws/blob/main/CHANGELOG.rst) for amazon.aws collection currently shows the title of `community.aws Release Notes`.

I'm almost certain this is an error.

This PR should change it to `amazon.aws Release Notes`.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->