### PR TITLE
tests: some ec2_instance targets are slower than normal

### DIFF
--- a/changelogs/fragments/ec2_instance-test-duration.yaml
+++ b/changelogs/fragments/ec2_instance-test-duration.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+- "Set a max duration of some ec2_instance integration tests to avoid timeout (https://github.com/ansible-collections/amazon.aws/pull/1019)."

--- a/tests/integration/targets/ec2_instance_block_devices/aliases
+++ b/tests/integration/targets/ec2_instance_block_devices/aliases
@@ -1,4 +1,4 @@
-
+time=10m
 cloud/aws
 ec2_instance_info
 ec2_instance

--- a/tests/integration/targets/ec2_instance_checkmode_tests/aliases
+++ b/tests/integration/targets/ec2_instance_checkmode_tests/aliases
@@ -1,4 +1,4 @@
-
+time=10m
 cloud/aws
 ec2_instance_info
 ec2_instance

--- a/tests/integration/targets/ec2_instance_default_vpc_tests/aliases
+++ b/tests/integration/targets/ec2_instance_default_vpc_tests/aliases
@@ -1,4 +1,4 @@
-
+time=10m
 cloud/aws
 ec2_instance_info
 ec2_instance

--- a/tests/integration/targets/ec2_instance_iam_instance_role/aliases
+++ b/tests/integration/targets/ec2_instance_iam_instance_role/aliases
@@ -1,4 +1,4 @@
-
+time=500s
 cloud/aws
 ec2_instance_info
 ec2_instance


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1625

Dedicate more time for the execution of some slow `ec2_instance` targets.

See: https://github.com/ansible-collections/amazon.aws/pull/978#issuecomment-1245671362