### PR TITLE
fix ignore_nonexistent_bucket bug for listing (#966)

### DIFF
--- a/changelogs/fragments/966-ignore_nonexistent_bucket_list.yml
+++ b/changelogs/fragments/966-ignore_nonexistent_bucket_list.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- s3_object - fix ignore_nonexistent_bucket is not used when listing a bucket (https://github.com/ansible-collections/amazon.aws/issues/966).

--- a/changelogs/fragments/966-ignore_nonexistent_bucket_list.yml
+++ b/changelogs/fragments/966-ignore_nonexistent_bucket_list.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- s3_object - fix ignore_nonexistent_bucket is not used when listing a bucket (https://github.com/ansible-collections/amazon.aws/issues/966).
+- s3_object - also use ``ignore_nonexistent_bucket`` when listing a bucket (https://github.com/ansible-collections/amazon.aws/issues/966).

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -1168,10 +1168,9 @@ def main():
 
     # Support for listing a set of keys
     if mode == 'list':
-        exists = bucket_check(module, s3, bucket)
 
         # If the bucket does not exist then bail out
-        if not exists:
+        if not bucketrtn:
             module.fail_json(msg="Target bucket (%s) cannot be found" % bucket)
 
         list_keys(module, s3, bucket, prefix, marker, max_keys)


### PR DESCRIPTION
##### SUMMARY
remove duplicated use of bucket_check() and reuse bucketrtn instead 
Fixes #966 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
s3_object

##### ADDITIONAL INFORMATION


