### PR TITLE
`ec2_instance` retry on `InsuffienctInstanceCapacity `

### DIFF
--- a/changelogs/fragments/1038-ec2-insufficient-capacity.yml
+++ b/changelogs/fragments/1038-ec2-insufficient-capacity.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ec2_instance - expanded the use of the automatic retries to ``InsuffienctInstanceCapacity`` (https://github.com/ansible-collections/amazon.aws/issues/1038).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -2069,6 +2069,7 @@ def main():
     retry_decorator = AWSRetry.jittered_backoff(
         catch_extra_error_codes=[
             'IncorrectState',
+            'InsuffienctInstanceCapacity',
         ]
     )
     client = module.client('ec2', retry_decorator=retry_decorator)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes #1038 

Expands the use of the `AWSRetry` decorator to include `InsuffienctInstanceCapacity` errors.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance

