### PR TITLE
Update docs workflows to use intersphinx links

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -18,9 +18,9 @@ jobs:
     with:
       init-lenient: false
       init-fail-on-error: true
-      # Please also update docs-push.yml
-      provide-link-targets: |
-        ansible_collections.community.aws.autoscaling_launch_config_module
+      intersphinx-links: |
+        community_aws:https://ansible-collections.github.io/community.aws/branch/main/
+        ansible_devel:https://docs.ansible.com/ansible-core/devel/
 
 
   build-docs:
@@ -31,9 +31,9 @@ jobs:
     with:
       init-lenient: true
       init-fail-on-error: false
-      # Please also update docs-push.yml
-      provide-link-targets: |
-        ansible_collections.community.aws.autoscaling_launch_config_module
+      intersphinx-links: |
+        community_aws:https://ansible-collections.github.io/community.aws/branch/main/
+        ansible_devel:https://docs.ansible.com/ansible-core/devel/
 
   comment:
     permissions:

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -21,9 +21,9 @@ jobs:
     with:
       init-lenient: false
       init-fail-on-error: true
-      # Please also update docs-pr.yml
-      provide-link-targets: |
-        ansible_collections.community.aws.autoscaling_launch_config_module
+      intersphinx-links: |
+        community_aws:https://ansible-collections.github.io/community.aws/branch/main/
+        ansible_devel:https://docs.ansible.com/ansible-core/devel/
 
   publish-docs-gh-pages:
     # use to prevent running on forks

--- a/changelogs/fragments/workflows-add-intersphinx.yml
+++ b/changelogs/fragments/workflows-add-intersphinx.yml
@@ -1,0 +1,2 @@
+trivial:
+- Update docs build/test workflows to use intersphinx links between amazon.aws and community.aws.


### PR DESCRIPTION
##### SUMMARY

Makes use of https://github.com/ansible-community/github-docs-build/pull/54 to add support for linking between amazon.aws and community.aws GitHub pages documentation.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

.github

##### ADDITIONAL INFORMATION
