### PR TITLE
ec2_metadata_facts: avoid an AttributeError

### DIFF
--- a/changelogs/fragments/ec2_metadata_facts_ami-launch-index.yaml
+++ b/changelogs/fragments/ec2_metadata_facts_ami-launch-index.yaml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- "ec2_metadata_facts - Avoid an exception caused by the type of the ami-launch-index field (https://github.com/ansible-collections/amazon.aws/pull/1140)."

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -528,7 +528,7 @@ class Ec2Metadata(object):
                         self._data['%s' % (new_uri)] = content
                         for (key, value) in json_dict.items():
                             self._data['%s:%s' % (new_uri, key.lower())] = value
-                    except json.JSONDecodeError:
+                    except (json.JSONDecodeError, AttributeError):
                         self._data['%s' % (new_uri)] = content  # not a stringified JSON string
 
     def fix_invalid_varnames(self, data):

--- a/tests/integration/targets/ec2_metadata_facts/aliases
+++ b/tests/integration/targets/ec2_metadata_facts/aliases
@@ -1,6 +1,2 @@
-# We're dependent on AWS actually starting up the instances in a timely manner.
-# This doesn't always happen...
-unstable
-
 non_local
 cloud/aws


### PR DESCRIPTION
`ami-launch-index` return an `int`. `json.load()` returns the same
value and the same type. This was causing an `AttributeError` exception
later in the code.

We now properly address the exception.

The commit also re-enables the functional test.
