### PR TITLE
Handle absence of classic link support for shared VPCs

### DIFF
--- a/changelogs/fragments/984-ec2_vpc_net_info_shared_vpc.yml
+++ b/changelogs/fragments/984-ec2_vpc_net_info_shared_vpc.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- ec2_vpc_net_info - handle classic link check for shared VPCs by throwing a warning instead of an error (https://github.com/ansible-collections/amazon.aws/pull/984)."
+- ec2_vpc_net_info - handle classic link check for shared VPCs by throwing a warning instead of an error (https://github.com/ansible-collections/amazon.aws/pull/984).

--- a/changelogs/fragments/984-ec2_vpc_net_info_shared_vpc.yml
+++ b/changelogs/fragments/984-ec2_vpc_net_info_shared_vpc.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "ec2_vpc_net_info - handle classic link check for shared vpcs by throwing a warning instead of an error.https://github.com/ansible-collections/amazon.aws/pull/984"

--- a/changelogs/fragments/984-ec2_vpc_net_info_shared_vpc.yml
+++ b/changelogs/fragments/984-ec2_vpc_net_info_shared_vpc.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- "ec2_vpc_net_info - handle classic link check for shared vpcs by throwing a warning instead of an error.https://github.com/ansible-collections/amazon.aws/pull/984"
+- ec2_vpc_net_info - handle classic link check for shared VPCs by throwing a warning instead of an error (https://github.com/ansible-collections/amazon.aws/pull/984)."

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -191,6 +191,8 @@ def describe_vpcs(connection, module):
     # We can get these results in bulk but still needs two separate calls to the API
     cl_enabled = {}
     cl_dns_support = {}
+    dns_support = {}
+    dns_hostnames = {}
     # Loop through the results and add the other VPC attributes we gathered
     for vpc in response['Vpcs']:
         error_message = "Unable to describe VPC attribute {0} on VPC {1}"
@@ -210,8 +212,10 @@ def describe_vpcs(connection, module):
                     vpc['ClassicLinkDnsSupported'] = item['ClassicLinkDnsSupported']
 
         # add the two DNS attributes
-        vpc['EnableDnsSupport'] = dns_support['EnableDnsSupport'].get('Value')
-        vpc['EnableDnsHostnames'] = dns_hostnames['EnableDnsHostnames'].get('Value')
+        if dns_support:
+            vpc['EnableDnsSupport'] = dns_support['EnableDnsSupport'].get('Value')
+        if dns_hostnames:
+            vpc['EnableDnsHostnames'] = dns_hostnames['EnableDnsHostnames'].get('Value')
         # for backwards compatibility
         vpc['id'] = vpc['VpcId']
         vpc_info.append(camel_dict_to_snake_dict(vpc))

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -167,6 +167,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
 
+
 def describe_vpcs(connection, module):
     """
     Describe VPCs.
@@ -219,7 +220,8 @@ def describe_vpcs(connection, module):
 
     module.exit_json(vpcs=vpc_info)
 
-def describe_classic_links (module, connection, vpc, attribute, error_message):
+
+def describe_classic_links(module, connection, vpc, attribute, error_message):
     result = None
     try:
         if attribute == "ClassicLinkEnabled":
@@ -234,6 +236,7 @@ def describe_classic_links (module, connection, vpc, attribute, error_message):
         module.fail_json_aws(e, msg='Unable to describe if {0} is enabled'.format(attribute))
     return result
 
+
 def describe_vpc_attribute(module, connection, vpc, attribute, error_message):
     result = None
     try:
@@ -243,7 +246,6 @@ def describe_vpc_attribute(module, connection, vpc, attribute, error_message):
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg=error_message.format(attribute, vpc))
     return result
-
 
 
 def main():


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #663 

One of the Classic Link Limitations is that

`You cannot link an EC2-Classic instance to a VPC that's in a different Region or a different AWS account.`.

When calling the DescribeVpcClassicLink operation on a shared VPC, it errors out saying "The vpc ID 'vpc-xxxx' does not exist".
This PR handles this error.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
