### PR TITLE
Use missing_required_lib more consistently

### DIFF
--- a/changelogs/fragments/1152-missing-botocore.yml
+++ b/changelogs/fragments/1152-missing-botocore.yml
@@ -1,0 +1,6 @@
+minor_changes:
+- aws_ec2 inventory plugin - use ``missing_required_lib`` for more consistent error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
+- aws_rds inventory plugin - use ``missing_required_lib`` for more consistent error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
+- aws_account_attribute lookup plugin - use ``missing_required_lib`` for more consistent error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
+- aws_secret lookup plugin - use ``missing_required_lib`` for more consistent error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
+- aws_ssm lookup plugin - use ``missing_required_lib`` for more consistent error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -273,6 +273,7 @@ except ImportError:
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native
 from ansible.module_utils._text import to_text
+from ansible.module_utils.basic import missing_required_lib
 from ansible.plugins.inventory import BaseInventoryPlugin
 from ansible.plugins.inventory import Cacheable
 from ansible.plugins.inventory import Constructable
@@ -858,7 +859,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         super(InventoryModule, self).parse(inventory, loader, path)
 
         if not HAS_BOTO3:
-            raise AnsibleError('The ec2 dynamic inventory plugin requires boto3 and botocore.')
+            raise AnsibleError(missing_required_lib('botocore and boto3'))
 
         self._read_config_data(path)
 

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -88,6 +88,7 @@ except ImportError:
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import missing_required_lib
 from ansible.plugins.inventory import BaseInventoryPlugin
 from ansible.plugins.inventory import Cacheable
 from ansible.plugins.inventory import Constructable
@@ -357,7 +358,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         super(InventoryModule, self).parse(inventory, loader, path)
 
         if not HAS_BOTO3:
-            raise AnsibleError('The RDS dynamic inventory plugin requires boto3 and botocore.')
+            raise AnsibleError(missing_required_lib('botocore and boto3'))
 
         self._set_credentials()
 

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -57,6 +57,7 @@ except ImportError:
 
 from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import missing_required_lib
 from ansible.plugins.lookup import LookupBase
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
@@ -99,7 +100,7 @@ class LookupModule(LookupBase):
     def run(self, terms, variables, **kwargs):
 
         if not HAS_BOTO3:
-            raise AnsibleError("The lookup aws_account_attribute requires boto3 and botocore.")
+            raise AnsibleError(missing_required_lib('botocore and boto3'))
 
         self.set_options(var_options=variables, direct=kwargs)
         boto_credentials = _get_credentials(self._options)

--- a/plugins/lookup/aws_secret.py
+++ b/plugins/lookup/aws_secret.py
@@ -129,6 +129,7 @@ except ImportError:
 from ansible.errors import AnsibleError
 from ansible.module_utils.six import string_types
 from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import missing_required_lib
 from ansible.plugins.lookup import LookupBase
 
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
@@ -177,7 +178,7 @@ class LookupModule(LookupBase):
                    :returns: A list of parameter values or a list of dictionaries if bypath=True.
                '''
         if not HAS_BOTO3:
-            raise AnsibleError('botocore and boto3 are required for aws_ssm lookup.')
+            raise AnsibleError(missing_required_lib('botocore and boto3'))
 
         deleted = on_deleted.lower()
         if not isinstance(deleted, string_types) or deleted not in ['error', 'warn', 'skip']:

--- a/plugins/lookup/aws_ssm.py
+++ b/plugins/lookup/aws_ssm.py
@@ -137,6 +137,7 @@ from ansible.module_utils._text import to_native
 from ansible.plugins.lookup import LookupBase
 from ansible.utils.display import Display
 from ansible.module_utils.six import string_types
+from ansible.module_utils.basic import missing_required_lib
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_conn
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import get_aws_connection_info
@@ -170,7 +171,7 @@ class LookupModule(LookupBase):
         '''
 
         if not HAS_BOTO3:
-            raise AnsibleError('botocore and boto3 are required for aws_ssm lookup.')
+            raise AnsibleError(missing_required_lib('botocore and boto3'))
 
         # validate arguments 'on_missing' and 'on_denied'
         if on_missing is not None and (not isinstance(on_missing, string_types) or on_missing.lower() not in ['error', 'warn', 'skip']):

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -123,7 +123,7 @@ class AnsibleAWSModule(object):
         if local_settings["check_boto3"]:
             if not HAS_BOTO3:
                 self._module.fail_json(
-                    msg=missing_required_lib('botocore or boto3'))
+                    msg=missing_required_lib('botocore and boto3'))
             if not self.botocore_at_least('1.21.0'):
                 self.warn('botocore < 1.21.0 is not supported or tested.'
                           '  Some features may not work.')


### PR DESCRIPTION
##### SUMMARY

The developer docs recomment using missing_required_lib rather than a custom error message:

https://docs.ansible.com/ansible/latest/dev_guide/developing_modules_best_practices.html#importing-and-using-shared-code

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/inventory/aws_ec2.py
plugins/inventory/aws_rds.py
plugins/lookup/aws_account_attribute.py
plugins/lookup/aws_secret.py
plugins/lookup/aws_ssm.py

##### ADDITIONAL INFORMATION
