### PR TITLE
S3 - remove deprecated S3_URL alias

### DIFF
--- a/changelogs/fragments/908-s3_url.yml
+++ b/changelogs/fragments/908-s3_url.yml
@@ -1,0 +1,3 @@
+breaking_changes:
+- s3_bucket - the previously deprecated alias ``S3_URL`` for the ``s3_url`` parameter has been removed.  Playbooks shuold be updated to use ``s3_url`` (https://github.com/ansible-collections/amazon.aws/pull/908).
+- s3_object - the previously deprecated alias ``S3_URL`` for the ``s3_url`` parameter has been removed.  Playbooks should be updated to use ``s3_url`` (https://github.com/ansible-collections/amazon.aws/pull/908).

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -48,9 +48,6 @@ options:
       - S3 URL endpoint for usage with DigitalOcean, Ceph, Eucalyptus and FakeS3 etc.
       - Assumes AWS if not specified.
       - For Walrus, use FQDN of the endpoint without scheme nor path.
-      - The S3_URL alias for this option has been deprecated and will be removed
-        in release 5.0.0.
-    aliases: [ S3_URL ]
     type: str
   ceph:
     description:
@@ -1001,7 +998,7 @@ def main():
         policy=dict(type='json'),
         name=dict(required=True),
         requester_pays=dict(type='bool'),
-        s3_url=dict(aliases=['S3_URL'], deprecated_aliases=[dict(name='S3_URL', version='5.0.0', collection_name='amazon.aws')]),
+        s3_url=dict(),
         state=dict(default='present', choices=['present', 'absent']),
         tags=dict(type='dict', aliases=['resource_tags']),
         purge_tags=dict(type='bool', default=True),

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -144,9 +144,6 @@ options:
   s3_url:
     description:
       - S3 URL endpoint for usage with Ceph, Eucalyptus and fakes3 etc. Otherwise assumes AWS.
-      - The S3_URL alias for this option has been deprecated and will be removed
-        in release 5.0.0.
-    aliases: [ S3_URL ]
     type: str
   dualstack:
     description:
@@ -957,7 +954,7 @@ def main():
         overwrite=dict(aliases=['force'], default='different'),
         prefix=dict(default=""),
         retries=dict(aliases=['retry'], type='int', default=0),
-        s3_url=dict(aliases=['S3_URL'], deprecated_aliases=[dict(name='S3_URL', version='5.0.0', collection_name='amazon.aws')]),
+        s3_url=dict(),
         dualstack=dict(default='no', type='bool'),
         rgw=dict(default='no', type='bool'),
         src=dict(type='path'),

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -7,5 +7,3 @@ plugins/modules/ec2_vpc_dhcp_option_info.py validate-modules:collection-deprecat
 plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
 plugins/modules/ec2_vpc_net.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
 plugins/modules/ec2_vpc_route_table.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/s3_bucket.py validate-modules:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/s3_object.py validate-modules:collection-deprecated-version # Deprecation planned for 5.0.0

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -7,5 +7,3 @@ plugins/modules/ec2_vpc_dhcp_option_info.py validate-modules:collection-deprecat
 plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
 plugins/modules/ec2_vpc_net.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
 plugins/modules/ec2_vpc_route_table.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/s3_bucket.py validate-modules:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/s3_object.py validate-modules:collection-deprecated-version # Deprecation planned for 5.0.0

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -7,5 +7,3 @@ plugins/modules/ec2_vpc_dhcp_option_info.py validate-modules:collection-deprecat
 plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
 plugins/modules/ec2_vpc_net.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
 plugins/modules/ec2_vpc_route_table.py pylint:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/s3_bucket.py validate-modules:collection-deprecated-version # Deprecation planned for 5.0.0
-plugins/modules/s3_object.py validate-modules:collection-deprecated-version # Deprecation planned for 5.0.0


### PR DESCRIPTION
##### SUMMARY

Remove the deprecated alias, this has been causing problems with the docs

##### ISSUE TYPE

- Feature Pull Request


##### COMPONENT NAME

s3_bucket
s3_object

##### ADDITIONAL INFORMATION
