### PR TITLE
Improve unit test coverage of module_utils.policy

### DIFF
--- a/changelogs/fragments/1136-DEPRECATE-sort_json_policy_dict.yml
+++ b/changelogs/fragments/1136-DEPRECATE-sort_json_policy_dict.yml
@@ -1,0 +1,7 @@
+deprecated_features:
+- module_utils.policy - ``ansible_collections.amazon.aws.module_utils.policy.sort_json_policy_dict``
+  has been deprecated consider using ``ansible_collections.amazon.aws.module_utils.poilcies.compare_policies`` instead
+  (https://github.com/ansible-collections/amazon.aws/pull/1136).
+minor_changes:
+- module_utils.policy - minor refacter of code to reduce complexity and improve test coverage
+  (https://github.com/ansible-collections/amazon.aws/pull/1136).

--- a/tests/unit/module_utils/policy/test_canonicalize.py
+++ b/tests/unit/module_utils/policy/test_canonicalize.py
@@ -1,0 +1,41 @@
+# (c) 2022 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.amazon.aws.plugins.module_utils.policy import _canonify_root_arn
+from ansible_collections.amazon.aws.plugins.module_utils.policy import _canonify_policy_dict_item
+from ansible_collections.amazon.aws.plugins.module_utils.policy import _tuplify_list
+
+from ansible_collections.amazon.aws.tests.unit.compat.mock import sentinel
+
+
+def test_tuplify_list():
+    my_list = ["one", 2, sentinel.list_item, False]
+    # Lists are tuplified
+    assert _tuplify_list(my_list) == tuple(my_list)
+    # Other types are not
+    assert _tuplify_list("one") == "one"
+    assert _tuplify_list(2) == 2
+    assert _tuplify_list(sentinel.single_item) is sentinel.single_item
+    assert _tuplify_list(False) is False
+
+
+def test_canonify_root_arn():
+    assert _canonify_root_arn("Some String") == "Some String"
+    assert _canonify_root_arn("123456789012") == "123456789012"
+    assert _canonify_root_arn("arn:aws:iam::123456789012:root") == "123456789012"
+
+
+def test_canonify_policy_dict_item_principal():
+    assert _canonify_policy_dict_item("*", "Principal") == {"AWS": "*"}
+    assert _canonify_policy_dict_item("*", "NotPrincipal") == {"AWS": "*"}
+    assert _canonify_policy_dict_item("*", "AnotherKey") == "*"
+    assert _canonify_policy_dict_item("NotWildCard", "Principal") == "NotWildCard"
+    assert _canonify_policy_dict_item("NotWildCard", "NotPrincipal") == "NotWildCard"
+    assert _canonify_policy_dict_item(sentinel.single_item, "Principal") is sentinel.single_item
+    assert _canonify_policy_dict_item(False, "Principal") is False
+    assert _canonify_policy_dict_item(True, "Principal") is True

--- a/tests/unit/module_utils/policy/test_py3cmp.py
+++ b/tests/unit/module_utils/policy/test_py3cmp.py
@@ -1,0 +1,43 @@
+# (c) 2022 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from ansible_collections.amazon.aws.plugins.module_utils.policy import _py3cmp
+
+
+def test_py3cmp_simple():
+    assert _py3cmp(1, 1) == 0
+    assert _py3cmp(1, 2) == -1
+    assert _py3cmp(2, 1) == 1
+    assert _py3cmp("1", "1") == 0
+    assert _py3cmp("1", "2") == -1
+    assert _py3cmp("2", "1") == 1
+    assert _py3cmp("a", "a") == 0
+    assert _py3cmp("a", "b") == -1
+    assert _py3cmp("b", "a") == 1
+    assert _py3cmp(("a",), ("a",)) == 0
+    assert _py3cmp(("a",), ("b",)) == -1
+    assert _py3cmp(("b",), ("a",)) == 1
+
+
+def test_py3cmp_mixed():
+    # Replicates the Python2 comparison behaviour of placing strings before tuples
+    assert _py3cmp(("a",), "a") == 1
+    assert _py3cmp("a", ("a",)) == -1
+
+    assert _py3cmp(("a",), "b") == 1
+    assert _py3cmp("b", ("a",)) == -1
+    assert _py3cmp(("b",), "a") == 1
+    assert _py3cmp("a", ("b",)) == -1
+
+    # intended for use by _hashable_policy, so expects either a string or a tuple
+    with pytest.raises(TypeError) as context:
+        _py3cmp((1,), 1)
+    with pytest.raises(TypeError) as context:
+        _py3cmp(1, (1,))

--- a/tests/unit/module_utils/policy/test_simple_hashable_policy.py
+++ b/tests/unit/module_utils/policy/test_simple_hashable_policy.py
@@ -1,0 +1,32 @@
+# (c) 2022 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.amazon.aws.plugins.module_utils.policy import _hashable_policy
+from ansible_collections.amazon.aws.tests.unit.compat.mock import sentinel
+
+
+def test_hashable_policy_none():
+    assert _hashable_policy(None, []) == []
+
+
+def test_hashable_policy_boolean():
+    assert _hashable_policy(True, []) == ("true", )
+    assert _hashable_policy(False, []) == ("false", )
+
+
+def test_hashable_policy_int():
+    assert _hashable_policy(1, []) == ("1", )
+    assert _hashable_policy(42, []) == ("42", )
+    assert _hashable_policy(0, []) == ("0", )
+
+
+def test_hashable_policy_string():
+    assert _hashable_policy("simple_string", []) == ["simple_string"]
+    assert _hashable_policy("123456789012", []) == ["123456789012"]
+    # This is a special case, we generally expect to have gone via _canonify_root_arn
+    assert _hashable_policy("arn:aws:iam::123456789012:root", []) == ["123456789012"]

--- a/tests/unit/module_utils/policy/test_sort_json_policy_dict.py
+++ b/tests/unit/module_utils/policy/test_sort_json_policy_dict.py
@@ -1,0 +1,64 @@
+# (c) 2022 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+from ansible_collections.amazon.aws.plugins.module_utils.policy import sort_json_policy_dict
+
+
+def test_nothing_to_sort():
+    simple_dict = {'key1': 'a'}
+    nested_dict = {'key1': {'key2': 'a'}}
+    very_nested_dict = {'key1': {'key2': {'key3': 'a'}}}
+    assert sort_json_policy_dict(simple_dict) == simple_dict
+    assert sort_json_policy_dict(nested_dict) == nested_dict
+    assert sort_json_policy_dict(very_nested_dict) == very_nested_dict
+
+
+def test_basic_sort():
+    simple_dict = {'key1': [1, 2, 3, 4], 'key2': [9, 8, 7, 6]}
+    sorted_dict = {'key1': [1, 2, 3, 4], 'key2': [6, 7, 8, 9]}
+    assert sort_json_policy_dict(simple_dict) == sorted_dict
+    assert sort_json_policy_dict(sorted_dict) == sorted_dict
+    simple_dict = {'key1': ["a", "b", "c", "d"], 'key2': ["z", "y", "x", "w"]}
+    sorted_dict = {'key1': ["a", "b", "c", "d"], 'key2': ["w", "x", "y", "z"]}
+    assert sort_json_policy_dict(sorted_dict) == sorted_dict
+
+
+def test_nested_list_sort():
+    nested_dict = {'key1': {'key2': [9, 8, 7, 6]}}
+    sorted_dict = {'key1': {'key2': [6, 7, 8, 9]}}
+    assert sort_json_policy_dict(nested_dict) == sorted_dict
+    assert sort_json_policy_dict(sorted_dict) == sorted_dict
+    nested_dict = {'key1': {'key2': ["z", "y", "x", "w"]}}
+    sorted_dict = {'key1': {'key2': ["w", "x", "y", "z"]}}
+    assert sort_json_policy_dict(nested_dict) == sorted_dict
+    assert sort_json_policy_dict(sorted_dict) == sorted_dict
+
+
+def test_nested_dict_list_sort():
+    nested_dict = {'key1': {'key2': {'key3': [9, 8, 7, 6]}}}
+    sorted_dict = {'key1': {'key2': {'key3': [6, 7, 8, 9]}}}
+    assert sort_json_policy_dict(nested_dict) == sorted_dict
+    assert sort_json_policy_dict(sorted_dict) == sorted_dict
+    nested_dict = {'key1': {'key2': {'key3': ["z", "y", "x", "w"]}}}
+    sorted_dict = {'key1': {'key2': {'key3': ["w", "x", "y", "z"]}}}
+    assert sort_json_policy_dict(nested_dict) == sorted_dict
+    assert sort_json_policy_dict(sorted_dict) == sorted_dict
+
+
+def test_list_of_dict_sort():
+    nested_dict = {'key1': [{'key2': [4, 3, 2, 1]}, {'key3': [9, 8, 7, 6]}]}
+    sorted_dict = {'key1': [{'key2': [1, 2, 3, 4]}, {'key3': [6, 7, 8, 9]}]}
+    assert sort_json_policy_dict(nested_dict) == sorted_dict
+    assert sort_json_policy_dict(sorted_dict) == sorted_dict
+
+
+def test_list_of_list_sort():
+    nested_dict = {'key1': [[4, 3, 2, 1], [9, 8, 7, 6]]}
+    sorted_dict = {'key1': [[1, 2, 3, 4], [6, 7, 8, 9]]}
+    assert sort_json_policy_dict(nested_dict) == sorted_dict
+    assert sort_json_policy_dict(sorted_dict) == sorted_dict


### PR DESCRIPTION
##### SUMMARY

- Improve unit test coverage of module_utils.policy
- Slight refactor of `_hashable_policy` to reduce complexity (and make testing easier)
- Deprecates `sort_json_policy_dict`, it's very naive and [was](https://github.com/ansible-collections/community.aws/pull/1551) only used by ecs_ecr

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/policy.py

##### ADDITIONAL INFORMATION