### PR TITLE
Add 'fake' link for community.aws module referenced in docs

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -18,6 +18,9 @@ jobs:
     with:
       init-lenient: false
       init-fail-on-error: true
+      # Please also update docs-push.yml
+      provide-link-targets: |
+        ansible_collections.community.aws.autoscaling_launch_config_module
 
 
   build-docs:
@@ -28,6 +31,9 @@ jobs:
     with:
       init-lenient: true
       init-fail-on-error: false
+      # Please also update docs-push.yml
+      provide-link-targets: |
+        ansible_collections.community.aws.autoscaling_launch_config_module
 
   comment:
     permissions:

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -21,6 +21,9 @@ jobs:
     with:
       init-lenient: false
       init-fail-on-error: true
+      # Please also update docs-pr.yml
+      provide-link-targets: |
+        ansible_collections.community.aws.autoscaling_launch_config_module
 
   publish-docs-gh-pages:
     # use to prevent running on forks


### PR DESCRIPTION
##### SUMMARY

autoscaling_group references `community.aws.autoscaling_launch_config`.  Because this isn't available on the main docs pages yet intersphinx can't find the right link.  Add a fake link during testing.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

.github/workflows/docs-pr.yml
.github/workflows/docs-push.yml

##### ADDITIONAL INFORMATION
