### PR TITLE
ec2_vpc_net_info: fix keyerror

### DIFF
--- a/changelogs/fragments/1109-ec2_vpc_net_info_keyerror.yml
+++ b/changelogs/fragments/1109-ec2_vpc_net_info_keyerror.yml
@@ -1,2 +1,3 @@
 bugfixes:
   - ec2_vpc_net_info - fix KeyError (https://github.com/ansible-collections/amazon.aws/pull/1109).
+  - ec2_vpc_net_info - remove hardcoded ``ClassicLinkEnabled`` parameter when request for ``ClassicLinkDnsSupported`` failed (https://github.com/ansible-collections/amazon.aws/pull/1109).

--- a/changelogs/fragments/1109-ec2_vpc_net_info_keyerror.yml
+++ b/changelogs/fragments/1109-ec2_vpc_net_info_keyerror.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_vpc_net_info - fix KeyError (https://github.com/ansible-collections/amazon.aws/pull/1109).

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -200,12 +200,12 @@ def describe_vpcs(connection, module):
         cl_dns_support = describe_classic_links(module, connection, vpc['VpcId'], 'ClassicLinkDnsSupported', error_message)
         dns_support = describe_vpc_attribute(module, connection, vpc['VpcId'], 'enableDnsSupport', error_message)
         dns_hostnames = describe_vpc_attribute(module, connection, vpc['VpcId'], 'enableDnsHostnames', error_message)
-        if cl_enabled:
+        if cl_enabled.get('VPC')[0].get('ClassicLinkEnabled'):
             # loop through the ClassicLink Enabled results and add the value for the correct VPC
             for item in cl_enabled['Vpcs']:
                 if vpc['VpcId'] == item['VpcId']:
                     vpc['ClassicLinkEnabled'] = item['ClassicLinkEnabled']
-        if cl_dns_support:
+        if cl_dns_support.get('Vpcs')[0].get('ClassicLinkEnabled'):
             # loop through the ClassicLink DNS support results and add the value for the correct VPC
             for item in cl_dns_support['Vpcs']:
                 if vpc['VpcId'] == item['VpcId']:

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -200,7 +200,7 @@ def describe_vpcs(connection, module):
         cl_dns_support = describe_classic_links(module, connection, vpc['VpcId'], 'ClassicLinkDnsSupported', error_message)
         dns_support = describe_vpc_attribute(module, connection, vpc['VpcId'], 'enableDnsSupport', error_message)
         dns_hostnames = describe_vpc_attribute(module, connection, vpc['VpcId'], 'enableDnsHostnames', error_message)
-        if cl_enabled.get('VPC')[0].get('ClassicLinkEnabled'):
+        if cl_enabled.get('Vpcs')[0].get('ClassicLinkEnabled'):
             # loop through the ClassicLink Enabled results and add the value for the correct VPC
             for item in cl_enabled['Vpcs']:
                 if vpc['VpcId'] == item['VpcId']:

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -233,7 +233,7 @@ def describe_classic_links(module, connection, vpc, attribute, error_message):
         else:
             result = connection.describe_vpc_classic_link_dns_support(VpcIds=[vpc], aws_retry=True)
     except is_boto3_error_code('UnsupportedOperation'):
-        result = {'Vpcs': [{'VpcId': vpc]}
+        result = {'Vpcs': [{'VpcId': vpc}]}
     except is_boto3_error_code('InvalidVpcID.NotFound'):
         module.warn(error_message.format(attribute, vpc))
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -233,7 +233,7 @@ def describe_classic_links(module, connection, vpc, attribute, error_message):
         else:
             result = connection.describe_vpc_classic_link_dns_support(VpcIds=[vpc], aws_retry=True)
     except is_boto3_error_code('UnsupportedOperation'):
-        result = {'Vpcs': [{'VpcId': vpc, 'ClassicLinkEnabled': False}]}
+        result = {'Vpcs': [{'VpcId': vpc]}
     except is_boto3_error_code('InvalidVpcID.NotFound'):
         module.warn(error_message.format(attribute, vpc))
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except

--- a/plugins/modules/ec2_vpc_net_info.py
+++ b/plugins/modules/ec2_vpc_net_info.py
@@ -200,16 +200,16 @@ def describe_vpcs(connection, module):
         cl_dns_support = describe_classic_links(module, connection, vpc['VpcId'], 'ClassicLinkDnsSupported', error_message)
         dns_support = describe_vpc_attribute(module, connection, vpc['VpcId'], 'enableDnsSupport', error_message)
         dns_hostnames = describe_vpc_attribute(module, connection, vpc['VpcId'], 'enableDnsHostnames', error_message)
-        if cl_enabled.get('Vpcs')[0].get('ClassicLinkEnabled'):
+        if cl_enabled:
             # loop through the ClassicLink Enabled results and add the value for the correct VPC
             for item in cl_enabled['Vpcs']:
                 if vpc['VpcId'] == item['VpcId']:
-                    vpc['ClassicLinkEnabled'] = item['ClassicLinkEnabled']
-        if cl_dns_support.get('Vpcs')[0].get('ClassicLinkEnabled'):
+                    vpc['ClassicLinkEnabled'] = item.get('ClassicLinkEnabled', False)
+        if cl_dns_support:
             # loop through the ClassicLink DNS support results and add the value for the correct VPC
             for item in cl_dns_support['Vpcs']:
                 if vpc['VpcId'] == item['VpcId']:
-                    vpc['ClassicLinkDnsSupported'] = item['ClassicLinkDnsSupported']
+                    vpc['ClassicLinkDnsSupported'] = item.get('ClassicLinkDnsSupported', False)
 
         # add the two DNS attributes
         if dns_support:


### PR DESCRIPTION
##### SUMMARY
Introduced in https://github.com/ansible-collections/amazon.aws/pull/984/ since `amazon.aws 5.0.0`

> KeyError: 'ClassicLinkDnsSupported'

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
ec2_vpc_net_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yml
---
- hosts: localhost

  tasks:
    - name: Get VPC Information
      ec2_vpc_net_info:
        region: eu-central-1
      register: vpc
    
    - debug:
        var: vpc
```

results in 

```
ansible-playbook [core 2.12.5]
  config file = /home/m/git/lekker/iac/ansible.cfg
  configured module search path = ['/home/m/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /home/m/.local/lib/python3.10/site-packages/ansible
  ansible collection location = /home/m/.ansible/collections:/usr/share/ansible/collections
  executable location = /home/m/.local/bin/ansible-playbook
  python version = 3.10.6 (main, Aug 10 2022, 11:40:04) [GCC 11.3.0]
  jinja version = 3.1.2
  libyaml = True
Using /home/m/git/lekker/iac/ansible.cfg as config file
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
yaml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
ini declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Skipping due to inventory source not existing or not being readable by the current user
toml declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
[WARNING]: No inventory was parsed, only implicit localhost is available
[WARNING]: provided hosts list is empty, only localhost is available. Note that
the implicit localhost does not match 'all'
redirecting (type: modules) ansible.builtin.ec2_vpc_net_info to amazon.aws.ec2_vpc_net_info
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.

PLAYBOOK: dev003.yml ***********************************************************
1 plays in dev003.yml

PLAY [localhost] ***************************************************************

TASK [Gathering Facts] *********************************************************
task path: /home/m/git/lekker/iac/dev003.yml:2
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: m
<127.0.0.1> EXEC /bin/sh -c 'echo ~m && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/m/.ansible/tmp `"&& mkdir "` echo /home/m/.ansible/tmp/ansible-tmp-1664956131.9332027-127698-125869016159264 `" && echo ansible-tmp-1664956131.9332027-127698-125869016159264="` echo /home/m/.ansible/tmp/ansible-tmp-1664956131.9332027-127698-125869016159264 `" ) && sleep 0'
Using module file /home/m/.local/lib/python3.10/site-packages/ansible/modules/setup.py
<127.0.0.1> PUT /home/m/.ansible/tmp/ansible-local-127691_siearhm/tmpyv6re_ml TO /home/m/.ansible/tmp/ansible-tmp-1664956131.9332027-127698-125869016159264/AnsiballZ_setup.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/m/.ansible/tmp/ansible-tmp-1664956131.9332027-127698-125869016159264/ /home/m/.ansible/tmp/ansible-tmp-1664956131.9332027-127698-125869016159264/AnsiballZ_setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3 /home/m/.ansible/tmp/ansible-tmp-1664956131.9332027-127698-125869016159264/AnsiballZ_setup.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/m/.ansible/tmp/ansible-tmp-1664956131.9332027-127698-125869016159264/ > /dev/null 2>&1 && sleep 0'
ok: [localhost]
META: ran handlers

TASK [Get VPC Information] *****************************************************
task path: /home/m/git/lekker/iac/dev003.yml:5
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: m
<127.0.0.1> EXEC /bin/sh -c 'echo ~m && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/m/.ansible/tmp `"&& mkdir "` echo /home/m/.ansible/tmp/ansible-tmp-1664956133.024292-127805-105124013383109 `" && echo ansible-tmp-1664956133.024292-127805-105124013383109="` echo /home/m/.ansible/tmp/ansible-tmp-1664956133.024292-127805-105124013383109 `" ) && sleep 0'
redirecting (type: modules) ansible.builtin.ec2_vpc_net_info to amazon.aws.ec2_vpc_net_info
Using module file /home/m/.ansible/collections/ansible_collections/amazon/aws/plugins/modules/ec2_vpc_net_info.py
<127.0.0.1> PUT /home/m/.ansible/tmp/ansible-local-127691_siearhm/tmphfs01m94 TO /home/m/.ansible/tmp/ansible-tmp-1664956133.024292-127805-105124013383109/AnsiballZ_ec2_vpc_net_info.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/m/.ansible/tmp/ansible-tmp-1664956133.024292-127805-105124013383109/ /home/m/.ansible/tmp/ansible-tmp-1664956133.024292-127805-105124013383109/AnsiballZ_ec2_vpc_net_info.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3 /home/m/.ansible/tmp/ansible-tmp-1664956133.024292-127805-105124013383109/AnsiballZ_ec2_vpc_net_info.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/m/.ansible/tmp/ansible-tmp-1664956133.024292-127805-105124013383109/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/home/m/.ansible/tmp/ansible-tmp-1664956133.024292-127805-105124013383109/AnsiballZ_ec2_vpc_net_info.py", line 107, in <module>
    _ansiballz_main()
  File "/home/m/.ansible/tmp/ansible-tmp-1664956133.024292-127805-105124013383109/AnsiballZ_ec2_vpc_net_info.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
  File "/home/m/.ansible/tmp/ansible-tmp-1664956133.024292-127805-105124013383109/AnsiballZ_ec2_vpc_net_info.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.amazon.aws.plugins.modules.ec2_vpc_net_info', init_globals=dict(_module_fqn='ansible_collections.amazon.aws.plugins.modules.ec2_vpc_net_info', _modlib_path=modlib_path),
  File "/usr/lib/python3.10/runpy.py", line 224, in run_module
    return _run_module_code(code, init_globals, run_name, mod_spec)
  File "/usr/lib/python3.10/runpy.py", line 96, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/usr/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/tmp/ansible_ec2_vpc_net_info_payload_oi896utp/ansible_ec2_vpc_net_info_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vpc_net_info.py", line 272, in <module>
  File "/tmp/ansible_ec2_vpc_net_info_payload_oi896utp/ansible_ec2_vpc_net_info_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vpc_net_info.py", line 268, in main
  File "/tmp/ansible_ec2_vpc_net_info_payload_oi896utp/ansible_ec2_vpc_net_info_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vpc_net_info.py", line 215, in describe_vpcs
KeyError: 'ClassicLinkDnsSupported'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/m/.ansible/tmp/ansible-tmp-1664956133.024292-127805-105124013383109/AnsiballZ_ec2_vpc_net_info.py\", line 107, in <module>\n    _ansiballz_main()\n  File \"/home/m/.ansible/tmp/ansible-tmp-1664956133.024292-127805-105124013383109/AnsiballZ_ec2_vpc_net_info.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n  File \"/home/m/.ansible/tmp/ansible-tmp-1664956133.024292-127805-105124013383109/AnsiballZ_ec2_vpc_net_info.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.amazon.aws.plugins.modules.ec2_vpc_net_info', init_globals=dict(_module_fqn='ansible_collections.amazon.aws.plugins.modules.ec2_vpc_net_info', _modlib_path=modlib_path),\n  File \"/usr/lib/python3.10/runpy.py\", line 224, in run_module\n    return _run_module_code(code, init_globals, run_name, mod_spec)\n  File \"/usr/lib/python3.10/runpy.py\", line 96, in _run_module_code\n    _run_code(code, mod_globals, init_globals,\n  File \"/usr/lib/python3.10/runpy.py\", line 86, in _run_code\n    exec(code, run_globals)\n  File \"/tmp/ansible_ec2_vpc_net_info_payload_oi896utp/ansible_ec2_vpc_net_info_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vpc_net_info.py\", line 272, in <module>\n  File \"/tmp/ansible_ec2_vpc_net_info_payload_oi896utp/ansible_ec2_vpc_net_info_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vpc_net_info.py\", line 268, in main\n  File \"/tmp/ansible_ec2_vpc_net_info_payload_oi896utp/ansible_ec2_vpc_net_info_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vpc_net_info.py\", line 215, in describe_vpcs\nKeyError: 'ClassicLinkDnsSupported'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE\nSee stdout/stderr for the exact error",
    "rc": 1
}

PLAY RECAP *********************************************************************
localhost                  : ok=1    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```
