### PR TITLE
inventory/aws_ec2: deprecate include_extra_api_calls

### DIFF
--- a/changelogs/fragments/inventory-aws_ec2-include_extra_api_calls-is-deprecated.yaml
+++ b/changelogs/fragments/inventory-aws_ec2-include_extra_api_calls-is-deprecated.yaml
@@ -1,3 +1,3 @@
 ---
 deprecated_features:
-- "inventory/aws_ec2 - the ``include_extra_api_calls`` is not deprecated, its value is silently ignored (https://github.com/ansible-collections/amazon.aws/pull/1097)."
+- "inventory/aws_ec2 - the ``include_extra_api_calls`` is now deprecated, its value is silently ignored (https://github.com/ansible-collections/amazon.aws/pull/1097)."

--- a/changelogs/fragments/inventory-aws_ec2-include_extra_api_calls-is-deprecated.yaml
+++ b/changelogs/fragments/inventory-aws_ec2-include_extra_api_calls-is-deprecated.yaml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+- "inventory/aws_ec2 - the ``include_extra_api_calls`` is not deprecated, its value is silently ignored (https://github.com/ansible-collections/amazon.aws/pull/1097)."

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -99,12 +99,6 @@ options:
     elements: dict
     default: []
     version_added: 1.5.0
-  include_extra_api_calls:
-    description:
-      - Add two additional API calls for every instance to include 'persistent' and 'events' host variables.
-      - Spot instances may be persistent and instances may have associated events.
-    type: bool
-    default: False
   strict_permissions:
     description:
       - By default if a 403 (Forbidden) error code is encountered this plugin will fail.
@@ -566,8 +560,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
                     new_instances = r['Instances']
                     for instance in new_instances:
                         instance.update(self._get_reservation_details(r))
-                        if self.get_option('include_extra_api_calls'):
-                            instance.update(self._get_event_set_and_persistence(connection, instance['InstanceId'], instance.get('SpotInstanceRequestId')))
                     instances.extend(new_instances)
             except botocore.exceptions.ClientError as e:
                 if e.response['ResponseMetadata']['HTTPStatusCode'] == 403 and not strict_permissions:
@@ -587,29 +579,6 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             'RequesterId': reservation.get('RequesterId', ''),
             'ReservationId': reservation['ReservationId']
         }
-
-    def _get_event_set_and_persistence(self, connection, instance_id, spot_instance):
-        host_vars = {'Events': '', 'Persistent': False}
-        try:
-            kwargs = {'InstanceIds': [instance_id]}
-            host_vars['Events'] = connection.describe_instance_status(**kwargs)['InstanceStatuses'][0].get('Events', '')
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            if not self.get_option('strict_permissions'):
-                pass
-            else:
-                raise AnsibleError("Failed to describe instance status: %s" % to_native(e))
-        if spot_instance:
-            try:
-                kwargs = {'SpotInstanceRequestIds': [spot_instance]}
-                host_vars['Persistent'] = bool(
-                    connection.describe_spot_instance_requests(**kwargs)['SpotInstanceRequests'][0].get('Type') == 'persistent'
-                )
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                if not self.get_option('strict_permissions'):
-                    pass
-                else:
-                    raise AnsibleError("Failed to describe spot instance requests: %s" % to_native(e))
-        return host_vars
 
     @classmethod
     def _get_tag_hostname(cls, preference, instance):

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -886,7 +886,10 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             cache = self.get_option('cache')
 
         if self.get_option('include_extra_api_calls'):
-            self.display.deprecate("The include_extra_api_calls option has been deprecated and will be removed in release 6.0.0.", date='2024-09-01', collection_name='amazon.aws')
+            self.display.deprecate(
+                "The include_extra_api_calls option has been deprecated "
+                " and will be removed in release 6.0.0.",
+                date='2024-09-01', collection_name='amazon.aws')
 
         # Generate inventory
         cache_needs_update = False

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -99,6 +99,13 @@ options:
     elements: dict
     default: []
     version_added: 1.5.0
+  include_extra_api_calls:
+    description:
+      - Add two additional API calls for every instance to include 'persistent' and 'events' host variables.
+      - Spot instances may be persistent and instances may have associated events.
+      - The I(include_extra_api_calls) option had been deprecated and will be removed in release 6.0.0.
+    type: bool
+    default: False
   strict_permissions:
     description:
       - By default if a 403 (Forbidden) error code is encountered this plugin will fail.
@@ -877,6 +884,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if cache:
             # get the user-specified directive
             cache = self.get_option('cache')
+
+        if self.get_option('include_extra_api_calls'):
+            self.display.deprecate("The include_extra_api_calls option has been deprecated and will be removed in release 6.0.0.", date='2024-09-01', collection_name='amazon.aws')
 
         # Generate inventory
         cache_needs_update = False

--- a/tests/unit/plugins/inventory/test_aws_ec2.py
+++ b/tests/unit/plugins/inventory/test_aws_ec2.py
@@ -499,6 +499,7 @@ def test_query_empty_include_exclude(inventory):
     result = inventory._query("us-east-1", [{"tag:Name": ["foobar"]}], [{"tag:Name": ["foobar"]}], strict_permissions=True)
     assert result == {"aws_ec2": []}
 
+
 def test_include_extra_api_calls_deprecated(inventory):
     inventory.display.deprecate = Mock()
     inventory._read_config_data = Mock()

--- a/tests/unit/plugins/inventory/test_aws_ec2.py
+++ b/tests/unit/plugins/inventory/test_aws_ec2.py
@@ -125,6 +125,16 @@ def inventory():
         "compose": {},
         "groups": {},
         "keyed_groups": [],
+        "regions": ["us-east-1"],
+        "filters": [],
+        "include_filters": [],
+        "exclude_filters": [],
+        "hostnames": [],
+        "strict_permissions": False,
+        "allow_duplicated_hosts": False,
+        "cache": False,
+        "include_extra_api_calls": False,
+        "use_contrib_script_compatible_sanitization": False,
     }
     inventory.inventory = MagicMock()
     return inventory
@@ -488,3 +498,16 @@ def test_query_empty_include_exclude(inventory):
     inventory._get_instances_by_region = Mock(side_effect=[[instance_foobar], [instance_foobar]])
     result = inventory._query("us-east-1", [{"tag:Name": ["foobar"]}], [{"tag:Name": ["foobar"]}], strict_permissions=True)
     assert result == {"aws_ec2": []}
+
+def test_include_extra_api_calls_deprecated(inventory):
+    inventory.display.deprecate = Mock()
+    inventory._read_config_data = Mock()
+    inventory._set_credentials = Mock()
+    inventory._query = Mock(return_value=[])
+
+    inventory.parse(inventory=[], loader=None, path=None)
+    assert inventory.display.deprecate.call_count == 0
+
+    inventory._options["include_extra_api_calls"] = True
+    inventory.parse(inventory=[], loader=None, path=None)
+    assert inventory.display.deprecate.call_count == 1


### PR DESCRIPTION
The `include_extra_api_calls` option of the inventory plugin is broken
and actually crashes the plugin with a `list index out of range` error.

It assumes `describe_instance_status` always returns a list with one entry
which is not the  case if the instance is stopped.
In addition, it reads the event from for a `Events` key that doesn't exist
in the answer structure.

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2.html#EC2.Client.describe_instance_status

The feature is not covered by any tests in our CI and obviously, nobody uses it.
