### PR TITLE
Inventory aws ec2 unit tests

### DIFF
--- a/changelogs/fragments/inventory-multi-hosts.yaml
+++ b/changelogs/fragments/inventory-multi-hosts.yaml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+- aws_ec2 - introduce the ``allow_duplicated_hosts`` configuration key (https://github.com/ansible-collections/amazon.aws/pull/1026).
+bugfixes:
+- aws_ec2 - address a regression introduced in 4.1.0 (https://github.com/ansible-collections/amazon.aws/pull/862) that cause the presnse of duplicated hosts in the inventory.

--- a/docs/docsite/rst/aws_ec2_guide.rst
+++ b/docs/docsite/rst/aws_ec2_guide.rst
@@ -158,7 +158,10 @@ Some examples are shown below:
     - dns-name
     - tag:Name
     - private-ip-address
-  
+
+By default, the inventory will only return the first match one of the ``hostnames`` entries.
+You may want to get all the potential matches in your inventory, this also implies you will get
+duplicated entries. To switch to this behavior, set the ``allow_duplicated_hosts`` configuration key to ``True``.
 
 ``keyed_groups``
 ----------------

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -751,8 +751,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         for host in hosts:
             if allow_duplicated_hosts:
                 hostname_list = self.get_all_hostnames(host, hostnames)
+            elif preferred_hostname := self._get_preferred_hostname(host, hostnames):
+                hostname_list = [preferred_hostname]
             else:
-                hostname_list = [self._get_preferred_hostname(host, hostnames)]
+                continue
 
             host = camel_dict_to_snake_dict(host, ignore_list=['Tags'])
             host['tags'] = boto3_tag_list_to_ansible_dict(host.get('tags', []))

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -71,6 +71,7 @@ options:
         and you want to get all the hostnames that match.
     type: bool
     default: False
+    version_added: 5.0.0
   filters:
     description:
       - A dictionary of filter value pairs.

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -611,7 +611,8 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     raise AnsibleError("Failed to describe spot instance requests: %s" % to_native(e))
         return host_vars
 
-    def _get_tag_hostname(self, preference, instance):
+    @classmethod
+    def _get_tag_hostname(cls, preference, instance):
         tag_hostnames = preference.split('tag:', 1)[1]
         if ',' in tag_hostnames:
             tag_hostnames = tag_hostnames.split(',')
@@ -664,10 +665,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             if hostname:
                 break
         if hostname:
-            if ':' in to_text(hostname):
-                return self._sanitize_group_name((to_text(hostname)))
-            else:
-                return to_text(hostname)
+            return self._sanitize_hostname(hostname)
 
     def get_all_hostnames(self, instance, hostnames):
         '''
@@ -732,22 +730,43 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
         return {'aws_ec2': instances}
 
-    def _populate(self, groups, hostnames, allow_duplicated_hosts=False):
+    def _populate(self, groups, hostnames, allow_duplicated_hosts=False, hostvars_prefix=None, hostvars_suffix=None, use_contrib_script_compatible_ec2_tag_keys=False):
         for group in groups:
             group = self.inventory.add_group(group)
             self._add_hosts(
                 hosts=groups[group],
                 group=group,
                 hostnames=hostnames,
-                allow_duplicated_hosts=allow_duplicated_hosts)
+                allow_duplicated_hosts=allow_duplicated_hosts,
+                hostvars_prefix=hostvars_prefix,
+                hostvars_suffix=hostvars_suffix,
+                use_contrib_script_compatible_ec2_tag_keys=use_contrib_script_compatible_ec2_tag_keys)
             self.inventory.add_child('all', group)
 
-    def _add_hosts(self, hosts, group, hostnames, allow_duplicated_hosts=False):
-        '''
-            :param hosts: a list of hosts to be added to a group
-            :param group: the name of the group to which the hosts belong
-            :param hostnames: a list of hostname destination variables in order of preference
-        '''
+    @classmethod
+    def prepare_host_vars(cls, original_host_vars, hostvars_prefix=None, hostvars_suffix=None, use_contrib_script_compatible_ec2_tag_keys=False):
+        host_vars = camel_dict_to_snake_dict(original_host_vars, ignore_list=['Tags'])
+        host_vars['tags'] = boto3_tag_list_to_ansible_dict(original_host_vars.get('Tags', []))
+
+        # Allow easier grouping by region
+        host_vars['placement']['region'] = host_vars['placement']['availability_zone'][:-1]
+
+        if use_contrib_script_compatible_ec2_tag_keys:
+            for k, v in host_vars['tags'].items():
+                host_vars["ec2_tag_%s" % k] = v
+
+        if hostvars_prefix or hostvars_suffix:
+            for hostvar, hostval in host_vars.copy().items():
+                del(host_vars[hostvar])
+                if hostvars_prefix:
+                    hostvar = hostvars_prefix + hostvar
+                if hostvars_suffix:
+                    hostvar = hostvar + hostvars_suffix
+                host_vars[hostvar] = hostval
+
+        return host_vars
+
+    def iter_entry(self, hosts, hostnames, allow_duplicated_hosts=False, hostvars_prefix=None, hostvars_suffix=None, use_contrib_script_compatible_ec2_tag_keys=False):
         for host in hosts:
             if allow_duplicated_hosts:
                 hostname_list = self.get_all_hostnames(host, hostnames)
@@ -756,46 +775,44 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             else:
                 continue
 
-            host = camel_dict_to_snake_dict(host, ignore_list=['Tags'])
-            host['tags'] = boto3_tag_list_to_ansible_dict(host.get('tags', []))
+            host_vars = self.prepare_host_vars(
+                host,
+                hostvars_prefix,
+                hostvars_suffix,
+                use_contrib_script_compatible_ec2_tag_keys)
+            for name in hostname_list:
+                yield to_text(name), host_vars
 
-            if self.get_option('use_contrib_script_compatible_ec2_tag_keys'):
-                for k, v in host['tags'].items():
-                    host["ec2_tag_%s" % k] = v
+    def _add_hosts(self, hosts, group, hostnames, allow_duplicated_hosts=False, hostvars_prefix=None, hostvars_suffix=None, use_contrib_script_compatible_ec2_tag_keys=False):
+        '''
+            :param hosts: a list of hosts to be added to a group
+            :param group: the name of the group to which the hosts belong
+            :param hostnames: a list of hostname destination variables in order of preference
+        '''
 
-            # Allow easier grouping by region
-            host['placement']['region'] = host['placement']['availability_zone'][:-1]
-
-            if not hostname_list:
-                continue
-            for hostname in hostname_list:
-                self.inventory.add_host(to_text(hostname), group=group)
-            hostvars_prefix = self.get_option("hostvars_prefix")
-            hostvars_suffix = self.get_option("hostvars_suffix")
-            new_vars = dict()
-            for hostvar, hostval in host.items():
-                if hostvars_prefix:
-                    hostvar = hostvars_prefix + hostvar
-                if hostvars_suffix:
-                    hostvar = hostvar + hostvars_suffix
-                new_vars[hostvar] = hostval
-                for hostname in hostname_list:
-                    self.inventory.set_variable(to_text(hostname), hostvar, hostval)
-            host.update(new_vars)
+        for name, host_vars in self.iter_entry(
+                hosts, hostnames,
+                allow_duplicated_hosts=allow_duplicated_hosts,
+                hostvars_prefix=hostvars_prefix,
+                hostvars_suffix=hostvars_suffix,
+                use_contrib_script_compatible_ec2_tag_keys=use_contrib_script_compatible_ec2_tag_keys):
+            self.inventory.add_host(name, group=group)
+            assert isinstance(host_vars, dict)
+            for k, v in host_vars.items():
+                self.inventory.set_variable(name, k, v)
 
             # Use constructed if applicable
 
             strict = self.get_option('strict')
 
             # Composed variables
-            for hostname in hostname_list:
-                self._set_composite_vars(self.get_option('compose'), host, to_text(hostname), strict=strict)
+            self._set_composite_vars(self.get_option('compose'), host_vars, name, strict=strict)
 
-                # Complex groups based on jinja2 conditionals, hosts that meet the conditional are added to group
-                self._add_host_to_composed_groups(self.get_option('groups'), host, to_text(hostname), strict=strict)
+            # Complex groups based on jinja2 conditionals, hosts that meet the conditional are added to group
+            self._add_host_to_composed_groups(self.get_option('groups'), host_vars, name, strict=strict)
 
-                # Create groups based on variable values and add the corresponding hosts to it
-                self._add_host_to_keyed_groups(self.get_option('keyed_groups'), host, to_text(hostname), strict=strict)
+            # Create groups based on variable values and add the corresponding hosts to it
+            self._add_host_to_keyed_groups(self.get_option('keyed_groups'), host_vars, name, strict=strict)
 
     def _set_credentials(self, loader):
         '''
@@ -874,6 +891,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         strict_permissions = self.get_option('strict_permissions')
         allow_duplicated_hosts = self.get_option('allow_duplicated_hosts')
 
+        hostvars_prefix = self.get_option("hostvars_prefix")
+        hostvars_suffix = self.get_option("hostvars_suffix")
+        use_contrib_script_compatible_ec2_tag_keys = self.get_option('use_contrib_script_compatible_ec2_tag_keys')
+
         cache_key = self.get_cache_key(path)
         # false when refresh_cache or --flush-cache is used
         if cache:
@@ -892,7 +913,13 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not cache or cache_needs_update:
             results = self._query(regions, include_filters, exclude_filters, strict_permissions)
 
-        self._populate(results, hostnames, allow_duplicated_hosts=allow_duplicated_hosts)
+        self._populate(
+            results,
+            hostnames,
+            allow_duplicated_hosts=allow_duplicated_hosts,
+            hostvars_prefix=hostvars_prefix,
+            hostvars_suffix=hostvars_suffix,
+            use_contrib_script_compatible_ec2_tag_keys=use_contrib_script_compatible_ec2_tag_keys)
 
         # If the cache has expired/doesn't exist or if refresh_inventory/flush cache is used
         # when the user is using caching, update the cached inventory

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags.yml
@@ -40,11 +40,11 @@
           assert:
             that:
               - "'aws_ec2' in groups"
-              - groups['aws_ec2'] | length == 2
+              - groups['aws_ec2'] | length == 1
               - "'Tag1_Test1' in groups['aws_ec2']"
-              - "'Tag2_Test2' in groups['aws_ec2']"
+              - "'Tag2_Test2' not in groups['aws_ec2']"
               - "'Tag1_Test1' in hostvars"
-              - "'Tag2_Test2' in hostvars"
+              - "'Tag2_Test2' not in hostvars"
 
       always:
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags_classic.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags_classic.yml
@@ -40,11 +40,11 @@
           assert:
             that:
               - "'aws_ec2' in groups"
-              - groups['aws_ec2'] | length == 2
+              - groups['aws_ec2'] | length == 1
               - "'Test1' in groups['aws_ec2']"
-              - "'Test2' in groups['aws_ec2']"
+              - "'Test2' not in groups['aws_ec2']"
               - "'Test1' in hostvars"
-              - "'Test2' in hostvars"
+              - "'Test2' not in hostvars"
 
       always:
 

--- a/tests/unit/plugins/inventory/test_aws_ec2.py
+++ b/tests/unit/plugins/inventory/test_aws_ec2.py
@@ -277,43 +277,186 @@ def test_add_host_empty_hostnames(inventory):
     inventory.inventory.add_host.assert_called_with("ip-10-85-0-4.ec2.internal", group="aws_ec2")
 
 
-def test_add_host_with_hostnames_and_one_criteria(inventory):
-    hosts = [{
-        "Placement": {
-            "AvailabilityZone": "us-east-1a",
-        },
-        "PublicDnsName": "sample-host",
-    }]
+def test_add_host_with_hostnames_no_criteria(inventory):
+    hosts = [{}]
 
-    inventory._add_hosts(hosts, "aws_ec2", hostnames=["tag:Name", "private-dns-name", "dns-name"])
+    inventory._add_hosts(
+        hosts, "aws_ec2", hostnames=["tag:Name", "private-dns-name", "dns-name"]
+    )
+    assert inventory.inventory.add_host.call_count == 0
+
+
+def test_add_host_with_hostnames_and_one_criteria(inventory):
+    hosts = [
+        {
+            "Placement": {
+                "AvailabilityZone": "us-east-1a",
+            },
+            "PublicDnsName": "sample-host",
+        }
+    ]
+
+    inventory._add_hosts(
+        hosts, "aws_ec2", hostnames=["tag:Name", "private-dns-name", "dns-name"]
+    )
     assert inventory.inventory.add_host.call_count == 1
     inventory.inventory.add_host.assert_called_with("sample-host", group="aws_ec2")
 
 
 def test_add_host_with_hostnames_and_two_matching_criteria(inventory):
-    hosts = [{
-        "Placement": {
-            "AvailabilityZone": "us-east-1a",
-        },
-        "PublicDnsName": "name-from-PublicDnsName",
-        "Tags": [{"Value": "name-from-tag-Name", "Key": "Name"}],
-    }]
+    hosts = [
+        {
+            "Placement": {
+                "AvailabilityZone": "us-east-1a",
+            },
+            "PublicDnsName": "name-from-PublicDnsName",
+            "Tags": [{"Value": "name-from-tag-Name", "Key": "Name"}],
+        }
+    ]
 
-    inventory._add_hosts(hosts, "aws_ec2", hostnames=["tag:Name", "private-dns-name", "dns-name"])
+    inventory._add_hosts(
+        hosts, "aws_ec2", hostnames=["tag:Name", "private-dns-name", "dns-name"]
+    )
     assert inventory.inventory.add_host.call_count == 1
-    inventory.inventory.add_host.assert_called_with("name-from-tag-Name", group="aws_ec2")
+    inventory.inventory.add_host.assert_called_with(
+        "name-from-tag-Name", group="aws_ec2"
+    )
 
 
-def test_add_host_with_hostnames_and_two_matching_criteria_and_allow_duplicated_hosts(inventory):
-    hosts = [{
-        "Placement": {
-            "AvailabilityZone": "us-east-1a",
-        },
-        "PublicDnsName": "name-from-PublicDnsName",
-        "Tags": [{"Value": "name-from-tag-Name", "Key": "Name"}],
-    }]
+def test_add_host_with_hostnames_and_two_matching_criteria_and_allow_duplicated_hosts(
+    inventory,
+):
+    hosts = [
+        {
+            "Placement": {
+                "AvailabilityZone": "us-east-1a",
+            },
+            "PublicDnsName": "name-from-PublicDnsName",
+            "Tags": [{"Value": "name-from-tag-Name", "Key": "Name"}],
+        }
+    ]
 
-    inventory._add_hosts(hosts, "aws_ec2", hostnames=["tag:Name", "private-dns-name", "dns-name"], allow_duplicated_hosts=True)
+    inventory._add_hosts(
+        hosts,
+        "aws_ec2",
+        hostnames=["tag:Name", "private-dns-name", "dns-name"],
+        allow_duplicated_hosts=True,
+    )
     assert inventory.inventory.add_host.call_count == 2
-    inventory.inventory.add_host.assert_any_call("name-from-PublicDnsName", group="aws_ec2")
+    inventory.inventory.add_host.assert_any_call(
+        "name-from-PublicDnsName", group="aws_ec2"
+    )
     inventory.inventory.add_host.assert_any_call("name-from-tag-Name", group="aws_ec2")
+
+
+def test_sanityize_hostname(inventory):
+    assert inventory._sanitize_hostname(1) == "1"
+    assert inventory._sanitize_hostname("a:b") == "a_b"
+    assert inventory._sanitize_hostname("a:/b") == "a__b"
+
+
+def test_sanityize_hostname_legacy(inventory):
+    inventory._sanitize_group_name = (
+        inventory._legacy_script_compatible_group_sanitization
+    )
+    assert inventory._sanitize_hostname("a:/b") == "a__b"
+
+
+@pytest.mark.parametrize(
+    "hostvars_prefix,hostvars_suffix,use_contrib_script_compatible_ec2_tag_keys,expectation",
+    [
+        (
+            None,
+            None,
+            False,
+            {
+                "my_var": 1,
+                "placement": {"availability_zone": "us-east-1a", "region": "us-east-1"},
+                "tags": {"Name": "my-name"},
+            },
+        ),
+        (
+            "pre",
+            "post",
+            False,
+            {
+                "premy_varpost": 1,
+                "preplacementpost": {
+                    "availability_zone": "us-east-1a",
+                    "region": "us-east-1",
+                },
+                "pretagspost": {"Name": "my-name"},
+                "premy_varpost": 1,
+            },
+        ),
+        (
+            None,
+            None,
+            True,
+            {
+                "my_var": 1,
+                "ec2_tag_Name": "my-name",
+                "placement": {"availability_zone": "us-east-1a", "region": "us-east-1"},
+                "tags": {"Name": "my-name"},
+            },
+        ),
+    ],
+)
+def test_prepare_host_vars(
+    inventory,
+    hostvars_prefix,
+    hostvars_suffix,
+    use_contrib_script_compatible_ec2_tag_keys,
+    expectation,
+):
+    original_host_vars = {
+        "my_var": 1,
+        "placement": {"availability_zone": "us-east-1a"},
+        "Tags": [{"Key": "Name", "Value": "my-name"}],
+    }
+    assert (
+        inventory.prepare_host_vars(
+            original_host_vars,
+            hostvars_prefix,
+            hostvars_suffix,
+            use_contrib_script_compatible_ec2_tag_keys,
+        )
+        == expectation
+    )
+
+
+def test_iter_entry(inventory):
+    hosts = [
+        {
+            "Placement": {
+                "AvailabilityZone": "us-east-1a",
+            },
+            "PublicDnsName": "first-host://",
+        },
+        {
+            "Placement": {
+                "AvailabilityZone": "us-east-1a",
+            },
+            "PublicDnsName": "second-host",
+            "Tags": [{"Key": "Name", "Value": "my-name"}],
+        },
+    ]
+
+    entries = list(inventory.iter_entry(hosts, hostnames=[]))
+    assert len(entries) == 2
+    assert entries[0][0] == "first_host___"
+    assert entries[1][0] == "second-host"
+    assert entries[1][1]["tags"]["Name"] == "my-name"
+
+    entries = list(
+        inventory.iter_entry(
+            hosts,
+            hostnames=[],
+            hostvars_prefix="a_",
+            hostvars_suffix="_b",
+            use_contrib_script_compatible_ec2_tag_keys=True,
+        )
+    )
+    assert len(entries) == 2
+    assert entries[0][0] == "first_host___"
+    assert entries[1][1]["a_tags_b"]["Name"] == "my-name"


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/1090

##### SUMMARY

Based on https://github.com/ansible-collections/amazon.aws/pull/1026 which should be merged first.

Break up the `_populate()` method into smaller functions. Use` @classmethod` when possible and reduce the use of `get_option()` to avoid side-effects.