### PR TITLE
inventory/aws_ec2: drop := operator because we still support py3.6

### DIFF
--- a/changelogs/fragments/inventory-aws_ec2-avoid-py38-syntax.yaml
+++ b/changelogs/fragments/inventory-aws_ec2-avoid-py38-syntax.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - "inventory/aws_ec2 - Avoid the := operator (py3.8+) because we still support Python 3.6."

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -774,9 +774,9 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         for host in hosts:
             if allow_duplicated_hosts:
                 hostname_list = self.get_all_hostnames(host, hostnames)
-            elif preferred_hostname := self._get_preferred_hostname(host, hostnames):
-                hostname_list = [preferred_hostname]
             else:
+                hostname_list = [self._get_preferred_hostname(host, hostnames)]
+            if not hostname_list or hostname_list[0] is None:
                 continue
 
             host_vars = self.prepare_host_vars(


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1649
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/1100

The operator was included with Python 3.8.

See: https://docs.python.org/3/whatsnew/3.8.html#assignment-expressions
