### PR TITLE
ec2_security_group: Set rules->group_name's datatype as raw

### DIFF
--- a/changelogs/fragments/638-ec2_security_group_group_name_datatype.yml
+++ b/changelogs/fragments/638-ec2_security_group_group_name_datatype.yml
@@ -1,0 +1,2 @@
+trivial:
+- set type as raw for rules->group_name as it can accept both str and list.

--- a/changelogs/fragments/638-ec2_security_group_group_name_datatype.yml
+++ b/changelogs/fragments/638-ec2_security_group_group_name_datatype.yml
@@ -1,2 +1,2 @@
 minor_changes:
-- ec2_security_group - set type as ``raw`` for rules->group_name as it can accept both ``str`` and ``list`` (https://github.com/ansible-collections/amazon.aws/pull/971).
+- ec2_security_group - set type as ``list`` for rules->group_name as it can accept both ``str`` and ``list`` (https://github.com/ansible-collections/amazon.aws/pull/971).

--- a/changelogs/fragments/638-ec2_security_group_group_name_datatype.yml
+++ b/changelogs/fragments/638-ec2_security_group_group_name_datatype.yml
@@ -1,2 +1,2 @@
-trivial:
-- set type as raw for rules->group_name as it can accept both str and list.
+minor_changes:
+- ec2_security_group - set type as ``raw`` for rules->group_name as it can accept both ``str`` and ``list`` (https://github.com/ansible-collections/amazon.aws/pull/971).

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -77,7 +77,7 @@ options:
               and I(group_name).
         group_name:
             type: list
-	    elements: str
+            elements: str
             description:
             - Name of the Security Group that traffic is coming from.
             - If the Security Group doesn't exist a new Security Group will be

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -76,11 +76,12 @@ options:
             - You can specify only one of I(cidr_ip), I(cidr_ipv6), I(ip_prefix), I(group_id)
               and I(group_name).
         group_name:
-            type: str
+            type: raw
             description:
             - Name of the Security Group that traffic is coming from.
             - If the Security Group doesn't exist a new Security Group will be
               created with I(group_desc) as the description.
+            - I(group_name) can accept values of type str and list.
             - You can specify only one of I(cidr_ip), I(cidr_ipv6), I(ip_prefix), I(group_id)
               and I(group_name).
         group_desc:

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -76,7 +76,8 @@ options:
             - You can specify only one of I(cidr_ip), I(cidr_ipv6), I(ip_prefix), I(group_id)
               and I(group_name).
         group_name:
-            type: raw
+            type: list
+	    elements: str
             description:
             - Name of the Security Group that traffic is coming from.
             - If the Security Group doesn't exist a new Security Group will be


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
rules-> group_name can accept values of type list and str. 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_security_group.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
