### PR TITLE
Add missing 'legacy_missing_tests' alias entries

### DIFF
--- a/changelogs/fragments/1061-legacy_aliases.yml
+++ b/changelogs/fragments/1061-legacy_aliases.yml
@@ -1,0 +1,2 @@
+trivial:
+- tests - Add missing entries to legacy_missing_tests alias file.

--- a/tests/integration/targets/legacy_missing_tests/aliases
+++ b/tests/integration/targets/legacy_missing_tests/aliases
@@ -1,1 +1,5 @@
 disabled
+
+lambda_event
+rds_instance_snapshot
+rds_snapshot_info


### PR DESCRIPTION
##### SUMMARY

During migrations a couple of 'legacy_missing_tests' aliase entries were missed.  Add them

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tests/integration/targets/legacy_missing_tests/aliases

##### ADDITIONAL INFORMATION
