### PR TITLE
Make example AWS UUIDS follow a specific pattern - RDS

### DIFF
--- a/changelogs/fragments/1073-gitleaks-2.yml
+++ b/changelogs/fragments/1073-gitleaks-2.yml
@@ -1,0 +1,2 @@
+trivial:
+- various modules - Update example Account IDs and IAM UUIDs for consistency (https://github.com/ansible-collections/amazon.aws/pull/1070).

--- a/plugins/modules/rds_instance_info.py
+++ b/plugins/modules/rds_instance_info.py
@@ -87,7 +87,7 @@ instances:
       description: ARN of the database instance
       returned: always
       type: str
-      sample: arn:aws:rds:us-west-2:111111111111:db:helloworld-rds
+      sample: arn:aws:rds:us-west-2:123456789012:db:helloworld-rds
     db_instance_class:
       description: Instance class of the database instance
       returned: always
@@ -248,7 +248,7 @@ instances:
       description: KMS Key ID
       returned: always
       type: str
-      sample: arn:aws:kms:us-west-2:111111111111:key/abcd1234-0000-abcd-1111-0123456789ab
+      sample: arn:aws:kms:us-west-2:123456789012:key/abcd1234-0000-abcd-1111-0123456789ab
     latest_restorable_time:
       description: Latest time to which a database can be restored with point-in-time restore
       returned: always

--- a/plugins/modules/rds_option_group.py
+++ b/plugins/modules/rds_option_group.py
@@ -207,7 +207,7 @@ option_group_arn:
     description: The Amazon Resource Name (ARN) for the option group.
     returned: always
     type: str
-    sample: "arn:aws:rds:ap-southeast-2:721066863947:og:ansible-test-option-group"
+    sample: "arn:aws:rds:ap-southeast-2:123456789012:og:ansible-test-option-group"
 option_group_description:
     description: Provides a description of the option group.
     returned: always

--- a/plugins/modules/rds_option_group_info.py
+++ b/plugins/modules/rds_option_group_info.py
@@ -97,7 +97,7 @@ option_groups_list:
             description: The Amazon Resource Name (ARN) for the option group.
             returned: always
             type: str
-            sample: "arn:aws:rds:ap-southeast-2:721066863947:og:ansible-test-option-group"
+            sample: "arn:aws:rds:ap-southeast-2:123456789012:og:ansible-test-option-group"
         option_group_description:
             description: Provides a description of the option group.
             returned: always

--- a/plugins/modules/rds_snapshot_info.py
+++ b/plugins/modules/rds_snapshot_info.py
@@ -94,7 +94,7 @@ snapshots:
       description: Snapshot ARN
       returned: always
       type: str
-      sample: arn:aws:rds:us-west-2:111111111111:snapshot:rds:hello-world-rds-us1-2018-05-16-04-03
+      sample: arn:aws:rds:us-west-2:123456789012:snapshot:rds:hello-world-rds-us1-2018-05-16-04-03
     db_snapshot_identifier:
       description: Snapshot name
       returned: always
@@ -129,7 +129,7 @@ snapshots:
       description: ID of the KMS Key encrypting the snapshot
       returned: always
       type: str
-      sample: arn:aws:kms:us-west-2:111111111111:key/abcd1234-1234-aaaa-0000-1234567890ab
+      sample: arn:aws:kms:us-west-2:123456789012:key/abcd1234-1234-aaaa-0000-1234567890ab
     license_model:
       description: License model
       returned: always
@@ -211,7 +211,7 @@ cluster_snapshots:
       description: ARN of the database snapshot
       returned: always
       type: str
-      sample: arn:aws:rds:ca-central-1:111111111111:cluster-snapshot:test-aurora-snapshot
+      sample: arn:aws:rds:ca-central-1:123456789012:cluster-snapshot:test-aurora-snapshot
     db_cluster_snapshot_identifier:
       description: Snapshot identifier
       returned: always
@@ -236,7 +236,7 @@ cluster_snapshots:
       description: ID of the KMS Key encrypting the snapshot
       returned: always
       type: str
-      sample: arn:aws:kms:ca-central-1:111111111111:key/abcd1234-abcd-1111-aaaa-0123456789ab
+      sample: arn:aws:kms:ca-central-1:123456789012:key/abcd1234-abcd-1111-aaaa-0123456789ab
     license_model:
       description: License model
       returned: always

--- a/plugins/modules/rds_subnet_group.py
+++ b/plugins/modules/rds_subnet_group.py
@@ -165,7 +165,7 @@ subnet_group:
             description: The ARN of the DB subnet group
             returned: I(state=present)
             type: str
-            sample: "arn:aws:rds:eu-north-1:721066863947:subgrp:ansible-test-13950442"
+            sample: "arn:aws:rds:eu-north-1:123456789012:subgrp:ansible-test-13950442"
         tags:
             description: The tags associated with the subnet group
             returned: I(state=present)


### PR DESCRIPTION
##### SUMMARY

Various AWS IAM resources have UUID which follow a [specific pattern](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html#identifiers-unique-ids).  Similarly AWS accounts are all 12 digit numbers (text aliases in a couple of cases).  To minimize the risk of accidental data leaks use a consistent Account ID in examples (`123456789012`), and a specific format for the UUIDS: `(AKIA|AGPA|AIDA|AROA|AIPA|ANPA|ANVA|ASIA)12345EXAMPLE54321`

While this does nothing about historic data, having consistency makes it easier to prevent future leaks.

**Note:** We should follow this up with an update to the developer docs, however I'd like to get this in prior to 5.0.0

Split from https://github.com/ansible-collections/amazon.aws/pull/1070 due to test concurrency problems

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/modules/rds_instance_info.py
plugins/modules/rds_option_group.py
plugins/modules/rds_option_group_info.py
plugins/modules/rds_snapshot_info.py
plugins/modules/rds_subnet_group.py

##### ADDITIONAL INFORMATION
