### PR TITLE
elbv2 - Fix KeyError when passing two TGs

### DIFF
--- a/changelogs/fragments/1089-elb_application_lb-ForwardConfig-KeyError.yml
+++ b/changelogs/fragments/1089-elb_application_lb-ForwardConfig-KeyError.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- elb_application_lb - fix ``KeyError`` when balancing across two Target Groups (https://github.com/ansible-collections/community.aws/issues/1089).

--- a/tests/unit/module_utils/test_elbv2.py
+++ b/tests/unit/module_utils/test_elbv2.py
@@ -27,6 +27,25 @@ one_action = [
     }
 ]
 
+one_action_two_tg = [
+    {
+        "ForwardConfig": {
+            "TargetGroupStickinessConfig": {"Enabled": False},
+            "TargetGroups": [
+                {
+                    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:966509639900:targetgroup/my-tg-58045486/5b231e04f663ae21",
+                    "Weight": 1,
+                },
+                {
+                    "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:966509639900:targetgroup/my-tg-dadf7b62/be2f50b4041f11ed",
+                    "Weight": 1,
+                }
+            ],
+        },
+        "Type": "forward",
+    }
+]
+
 
 def test__prune_ForwardConfig():
     expectation = {
@@ -34,6 +53,8 @@ def test__prune_ForwardConfig():
         "Type": "forward",
     }
     assert elbv2._prune_ForwardConfig(one_action[0]) == expectation
+    # https://github.com/ansible-collections/community.aws/issues/1089
+    assert elbv2._prune_ForwardConfig(one_action_two_tg[0]) == one_action_two_tg[0]
 
 
 def _prune_secret():


### PR DESCRIPTION
##### SUMMARY

Fixes: https://github.com/ansible-collections/community.aws/issues/1089

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/module_utils/elbv2.py

##### ADDITIONAL INFORMATION

Based on the docs, if you want to balance across multiple TGs you **shouldn't** pass a TargetGroupArn, and instead just the ForwardConfig.  (https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/elbv2.html#ElasticLoadBalancingv2.Client.create_listener)

> The Amazon Resource Name (ARN) of the target group. Specify only when `Type` is forward and you want to route to a single target group. To route to one or more target groups, use `ForwardConfig` instead.

However, it is also valid (but redundant) to Pass the ARN and a ForwardConfig
> If you specify both `ForwardConfig` and `TargetGroupArn`, you can specify only one target group using ForwardConfig and it must be the same target group specified in `TargetGroupArn`.

Original Error:

```
The full traceback is:
Traceback (most recent call last):
  File "/home/alex/.ansible/tmp/ansible-tmp-1650531340.4967074-29141-25081229266719/AnsiballZ_elb_application_lb.py", line 102, in <module>
    _ansiballz_main()
  File "/home/alex/.ansible/tmp/ansible-tmp-1650531340.4967074-29141-25081229266719/AnsiballZ_elb_application_lb.py", line 94, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/alex/.ansible/tmp/ansible-tmp-1650531340.4967074-29141-25081229266719/AnsiballZ_elb_application_lb.py", line 40, in invoke_module
    runpy.run_module(mod_name='ansible_collections.community.aws.plugins.modules.elb_application_lb', init_globals=None, run_name='__main__', alter_sys=True)
  File "/usr/lib/python3.10/runpy.py", line 209, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.10/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_community.aws.elb_application_lb_payload_dy92ctf5/ansible_community.aws.elb_application_lb_payload.zip/ansible_collections/community/aws/plugins/modules/elb_application_lb.py", line 821, in <module>
  File "/tmp/ansible_community.aws.elb_application_lb_payload_dy92ctf5/ansible_community.aws.elb_application_lb_payload.zip/ansible_collections/community/aws/plugins/modules/elb_application_lb.py", line 815, in main
  File "/tmp/ansible_community.aws.elb_application_lb_payload_dy92ctf5/ansible_community.aws.elb_application_lb_payload.zip/ansible_collections/community/aws/plugins/modules/elb_application_lb.py", line 653, in create_or_update_alb
  File "/tmp/ansible_community.aws.elb_application_lb_payload_dy92ctf5/ansible_community.aws.elb_application_lb_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/elbv2.py", line 928, in compare_rules
  File "/tmp/ansible_community.aws.elb_application_lb_payload_dy92ctf5/ansible_community.aws.elb_application_lb_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/elbv2.py", line 894, in _compare_rule
  File "/tmp/ansible_community.aws.elb_application_lb_payload_dy92ctf5/ansible_community.aws.elb_application_lb_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/elbv2.py", line 894, in <listcomp>
  File "/tmp/ansible_community.aws.elb_application_lb_payload_dy92ctf5/ansible_community.aws.elb_application_lb_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/elbv2.py", line 29, in _prune_ForwardConfig
KeyError: 'TargetGroupArn'
```