### PR TITLE
inventory/aws_rds: fix a recent regression

### DIFF
--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -359,6 +359,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not HAS_BOTO3:
             raise AnsibleError('The RDS dynamic inventory plugin requires boto3 and botocore.')
 
+        self._read_config_data(path)
         self._set_credentials()
 
         # get user specifications


### PR DESCRIPTION
Put back the `self._read_config_data(path)` call that was removed during
478022695b333043857a6929b350a2a3c07ae567.

Without this call we end up with an empty `aws_rds` in the output if
the inventory file is empty.

To reproduce:
```
cd tests/integration/targets/inventory_aws_rds
ANSIBLE_INVENTORY_ENABLED=amazon.aws.aws_rds ANSIBLE_INVENTORY=test.aws_rds.yml ansible-playbook playbooks/test_invalid_aws_rds_inventory_config.yml -vvvv
```

```
ok: [127.0.0.1] => {
    "groups": {
        "all": [],
        "aws_rds": [],   <--- the unexpected key
        "ungrouped": []
    }
```
