### PR TITLE
Update version_added information for modules which migrate to amazon.aws in 5.0.0

### DIFF
--- a/changelogs/fragments/version_added-5.yml
+++ b/changelogs/fragments/version_added-5.yml
@@ -1,0 +1,3 @@
+trivial:
+- various modules - bumped module ``version_added`` to match when they were added to the amazon.aws collection
+- various modules - added ``version_added_collection`` where features were added as part of community.aws

--- a/plugins/modules/autoscaling_group.py
+++ b/plugins/modules/autoscaling_group.py
@@ -9,13 +9,14 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: autoscaling_group
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Create or delete AWS AutoScaling Groups (ASGs)
 description:
   - Can create or delete AWS AutoScaling Groups.
   - Can be used with the M(community.aws.autoscaling_launch_config) module to manage Launch Configurations.
   - Prior to release 5.0.0 this module was called C(community.aws.ec2_asg).
     The usage did not change.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 author:
   - "Gareth Rushgrove (@garethr)"
 options:
@@ -106,6 +107,7 @@ options:
         required: false
         type: dict
         version_added: 1.5.0
+        version_added_collection: community.aws
         suboptions:
           on_demand_allocation_strategy:
             description:
@@ -113,6 +115,7 @@ options:
             type: str
             required: false
             version_added: 1.5.0
+            version_added_collection: community.aws
           on_demand_base_capacity:
             description:
               - >-
@@ -124,6 +127,7 @@ options:
             type: int
             required: false
             version_added: 1.5.0
+            version_added_collection: community.aws
           on_demand_percentage_above_base_capacity:
             description:
               - Controls the percentages of On-Demand Instances and Spot Instances for your additional capacity beyond OnDemandBaseCapacity.
@@ -132,12 +136,14 @@ options:
             type: int
             required: false
             version_added: 1.5.0
+            version_added_collection: community.aws
           spot_allocation_strategy:
             description:
               - Indicates how to allocate instances across Spot Instance pools.
             type: str
             required: false
             version_added: 1.5.0
+            version_added_collection: community.aws
           spot_instance_pools:
             description:
               - >-
@@ -148,6 +154,7 @@ options:
             type: int
             required: false
             version_added: 1.5.0
+            version_added_collection: community.aws
           spot_max_price:
             description:
               - The maximum price per unit hour that you are willing to pay for a Spot Instance.
@@ -156,6 +163,7 @@ options:
             type: str
             required: false
             version_added: 1.5.0
+            version_added_collection: community.aws
     type: dict
   placement_group:
     description:
@@ -194,12 +202,14 @@ options:
     type: list
     elements: str
     version_added: 3.2.0
+    version_added_collection: community.aws
   decrement_desired_capacity:
     description:
       - Indicates whether the AutoScalingGroup decrements the desired capacity value by the number of instances detached.
     default: false
     type: bool
     version_added: 3.2.0
+    version_added_collection: community.aws
   lc_check:
     description:
       - Check to make sure instances that are being replaced with I(replace_instances) do not already have the current I(launch_config).
@@ -230,6 +240,7 @@ options:
     default: false
     type: bool
     version_added: 3.2.0
+    version_added_collection: community.aws
   health_check_period:
     description:
       - Length of time in seconds after a new EC2 instance comes into service that Auto Scaling starts checking its health.

--- a/plugins/modules/autoscaling_group_info.py
+++ b/plugins/modules/autoscaling_group_info.py
@@ -9,12 +9,13 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: autoscaling_group_info
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Gather information about EC2 Auto Scaling Groups (ASGs) in AWS
 description:
   - Gather information about EC2 Auto Scaling Groups (ASGs) in AWS.
   - Prior to release 5.0.0 this module was called C(community.aws.ec2_asg_info).
     The usage did not change.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 author:
   - "Rob White (@wimnat)"
 options:

--- a/plugins/modules/cloudtrail.py
+++ b/plugins/modules/cloudtrail.py
@@ -9,10 +9,11 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: cloudtrail
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: manage CloudTrail create, delete, update
 description:
   - Creates, deletes, or updates CloudTrail configuration. Ensures logging is also enabled.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 author:
   - Ansible Core Team
   - Ted Timmons (@tedder)

--- a/plugins/modules/cloudwatch_metric_alarm.py
+++ b/plugins/modules/cloudwatch_metric_alarm.py
@@ -21,12 +21,13 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 module: cloudwatch_metric_alarm
 short_description: "Create/update or delete AWS CloudWatch 'metric alarms'"
-version_added: 1.0.0
+version_added: 5.0.0
 description:
  - Can create or delete AWS CloudWatch metric alarms.
  - Metrics you wish to alarm on must already exist.
  - Prior to release 5.0.0 this module was called C(community.aws.ec2_metric_alarm).
    The usage did not change.
+ - This module was originally added to C(community.aws) in release 1.0.0.
 author:
   - "Zacharie Eakin (@Zeekin)"
 options:

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -9,16 +9,18 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: cloudwatchevent_rule
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Manage CloudWatch Event rules and targets
 description:
   - This module creates and manages CloudWatch event rules and targets.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 
-author: "Jim Dalton (@jsdalton) <jim.dalton@gmail.com>"
+author:
+  - "Jim Dalton (@jsdalton) <jim.dalton@gmail.com>"
 notes:
   - A rule must contain at least an I(event_pattern) or I(schedule_expression). A
     rule can have both an I(event_pattern) and a I(schedule_expression), in which
@@ -96,6 +98,7 @@ options:
         description:
           - Settings to support providing custom input to a target based on certain event data.
         version_added: 4.1.0
+        version_added_collection: community.aws
         suboptions:
           input_paths_map:
             type: dict

--- a/plugins/modules/cloudwatchlogs_log_group.py
+++ b/plugins/modules/cloudwatchlogs_log_group.py
@@ -10,13 +10,14 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: cloudwatchlogs_log_group
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: create or delete log_group in CloudWatchLogs
+description:
+  - Create or delete log_group in CloudWatchLogs.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 notes:
   - For details of the parameters and returns see U(http://boto3.readthedocs.io/en/latest/reference/services/logs.html).
   - Support for I(purge_tags) was added in release 4.0.0.
-description:
-  - Create or delete log_group in CloudWatchLogs.
 author:
   - Willian Ricardo (@willricardo) <willricardo@gmail.com>
 options:
@@ -95,6 +96,7 @@ log_groups:
     returned: success
     type: complex
     version_added: 4.0.0
+    version_added_collection: community.aws
     contains:
         log_group_name:
             description: The name of the log group.

--- a/plugins/modules/cloudwatchlogs_log_group_info.py
+++ b/plugins/modules/cloudwatchlogs_log_group_info.py
@@ -10,10 +10,11 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: cloudwatchlogs_log_group_info
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Get information about log_group in CloudWatchLogs
 description:
   - Lists the specified log groups. You can list all your log groups or filter the results by prefix.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 author:
   - Willian Ricardo (@willricardo) <willricardo@gmail.com>
 options:
@@ -72,6 +73,7 @@ log_groups:
             returned: always
             type: dict
             version_added: 4.0.0
+            version_added_collection: community.aws
 '''
 
 try:

--- a/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
+++ b/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
@@ -8,13 +8,14 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: cloudwatchlogs_log_group_metric_filter
-version_added: 1.0.0
+version_added: 5.0.0
 author:
   - "Markus Bergholz (@markuman)"
 short_description: Manage CloudWatch log group metric filter
 description:
   - Create, modify and delete CloudWatch log group metric filter.
   - CloudWatch log group metric filter can be use with M(community.aws.ec2_metric_alarm).
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
     state:
       description:
@@ -58,9 +59,9 @@ options:
             - The value to emit when a filter pattern does not match a log event.
           type: float
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 
 '''
 

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -11,11 +11,12 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ec2_eip
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: manages EC2 elastic IP (EIP) addresses.
 description:
   - This module can allocate or release an EIP.
   - This module can associate/disassociate an EIP with instances or network interfaces.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   device_id:
     description:

--- a/plugins/modules/ec2_eip_info.py
+++ b/plugins/modules/ec2_eip_info.py
@@ -9,11 +9,13 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: ec2_eip_info
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: List EC2 EIP details
 description:
-    - List details of EC2 Elastic IP addresses.
-author: "Brad Macpherson (@iiibrad)"
+  - List details of EC2 Elastic IP addresses.
+  - This module was originally added to C(community.aws) in release 1.0.0.
+author:
+  - "Brad Macpherson (@iiibrad)"
 options:
   filters:
     description:
@@ -24,9 +26,9 @@ options:
     default: {}
     type: dict
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 
 '''
 

--- a/plugins/modules/elb_application_lb.py
+++ b/plugins/modules/elb_application_lb.py
@@ -21,10 +21,11 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: elb_application_lb
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Manage an Application Load Balancer
 description:
   - Manage an AWS Application Elastic Load Balancer. See U(https://aws.amazon.com/blogs/aws/new-aws-application-load-balancer/) for details.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 author:
   - "Rob White (@wimnat)"
 options:
@@ -64,24 +65,28 @@ options:
     type: str
     choices: ['monitor', 'defensive', 'strictest']
     version_added: 3.2.0
+    version_added_collection: community.aws
   http_drop_invalid_header_fields:
     description:
       - Indicates whether HTTP headers with invalid header fields are removed by the load balancer C(True) or routed to targets C(False).
       - Defaults to C(False).
     type: bool
     version_added: 3.2.0
+    version_added_collection: community.aws
   http_x_amzn_tls_version_and_cipher_suite:
     description:
       - Indicates whether the two headers are added to the client request before sending it to the target.
       - Defaults to C(False).
     type: bool
     version_added: 3.2.0
+    version_added_collection: community.aws
   http_xff_client_port:
     description:
       - Indicates whether the X-Forwarded-For header should preserve the source port that the client used to connect to the load balancer.
       - Defaults to C(False).
     type: bool
     version_added: 3.2.0
+    version_added_collection: community.aws
   idle_timeout:
     description:
       - The number of seconds to wait before an idle connection is closed.
@@ -213,6 +218,7 @@ options:
       - Defaults to C(False).
     type: bool
     version_added: 3.2.0
+    version_added_collection: community.aws
 extends_documentation_fragment:
   - amazon.aws.aws
   - amazon.aws.ec2

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -9,11 +9,13 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: elb_application_lb_info
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Gather information about Application Load Balancers in AWS
 description:
-    - Gather information about Application Load Balancers in AWS
-author: Rob White (@wimnat)
+  - Gather information about Application Load Balancers in AWS
+  - This module was originally added to C(community.aws) in release 1.0.0.
+author:
+  - Rob White (@wimnat)
 options:
   load_balancer_arns:
     description:
@@ -29,9 +31,9 @@ options:
     elements: str
 
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 
 '''
 

--- a/plugins/modules/iam_policy.py
+++ b/plugins/modules/iam_policy.py
@@ -9,12 +9,13 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: iam_policy
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Manage inline IAM policies for users, groups, and roles
 description:
   - Allows uploading or removing inline IAM policies for IAM users, groups or roles.
   - To administer managed policies please see M(community.aws.iam_user), M(community.aws.iam_role),
     M(community.aws.iam_group) and M(community.aws.iam_managed_policy)
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   iam_type:
     description:

--- a/plugins/modules/iam_policy_info.py
+++ b/plugins/modules/iam_policy_info.py
@@ -9,10 +9,11 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: iam_policy_info
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Retrieve inline IAM policies for users, groups, and roles
 description:
-     - Supports fetching of inline IAM policies for IAM users, groups and roles.
+  - Supports fetching of inline IAM policies for IAM users, groups and roles.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   iam_type:
     description:
@@ -30,14 +31,12 @@ options:
       - Name of a specific IAM inline policy you with to retrieve.
     required: false
     type: str
-
 author:
-    - Mark Chappell (@tremble)
-
+  - Mark Chappell (@tremble)
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 
 '''
 

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -9,12 +9,14 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: iam_user
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Manage AWS IAM users
 description:
   - A module to manage AWS IAM users.
   - The module does not manage groups that users belong to, groups memberships can be managed using M(community.aws.iam_group).
-author: Josh Souza (@joshsouza)
+  - This module was originally added to C(community.aws) in release 1.0.0.
+author:
+  - Josh Souza (@joshsouza)
 options:
   name:
     description:
@@ -27,6 +29,7 @@ options:
     required: false
     type: str
     version_added: 2.2.0
+    version_added_collection: community.aws
   password_reset_required:
     description:
       - Defines if the user is required to set a new password after login.
@@ -34,6 +37,7 @@ options:
     type: bool
     default: false
     version_added: 3.1.0
+    version_added_collection: community.aws
   update_password:
     default: always
     choices: ['always', 'on_create']
@@ -43,12 +47,14 @@ options:
       - I(update_password=on_create) will only set the password for newly created users.
     type: str
     version_added: 2.2.0
+    version_added_collection: community.aws
   remove_password:
     description:
       - Option to delete user login passwords.
       - This field is mutually exclusive to I(password).
     type: 'bool'
     version_added: 2.2.0
+    version_added_collection: community.aws
   managed_policies:
     description:
       - A list of managed policy ARNs or friendly names to attach to the user.
@@ -77,12 +83,14 @@ options:
     default: True
     type: bool
     version_added: 2.2.0
+    version_added_collection: community.aws
   wait_timeout:
     description:
       - How long (in seconds) to wait for creation / updates to complete.
     default: 120
     type: int
     version_added: 2.2.0
+    version_added_collection: community.aws
 notes:
   - Support for I(tags) and I(purge_tags) was added in release 2.1.0.
 extends_documentation_fragment:

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -11,35 +11,36 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: iam_user_info
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Gather IAM user(s) facts in AWS
 description:
   - This module can be used to gather IAM user(s) facts in AWS.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 author:
   - Constantin Bugneac (@Constantin07)
   - Abhijeet Kasurde (@Akasurde)
 options:
   name:
     description:
-     - The name of the IAM user to look for.
+      - The name of the IAM user to look for.
     required: false
     type: str
   group:
     description:
-     - The group name name of the IAM user to look for. Mutually exclusive with C(path).
+      - The group name name of the IAM user to look for. Mutually exclusive with C(path).
     required: false
     type: str
   path:
     description:
-     - The path to the IAM user. Mutually exclusive with C(group).
-     - If specified, then would get all user names whose path starts with user provided value.
+      - The path to the IAM user. Mutually exclusive with C(group).
+      - If specified, then would get all user names whose path starts with user provided value.
     required: false
     default: '/'
     type: str
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 
 '''
 

--- a/plugins/modules/kms_key.py
+++ b/plugins/modules/kms_key.py
@@ -9,13 +9,14 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: kms_key
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Perform various KMS key management tasks
 description:
   - Manage role/user access to a KMS key.
   - Not designed for encrypting/decrypting.
   - Prior to release 5.0.0 this module was called C(community.aws.aws_kms).
     The usage did not change.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   alias:
     description:
@@ -72,6 +73,7 @@ options:
     type: int
     aliases: ['deletion_delay']
     version_added: 1.4.0
+    version_added_collection: community.aws
   purge_grants:
     description:
       - Whether the I(grants) argument should cause grants not in the list to be removed.
@@ -124,6 +126,7 @@ options:
     default: SYMMETRIC_DEFAULT
     choices: ['SYMMETRIC_DEFAULT', 'RSA_2048', 'RSA_3072', 'RSA_4096', 'ECC_NIST_P256', 'ECC_NIST_P384', 'ECC_NIST_P521', 'ECC_SECG_P256K1']
     version_added: 2.1.0
+    version_added_collection: community.aws
   key_usage:
     description:
       - Determines the cryptographic operations for which you can use the KMS key.
@@ -132,6 +135,7 @@ options:
     default: ENCRYPT_DECRYPT
     choices: ['ENCRYPT_DECRYPT', 'SIGN_VERIFY']
     version_added: 2.1.0
+    version_added_collection: community.aws
 author:
   - Ted Timmons (@tedder)
   - Will Thames (@willthames)
@@ -241,6 +245,7 @@ deletion_date:
   returned: when key_state is PendingDeletion
   sample: "2017-04-18T15:12:08.551000+10:00"
   version_added: 3.3.0
+  version_added_collection: community.aws
 description:
   description: Description of the key.
   type: str
@@ -334,6 +339,7 @@ key_policies:
       - "kms:RevokeGrant"
       Resource: "*"
   version_added: 3.3.0
+  version_added_collection: community.aws
 tags:
   description: Dictionary of tags applied to the key. Empty when access is denied even if there are tags.
   type: dict

--- a/plugins/modules/kms_key_info.py
+++ b/plugins/modules/kms_key_info.py
@@ -9,12 +9,13 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: kms_key_info
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Gather information about AWS KMS keys
 description:
   - Gather information about AWS KMS keys including tags and grants.
   - Prior to release 5.0.0 this module was called C(community.aws.aws_kms_info).
     The usage did not change.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 author:
   - "Will Thames (@willthames)"
 options:
@@ -27,6 +28,7 @@ options:
       - key_alias
     type: str
     version_added: 1.4.0
+    version_added_collection: community.aws
   key_id:
     description:
       - Key ID or ARN of the key.
@@ -36,6 +38,7 @@ options:
       - key_arn
     type: str
     version_added: 1.4.0
+    version_added_collection: community.aws
   filters:
     description:
       - A dict of filters to apply. Each dict item consists of a filter key and a filter value.
@@ -123,6 +126,7 @@ kms_keys:
       returned: when key_state is PendingDeletion
       sample: "2017-04-18T15:12:08.551000+10:00"
       version_added: 3.3.0
+      version_added_collection: community.aws
     description:
       description: Description of the key.
       type: str
@@ -223,6 +227,7 @@ kms_keys:
           - "kms:RevokeGrant"
           Resource: "*"
       version_added: 3.3.0
+      version_added_collection: community.aws
     grants:
       description: List of grants associated with a key.
       type: list

--- a/plugins/modules/lambda.py
+++ b/plugins/modules/lambda.py
@@ -9,10 +9,11 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: lambda
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Manage AWS Lambda functions
 description:
-   - Allows for the management of Lambda functions.
+  - Allows for the management of Lambda functions.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   name:
     description:
@@ -108,6 +109,7 @@ options:
       - The KMS key ARN used to encrypt the function's environment variables.
     type: str
     version_added: 3.3.0
+    version_added_collection: community.aws
   architecture:
     description:
       - The instruction set architecture that the function supports.

--- a/plugins/modules/lambda_alias.py
+++ b/plugins/modules/lambda_alias.py
@@ -9,15 +9,17 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: lambda_alias
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Creates, updates or deletes AWS Lambda function aliases
 description:
-    - This module allows the management of AWS Lambda functions aliases via the Ansible
-      framework.  It is idempotent and supports "Check" mode.    Use module M(amazon.aws.lambda) to manage the lambda function
-      itself and M(amazon.aws.lambda_event) to manage event source mappings.
+  - This module allows the management of AWS Lambda functions aliases via the Ansible
+    framework.  It is idempotent and supports "Check" mode.    Use module M(amazon.aws.lambda) to manage the lambda function
+    itself and M(amazon.aws.lambda_event) to manage event source mappings.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 
-
-author: Pierre Jodouin (@pjodouin), Ryan Scott Brown (@ryansb)
+author:
+  - Pierre Jodouin (@pjodouin)
+  - Ryan Scott Brown (@ryansb)
 options:
   function_name:
     description:
@@ -47,9 +49,9 @@ options:
     aliases: ['version']
     type: int
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 
 '''
 

--- a/plugins/modules/lambda_event.py
+++ b/plugins/modules/lambda_event.py
@@ -9,17 +9,19 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: lambda_event
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Creates, updates or deletes AWS Lambda function event mappings
 description:
-    - This module allows the management of AWS Lambda function event source mappings such as DynamoDB and Kinesis stream
-      events via the Ansible framework. These event source mappings are relevant only in the AWS Lambda pull model, where
-      AWS Lambda invokes the function.
-      It is idempotent and supports "Check" mode.  Use module M(amazon.aws.lambda) to manage the lambda
-      function itself and M(amazon.aws.lambda_alias) to manage function aliases.
+  - This module allows the management of AWS Lambda function event source mappings such as DynamoDB and Kinesis stream
+    events via the Ansible framework. These event source mappings are relevant only in the AWS Lambda pull model, where
+    AWS Lambda invokes the function.
+    It is idempotent and supports "Check" mode.  Use module M(amazon.aws.lambda) to manage the lambda
+    function itself and M(amazon.aws.lambda_alias) to manage function aliases.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 
-
-author: Pierre Jodouin (@pjodouin), Ryan Brown (@ryansb)
+author:
+  - Pierre Jodouin (@pjodouin)
+  - Ryan Brown (@ryansb)
 options:
   lambda_function_arn:
     description:
@@ -79,9 +81,9 @@ options:
     required: true
     type: dict
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 
 '''
 

--- a/plugins/modules/lambda_execute.py
+++ b/plugins/modules/lambda_execute.py
@@ -9,13 +9,14 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: lambda_execute
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Execute an AWS Lambda function
 description:
   - This module executes AWS Lambda functions, allowing synchronous and asynchronous
     invocation.
   - Prior to release 5.0.0 this module was called C(community.aws.execute_lambda).
     The usage did not change.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 extends_documentation_fragment:
   - amazon.aws.aws
   - amazon.aws.ec2

--- a/plugins/modules/lambda_info.py
+++ b/plugins/modules/lambda_info.py
@@ -9,12 +9,13 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: lambda_info
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Gathers AWS Lambda function details
 description:
   - Gathers various details related to Lambda functions, including aliases, versions and event source mappings.
   - Use module M(amazon.aws.lambda) to manage the lambda function itself, M(amazon.aws.lambda_alias) to manage function aliases,
     M(amazon.aws.lambda_event) to manage lambda event source mappings, and M(amazon.aws.lambda_policy) to manage policy statements.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   query:
     description:
@@ -87,6 +88,7 @@ functions:
     type: list
     elements: dict
     version_added: 4.1.0
+    version_added_collection: community.aws
     contains:
         aliases:
             description: The aliases associated with the function.

--- a/plugins/modules/lambda_policy.py
+++ b/plugins/modules/lambda_policy.py
@@ -10,16 +10,15 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: lambda_policy
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Creates, updates or deletes AWS Lambda policy statements.
 description:
-    - This module allows the management of AWS Lambda policy statements.
-    - It is idempotent and supports "Check" mode.
-    - Use module M(amazon.aws.lambda) to manage the lambda function itself, M(amazon.aws.lambda_alias) to manage function aliases,
-      M(amazon.aws.lambda_event) to manage event source mappings such as Kinesis streams, M(community.aws.execute_lambda) to execute a
-      lambda function and M(amazon.aws.lambda_info) to gather information relating to one or more lambda functions.
-
-
+  - This module allows the management of AWS Lambda policy statements.
+  - It is idempotent and supports "Check" mode.
+  - Use module M(amazon.aws.lambda) to manage the lambda function itself, M(amazon.aws.lambda_alias) to manage function aliases,
+    M(amazon.aws.lambda_event) to manage event source mappings such as Kinesis streams, M(community.aws.execute_lambda) to execute a
+    lambda function and M(amazon.aws.lambda_info) to gather information relating to one or more lambda functions.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 author:
   - Pierre Jodouin (@pjodouin)
   - Michael De La Rue (@mikedlr)
@@ -98,9 +97,9 @@ options:
     type: str
 
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 
 '''
 

--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -10,18 +10,19 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: rds_cluster
-version_added: "3.2.0"
+version_added: 5.0.0
 short_description: rds_cluster module
 description:
-    - Create, modify, and delete RDS clusters.
+  - Create, modify, and delete RDS clusters.
+  - This module was originally added to C(community.aws) in release 3.2.0.
 extends_documentation_fragment:
-    - amazon.aws.aws
-    - amazon.aws.ec2
-    - amazon.aws.tags
-    - amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.tags
+  - amazon.aws.boto3
 author:
-    - Sloane Hertel (@s-hertel)
-    - Alina Buzachis (@alinabuzachis)
+  - Sloane Hertel (@s-hertel)
+  - Alina Buzachis (@alinabuzachis)
 options:
   # General module options
     state:

--- a/plugins/modules/rds_cluster_info.py
+++ b/plugins/modules/rds_cluster_info.py
@@ -9,10 +9,11 @@ __metaclass__ = type
 
 DOCUMENTATION = r'''
 module: rds_cluster_info
-version_added: 3.2.0
+version_added: 5.0.0
 short_description: Obtain information about one or more RDS clusters
 description:
   - Obtain information about one or more RDS clusters.
+  - This module was originally added to C(community.aws) in release 3.2.0.
 options:
     db_cluster_identifier:
         description:
@@ -29,11 +30,11 @@ options:
               See U(https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBClusters.html).
         type: dict
 author:
-    - Alina Buzachis (@alinabuzachis)
+  - Alina Buzachis (@alinabuzachis)
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 
 '''
 

--- a/plugins/modules/rds_cluster_snapshot.py
+++ b/plugins/modules/rds_cluster_snapshot.py
@@ -10,10 +10,11 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: rds_cluster_snapshot
-version_added: 4.0.0
+version_added: 5.0.0
 short_description: Manage Amazon RDS snapshots of DB clusters
 description:
   - Create, modify and delete RDS snapshots of DB clusters.
+  - This module was originally added to C(community.aws) in release 4.0.0.
 options:
   state:
     description:

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -9,17 +9,18 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: rds_instance
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Manage RDS instances
 description:
-    - Create, modify, and delete RDS instances.
+ - Create, modify, and delete RDS instances.
+ - This module was originally added to C(community.aws) in release 1.0.0.
 extends_documentation_fragment:
-    - amazon.aws.aws
-    - amazon.aws.ec2
-    - amazon.aws.tags
-    - amazon.aws.boto3
+ - amazon.aws.aws
+ - amazon.aws.ec2
+ - amazon.aws.tags
+ - amazon.aws.boto3
 author:
-    - Sloane Hertel (@s-hertel)
+ - Sloane Hertel (@s-hertel)
 
 options:
   # General module options
@@ -167,6 +168,7 @@ options:
              By default, deletion protection is disabled.
         type: bool
         version_added: 3.3.0
+        version_added_collection: community.aws
     domain:
         description:
           - The Active Directory Domain to restore the instance in.
@@ -229,6 +231,7 @@ options:
             type: str
             required: true
         version_added: 3.3.0
+        version_added_collection: community.aws
     iops:
         description:
           - The Provisioned IOPS (I/O operations per second) value. Is only set when using I(storage_type) is set to io1.
@@ -346,6 +349,7 @@ options:
         type: bool
         default: False
         version_added: 3.3.0
+        version_added_collection: community.aws
     restore_time:
         description:
           - If using I(creation_source=instance) this indicates the UTC date and time to restore from the source instance.
@@ -441,6 +445,7 @@ options:
         type: bool
         default: True
         version_added: 1.5.0
+        version_added_collection: community.aws
 '''
 
 EXAMPLES = r'''
@@ -683,6 +688,7 @@ deletion_protection:
   type: bool
   sample: False
   version_added: 3.3.0
+  version_added_collection: community.aws
 domain_memberships:
   description: The Active Directory Domain membership records associated with the DB instance.
   returned: always

--- a/plugins/modules/rds_instance_info.py
+++ b/plugins/modules/rds_instance_info.py
@@ -11,10 +11,11 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: rds_instance_info
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: obtain information about one or more RDS instances
 description:
   - Obtain information about one or more RDS instances.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   db_instance_identifier:
     description:
@@ -29,12 +30,12 @@ options:
         See U(https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBInstances.html)
     type: dict
 author:
-    - "Will Thames (@willthames)"
-    - "Michael De La Rue (@mikedlr)"
+  - "Will Thames (@willthames)"
+  - "Michael De La Rue (@mikedlr)"
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 
 '''
 
@@ -195,6 +196,7 @@ instances:
       type: bool
       sample: False
       version_added: 3.3.0
+      version_added_collection: community.aws
     domain_memberships:
       description: List of domain memberships
       returned: always

--- a/plugins/modules/rds_instance_snapshot.py
+++ b/plugins/modules/rds_instance_snapshot.py
@@ -11,10 +11,11 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: rds_instance_snapshot
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Manage Amazon RDS instance snapshots
 description:
   - Creates or deletes RDS snapshots.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   state:
     description:
@@ -47,17 +48,20 @@ options:
       - source_snapshot_id
     type: str
     version_added: 3.3.0
+    version_added_collection: community.aws
   source_region:
     description:
       - The region that contains the snapshot to be copied.
     type: str
     version_added: 3.3.0
+    version_added_collection: community.aws
   copy_tags:
     description:
       - Whether to copy all tags from I(source_db_snapshot_identifier) to I(db_instance_identifier).
     type: bool
     default: False
     version_added: 3.3.0
+    version_added_collection: community.aws
   wait:
     description:
       - Whether or not to wait for snapshot creation or deletion.
@@ -193,6 +197,7 @@ source_db_snapshot_identifier:
   type: str
   sample: arn:aws:rds:us-west-2:123456789012:snapshot:ansible-test-16638696-test-snapshot-source
   version_added: 3.3.0
+  version_added_collection: community.aws
 snapshot_create_time:
   description: Creation time of the snapshot.
   returned: always

--- a/plugins/modules/rds_option_group.py
+++ b/plugins/modules/rds_option_group.py
@@ -9,9 +9,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 module: rds_option_group
 short_description: Manages the creation, modification, deletion of RDS option groups
-version_added: 2.1.0
+version_added: 5.0.0
 description:
   - Manages the creation, modification, deletion of RDS option groups.
+  - This module was originally added to C(community.aws) in release 2.1.0.
 author:
   - "Nick Aslanidis (@naslanidis)"
   - "Will Thames (@willthames)"

--- a/plugins/modules/rds_option_group_info.py
+++ b/plugins/modules/rds_option_group_info.py
@@ -10,9 +10,10 @@ DOCUMENTATION = r'''
 ---
 module: rds_option_group_info
 short_description: rds_option_group_info module
-version_added: 2.1.0
+version_added: 5.0.0
 description:
-    - Gather information about RDS option groups.
+  - Gather information about RDS option groups.
+  - This module was originally added to C(community.aws) in release 2.1.0.
 author: "Alina Buzachis (@alinabuzachis)"
 options:
     option_group_name:
@@ -48,9 +49,9 @@ options:
         default: ''
         required: false
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/rds_param_group.py
+++ b/plugins/modules/rds_param_group.py
@@ -9,10 +9,11 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: rds_param_group
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: manage RDS parameter groups
 description:
   - Creates, modifies, and deletes RDS parameter groups.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   state:
     description:

--- a/plugins/modules/rds_snapshot_info.py
+++ b/plugins/modules/rds_snapshot_info.py
@@ -11,11 +11,12 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: rds_snapshot_info
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: obtain information about one or more RDS snapshots
 description:
   - Obtain information about one or more RDS snapshots. These can be for unclustered snapshots or snapshots of clustered DBs (Aurora).
   - Aurora snapshot information may be obtained if no identifier parameters are passed or if one of the cluster parameters are passed.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   db_snapshot_identifier:
     description:
@@ -51,11 +52,11 @@ options:
     choices: ['automated', 'manual', 'shared', 'public']
     type: str
 author:
-    - "Will Thames (@willthames)"
+  - "Will Thames (@willthames)"
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 
 '''
 

--- a/plugins/modules/rds_subnet_group.py
+++ b/plugins/modules/rds_subnet_group.py
@@ -12,10 +12,11 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: rds_subnet_group
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: manage RDS database subnet groups
 description:
   - Creates, modifies, and deletes RDS database subnet groups.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   state:
     description:
@@ -132,6 +133,7 @@ subnet_group:
                     returned: I(state=present)
                     type: dict
                     version_added: 3.2.0
+                    version_added_collection: community.aws
                     sample:
                         name: "eu-north-1b"
                 subnet_identifier:
@@ -139,18 +141,21 @@ subnet_group:
                     returned: I(state=present)
                     type: str
                     version_added: 3.2.0
+                    version_added_collection: community.aws
                     sample: "subnet-08c94870f4480797e"
                 subnet_outpost:
                     description: This value specifies the Outpost.
                     returned: I(state=present)
                     type: dict
                     version_added: 3.2.0
+                    version_added_collection: community.aws
                     sample: {}
                 subnet_status:
                     description: The status of the subnet.
                     returned: I(state=present)
                     type: str
                     version_added: 3.2.0
+                    version_added_collection: community.aws
                     sample: "Active"
         status:
             description: The status of the DB subnet group (maintained for backward compatibility)
@@ -172,6 +177,7 @@ subnet_group:
             returned: I(state=present)
             type: dict
             version_added: 3.2.0
+            version_added_collection: community.aws
             sample:
                 tag1: Tag1
                 tag2: Tag2

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -12,10 +12,11 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 ---
 module: route53
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: add or delete entries in Amazons Route 53 DNS service
 description:
-     - Creates and deletes DNS records in Amazons Route 53 service.
+  - Creates and deletes DNS records in Amazons Route 53 service.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   state:
     description:
@@ -132,6 +133,7 @@ options:
         type: str
     type: dict
     version_added: 3.3.0
+    version_added_collection: community.aws
   health_check:
     description:
       - Health check to associate with this record
@@ -159,11 +161,11 @@ options:
     default: 300
     type: int
 author:
-- Bruce Pennypacker (@bpennypacker)
-- Mike Buzzetti (@jimbydamonk)
+  - Bruce Pennypacker (@bpennypacker)
+  - Mike Buzzetti (@jimbydamonk)
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.boto3
 '''
 
 RETURN = r'''
@@ -197,6 +199,7 @@ set:
       type: dict
       sample: { continent_code: "NA", country_code: "US", subdivision_code: "CA" }
       version_added: 3.3.0
+      version_added_collection: community.aws
     health_check:
       description: health_check associated with this record.
       returned: always

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -9,12 +9,13 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: route53_health_check
-version_added: 1.0.0
+version_added: 5.0.0
 short_description: Manage health-checks in Amazons Route53 DNS service
 description:
   - Creates and deletes DNS Health checks in Amazons Route53 service.
   - Only the port, resource_path, string_match and request_interval are
     considered when updating existing health-checks.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   state:
     description:
@@ -30,6 +31,7 @@ options:
       - Defaults to C(true) when creating a new health check.
     type: bool
     version_added: 2.1.0
+    version_added_collection: community.aws
   ip_address:
     description:
       - IP address of the end-point to check. Either this or I(fqdn) has to be provided.
@@ -94,12 +96,14 @@ options:
     required: False
     aliases: ['name']
     version_added: 4.1.0
+    version_added_collection: community.aws
   use_unique_names:
     description:
       - Used together with I(health_check_name) to set/make use of I(health_check_name) as a unique identifier.
     type: bool
     required: False
     version_added: 4.1.0
+    version_added_collection: community.aws
   health_check_id:
     description:
       - ID of the health check to be update or deleted.
@@ -108,6 +112,7 @@ options:
     required: False
     aliases: ['id']
     version_added: 4.1.0
+    version_added_collection: community.aws
 author:
   - "zimbatm (@zimbatm)"
 notes:

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -9,9 +9,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 module: route53_info
 short_description: Retrieves route53 details using AWS methods
-version_added: 1.0.0
+version_added: 5.0.0
 description:
-    - Gets various details related to Route53 zone, record set or health check details.
+  - Gets various details related to Route53 zone, record set or health check details.
+  - This module was originally added to C(community.aws) in release 1.0.0.
 options:
   query:
     description:
@@ -126,11 +127,12 @@ options:
         ]
     default: 'list'
     type: str
-author: Karen Cheng (@Etherdaemon)
+author:
+  - Karen Cheng (@Etherdaemon)
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
 
 '''
 
@@ -255,6 +257,7 @@ resource_record_sets:
                     type: str
                     sample: 'NY'
     version_added: 4.0.0
+    version_added_collection: community.aws
 hosted_zones:
     description: A list of hosted zones returned by list_hosted_zones in boto3.
     returned: when I(query=hosted_zone)
@@ -290,6 +293,7 @@ hosted_zones:
                     type: bool
                     sample: false
     version_added: 4.0.0
+    version_added_collection: community.aws
 health_checks:
     description: A list of Route53 health checks returned by list_health_checks in boto3.
     type: list
@@ -361,18 +365,21 @@ health_checks:
                     type: str
                     sample: HTTPS
     version_added: 4.0.0
+    version_added_collection: community.aws
 checker_ip_ranges:
     description: A list of IP ranges in CIDR format for Amazon Route 53 health checkers.
     returned: when I(query=checker_ip_range)
     type: list
     elements: str
     version_added: 4.1.0
+    version_added_collection: community.aws
 delegation_sets:
     description: A list of dicts that contains information about the reusable delegation set.
     returned: when I(query=reusable_delegation_set)
     type: list
     elements: dict
     version_added: 4.1.0
+    version_added_collection: community.aws
 health_check:
     description: A dict of Route53 health check details returned by get_health_check_status in boto3.
     type: dict
@@ -443,6 +450,7 @@ health_check:
                     type: str
                     sample: HTTPS
     version_added: 4.1.0
+    version_added_collection: community.aws
 ResourceRecordSets:
     description: A deprecated CamelCased list of resource record sets returned by list_resource_record_sets in boto3. \
                  This list contains same elements/parameters as it's snake_cased version mentioned above. \

--- a/plugins/modules/route53_zone.py
+++ b/plugins/modules/route53_zone.py
@@ -8,9 +8,10 @@ __metaclass__ = type
 DOCUMENTATION = r'''
 module: route53_zone
 short_description: add or delete Route53 zones
-version_added: 1.0.0
+version_added: 5.0.0
 description:
     - Creates and deletes Route53 private and public zones.
+    - This module was originally added to C(community.aws) in release 1.0.0.
 options:
     zone:
         description:


### PR DESCRIPTION
##### SUMMARY

Felix has pointed out in IRC/Matrix that for modules which migrated to amazon.aws it can be a little confusing when you try to look back in logs to find exactly what needs to be installed for a feature (installing amazon.aws.4.3.0 doesn't guarantee that community.aws 4.x is installed)

Update the main 'version_added' to match the version that the modules were moved to amazon.aws, and add the version_added_collection for existing new features.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

various modules

##### ADDITIONAL INFORMATION
