### PR TITLE
new modules: lambda_layer and lambda_layer_info

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -90,6 +90,7 @@ action_groups:
   - s3_object
   - s3_object_info
   - lambda_layer
+  - lambda_layer_info
 plugin_routing:
   action:
     aws_s3:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -70,6 +70,8 @@ action_groups:
   - lambda_event
   - lambda_execute
   - lambda_info
+  - lambda_layer
+  - lambda_layer_info
   - lambda_policy
   - rds_cluster
   - rds_cluster_info
@@ -89,8 +91,6 @@ action_groups:
   - s3_bucket
   - s3_object
   - s3_object_info
-  - lambda_layer
-  - lambda_layer_info
 plugin_routing:
   action:
     aws_s3:

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -89,6 +89,7 @@ action_groups:
   - s3_bucket
   - s3_object
   - s3_object_info
+  - lambda_layer
 plugin_routing:
   action:
     aws_s3:

--- a/plugins/modules/lambda_layer.py
+++ b/plugins/modules/lambda_layer.py
@@ -95,7 +95,6 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-- amazon.aws.aws_boto3
 
 '''
 

--- a/plugins/modules/lambda_layer.py
+++ b/plugins/modules/lambda_layer.py
@@ -95,6 +95,7 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
+- amazon.aws.boto3
 
 '''
 

--- a/plugins/modules/lambda_layer.py
+++ b/plugins/modules/lambda_layer.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: lambda_layer
-version_added: 5.0.0
+version_added: 5.1.0
 short_description: Creates an AWS Lambda layer or deletes an AWS Lambda layer version
 description:
   - This module allows the management of AWS Lambda functions aliases via the Ansible

--- a/plugins/modules/lambda_layer.py
+++ b/plugins/modules/lambda_layer.py
@@ -1,0 +1,350 @@
+#!/usr/bin/python
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: lambda_layer
+version_added: 5.0.0
+short_description: Creates AWS Lambda layer or deletes AWS Lambda layer version
+description:
+  - This module allows the management of AWS Lambda functions aliases via the Ansible
+  - Creates an Lambda layer from a ZIP archive.
+    Each time you call this module with the same layer name, a new version is created.
+  - Deletes a version of an Lambda layer.
+
+author: "Aubin Bikouo (@abikouo)"
+options:
+  state:
+    description:
+    - Determines if an Lambda layer should be created, or deleted. When set to C(present), an Lambda layer version will be
+      created. If set to C(absent), an existing Lambda layer version will be deleted.
+    type: str
+    default: present
+    choices: [ absent, present ]
+  name:
+    description:
+    - The name or Amazon Resource Name (ARN) of the Lambda layer.
+    type: str
+    required: true
+    aliases:
+    - layer_name
+  description:
+    description:
+    - The description of the version.
+    - Ignored when C(state) is set to I(absent).
+    - Mutually exclusive with C(version).
+    type: str
+  content:
+    description:
+    - The function layer archive.
+    - Required when I(state) is set to C(present).
+    - Ignored when I(state) is set to C(absent).
+    - Mutually exclusive with C(version).
+    type: dict
+    suboptions:
+      s3_bucket:
+        description:
+        - The Amazon S3 bucket of the layer archive.
+        type: str
+      s3_key:
+        description:
+        - The Amazon S3 key of the layer archive.
+        type: str
+      s3_object_version:
+        description:
+        - For versioned objects, the version of the layer archive object to use.
+        type: str
+      zip_file:
+        description:
+        - Path to the base64-encoded file of the layer archive.
+        type: path
+  compatible_runtimes:
+    description:
+    - A list of compatible function runtimes.
+    - Ignored when C(state) is set to I(absent).
+    - Mutually exclusive with C(version).
+    type: list
+    elements: str
+  license_info:
+    description:
+    - The layer's software license. It can be any of an SPDX license identifier,
+      the URL of a license hosted on the internet or the full text of the license.
+    - Ignored when C(state) is set to I(absent).
+    - Mutually exclusive with C(version).
+    type: str
+  compatible_architectures:
+    description:
+    - A list of compatible instruction set architectures. For example, x86_64.
+    - Mutually exclusive with C(version).
+    type: list
+    elements: str
+  version:
+    description:
+    - The version number of the layer to delete.
+    - Required when C(state) is set to I(absent).
+    - Ignored when C(state) is set to I(present).
+    - Mutually exclusive with C(description), C(content), C(compatible_runtimes),
+      C(license_info), C(compatible_architectures).
+    type: int
+extends_documentation_fragment:
+- amazon.aws.aws
+- amazon.aws.ec2
+
+'''
+
+EXAMPLES = '''
+---
+# Create a new Python library layer version from a zip archive located into a S3 bucket
+- name: Create a new python library layer
+  lambda_layer:
+    state: present
+    name: sample-layer
+    description: 'My Python layer'
+    content:
+      s3_bucket: 'lambda-layers-us-west-2-123456789012'
+      s3_key: 'python_layer.zip'
+    compatible_runtimes:
+      - python3.6
+      - python3.7
+    license_info: MIT
+    compatible_architectures:
+      - x86_64
+
+# Create a layer version from a zip in the local filesystem
+- name: Create a new layer from a zip in the local filesystem
+  lambda_layer:
+    state: present
+    name: sample-layer
+    description: 'My Python layer'
+    content:
+      zip_file: 'python_layer.zip'
+    compatible_runtimes:
+      - python3.6
+      - python3.7
+    license_info: MIT
+    compatible_architectures:
+      - x86_64
+
+# Delete a layer version
+- name: Delete a layer version
+  lambda_layer:
+    state: present
+    name: sample-layer
+    version: 2
+'''
+
+RETURN = '''
+layer_version:
+  description: info about the layer version that was created or deleted.
+  returned: always
+  type: complex
+  contains:
+    content:
+        description: Details about the layer version.
+        returned: I(state=present)
+        type: complex
+        contains:
+          location:
+            description: A link to the layer archive in Amazon S3 that is valid for 10 minutes.
+            returned: I(state=present)
+            type: str
+            sample: "https://awslambda-us-east-1-layers.s3.us-east-1.amazonaws.com/snapshots/123456789012/pylayer-9da91deffd3b4941b8baeeae5daeffe4"
+          code_sha256:
+            description: The SHA-256 hash of the layer archive.
+            returned: I(state=present)
+            type: str
+            sample: "VLluleJZ3HTwDrdYolSMrS+8iPwEkcoXXaegjXf+dmc="
+          code_size:
+            description: The size of the layer archive in bytes.
+            returned: I(state=present)
+            type: int
+            sample: 9473675
+          signing_profile_version_arn:
+            description: The Amazon Resource Name (ARN) for a signing profile version.
+            returned: When a signing profile is defined
+            type: str
+          signing_job_arn:
+            description: The Amazon Resource Name (ARN) of a signing job.
+            returned: When a signing profile is defined
+            type: str
+    layer_arn:
+        description: The ARN of the layer.
+        returned: if the layer version exists or has been created
+        type: str
+        sample: "arn:aws:lambda:eu-west-2:123456789012:layer:pylayer"
+    layer_version_arn:
+        description: The ARN of the layer version.
+        returned: if the layer version exists or has been created
+        type: str
+        sample: "arn:aws:lambda:eu-west-2:123456789012:layer:pylayer:2"
+    description:
+        description: The description of the version.
+        returned: I(state=present)
+        type: str
+    created_date:
+        description: The date that the layer version was created, in ISO-8601 format (YYYY-MM-DDThh:mm:ss.sTZD).
+        returned: if the layer version exists or has been created
+        type: str
+        sample: "2022-09-28T14:27:35.866+0000"
+    version:
+        description: The version number.
+        returned: if the layer version exists or has been created
+        type: str
+        sample: 1
+    compatible_runtimes:
+        description: A list of compatible runtimes.
+        returned: if it was defined for the layer version.
+        type: list
+        sample: ["python3.7"]
+    license_info:
+        description: The layer's software license.
+        returned: if it was defined for the layer version.
+        type: str
+        sample: "GPL-3.0-only"
+    compatible_architectures:
+        description: A list of compatible instruction set architectures.
+        returned: if it was defined for the layer version.
+        type: list
+'''
+
+try:
+    import botocore
+except ImportError:
+    pass  # Handled by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+
+
+def list_layer_versions(module, lambda_client):
+
+    try:
+        params = dict(LayerName=module.params.get("name"))
+        paginator = lambda_client.get_paginator('list_layer_versions')
+        layer_versions = paginator.paginate(**params).build_full_result()['LayerVersions']
+        return [camel_dict_to_snake_dict(layer) for layer in layer_versions]
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Unable to list layer versions for name {0}".format(module.params.get("name")))
+
+
+def create_layer_version(module, lambda_client):
+    if module.check_mode:
+        module.exit_json(msg="Create operation skipped - running in check mode", changed=True)
+
+    params = dict(LayerName=module.params.get("name"))
+    keys = [
+        ('description', 'Description'),
+        ('compatible_runtimes', 'CompatibleRuntimes'),
+        ('license_info', 'LicenseInfo'),
+        ('compatible_architectures', 'CompatibleArchitectures'),
+    ]
+    for k, d in keys:
+        if module.params.get(k) is not None:
+            params[d] = module.params.get(k)
+
+    # Read zip file if any
+    zip_file = module.params["content"].get("zip_file")
+    if zip_file is not None:
+        with open(zip_file, "rb") as zf:
+            module.params["content"]["zip_file"] = zf.read()
+
+    content = dict()
+    content_keys = [
+        ('s3_bucket', 'S3Bucket'),
+        ('s3_key', 'S3Key'),
+        ('s3_object_version', 'S3ObjectVersion'),
+        ('zip_file', 'ZipFile'),
+    ]
+    for k, d in content_keys:
+        if module.params["content"].get(k) is not None:
+            content[d] = module.params["content"].get(k)
+    params["Content"] = content
+    try:
+        layer_version = lambda_client.publish_layer_version(**params)
+        layer_version.pop("ResponseMetadata", None)
+        module.exit_json(changed=True, layer_version=camel_dict_to_snake_dict(layer_version))
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+        module.fail_json_aws(e, msg="Failed to publish a new layer version (check that you have required permissions).")
+
+
+def delete_layer_version(module, lambda_client):
+    layer_versions = list_layer_versions(module, lambda_client)
+    version = module.params.get("version")
+    layer_version_instance = dict()
+    changed = False
+    for layer in layer_versions:
+        if layer["version"] == version:
+            layer_version_instance = layer
+            changed = True
+            if not module.check_mode:
+                params = dict(LayerName=module.params.get("name"), VersionNumber=version)
+                try:
+                    lambda_client.delete_layer_version(**params)
+                except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+                    module.fail_json_aws(e, msg="Failed to delete layer version.")
+    module.exit_json(changed=changed, layer_version=layer_version_instance)
+
+
+def execute_module(module, lambda_client):
+
+    state = module.params.get("state")
+    if state == "present":
+        # Create layer version
+        create_layer_version(module, lambda_client)
+    else:
+        # Delete layer version
+        delete_layer_version(module, lambda_client)
+
+
+def main():
+    argument_spec = dict(
+        state=dict(type="str", choices=["present", "absent"], default="present"),
+        name=dict(type="str", required=True, aliases=["layer_name"]),
+        description=dict(type="str"),
+        content=dict(
+            type="dict",
+            options=dict(
+                s3_bucket=dict(type="str"),
+                s3_key=dict(type="str", no_log=False),
+                s3_object_version=dict(type="str"),
+                zip_file=dict(type="path"),
+            ),
+            required_together=[['s3_bucket', 's3_key']],
+            required_one_of=[['s3_bucket', 'zip_file']],
+            mutually_exclusive=[['s3_bucket', 'zip_file']],
+        ),
+        compatible_runtimes=dict(type="list", elements="str"),
+        license_info=dict(type="str"),
+        compatible_architectures=dict(type="list", elements="str"),
+        version=dict(type="int"),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        required_if=[
+            ("state", "present", ["content"]),
+            ("state", "absent", ["version"]),
+        ],
+        mutually_exclusive=[
+            ['version', 'description'],
+            ['version', 'content'],
+            ['version', 'compatible_runtimes'],
+            ['version', 'license_info'],
+            ['version', 'compatible_architectures'],
+        ],
+        supports_check_mode=True,
+    )
+
+    lambda_client = module.client('lambda', retry_decorator=AWSRetry.jittered_backoff())
+    execute_module(module, lambda_client)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/lambda_layer_info.py
+++ b/plugins/modules/lambda_layer_info.py
@@ -26,21 +26,22 @@ options:
   compatible_runtime:
     description:
     - A runtime identifier.
-    - Specify this option without C(name) to list only latest layers versions of layers that indicate
+    - Specify this option without I(name) to list only latest layers versions of layers that indicate
       that they're compatible with that runtime.
-    - Specify this option with C(name) to list only layer versions that indicate that
+    - Specify this option with I(name) to list only layer versions that indicate that
       they're compatible with that runtime.
     type: str
   compatible_architecture:
     description:
     - A compatible instruction set architectures.
-    - Specify this option without C(name) to include only to list only latest layers versions of layers that
+    - Specify this option without I(name) to include only to list only latest layers versions of layers that
       are compatible with that instruction set architecture.
-    - Specify this option with C(name) to include only layer versions that are compatible with that architecture.
+    - Specify this option with I(name) to include only layer versions that are compatible with that architecture.
     type: str
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
+- amazon.aws.aws_boto3
 
 '''
 
@@ -48,22 +49,22 @@ EXAMPLES = '''
 ---
 # Display information about the versions for the layer named blank-java-lib
 - name: Retrieve layer versions
-  lambda_layer_info:
+  amazon.aws.lambda_layer_info:
     name: blank-java-lib
 
 # Display information about the versions for the layer named blank-java-lib compatible with architecture x86_64
 - name: Retrieve layer versions
-  lambda_layer_info:
+  amazon.aws.lambda_layer_info:
     name: blank-java-lib
     compatible_architecture: x86_64
 
 # list latest versions of available layers
 - name: list latest versions for all layers
-  lambda_layer_info:
+  amazon.aws.lambda_layer_info:
 
 # list latest versions of available layers compatible with runtime python3.7
 - name: list latest versions for all layers
-  lambda_layer_info:
+  amazon.aws.lambda_layer_info:
     compatible_runtime: python3.7
 '''
 
@@ -97,7 +98,7 @@ layers_versions:
     version:
         description: The version number.
         returned: if the layer version exists or has been created
-        type: str
+        type: int
         sample: 1
     compatible_runtimes:
         description: A list of compatible runtimes.

--- a/plugins/modules/lambda_layer_info.py
+++ b/plugins/modules/lambda_layer_info.py
@@ -163,8 +163,9 @@ def list_layers(module, lambda_client):
     try:
         layers = _list_layers(lambda_client, **params)['Layers']
         layer_versions = []
-        for layer in layers:
-            layer.update(layer.pop("LatestMatchingVersion", None))
+        for item in layers:
+            layer = {key: value for key, value in item.items() if key != "LatestMatchingVersion"}
+            layer.update(item.get("LatestMatchingVersion"))
             layer_versions.append(camel_dict_to_snake_dict(layer))
         return layer_versions
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:

--- a/plugins/modules/lambda_layer_info.py
+++ b/plugins/modules/lambda_layer_info.py
@@ -9,7 +9,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: lambda_layer_info
-version_added: 5.0.0
+version_added: 5.1.0
 short_description: List lambda layer or lambda layer versions
 description:
   - This module is used to list the versions of an Lambda layer or all available lambda layers.

--- a/plugins/modules/lambda_layer_info.py
+++ b/plugins/modules/lambda_layer_info.py
@@ -41,6 +41,7 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
+- amazon.aws.boto3
 
 '''
 

--- a/plugins/modules/lambda_layer_info.py
+++ b/plugins/modules/lambda_layer_info.py
@@ -181,19 +181,24 @@ def list_layers(lambda_client, compatible_runtime=None, compatible_architecture=
 
 def execute_module(module, lambda_client):
 
+    params = {}
+    f_operation = list_layers
     name = module.params.get("name")
+    if name is not None:
+        f_operation = list_layer_versions
+        params["name"] = name
     compatible_runtime = module.params.get("compatible_runtime")
+    if compatible_runtime is not None:
+        params["compatible_runtime"] = compatible_runtime
     compatible_architecture = module.params.get("compatible_architecture")
+    if compatible_architecture is not None:
+        params["compatible_architecture"] = compatible_architecture
 
     try:
-        if name is not None:
-            result = list_layer_versions(lambda_client, name, compatible_runtime, compatible_architecture)
-        else:
-            result = list_layers(lambda_client, compatible_runtime, compatible_architecture)
-
+        result = f_operation(lambda_client, **params)
         module.exit_json(changed=False, layers_versions=result)
     except LambdaLayerInfoFailure as e:
-        module.fail_json_aws(e.exc, msg=e.msg)
+        module.fail_json_aws(exception=e.exc, msg=e.msg)
 
 
 def main():

--- a/plugins/modules/lambda_layer_info.py
+++ b/plugins/modules/lambda_layer_info.py
@@ -1,0 +1,189 @@
+#!/usr/bin/python
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: lambda_layer_info
+version_added: 5.0.0
+short_description: List lambda layer or lambda layer versions
+description:
+  - This module is used to list the versions of an Lambda layer or all available lambda layers.
+  - The lambda layer versions that have been deleted aren't listed.
+
+author: "Aubin Bikouo (@abikouo)"
+options:
+  name:
+    description:
+    - The name or Amazon Resource Name (ARN) of the Lambda layer.
+    type: str
+    aliases:
+    - layer_name
+  compatible_runtime:
+    description:
+    - A runtime identifier.
+    - Specify this option without C(name) to list only latest layers versions of layers that indicate
+      that they're compatible with that runtime.
+    - Specify this option with C(name) to list only layer versions that indicate that
+      they're compatible with that runtime.
+    type: str
+  compatible_architecture:
+    description:
+    - A compatible instruction set architectures.
+    - Specify this option without C(name) to include only to list only latest layers versions of layers that
+      are compatible with that instruction set architecture.
+    - Specify this option with C(name) to include only layer versions that are compatible with that architecture.
+    type: str
+extends_documentation_fragment:
+- amazon.aws.aws
+- amazon.aws.ec2
+
+'''
+
+EXAMPLES = '''
+---
+# Display information about the versions for the layer named blank-java-lib
+- name: Retrieve layer versions
+  lambda_layer_info:
+    name: blank-java-lib
+
+# Display information about the versions for the layer named blank-java-lib compatible with architecture x86_64
+- name: Retrieve layer versions
+  lambda_layer_info:
+    name: blank-java-lib
+    compatible_architecture: x86_64
+
+# list latest versions of available layers
+- name: list latest versions for all layers
+  lambda_layer_info:
+
+# list latest versions of available layers compatible with runtime python3.7
+- name: list latest versions for all layers
+  lambda_layer_info:
+    compatible_runtime: python3.7
+'''
+
+RETURN = '''
+layers_versions:
+  description:
+  - The layers versions that exists.
+  returned: success
+  type: list
+  elements: dict
+  contains:
+    layer_arn:
+        description: The ARN of the layer.
+        returned: when C(name) is provided
+        type: str
+        sample: "arn:aws:lambda:eu-west-2:123456789012:layer:pylayer"
+    layer_version_arn:
+        description: The ARN of the layer version.
+        returned: if the layer version exists or has been created
+        type: str
+        sample: "arn:aws:lambda:eu-west-2:123456789012:layer:pylayer:2"
+    description:
+        description: The description of the version.
+        returned: I(state=present)
+        type: str
+    created_date:
+        description: The date that the layer version was created, in ISO-8601 format (YYYY-MM-DDThh:mm:ss.sTZD).
+        returned: if the layer version exists or has been created
+        type: str
+        sample: "2022-09-28T14:27:35.866+0000"
+    version:
+        description: The version number.
+        returned: if the layer version exists or has been created
+        type: str
+        sample: 1
+    compatible_runtimes:
+        description: A list of compatible runtimes.
+        returned: if it was defined for the layer version.
+        type: list
+        sample: ["python3.7"]
+    license_info:
+        description: The layer's software license.
+        returned: if it was defined for the layer version.
+        type: str
+        sample: "GPL-3.0-only"
+    compatible_architectures:
+        description: A list of compatible instruction set architectures.
+        returned: if it was defined for the layer version.
+        type: list
+'''
+
+try:
+    import botocore
+except ImportError:
+    pass  # Handled by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+
+
+def list_layer_versions(module, lambda_client):
+
+    params = dict(LayerName=module.params.get("name"))
+    if module.params.get("compatible_runtime"):
+        params["CompatibleRuntime"] = module.params.get("compatible_runtime")
+    if module.params.get("compatible_architecture"):
+        params["CompatibleArchitecture"] = module.params.get("compatible_architecture")
+    try:
+        paginator = lambda_client.get_paginator('list_layer_versions')
+        layer_versions = paginator.paginate(**params).build_full_result()['LayerVersions']
+        return [camel_dict_to_snake_dict(layer) for layer in layer_versions]
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Unable to list layer versions for name {0}".format(module.params.get("name")))
+
+
+def list_layers(module, lambda_client):
+
+    params = dict()
+    if module.params.get("compatible_runtime"):
+        params["CompatibleRuntime"] = module.params.get("compatible_runtime")
+    if module.params.get("compatible_architecture"):
+        params["CompatibleArchitecture"] = module.params.get("compatible_architecture")
+    try:
+        paginator = lambda_client.get_paginator('list_layers')
+        layers = paginator.paginate(**params).build_full_result()['Layers']
+        layer_versions = []
+        for layer in layers:
+            layer.update(layer.pop("LatestMatchingVersion", None))
+            layer_versions.append(camel_dict_to_snake_dict(layer))
+        return layer_versions
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Unable to list layers {0}".format(params))
+
+
+def execute_module(module, lambda_client):
+
+    operation = list_layers
+    if module.params.get("name") is not None:
+        operation = list_layer_versions
+
+    module.exit_json(changed=False, layers_versions=operation(module, lambda_client))
+
+
+def main():
+    argument_spec = dict(
+        name=dict(type="str", aliases=["layer_name"]),
+        compatible_runtime=dict(type="str"),
+        compatible_architecture=dict(type="str"),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    lambda_client = module.client('lambda', retry_decorator=AWSRetry.jittered_backoff())
+    execute_module(module, lambda_client)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/lambda_layer_info.py
+++ b/plugins/modules/lambda_layer_info.py
@@ -41,7 +41,6 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-- amazon.aws.aws_boto3
 
 '''
 

--- a/tests/integration/targets/lambda_layer/aliases
+++ b/tests/integration/targets/lambda_layer/aliases
@@ -1,3 +1,2 @@
 cloud/aws
 lambda_layer_info
-disabled

--- a/tests/integration/targets/lambda_layer/aliases
+++ b/tests/integration/targets/lambda_layer/aliases
@@ -1,0 +1,3 @@
+cloud/aws
+lambda_layer_info
+disabled

--- a/tests/integration/targets/lambda_layer/defaults/main.yml
+++ b/tests/integration/targets/lambda_layer/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+lambda_hander_content: |
+  # Copyright: Ansible Project
+  # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+  import logging
+  from datetime import datetime
+  logger = logging.getLogger()
+  logger.setLevel(logging.INFO)
+  def lambda_handler(event, context):
+      logger.info('Ansible amazon.aws collection lambda handler executed at {0}'.format(datetime.now().strftime("%y%m%d-%H%M%S")))

--- a/tests/integration/targets/lambda_layer/tasks/main.yml
+++ b/tests/integration/targets/lambda_layer/tasks/main.yml
@@ -1,0 +1,222 @@
+---
+- module_defaults:
+    group/aws:
+      aws_access_key: '{{ aws_access_key | default(omit) }}'
+      aws_secret_key: '{{ aws_secret_key | default(omit) }}'
+      security_token: '{{ security_token | default(omit) }}'
+      region: '{{ aws_region | default(omit) }}'
+
+  collections:
+    - amazon.aws
+
+  vars:
+    s3_bucket_name: "{{ resource_prefix }}-bucket"
+    s3_bucket_object: "{{ resource_prefix }}-obj-1"
+    layer_name: "{{ resource_prefix }}-layer"
+
+  block:
+    - name: Create temporary directory
+      tempfile:
+        state: directory
+        suffix: .lambda_handler
+      register: _dir
+
+    - copy:
+        content: "{{ lambda_hander_content }}"
+        dest: "{{ _dir.path }}/lambda_handler.py"
+        remote_src: true
+
+    - set_fact:
+        zip_file_path: "{{ _dir.path }}/lambda_handler.zip"
+
+    - name: Create lambda handler archive
+      archive:
+        path: "{{ _dir.path }}/lambda_handler.py"
+        dest: "{{ zip_file_path }}"
+        format: zip
+
+    - name: Create S3 bucket for testing
+      s3_bucket:
+        name: "{{ s3_bucket_name }}"
+        state: present
+
+    - name: add object into bucket
+      s3_object:
+        bucket: "{{ s3_bucket_name }}"
+        mode: put
+        object: "{{ s3_bucket_object }}"
+        permission: public-read
+        src: "{{ zip_file_path }}"
+
+    - name: Create lambda layer (check_mode=true)
+      lambda_layer:
+        name: "{{ layer_name }}"
+        description: '{{ resource_prefix }} lambda layer first version'
+        content:
+          zip_file: "{{ zip_file_path }}"
+        compatible_runtimes:
+          - python3.7
+        license_info: GPL-3.0-only
+      register: create_check_mode
+      check_mode: true
+
+    - name: Retrieve all layers versions
+      lambda_layer_info:
+        name: "{{ layer_name }}"
+      register: layers
+
+    - name: Ensure lambda layer was not created
+      assert:
+        that:
+          - create_check_mode is changed
+          - create_check_mode.msg == "Create operation skipped - running in check mode"
+          - layers.layers_versions | length == 0
+
+    - name: Create lambda layer (first version)
+      lambda_layer:
+        name: "{{ layer_name }}"
+        description: '{{ resource_prefix }} lambda layer first version'
+        content:
+          zip_file: "{{ zip_file_path }}"
+        compatible_runtimes:
+          - python3.7
+        license_info: GPL-3.0-only
+      register: first_version
+
+    - name: Create another lambda layer version
+      lambda_layer:
+        name: "{{ layer_name }}"
+        description: '{{ resource_prefix }} lambda layer second version'
+        content:
+          s3_bucket: "{{ s3_bucket_name }}"
+          s3_key: "{{ s3_bucket_object }}"
+        compatible_runtimes:
+          - python3.7
+        license_info: GPL-3.0-only
+      register: last_version
+
+    - name: Retrieve all layers with latest version
+      lambda_layer_info:
+      register: layers
+    
+    - name: Ensure layer created above was found
+      assert:
+        that:
+          - '"layers_versions" in layers'
+          - last_version.layer_version.layer_arn in layers_arns
+          - last_version.layer_version.layer_version_arn in layers_version_arns
+          - first_version.layer_version.layer_version_arn not in layers_version_arns
+      vars:
+        layers_arns: '{{ layers.layers_versions | map(attribute="layer_arn") | list }}'
+        layers_version_arns: '{{ layers.layers_versions | map(attribute="layer_version_arn") | list }}'
+
+    - name: Retrieve all layers versions
+      lambda_layer_info:
+        name: "{{ layer_name }}"
+      register: layers
+
+    - name: Ensure layer created above was found
+      assert:
+        that:
+          - '"layers_versions" in layers'
+          - layers.layers_versions | length == 2
+          - last_version.layer_version.layer_version_arn in layers_version_arns
+          - first_version.layer_version.layer_version_arn in layers_version_arns
+      vars:
+        layers_version_arns: '{{ layers.layers_versions | map(attribute="layer_version_arn") | list }}'
+
+    - name: Delete latest layer version
+      lambda_layer:
+        name: "{{ layer_name }}"
+        version: "{{ last_version.layer_version.version }}"
+        state: absent
+      check_mode: true
+      register: delete_check_mode
+
+    - name: Retrieve all layers versions
+      lambda_layer_info:
+        name: "{{ layer_name }}"
+      register: layers
+
+    - name: Ensure layer still contains the same number of versions
+      assert:
+        that:
+          - delete_check_mode is changed
+          - layers.layers_versions | length == 2
+          - last_version.layer_version.layer_version_arn in layers_version_arns
+          - first_version.layer_version.layer_version_arn in layers_version_arns
+      vars:
+        layers_version_arns: '{{ layers.layers_versions | map(attribute="layer_version_arn") | list }}'
+
+    - name: Delete latest layer version
+      lambda_layer:
+        name: "{{ layer_name }}"
+        version: "{{ last_version.layer_version.version }}"
+        state: absent
+      register: delete_layer
+
+    - name: Retrieve all layers versions
+      lambda_layer_info:
+        name: "{{ layer_name }}"
+      register: layers
+
+    - name: Ensure layer still contains the same number of versions
+      assert:
+        that:
+          - delete_layer is changed
+          - layers.layers_versions | length == 1
+          - last_version.layer_version.layer_version_arn not in layers_version_arns
+          - first_version.layer_version.layer_version_arn in layers_version_arns
+      vars:
+        layers_version_arns: '{{ layers.layers_versions | map(attribute="layer_version_arn") | list }}'
+
+    - name: Delete again the latest layer version (idempotency)
+      lambda_layer:
+        name: "{{ layer_name }}"
+        version: "{{ last_version.layer_version.version }}"
+        state: absent
+      register: delete_idempotent
+
+    - name: Ensure nothing changed
+      assert:
+        that:
+          - delete_idempotent is not changed
+
+    - name: Delete first layer version
+      lambda_layer:
+        name: "{{ layer_name }}"
+        version: "{{ first_version.layer_version.version }}"
+        state: absent
+      register: delete_layer
+
+    - name: Retrieve all layers versions
+      lambda_layer_info:
+        name: "{{ layer_name }}"
+      register: layers
+
+    - name: Ensure layer does not exist anymore
+      assert:
+        that:
+          - delete_layer is changed
+          - layers.layers_versions | length == 0
+
+  always:
+    - name: Delete temporary directory
+      file:
+        state: absent
+        path: "{{ _dir.path }}"
+      ignore_errors: true
+
+    - name: Remove object from bucket
+      s3_object:
+        bucket: "{{ s3_bucket_name }}"
+        mode: delobj
+        object: "{{ s3_bucket_object }}"
+      ignore_errors: true
+
+    - name: Delete S3 bucket
+      s3_bucket:
+        name: "{{ s3_bucket_name }}"
+        force: true
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/lambda_layer/tasks/main.yml
+++ b/tests/integration/targets/lambda_layer/tasks/main.yml
@@ -1,10 +1,11 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key | default(omit) }}'
-      aws_secret_key: '{{ aws_secret_key | default(omit) }}'
-      security_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region | default(omit) }}'
+      # aws_access_key: '{{ aws_access_key | default(omit) }}'
+      # aws_secret_key: '{{ aws_secret_key | default(omit) }}'
+      # security_token: '{{ security_token | default(omit) }}'
+      # region: '{{ aws_region | default(omit) }}'
+      aws_profile: "eu_london"
 
   collections:
     - amazon.aws
@@ -103,9 +104,11 @@
       assert:
         that:
           - '"layers_versions" in layers'
-          - last_version.layer_version.layer_arn in layers_arns
-          - last_version.layer_version.layer_version_arn in layers_version_arns
-          - first_version.layer_version.layer_version_arn not in layers_version_arns
+          - first_version.layer_versions | length == 1
+          - last_version.layer_versions | length == 1
+          - last_version.layer_versions.0.layer_arn in layers_arns
+          - last_version.layer_versions.0.layer_version_arn in layers_version_arns
+          - first_version.layer_versions.0.layer_version_arn not in layers_version_arns
       vars:
         layers_arns: '{{ layers.layers_versions | map(attribute="layer_arn") | list }}'
         layers_version_arns: '{{ layers.layers_versions | map(attribute="layer_version_arn") | list }}'
@@ -120,15 +123,17 @@
         that:
           - '"layers_versions" in layers'
           - layers.layers_versions | length == 2
-          - last_version.layer_version.layer_version_arn in layers_version_arns
-          - first_version.layer_version.layer_version_arn in layers_version_arns
+          - first_version.layer_versions | length == 1
+          - last_version.layer_versions | length == 1
+          - last_version.layer_versions.0.layer_version_arn in layers_version_arns
+          - first_version.layer_versions.0.layer_version_arn in layers_version_arns
       vars:
         layers_version_arns: '{{ layers.layers_versions | map(attribute="layer_version_arn") | list }}'
 
     - name: Delete latest layer version
       lambda_layer:
         name: "{{ layer_name }}"
-        version: "{{ last_version.layer_version.version }}"
+        version: "{{ last_version.layer_versions.0.version }}"
         state: absent
       check_mode: true
       register: delete_check_mode
@@ -138,20 +143,21 @@
         name: "{{ layer_name }}"
       register: layers
 
-    - name: Ensure layer still contains the same number of versions
+    - name: Ensure no layer version was deleted
       assert:
         that:
           - delete_check_mode is changed
+          - delete_check_mode.layer_versions | length == 1
           - layers.layers_versions | length == 2
-          - last_version.layer_version.layer_version_arn in layers_version_arns
-          - first_version.layer_version.layer_version_arn in layers_version_arns
+          - last_version.layer_versions.0.layer_version_arn in layers_version_arns
+          - first_version.layer_versions.0.layer_version_arn in layers_version_arns
       vars:
         layers_version_arns: '{{ layers.layers_versions | map(attribute="layer_version_arn") | list }}'
 
     - name: Delete latest layer version
       lambda_layer:
         name: "{{ layer_name }}"
-        version: "{{ last_version.layer_version.version }}"
+        version: "{{ last_version.layer_versions.0.version }}"
         state: absent
       register: delete_layer
 
@@ -160,20 +166,21 @@
         name: "{{ layer_name }}"
       register: layers
 
-    - name: Ensure layer still contains the same number of versions
+    - name: Ensure latest layer version was deleted
       assert:
         that:
           - delete_layer is changed
+          - delete_layer.layer_versions | length == 1
           - layers.layers_versions | length == 1
-          - last_version.layer_version.layer_version_arn not in layers_version_arns
-          - first_version.layer_version.layer_version_arn in layers_version_arns
+          - last_version.layer_versions.0.layer_version_arn not in layers_version_arns
+          - first_version.layer_versions.0.layer_version_arn in layers_version_arns
       vars:
         layers_version_arns: '{{ layers.layers_versions | map(attribute="layer_version_arn") | list }}'
 
     - name: Delete again the latest layer version (idempotency)
       lambda_layer:
         name: "{{ layer_name }}"
-        version: "{{ last_version.layer_version.version }}"
+        version: "{{ last_version.layer_versions.0.version }}"
         state: absent
       register: delete_idempotent
 
@@ -182,10 +189,22 @@
         that:
           - delete_idempotent is not changed
 
-    - name: Delete first layer version
+    - name: Create multiple lambda layer versions
       lambda_layer:
         name: "{{ layer_name }}"
-        version: "{{ first_version.layer_version.version }}"
+        description: '{{ resource_prefix }} lambda layer version compatible with python3.{{ item }}'
+        content:
+          s3_bucket: "{{ s3_bucket_name }}"
+          s3_key: "{{ s3_bucket_object }}"
+        compatible_runtimes:
+          - "python3.{{ item }}"
+        license_info: GPL-3.0-only
+      with_items: ["9", "10"]
+
+    - name: Delete all layer versions
+      lambda_layer:
+        name: "{{ layer_name }}"
+        version: -1
         state: absent
       register: delete_layer
 
@@ -198,9 +217,17 @@
       assert:
         that:
           - delete_layer is changed
+          - delete_layer.layer_versions | length > 1
           - layers.layers_versions | length == 0
 
   always:
+    - name: Delete lambda layer if not deleted during testing
+      lambda_layer:
+        name: "{{ layer_name }}"
+        version: -1
+        state: absent
+      ignore_errors: true
+
     - name: Delete temporary directory
       file:
         state: absent

--- a/tests/integration/targets/lambda_layer/tasks/main.yml
+++ b/tests/integration/targets/lambda_layer/tasks/main.yml
@@ -1,11 +1,10 @@
 ---
 - module_defaults:
     group/aws:
-      # aws_access_key: '{{ aws_access_key | default(omit) }}'
-      # aws_secret_key: '{{ aws_secret_key | default(omit) }}'
-      # security_token: '{{ security_token | default(omit) }}'
-      # region: '{{ aws_region | default(omit) }}'
-      aws_profile: "eu_london"
+      aws_access_key: '{{ aws_access_key | default(omit) }}'
+      aws_secret_key: '{{ aws_secret_key | default(omit) }}'
+      security_token: '{{ security_token | default(omit) }}'
+      region: '{{ aws_region | default(omit) }}'
 
   collections:
     - amazon.aws

--- a/tests/unit/plugins/modules/test_lambda_layer.py
+++ b/tests/unit/plugins/modules/test_lambda_layer.py
@@ -1,0 +1,425 @@
+#
+# (c) 2022 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+from tempfile import NamedTemporaryFile
+
+from ansible_collections.amazon.aws.tests.unit.compat.mock import MagicMock
+from ansible_collections.amazon.aws.plugins.modules import lambda_layer
+
+
+def setup_testing(module_params):
+    connection = MagicMock(name="connection")
+    module = MagicMock(name="module")
+    module.params = module_params
+    module.params.setdefault("state", "present")
+    module.check_mode = False
+    module.exit_json.side_effect = SystemExit(1)
+    module.fail_json.side_effect = SystemExit(2)
+
+    conn_paginator = MagicMock(name="connection.paginator")
+    paginate = MagicMock(name="paginator.paginate")
+    connection.get_paginator.return_value = conn_paginator
+    conn_paginator.paginate.return_value = paginate
+    # paginate.build_full_result.return_value = list_layers_versions_paginate_result
+    connection.delete_layer_version.return_value = None
+
+    return module, connection, conn_paginator, paginate
+
+
+def test_delete_non_existing_layer():
+    module_params = dict(
+        state="absent",
+        name="testlayer",
+        version=4,
+    )
+
+    module, lambda_client, conn_paginator, paginate = setup_testing(module_params)
+    paginate.build_full_result.return_value = dict(
+        LayerVersions=[],
+        ResponseMetadata=dict(http_header=True),
+        NextMarker="abcdef123"
+    )
+
+    with pytest.raises(SystemExit):
+        lambda_layer.execute_module(module, lambda_client)
+
+    lambda_client.get_paginator.assert_called_with("list_layer_versions")
+    conn_paginator.paginate.assert_called_with(
+        LayerName="testlayer",
+    )
+    paginate.build_full_result.assert_called_once()
+    module.exit_json.assert_called_with(
+        changed=False,
+        layer_version=dict()
+    )
+
+
+def test_delete_layer_non_existing_version():
+    module_params = dict(
+        state="absent",
+        name="testlayer",
+        version=4,
+    )
+
+    module, lambda_client, conn_paginator, paginate = setup_testing(module_params)
+    paginate.build_full_result.return_value = {
+        "LayerVersions": [
+            {
+                'CompatibleRuntimes': ["python3.7"],
+                'CreatedDate': "2022-09-29T10:31:35.977+0000",
+                'LayerVersionArn': "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:2",
+                "LicenseInfo": "MIT",
+                'Version': 2,
+                'CompatibleArchitectures': [
+                    'arm64'
+                ]
+            },
+            {
+                "CompatibleRuntimes": ["python3.7"],
+                "CreatedDate": "2022-09-29T10:31:26.341+0000",
+                "Description": "lambda layer first version",
+                "LayerVersionArn": "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:1",
+                "LicenseInfo": "GPL-3.0-only",
+                "Version": 1
+            }
+        ],
+        "ResponseMetadata": {
+            "http_header": True
+        },
+        "NextMarker": "abcdef123"
+    }
+
+    with pytest.raises(SystemExit):
+        lambda_layer.execute_module(module, lambda_client)
+
+    lambda_client.get_paginator.assert_called_with("list_layer_versions")
+    conn_paginator.paginate.assert_called_with(
+        LayerName="testlayer",
+    )
+    paginate.build_full_result.assert_called_once()
+    module.exit_json.assert_called_with(
+        changed=False,
+        layer_version=dict()
+    )
+
+
+def test_delete_layer_existing_version():
+    module_params = dict(
+        state="absent",
+        name="testlayer",
+        version=2,
+    )
+
+    module, lambda_client, conn_paginator, paginate = setup_testing(module_params)
+
+    paginate.build_full_result.return_value = {
+        "LayerVersions": [
+            {
+                'CompatibleRuntimes': ["python3.7"],
+                'CreatedDate': "2022-09-29T10:31:35.977+0000",
+                'LayerVersionArn': "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:2",
+                "LicenseInfo": "MIT",
+                'Version': 2,
+                'CompatibleArchitectures': [
+                    'arm64'
+                ]
+            },
+            {
+                "CompatibleRuntimes": ["python3.7"],
+                "CreatedDate": "2022-09-29T10:31:26.341+0000",
+                "Description": "lambda layer first version",
+                "LayerVersionArn": "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:1",
+                "LicenseInfo": "GPL-3.0-only",
+                "Version": 1
+            }
+        ],
+        "ResponseMetadata": {
+            "http_header": True
+        },
+        "NextMarker": "abcdef123"
+    }
+
+    with pytest.raises(SystemExit):
+        lambda_layer.execute_module(module, lambda_client)
+
+    lambda_client.get_paginator.assert_called_with("list_layer_versions")
+    conn_paginator.paginate.assert_called_with(
+        LayerName="testlayer",
+    )
+    paginate.build_full_result.assert_called_once()
+    lambda_client.delete_layer_version.assert_called_with(
+        LayerName="testlayer",
+        VersionNumber=2
+    )
+    module.exit_json.assert_called_with(
+        changed=True,
+        layer_version={
+            "compatible_runtimes": ["python3.7"],
+            "created_date": "2022-09-29T10:31:35.977+0000",
+            "layer_version_arn": "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:2",
+            "license_info": "MIT",
+            "version": 2,
+            'compatible_architectures': [
+                'arm64'
+            ]
+        },
+    )
+
+
+def test_delete_layer_existing_version_using_check_mode():
+    module_params = dict(
+        state="absent",
+        name="testlayer",
+        version=2,
+    )
+
+    module, lambda_client, conn_paginator, paginate = setup_testing(module_params)
+    module.check_mode = True
+    paginate.build_full_result.return_value = {
+        "LayerVersions": [
+            {
+                'CompatibleRuntimes': ["python3.7"],
+                'CreatedDate': "2022-09-29T10:31:35.977+0000",
+                'LayerVersionArn': "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:2",
+                "LicenseInfo": "MIT",
+                'Version': 2,
+                'CompatibleArchitectures': [
+                    'arm64'
+                ]
+            },
+            {
+                "CompatibleRuntimes": ["python3.7"],
+                "CreatedDate": "2022-09-29T10:31:26.341+0000",
+                "Description": "lambda layer first version",
+                "LayerVersionArn": "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:1",
+                "LicenseInfo": "GPL-3.0-only",
+                "Version": 1
+            }
+        ],
+        "ResponseMetadata": {
+            "http_header": True
+        },
+        "NextMarker": "abcdef123"
+    }
+
+    with pytest.raises(SystemExit):
+        lambda_layer.execute_module(module, lambda_client)
+
+    lambda_client.get_paginator.assert_called_with("list_layer_versions")
+    conn_paginator.paginate.assert_called_with(
+        LayerName="testlayer",
+    )
+    paginate.build_full_result.assert_called_once()
+    lambda_client.delete_layer_version.assert_not_called()
+    module.exit_json.assert_called_with(
+        changed=True,
+        layer_version={
+            "compatible_runtimes": ["python3.7"],
+            "created_date": "2022-09-29T10:31:35.977+0000",
+            "layer_version_arn": "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:2",
+            "license_info": "MIT",
+            "version": 2,
+            'compatible_architectures': [
+                'arm64'
+            ]
+        },
+    )
+
+
+def test_create_layer_using_check_mode():
+    module_params = dict(
+        name="testlayer",
+        description="ansible units testing sample layer",
+        content=dict(
+            s3_bucket="mybucket",
+            s3_key="mybucket-key",
+            s3_object_version="v1"
+        ),
+        license_info="MIT"
+    )
+
+    module, lambda_client, conn_paginator, paginate = setup_testing(module_params)
+    module.check_mode = True
+    paginate.build_full_result.return_value = None
+
+    with pytest.raises(SystemExit):
+        lambda_layer.execute_module(module, lambda_client)
+
+    lambda_client.get_paginator.assert_not_called()
+    conn_paginator.paginate.assert_not_called()
+    paginate.build_full_result.assert_not_called()
+    lambda_client.publish_layer_version.assert_not_called()
+    module.exit_json.assert_called_with(
+        changed=True,
+        msg="Create operation skipped - running in check mode"
+    )
+
+
+def test_create_layer_using_s3_bucket():
+    module_params = dict(
+        name="testlayer",
+        description="ansible units testing sample layer",
+        content=dict(
+            s3_bucket="mybucket",
+            s3_key="mybucket-key",
+            s3_object_version="v1"
+        ),
+        license_info="MIT"
+    )
+
+    module, lambda_client, conn_paginator, paginate = setup_testing(module_params)
+    paginate.build_full_result.return_value = None
+    lambda_client.publish_layer_version.return_value = {
+        'CompatibleRuntimes': [
+            'python3.6',
+            'python3.7',
+        ],
+        'Content': {
+            'CodeSha256': 'tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=',
+            'CodeSize': 169,
+            'Location': 'https://awslambda-us-west-2-layers.s3.us-west-2.amazonaws.com/snapshots/123456789012/my-layer-4aaa2fbb',
+        },
+        'CreatedDate': '2018-11-14T23:03:52.894+0000',
+        'Description': "ansible units testing sample layer",
+        'LayerArn': 'arn:aws:lambda:us-west-2:123456789012:layer:my-layer',
+        'LayerVersionArn': 'arn:aws:lambda:us-west-2:123456789012:layer:testlayer:1',
+        'LicenseInfo': 'MIT',
+        'Version': 1,
+        'ResponseMetadata': {
+            'http_header': 'true',
+        },
+    }
+
+    with pytest.raises(SystemExit):
+        lambda_layer.execute_module(module, lambda_client)
+
+    lambda_client.get_paginator.assert_not_called()
+    conn_paginator.paginate.assert_not_called()
+    paginate.build_full_result.assert_not_called()
+
+    lambda_client.publish_layer_version.assert_called_with(
+        LayerName="testlayer",
+        Description="ansible units testing sample layer",
+        LicenseInfo="MIT",
+        Content=dict(
+            S3Bucket="mybucket",
+            S3Key="mybucket-key",
+            S3ObjectVersion="v1"
+        )
+    )
+
+    module.exit_json.assert_called_with(
+        changed=True,
+        layer_version={
+            'compatible_runtimes': ['python3.6', 'python3.7'],
+            'content': {
+                'code_sha256': 'tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=',
+                'code_size': 169,
+                'location': 'https://awslambda-us-west-2-layers.s3.us-west-2.amazonaws.com/snapshots/123456789012/my-layer-4aaa2fbb'
+            },
+            'created_date': '2018-11-14T23:03:52.894+0000',
+            'description': 'ansible units testing sample layer',
+            'layer_arn': 'arn:aws:lambda:us-west-2:123456789012:layer:my-layer',
+            'layer_version_arn': 'arn:aws:lambda:us-west-2:123456789012:layer:testlayer:1',
+            'license_info': 'MIT',
+            'version': 1
+        }
+    )
+
+
+def test_create_layer_using_zip_file():
+
+    zip_file_content = b"simple lambda layer content"
+    with NamedTemporaryFile() as tf:
+        tf.write(zip_file_content)
+        tf.flush()
+
+        module_params = dict(
+            name="testlayer",
+            description="ansible units testing sample layer",
+            content=dict(
+                zip_file=tf.name,
+            ),
+            compatible_runtimes=[
+                "nodejs",
+                "python3.9"
+            ],
+            compatible_architectures=[
+                'x86_64',
+                'arm64'
+            ]
+        )
+
+        module, lambda_client, conn_paginator, paginate = setup_testing(module_params)
+        paginate.build_full_result.return_value = None
+        lambda_client.publish_layer_version.return_value = {
+            'CompatibleRuntimes': [
+                'nodejs',
+                'python3.9',
+            ],
+            "CompatibleArchitectures": [
+                'x86_64',
+                'arm64'
+            ],
+            'Content': {
+                'CodeSha256': 'tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=',
+                'CodeSize': 169,
+                'Location': 'https://awslambda-us-west-2-layers.s3.us-west-2.amazonaws.com/snapshots/123456789012/my-layer-4aaa2fbb',
+            },
+            'CreatedDate': '2018-11-14T23:03:52.894+0000',
+            'Description': "ansible units testing sample layer",
+            'LayerArn': 'arn:aws:lambda:us-west-2:123456789012:layer:my-layer',
+            'LayerVersionArn': 'arn:aws:lambda:us-west-2:123456789012:layer:testlayer:2',
+            'Version': 2,
+            'ResponseMetadata': {
+                'http_header': 'true',
+            },
+        }
+
+        with pytest.raises(SystemExit):
+            lambda_layer.execute_module(module, lambda_client)
+
+        lambda_client.get_paginator.assert_not_called()
+        conn_paginator.paginate.assert_not_called()
+        paginate.build_full_result.assert_not_called()
+
+        lambda_client.publish_layer_version.assert_called_with(
+            LayerName="testlayer",
+            Description="ansible units testing sample layer",
+            CompatibleRuntimes=[
+                "nodejs",
+                "python3.9"
+            ],
+            CompatibleArchitectures=[
+                'x86_64',
+                'arm64'
+            ],
+            Content=dict(
+                ZipFile=zip_file_content
+            )
+        )
+
+        module.exit_json.assert_called_with(
+            changed=True,
+            layer_version={
+                'compatible_runtimes': ['nodejs', 'python3.9'],
+                "compatible_architectures": ['x86_64', 'arm64'],
+                'content': {
+                    'code_sha256': 'tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=',
+                    'code_size': 169,
+                    'location': 'https://awslambda-us-west-2-layers.s3.us-west-2.amazonaws.com/snapshots/123456789012/my-layer-4aaa2fbb'
+                },
+                'created_date': '2018-11-14T23:03:52.894+0000',
+                'description': 'ansible units testing sample layer',
+                'layer_arn': 'arn:aws:lambda:us-west-2:123456789012:layer:my-layer',
+                'layer_version_arn': 'arn:aws:lambda:us-west-2:123456789012:layer:testlayer:2',
+                'version': 2
+            }
+        )

--- a/tests/unit/plugins/modules/test_lambda_layer.py
+++ b/tests/unit/plugins/modules/test_lambda_layer.py
@@ -12,7 +12,6 @@ from tempfile import NamedTemporaryFile
 import os
 
 from unittest.mock import MagicMock, call
-from unittest import TestCase
 from ansible_collections.amazon.aws.plugins.modules import lambda_layer
 
 
@@ -247,299 +246,252 @@ def test_delete_layer_failure():
         lambda_layer.delete_layer_version(lambda_client, params)
 
 
-class CreateLayerTestCase(TestCase):
-    def setUp(self):
-        self.lambda_client = MagicMock()
-        lambda_layer.list_layer_versions = MagicMock()
+@pytest.mark.parametrize(
+    "b_s3content",
+    [
+        (True),
+        (False)
+    ]
+)
+def test_create_layer(b_s3content):
+    params = {
+        "name": "testlayer",
+        "description": "ansible units testing sample layer",
+        "content": {},
+        "license_info": "MIT"
+    }
 
-        self.zip_file_data = b"simple lambda layer content"
-        self.file_handler = NamedTemporaryFile(delete=False)
-        self.file_handler.write(self.zip_file_data)
-        self.file_handler.flush()
+    lambda_client = MagicMock()
+    lambda_layer.list_layer_versions = MagicMock()
 
-    def tearDown(self):
-        self.file_handler.close()
-        os.unlink(self.file_handler.name)
+    lambda_client.publish_layer_version.return_value = {
+        'CompatibleRuntimes': [
+            'python3.6',
+            'python3.7',
+        ],
+        'Content': {
+            'CodeSha256': 'tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=',
+            'CodeSize': 169,
+            'Location': 'https://awslambda-us-west-2-layers.s3.us-west-2.amazonaws.com/snapshots/123456789012/my-layer-4aaa2fbb',
+        },
+        'CreatedDate': '2018-11-14T23:03:52.894+0000',
+        'Description': "ansible units testing sample layer",
+        'LayerArn': 'arn:aws:lambda:us-west-2:123456789012:layer:my-layer',
+        'LayerVersionArn': 'arn:aws:lambda:us-west-2:123456789012:layer:testlayer:1',
+        'LicenseInfo': 'MIT',
+        'Version': 1,
+        'ResponseMetadata': {
+            'http_header': 'true',
+        },
+    }
 
-    def test_check_mode(self):
-        params = {
-            "name": "testlayer",
-            "description": "ansible units testing sample layer",
-            "content": {
-                "s3_bucket": "mybucket",
-                "s3_key": "mybucket-key",
-                "s3_object_version": "v1"
-            },
-            "license_info": "MIT"
-        }
-
-        result = lambda_layer.create_layer_version(self.lambda_client, params, check_mode=True)
-        assert result == {"msg": "Create operation skipped - running in check mode", "changed": True}
-
-        lambda_layer.list_layer_versions.assert_not_called()
-        self.lambda_client.publish_layer_version.assert_not_called()
-
-    def test_using_s3_bucket(self):
-        params = {
-            "name": "testlayer",
-            "description": "ansible units testing sample layer",
-            "content": {
-                "s3_bucket": "mybucket",
-                "s3_key": "mybucket-key",
-                "s3_object_version": "v1"
-            },
-            "license_info": "MIT"
-        }
-
-        self.lambda_client.publish_layer_version.return_value = {
-            'CompatibleRuntimes': [
-                'python3.6',
-                'python3.7',
-            ],
-            'Content': {
-                'CodeSha256': 'tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=',
-                'CodeSize': 169,
-                'Location': 'https://awslambda-us-west-2-layers.s3.us-west-2.amazonaws.com/snapshots/123456789012/my-layer-4aaa2fbb',
-            },
-            'CreatedDate': '2018-11-14T23:03:52.894+0000',
-            'Description': "ansible units testing sample layer",
-            'LayerArn': 'arn:aws:lambda:us-west-2:123456789012:layer:my-layer',
-            'LayerVersionArn': 'arn:aws:lambda:us-west-2:123456789012:layer:testlayer:1',
-            'LicenseInfo': 'MIT',
-            'Version': 1,
-            'ResponseMetadata': {
-                'http_header': 'true',
-            },
-        }
-
-        expected = {
-            "changed": True,
-            "layer_versions": [
-                {
-                    'compatible_runtimes': ['python3.6', 'python3.7'],
-                    'content': {
-                        'code_sha256': 'tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=',
-                        'code_size': 169,
-                        'location': 'https://awslambda-us-west-2-layers.s3.us-west-2.amazonaws.com/snapshots/123456789012/my-layer-4aaa2fbb'
-                    },
-                    'created_date': '2018-11-14T23:03:52.894+0000',
-                    'description': 'ansible units testing sample layer',
-                    'layer_arn': 'arn:aws:lambda:us-west-2:123456789012:layer:my-layer',
-                    'layer_version_arn': 'arn:aws:lambda:us-west-2:123456789012:layer:testlayer:1',
-                    'license_info': 'MIT',
-                    'version': 1
-                }
-            ]
-        }
-
-        result = lambda_layer.create_layer_version(self.lambda_client, params)
-        assert result == expected
-
-        self.lambda_client.publish_layer_version.assert_called_with(
-            LayerName="testlayer",
-            Description="ansible units testing sample layer",
-            LicenseInfo="MIT",
-            Content={
-                "S3Bucket": "mybucket",
-                "S3Key": "mybucket-key",
-                "S3ObjectVersion": "v1"
+    expected = {
+        "changed": True,
+        "layer_versions": [
+            {
+                'compatible_runtimes': ['python3.6', 'python3.7'],
+                'content': {
+                    'code_sha256': 'tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=',
+                    'code_size': 169,
+                    'location': 'https://awslambda-us-west-2-layers.s3.us-west-2.amazonaws.com/snapshots/123456789012/my-layer-4aaa2fbb'
+                },
+                'created_date': '2018-11-14T23:03:52.894+0000',
+                'description': 'ansible units testing sample layer',
+                'layer_arn': 'arn:aws:lambda:us-west-2:123456789012:layer:my-layer',
+                'layer_version_arn': 'arn:aws:lambda:us-west-2:123456789012:layer:testlayer:1',
+                'license_info': 'MIT',
+                'version': 1
             }
-        )
+        ]
+    }
 
-    def test_using_zip_file(self):
-        params = {
-            "name": "testlayer",
-            "description": "ansible units testing sample layer",
-            "content": {
-                "zip_file": self.file_handler.name,
-            },
-            "compatible_runtimes": [
-                "nodejs",
-                "python3.9"
-            ],
-            "compatible_architectures": [
-                'x86_64',
-                'arm64'
-            ]
+    zfile_handler = None
+
+    if b_s3content:
+        params["content"] = {
+            "s3_bucket": "mybucket",
+            "s3_key": "mybucket-key",
+            "s3_object_version": "v1"
+        }
+        content_arg = {
+            "S3Bucket": "mybucket",
+            "S3Key": "mybucket-key",
+            "S3ObjectVersion": "v1"
+        }
+    else:
+        binary_data = b"simple lambda layer content"
+        zfile_handler = NamedTemporaryFile(delete=False)
+        zfile_handler.write(binary_data)
+        zfile_handler.flush()
+
+        params["content"] = {"zip_file": zfile_handler.name}
+        content_arg = {
+            "ZipFile": binary_data,
         }
 
-        self.lambda_client.publish_layer_version.return_value = {
-            'CompatibleRuntimes': [
-                'nodejs',
-                'python3.9',
-            ],
-            "CompatibleArchitectures": [
-                'x86_64',
-                'arm64'
-            ],
-            'Content': {
-                'CodeSha256': 'tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=',
-                'CodeSize': 169,
-                'Location': 'https://awslambda-us-west-2-layers.s3.us-west-2.amazonaws.com/snapshots/123456789012/my-layer-4aaa2fbb',
-            },
-            'CreatedDate': '2018-11-14T23:03:52.894+0000',
-            'Description': "ansible units testing sample layer",
-            'LayerArn': 'arn:aws:lambda:us-west-2:123456789012:layer:my-layer',
-            'LayerVersionArn': 'arn:aws:lambda:us-west-2:123456789012:layer:testlayer:2',
-            'Version': 2,
-            'ResponseMetadata': {
-                'http_header': 'true',
-            },
-        }
+    result = lambda_layer.create_layer_version(lambda_client, params)
 
-        expected = {
-            "changed": True,
-            "layer_versions": [
-                {
-                    'compatible_runtimes': ['nodejs', 'python3.9'],
-                    "compatible_architectures": ['x86_64', 'arm64'],
-                    'content': {
-                        'code_sha256': 'tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=',
-                        'code_size': 169,
-                        'location': 'https://awslambda-us-west-2-layers.s3.us-west-2.amazonaws.com/snapshots/123456789012/my-layer-4aaa2fbb'
-                    },
-                    'created_date': '2018-11-14T23:03:52.894+0000',
-                    'description': 'ansible units testing sample layer',
-                    'layer_arn': 'arn:aws:lambda:us-west-2:123456789012:layer:my-layer',
-                    'layer_version_arn': 'arn:aws:lambda:us-west-2:123456789012:layer:testlayer:2',
-                    'version': 2
-                }
-            ]
-        }
+    if zfile_handler:
+        zfile_handler.close()
+        os.unlink(zfile_handler.name)
 
-        result = lambda_layer.create_layer_version(self.lambda_client, params)
-        assert result == expected
+    assert result == expected
 
-        self.lambda_client.publish_layer_version.assert_called_with(
-            LayerName="testlayer",
-            Description="ansible units testing sample layer",
-            CompatibleRuntimes=[
-                "nodejs",
-                "python3.9"
-            ],
-            CompatibleArchitectures=[
-                'x86_64',
-                'arm64'
-            ],
-            Content={
-                "ZipFile": self.zip_file_data
-            },
-        )
+    lambda_client.publish_layer_version.assert_called_with(
+        LayerName="testlayer",
+        Description="ansible units testing sample layer",
+        LicenseInfo="MIT",
+        Content=content_arg,
+    )
 
-    def test_failure(self):
-        params = {
-            "name": "testlayer",
-            "description": "ansible units testing sample layer",
-            "content": {
-                "zip_file": self.file_handler.name,
-            },
-            "compatible_runtimes": [
-                "nodejs",
-                "python3.9"
-            ],
-            "compatible_architectures": [
-                'x86_64',
-                'arm64'
-            ]
-        }
-
-        self.lambda_client.publish_layer_version.side_effect = raise_lambdalayer_exception()
-        with pytest.raises(lambda_layer.LambdaLayerFailure):
-            lambda_layer.create_layer_version(self.lambda_client, params)
-
-    def test_using_unexisting_file(self):
-        params = {
-            "name": "testlayer",
-            "description": "ansible units testing sample layer",
-            "content": {
-                "zip_file": "this_file_does_not_exist",
-            },
-            "compatible_runtimes": [
-                "nodejs",
-                "python3.9"
-            ],
-            "compatible_architectures": [
-                'x86_64',
-                'arm64'
-            ]
-        }
-
-        self.lambda_client.publish_layer_version.return_value = {}
-        with pytest.raises(FileNotFoundError):
-            lambda_layer.create_layer_version(self.lambda_client, params)
-
-        self.lambda_client.publish_layer_version.assert_not_called()
+    lambda_layer.list_layer_versions.assert_not_called()
 
 
-class ExecuteModuleTestCase(TestCase):
+def test_create_layer_check_mode():
+    params = {
+        "name": "testlayer",
+        "description": "ansible units testing sample layer",
+        "content": {
+            "s3_bucket": "mybucket",
+            "s3_key": "mybucket-key",
+            "s3_object_version": "v1"
+        },
+        "license_info": "MIT"
+    }
 
-    def setUp(self):
-        self.module = MagicMock()
-        self.module.check_mode = False
-        self.module.exit_json.side_effect = SystemExit(1)
-        self.module.fail_json_aws.side_effect = SystemExit(2)
+    lambda_client = MagicMock()
+    lambda_layer.list_layer_versions = MagicMock()
 
-        self.lambda_client = MagicMock()
+    result = lambda_layer.create_layer_version(lambda_client, params, check_mode=True)
+    assert result == {"msg": "Create operation skipped - running in check mode", "changed": True}
 
-        lambda_layer.create_layer_version = MagicMock()
-        lambda_layer.delete_layer_version = MagicMock()
+    lambda_layer.list_layer_versions.assert_not_called()
+    lambda_client.publish_layer_version.assert_not_called()
 
-    def test_create_layer(self):
-        params = {
-            "name": "test-layer"
-        }
-        self.module.params = params
 
-        result = {"changed": True, "layers_versions": {}}
-        lambda_layer.create_layer_version.return_value = result
+def test_create_layer_failure():
+    params = {
+        "name": "testlayer",
+        "description": "ansible units testing sample layer",
+        "content": {
+            "s3_bucket": "mybucket",
+            "s3_key": "mybucket-key",
+            "s3_object_version": "v1"
+        },
+        "compatible_runtimes": [
+            "nodejs",
+            "python3.9"
+        ],
+        "compatible_architectures": [
+            'x86_64',
+            'arm64'
+        ]
+    }
+    lambda_client = MagicMock()
+    lambda_client.publish_layer_version.side_effect = raise_lambdalayer_exception()
 
-        with pytest.raises(SystemExit):
-            lambda_layer.execute_module(self.module, self.lambda_client)
+    with pytest.raises(lambda_layer.LambdaLayerFailure):
+        lambda_layer.create_layer_version(lambda_client, params)
 
-        self.module.exit_json.assert_called_with(
-            **result
-        )
-        self.module.fail_json_aws.assert_not_called()
-        lambda_layer.create_layer_version.assert_called_with(
-            self.lambda_client, params, self.module.check_mode
-        )
-        lambda_layer.delete_layer_version.assert_not_called()
 
-    def test_delete_layer(self):
-        params = {
-            "name": "test-layer", "state": "absent"
-        }
-        self.module.params = params
+def test_create_layer_using_unexisting_file():
+    params = {
+        "name": "testlayer",
+        "description": "ansible units testing sample layer",
+        "content": {
+            "zip_file": "this_file_does_not_exist",
+        },
+        "compatible_runtimes": [
+            "nodejs",
+            "python3.9"
+        ],
+        "compatible_architectures": [
+            'x86_64',
+            'arm64'
+        ]
+    }
 
-        result = {"changed": True, "layers_versions": []}
-        lambda_layer.delete_layer_version.return_value = result
+    lambda_client = MagicMock()
+    lambda_layer.list_layer_versions = MagicMock()
 
-        with pytest.raises(SystemExit):
-            lambda_layer.execute_module(self.module, self.lambda_client)
+    lambda_client.publish_layer_version.return_value = {}
+    with pytest.raises(FileNotFoundError):
+        lambda_layer.create_layer_version(lambda_client, params)
 
-        self.module.exit_json.assert_called_with(
-            **result
-        )
-        self.module.fail_json_aws.assert_not_called()
-        lambda_layer.delete_layer_version.assert_called_with(
-            self.lambda_client, params, self.module.check_mode
-        )
-        lambda_layer.create_layer_version.assert_not_called()
+    lambda_client.publish_layer_version.assert_not_called()
 
-    def test_failure(self):
-        params = {
-            "name": "test-layer", "state": "absent"
-        }
-        self.module.params = params
 
+@pytest.mark.parametrize(
+    "params,failure",
+    [
+        (
+            {"name": "test-layer"},
+            False
+        ),
+        (
+            {"name": "test-layer", "state": "absent"},
+            False
+        ),
+        (
+            {"name": "test-layer"},
+            True
+        ),
+        (
+            {"name": "test-layer", "state": "absent"},
+            True
+        ),
+    ]
+)
+def test_execute_module(params, failure):
+
+    module = MagicMock()
+    module.params = params
+    module.check_mode = False
+    module.exit_json.side_effect = SystemExit(1)
+    module.fail_json_aws.side_effect = SystemExit(2)
+
+    lambda_client = MagicMock()
+
+    lambda_layer.create_layer_version = MagicMock()
+    lambda_layer.delete_layer_version = MagicMock()
+
+    state = params.get("state", "present")
+    result = {"changed": True, "layers_versions": {}}
+
+    if not failure:
+        if state == "present":
+            lambda_layer.create_layer_version.return_value = result
+            with pytest.raises(SystemExit):
+                lambda_layer.execute_module(module, lambda_client)
+
+            module.exit_json.assert_called_with(**result)
+            module.fail_json_aws.assert_not_called()
+            lambda_layer.create_layer_version.assert_called_with(
+                lambda_client, params, module.check_mode
+            )
+            lambda_layer.delete_layer_version.assert_not_called()
+
+        elif state == "absent":
+            lambda_layer.delete_layer_version.return_value = result
+            with pytest.raises(SystemExit):
+                lambda_layer.execute_module(module, lambda_client)
+
+            module.exit_json.assert_called_with(**result)
+            module.fail_json_aws.assert_not_called()
+            lambda_layer.delete_layer_version.assert_called_with(
+                lambda_client, params, module.check_mode
+            )
+            lambda_layer.create_layer_version.assert_not_called()
+    else:
         exc = "lambdalayer_execute_module_exception"
         msg = "this_exception_is_used_for_unit_testing"
+        lambda_layer.create_layer_version.side_effect = raise_lambdalayer_exception(exc, msg)
         lambda_layer.delete_layer_version.side_effect = raise_lambdalayer_exception(exc, msg)
 
         with pytest.raises(SystemExit):
-            lambda_layer.execute_module(self.module, self.lambda_client)
+            lambda_layer.execute_module(module, lambda_client)
 
-        self.module.exit_json.assert_not_called()
-        self.module.fail_json_aws.assert_called_with(
+        module.exit_json.assert_not_called()
+        module.fail_json_aws.assert_called_with(
             exc, msg=msg
         )

--- a/tests/unit/plugins/modules/test_lambda_layer.py
+++ b/tests/unit/plugins/modules/test_lambda_layer.py
@@ -156,7 +156,6 @@ def test_delete_layer_existing_version():
     lambda_client.delete_layer_version.assert_called_with(
         LayerName="testlayer",
         VersionNumber=2,
-        aws_retry=True,
     )
     module.exit_json.assert_called_with(
         changed=True,
@@ -387,7 +386,6 @@ def test_create_layer_using_s3_bucket():
             S3Key="mybucket-key",
             S3ObjectVersion="v1"
         ),
-        aws_retry=True,
     )
 
     module.exit_json.assert_called_with(
@@ -481,7 +479,6 @@ def test_create_layer_using_zip_file():
             Content=dict(
                 ZipFile=zip_file_content
             ),
-            aws_retry=True,
         )
 
         module.exit_json.assert_called_with(

--- a/tests/unit/plugins/modules/test_lambda_layer.py
+++ b/tests/unit/plugins/modules/test_lambda_layer.py
@@ -155,7 +155,8 @@ def test_delete_layer_existing_version():
     paginate.build_full_result.assert_called_once()
     lambda_client.delete_layer_version.assert_called_with(
         LayerName="testlayer",
-        VersionNumber=2
+        VersionNumber=2,
+        aws_retry=True,
     )
     module.exit_json.assert_called_with(
         changed=True,
@@ -311,7 +312,8 @@ def test_create_layer_using_s3_bucket():
             S3Bucket="mybucket",
             S3Key="mybucket-key",
             S3ObjectVersion="v1"
-        )
+        ),
+        aws_retry=True,
     )
 
     module.exit_json.assert_called_with(
@@ -402,7 +404,8 @@ def test_create_layer_using_zip_file():
             ],
             Content=dict(
                 ZipFile=zip_file_content
-            )
+            ),
+            aws_retry=True,
         )
 
         module.exit_json.assert_called_with(

--- a/tests/unit/plugins/modules/test_lambda_layer.py
+++ b/tests/unit/plugins/modules/test_lambda_layer.py
@@ -27,7 +27,6 @@ def setup_testing(module_params):
     paginate = MagicMock(name="paginator.paginate")
     connection.get_paginator.return_value = conn_paginator
     conn_paginator.paginate.return_value = paginate
-    # paginate.build_full_result.return_value = list_layers_versions_paginate_result
     connection.delete_layer_version.return_value = None
 
     return module, connection, conn_paginator, paginate

--- a/tests/unit/plugins/modules/test_lambda_layer_info.py
+++ b/tests/unit/plugins/modules/test_lambda_layer_info.py
@@ -1,0 +1,314 @@
+#
+# (c) 2022 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.amazon.aws.tests.unit.compat.mock import MagicMock
+from ansible_collections.amazon.aws.plugins.modules import lambda_layer_info
+
+
+list_layers_paginate_result = {
+    'NextMarker': '002',
+    'Layers': [
+        {
+            'LayerName': "test-layer-01",
+            'LayerArn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-01",
+            'LatestMatchingVersion': {
+                'LayerVersionArn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-01:1",
+                'Version': 1,
+                'Description': "lambda layer created for unit tests",
+                'CreatedDate': "2022-09-29T10:31:26.341+0000",
+                'CompatibleRuntimes': [
+                    'nodejs',
+                    'nodejs4.3',
+                    'nodejs6.10'
+                ],
+                'LicenseInfo': 'MIT',
+                'CompatibleArchitectures': [
+                    'arm64'
+                ]
+            }
+        },
+        {
+            'LayerName': "test-layer-02",
+            'LayerArn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-02",
+            'LatestMatchingVersion': {
+                'LayerVersionArn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-02:1",
+                'Version': 1,
+                'CreatedDate': "2022-09-29T10:31:26.341+0000",
+                'CompatibleArchitectures': [
+                    'arm64'
+                ]
+            }
+        },
+    ],
+    'ResponseMetadata': {
+        'http': 'true',
+    },
+}
+
+list_layers_result = [
+    {
+        'layer_name': "test-layer-01",
+        'layer_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-01",
+        'layer_version_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-01:1",
+        'version': 1,
+        'description': "lambda layer created for unit tests",
+        'created_date': "2022-09-29T10:31:26.341+0000",
+        'compatible_runtimes': [
+            'nodejs',
+            'nodejs4.3',
+            'nodejs6.10'
+        ],
+        'license_info': 'MIT',
+        'compatible_architectures': [
+            'arm64'
+        ]
+    },
+    {
+        'layer_name': "test-layer-02",
+        'layer_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-02",
+        'layer_version_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-02:1",
+        'version': 1,
+        'created_date': "2022-09-29T10:31:26.341+0000",
+        'compatible_architectures': [
+            'arm64'
+        ]
+    }
+]
+
+
+list_layers_versions_paginate_result = {
+    'LayerVersions': [
+        {
+            'CompatibleRuntimes': ["python3.7"],
+            'CreatedDate': "2022-09-29T10:31:35.977+0000",
+            'LayerVersionArn': "arn:aws:lambda:eu-west-2:123456789012:layer:layer-01:2",
+            "LicenseInfo": "MIT",
+            'Version': 2,
+            'CompatibleArchitectures': [
+                'arm64'
+            ]
+        },
+        {
+            "CompatibleRuntimes": ["python3.7"],
+            "CreatedDate": "2022-09-29T10:31:26.341+0000",
+            "Description": "lambda layer first version",
+            "LayerVersionArn": "arn:aws:lambda:eu-west-2:123456789012:layer:layer-01:1",
+            "LicenseInfo": "GPL-3.0-only",
+            "Version": 1
+        }
+    ],
+    'ResponseMetadata': {
+        'http': 'true',
+    },
+    'NextMarker': '001',
+}
+
+
+list_layers_versions_result = [
+    {
+        "compatible_runtimes": ["python3.7"],
+        "created_date": "2022-09-29T10:31:35.977+0000",
+        "layer_version_arn": "arn:aws:lambda:eu-west-2:123456789012:layer:layer-01:2",
+        "license_info": "MIT",
+        "version": 2,
+        'compatible_architectures': [
+            'arm64'
+        ]
+    },
+    {
+        "compatible_runtimes": ["python3.7"],
+        "created_date": "2022-09-29T10:31:26.341+0000",
+        "description": "lambda layer first version",
+        "layer_version_arn": "arn:aws:lambda:eu-west-2:123456789012:layer:layer-01:1",
+        "license_info": "GPL-3.0-only",
+        "version": 1
+    }
+]
+
+
+def setup_testing(module_params, paginate_results):
+    connection = MagicMock(name="connection")
+    module = MagicMock(name="module")
+    module.params = module_params
+
+    module.exit_json.side_effect = SystemExit(1)
+    module.fail_json.side_effect = SystemExit(2)
+
+    conn_paginator = MagicMock(name="connection.paginator")
+    paginate = MagicMock(name="paginator.paginate")
+    connection.get_paginator.return_value = conn_paginator
+    conn_paginator.paginate.return_value = paginate
+    paginate.build_full_result.return_value = paginate_results
+
+    return module, connection, conn_paginator, paginate
+
+
+def test_list_layers_with_latest_version_with_compatible_runtimes_and_architectures():
+
+    module_params = dict(compatible_runtime="nodejs", compatible_architecture="arm64")
+    module, connection, conn_paginator, paginate = setup_testing(module_params, list_layers_paginate_result)
+
+    with pytest.raises(SystemExit):
+        lambda_layer_info.execute_module(module, connection)
+
+    connection.get_paginator.assert_called_with("list_layers")
+    conn_paginator.paginate.assert_called_with(
+        CompatibleRuntime="nodejs",
+        CompatibleArchitecture="arm64",
+    )
+    paginate.build_full_result.assert_called_once()
+
+    module.exit_json.assert_called_with(
+        changed=False,
+        layers_versions=list_layers_result
+    )
+
+
+def test_list_layers_with_latest_version_with_compatible_runtimes_only():
+
+    module_params = dict(compatible_runtime="nodejs")
+    module, connection, conn_paginator, paginate = setup_testing(module_params, list_layers_paginate_result)
+
+    with pytest.raises(SystemExit):
+        lambda_layer_info.execute_module(module, connection)
+
+    connection.get_paginator.assert_called_with("list_layers")
+    conn_paginator.paginate.assert_called_with(
+        CompatibleRuntime="nodejs"
+    )
+    paginate.build_full_result.assert_called_once()
+
+    module.exit_json.assert_called_with(
+        changed=False,
+        layers_versions=list_layers_result
+    )
+
+
+def test_list_layers_with_latest_version_with_compatible_architectures_only():
+
+    module_params = dict(compatible_architecture="arm64")
+    module, connection, conn_paginator, paginate = setup_testing(module_params, list_layers_paginate_result)
+
+    with pytest.raises(SystemExit):
+        lambda_layer_info.execute_module(module, connection)
+
+    connection.get_paginator.assert_called_with("list_layers")
+    conn_paginator.paginate.assert_called_with(
+        CompatibleArchitecture="arm64"
+    )
+    paginate.build_full_result.assert_called_once()
+
+    module.exit_json.assert_called_with(
+        changed=False,
+        layers_versions=list_layers_result
+    )
+
+
+def test_list_layers_with_latest_version_without_any_params():
+
+    module_params = dict()
+    module, connection, conn_paginator, paginate = setup_testing(module_params, list_layers_paginate_result)
+
+    with pytest.raises(SystemExit):
+        lambda_layer_info.execute_module(module, connection)
+
+    connection.get_paginator.assert_called_with("list_layers")
+    conn_paginator.paginate.assert_called_with()
+    paginate.build_full_result.assert_called_once()
+
+    module.exit_json.assert_called_with(
+        changed=False,
+        layers_versions=list_layers_result
+    )
+
+
+def test_list_layers_versions_with_latest_version_with_all_parameters():
+
+    module_params = dict(name="layer-01", compatible_runtime="nodejs", compatible_architecture="arm64")
+    module, connection, conn_paginator, paginate = setup_testing(module_params, list_layers_versions_paginate_result)
+
+    with pytest.raises(SystemExit):
+        lambda_layer_info.execute_module(module, connection)
+
+    connection.get_paginator.assert_called_with("list_layer_versions")
+    conn_paginator.paginate.assert_called_with(
+        LayerName="layer-01",
+        CompatibleRuntime="nodejs",
+        CompatibleArchitecture="arm64",
+    )
+    paginate.build_full_result.assert_called_once()
+
+    module.exit_json.assert_called_with(
+        changed=False,
+        layers_versions=list_layers_versions_result
+    )
+
+
+def test_list_layers_versions_with_latest_version_with_name_and_compatible_runtimes_only():
+
+    module_params = dict(name="layer-01", compatible_runtime="nodejs")
+    module, connection, conn_paginator, paginate = setup_testing(module_params, list_layers_versions_paginate_result)
+
+    with pytest.raises(SystemExit):
+        lambda_layer_info.execute_module(module, connection)
+
+    connection.get_paginator.assert_called_with("list_layer_versions")
+    conn_paginator.paginate.assert_called_with(
+        LayerName="layer-01",
+        CompatibleRuntime="nodejs"
+    )
+    paginate.build_full_result.assert_called_once()
+
+    module.exit_json.assert_called_with(
+        changed=False,
+        layers_versions=list_layers_versions_result
+    )
+
+
+def test_list_layers_versions_with_name_and_compatible_architectures_only():
+
+    module_params = dict(name="layer-01", compatible_architecture="arm64")
+    module, connection, conn_paginator, paginate = setup_testing(module_params, list_layers_versions_paginate_result)
+
+    with pytest.raises(SystemExit):
+        lambda_layer_info.execute_module(module, connection)
+
+    connection.get_paginator.assert_called_with("list_layer_versions")
+    conn_paginator.paginate.assert_called_with(
+        LayerName="layer-01",
+        CompatibleArchitecture="arm64"
+    )
+    paginate.build_full_result.assert_called_once()
+
+    module.exit_json.assert_called_with(
+        changed=False,
+        layers_versions=list_layers_versions_result
+    )
+
+
+def test_list_layers_versions_with_name_only():
+
+    module_params = dict(name="layer-01")
+    module, connection, conn_paginator, paginate = setup_testing(module_params, list_layers_versions_paginate_result)
+
+    with pytest.raises(SystemExit):
+        lambda_layer_info.execute_module(module, connection)
+
+    connection.get_paginator.assert_called_with("list_layer_versions")
+    conn_paginator.paginate.assert_called_with(
+        LayerName="layer-01",
+    )
+    paginate.build_full_result.assert_called_once()
+
+    module.exit_json.assert_called_with(
+        changed=False,
+        layers_versions=list_layers_versions_result
+    )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The module `lambda_layer` allows user to publish or delete lambda layer version, while `lambda_layer_info` is used to list lambda layers or all versions of a specific lambda layer
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lambda_layer
lambda_layer_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```

Closes: #1116
