### PR TITLE
Bump botocore requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ As the AWS SDK for Python (Boto3 and Botocore) has [ceased supporting Python 2.7
 
 Starting with the 2.0.0 releases of amazon.aws and community.aws, it is generally the collection's policy to support the versions of `botocore` and `boto3` that were released 12 months prior to the most recent major collection release, following semantic versioning (for example, 2.0.0, 3.0.0).
 
-Version 4.0.0 of this collection supports `boto3 >= 1.17.0` and `botocore >= 1.20.0`
+Version 5.0.0 of this collection supports `boto3 >= 1.18.0` and `botocore >= 1.21.0`
 
 All support for the original AWS SDK `boto` was removed in release 4.0.0.
 

--- a/changelogs/fragments/botocore.yml
+++ b/changelogs/fragments/botocore.yml
@@ -1,0 +1,6 @@
+breaking_changes:
+- amazon.aws collection - The amazon.aws collection has dropped support for ``botocore<1.21.0`` and
+  ``boto3<1.18.0``. Most modules will continue to work with older versions of the AWS SDK, however
+  compatability with older versions of the SDK is not guaranteed and will not be tested. When using
+  older versions of the SDK a warning will be emitted by Ansible
+  (https://github.com/ansible-collections/community.aws/pull/1359).

--- a/plugins/doc_fragments/aws.py
+++ b/plugins/doc_fragments/aws.py
@@ -68,8 +68,8 @@ options:
     type: dict
 requirements:
   - python >= 3.6
-  - boto3 >= 1.17.0
-  - botocore >= 1.20.0
+  - boto3 >= 1.18.0
+  - botocore >= 1.21.0
 notes:
   - If parameters are not set within the module, the following
     environment variables can be used in decreasing order of precedence

--- a/plugins/doc_fragments/aws_boto3.py
+++ b/plugins/doc_fragments/aws_boto3.py
@@ -14,6 +14,6 @@ class ModuleDocFragment(object):
 options: {}
 requirements:
   - python >= 3.6
-  - boto3 >= 1.17.0
-  - botocore >= 1.20.0
+  - boto3 >= 1.18.0
+  - botocore >= 1.21.0
 '''

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -125,11 +125,11 @@ class AnsibleAWSModule(object):
                 self._module.fail_json(
                     msg=missing_required_lib('botocore or boto3'))
             current_versions = self._gather_versions()
-            if not self.botocore_at_least('1.20.0'):
-                self.warn('botocore < 1.20.0 is not supported or tested.'
+            if not self.botocore_at_least('1.21.0'):
+                self.warn('botocore < 1.21.0 is not supported or tested.'
                           '  Some features may not work.')
-            if not self.boto3_at_least("1.17.0"):
-                self.warn('boto3 < 1.17.0 is not supported or tested.'
+            if not self.boto3_at_least("1.18.0"):
+                self.warn('boto3 < 1.18.0 is not supported or tested.'
                           '  Some features may not work.')
 
         self.check_mode = self._module.check_mode

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # - tests/unit/constraints.txt
 # - tests/integration/constraints.txt
 # - tests/integration/targets/setup_botocore_pip
-botocore>=1.20.0
-boto3>=1.17.0
+botocore>=1.21.0
+boto3>=1.18.0

--- a/tests/integration/constraints.txt
+++ b/tests/integration/constraints.txt
@@ -1,7 +1,7 @@
 # Specifically run tests against the oldest versions that we support
-boto3==1.17.0
-botocore==1.20.0
+boto3==1.18.0
+botocore==1.21.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.19.0
+awscli==1.20.0

--- a/tests/integration/targets/setup_botocore_pip/defaults/main.yml
+++ b/tests/integration/targets/setup_botocore_pip/defaults/main.yml
@@ -1,2 +1,2 @@
-default_botocore_version: '1.20.0'
-default_boto3_version: '1.17.0'
+default_botocore_version: '1.21.0'
+default_boto3_version: '1.18.0'

--- a/tests/unit/constraints.txt
+++ b/tests/unit/constraints.txt
@@ -1,7 +1,7 @@
 # Specifically run tests against the oldest versions that we support
-boto3==1.17.0
-botocore==1.20.0
+boto3==1.18.0
+botocore==1.21.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.19.0
+awscli==1.20.0

--- a/tests/unit/module_utils/core/ansible_aws_module/test_minimal_versions.py
+++ b/tests/unit/module_utils/core/ansible_aws_module/test_minimal_versions.py
@@ -20,10 +20,10 @@ class TestMinimalVersions(object):
     # Prepare some data for use in our testing
     # ========================================================
     def setup_method(self):
-        self.MINIMAL_BOTO3 = '1.17.0'
-        self.MINIMAL_BOTOCORE = '1.20.0'
-        self.OLD_BOTO3 = '1.16.999'
-        self.OLD_BOTOCORE = '1.19.999'
+        self.MINIMAL_BOTO3 = '1.18.0'
+        self.MINIMAL_BOTOCORE = '1.21.0'
+        self.OLD_BOTO3 = '1.17.999'
+        self.OLD_BOTOCORE = '1.20.999'
 
     # ========================================================
     #   Test we don't warn when using valid versions


### PR DESCRIPTION
##### SUMMARY

Inline with the documented policy, bump botocore (and boto3/awscli) requirements for main branch

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

README.md
plugins/module_utils/modules.py
requirements.txt
tests/integration/constraints.txt
tests/unit/constraints.txt

##### ADDITIONAL INFORMATION

(community.aws PRs will follow after the amazon.aws PRs are approved)

```
[✔ mchappel@mchappel botocore] $ git show 1.21.0
tag 1.21.0
Tagger: aws-sdk-python-automation <github-aws-sdk-python-automation@amazon.com>
Date:   Thu Jul 15 18:08:47 2021 +0000

Tagging 1.21.0 release.
```