### PR TITLE
Update ec2_vpc_dhcp_option_info to remove deprecated alias

### DIFF
--- a/plugins/modules/ec2_vpc_dhcp_option_info.py
+++ b/plugins/modules/ec2_vpc_dhcp_option_info.py
@@ -57,7 +57,7 @@ EXAMPLES = '''
   amazon.aws.ec2_vpc_dhcp_option_info:
     region: ap-southeast-2
     profile: production
-    DhcpOptionsIds: dopt-123fece2
+    dhcp_options_ids: dopt-123fece2
   register: dhcp_info
 
 '''


### PR DESCRIPTION
##### SUMMARY

With #913 the CamelCase aliases in ec2_vpc_dhcp_option_info were dropped.

Updates the example to use the snake case version

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/modules/ec2_vpc_dhcp_option_info.py

##### ADDITIONAL INFORMATION
