### PR TITLE
tox: add complexity-report target

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,3 +18,10 @@ commands = pytest --cov-report html --cov plugins {posargs:tests/}
 deps = coverage
 skip_install = true
 commands = coverage erase
+
+[testenv:complexity-report]
+deps =
+  # See: https://github.com/lordmauve/flake8-html/issues/30
+  flake8>=3.3.0,<5.0.0'
+  flake8-html
+commands = -flake8 --select C90 --max-complexity 10 --format=html --htmldir={posargs} plugins


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1656

The target generates a MCCabe complexity report in HTML that is exposed in the CI output.

Example: https://7409a00e1108ff27cfe6-3e5213eac2b0662b5ee6d363d9d4dcd9.ssl.cf1.rackcdn.com/1119/b90d2618ab09f30ad3540afd5bb3890af51db32c/check/cloud-tox-py3/2f3e4dc/docs/complexity/index.html
