### PR TITLE
Fix deprecation warning on instance_type

### DIFF
--- a/changelogs/fragments/980-instance-type-deprecation-warning.yml
+++ b/changelogs/fragments/980-instance-type-deprecation-warning.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- s3_instance - Only show the deprecation warning for the default value of ``instance_type`` when ``count`` or ``exact_count`` are specified (https://github.com/ansible-collections/amazon.aws/issues/980).

--- a/changelogs/fragments/980-instance-type-deprecation-warning.yml
+++ b/changelogs/fragments/980-instance-type-deprecation-warning.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- s3_instance - Only show the deprecation warning for the default value of ``instance_type`` when ``count`` or ``exact_count`` are specified (https://github.com/ansible-collections/amazon.aws/issues/980).
+- ec2_instance - Only show the deprecation warning for the default value of ``instance_type`` when ``count`` or ``exact_count`` are specified (https://github.com//issues/980).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -2050,9 +2050,11 @@ def main():
         supports_check_mode=True
     )
 
-    if not module.params.get('instance_type') and not module.params.get('launch_template') and module.params.get('state') != 'absent':
-        module.deprecate("Default value instance_type has been deprecated, in the future you must set an instance_type or a launch_template",
-                         date='2023-01-01', collection_name='amazon.aws')
+    if not module.params.get('instance_type') and not module.params.get('launch_template'):
+        if module.params.get('state') not in ('absent', 'stopped'):
+            if module.params.get('count') or module.params.get('exact_count'):
+                module.deprecate("Default value instance_type has been deprecated, in the future you must set an instance_type or a launch_template",
+                                 date='2023-01-01', collection_name='amazon.aws')
     result = dict()
 
     if module.params.get('network'):


### PR DESCRIPTION
##### SUMMARY

Specifying `instance_type` should not be required unless `count` or `exact_count` are specified.

If the user is just trying to start/stop instances then we don't need to ask for size.

Fixes #980 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_instance

##### ADDITIONAL INFORMATION
