### PR TITLE
Minor Linting fixups - 2022-08-05

### DIFF
--- a/changelogs/fragments/954-linting.yml
+++ b/changelogs/fragments/954-linting.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- ec2_eni_info - the mutual exclusivity of the ``eni_id`` and ``filters`` parameters is now enforced, previously ``filters`` would be ignored if ``eni_id`` was set (https://github.com/ansible-collections/amazon.aws/pull/954).

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -577,7 +577,7 @@ def check_mode_changeset(module, stack_params, cfn):
 
     try:
         change_set = cfn.create_change_set(aws_retry=True, **stack_params)
-        for i in range(60):  # total time 5 min
+        for _i in range(60):  # total time 5 min
             description = cfn.describe_change_set(aws_retry=True, ChangeSetName=change_set['Id'])
             if description['Status'] in ('CREATE_COMPLETE', 'FAILED'):
                 break

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -13,12 +13,7 @@ module: cloudformation
 version_added: 1.0.0
 short_description: Create or delete an AWS CloudFormation stack
 description:
-     - Launches or updates an AWS CloudFormation stack and waits for it complete.
-notes:
-     - CloudFormation features change often, and this module tries to keep up. That means your botocore version should be fresh.
-       The version listed in the requirements is the oldest version that works with the module as a whole.
-       Some features may require recent versions, and we do not pinpoint a minimum version for each feature.
-       Instead of relying on the minimum version, keep botocore up to date. AWS is always releasing features and fixing bugs.
+  - Launches or updates an AWS CloudFormation stack and waits for it complete.
 options:
   stack_name:
     description:
@@ -118,12 +113,12 @@ options:
     type: str
   role_arn:
     description:
-    - The role that AWS CloudFormation assumes to create the stack. See the AWS CloudFormation Service Role
-      docs U(https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html)
+      - The role that AWS CloudFormation assumes to create the stack. See the AWS CloudFormation Service Role
+        docs U(https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/using-iam-servicerole.html)
     type: str
   termination_protection:
     description:
-    - Enable or disable termination protection on the stack.
+      - Enable or disable termination protection on the stack.
     type: bool
   template_body:
     description:
@@ -135,40 +130,41 @@ options:
     type: str
   events_limit:
     description:
-    - Maximum number of CloudFormation events to fetch from a stack when creating or updating it.
+      - Maximum number of CloudFormation events to fetch from a stack when creating or updating it.
     default: 200
     type: int
   backoff_delay:
     description:
-    - Number of seconds to wait for the next retry.
+      - Number of seconds to wait for the next retry.
     default: 3
     type: int
     required: False
   backoff_max_delay:
     description:
-    - Maximum amount of time to wait between retries.
+      - Maximum amount of time to wait between retries.
     default: 30
     type: int
     required: False
   backoff_retries:
     description:
-    - Number of times to retry operation.
-    - AWS API throttling mechanism fails CloudFormation module so we have to retry a couple of times.
+      - Number of times to retry operation.
+      - AWS API throttling mechanism fails CloudFormation module so we have to retry a couple of times.
     default: 10
     type: int
     required: False
   capabilities:
     description:
-    - Specify capabilities that stack template contains.
-    - Valid values are C(CAPABILITY_IAM), C(CAPABILITY_NAMED_IAM) and C(CAPABILITY_AUTO_EXPAND).
+      - Specify capabilities that stack template contains.
+      - Valid values are C(CAPABILITY_IAM), C(CAPABILITY_NAMED_IAM) and C(CAPABILITY_AUTO_EXPAND).
     type: list
     elements: str
     default: [ CAPABILITY_IAM, CAPABILITY_NAMED_IAM ]
 
-author: "James S. Martin (@jsmartin)"
+author:
+  - "James S. Martin (@jsmartin)"
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
+  - amazon.aws.aws
+  - amazon.aws.ec2
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -12,22 +12,21 @@ module: ec2_eni
 version_added: 1.0.0
 short_description: Create and optionally attach an Elastic Network Interface (ENI) to an instance
 description:
-    - Create and optionally attach an Elastic Network Interface (ENI) to an instance. If an ENI ID or private_ip is
-      provided, the existing ENI (if any) will be modified. The 'attached' parameter controls the attachment status
-      of the network interface.
+  - Create and optionally attach an Elastic Network Interface (ENI) to an instance.
+  - If I(eni_id) or I(private_ip) is provided, the existing ENI (if any) will be modified.
+  - The I(attached) parameter controls the attachment status of the network interface.
 author:
-    - "Rob White (@wimnat)"
-    - "Mike Healey (@healem)"
+  - "Rob White (@wimnat)"
+  - "Mike Healey (@healem)"
 options:
   eni_id:
     description:
       - The ID of the ENI (to modify).
-      - If I(eni_id=None) and I(state=present), a new eni will be created.
+      - If I(eni_id=None) and I(state=present), a new ENI will be created.
     type: str
   instance_id:
     description:
       - Instance ID that you wish to attach ENI to.
-      - Since version 2.2, use the I(attached) parameter to attach or detach an ENI. Prior to 2.2, to detach an ENI from an instance, use C(None).
     type: str
   private_ip_address:
     description:
@@ -43,8 +42,8 @@ options:
     type: str
   security_groups:
     description:
-      - List of security groups associated with the interface. Only used when I(state=present).
-      - Since version 2.2, you can specify security groups by ID or by name or a combination of both. Prior to 2.2, you can specify only by ID.
+      - List of security groups associated with the interface.
+      - Ignored when I(state=absent).
     type: list
     elements: str
   state:
@@ -84,7 +83,7 @@ options:
   secondary_private_ip_addresses:
     description:
       - A list of IP addresses to assign as secondary IP addresses to the network interface.
-        This option is mutually exclusive of I(secondary_private_ip_address_count)
+      - This option is mutually exclusive of I(secondary_private_ip_address_count).
     required: false
     type: list
     elements: str
@@ -96,7 +95,8 @@ options:
     type: bool
   secondary_private_ip_address_count:
     description:
-      - The number of secondary IP addresses to assign to the network interface. This option is mutually exclusive of I(secondary_private_ip_addresses)
+      - The number of secondary IP addresses to assign to the network interface.
+      - This option is mutually exclusive of I(secondary_private_ip_addresses).
     required: false
     type: int
   allow_reassignment:
@@ -115,14 +115,13 @@ options:
     required: false
     type: str
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.tags
-
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.tags
 notes:
-    - This module identifies and ENI based on either the I(eni_id), a combination of I(private_ip_address) and I(subnet_id),
-      or a combination of I(instance_id) and I(device_id). Any of these options will let you specify a particular ENI.
-    - Support for I(tags) and I(purge_tags) was added in release 1.3.0.
+  - This module identifies and ENI based on either the I(eni_id), a combination of I(private_ip_address) and I(subnet_id),
+    or a combination of I(instance_id) and I(device_id). Any of these options will let you specify a particular ENI.
+  - Support for I(tags) and I(purge_tags) was added in release 1.3.0.
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -341,7 +341,6 @@ def get_eni_info(interface):
 
 
 def correct_ips(connection, ip_list, module, eni_id):
-    all_there = True
     eni = describe_eni(connection, module, eni_id)
     private_addresses = set()
     if "PrivateIpAddresses" in eni:
@@ -354,7 +353,6 @@ def correct_ips(connection, ip_list, module, eni_id):
 
 
 def absent_ips(connection, ip_list, module, eni_id):
-    all_there = True
     eni = describe_eni(connection, module, eni_id)
     private_addresses = set()
     if "PrivateIpAddresses" in eni:
@@ -498,7 +496,6 @@ def modify_eni(connection, module, eni):
     device_index = module.params.get("device_index")
     description = module.params.get('description')
     security_groups = module.params.get('security_groups')
-    force_detach = module.params.get("force_detach")
     source_dest_check = module.params.get("source_dest_check")
     delete_on_termination = module.params.get("delete_on_termination")
     secondary_private_ip_addresses = module.params.get("secondary_private_ip_addresses")
@@ -696,7 +693,6 @@ def detach_eni(connection, eni, module):
     if module.check_mode:
         module.exit_json(changed=True, msg="Would have detached ENI if not in check mode.")
 
-    attached = module.params.get("attached")
     eni_id = eni["NetworkInterfaceId"]
 
     force_detach = module.params.get("force_detach")

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -283,7 +283,11 @@ def main():
         ['eni_id', 'filters']
     ]
 
-    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+        mutually_exclusive=mutually_exclusive,
+    )
 
     connection = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -10,10 +10,11 @@ DOCUMENTATION = '''
 ---
 module: ec2_eni_info
 version_added: 1.0.0
-short_description: Gather information about ec2 ENI interfaces in AWS
+short_description: Gather information about EC2 ENI interfaces in AWS
 description:
-    - Gather information about ec2 ENI interfaces in AWS.
-author: "Rob White (@wimnat)"
+  - Gather information about EC2 ENI interfaces in AWS.
+author:
+  - "Rob White (@wimnat)"
 options:
   eni_id:
     description:
@@ -28,9 +29,8 @@ options:
       - This option is mutually exclusive of I(eni_id).
     type: dict
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-
+  - amazon.aws.aws
+  - amazon.aws.ec2
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1044,7 +1044,7 @@ def add_or_update_instance_profile(instance, desired_profile_name):
             # check for InvalidAssociationID.NotFound
             module.fail_json_aws(e, "Could not find instance profile association")
         try:
-            resp = client.replace_iam_instance_profile_association(
+            client.replace_iam_instance_profile_association(
                 aws_retry=True,
                 AssociationId=association['IamInstanceProfileAssociations'][0]['AssociationId'],
                 IamInstanceProfile={'Arn': determine_iam_role(desired_profile_name)}
@@ -1056,7 +1056,7 @@ def add_or_update_instance_profile(instance, desired_profile_name):
     if not instance_profile_setting and desired_profile_name:
         # create association
         try:
-            resp = client.associate_iam_instance_profile(
+            client.associate_iam_instance_profile(
                 aws_retry=True,
                 IamInstanceProfile={'Arn': determine_iam_role(desired_profile_name)},
                 InstanceId=instance['InstanceId']
@@ -1510,7 +1510,6 @@ def change_network_attachments(instance, params):
 
 
 def find_instances(ids=None, filters=None):
-    paginator = client.get_paginator('describe_instances')
     sanitized_filters = dict()
 
     if ids:
@@ -1858,7 +1857,7 @@ def enforce_count(existing_matches, module, desired_module_state):
                 module.exit_json(changed=True, msg='Would have terminated following instances if not in check mode {0}'.format(terminate_ids))
             # terminate instances
             try:
-                result = client.terminate_instances(aws_retry=True, InstanceIds=terminate_ids)
+                client.terminate_instances(aws_retry=True, InstanceIds=terminate_ids)
                 await_instances(terminate_ids, desired_module_state='terminated', force_wait=True)
             except is_boto3_error_code('InvalidInstanceID.NotFound'):
                 pass

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -16,7 +16,7 @@ author:
   - "Razique Mahroua (@Razique)"
 short_description: Maintain an EC2 security group
 description:
-    - Maintains EC2 security groups.
+  - Maintains EC2 security groups.
 options:
   name:
     description:
@@ -46,9 +46,6 @@ options:
       - List of firewall inbound rules to enforce in this group (see example). If none are supplied,
         no inbound rules will be enabled. Rules list may include its own name in I(group_name).
         This allows idempotent loopback additions (e.g. allow group to access itself).
-        Rule sources list support was added in version 2.4. This allows to define multiple sources per
-        source type as well as multiple source types per rule. Prior to 2.4 an individual source is allowed.
-        In version 2.5 support for rule descriptions was added.
     required: false
     type: list
     elements: dict
@@ -132,8 +129,6 @@ options:
     description:
       - List of firewall outbound rules to enforce in this group (see example). If none are supplied,
         a default all-out rule is assumed. If an empty list is supplied, no outbound rules will be enabled.
-        Rule Egress sources list support was added in version 2.4. In version 2.5 support for rule descriptions
-        was added.
     required: false
     type: list
     elements: dict
@@ -237,9 +232,9 @@ options:
     type: bool
 
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.tags
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.tags
 
 
 notes:

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -1055,7 +1055,7 @@ def wait_for_rule_propagation(module, client, group, desired_ingress, desired_eg
     tries = 6
 
     def await_rules(group, desired_rules, purge, rule_key):
-        for i in range(tries):
+        for _i in range(tries):
             current_rules = set(sum([list(rule_from_group_permission(p)) for p in group[rule_key]], []))
             if purge and len(current_rules ^ set(desired_rules)) == 0:
                 return group
@@ -1353,8 +1353,8 @@ def main():
         current_ingress = sum([list(rule_from_group_permission(p)) for p in group['IpPermissions']], [])
         current_egress = sum([list(rule_from_group_permission(p)) for p in group['IpPermissionsEgress']], [])
 
-        for new_rules, rule_type, named_tuple_rule_list in [(rules, 'in', named_tuple_ingress_list),
-                                                            (rules_egress, 'out', named_tuple_egress_list)]:
+        for new_rules, _rule_type, named_tuple_rule_list in [(rules, 'in', named_tuple_ingress_list),
+                                                             (rules_egress, 'out', named_tuple_egress_list)]:
             if new_rules is None:
                 continue
             for rule in new_rules:
@@ -1438,7 +1438,6 @@ def main():
 
         # Revoke old rules
         changed |= remove_old_permissions(client, module, revoke_ingress, revoke_egress, group['GroupId'])
-        rule_msg = 'Revoking {0}, and egress {1}'.format(revoke_ingress, revoke_egress)
 
         new_ingress_permissions = [to_permission(r) for r in (set(named_tuple_ingress_list) - set(current_ingress))]
         new_ingress_permissions = rules_to_permissions(set(named_tuple_ingress_list) - set(current_ingress))

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -606,8 +606,6 @@ def modify_dot_attribute(module, ec2_conn, instance_dict, device_name):
 
 
 def get_attachment_data(volume_dict, wanted_state=None):
-    changed = False
-
     attachment_data = []
     if not volume_dict:
         return attachment_data

--- a/plugins/modules/ec2_vol_info.py
+++ b/plugins/modules/ec2_vol_info.py
@@ -10,9 +10,9 @@ DOCUMENTATION = '''
 ---
 module: ec2_vol_info
 version_added: 1.0.0
-short_description: Gather information about ec2 volumes in AWS
+short_description: Gather information about EC2 volumes in AWS
 description:
-    - Gather information about ec2 volumes in AWS.
+  - Gather information about EC2 volumes in AWS.
 author: "Rob White (@wimnat)"
 options:
   filters:
@@ -21,9 +21,8 @@ options:
       - A dict of filters to apply. Each dict item consists of a filter key and a filter value.
       - See U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVolumes.html) for possible filters.
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-
+  - amazon.aws.aws
+  - amazon.aws.ec2
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/ec2_vol_info.py
+++ b/plugins/modules/ec2_vol_info.py
@@ -141,8 +141,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_li
 
 def get_volume_info(volume, region):
 
-    attachment = volume["attachments"]
-
     attachment_data = []
     for data in volume["attachments"]:
         attachment_data.append({

--- a/plugins/modules/ec2_vpc_dhcp_option.py
+++ b/plugins/modules/ec2_vpc_dhcp_option.py
@@ -14,27 +14,26 @@ short_description: Manages DHCP Options, and can ensure the DHCP options for the
   requested
 description:
   - This module removes, or creates DHCP option sets, and can associate them to a VPC.
-    Optionally, a new DHCP Options set can be created that converges a VPC's existing
+  - Optionally, a new DHCP Options set can be created that converges a VPC's existing
     DHCP option set with values provided.
-    When dhcp_options_id is provided, the module will
+  - When dhcp_options_id is provided, the module will
     1. remove (with state='absent')
     2. ensure tags are applied (if state='present' and tags are provided
     3. attach it to a VPC (if state='present' and a vpc_id is provided.
-    If any of the optional values are missing, they will either be treated
+  - If any of the optional values are missing, they will either be treated
     as a no-op (i.e., inherit what already exists for the VPC)
-    To remove existing options while inheriting, supply an empty value
+  - To remove existing options while inheriting, supply an empty value
     (e.g. set ntp_servers to [] if you want to remove them from the VPC's options)
-    Most of the options should be self-explanatory.
-author: "Joel Thompson (@joelthompson)"
+author:
+  - "Joel Thompson (@joelthompson)"
 options:
   domain_name:
     description:
-      - The domain name to set in the DHCP option sets
+      - The domain name to set in the DHCP option sets.
     type: str
   dns_servers:
     description:
-      - A list of hosts to set the DNS servers for the VPC to. (Should be a
-        list of IP addresses rather than host names.)
+      - A list of IP addresses to set the DNS servers for the VPC to.
     type: list
     elements: str
   ntp_servers:
@@ -56,13 +55,13 @@ options:
   vpc_id:
     description:
       - VPC ID to associate with the requested DHCP option set.
-        If no vpc id is provided, and no matching option set is found then a new
+      - If no VPC ID is provided, and no matching option set is found then a new
         DHCP option set is created.
     type: str
   delete_old:
     description:
       - Whether to delete the old VPC DHCP option set when associating a new one.
-        This is primarily useful for debugging/development purposes when you
+      - This is primarily useful for debugging/development purposes when you
         want to quickly roll back to the old option set. Note that this setting
         will be ignored, and the old DHCP option set will be preserved, if it
         is in use by any other VPC. (Otherwise, AWS will return an error.)
@@ -71,16 +70,10 @@ options:
   inherit_existing:
     description:
       - For any DHCP options not specified in these parameters, whether to
-        inherit them from the options set already applied to vpc_id, or to
+        inherit them from the options set already applied to I(vpc_id), or to
         reset them to be empty.
     type: bool
-    default: 'no'
-  tags:
-    description:
-      - Tags to be applied to a VPC options set if a new one is created, or
-        if I(dhcp_options_id) is provided. (options must match)
-    aliases: [ 'resource_tags']
-    type: dict
+    default: false
   dhcp_options_id:
     description:
       - The resource_id of an existing DHCP options set.
@@ -96,11 +89,11 @@ options:
     choices: [ 'absent', 'present' ]
     type: str
 notes:
-- Support for I(purge_tags) was added in release 2.0.0.
+  - Support for I(purge_tags) was added in release 2.0.0.
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.tags
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.tags
 '''
 
 RETURN = """

--- a/plugins/modules/ec2_vpc_dhcp_option.py
+++ b/plugins/modules/ec2_vpc_dhcp_option.py
@@ -512,7 +512,7 @@ def main():
         try:
             # Preserve the boto2 module's behaviour of checking if the option set exists first,
             # and return the same error message if it does not
-            dhcp_options = client.describe_dhcp_options(aws_retry=True, DhcpOptionsIds=[dhcp_options_id])
+            client.describe_dhcp_options(aws_retry=True, DhcpOptionsIds=[dhcp_options_id])
             # If that didn't fail, then we know the option ID exists
             found = True
         except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:

--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -213,7 +213,6 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils._text import to_native
 from ansible.module_utils.common.network import to_subnet
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 

--- a/plugins/modules/ec2_vpc_subnet.py
+++ b/plugins/modules/ec2_vpc_subnet.py
@@ -265,7 +265,6 @@ def handle_waiter(conn, module, waiter_name, params, start_time):
 
 def create_subnet(conn, module, vpc_id, cidr, ipv6_cidr=None, outpost_arn=None, az=None, start_time=None):
     wait = module.params['wait']
-    wait_timeout = module.params['wait_timeout']
 
     params = dict(VpcId=vpc_id,
                   CidrBlock=cidr)
@@ -476,7 +475,7 @@ def ensure_subnet_present(conn, module):
 
 
 def ensure_final_subnet(conn, module, subnet, start_time):
-    for rewait in range(0, 30):
+    for _rewait in range(0, 30):
         map_public_correct = False
         assign_ipv6_correct = False
 

--- a/plugins/modules/ec2_vpc_subnet.py
+++ b/plugins/modules/ec2_vpc_subnet.py
@@ -12,66 +12,70 @@ module: ec2_vpc_subnet
 version_added: 1.0.0
 short_description: Manage subnets in AWS virtual private clouds
 description:
-    - Manage subnets in AWS virtual private clouds.
+  - Manage subnets in AWS virtual private clouds.
 author:
-- Robert Estelle (@erydo)
-- Brad Davidson (@brandond)
+  - Robert Estelle (@erydo)
+  - Brad Davidson (@brandond)
 options:
   az:
     description:
-      - "The availability zone for the subnet."
+      - The availability zone for the subnet.
+      - Required if I(outpost_arn) is set.
     type: str
   cidr:
     description:
-      - "The CIDR block for the subnet. E.g. 192.0.2.0/24."
+      - The CIDR block for the subnet. E.g. C(192.0.2.0/24).
     type: str
     required: true
   ipv6_cidr:
     description:
-      - "The IPv6 CIDR block for the subnet. The VPC must have a /56 block assigned and this value must be a valid IPv6 /64 that falls in the VPC range."
-      - "Required if I(assign_instances_ipv6=true)"
+      - The IPv6 CIDR block for the subnet.
+      - The VPC must have a /56 block assigned and this value must be a valid IPv6 /64 that falls in the VPC range.
+      - Required if I(assign_instances_ipv6=true)
     type: str
   outpost_arn:
     description:
       - The Amazon Resource Name (ARN) of the Outpost.
       - If set, allows to create subnet in an Outpost.
-      - To specify outpost_arn, availability zone of Outpost subnet must be specified.
+      - If I(outpost_arn) is set, I(az) must also be specified.
     type: str
   state:
     description:
-      - "Create or remove the subnet."
+      - Create or remove the subnet.
     default: present
     choices: [ 'present', 'absent' ]
     type: str
   vpc_id:
     description:
-      - "VPC ID of the VPC in which to create or delete the subnet."
+      -"VPC ID of the VPC in which to create or delete the subnet.
     required: true
     type: str
   map_public:
     description:
-      - "Specify C(yes) to indicate that instances launched into the subnet should be assigned public IP address by default."
+      - Whether instances launched into the subnet should default to being assigned public IP address.
     type: bool
-    default: 'no'
+    default: false
   assign_instances_ipv6:
     description:
-      - "Specify C(yes) to indicate that instances launched into the subnet should be automatically assigned an IPv6 address."
+      - Whether instances launched into the subnet should default to being automatically assigned an IPv6 address.
+      - If I(assign_instances_ipv6=true), I(ipv6_cidr) must also be specified.
     type: bool
     default: false
   wait:
     description:
-      - "When I(wait=true) and I(state=present), module will wait for subnet to be in available state before continuing."
+      - Whether to wait for changes to complete.
     type: bool
     default: true
   wait_timeout:
     description:
-      - "Number of seconds to wait for subnet to become available I(wait=True)."
+      - Number of seconds to wait for changes to complete
+      - Ignored unless I(wait=True).
     default: 300
     type: int
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.tags
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.tags
 '''
 
 EXAMPLES = '''

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -277,14 +277,14 @@ options:
     default: 180
 
 notes:
-- The ec2_elb fact previously set by this module was deprecated in release 2.1.0 and since release
-  4.0.0 is no longer set.
-- Support for I(purge_tags) was added in release 2.1.0.
+  - The ec2_elb fact previously set by this module was deprecated in release 2.1.0 and since release
+    4.0.0 is no longer set.
+  - Support for I(purge_tags) was added in release 2.1.0.
 
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.tags
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.tags
 '''
 
 EXAMPLES = """

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -972,11 +972,11 @@ class ElbManager(object):
         if not wait and not self.wait:
             return
         try:
-            elb_removed = self._wait_for_elb_removed()
+            self._wait_for_elb_removed()
             # Unfortunately even though the ELB itself is removed quickly
             # the interfaces take longer so reliant security groups cannot
             # be deleted until the interface has registered as removed.
-            elb_interface_removed = self._wait_for_elb_interface_removed()
+            self._wait_for_elb_interface_removed()
         except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
             self.module.fail_json_aws(e, msg="Failed while waiting for load balancer deletion")
 
@@ -1719,7 +1719,6 @@ class ElbManager(object):
         if not self.listeners:
             return False
 
-        ensure_proxy_protocol = False
         backend_policies = self._get_backend_policies()
         proxy_policies = set(self._get_proxy_policies())
 

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -766,7 +766,6 @@ def put_bucket_key_with_retry(module, s3_client, name, expected_encryption):
             put_bucket_key(s3_client, name, expected_encryption)
         except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Failed to set bucket Key")
-        result = s3_client.get_bucket_encryption(Bucket=name)
         current_encryption = wait_bucket_key_is_applied(module, s3_client, name, expected_encryption,
                                                         should_fail=(retries == max_retries), retries=5)
         if current_encryption == expected_encryption:
@@ -1117,7 +1116,7 @@ def main():
         argument_spec=argument_spec, required_by=required_by, mutually_exclusive=mutually_exclusive
     )
 
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+    region, _ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
 
     if module.params.get('validate_bucket_name'):
         validate_bucket_name(module, module.params["name"])
@@ -1153,9 +1152,6 @@ def main():
     state = module.params.get("state")
     encryption = module.params.get("encryption")
     encryption_key_id = module.params.get("encryption_key_id")
-    bucket_key_enabled = module.params.get("bucket_key_enabled")
-    delete_object_ownership = module.params.get('delete_object_ownership')
-    object_ownership = module.params.get('object_ownership')
 
     # Parameter validation
     if encryption_key_id is not None and encryption != 'aws:kms':

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -23,10 +23,10 @@ module: s3_bucket
 version_added: 1.0.0
 short_description: Manage S3 buckets in AWS, DigitalOcean, Ceph, Walrus, FakeS3 and StorageGRID
 description:
-    - Manage S3 buckets in AWS, DigitalOcean, Ceph, Walrus, FakeS3 and StorageGRID.
+  - Manage S3 buckets in AWS, DigitalOcean, Ceph, Walrus, FakeS3 and StorageGRID.
 author:
-    - Rob White (@wimnat)
-    - Aubin Bikouo (@abikouo)
+  - Rob White (@wimnat)
+  - Aubin Bikouo (@abikouo)
 options:
   force:
     description:
@@ -161,15 +161,15 @@ options:
     default: True
 
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.tags
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.tags
 
 notes:
-    - If C(requestPayment), C(policy), C(tagging) or C(versioning)
-      operations/API aren't implemented by the endpoint, module doesn't fail
-      if each parameter satisfies the following condition.
-      I(requester_pays) is C(False), I(policy), I(tags), and I(versioning) are C(None).
+  - If C(requestPayment), C(policy), C(tagging) or C(versioning)
+    operations/API aren't implemented by the endpoint, module doesn't fail
+    if each parameter satisfies the following condition.
+    I(requester_pays) is C(False), I(policy), I(tags), and I(versioning) are C(None).
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -598,7 +598,7 @@ def create_dirkey(module, s3, bucket, obj, encrypt, expiry):
         module.fail_json_aws(e, msg="Failed while creating object %s." % obj)
 
     # Tags
-    tags, changed = ensure_tags(s3, module, bucket, obj)
+    tags, _changed = ensure_tags(s3, module, bucket, obj)
 
     try:
         url = s3.generate_presigned_url(ClientMethod='put_object',
@@ -687,7 +687,7 @@ def upload_s3file(module, s3, bucket, obj, expiry, metadata, encrypt, headers, s
             module.fail_json_aws(e, msg="Unable to set object ACL")
 
     # Tags
-    tags, changed = ensure_tags(s3, module, bucket, obj)
+    tags, _changed = ensure_tags(s3, module, bucket, obj)
 
     url = put_download_url(module, s3, bucket, obj, expiry)
 
@@ -700,10 +700,14 @@ def download_s3file(module, s3, bucket, obj, dest, retries, version=None):
     # retries is the number of loops; range/xrange needs to be one
     # more to get that count of loops.
     try:
+        # Note: Something of a permissions related hack
+        # get_object returns the HEAD information, plus a *stream* which can be read.
+        # because the stream's dropped on the floor, we never pull the data and this is the
+        # functional equivalent of calling get_head which still relying on the 'GET' permission
         if version:
-            key = s3.get_object(Bucket=bucket, Key=obj, VersionId=version)
+            s3.get_object(Bucket=bucket, Key=obj, VersionId=version)
         else:
-            key = s3.get_object(Bucket=bucket, Key=obj)
+            s3.get_object(Bucket=bucket, Key=obj)
     except is_boto3_error_code(['404', '403']) as e:
         # AccessDenied errors may be triggered if 1) file does not exist or 2) file exists but
         # user does not have the s3:GetObject permission. 404 errors are handled by download_file().
@@ -806,7 +810,7 @@ def copy_object_to_bucket(module, s3, bucket, obj, encrypt, metadata, validate, 
                         params[extra_args_option] = metadata[option]
                     else:
                         params['Metadata'][option] = metadata[option]
-            copy_result = s3.copy_object(**params)
+            s3.copy_object(**params)
             for acl in module.params.get('permission'):
                 s3.put_object_acl(ACL=acl, Bucket=bucket, Key=obj)
             # Tags
@@ -1016,7 +1020,7 @@ def main():
     if overwrite == 'different' and not HAS_MD5:
         module.fail_json(msg='overwrite=different is unavailable: ETag calculation requires MD5 support')
 
-    region, ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
+    region, _ec2_url, aws_connect_kwargs = get_aws_connection_info(module, boto3=True)
 
     if region in ('us-east-1', '', None):
         # default to US Standard region
@@ -1066,7 +1070,7 @@ def main():
             if object_ownership == 'BucketOwnerEnforced':
                 acl_disabled = True
         # if bucket ownership controls are not found
-        except botocore.exceptions.ClientError as e:
+        except botocore.exceptions.ClientError:
             pass
 
     # separate types of ACLs
@@ -1201,7 +1205,7 @@ def main():
             else:
                 # only use valid bucket acls for the create_bucket function
                 module.params['permission'] = bucket_acl
-                created = create_bucket(module, s3, bucket, location)
+                create_bucket(module, s3, bucket, location)
                 # only use valid object acls for the create_dirkey function
                 module.params['permission'] = object_acl
                 create_dirkey(module, s3, bucket, dirobj, encrypt, expiry)

--- a/tests/integration/targets/elb_classic_lb/tasks/https_listeners.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/https_listeners.yml
@@ -127,3 +127,6 @@
     that:
       - delete_result is changed
       - delete_result is not failed
+  # AWS doesn't always cleanup the associations properly
+  # https://repost.aws/questions/QU63csgGNEQl2M--xCdy-oxw/cant-delete-certificate-because-there-are-dangling-load-balancer-resources
+  ignore_errors: True


### PR DESCRIPTION
##### SUMMARY

Minor linting fixups

- docs linting and cleanup
- unused variables
- unused import
- "mutually_exclusive" which was accidentally dropped on the floor.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/cloudformation.py
plugins/modules/ec2_eni.py
plugins/modules/ec2_eni_info.py
plugins/modules/ec2_instance.py
plugins/modules/ec2_security_group.py
plugins/modules/ec2_vol.py
plugins/modules/ec2_vol_info.py
plugins/modules/ec2_vpc_dhcp_option.py
plugins/modules/ec2_vpc_net.py
plugins/modules/ec2_vpc_subnet.py
plugins/modules/elb_classic_lb.py
plugins/modules/s3_bucket.py
plugins/modules/s3_object.py

##### ADDITIONAL INFORMATION

Removes some documentation references to old "versions", these were Ansible versions which are long out of support.

CloudFormations module previously talked about keeping boto3 and botocore up to date.  Now that we have an official policy around supported versions this is no longer as relevant and the module itself is no longer changing as fast.