### PR TITLE
ignore-2.15: ignore route53's get state

### DIFF
--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,0 +1,1 @@
+plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/1066

The error is:

```
ERROR: plugins/modules/route53.py:0:0: parameter-state-invalid-choice: Argument 'state' includes the value 'get' as a choice
```
