### PR TITLE
Revert "Work around for #1083 (#1086)"

### DIFF
--- a/changelogs/fragments/1083-__spec__-is-None.yml
+++ b/changelogs/fragments/1083-__spec__-is-None.yml
@@ -1,2 +1,0 @@
-bugfixes:
-- 'module_utils/cloud - Fix ``ValueError: ansible_collections.amazon.aws.plugins.module_utils.core.__spec__ is None`` error on Ansible 2.9 (https://github.com/ansible-collections/amazon.aws/issues/1083).'

--- a/plugins/module_utils/cloud.py
+++ b/plugins/module_utils/cloud.py
@@ -32,12 +32,7 @@ __metaclass__ = type
 import time
 import functools
 import random
-
-try:
-    import ansible.module_utils.common.warnings as ansible_warnings
-    ANCIENT_ANSIBLE = False
-except ImportError:
-    ANCIENT_ANSIBLE = True
+import ansible.module_utils.common.warnings as ansible_warnings
 
 
 class BackoffIterator:
@@ -205,10 +200,9 @@ class CloudRetry:
         """
         # This won't emit a warning (we don't have the context available to us), but will trigger
         # sanity failures as we prepare for 6.0.0
-        if not ANCIENT_ANSIBLE:
-            ansible_warnings.deprecate(
-                'CloudRetry.backoff has been deprecated, please use CloudRetry.exponential_backoff instead',
-                version='6.0.0', collection_name='amazon.aws')
+        ansible_warnings.deprecate(
+            'CloudRetry.backoff has been deprecated, please use CloudRetry.exponential_backoff instead',
+            version='6.0.0', collection_name='amazon.aws')
 
         return cls.exponential_backoff(
             retries=tries,


### PR DESCRIPTION
This reverts commit e0aeafdc00558665e9ec4c36e6c0f15835881b5f.

##### SUMMARY

Following #1087 we no longer need the workaround for #1083.

The work around has been backported to stable-4, which still announces support for Ansible 2.9, however we've now dropped support for 2.9 so don't need this in main/5.0.0

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/cloud.py

##### ADDITIONAL INFORMATION
