### PR TITLE
ec2_vol - integration test stability

### DIFF
--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -606,8 +606,6 @@ def modify_dot_attribute(module, ec2_conn, instance_dict, device_name):
 
 
 def get_attachment_data(volume_dict, wanted_state=None):
-    changed = False
-
     attachment_data = []
     if not volume_dict:
         return attachment_data

--- a/plugins/modules/ec2_vol_info.py
+++ b/plugins/modules/ec2_vol_info.py
@@ -10,9 +10,9 @@ DOCUMENTATION = '''
 ---
 module: ec2_vol_info
 version_added: 1.0.0
-short_description: Gather information about ec2 volumes in AWS
+short_description: Gather information about EC2 volumes in AWS
 description:
-    - Gather information about ec2 volumes in AWS.
+  - Gather information about EC2 volumes in AWS.
 author: "Rob White (@wimnat)"
 options:
   filters:
@@ -21,9 +21,8 @@ options:
       - A dict of filters to apply. Each dict item consists of a filter key and a filter value.
       - See U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeVolumes.html) for possible filters.
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-
+  - amazon.aws.aws
+  - amazon.aws.ec2
 '''
 
 EXAMPLES = '''
@@ -140,8 +139,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_li
 
 
 def get_volume_info(volume, region):
-
-    attachment = volume["attachments"]
 
     attachment_data = []
     for data in volume["attachments"]:

--- a/tests/integration/targets/ec2_vol/tasks/main.yml
+++ b/tests/integration/targets/ec2_vol/tasks/main.yml
@@ -229,10 +229,25 @@
           - vol_attach_result.changed
           - "'device' in vol_attach_result and vol_attach_result.device == '/dev/sdg'"
           - "'volume' in vol_attach_result"
-          - vol_attach_result.volume.attachment_set[0].status in ['attached', 'attaching']
-          - vol_attach_result.volume.attachment_set[0].instance_id == test_instance.instance_ids[0]
-          - vol_attach_result.volume.attachment_set[0].device == '/dev/sdg'
-          - not vol_attach_result.volume.attachment_set[0].delete_on_termination
+
+    # There's a delay between the volume being "In Use", and the attachment being reported.  This
+    # can result in a race condition on the results.  (There's no clean waiter to use either)
+    - name: wait for volume to report attached/attaching
+      ec2_vol_info:
+        filters:
+          volume-id: '{{ volume1.volume_id }}'
+      register: vol_attach_info
+      until:
+        - vol_attach_info.volumes[0].attachment_set | length >=1
+      retries: 5
+      delay: 2
+
+    - assert:
+        that:
+          - vol_attach_info.volumes[0].attachment_set[0].status in ['attached', 'attaching']
+          - vol_attach_info.volumes[0].attachment_set[0].instance_id == test_instance.instance_ids[0]
+          - vol_attach_info.volumes[0].attachment_set[0].device == '/dev/sdg'
+          - not vol_attach_info.volumes[0].attachment_set[0].delete_on_termination
 
     - name: attach existing volume to an instance (idempotent - check_mode)
       ec2_vol:


### PR DESCRIPTION
##### SUMMARY

The ec2_vol integration test for attaching a volume will sometimes return in the brief window between the volume being "InUse" and the attachment information being reported on the volume.  Since there's no clean waiter we can use, attempt to make the integration test a little less fragile by allowing for retries.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vol

##### ADDITIONAL INFORMATION
