### PR TITLE
Post 3.4.0 / 4.1.0 cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,28 @@ amazon.aws Release Notes
 .. contents:: Topics
 
 
+v4.1.0
+======
+
+Minor Changes
+-------------
+
+- ec2_instance - expanded the use of the automatic retries on temporary failures (https://github.com/ansible-collections/amazon.aws/issues/927).
+- s3_bucket - updated module to enable support for setting S3 Bucket Keys for SSE-KMS (https://github.com/ansible-collections/amazon.aws/pull/882).
+
+Deprecated Features
+-------------------
+
+- amazon.aws collection - due to the AWS SDKs announcing the end of support for Python less than 3.7 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/) support for Python less than 3.7 by this collection has been deprecated and will be removed in a release after 2023-05-31 (https://github.com/ansible-collections/amazon.aws/pull/935).
+
+Bugfixes
+--------
+
+- aws_ec2 - ensure the correct number of hosts are returned when tags as hostnames are used (https://github.com/ansible-collections/amazon.aws/pull/862).
+- elb_application_lb - fix ``KeyError`` when balancing across two Target Groups (https://github.com/ansible-collections/community.aws/issues/1089).
+- elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating a new ELB in check mode with a health check (https://github.com/ansible-collections/amazon.aws/pull/915).
+- elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating a new ELB using security group names (https://github.com/ansible-collections/amazon.aws/issues/914).
+
 v4.0.0
 ======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
-===========================
+========================
 amazon.aws Release Notes
-===========================
+========================
 
 .. contents:: Topics
 
@@ -84,6 +84,21 @@ Bugfixes
 - ec2_vpc_net - fix a bug where CIDR configuration would be updated in check mode (https://github.com/ansible/ansible/issues/62678).
 - ec2_vpc_net - fix a bug where the module would get stuck if DNS options were updated in check mode (https://github.com/ansible/ansible/issues/62677).
 - elb_classic_lb - modify the return value of _format_listeners method to resolve a failure creating https listeners (https://github.com/ansible-collections/amazon.aws/pull/860).
+
+v3.4.0
+======
+
+Minor Changes
+-------------
+
+- ec2_instance - expanded the use of the automatic retries on temporary failures (https://github.com/ansible-collections/amazon.aws/issues/927).
+
+Bugfixes
+--------
+
+- elb_application_lb - fix ``KeyError`` when balancing across two Target Groups (https://github.com/ansible-collections/community.aws/issues/1089).
+- elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating a new ELB in check mode with a health check (https://github.com/ansible-collections/amazon.aws/pull/915).
+- elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating a new ELB using security group names (https://github.com/ansible-collections/amazon.aws/issues/914).
 
 v3.3.1
 ======

--- a/README.md
+++ b/README.md
@@ -56,36 +56,36 @@ Name | Description
 [amazon.aws.aws_caller_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.aws_caller_info_module.rst)|Get information about the user and account being used to make AWS calls
 [amazon.aws.cloudformation](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.cloudformation_module.rst)|Create or delete an AWS CloudFormation stack
 [amazon.aws.cloudformation_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.cloudformation_info_module.rst)|Obtain information about an AWS CloudFormation stack
-[amazon.aws.ec2_ami](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_ami_module.rst)|Create or destroy an image (AMI) in ec2
+[amazon.aws.ec2_ami](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_ami_module.rst)|Create or destroy an image (AMI) in EC2
 [amazon.aws.ec2_ami_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_ami_info_module.rst)|Gather information about ec2 AMIs
 [amazon.aws.ec2_eni](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_eni_module.rst)|Create and optionally attach an Elastic Network Interface (ENI) to an instance
 [amazon.aws.ec2_eni_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_eni_info_module.rst)|Gather information about ec2 ENI interfaces in AWS
-[amazon.aws.ec2_group](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_group_module.rst)|Maintain an ec2 VPC security group
-[amazon.aws.ec2_group_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_group_info_module.rst)|Gather information about ec2 security groups in AWS
 [amazon.aws.ec2_instance](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_instance_module.rst)|Create & manage EC2 instances
 [amazon.aws.ec2_instance_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_instance_info_module.rst)|Gather information about ec2 instances in AWS
-[amazon.aws.ec2_key](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_key_module.rst)|Create or delete an ec2 key pair
+[amazon.aws.ec2_key](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_key_module.rst)|Create or delete an EC2 key pair
 [amazon.aws.ec2_metadata_facts](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_metadata_facts_module.rst)|Gathers facts (instance metadata) about remote hosts within EC2
+[amazon.aws.ec2_security_group](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_security_group_module.rst)|Maintain an EC2 security group
+[amazon.aws.ec2_security_group_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_security_group_info_module.rst)|Gather information about EC2 security groups in AWS
 [amazon.aws.ec2_snapshot](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_snapshot_module.rst)|Creates a snapshot from an existing volume
 [amazon.aws.ec2_snapshot_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_snapshot_info_module.rst)|Gathers information about EC2 volume snapshots in AWS
 [amazon.aws.ec2_spot_instance](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_spot_instance_module.rst)|Request, stop, reboot or cancel spot instance
 [amazon.aws.ec2_spot_instance_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_spot_instance_info_module.rst)|Gather information about ec2 spot instance requests
 [amazon.aws.ec2_tag](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_tag_module.rst)|Create and remove tags on ec2 resources
 [amazon.aws.ec2_tag_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_tag_info_module.rst)|List tags on ec2 resources
-[amazon.aws.ec2_vol](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vol_module.rst)|Create and attach a volume, return volume id and device map
+[amazon.aws.ec2_vol](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vol_module.rst)|Create and attach a volume, return volume ID and device map
 [amazon.aws.ec2_vol_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vol_info_module.rst)|Gather information about ec2 volumes in AWS
 [amazon.aws.ec2_vpc_dhcp_option](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_dhcp_option_module.rst)|Manages DHCP Options, and can ensure the DHCP options for the given VPC match what's requested
-[amazon.aws.ec2_vpc_dhcp_option_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_dhcp_option_info_module.rst)|Gather information about dhcp options sets in AWS
-[amazon.aws.ec2_vpc_endpoint](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_endpoint_module.rst)|Create and delete AWS VPC Endpoints.
+[amazon.aws.ec2_vpc_dhcp_option_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_dhcp_option_info_module.rst)|Gather information about DHCP options sets in AWS
+[amazon.aws.ec2_vpc_endpoint](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_endpoint_module.rst)|Create and delete AWS VPC endpoints
 [amazon.aws.ec2_vpc_endpoint_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_endpoint_info_module.rst)|Retrieves AWS VPC endpoints details using AWS methods
 [amazon.aws.ec2_vpc_endpoint_service_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_endpoint_service_info_module.rst)|Retrieves AWS VPC endpoint service details
 [amazon.aws.ec2_vpc_igw](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_igw_module.rst)|Manage an AWS VPC Internet gateway
 [amazon.aws.ec2_vpc_igw_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_igw_info_module.rst)|Gather information about internet gateways in AWS
 [amazon.aws.ec2_vpc_nat_gateway](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_nat_gateway_module.rst)|Manage AWS VPC NAT Gateways
 [amazon.aws.ec2_vpc_nat_gateway_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_nat_gateway_info_module.rst)|Retrieves AWS VPC Managed Nat Gateway details using AWS methods
-[amazon.aws.ec2_vpc_net](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_net_module.rst)|Configure AWS virtual private clouds
+[amazon.aws.ec2_vpc_net](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_net_module.rst)|Configure AWS Virtual Private Clouds
 [amazon.aws.ec2_vpc_net_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_net_info_module.rst)|Gather information about ec2 VPCs in AWS
-[amazon.aws.ec2_vpc_route_table](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_route_table_module.rst)|Manage route tables for AWS virtual private clouds
+[amazon.aws.ec2_vpc_route_table](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_route_table_module.rst)|Manage route tables for AWS Virtual Private Clouds
 [amazon.aws.ec2_vpc_route_table_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_route_table_info_module.rst)|Gather information about ec2 VPC route tables in AWS
 [amazon.aws.ec2_vpc_subnet](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_subnet_module.rst)|Manage subnets in AWS virtual private clouds
 [amazon.aws.ec2_vpc_subnet_info](https://github.com/ansible-collections/amazon.aws/blob/main/docs/amazon.aws.ec2_vpc_subnet_info_module.rst)|Gather information about ec2 VPC subnets in AWS

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -819,6 +819,23 @@ releases:
     release_date: '2022-05-26'
   3.3.1:
     release_date: '2022-06-22'
+  3.4.0:
+    changes:
+      bugfixes:
+      - elb_application_lb - fix ``KeyError`` when balancing across two Target Groups
+        (https://github.com/ansible-collections/community.aws/issues/1089).
+      - elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating
+        a new ELB in check mode with a health check (https://github.com/ansible-collections/amazon.aws/pull/915).
+      - elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating
+        a new ELB using security group names (https://github.com/ansible-collections/amazon.aws/issues/914).
+      minor_changes:
+      - ec2_instance - expanded the use of the automatic retries on temporary failures
+        (https://github.com/ansible-collections/amazon.aws/issues/927).
+    fragments:
+    - 1089-elb_application_lb-ForwardConfig-KeyError.yml
+    - 914-elb_classic_lb-security_group_names.yml
+    - 927-ec2_instance-retries.yml
+    release_date: '2022-08-02'
   4.0.0:
     changes:
       breaking_changes:

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -980,3 +980,32 @@ releases:
     - 878-ec2_group.yml
     - release-4--botocore.yml
     release_date: '2022-06-22'
+  4.1.0:
+    changes:
+      bugfixes:
+      - aws_ec2 - ensure the correct number of hosts are returned when tags as hostnames
+        are used (https://github.com/ansible-collections/amazon.aws/pull/862).
+      - elb_application_lb - fix ``KeyError`` when balancing across two Target Groups
+        (https://github.com/ansible-collections/community.aws/issues/1089).
+      - elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating
+        a new ELB in check mode with a health check (https://github.com/ansible-collections/amazon.aws/pull/915).
+      - elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating
+        a new ELB using security group names (https://github.com/ansible-collections/amazon.aws/issues/914).
+      deprecated_features:
+      - amazon.aws collection - due to the AWS SDKs announcing the end of support
+        for Python less than 3.7 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
+        support for Python less than 3.7 by this collection has been deprecated and
+        will be removed in a release after 2023-05-31 (https://github.com/ansible-collections/amazon.aws/pull/935).
+      minor_changes:
+      - ec2_instance - expanded the use of the automatic retries on temporary failures
+        (https://github.com/ansible-collections/amazon.aws/issues/927).
+      - s3_bucket - updated module to enable support for setting S3 Bucket Keys for
+        SSE-KMS (https://github.com/ansible-collections/amazon.aws/pull/882).
+    fragments:
+    - 1089-elb_application_lb-ForwardConfig-KeyError.yml
+    - 862-aws_ec2-hostnames.yml
+    - 882-s3_bucket-bucket-keys.yml
+    - 914-elb_classic_lb-security_group_names.yml
+    - 927-ec2_instance-retries.yml
+    - python.yml
+    release_date: '2022-08-02'

--- a/changelogs/fragments/1089-elb_application_lb-ForwardConfig-KeyError.yml
+++ b/changelogs/fragments/1089-elb_application_lb-ForwardConfig-KeyError.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- elb_application_lb - fix ``KeyError`` when balancing across two Target Groups (https://github.com/ansible-collections/community.aws/issues/1089).

--- a/changelogs/fragments/862-aws_ec2-hostnames.yml
+++ b/changelogs/fragments/862-aws_ec2-hostnames.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- aws_ec2 - ensure the correct number of hosts are returned when tags as hostnames are used (https://github.com/ansible-collections/amazon.aws/pull/862).

--- a/changelogs/fragments/882-s3_bucket-bucket-keys.yml
+++ b/changelogs/fragments/882-s3_bucket-bucket-keys.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- s3_bucket - updated module to enable support for setting S3 Bucket Keys for SSE-KMS (https://github.com/ansible-collections/amazon.aws/pull/882).

--- a/changelogs/fragments/914-elb_classic_lb-security_group_names.yml
+++ b/changelogs/fragments/914-elb_classic_lb-security_group_names.yml
@@ -1,3 +1,0 @@
-bugfixes:
-- elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating a new ELB using security group names (https://github.com/ansible-collections/amazon.aws/issues/914).
-- elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating a new ELB in check mode with a health check (https://github.com/ansible-collections/amazon.aws/pull/915).

--- a/changelogs/fragments/927-ec2_instance-retries.yml
+++ b/changelogs/fragments/927-ec2_instance-retries.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- ec2_instance - expanded the use of the automatic retries on temporary failures (https://github.com/ansible-collections/amazon.aws/issues/927).

--- a/docs/amazon.aws.aws_account_attribute_lookup.rst
+++ b/docs/amazon.aws.aws_account_attribute_lookup.rst
@@ -25,8 +25,8 @@ Requirements
 The below requirements are needed on the local Ansible controller node that executes this lookup.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.aws_az_info_module.rst
+++ b/docs/amazon.aws.aws_az_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.aws_az_info_module.rst
+++ b/docs/amazon.aws.aws_az_info_module.rst
@@ -18,7 +18,6 @@ Version added: 1.0.0
 Synopsis
 --------
 - Gather information about availability zones in AWS.
-- This module was called :ref:`amazon.aws.aws_az_facts <amazon.aws.aws_az_facts_module>` before Ansible 2.9. The usage did not change.
 
 
 

--- a/docs/amazon.aws.aws_caller_info_module.rst
+++ b/docs/amazon.aws.aws_caller_info_module.rst
@@ -27,8 +27,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.aws_ec2_inventory.rst
+++ b/docs/amazon.aws.aws_ec2_inventory.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the local Ansible controller node that executes this inventory.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.aws_rds_inventory.rst
+++ b/docs/amazon.aws.aws_rds_inventory.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the local Ansible controller node that executes this inventory.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.aws_secret_lookup.rst
+++ b/docs/amazon.aws.aws_secret_lookup.rst
@@ -27,8 +27,8 @@ Requirements
 The below requirements are needed on the local Ansible controller node that executes this lookup.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.aws_ssm_lookup.rst
+++ b/docs/amazon.aws.aws_ssm_lookup.rst
@@ -28,8 +28,8 @@ Requirements
 The below requirements are needed on the local Ansible controller node that executes this lookup.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.cloudformation_info_module.rst
+++ b/docs/amazon.aws.cloudformation_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.cloudformation_module.rst
+++ b/docs/amazon.aws.cloudformation_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_ami_info_module.rst
+++ b/docs/amazon.aws.ec2_ami_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_ami_module.rst
+++ b/docs/amazon.aws.ec2_ami_module.rst
@@ -5,7 +5,7 @@
 amazon.aws.ec2_ami
 ******************
 
-**Create or destroy an image (AMI) in ec2**
+**Create or destroy an image (AMI) in EC2**
 
 
 Version added: 1.0.0
@@ -17,7 +17,7 @@ Version added: 1.0.0
 
 Synopsis
 --------
-- Registers or deregisters ec2 images.
+- Registers or deregisters EC2 images.
 
 
 
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters
@@ -54,7 +54,7 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">"x86_64"</div>
                 </td>
                 <td>
-                        <div>The target architecture of the image to register</div>
+                        <div>The target architecture of the image to register.</div>
                 </td>
             </tr>
             <tr>
@@ -136,7 +136,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>A list of valid billing codes. To be used with valid accounts by aws marketplace vendors.</div>
+                        <div>A list of valid billing codes. To be used with valid accounts by AWS Marketplace vendors.</div>
                 </td>
             </tr>
             <tr>
@@ -243,8 +243,6 @@ Parameters
                 </td>
                 <td>
                         <div>The device name. For example <code>/dev/sda</code>.</div>
-                        <div>The <code>DeviceName</code> alias had been deprecated and will be removed in release 5.0.0.</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: DeviceName</div>
                 </td>
             </tr>
             <tr>
@@ -280,7 +278,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>When using an <code>io1</code> <em>volume_type</em> this sets the number of IOPS provisioned for the volume</div>
+                        <div>When using an <code>io1</code> <em>volume_type</em> this sets the number of IOPS provisioned for the volume.</div>
                 </td>
             </tr>
             <tr>
@@ -301,8 +299,6 @@ Parameters
                 </td>
                 <td>
                         <div>Suppresses the specified device included in the block device mapping of the AMI.</div>
-                        <div>The <code>NoDevice</code> alias has been deprecated and will be removed in release 5.0.0.</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: NoDevice</div>
                 </td>
             </tr>
             <tr>
@@ -336,8 +332,6 @@ Parameters
                 <td>
                         <div>The virtual name for the device.</div>
                         <div>See the AWS documentation for more detail <a href='https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html'>https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html</a>.</div>
-                        <div>The <code>VirtualName</code> alias has been deprecated and will be removed in release 5.0.0.</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: VirtualName</div>
                 </td>
             </tr>
             <tr>
@@ -353,7 +347,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The size of the volume (in GiB)</div>
+                        <div>The size of the volume (in GiB).</div>
                         <div style="font-size: small; color: darkgreen"><br/>aliases: size</div>
                 </td>
             </tr>
@@ -436,7 +430,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The s3 location of an image to use for the AMI.</div>
+                        <div>The S3 location of an image to use for the AMI.</div>
                 </td>
             </tr>
             <tr>
@@ -481,8 +475,11 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Users and groups that should be able to launch the AMI. Expects dictionary with a key of user_ids and/or group_names. user_ids should be a list of account ids. group_name should be a list of groups, &quot;all&quot; is the only acceptable value currently.</div>
-                        <div>You must pass all desired launch permissions if you wish to modify existing launch permissions (passing just groups will remove all users)</div>
+                        <div>Users and groups that should be able to launch the AMI.</div>
+                        <div>Expects dictionary with a key of <code>user_ids</code> and/or <code>group_names</code>.</div>
+                        <div><code>user_ids</code> should be a list of account IDs.</div>
+                        <div><code>group_name</code> should be a list of groups, <code>all</code> is the only acceptable value currently.</div>
+                        <div>You must pass all desired launch permissions if you wish to modify existing launch permissions (passing just groups will remove all users).</div>
                 </td>
             </tr>
             <tr>
@@ -547,14 +544,13 @@ Parameters
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>no</li>
-                                    <li>yes</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
                         </ul>
                 </td>
                 <td>
                         <div>If <em>purge_tags=true</em> and <em>tags</em> is set, existing tags will be purged from the resource to match exactly what is defined by <em>tags</em> parameter.</div>
                         <div>If the <em>tags</em> parameter is not set then tags will not be modified, even if <em>purge_tags=True</em>.</div>
                         <div>Tag keys beginning with <code>aws:</code> are reserved by Amazon and can not be modified.  As such they will be ignored for the purposes of the <em>purge_tags</em> parameter.  See the Amazon documentation for more information <a href='https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions'>https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions</a>.</div>
-                        <div>The current default value of <code>False</code> has been deprecated.  The default value will change to <code>True</code> in release 5.0.0.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/amazon.aws.ec2_eni_info_module.rst
+++ b/docs/amazon.aws.ec2_eni_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_eni_module.rst
+++ b/docs/amazon.aws.ec2_eni_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_instance_info_module.rst
+++ b/docs/amazon.aws.ec2_instance_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_instance_module.rst
+++ b/docs/amazon.aws.ec2_instance_module.rst
@@ -18,8 +18,9 @@ Version added: 1.0.0
 Synopsis
 --------
 - Create and manage AWS EC2 instances.
-- Note: This module does not support creating `EC2 Spot instances <https://aws.amazon.com/ec2/spot/>`_. The :ref:`amazon.aws.ec2 <amazon.aws.ec2_module>` module can create and manage spot instances.
+- Note: This module does not support creating `EC2 Spot instances <https://aws.amazon.com/ec2/spot/>`_.
 
+- The :ref:`amazon.aws.ec2_spot_instance <amazon.aws.ec2_spot_instance_module>` module can create and manage spot instances.
 
 
 

--- a/docs/amazon.aws.ec2_instance_module.rst
+++ b/docs/amazon.aws.ec2_instance_module.rst
@@ -18,8 +18,7 @@ Version added: 1.0.0
 Synopsis
 --------
 - Create and manage AWS EC2 instances.
-- Note: This module does not support creating `EC2 Spot instances <https://aws.amazon.com/ec2/spot/>`_.
-
+- This module does not support creating `EC2 Spot instances <https://aws.amazon.com/ec2/spot/>`_.
 - The :ref:`amazon.aws.ec2_spot_instance <amazon.aws.ec2_spot_instance_module>` module can create and manage spot instances.
 
 
@@ -29,8 +28,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters
@@ -161,7 +160,7 @@ Parameters
                 </td>
                 <td>
                         <div>For T series instances, choose whether to allow increased charges to buy CPU credits if the default pool is depleted.</div>
-                        <div>Choose <em>unlimited</em> to enable buying additional CPU credits.</div>
+                        <div>Choose <code>unlimited</code> to enable buying additional CPU credits.</div>
                 </td>
             </tr>
             <tr>
@@ -255,7 +254,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Whether to allow detailed cloudwatch metrics to be collected, enabling more detailed alerting.</div>
+                        <div>Whether to allow detailed CloudWatch metrics to be collected, enabling more detailed alerting.</div>
                 </td>
             </tr>
             <tr>
@@ -456,7 +455,9 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The ARN or name of an EC2-enabled instance role to be used. If a name is not provided in arn format then the ListInstanceProfiles permission must also be granted. <a href='https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListInstanceProfiles.html'>https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListInstanceProfiles.html</a> If no full ARN is provided, the role with a matching name will be used from the active AWS account.</div>
+                        <div>The ARN or name of an EC2-enabled instance role to be used.</div>
+                        <div>If a name is not provided in ARN format then the ListInstanceProfiles permission must also be granted. <a href='https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListInstanceProfiles.html'>https://docs.aws.amazon.com/IAM/latest/APIReference/API_ListInstanceProfiles.html</a></div>
+                        <div>If no full ARN is provided, the role with a matching name will be used from the active AWS account.</div>
                 </td>
             </tr>
             <tr>
@@ -471,8 +472,10 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Instance type to use for the instance, see <a href='https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html'>https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html</a> Only required when instance is not already present.</div>
-                        <div>If not specified, t2.micro will be used.</div>
+                        <div>Instance type to use for the instance, see <a href='https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html'>https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html</a>.</div>
+                        <div>Only required when instance is not already present.</div>
+                        <div>If not specified, <code>t2.micro</code> will be used.</div>
+                        <div>In a release after 2023-01-01 the default will be removed and either <em>instance_type</em> or <em>launch_template</em> must be specificed when launching an instance.</div>
                 </td>
             </tr>
             <tr>
@@ -488,6 +491,7 @@ Parameters
                 </td>
                 <td>
                         <div>Name of the SSH access key to assign to the instance - must exist in the region the instance is created.</div>
+                        <div>Use <span class='module'>amazon.aws.ec2_key</span> to manage SSH keys.</div>
                 </td>
             </tr>
             <tr>
@@ -518,7 +522,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>the ID of the launch template (optional if name is specified).</div>
+                        <div>The ID of the launch template (optional if name is specified).</div>
                 </td>
             </tr>
             <tr>
@@ -534,7 +538,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>the pretty name of the launch template (optional if id is specified).</div>
+                        <div>The pretty name of the launch template (optional if id is specified).</div>
                 </td>
             </tr>
             <tr>
@@ -550,7 +554,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>the specific version of the launch template to use. If unspecified, the template default is chosen.</div>
+                        <div>The specific version of the launch template to use. If unspecified, the template default is chosen.</div>
                 </td>
             </tr>
 
@@ -611,7 +615,8 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>- Wether the instance metadata endpoint is available via IPv6 (<code>enabled</code>) or not (<code>disabled</code>). - Requires botocore &gt;= 1.21.29</div>
+                        <div>Wether the instance metadata endpoint is available via IPv6 (<code>enabled</code>) or not (<code>disabled</code>).</div>
+                        <div>Requires botocore &gt;= 1.21.29</div>
                 </td>
             </tr>
             <tr>
@@ -629,7 +634,8 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">1</div>
                 </td>
                 <td>
-                        <div>The desired HTTP PUT response hop limit for instance metadata requests. The larger the number, the further instance metadata requests can travel.</div>
+                        <div>The desired HTTP PUT response hop limit for instance metadata requests.</div>
+                        <div>The larger the number, the further instance metadata requests can travel.</div>
                 </td>
             </tr>
             <tr>
@@ -704,7 +710,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Either a dictionary containing the key &#x27;interfaces&#x27; corresponding to a list of network interface IDs or containing specifications for a single network interface.</div>
+                        <div>Either a dictionary containing the key <code>interfaces</code> corresponding to a list of network interface IDs or containing specifications for a single network interface.</div>
                         <div>Use the <span class='module'>amazon.aws.ec2_eni</span> module to create ENIs with special settings.</div>
                 </td>
             </tr>
@@ -725,7 +731,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>when true assigns a public IP address to the interface</div>
+                        <div>When <code>true</code> assigns a public IP address to the interface.</div>
                 </td>
             </tr>
             <tr>
@@ -761,7 +767,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>a description for the network interface</div>
+                        <div>A description for the network interface.</div>
                 </td>
             </tr>
             <tr>
@@ -777,7 +783,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The index of the interface to modify</div>
+                        <div>The index of the interface to modify.</div>
                 </td>
             </tr>
             <tr>
@@ -794,7 +800,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>a list of security group IDs to attach to the interface</div>
+                        <div>A list of security group IDs to attach to the interface.</div>
                 </td>
             </tr>
             <tr>
@@ -811,7 +817,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>a list of ENI IDs (strings) or a list of objects containing the key <em>id</em>.</div>
+                        <div>A list of ENI IDs (strings) or a list of objects containing the key <em>id</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -828,7 +834,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>a list of IPv6 addresses to assign to the network interface</div>
+                        <div>A list of IPv6 addresses to assign to the network interface.</div>
                 </td>
             </tr>
             <tr>
@@ -844,7 +850,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>an IPv4 address to assign to the interface</div>
+                        <div>An IPv4 address to assign to the interface.</div>
                 </td>
             </tr>
             <tr>
@@ -861,7 +867,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>a list of IPv4 addresses to assign to the network interface</div>
+                        <div>A list of IPv4 addresses to assign to the network interface.</div>
                 </td>
             </tr>
             <tr>
@@ -881,7 +887,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>controls whether source/destination checking is enabled on the interface</div>
+                        <div>Controls whether source/destination checking is enabled on the interface.</div>
                 </td>
             </tr>
             <tr>
@@ -897,7 +903,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>the subnet to connect the network interface to</div>
+                        <div>The subnet to connect the network interface to.</div>
                 </td>
             </tr>
 
@@ -913,7 +919,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The placement group that needs to be assigned to the instance</div>
+                        <div>The placement group that needs to be assigned to the instance.</div>
                 </td>
             </tr>
             <tr>
@@ -944,14 +950,13 @@ Parameters
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>no</li>
-                                    <li>yes</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
                         </ul>
                 </td>
                 <td>
                         <div>If <em>purge_tags=true</em> and <em>tags</em> is set, existing tags will be purged from the resource to match exactly what is defined by <em>tags</em> parameter.</div>
                         <div>If the <em>tags</em> parameter is not set then tags will not be modified, even if <em>purge_tags=True</em>.</div>
                         <div>Tag keys beginning with <code>aws:</code> are reserved by Amazon and can not be modified.  As such they will be ignored for the purposes of the <em>purge_tags</em> parameter.  See the Amazon documentation for more information <a href='https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions'>https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions</a>.</div>
-                        <div>The current default value of <code>False</code> has been deprecated.  The default value will change to <code>True</code> in release 5.0.0.</div>
                 </td>
             </tr>
             <tr>
@@ -982,7 +987,8 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>A security group ID or name. Mutually exclusive with <em>security_groups</em>.</div>
+                        <div>A security group ID or name.</div>
+                        <div>Mutually exclusive with <em>security_groups</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -998,7 +1004,8 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>A list of security group IDs or names (strings). Mutually exclusive with <em>security_group</em>.</div>
+                        <div>A list of security group IDs or names (strings).</div>
+                        <div>Mutually exclusive with <em>security_group</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -1104,7 +1111,8 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Whether to enable termination protection. This module will not terminate an instance with termination protection active, it must be turned off first.</div>
+                        <div>Whether to enable termination protection.</div>
+                        <div>This module will not terminate an instance with termination protection active, it must be turned off first.</div>
                 </td>
             </tr>
             <tr>
@@ -1186,7 +1194,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Opaque blob of data which is made available to the ec2 instance</div>
+                        <div>Opaque blob of data which is made available to the EC2 instance.</div>
                 </td>
             </tr>
             <tr>
@@ -1222,7 +1230,7 @@ Parameters
                 </td>
                 <td>
                         <div>A list of block device mappings, by default this will always use the AMI root device so the volumes option is primarily for adding more storage.</div>
-                        <div>A mapping contains the (optional) keys device_name, virtual_name, ebs.volume_type, ebs.volume_size, ebs.kms_key_id, ebs.snapshot_id, ebs.iops, and ebs.delete_on_termination.</div>
+                        <div>A mapping contains the (optional) keys <code>device_name</code>, <code>virtual_name</code>, <code>ebs.volume_type</code>, <code>ebs.volume_size</code>, <code>ebs.kms_key_id</code>, <code>ebs.snapshot_id</code>, <code>ebs.iops</code>, and <code>ebs.delete_on_termination</code>.</div>
                         <div>For more information about each parameter, see <a href='https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html'>https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_BlockDeviceMapping.html</a>.</div>
                 </td>
             </tr>
@@ -1238,7 +1246,8 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>The subnet ID in which to launch the instance (VPC) If none is provided, <span class='module'>amazon.aws.ec2_instance</span> will chose the default zone of the default VPC.</div>
+                        <div>The subnet ID in which to launch the instance (VPC).</div>
+                        <div>If none is provided, <span class='module'>amazon.aws.ec2_instance</span> will chose the default zone of the default VPC.</div>
                         <div style="font-size: small; color: darkgreen"><br/>aliases: subnet_id</div>
                 </td>
             </tr>
@@ -1258,7 +1267,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Whether or not to wait for the desired state (use wait_timeout to customize this).</div>
+                        <div>Whether or not to wait for the desired <em>state</em> (use (wait_timeout) to customize this).</div>
                 </td>
             </tr>
             <tr>

--- a/docs/amazon.aws.ec2_key_module.rst
+++ b/docs/amazon.aws.ec2_key_module.rst
@@ -5,7 +5,7 @@
 amazon.aws.ec2_key
 ******************
 
-**Create or delete an ec2 key pair**
+**Create or delete an EC2 key pair**
 
 
 Version added: 1.0.0
@@ -17,7 +17,7 @@ Version added: 1.0.0
 
 Synopsis
 --------
-- create or delete an ec2 key pair.
+- Create or delete an EC2 key pair.
 
 
 
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters
@@ -244,14 +244,13 @@ Parameters
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>no</li>
-                                    <li>yes</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
                         </ul>
                 </td>
                 <td>
                         <div>If <em>purge_tags=true</em> and <em>tags</em> is set, existing tags will be purged from the resource to match exactly what is defined by <em>tags</em> parameter.</div>
                         <div>If the <em>tags</em> parameter is not set then tags will not be modified, even if <em>purge_tags=True</em>.</div>
                         <div>Tag keys beginning with <code>aws:</code> are reserved by Amazon and can not be modified.  As such they will be ignored for the purposes of the <em>purge_tags</em> parameter.  See the Amazon documentation for more information <a href='https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions'>https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions</a>.</div>
-                        <div>The current default value of <code>False</code> has been deprecated.  The default value will change to <code>True</code> in release 5.0.0.</div>
                 </td>
             </tr>
             <tr>
@@ -304,7 +303,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>create or delete keypair</div>
+                        <div>Create or delete keypair.</div>
                 </td>
             </tr>
             <tr>
@@ -365,7 +364,7 @@ Examples
 
     # Note: These examples do not set authentication details, see the AWS Guide for details.
 
-    - name: create a new ec2 key pair, returns generated private key
+    - name: create a new EC2 key pair, returns generated private key
       amazon.aws.ec2_key:
         name: my_keypair
 

--- a/docs/amazon.aws.ec2_security_group_info_module.rst
+++ b/docs/amazon.aws.ec2_security_group_info_module.rst
@@ -1,11 +1,11 @@
-.. _amazon.aws.ec2_group_info_module:
+.. _amazon.aws.ec2_security_group_info_module:
 
 
-*************************
-amazon.aws.ec2_group_info
-*************************
+**********************************
+amazon.aws.ec2_security_group_info
+**********************************
 
-**Gather information about ec2 security groups in AWS**
+**Gather information about EC2 security groups in AWS**
 
 
 Version added: 1.0.0
@@ -17,7 +17,7 @@ Version added: 1.0.0
 
 Synopsis
 --------
-- Gather information about ec2 security groups in AWS.
+- Gather information about EC2 security groups in AWS.
 
 
 
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters
@@ -235,7 +235,8 @@ Notes
 -----
 
 .. note::
-   - By default, the module will return all security groups. To limit results use the appropriate filters.
+   - By default, the module will return all security groups in a region. To limit results use the appropriate filters.
+   - Prior to release 5.0.0 this module was called ``amazon.aws.ec2_group_info``. The usage did not change.
    - If parameters are not set within the module, the following environment variables can be used in decreasing order of precedence ``AWS_URL`` or ``EC2_URL``, ``AWS_PROFILE`` or ``AWS_DEFAULT_PROFILE``, ``AWS_ACCESS_KEY_ID`` or ``AWS_ACCESS_KEY`` or ``EC2_ACCESS_KEY``, ``AWS_SECRET_ACCESS_KEY`` or ``AWS_SECRET_KEY`` or ``EC2_SECRET_KEY``, ``AWS_SECURITY_TOKEN`` or ``EC2_SECURITY_TOKEN``, ``AWS_REGION`` or ``EC2_REGION``, ``AWS_CA_BUNDLE``
    - When no credentials are explicitly provided the AWS SDK (boto3) that Ansible uses will fall back to its configuration files (typically ``~/.aws/credentials``). See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html for more information.
    - ``AWS_REGION`` or ``EC2_REGION`` can be typically be used to specify the AWS region, when required, but this can also be defined in the configuration files.
@@ -250,36 +251,36 @@ Examples
     # Note: These examples do not set authentication details, see the AWS Guide for details.
 
     # Gather information about all security groups
-    - amazon.aws.ec2_group_info:
+    - amazon.aws.ec2_security_group_info:
 
     # Gather information about all security groups in a specific VPC
-    - amazon.aws.ec2_group_info:
+    - amazon.aws.ec2_security_group_info:
         filters:
           vpc-id: vpc-12345678
 
     # Gather information about all security groups in a specific VPC
-    - amazon.aws.ec2_group_info:
+    - amazon.aws.ec2_security_group_info:
         filters:
           vpc-id: vpc-12345678
 
     # Gather information about a security group
-    - amazon.aws.ec2_group_info:
+    - amazon.aws.ec2_security_group_info:
         filters:
           group-name: example-1
 
     # Gather information about a security group by id
-    - amazon.aws.ec2_group_info:
+    - amazon.aws.ec2_security_group_info:
         filters:
           group-id: sg-12345678
 
     # Gather information about a security group with multiple filters, also mixing the use of underscores as filter keys
-    - amazon.aws.ec2_group_info:
+    - amazon.aws.ec2_security_group_info:
         filters:
           group_id: sg-12345678
           vpc-id: vpc-12345678
 
     # Gather information about various security groups
-    - amazon.aws.ec2_group_info:
+    - amazon.aws.ec2_security_group_info:
         filters:
           group-name:
             - example-1
@@ -288,7 +289,7 @@ Examples
 
     # Gather information about any security group with a tag key Name and value Example.
     # The quotes around 'tag:name' are important because of the colon in the value
-    - amazon.aws.ec2_group_info:
+    - amazon.aws.ec2_security_group_info:
         filters:
           "tag:Name": Example
 

--- a/docs/amazon.aws.ec2_security_group_module.rst
+++ b/docs/amazon.aws.ec2_security_group_module.rst
@@ -1,11 +1,11 @@
-.. _amazon.aws.ec2_group_module:
+.. _amazon.aws.ec2_security_group_module:
 
 
-********************
-amazon.aws.ec2_group
-********************
+*****************************
+amazon.aws.ec2_security_group
+*****************************
 
-**Maintain an ec2 VPC security group**
+**Maintain an EC2 security group**
 
 
 Version added: 1.0.0
@@ -17,7 +17,7 @@ Version added: 1.0.0
 
 Synopsis
 --------
-- Maintains ec2 security groups.
+- Maintains EC2 security groups.
 
 
 
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters
@@ -839,7 +839,7 @@ Notes
 
 .. note::
    - If a rule declares a group_name and that group doesn't exist, it will be automatically created. In that case, group_desc should be provided as well. The module will refuse to create a depended-on group without a description.
-   - Preview diff mode support is added in version 2.7.
+   - Prior to release 5.0.0 this module was called ``amazon.aws.ec2_group_info``.  The usage did not change.
    - If parameters are not set within the module, the following environment variables can be used in decreasing order of precedence ``AWS_URL`` or ``EC2_URL``, ``AWS_PROFILE`` or ``AWS_DEFAULT_PROFILE``, ``AWS_ACCESS_KEY_ID`` or ``AWS_ACCESS_KEY`` or ``EC2_ACCESS_KEY``, ``AWS_SECRET_ACCESS_KEY`` or ``AWS_SECRET_KEY`` or ``EC2_SECRET_KEY``, ``AWS_SECURITY_TOKEN`` or ``EC2_SECURITY_TOKEN``, ``AWS_REGION`` or ``EC2_REGION``, ``AWS_CA_BUNDLE``
    - When no credentials are explicitly provided the AWS SDK (boto3) that Ansible uses will fall back to its configuration files (typically ``~/.aws/credentials``). See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html for more information.
    - ``AWS_REGION`` or ``EC2_REGION`` can be typically be used to specify the AWS region, when required, but this can also be defined in the configuration files.
@@ -852,7 +852,7 @@ Examples
 .. code-block:: yaml
 
     - name: example using security group rule descriptions
-      amazon.aws.ec2_group:
+      amazon.aws.ec2_security_group:
         name: "{{ name }}"
         description: sg with rule descriptions
         vpc_id: vpc-xxxxxxxx
@@ -866,7 +866,7 @@ Examples
             rule_desc: allow all on port 80
 
     - name: example using ICMP types and codes
-      amazon.aws.ec2_group:
+      amazon.aws.ec2_security_group:
         name: "{{ name }}"
         description: sg for ICMP
         vpc_id: vpc-xxxxxxxx
@@ -879,7 +879,7 @@ Examples
             cidr_ip: 0.0.0.0/0
 
     - name: example ec2 group
-      amazon.aws.ec2_group:
+      amazon.aws.ec2_security_group:
         name: example
         description: an example EC2 group
         vpc_id: 12345
@@ -939,7 +939,7 @@ Examples
             group_desc: other example EC2 group
 
     - name: example2 ec2 group
-      amazon.aws.ec2_group:
+      amazon.aws.ec2_security_group:
         name: example2
         description: an example2 EC2 group
         vpc_id: 12345
@@ -979,7 +979,7 @@ Examples
       diff: True
 
     - name: "Delete group by its id"
-      amazon.aws.ec2_group:
+      amazon.aws.ec2_security_group:
         region: eu-west-1
         group_id: sg-33b4ee5b
         state: absent

--- a/docs/amazon.aws.ec2_snapshot_info_module.rst
+++ b/docs/amazon.aws.ec2_snapshot_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_snapshot_module.rst
+++ b/docs/amazon.aws.ec2_snapshot_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_spot_instance_info_module.rst
+++ b/docs/amazon.aws.ec2_spot_instance_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_spot_instance_module.rst
+++ b/docs/amazon.aws.ec2_spot_instance_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_tag_info_module.rst
+++ b/docs/amazon.aws.ec2_tag_info_module.rst
@@ -28,8 +28,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_tag_module.rst
+++ b/docs/amazon.aws.ec2_tag_module.rst
@@ -28,8 +28,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vol_info_module.rst
+++ b/docs/amazon.aws.ec2_vol_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vol_module.rst
+++ b/docs/amazon.aws.ec2_vol_module.rst
@@ -5,7 +5,7 @@
 amazon.aws.ec2_vol
 ******************
 
-**Create and attach a volume, return volume id and device map**
+**Create and attach a volume, return volume ID and device map**
 
 
 Version added: 1.0.0
@@ -27,8 +27,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters
@@ -158,7 +158,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Device id to override device mapping. Assumes /dev/sdf for Linux/UNIX and /dev/xvdf for Windows.</div>
+                        <div>Device ID to override device mapping. Assumes /dev/sdf for Linux/UNIX and /dev/xvdf for Windows.</div>
                 </td>
             </tr>
             <tr>
@@ -208,7 +208,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Volume id if you wish to attach an existing volume (requires instance) or remove an existing volume</div>
+                        <div>Volume ID if you wish to attach an existing volume (requires instance) or remove an existing volume.</div>
                 </td>
             </tr>
             <tr>
@@ -223,7 +223,8 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Instance ID if you wish to attach the volume. Since 1.9 you can set to None to detach.</div>
+                        <div>Instance ID if you wish to attach the volume.</div>
+                        <div>Set to <code>None</code> to detach the volume.</div>
                 </td>
             </tr>
             <tr>
@@ -253,7 +254,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Specify the id of the KMS key to use.</div>
+                        <div>Specify the ID of the KMS key to use.</div>
                 </td>
             </tr>
             <tr>
@@ -293,7 +294,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>If set to <code>yes</code>, Multi-Attach will be enabled when creating the volume.</div>
+                        <div>If set to <code>true</code>, Multi-Attach will be enabled when creating the volume.</div>
                         <div>When you create a new volume, Multi-Attach is disabled by default.</div>
                         <div>This parameter is supported with io1 and io2 volumes only.</div>
                 </td>
@@ -310,7 +311,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Volume Name tag if you wish to attach an existing volume (requires instance)</div>
+                        <div>Volume Name tag if you wish to attach an existing volume (requires instance).</div>
                 </td>
             </tr>
             <tr>
@@ -358,14 +359,13 @@ Parameters
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>no</li>
-                                    <li>yes</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
                         </ul>
                 </td>
                 <td>
                         <div>If <em>purge_tags=true</em> and <em>tags</em> is set, existing tags will be purged from the resource to match exactly what is defined by <em>tags</em> parameter.</div>
                         <div>If the <em>tags</em> parameter is not set then tags will not be modified, even if <em>purge_tags=True</em>.</div>
                         <div>Tag keys beginning with <code>aws:</code> are reserved by Amazon and can not be modified.  As such they will be ignored for the purposes of the <em>purge_tags</em> parameter.  See the Amazon documentation for more information <a href='https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions'>https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions</a>.</div>
-                        <div>The current default value of <code>False</code> has been deprecated.  The default value will change to <code>True</code> in release 5.0.0.</div>
                 </td>
             </tr>
             <tr>
@@ -434,7 +434,8 @@ Parameters
                 </td>
                 <td>
                         <div>Whether to ensure the volume is present or absent.</div>
-                        <div><em>state=list</em> was deprecated in release 1.1.0 and is no longer available with release 4.0.0.  The &#x27;list&#x27; functionality has been moved to a dedicated module <span class='module'>amazon.aws.ec2_vol_info</span>.</div>
+                        <div><em>state=list</em> was deprecated in release 1.1.0 and is no longer available with release 4.0.0.</div>
+                        <div>The <code>list</code> functionality has been moved to a dedicated module <span class='module'>amazon.aws.ec2_vol_info</span>.</div>
                 </td>
             </tr>
             <tr>
@@ -527,7 +528,8 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Type of EBS volume; standard (magnetic), gp2 (SSD), gp3 (SSD), io1 (Provisioned IOPS), io2 (Provisioned IOPS), st1 (Throughput Optimized HDD), sc1 (Cold HDD). &quot;Standard&quot; is the old EBS default and continues to remain the Ansible default for backwards compatibility.</div>
+                        <div>Type of EBS volume; <code>standard</code> (magnetic), <code>gp2</code> (SSD), <code>gp3</code> (SSD), <code>io1</code> (Provisioned IOPS), <code>io2</code> (Provisioned IOPS), <code>st1</code> (Throughput Optimized HDD), <code>sc1</code> (Cold HDD).</div>
+                        <div><code>standard</code> is the old EBS default and continues to remain the Ansible default for backwards compatibility.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/amazon.aws.ec2_vpc_dhcp_option_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_dhcp_option_info_module.rst
@@ -5,7 +5,7 @@
 amazon.aws.ec2_vpc_dhcp_option_info
 ***********************************
 
-**Gather information about dhcp options sets in AWS**
+**Gather information about DHCP options sets in AWS**
 
 
 Version added: 1.0.0
@@ -17,7 +17,7 @@ Version added: 1.0.0
 
 Synopsis
 --------
-- Gather information about dhcp options sets in AWS.
+- Gather information about DHCP options sets in AWS.
 
 
 
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters
@@ -139,9 +139,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Get details of specific DHCP Option IDs.</div>
-                        <div>The <code>DhcpOptionIds</code> alias has been deprecated and will be removed in release 5.0.0.</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: DhcpOptionIds</div>
+                        <div>Get details of specific DHCP option IDs.</div>
                 </td>
             </tr>
             <tr>
@@ -160,9 +158,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Checks whether you have the required permissions to view the DHCP Options.</div>
-                        <div>The <code>DryRun</code> alias has been deprecated and will be removed in release 5.0.0.</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: DryRun</div>
+                        <div>Checks whether you have the required permissions to view the DHCP options.</div>
                 </td>
             </tr>
             <tr>
@@ -304,7 +300,7 @@ Examples
       amazon.aws.ec2_vpc_dhcp_option_info:
         region: ap-southeast-2
         profile: production
-        DhcpOptionsIds: dopt-123fece2
+        dhcp_options_ids: dopt-123fece2
       register: dhcp_info
 
 

--- a/docs/amazon.aws.ec2_vpc_dhcp_option_module.rst
+++ b/docs/amazon.aws.ec2_vpc_dhcp_option_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_endpoint_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_endpoint_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_endpoint_module.rst
+++ b/docs/amazon.aws.ec2_vpc_endpoint_module.rst
@@ -5,7 +5,7 @@
 amazon.aws.ec2_vpc_endpoint
 ***************************
 
-**Create and delete AWS VPC Endpoints.**
+**Create and delete AWS VPC endpoints**
 
 
 Version added: 1.0.0
@@ -28,8 +28,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters
@@ -121,7 +121,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>Optional client token to ensure idempotency</div>
+                        <div>Optional client token to ensure idempotency.</div>
                 </td>
             </tr>
             <tr>
@@ -171,7 +171,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>A properly formatted json policy as string, see <a href='https://github.com/ansible/ansible/issues/7005#issuecomment-42894813'>https://github.com/ansible/ansible/issues/7005#issuecomment-42894813</a>. Cannot be used with <em>policy_file</em>.</div>
+                        <div>A properly formatted JSON policy as string, see <a href='https://github.com/ansible/ansible/issues/7005#issuecomment-42894813'>https://github.com/ansible/ansible/issues/7005#issuecomment-42894813</a>. Cannot be used with <em>policy_file</em>.</div>
                         <div>Option when creating an endpoint. If not provided AWS will utilise a default policy which provides full access to the service.</div>
                 </td>
             </tr>
@@ -221,14 +221,13 @@ Parameters
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>no</li>
-                                    <li>yes</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
                         </ul>
                 </td>
                 <td>
                         <div>If <em>purge_tags=true</em> and <em>tags</em> is set, existing tags will be purged from the resource to match exactly what is defined by <em>tags</em> parameter.</div>
                         <div>If the <em>tags</em> parameter is not set then tags will not be modified, even if <em>purge_tags=True</em>.</div>
                         <div>Tag keys beginning with <code>aws:</code> are reserved by Amazon and can not be modified.  As such they will be ignored for the purposes of the <em>purge_tags</em> parameter.  See the Amazon documentation for more information <a href='https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions'>https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions</a>.</div>
-                        <div>The current default value of <code>False</code> has been deprecated.  The default value will change to <code>True</code> in release 5.0.0.</div>
                 </td>
             </tr>
             <tr>
@@ -260,8 +259,9 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>List of one or more route table ids to attach to the endpoint. A route is added to the route table with the destination of the endpoint if provided.</div>
-                        <div>Route table ids are only valid for gateway type endpoints.</div>
+                        <div>List of one or more route table IDs to attach to the endpoint.</div>
+                        <div>A route is added to the route table with the destination of the endpoint if provided.</div>
+                        <div>Route table IDs are only valid for <code>Gateway</code> endpoints.</div>
                 </td>
             </tr>
             <tr>
@@ -294,7 +294,7 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>An AWS supported vpc endpoint service. Use the <span class='module'>amazon.aws.ec2_vpc_endpoint_info</span> module to describe the supported endpoint services.</div>
+                        <div>An AWS supported VPC endpoint service. Use the <span class='module'>amazon.aws.ec2_vpc_endpoint_info</span> module to describe the supported endpoint services.</div>
                         <div>Required when creating an endpoint.</div>
                 </td>
             </tr>
@@ -314,8 +314,8 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>present to ensure resource is created.</div>
-                        <div>absent to remove resource</div>
+                        <div><code>present</code> to ensure resource is created.</div>
+                        <div><code>absent</code> to remove resource.</div>
                 </td>
             </tr>
             <tr>
@@ -366,7 +366,8 @@ Parameters
                 <td>
                 </td>
                 <td>
-                        <div>One or more vpc endpoint ids to remove from the AWS account</div>
+                        <div>One or more VPC endpoint IDs to remove from the AWS account.</div>
+                        <div>Required if <em>state=absent</em>.</div>
                 </td>
             </tr>
             <tr>
@@ -457,7 +458,8 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>When specified, will wait for either available status for state present. Unfortunately this is ignored for delete actions due to a difference in behaviour from AWS.</div>
+                        <div>When specified, will wait for status to reach <code>available</code> for <em>state=present</em>.</div>
+                        <div>Unfortunately this is ignored for delete actions due to a difference in behaviour from AWS.</div>
                 </td>
             </tr>
             <tr>
@@ -473,7 +475,9 @@ Parameters
                         <b>Default:</b><br/><div style="color: blue">320</div>
                 </td>
                 <td>
-                        <div>Used in conjunction with wait. Number of seconds to wait for status. Unfortunately this is ignored for delete actions due to a difference in behaviour from AWS.</div>
+                        <div>Used in conjunction with <em>wait</em>.</div>
+                        <div>Number of seconds to wait for status.</div>
+                        <div>Unfortunately this is ignored for delete actions due to a difference in behaviour from AWS.</div>
                 </td>
             </tr>
     </table>

--- a/docs/amazon.aws.ec2_vpc_endpoint_service_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_endpoint_service_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_igw_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_igw_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_igw_module.rst
+++ b/docs/amazon.aws.ec2_vpc_igw_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_nat_gateway_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_nat_gateway_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_nat_gateway_module.rst
+++ b/docs/amazon.aws.ec2_vpc_nat_gateway_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_net_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_net_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_net_module.rst
+++ b/docs/amazon.aws.ec2_vpc_net_module.rst
@@ -5,7 +5,7 @@
 amazon.aws.ec2_vpc_net
 **********************
 
-**Configure AWS virtual private clouds**
+**Configure AWS Virtual Private Clouds**
 
 
 Version added: 1.0.0
@@ -17,7 +17,7 @@ Version added: 1.0.0
 
 Synopsis
 --------
-- Create, modify, and terminate AWS virtual private clouds.
+- Create, modify, and terminate AWS Virtual Private Clouds (VPCs).
 
 
 
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters
@@ -251,7 +251,7 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>By default the module will not create another VPC if there is another VPC with the same name and CIDR block. Specify this as true if you want duplicate VPCs created.</div>
+                        <div>By default the module will not create another VPC if there is another VPC with the same name and CIDR block. Specify <em>multi_ok=true</em> if you want duplicate VPCs created.</div>
                 </td>
             </tr>
             <tr>
@@ -319,14 +319,13 @@ Parameters
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>no</li>
-                                    <li>yes</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
                         </ul>
                 </td>
                 <td>
                         <div>If <em>purge_tags=true</em> and <em>tags</em> is set, existing tags will be purged from the resource to match exactly what is defined by <em>tags</em> parameter.</div>
                         <div>If the <em>tags</em> parameter is not set then tags will not be modified, even if <em>purge_tags=True</em>.</div>
                         <div>Tag keys beginning with <code>aws:</code> are reserved by Amazon and can not be modified.  As such they will be ignored for the purposes of the <em>purge_tags</em> parameter.  See the Amazon documentation for more information <a href='https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions'>https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions</a>.</div>
-                        <div>The current default value of <code>False</code> has been deprecated.  The default value will change to <code>True</code> in release 5.0.0.</div>
                 </td>
             </tr>
             <tr>

--- a/docs/amazon.aws.ec2_vpc_route_table_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_route_table_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_route_table_module.rst
+++ b/docs/amazon.aws.ec2_vpc_route_table_module.rst
@@ -5,7 +5,7 @@
 amazon.aws.ec2_vpc_route_table
 ******************************
 
-**Manage route tables for AWS virtual private clouds**
+**Manage route tables for AWS Virtual Private Clouds**
 
 
 Version added: 1.0.0
@@ -17,7 +17,7 @@ Version added: 1.0.0
 
 Synopsis
 --------
-- Manage route tables for AWS virtual private clouds
+- Manage route tables for AWS Virtual Private Clouds (VPCs).
 
 
 
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters
@@ -249,7 +249,8 @@ Parameters
                         </ul>
                 </td>
                 <td>
-                        <div>Purge existing subnets that are not found in subnets. Ignored unless the subnets option is supplied.</div>
+                        <div>Purge existing subnets that are not found in subnets.</div>
+                        <div>Ignored unless the subnets option is supplied.</div>
                 </td>
             </tr>
             <tr>
@@ -264,14 +265,13 @@ Parameters
                 <td>
                         <ul style="margin: 0; padding: 0"><b>Choices:</b>
                                     <li>no</li>
-                                    <li>yes</li>
+                                    <li><div style="color: blue"><b>yes</b>&nbsp;&larr;</div></li>
                         </ul>
                 </td>
                 <td>
                         <div>If <em>purge_tags=true</em> and <em>tags</em> is set, existing tags will be purged from the resource to match exactly what is defined by <em>tags</em> parameter.</div>
                         <div>If the <em>tags</em> parameter is not set then tags will not be modified, even if <em>purge_tags=True</em>.</div>
                         <div>Tag keys beginning with <code>aws:</code> are reserved by Amazon and can not be modified.  As such they will be ignored for the purposes of the <em>purge_tags</em> parameter.  See the Amazon documentation for more information <a href='https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions'>https://docs.aws.amazon.com/general/latest/gr/aws_tagging.html#tag-conventions</a>.</div>
-                        <div>The current default value of <code>False</code> has been deprecated.  The default value will change to <code>True</code> in release 5.0.0.</div>
                 </td>
             </tr>
             <tr>
@@ -471,7 +471,7 @@ Examples
             gateway_id: "{{ igw.gateway_id }}"
       register: public_route_table
 
-    - name: Create vpc gateway
+    - name: Create VPC gateway
       amazon.aws.ec2_vpc_igw:
         vpc_id: vpc-1245678
       register: vpc_igw

--- a/docs/amazon.aws.ec2_vpc_subnet_info_module.rst
+++ b/docs/amazon.aws.ec2_vpc_subnet_info_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.ec2_vpc_subnet_module.rst
+++ b/docs/amazon.aws.ec2_vpc_subnet_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.elb_classic_lb_module.rst
+++ b/docs/amazon.aws.elb_classic_lb_module.rst
@@ -27,8 +27,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters

--- a/docs/amazon.aws.s3_bucket_module.rst
+++ b/docs/amazon.aws.s3_bucket_module.rst
@@ -26,8 +26,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters
@@ -544,8 +544,6 @@ Parameters
                         <div>S3 URL endpoint for usage with DigitalOcean, Ceph, Eucalyptus and FakeS3 etc.</div>
                         <div>Assumes AWS if not specified.</div>
                         <div>For Walrus, use FQDN of the endpoint without scheme nor path.</div>
-                        <div>The S3_URL alias for this option has been deprecated and will be removed in release 5.0.0.</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: S3_URL</div>
                 </td>
             </tr>
             <tr>

--- a/docs/amazon.aws.s3_bucket_module.rst
+++ b/docs/amazon.aws.s3_bucket_module.rst
@@ -133,6 +133,28 @@ Parameters
             <tr>
                 <td colspan="2">
                     <div class="ansibleOptionAnchor" id="parameter-"></div>
+                    <b>bucket_key_enabled</b>
+                    <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
+                    <div style="font-size: small">
+                        <span style="color: purple">boolean</span>
+                    </div>
+                    <div style="font-style: italic; font-size: small; color: darkgreen">added in 4.1.0</div>
+                </td>
+                <td>
+                        <ul style="margin: 0; padding: 0"><b>Choices:</b>
+                                    <li>no</li>
+                                    <li>yes</li>
+                        </ul>
+                </td>
+                <td>
+                        <div>Enable S3 Bucket Keys for SSE-KMS on new objects.</div>
+                        <div>See the AWS documentation for more information <a href='https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html'>https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucket-key.html</a>.</div>
+                        <div>Bucket Key encryption is only supported if <em>encryption=aws:kms</em>.</div>
+                </td>
+            </tr>
+            <tr>
+                <td colspan="2">
+                    <div class="ansibleOptionAnchor" id="parameter-"></div>
                     <b>ceph</b>
                     <a class="ansibleOptionLink" href="#parameter-" title="Permalink to this option"></a>
                     <div style="font-size: small">
@@ -706,6 +728,12 @@ Examples
         state: present
         encryption: "aws:kms"
         encryption_key_id: "arn:aws:kms:us-east-1:1234/5678example"
+
+    # Create a bucket with aws:kms encryption, Bucket key
+    - amazon.aws.s3_bucket:
+        name: mys3bucket
+        bucket_key_enabled: true
+        encryption: "aws:kms"
 
     # Create a bucket with aws:kms encryption, default key
     - amazon.aws.s3_bucket:

--- a/docs/amazon.aws.s3_object_module.rst
+++ b/docs/amazon.aws.s3_object_module.rst
@@ -28,8 +28,8 @@ Requirements
 The below requirements are needed on the host that executes this module.
 
 - python >= 3.6
-- boto3 >= 1.17.0
-- botocore >= 1.20.0
+- boto3 >= 1.18.0
+- botocore >= 1.21.0
 
 
 Parameters
@@ -669,8 +669,6 @@ Parameters
                 </td>
                 <td>
                         <div>S3 URL endpoint for usage with Ceph, Eucalyptus and fakes3 etc. Otherwise assumes AWS.</div>
-                        <div>The S3_URL alias for this option has been deprecated and will be removed in release 5.0.0.</div>
-                        <div style="font-size: small; color: darkgreen"><br/>aliases: S3_URL</div>
                 </td>
             </tr>
             <tr>


### PR DESCRIPTION
##### SUMMARY

- Refresh RST docs (just takes the opportunity)
- Merge in release notes from 3.4.0
- Merge in release notes from 4.1.0
- Clean up changelog fragments from features/fixes released in 4.1.0

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION

This deliberately leaves the Python 3.6 deprecation changelog fragment in place, for additional visibility once 5.0.0 is released.