### PR TITLE
tests: use Fedora image from the Fedora org

### DIFF
--- a/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/find_ami.yml
+++ b/tests/integration/targets/ec2_instance/roles/ec2_instance/tasks/find_ami.yml
@@ -3,7 +3,7 @@
   - name: "Find AMI to use"
     run_once: yes
     ec2_ami_info:
-      owners: 'amazon'
+      owners: 125523088429  # Fedora org
       filters:
         name: '{{ ec2_ami_name }}'
     register: ec2_amis


### PR DESCRIPTION
We recently face cases where the search with owner==`amazon` was returning
nothing.

See: https://github.com/ansible-collections/community.aws/pull/1429