### PR TITLE
s3_object - Be more defensive when checking the results of get_bucket_ownership_controls

### DIFF
--- a/changelogs/fragments/1115-s3_object-scaleway.yml
+++ b/changelogs/fragments/1115-s3_object-scaleway.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- s3_object - be more defensive when checking the results of ``s3.get_bucket_ownership_controls`` (https://github.com/ansible-collections/amazon.aws/issues/1115).

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -1083,9 +1083,11 @@ def main():
     exists = bucket_check(module, s3, bucket)
     if exists:
         try:
-            object_ownership = s3.get_bucket_ownership_controls(Bucket=bucket)['OwnershipControls']['Rules'][0]['ObjectOwnership']
-            if object_ownership == 'BucketOwnerEnforced':
-                acl_disabled = True
+            ownership_controls = s3.get_bucket_ownership_controls(Bucket=bucket)['OwnershipControls']
+            if ownership_controls.get('Rules'):
+                object_ownership = ownership_controls['Rules'][0]['ObjectOwnership']
+                if object_ownership == 'BucketOwnerEnforced':
+                    acl_disabled = True
         # if bucket ownership controls are not found
         except botocore.exceptions.ClientError:
             pass


### PR DESCRIPTION
##### SUMMARY

Scaleway have half-implemented get_bucket_ownership_controls, but don't return any rules.  Be a little more defensive when checking the return value of get_bucket_ownership_controls.  The API doesn't strictly say a Rule will always be returned.

Fixes: #1115

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

s3_object

##### ADDITIONAL INFORMATION