### PR TITLE
tox: generate coverage report for all the plugins

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
   pytest-ansible-units
   -rtest-requirements.txt
   with_constraints: -rtests/unit/constraints.txt
-commands = pytest --cov-report html --cov plugins {posargs:tests/}
+commands = pytest --cov-report html --cov plugins/callback --cov plugins/inventory --cov plugins/lookup --cov plugins/module_utils --cov plugins/modules plugins {posargs:tests/}
 
 [testenv:clean]
 deps = coverage


### PR DESCRIPTION
Include all the plugins in the coverage report, including those with
zero coverage currently.
