### PR TITLE
Fix AttributeError when running ec2_metadata_facts

### DIFF
--- a/changelogs/fragments/1134-ec2_metadata_facts-AttributeError.yml
+++ b/changelogs/fragments/1134-ec2_metadata_facts-AttributeError.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_metadata_facts - fixed ``AttributeError`` (https://github.com/ansible-collections/amazon.aws/issues/1134).

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -528,7 +528,7 @@ class Ec2Metadata(object):
                         self._data['%s' % (new_uri)] = content
                         for (key, value) in json_dict.items():
                             self._data['%s:%s' % (new_uri, key.lower())] = value
-                    except json.JSONDecodeError:
+                    except (json.JSONDecodeError, AttributeError):
                         self._data['%s' % (new_uri)] = content  # not a stringified JSON string
 
     def fix_invalid_varnames(self, data):


### PR DESCRIPTION
##### SUMMARY

Prior to 5.0.0 we caught "Exception" within fetch, this was limited to json.JSONDecodeError, however it looks like we also needed to catch AttributeError for non-dict JSON

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_metadata_facts

##### ADDITIONAL INFORMATION

fixes: #1134