### PR TITLE
Cleanup after 4.2.0 Release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,20 @@ amazon.aws Release Notes
 .. contents:: Topics
 
 
+v4.2.0
+======
+
+Minor Changes
+-------------
+
+- ec2_security_group - set type as ``list`` for rules->group_name as it can accept both ``str`` and ``list`` (https://github.com/ansible-collections/amazon.aws/pull/971).
+- various modules - linting fixups (https://github.com/ansible-collections/amazon.aws/pull/953).
+
+Deprecated Features
+-------------------
+
+- module_utils.cloud - removal of the ``CloudRetry.backoff`` has been delayed until release 6.0.0.  It is recommended to update custom modules to use ``jittered_backoff`` or ``exponential_backoff`` instead (https://github.com/ansible-collections/amazon.aws/pull/951).
+
 v4.1.0
 ======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1009,3 +1009,18 @@ releases:
     - 927-ec2_instance-retries.yml
     - python.yml
     release_date: '2022-08-02'
+  4.2.0:
+    changes:
+      deprecated_features:
+      - module_utils.cloud - removal of the ``CloudRetry.backoff`` has been delayed
+        until release 6.0.0.  It is recommended to update custom modules to use ``jittered_backoff``
+        or ``exponential_backoff`` instead (https://github.com/ansible-collections/amazon.aws/pull/951).
+      minor_changes:
+      - ec2_security_group - set type as ``list`` for rules->group_name as it can
+        accept both ``str`` and ``list`` (https://github.com/ansible-collections/amazon.aws/pull/971).
+      - various modules - linting fixups (https://github.com/ansible-collections/amazon.aws/pull/953).
+    fragments:
+    - 638-ec2_security_group_group_name_datatype.yml
+    - 951-cloudretry.yml
+    - 965-linting.yml
+    release_date: '2022-09-14'

--- a/changelogs/fragments/638-ec2_security_group_group_name_datatype.yml
+++ b/changelogs/fragments/638-ec2_security_group_group_name_datatype.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- ec2_security_group - set type as ``list`` for rules->group_name as it can accept both ``str`` and ``list`` (https://github.com/ansible-collections/amazon.aws/pull/971).

--- a/changelogs/fragments/951-cloudretry.yml
+++ b/changelogs/fragments/951-cloudretry.yml
@@ -1,2 +1,0 @@
-deprecated_features:
-- module_utils.cloud - removal of the ``CloudRetry.backoff`` has been delayed until release 6.0.0.  It is recommended to update custom modules to use ``jittered_backoff`` or ``exponential_backoff`` instead (https://github.com/ansible-collections/amazon.aws/pull/951).


### PR DESCRIPTION
##### SUMMARY

With 4.2.0 tagged we now need to forward-port the changelog updates from 4.2.0

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

CHANGELOG.rst
changelogs/changelog.yaml
changelogs/fragments/

##### ADDITIONAL INFORMATION