### PR TITLE
Add Param to to s3_object module to enforce SigV4 for get operations

### DIFF
--- a/changelogs/fragments/1013-add-support-for-signature-version-4-to-the-s3_object-geturl-mode.yml
+++ b/changelogs/fragments/1013-add-support-for-signature-version-4-to-the-s3_object-geturl-mode.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- s3_object - added the ``sig_v4`` paramater, enbling the user to opt in to signature version 4 for download/get operations. (https://github.com/ansible-collections/amazon.aws/issues/1013)

--- a/changelogs/fragments/1013-add-support-for-signature-version-4-to-the-s3_object-geturl-mode.yml
+++ b/changelogs/fragments/1013-add-support-for-signature-version-4-to-the-s3_object-geturl-mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- s3_object - added the ``sig_v4`` paramater, enbling the user to opt in to signature version 4 for download/get operations. (https://github.com/ansible-collections/amazon.aws/issues/1013)

--- a/changelogs/fragments/1014-add-support-for-signature-version-4-to-the-s3_object-geturl-mode.yml
+++ b/changelogs/fragments/1014-add-support-for-signature-version-4-to-the-s3_object-geturl-mode.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- s3_object - added the ``sig_v4`` paramater, enbling the user to opt in to signature version 4 for download/get operations. (https://github.com/ansible-collections/amazon.aws/pull/1014)

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -101,7 +101,7 @@ options:
     description:
       - Forces the Boto SDK to use Signature Version 4.
       - Only applies to get modes, I(mode=get), I(mode=getstr), I(mode=geturl).
-    default: false
+    default: true
     type: bool
     version_added: 5.0.0
   permission:
@@ -966,7 +966,7 @@ def main():
         max_keys=dict(default=1000, type='int', no_log=False),
         metadata=dict(type='dict'),
         mode=dict(choices=['get', 'put', 'delete', 'create', 'geturl', 'getstr', 'delobj', 'list', 'copy'], required=True),
-        sig_v4=dict(default=False, type='bool'),
+        sig_v4=dict(default=True, type='bool'),
         object=dict(),
         permission=dict(type='list', elements='str', default=['private']),
         version=dict(default=None),

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -99,10 +99,11 @@ options:
     type: str
   sig_v4:
     description:
-      - Forces the Boto SDK to use Signature Version 4
-      - Only applies to get modes, I(mode=get), I(mode=getstr), I(mode=geturl)
+      - Forces the Boto SDK to use Signature Version 4.
+      - Only applies to get modes, I(mode=get), I(mode=getstr), I(mode=geturl).
     default: false
     type: bool
+    version_added: 5.0.0
   permission:
     description:
       - This option lets the user set the canned permissions on the object/bucket that are created.

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -965,7 +965,7 @@ def main():
         max_keys=dict(default=1000, type='int', no_log=False),
         metadata=dict(type='dict'),
         mode=dict(choices=['get', 'put', 'delete', 'create', 'geturl', 'getstr', 'delobj', 'list', 'copy'], required=True),
-        sig_v4=dict(default=False, type='bool')
+        sig_v4=dict(default=False, type='bool'),
         object=dict(),
         permission=dict(type='list', elements='str', default=['private']),
         version=dict(default=None),

--- a/tests/integration/targets/s3_object/tasks/main.yml
+++ b/tests/integration/targets/s3_object/tasks/main.yml
@@ -23,7 +23,7 @@
 
     - name: Create content
       set_fact:
-          content: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits,punctuation') }}"
+        content: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits,punctuation') }}"
 
     - name: test create bucket without permissions
       module_defaults: { group/aws: {} }
@@ -326,6 +326,22 @@
       s3_object:
         bucket: "{{ bucket_name }}"
         mode: geturl
+        object: delete.txt
+      retries: 3
+      delay: 3
+      register: result
+      until: result is changed
+
+    - assert:
+        that:
+          - "'Download url:' in result.msg"
+          - result is changed
+
+    - name: test geturl of the object with sigv4
+      s3_object:
+        bucket: "{{ bucket_name }}"
+        mode: geturl
+        sig_v4: true
         object: delete.txt
       retries: 3
       delay: 3


### PR DESCRIPTION
##### SUMMARY
This pull request adds a parameter to the `s3_object `module that enables users to force/require the Boto SDK to use SigV4 for get operations.

Fixes https://github.com/ansible-collections/amazon.aws/issues/1013

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
s3_object

##### ADDITIONAL INFORMATION
N/A