### PR TITLE
test-requirements.txt: relax the dependency on pytest

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,7 +4,7 @@ boto3
 coverage==4.5.4
 placebo
 mock
-pytest==6.2.0
+pytest
 pytest-xdist
 # We should avoid these two modules with py3
 pytest-mock


### PR DESCRIPTION
pytest 6.2.0 is getting old and a recent version should work as expected.
