### PR TITLE
ec2_instance: fix to handle create instance in specified AZ

### DIFF
--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1125,7 +1125,7 @@ def build_network_spec(params):
                 module.fail_json(
                     msg="No default subnet could be found - you must include a VPC subnet ID (vpc_subnet_id parameter) to create an instance")
             else:
-                sub = get_default_subnet(default_vpc)
+                sub = get_default_subnet(default_vpc, availability_zone=module.params.get('availability_zone'))
                 spec['SubnetId'] = sub['SubnetId']
 
         if network.get('private_ip_address'):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR adds a fix to allow launching an instance in specified AZ when `vpc_subnet_id` is not specified.
The current code does not consider the AZ and launches the instance in `default subnet` of `default vpc` for the specified region.
https://github.com/ansible-collections/amazon.aws/blob/main/plugins/modules/ec2_instance.py#L1584-L1593
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1120 
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Without the fix, the below playbook will launch instance in `default subnet` ignoring specified `AZ`.
Example Playbook to launch instance in `us-west-2b` AZ.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
---
- name: Spin up ec2 instance
  hosts: localhost
  gather_facts: false
  tasks:
    - name: Launch regular ec2 instances in us-west-1b
      amazon.aws.ec2_instance:
        name: "test-instance-us-west-1b"
        instance_type: t2.micro
        image_id: ami-xxxxx
        state: present
        availability_zone: us-west-1b
        region: us-west-1
        tags:
          terminate-this: yes
        network:
          assign_public_ip: yes
      register: create_result

    - ec2_instance_info:
        instance_ids:
          - "{{ create_result.instance_ids[0] }}"
        region: us-west-1
      register: info_result
    - assert:
        that: info_result.instances[0].placement.availability_zone == 'us-west-1b'
```
