### PR TITLE
Fix `AttributeError: 'AnsibleAWSModule' object has no attribute 'fail'` error

### DIFF
--- a/changelogs/fragments/1045-botocore_fail.yml
+++ b/changelogs/fragments/1045-botocore_fail.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- module_utils/botocore - fix ``object has no attribute 'fail'`` error in error handling (https://github.com/ansible-collections/amazon.aws/pull/1045).

--- a/plugins/module_utils/botocore.py
+++ b/plugins/module_utils/botocore.py
@@ -185,7 +185,7 @@ def get_aws_connection_info(module, boto3=None):
             profile_name = os.environ.get('AWS_DEFAULT_PROFILE')
 
     if profile_name and (access_key or secret_key or security_token):
-        module.fail("Passing both a profile and access tokens is not supported.")
+        module.fail_json(msg="Passing both a profile and access tokens is not supported.")
 
     if not endpoint_url:
         if 'AWS_URL' in os.environ:

--- a/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/profiles.yml
+++ b/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/profiles.yml
@@ -55,3 +55,20 @@
     - '"msg" in bad_profile'
     - '"junk-profile" in bad_profile.msg'
     - '"could not be found" in bad_profile.msg'
+
+- name: 'Test with profile and credentials (should error)'
+  example_module:
+    profile: 'test_profile'
+    aws_region: '{{ aws_region }}'
+    aws_access_key: '{{ aws_access_key }}'
+    aws_secret_key: '{{ aws_secret_key }}'
+    aws_security_token: '{{ security_token }}'
+  register: bad_profile
+  ignore_errors: True
+
+- assert:
+    that:
+    - bad_profile is failed
+    - '"msg" in bad_profile'
+    - '"Passing both" in bad_profile.msg'
+    - '"not supported" in bad_profile.msg'


### PR DESCRIPTION
##### SUMMARY

When passing both a profile and credentials we now fail, however we called `fail` rather than `fail_json`.  This results in:

```
File \"/tmp/ansible_amazon.aws.aws_caller_info_payload_e_b294g4/ansible_amazon.aws.aws_caller_info_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/modules.py\", line 188, in client
File \"/tmp/ansible_amazon.aws.aws_caller_info_payload_e_b294g4/ansible_amazon.aws.aws_caller_info_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/botocore.py\", line 186, in get_aws_connection_info
AttributeError: 'AnsibleAWSModule' object has no attribute 'fail'",
```

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/module_utils/botocore.py

##### ADDITIONAL INFORMATION
