### PR TITLE
Bump CloudRetry.backoff deprecation to 6.0.0

### DIFF
--- a/changelogs/fragments/951-cloudretry.yml
+++ b/changelogs/fragments/951-cloudretry.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- module_utils.cloud - removal of the ``CloudRetry.backoff`` has been delayed until release 6.0.0.  It is recommended to update custom modules to use ``jittered_backoff`` or ``exponential_backoff`` instead (https://github.com/ansible-collections/amazon.aws/pull/951).

--- a/plugins/module_utils/cloud.py
+++ b/plugins/module_utils/cloud.py
@@ -32,6 +32,7 @@ __metaclass__ = type
 import time
 import functools
 import random
+import ansible.module_utils.common.warnings as ansible_warnings
 
 
 class BackoffIterator:
@@ -100,7 +101,7 @@ class CloudRetry:
     def found(response_code, catch_extra_error_codes=None):
         def _is_iterable():
             try:
-                it = iter(catch_extra_error_codes)
+                iter(catch_extra_error_codes)
             except TypeError:
                 # not iterable
                 return False
@@ -184,7 +185,7 @@ class CloudRetry:
         """
         Wrap a callable with retry behavior.
         Developers should use CloudRetry.exponential_backoff instead.
-        This method has been deprecated and will be removed in release 4.0.0, consider using exponential_backoff method instead.
+        This method has been deprecated and will be removed in release 6.0.0, consider using exponential_backoff method instead.
         Args:
             retries (int): Number of times to retry a failed request before giving up
                 default=10
@@ -197,6 +198,12 @@ class CloudRetry:
         Returns:
             Callable: A generator that calls the decorated function using an exponential backoff.
         """
+        # This won't emit a warning (we don't have the context available to us), but will trigger
+        # sanity failures as we prepare for 6.0.0
+        ansible_warnings.deprecate(
+            'CloudRetry.backoff has been deprecated, please use CloudRetry.exponential_backoff instead',
+            version='6.0.0', collection_name='amazon.aws')
+
         return cls.exponential_backoff(
             retries=tries,
             delay=delay,

--- a/tests/unit/module_utils/test_cloud.py
+++ b/tests/unit/module_utils/test_cloud.py
@@ -114,6 +114,23 @@ class CloudRetryUtils(unittest.TestCase):
         pass
 
     # ========================================================
+    #   retry original backoff
+    # ========================================================
+    def test_retry_backoff(self):
+
+        @CloudRetryUtils.UnitTestsRetry.backoff(tries=3, delay=1, backoff=1.1, catch_extra_error_codes=CloudRetryUtils.error_codes)
+        def test_retry_func():
+            if test_retry_func.counter < 2:
+                test_retry_func.counter += 1
+                raise self.TestException(status=random.choice(CloudRetryUtils.error_codes))
+            else:
+                return True
+
+        test_retry_func.counter = 0
+        ret = test_retry_func()
+        assert ret is True
+
+    # ========================================================
     #   retry exponential backoff
     # ========================================================
     def test_retry_exponential_backoff(self):
@@ -143,7 +160,9 @@ class CloudRetryUtils(unittest.TestCase):
 
         test_retry_func.counter = 0
         try:
-            ret = test_retry_func()
+            test_retry_func()
+            # We expect the Exception to be thrown...
+            assert False
         except self.TestException as exc:
             assert exc.status == unexpected_except.status
 
@@ -176,7 +195,9 @@ class CloudRetryUtils(unittest.TestCase):
 
         test_retry_func.counter = 0
         try:
-            ret = test_retry_func()
+            test_retry_func()
+            # We expect the Exception to be thrown...
+            assert False
         except self.TestException as exc:
             assert exc.status == unexpected_except.status
 
@@ -210,7 +231,7 @@ class CloudRetryUtils(unittest.TestCase):
 
         # run the method 3 times and assert that each it is retrying after 2secs
         # the elapsed execution time should be closed to 2sec
-        for u in range(3):
+        for _i in range(3):
             start = datetime.now()
             raised = False
             try:

--- a/tests/unit/module_utils/test_cloud.py
+++ b/tests/unit/module_utils/test_cloud.py
@@ -159,12 +159,10 @@ class CloudRetryUtils(unittest.TestCase):
                 raise unexpected_except
 
         test_retry_func.counter = 0
-        try:
+        with self.assertRaises(self.TestException) as exc:
             test_retry_func()
-            # We expect the Exception to be thrown...
-            assert False
-        except self.TestException as exc:
-            assert exc.status == unexpected_except.status
+
+        assert exc.exception.status == unexpected_except.status
 
     # ========================================================
     #   retry jittered backoff
@@ -194,12 +192,10 @@ class CloudRetryUtils(unittest.TestCase):
                 raise unexpected_except
 
         test_retry_func.counter = 0
-        try:
+        with self.assertRaises(self.TestException) as exc:
             test_retry_func()
-            # We expect the Exception to be thrown...
-            assert False
-        except self.TestException as exc:
-            assert exc.status == unexpected_except.status
+
+        assert exc.exception.status == unexpected_except.status
 
     # ========================================================
     #   retry with custom class
@@ -234,14 +230,10 @@ class CloudRetryUtils(unittest.TestCase):
         for _i in range(3):
             start = datetime.now()
             raised = False
-            try:
+            with self.assertRaises(self.TestException):
                 _fail()
-            except self.TestException:
-                raised = True
-                duration = (datetime.now() - start).seconds
-                assert duration == 2
-            finally:
-                assert raised
+            duration = (datetime.now() - start).seconds
+            assert duration == 2
 
     def test_only_base_exception(self):
         def _fail_index():
@@ -274,11 +266,7 @@ class CloudRetryUtils(unittest.TestCase):
 
             start = datetime.now()
             raised = False
-            try:
+            with self.assertRaises(Exception):
                 decorator(function)()
-            except Exception:
-                raised = True
-                _duration = (datetime.now() - start).seconds
-                assert duration == _duration
-            finally:
-                assert raised
+            _duration = (datetime.now() - start).seconds
+            assert duration == _duration


### PR DESCRIPTION
##### SUMMARY

We originally slated CloudRetry.backoff to go away with 4.0.0, bump it out to 6.0.0 since we missed the cut-off (no hurry)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/cloud.py

##### ADDITIONAL INFORMATION
