### PR TITLE
More work on ELBv2 module_utils

### DIFF
--- a/changelogs/fragments/604-elb_network_lb.yml
+++ b/changelogs/fragments/604-elb_network_lb.yml
@@ -1,0 +1,6 @@
+bugfixes:
+- module_utils/elbv2 - improvements to idempotency when comparing listeners (https://github.com/ansible-collections/community.aws/issues/604).
+- module_utils/elbv2 - fixes ``KeyError`` when using ``UseExistingClientSecret`` rather than ``ClientSecret`` (https://github.com/ansible-collections/amazon.aws/pull/940).
+minor_changes:
+- module_utils/elbv2 - ensures that ``ip_address_type`` is set on creation rather than re-setting it after creation (https://github.com/ansible-collections/amazon.aws/pull/940).
+- module_utils/elbv2 - uses new waiters with retries for temporary failures (https://github.com/ansible-collections/amazon.aws/pull/940).

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -95,8 +95,13 @@ def _prune_ForwardConfig(action):
 # or the module will always see the new and current actions as different
 # and try to apply the same config
 def _prune_secret(action):
-    if action['Type'] == 'authenticate-oidc':
-        action['AuthenticateOidcConfig'].pop('ClientSecret')
+    if action['Type'] != 'authenticate-oidc':
+        return action
+
+    action['AuthenticateOidcConfig'].pop('ClientSecret', None)
+    if action['AuthenticateOidcConfig'].get('UseExistingClientSecret', False):
+        action['AuthenticateOidcConfig'].pop('UseExistingClientSecret')
+
     return action
 
 

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -68,6 +68,7 @@ def _simple_forward_config_arn(config, parent_arn):
 
     return target_group_arn
 
+
 # ForwardConfig may be optional if we've got a single TargetGroupArn entry
 def _prune_ForwardConfig(action):
     """

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -246,6 +246,8 @@ class ElasticLoadBalancerV2(object):
         except (BotoCoreError, ClientError) as e:
             self.module.fail_json_aws(e)
 
+        self.wait_for_deletion(self.elb['LoadBalancerArn'])
+
         self.changed = True
 
     def compare_subnets(self):
@@ -293,8 +295,6 @@ class ElasticLoadBalancerV2(object):
             )(LoadBalancerArn=self.elb['LoadBalancerArn'], Subnets=self.subnets)
         except (BotoCoreError, ClientError) as e:
             self.module.fail_json_aws(e)
-
-        self.wait_for_deletion(self.elb['LoadBalancerArn'])
 
         self.changed = True
 

--- a/tests/integration/targets/elb_classic_lb/tasks/https_listeners.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/https_listeners.yml
@@ -119,6 +119,9 @@
   community.aws.aws_acm:
     certificate_arn: '{{ cert_arn }}'
     state: absent
+  # AWS doesn't always cleanup the associations properly
+  # https://repost.aws/questions/QU63csgGNEQl2M--xCdy-oxw/cant-delete-certificate-because-there-are-dangling-load-balancer-resources
+  ignore_errors: True
   register: delete_result
 - assert:
     that:

--- a/tests/unit/module_utils/elbv2/test_prune.py
+++ b/tests/unit/module_utils/elbv2/test_prune.py
@@ -51,11 +51,14 @@ simple_actions = [
     dict(Type='forward', TargetGroupArn=example_arn, ForwardConfig=dict(TargetGroups=[dict(TargetGroupArn=example_arn, Weight=42)])),
     dict(Type='forward', ForwardConfig=dict(TargetGroups=[dict(TargetGroupArn=example_arn, Weight=42)])),
 
-    dict(Type='forward', TargetGroupArn=example_arn, ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False), TargetGroups=[dict(TargetGroupArn=example_arn)])),
+    dict(Type='forward', TargetGroupArn=example_arn, ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False),
+                                                                        TargetGroups=[dict(TargetGroupArn=example_arn)])),
     dict(Type='forward', ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False), TargetGroups=[dict(TargetGroupArn=example_arn)])),
-    dict(Type='forward', TargetGroupArn=example_arn, ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False), TargetGroups=[dict(TargetGroupArn=example_arn, Weight=1)])),
+    dict(Type='forward', TargetGroupArn=example_arn, ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False),
+                                                                        TargetGroups=[dict(TargetGroupArn=example_arn, Weight=1)])),
     dict(Type='forward', ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False), TargetGroups=[dict(TargetGroupArn=example_arn, Weight=1)])),
-    dict(Type='forward', TargetGroupArn=example_arn, ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False), TargetGroups=[dict(TargetGroupArn=example_arn, Weight=42)])),
+    dict(Type='forward', TargetGroupArn=example_arn, ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False),
+                                                                        TargetGroups=[dict(TargetGroupArn=example_arn, Weight=42)])),
     dict(Type='forward', ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False), TargetGroups=[dict(TargetGroupArn=example_arn, Weight=42)])),
 ]
 
@@ -133,7 +136,9 @@ oidc_actions = [
     ),
 ]
 
+
 ####
+
 
 # Original tests
 def test__prune_secret():
@@ -149,7 +154,9 @@ def test__prune_ForwardConfig():
     pruned_config = elbv2._prune_ForwardConfig(one_action_two_tg[0])
     assert pruned_config == one_action_two_tg[0]
 
+
 ####
+
 
 @pytest.mark.parametrize("action", simple_actions)
 def test__prune_ForwardConfig_simplifiable_actions(action):

--- a/tests/unit/module_utils/elbv2/test_prune.py
+++ b/tests/unit/module_utils/elbv2/test_prune.py
@@ -1,0 +1,81 @@
+#
+# (c) 2021 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.amazon.aws.plugins.module_utils import elbv2
+
+example_arn = 'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/nlb-123456789abc/abcdef0123456789'
+example_arn2 = 'arn:aws:elasticloadbalancing:us-east-1:123456789012:targetgroup/nlb-0123456789ab/0123456789abcdef'
+
+one_action = [
+    dict(
+        ForwardConfig=dict(
+            TargetGroupStickinessConfig=dict(Enabled=False),
+            TargetGroups=[
+                dict(TargetGroupArn=example_arn, Weight=1),
+            ]
+        ),
+        TargetGroupArn=example_arn, Type='forward',
+    )
+]
+
+one_action_two_tg = [
+    dict(
+        ForwardConfig=dict(
+            TargetGroupStickinessConfig=dict(Enabled=False),
+            TargetGroups=[
+                dict(TargetGroupArn=example_arn, Weight=1),
+                dict(TargetGroupArn=example_arn2, Weight=1),
+            ]
+        ),
+        TargetGroupArn=example_arn, Type='forward',
+    )
+]
+
+simplified_action = dict(Type='forward', TargetGroupArn=example_arn)
+# Examples of various minimalistic actions which are all the same
+simple_actions = [
+    dict(Type='forward', TargetGroupArn=example_arn),
+
+    dict(Type='forward', TargetGroupArn=example_arn, ForwardConfig=dict(TargetGroups=[dict(TargetGroupArn=example_arn)])),
+    dict(Type='forward', ForwardConfig=dict(TargetGroups=[dict(TargetGroupArn=example_arn)])),
+    dict(Type='forward', TargetGroupArn=example_arn, ForwardConfig=dict(TargetGroups=[dict(TargetGroupArn=example_arn, Weight=1)])),
+    dict(Type='forward', ForwardConfig=dict(TargetGroups=[dict(TargetGroupArn=example_arn, Weight=1)])),
+    dict(Type='forward', TargetGroupArn=example_arn, ForwardConfig=dict(TargetGroups=[dict(TargetGroupArn=example_arn, Weight=42)])),
+    dict(Type='forward', ForwardConfig=dict(TargetGroups=[dict(TargetGroupArn=example_arn, Weight=42)])),
+
+    dict(Type='forward', TargetGroupArn=example_arn, ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False), TargetGroups=[dict(TargetGroupArn=example_arn)])),
+    dict(Type='forward', ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False), TargetGroups=[dict(TargetGroupArn=example_arn)])),
+    dict(Type='forward', TargetGroupArn=example_arn, ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False), TargetGroups=[dict(TargetGroupArn=example_arn, Weight=1)])),
+    dict(Type='forward', ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False), TargetGroups=[dict(TargetGroupArn=example_arn, Weight=1)])),
+    dict(Type='forward', TargetGroupArn=example_arn, ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False), TargetGroups=[dict(TargetGroupArn=example_arn, Weight=42)])),
+    dict(Type='forward', ForwardConfig=dict(TargetGroupStickinessConfig=dict(Enabled=False), TargetGroups=[dict(TargetGroupArn=example_arn, Weight=42)])),
+]
+
+
+def test_prune_secret():
+    assert elbv2._prune_secret(one_action[0]) == one_action[0]
+
+
+# Original tests
+def test__prune_ForwardConfig():
+    expectation = {"TargetGroupArn": example_arn, "Type": "forward"}
+    pruned_config = elbv2._prune_ForwardConfig(one_action[0])
+    assert pruned_config == expectation
+
+    # https://github.com/ansible-collections/community.aws/issues/1089
+    pruned_config = elbv2._prune_ForwardConfig(one_action_two_tg[0])
+    assert pruned_config == one_action_two_tg[0]
+
+
+@pytest.mark.parametrize("action", simple_actions)
+def test_simpliifable_actions(action):
+    pruned_config = elbv2._prune_ForwardConfig(action)
+    assert pruned_config == simplified_action

--- a/tests/unit/module_utils/test_elbv2.py
+++ b/tests/unit/module_utils/test_elbv2.py
@@ -47,20 +47,6 @@ one_action_two_tg = [
 ]
 
 
-def test__prune_ForwardConfig():
-    expectation = {
-        "TargetGroupArn": "arn:aws:elasticloadbalancing:us-east-1:966509639900:targetgroup/my-tg-58045486/5b231e04f663ae21",
-        "Type": "forward",
-    }
-    assert elbv2._prune_ForwardConfig(one_action[0]) == expectation
-    # https://github.com/ansible-collections/community.aws/issues/1089
-    assert elbv2._prune_ForwardConfig(one_action_two_tg[0]) == one_action_two_tg[0]
-
-
-def _prune_secret():
-    assert elbv2._prune_secret(one_action[0]) == one_action[0]
-
-
 def _sort_actions_one_entry():
     assert elbv2._sort_actions(one_action) == one_action
 


### PR DESCRIPTION
##### SUMMARY

- Refactors LB creation and makes sure that  ip_address_type is set on creation (bug found when working on fixing NLB tests)
- Fixes bug with DefaultAction comparisons
- Extends tests for _prune_ForwardConfig
- Extends tests for _prune_secrets
- Fixes KeyError bug uncovered when extending tests for _prune_secrets

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/module_utils/elbv2.py

##### ADDITIONAL INFORMATION

Fixes: https://github.com/ansible-collections/community.aws/issues/604
See also: https://github.com/ansible-collections/community.aws/pull/1365