### PR TITLE
inventory/aws_ec2: allow multi-entries for one host

### DIFF
--- a/changelogs/fragments/inventory-multi-hosts.yaml
+++ b/changelogs/fragments/inventory-multi-hosts.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+- aws_ec2 - introduce the ``allow_duplicated_hosts`` configuration key (https://github.com/ansible-collections/amazon.aws/pull/1026).
+bugfixes:
+- aws_ec2 - address a regression introduced in 4.1.0 (https://github.com/ansible-collections/amazon.aws/pull/862) that cause the presnse of duplicated hosts in the inventory.

--- a/docs/docsite/rst/aws_ec2_guide.rst
+++ b/docs/docsite/rst/aws_ec2_guide.rst
@@ -158,7 +158,10 @@ Some examples are shown below:
     - dns-name
     - tag:Name
     - private-ip-address
-  
+
+By default, the inventory will only return the first match one of the ``hostnames`` entries.
+You may want to get all the potential matches in your inventory, this also implies you will get
+duplicated entries. To switch to this behavior, set the ``allow_duplicated_hosts`` configuration key to ``True``.
 
 ``keyed_groups``
 ----------------

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -751,8 +751,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         for host in hosts:
             if allow_duplicated_hosts:
                 hostname_list = self.get_all_hostnames(host, hostnames)
+            elif preferred_hostname := self._get_preferred_hostname(host, hostnames):
+                hostname_list = [preferred_hostname]
             else:
-                hostname_list = [self._get_preferred_hostname(host, hostnames)]
+                continue
 
             host = camel_dict_to_snake_dict(host, ignore_list=['Tags'])
             host['tags'] = boto3_tag_list_to_ansible_dict(host.get('tags', []))

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -71,6 +71,7 @@ options:
         and you want to get all the hostnames that match.
     type: bool
     default: False
+    version_added: 5.0.0
   filters:
     description:
       - A dictionary of filter value pairs.

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -747,6 +747,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             :param hosts: a list of hosts to be added to a group
             :param group: the name of the group to which the hosts belong
             :param hostnames: a list of hostname destination variables in order of preference
+            :param bool allow_duplicated_hosts: allow multiple copy for the same host with a different name
         '''
         for host in hosts:
             if allow_duplicated_hosts:

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -66,7 +66,7 @@ options:
         required: False
   allow_duplicated_hosts:
     description:
-      - By default, only the first name that back the I(hostnames) list is returned.
+      - By default, the first name that matches an entry of the I(hostnames) list is returned.
       - Turn this flag on if you don't mind having duplicated entries in the inventory
         and you want to get all the hostnames that match.
     type: bool

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags.yml
@@ -40,11 +40,11 @@
           assert:
             that:
               - "'aws_ec2' in groups"
-              - groups['aws_ec2'] | length == 2
+              - groups['aws_ec2'] | length == 1
               - "'Tag1_Test1' in groups['aws_ec2']"
-              - "'Tag2_Test2' in groups['aws_ec2']"
+              - "'Tag2_Test2' not in groups['aws_ec2']"
               - "'Tag1_Test1' in hostvars"
-              - "'Tag2_Test2' in hostvars"
+              - "'Tag2_Test2' not in hostvars"
 
       always:
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags_classic.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags_classic.yml
@@ -40,11 +40,11 @@
           assert:
             that:
               - "'aws_ec2' in groups"
-              - groups['aws_ec2'] | length == 2
+              - groups['aws_ec2'] | length == 1
               - "'Test1' in groups['aws_ec2']"
-              - "'Test2' in groups['aws_ec2']"
+              - "'Test2' not in groups['aws_ec2']"
               - "'Test1' in hostvars"
-              - "'Test2' in hostvars"
+              - "'Test2' not in hostvars"
 
       always:
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/1066

Add an option to allow multiple duplicated entries for one single instance.

Closes: #950
