### PR TITLE
ec2_instance - expand use of AWSRetry

### DIFF
--- a/changelogs/fragments/927-ec2_instance-retries.yml
+++ b/changelogs/fragments/927-ec2_instance-retries.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_instance - expanded the use of the automatic retries on temporary failures (https://github.com/ansible-collections/amazon.aws/issues/927).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1858,9 +1858,11 @@ def enforce_count(existing_matches, module, desired_module_state):
                 module.exit_json(changed=True, msg='Would have terminated following instances if not in check mode {0}'.format(terminate_ids))
             # terminate instances
             try:
-                result = client.terminate_instances(InstanceIds=terminate_ids)
+                result = client.terminate_instances(aws_retry=True, InstanceIds=terminate_ids)
                 await_instances(terminate_ids, desired_module_state='terminated', force_wait=True)
-            except botocore.exceptions.ClientError as e:
+            except is_boto3_error_code('InvalidInstanceID.NotFound'):
+                pass
+            except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
                 module.fail_json(e, msg='Unable to terminate instances')
             module.exit_json(
                 changed=True,
@@ -1936,12 +1938,12 @@ def ensure_present(existing_matches, desired_module_state):
 
 def run_instances(**instance_spec):
     try:
-        return client.run_instances(**instance_spec)
+        return client.run_instances(aws_retry=True, **instance_spec)
     except is_boto3_error_message('Invalid IAM Instance Profile ARN'):
         # If the instance profile has just been created, it takes some time to be visible by ec2
         # So we wait 10 second and retry the run_instances
         time.sleep(10)
-        return client.run_instances(**instance_spec)
+        return client.run_instances(aws_retry=True, **instance_spec)
 
 
 def build_filters():


### PR DESCRIPTION
##### SUMMARY
 
fixes: #927

A few code paths weren't using AWSRetry when the should have, probably a leftover from when retries included the NotFound exceptions.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_instance

##### ADDITIONAL INFORMATION
