### PR TITLE
Add metrics and extended_statistic keys to cloudwatch module

### DIFF
--- a/changelogs/fragments/1133-add_metrics_cloudwatch.yml
+++ b/changelogs/fragments/1133-add_metrics_cloudwatch.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- cloudwatch - Add metrics and extended_statistic keys to cloudwatch module (https://github.com/ansible-collections/amazon.aws/pull/1133).

--- a/plugins/modules/cloudwatch_metric_alarm.py
+++ b/plugins/modules/cloudwatch_metric_alarm.py
@@ -473,9 +473,7 @@ def main():
     params['OKActions'] = module.params.get('ok_actions', [])
     params['TreatMissingData'] = module.params.get('treat_missing_data')
     if module.params.get('metrics'):
-        params['Metrics'] = []
-        for element in module.params.get('metrics'):
-            params['Metrics'].append(snake_dict_to_camel_dict(element, capitalize_first=True))
+        params['Metrics'] = snake_dict_to_camel_dict(module.params['metrics'], capitalize_first=True)
     if module.params.get('extended_statistic'):
         params['ExtendedStatistic'] = module.params.get('extended_statistic')
 

--- a/plugins/modules/cloudwatch_metric_alarm.py
+++ b/plugins/modules/cloudwatch_metric_alarm.py
@@ -60,30 +60,34 @@ options:
                 description:
                   - A short name used to tie this object to the results in the response. 
                 type: str
-            metricstat:
+            metric_stat:
                 description: The metric to be returned, along with statistics, period, and units. 
                 type: dict
                 suboptions:
-                    namespace:
-                        description: The namespace of the metric.
-                        type: str
-                    metricname:
-                        description: The name of the metric. 
-                        type: str
-                        required: True
-                    dimensions:
-                        description: a name/value pair that is part of the identity of a metric.
-                        type: list
-                        elements: dict
+                    metric:
+                        description: The metric to return, including the metric name, namespace, and dimensions.
+                        type: dict
                         suboptions:
-                            name:
-                                description: The name of the dimension.
+                            namespace:
+                                description: The namespace of the metric.
+                                type: str
+                            metric_name:
+                                description: The name of the metric. 
                                 type: str
                                 required: True
-                            value:
-                                description: The value of the dimension.
-                                type: str
-                                required: True
+                            dimensions:
+                                description: a name/value pair that is part of the identity of a metric.
+                                type: list
+                                elements: dict
+                                suboptions:
+                                    name:
+                                        description: The name of the dimension.
+                                        type: str
+                                        required: True
+                                    value:
+                                        description: The value of the dimension.
+                                        type: str
+                                        required: True
                     period:
                         description: The granularity, in seconds, of the returned data points. 
                         type: int
@@ -95,23 +99,23 @@ options:
                     unit:
                         description: Unit to use when storing the metric.
                         type: str
-              expression:
-                  description: 
-                    - This field can contain either a Metrics Insights query,
-                      or a metric math expression to be performed on the returned data.
-                  type: str
-              label:
-                  description: A human-readable label for this metric or expression. 
-                  type: str
-              return_data:
-                  description: This option indicates whether to return the timestamps and raw data values of this metric.
-                  type: bool
-              period:
-                  description: The granularity, in seconds, of the returned data points. 
-                  type: int
-              account_id:
-                  description: The ID of the account where the metrics are located, if this is a cross-account alarm.
-                  type: str
+            expression:
+                description: 
+                  - This field can contain either a Metrics Insights query,
+                    or a metric math expression to be performed on the returned data.
+                type: str
+            label:
+                description: A human-readable label for this metric or expression. 
+                type: str
+            return_data:
+                description: This option indicates whether to return the timestamps and raw data values of this metric.
+                type: bool
+            period:
+                description: The granularity, in seconds, of the returned data points. 
+                type: int
+            account_id:
+                description: The ID of the account where the metrics are located, if this is a cross-account alarm.
+                type: str
     namespace:
         description:
           - Name of the appropriate namespace (C(AWS/EC2), C(System/Linux), etc.), which determines the category it will appear under in CloudWatch.
@@ -238,7 +242,7 @@ EXAMPLES = r'''
       state: present
       region: ap-southeast-2
       name: "cpu-low"
-      metric: "CPUUtilization"
+      metric_name: "CPUUtilization"
       namespace: "AWS/EC2"
       statistic: Average
       comparison: "LessThanOrEqualToThreshold"
@@ -250,6 +254,26 @@ EXAMPLES = r'''
       dimensions: {'InstanceId':'i-XXX'}
       alarm_actions: ["action1","action2"]
 
+  - name: create alarm with metrics
+    amazon.aws.cloudwatch_metric_alarm:
+      state: present
+      region: ap-southeast-2
+      name: "cpu-low"
+      metrics:
+        - id: 'CPU'
+          metric_stat:
+              metric:
+                  dimensions:
+                      name: "InstanceId"
+                      value: "i-xx"
+                  metric_name: "CPUUtilization"
+                  namespace: "AWS/EC2"
+              period: "300"
+              stat: "Average"
+              unit: "Percent"
+          return_data: False
+      alarm_actions: ["action1","action2"]
+      
   - name: Create an alarm to recover a failed instance
     amazon.aws.cloudwatch_metric_alarm:
       state: present

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
@@ -378,6 +378,75 @@
     ec2_metric_alarm:
       state: absent
       name: '{{ alarm_full_name }}'
+    register: ec2_instance_metric_alarm_deletion
+
+  - name: Verify that the alarm reports deleted/changed
+    assert:
+      that:
+      - ec2_instance_metric_alarm_deletion.changed
+
+  - name: get info on alarms
+    amazon.aws.cloudwatch_metric_alarm_info:
+      alarm_names:
+        - "{{ alarm_full_name }}"
+    register: alarm_info
+
+  - name: Verify that the alarm was deleted using cli
+    assert:
+      that:
+        - 'alarm_info.metric_alarms | length == 0'
+
+  - name: create ec2 metric alarm with metrics
+    ec2_metric_alarm:
+      state: present
+      name: '{{ alarm_full_name }}'
+      treat_missing_data: missing
+      comparison: LessThanOrEqualToThreshold
+      threshold: 5.0
+      evaluation_periods: 3
+      description: This will alarm when an instance's cpu usage average is lower than
+        5% for 15 minutes
+      metrics:
+        - id: cpu
+          metric_stat:
+              metric:
+                  dimensions:
+                    - name: "InstanceId"
+                      value: "{{ ec2_instance_results.instances[0].instance_id }}"
+                  metric_name: "CPUUtilization"
+                  namespace: "AWS/EC2"
+              period: 300
+              stat: "Average"
+              unit: "Percent"
+          return_data: true
+    register: ec2_instance_metric_alarm_metrics
+
+  - name: get info on alarms
+    amazon.aws.cloudwatch_metric_alarm_info:
+      alarm_names:
+        - "{{ alarm_full_name }}"
+    register: alarm_info_metrics
+
+  - name: verify that an alarm was created
+    assert:
+      that:
+      - ec2_instance_metric_alarm_metrics.changed
+      - ec2_instance_metric_alarm_metrics.alarm_arn
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.stat == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.stat'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.namespace == alarm_info_metrics.metric_alarms[0].nmetrics[0].metric_stat.metric.namespace'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.metric_name == alarm_info_metrics.metric_alarms[0].nmetrics[0].metric_stat.metric.metric_name'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.dimensions[0].name == alarm_info_metrics.metric_alarms[0].nmetrics[0].metric_stat.metric.dimensions[0].name'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.dimensions[0].value == alarm_info_metrics.metric_alarms[0].nmetrics[0].metric_stat.metric.dimensions[0].value'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.id == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.id'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.period == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.period'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.unit == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.unit'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.return_data == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.return_data'
+
+
+  - name: try to remove the alarm
+    ec2_metric_alarm:
+      state: absent
+      name: '{{ alarm_full_name }}'
     register: ec2_instance_metric_alarm_deletion_no_unit
 
   - name: Verify that the alarm reports deleted/changed

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
@@ -433,14 +433,14 @@
       - ec2_instance_metric_alarm_metrics.changed
       - ec2_instance_metric_alarm_metrics.alarm_arn
       - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.stat == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.stat'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.namespace == alarm_info_metrics.metric_alarms[0].nmetrics[0].metric_stat.metric.namespace'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.metric_name == alarm_info_metrics.metric_alarms[0].nmetrics[0].metric_stat.metric.metric_name'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.dimensions[0].name == alarm_info_metrics.metric_alarms[0].nmetrics[0].metric_stat.metric.dimensions[0].name'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.dimensions[0].value == alarm_info_metrics.metric_alarms[0].nmetrics[0].metric_stat.metric.dimensions[0].value'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.id == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.id'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.namespace == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.metric.namespace'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.metric_name == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.metric.metric_name'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.dimensions[0].name == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.metric.dimensions[0].name'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.dimensions[0].value == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.metric.dimensions[0].value'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].id == alarm_info_metrics.metric_alarms[0].metrics[0].id'
       - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.period == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.period'
       - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.unit == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.unit'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.return_data == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.return_data'
+      - 'ec2_instance_metric_alarm_metrics.metrics[0].return_data == alarm_info_metrics.metric_alarms[0].metrics[0].return_data'
 
 
   - name: try to remove the alarm

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
@@ -465,6 +465,43 @@
       that:
         - 'alarm_info_no_unit.metric_alarms | length == 0'
 
+  - name: create ec2 metric alarm by providing mutually exclusive values
+    ec2_metric_alarm:
+      dimensions:
+        InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
+      state: present
+      name: '{{ alarm_full_name }}'
+      metric: CPUUtilization
+      namespace: AWS/EC2
+      treat_missing_data: missing
+      statistic: Average
+      comparison: LessThanOrEqualToThreshold
+      threshold: 5.0
+      period: 300
+      evaluation_periods: 3
+      description: This will alarm when an instance's cpu usage average is lower than
+        5% for 15 minutes
+      metrics:
+        - id: cpu
+          metric_stat:
+              metric:
+                  dimensions:
+                    - name: "InstanceId"
+                      value: "{{ ec2_instance_results.instances[0].instance_id }}"
+                  metric_name: "CPUUtilization"
+                  namespace: "AWS/EC2"
+              period: 300
+              stat: "Average"
+              unit: "Percent"
+          return_data: true
+    register: ec2_instance_metric_mutually_exclusive
+    ignore_errors: true
+
+  - assert:
+      that:
+      - ec2_instance_metric_mutually_exclusive.failed
+      - '"parameters are mutually exclusive" in ec2_instance_metric_mutually_exclusive.msg'
+
   always:
   - name: try to delete the alarm
     ec2_metric_alarm:


### PR DESCRIPTION
Signed-off-by: GomathiselviS <gomathiselvi@gmail.com>

To support https://issues.redhat.com/browse/ACA-638 , a new key metric ( a list of dicts) is added to the cloudwatch module

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudwatch.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
