### PR TITLE
Remove deprecated CloudRetry.backoff (and AWSRetry.backoff)

### DIFF
--- a/changelogs/fragments/1110-deprecation-complete-cloudretry-backoff.yml
+++ b/changelogs/fragments/1110-deprecation-complete-cloudretry-backoff.yml
@@ -1,0 +1,4 @@
+breaking_changes:
+- module_utils.cloud - the previously deprecated ``CloudRetry.backoff`` has been removed.
+  Please use ``CloudRetry.exponential_backoff`` or ``CloudRetry.jittered_backoff``
+  instead (https://github.com/ansible-collections/amazon.aws/issues/1110).

--- a/plugins/module_utils/cloud.py
+++ b/plugins/module_utils/cloud.py
@@ -179,35 +179,3 @@ class CloudRetry:
             catch_extra_error_codes=catch_extra_error_codes,
             sleep_time_generator=sleep_time_generator,
         )
-
-    @classmethod
-    def backoff(cls, tries=10, delay=3, backoff=1.1, catch_extra_error_codes=None):
-        """
-        Wrap a callable with retry behavior.
-        Developers should use CloudRetry.exponential_backoff instead.
-        This method has been deprecated and will be removed in release 6.0.0, consider using exponential_backoff method instead.
-        Args:
-            retries (int): Number of times to retry a failed request before giving up
-                default=10
-            delay (int or float): Initial delay between retries in seconds
-                default=3
-            backoff (int or float): backoff multiplier e.g. value of 2 will  double the delay each retry
-                default=1.1
-            catch_extra_error_codes: Additional error messages to catch, in addition to those which may be defined by a subclass of CloudRetry
-                default=None
-        Returns:
-            Callable: A generator that calls the decorated function using an exponential backoff.
-        """
-        # This won't emit a warning (we don't have the context available to us), but will trigger
-        # sanity failures as we prepare for 6.0.0
-        ansible_warnings.deprecate(
-            'CloudRetry.backoff has been deprecated, please use CloudRetry.exponential_backoff instead',
-            version='6.0.0', collection_name='amazon.aws')
-
-        return cls.exponential_backoff(
-            retries=tries,
-            delay=delay,
-            backoff=backoff,
-            max_delay=None,
-            catch_extra_error_codes=catch_extra_error_codes,
-        )

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,4 +1,3 @@
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
 plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112
-plugins/module_utils/cloud.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1110

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,4 +1,3 @@
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
 plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112
-plugins/module_utils/cloud.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1110

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,4 +1,3 @@
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
 plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112
-plugins/module_utils/cloud.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1110

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,4 +1,3 @@
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
 plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112
-plugins/module_utils/cloud.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1110

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,4 +1,3 @@
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
 plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112
-plugins/module_utils/cloud.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1110

--- a/tests/unit/module_utils/cloud/test_cloud_retry.py
+++ b/tests/unit/module_utils/cloud/test_cloud_retry.py
@@ -72,24 +72,6 @@ class TestCloudRetry():
             return True
 
     # ========================================================
-    #   retry original backoff
-    # ========================================================
-    def test_retry_backoff(self):
-
-        @TestCloudRetry.UnitTestsRetry.backoff(tries=3, delay=1, backoff=1.1,
-                                               catch_extra_error_codes=TestCloudRetry.error_codes)
-        def test_retry_func():
-            if test_retry_func.counter < 2:
-                test_retry_func.counter += 1
-                raise self.TestException(status=random.choice(TestCloudRetry.error_codes))
-            else:
-                return True
-
-        test_retry_func.counter = 0
-        ret = test_retry_func()
-        assert ret is True
-
-    # ========================================================
     #   retry exponential backoff
     # ========================================================
     def test_retry_exponential_backoff(self):

--- a/tests/unit/module_utils/cloud/test_decorator_generation.py
+++ b/tests/unit/module_utils/cloud/test_decorator_generation.py
@@ -123,34 +123,3 @@ def test_create_jittered_backoff_with_args(patch_cloud_retry):
     assert sleep_time_generator.backoff == 3
     assert sleep_time_generator.max_delay == 61
     assert sleep_time_generator.jitter is True
-
-
-def test_create_legacy_backoff_with_defaults(patch_cloud_retry):
-    cloud_retry, decorator_generator = patch_cloud_retry()
-
-    decorator = cloud_retry.backoff()
-
-    gen_kw_args, sleep_time_generator = check_common_side_effects(decorator_generator)
-
-    assert gen_kw_args['catch_extra_error_codes'] is None
-    assert gen_kw_args['retries'] == 10
-    assert sleep_time_generator.delay == 3
-    assert sleep_time_generator.backoff == 1.1
-    assert sleep_time_generator.max_delay is None
-    assert sleep_time_generator.jitter is False
-
-
-def test_create_legacy_backoff_with_args(patch_cloud_retry):
-    cloud_retry, decorator_generator = patch_cloud_retry()
-
-    # Note: the Keyword Args have different names here, and not all of them can be passed...
-    decorator = cloud_retry.backoff(tries=11, delay=4, backoff=3, catch_extra_error_codes=[42])
-
-    gen_kw_args, sleep_time_generator = check_common_side_effects(decorator_generator)
-
-    assert gen_kw_args['catch_extra_error_codes'] == [42]
-    assert gen_kw_args['retries'] == 11
-    assert sleep_time_generator.delay == 4
-    assert sleep_time_generator.backoff == 3
-    assert sleep_time_generator.max_delay is None
-    assert sleep_time_generator.jitter is False

--- a/tests/unit/module_utils/retries/test_awsretry.py
+++ b/tests/unit/module_utils/retries/test_awsretry.py
@@ -26,7 +26,7 @@ class TestAWSRetry():
     def test_no_failures(self):
         self.counter = 0
 
-        @AWSRetry.backoff(tries=2, delay=0.1)
+        @AWSRetry.exponential_backoff(retries=2, delay=0.1)
         def no_failures():
             self.counter += 1
 
@@ -37,7 +37,7 @@ class TestAWSRetry():
         self.counter = 0
         err_response = {'Error': {'Code': 'MalformedPolicyDocument'}}
 
-        @AWSRetry.backoff(tries=2, delay=0.1, catch_extra_error_codes=['MalformedPolicyDocument'])
+        @AWSRetry.exponential_backoff(retries=2, delay=0.1, catch_extra_error_codes=['MalformedPolicyDocument'])
         def extend_failures():
             self.counter += 1
             if self.counter < 2:
@@ -53,7 +53,7 @@ class TestAWSRetry():
         self.counter = 0
         err_response = {'Error': {'Code': 'InternalFailure'}}
 
-        @AWSRetry.backoff(tries=2, delay=0.1)
+        @AWSRetry.exponential_backoff(retries=2, delay=0.1)
         def retry_once():
             self.counter += 1
             if self.counter < 2:
@@ -69,7 +69,7 @@ class TestAWSRetry():
         self.counter = 0
         err_response = {'Error': {'Code': 'RequestLimitExceeded'}}
 
-        @AWSRetry.backoff(tries=4, delay=0.1)
+        @AWSRetry.exponential_backoff(retries=4, delay=0.1)
         def fail():
             self.counter += 1
             raise botocore.exceptions.ClientError(err_response, 'toooo fast!!')
@@ -84,7 +84,7 @@ class TestAWSRetry():
         self.counter = 0
         err_response = {'Error': {'Code': 'AuthFailure'}}
 
-        @AWSRetry.backoff(tries=4, delay=0.1)
+        @AWSRetry.exponential_backoff(retries=4, delay=0.1)
         def raise_unexpected_error():
             self.counter += 1
             raise botocore.exceptions.ClientError(err_response, 'unexpected error')


### PR DESCRIPTION
##### SUMMARY

Originally slated for removal in 4.0.0 and backed off to 6.0.0 in #951.  Now that we've branched stable-5 we can remove the deprecated decorator

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/cloud.py

##### ADDITIONAL INFORMATION

fixes: #1110 