### PR TITLE
Deprecate module_utils.urls

### DIFF
--- a/changelogs/fragments/DEPRECATE-module_utils-urls.yml
+++ b/changelogs/fragments/DEPRECATE-module_utils-urls.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- module_utils.url - ``ansible_collections.amazon.aws.module_utils.urls`` is believed to be unused and has been deprecated and will be removed in release 7.0.0.

--- a/plugins/module_utils/urls.py
+++ b/plugins/module_utils/urls.py
@@ -20,11 +20,17 @@ from ansible.module_utils.urls import open_url
 from .ec2 import HAS_BOTO3
 from .ec2 import get_aws_connection_info
 
+import ansible.module_utils.common.warnings as ansible_warnings
+
 
 def hexdigest(s):
     """
     Returns the sha256 hexdigest of a string after encoding.
     """
+
+    ansible_warnings.deprecate(
+        'amazon.aws.module_utils.urls.hexdigest is unused and has been deprecated.',
+        version='7.0.0', collection_name='amazon.aws')
 
     return hashlib.sha256(s.encode("utf-8")).hexdigest()
 
@@ -35,6 +41,10 @@ def format_querystring(params=None):
 
     It's specially sorted for cannonical requests
     """
+
+    ansible_warnings.deprecate(
+        'amazon.aws.module_utils.urls.format_querystring is unused and has been deprecated.',
+        version='7.0.0', collection_name='amazon.aws')
 
     if not params:
         return ""
@@ -50,6 +60,10 @@ def sign(key, msg):
     Return digest for key applied to msg
     '''
 
+    ansible_warnings.deprecate(
+        'amazon.aws.module_utils.urls.sign is unused and has been deprecated.',
+        version='7.0.0', collection_name='amazon.aws')
+
     return hmac.new(key, msg.encode("utf-8"), hashlib.sha256).digest()
 
 
@@ -57,6 +71,10 @@ def get_signature_key(key, dateStamp, regionName, serviceName):
     '''
     Returns signature key for AWS resource
     '''
+
+    ansible_warnings.deprecate(
+        'amazon.aws.module_utils.urls.get_signature_key is unused and has been deprecated.',
+        version='7.0.0', collection_name='amazon.aws')
 
     kDate = sign(("AWS4" + key).encode("utf-8"), dateStamp)
     kRegion = sign(kDate, regionName)
@@ -69,6 +87,10 @@ def get_aws_credentials_object(module):
     '''
     Returns aws_access_key_id, aws_secret_access_key, session_token for a module.
     '''
+
+    ansible_warnings.deprecate(
+        'amazon.aws.module_utils.urls.get_aws_credentials_object is unused and has been deprecated.',
+        version='7.0.0', collection_name='amazon.aws')
 
     if not HAS_BOTO3:
         module.fail_json("get_aws_credentials_object requires boto3")
@@ -113,6 +135,10 @@ def signed_request(
 
     :returns: HTTPResponse
     """
+
+    module.deprecate(
+        'amazon.aws.module_utils.urls.signed_request is unused and has been deprecated.',
+        version='7.0.0', collection_name='amazon.aws')
 
     if not HAS_BOTO3:
         module.fail_json("A sigv4 signed_request requires boto3")


### PR DESCRIPTION
##### SUMMARY

Originally introduced in https://github.com/ansible/ansible/pull/42758, as far as I can tell the module_utils/urls.py has never actually been used by a module.  It's primary purpose was to add support for Sigv4, but boto3/botocore support this out of the box now and we shouldn't be reimplementing it.

We have no tests for this code, nothing's using it, and it's in the "supported" repo.  Let's prune out this code, if someone external's using it hopefully someone will raise an issue and we can reconsider the deprecation.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/urls.py

##### ADDITIONAL INFORMATION
