### PR TITLE
unit-tests: module_utils/test_rds.py requires py37+

### DIFF
--- a/changelogs/fragments/unit-tests_test_rds_py37_only.yaml
+++ b/changelogs/fragments/unit-tests_test_rds_py37_only.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+- "module_utils/test_rds.py unit-tests only works with Python 3.7." 

--- a/tests/unit/module_utils/test_rds.py
+++ b/tests/unit/module_utils/test_rds.py
@@ -6,8 +6,13 @@
 from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
-from contextlib import nullcontext
+import sys
 import pytest
+
+if sys.version_info < (3, 7):
+    pytest.skip("contextlib.nullcontext was introduced in Python 3.7", allow_module_level=True)
+
+from contextlib import nullcontext
 
 try:
     import botocore


### PR DESCRIPTION
`contextlib.nullcontext` was introduced with Python 3.7
