### PR TITLE
ec2_metadata_facts - Fix read failure in ansible 2.13+

### DIFF
--- a/changelogs/fragments/943-ec2_metadata_facts-fix-NoneType-callable.yml
+++ b/changelogs/fragments/943-ec2_metadata_facts-fix-NoneType-callable.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_metadata_facts - fix ``'NoneType' object is not callable`` exception when using Ansible 2.13+ (https://github.com/ansible-collections/amazon.aws/issues/942).

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -477,7 +477,7 @@ class Ec2Metadata(object):
             if info.get('status') not in (200, 404):
                 # fail out now
                 self.module.fail_json(msg='Failed to retrieve metadata from AWS: {0}'.format(info['msg']), response=info)
-        if response:
+        if response and info['status'] < 400:
             data = response.read()
         else:
             data = None


### PR DESCRIPTION
##### SUMMARY
Ansible 2.13+ changes the return conventions of fetch_url when an error occurs. Add a guard to prevent calling `read` which will be None.

Fixes #942

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_metadata_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
