### PR TITLE
Cleanup integration tests after all of the module renames

### DIFF
--- a/changelogs/fragments/rename-cleanup-tests.yml
+++ b/changelogs/fragments/rename-cleanup-tests.yml
@@ -1,0 +1,2 @@
+trivial:
+- integration tests - Cleanup integration tests after mass module renames.

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/create_update_delete.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/create_update_delete.yml
@@ -1,14 +1,12 @@
-# tasks file for test_ec2_asg
-
     # ============================================================
 
-- name: Test create/update/delete AutoScalingGroups with ec2_asg
+- name: Test create/update/delete AutoScalingGroups with autoscaling_group
   block:
 
     # ============================================================
 
   - name: test without specifying required module options
-    ec2_asg:
+    autoscaling_group:
       aws_access_key: '{{ aws_access_key }}'
       aws_secret_key: '{{ aws_secret_key }}'
       security_token: '{{ security_token | default(omit) }}'
@@ -21,7 +19,7 @@
 
 
   - name: ensure launch configs exist
-    ec2_lc:
+    autoscaling_launch_config:
       name: '{{ item }}'
       assign_public_ip: true
       image_id: '{{ ec2_ami_id }}'
@@ -42,7 +40,7 @@
     # ============================================================
 
   - name: launch asg and wait for instances to be deemed healthy (no ELB)
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_config_name: '{{ resource_prefix }}-lc'
       desired_capacity: 1
@@ -57,7 +55,7 @@
       - output.viable_instances == 1
 
   - name: Enable metrics collection - check_mode
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       metrics_collection: yes
     register: output
@@ -69,7 +67,7 @@
       - '"autoscaling:UpdateAutoScalingGroup" not in output.resource_actions'
 
   - name: Enable metrics collection
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       metrics_collection: yes
     register: output
@@ -78,7 +76,7 @@
       - output is changed
 
   - name: Enable metrics collection (idempotency)
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       metrics_collection: yes
     register: output
@@ -87,7 +85,7 @@
       - output is not changed
 
   - name: Disable metrics collection - check_mode
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       metrics_collection: no
     register: output
@@ -100,7 +98,7 @@
 
 
   - name: Disable metrics collection
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       metrics_collection: no
     register: output
@@ -109,7 +107,7 @@
       - output is changed
 
   - name: Disable metrics collection (idempotency)
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       metrics_collection: no
     register: output
@@ -118,13 +116,13 @@
       - output is not changed
 
   - name: kill asg
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       state: absent
       wait_timeout: 800
     async: 400
   - name: launch asg and do not wait for instances to be deemed healthy (no ELB)
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_config_name: '{{ resource_prefix }}-lc'
       desired_capacity: 1
@@ -139,7 +137,7 @@
       - output.viable_instances == 0
 
   - name: kill asg
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       state: absent
       wait_timeout: 800
@@ -149,7 +147,7 @@
     delay: 10
     async: 400
   - name: create asg with asg metrics enabled
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       metrics_collection: true
       launch_config_name: '{{ resource_prefix }}-lc'
@@ -164,13 +162,13 @@
       - "'Group' in output.metrics_collection.0.Metric"
 
   - name: kill asg
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       state: absent
       wait_timeout: 800
     async: 400
   - name: launch load balancer
-    ec2_elb_lb:
+    elb_classic_lb:
       name: '{{ load_balancer_name }}'
       state: present
       security_group_ids:
@@ -191,7 +189,7 @@
         healthy_threshold: 2
     register: load_balancer
   - name: launch asg and wait for instances to be deemed healthy (ELB)
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_config_name: '{{ resource_prefix }}-lc'
       health_check_type: ELB
@@ -213,7 +211,7 @@
 
     # grow scaling group to 3
   - name: add 2 more instances wait for instances to be deemed healthy (ELB)
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_config_name: '{{ resource_prefix }}-lc'
       health_check_type: ELB
@@ -235,7 +233,7 @@
 
     # Test max_instance_lifetime option
   - name: enable asg max_instance_lifetime
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       max_instance_lifetime: 604801
     register: output
@@ -245,7 +243,7 @@
       - output.max_instance_lifetime == 604801
 
   - name: run without max_instance_lifetime
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_config_name: '{{ resource_prefix }}-lc'
   - name: ensure max_instance_lifetime not affected by defaults
@@ -254,7 +252,7 @@
       - output.max_instance_lifetime == 604801
 
   - name: disable asg max_instance_lifetime
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_config_name: '{{ resource_prefix }}-lc'
       max_instance_lifetime: 0
@@ -268,7 +266,7 @@
 
     # perform rolling replace with different launch configuration
   - name: perform rolling update to new AMI
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_config_name: '{{ resource_prefix }}-lc-2'
       health_check_type: ELB
@@ -295,7 +293,7 @@
 
     # perform rolling replace with the original launch configuration
   - name: perform rolling update to new AMI while removing the load balancer
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_config_name: '{{ resource_prefix }}-lc'
       health_check_type: EC2
@@ -322,7 +320,7 @@
 
     # perform rolling replace with new launch configuration and lc_check:false
   - name: 'perform rolling update to new AMI with lc_check: false'
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_config_name: '{{ resource_prefix }}-lc-2'
       health_check_type: EC2
@@ -338,8 +336,8 @@
       lc_check: false
       wait_timeout: 1800
       state: present
-  - name: get ec2_asg info
-    ec2_asg_info:
+  - name: get autoscaling_group info
+    autoscaling_group_info:
       name: '{{ resource_prefix }}-asg'
     register: output
   - assert:
@@ -349,13 +347,13 @@
     # ============================================================
 
   - name: kill asg
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       state: absent
       wait_timeout: 800
     async: 400
   - name: 'new asg with lc_check: false'
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_config_name: '{{ resource_prefix }}-lc'
       health_check_type: EC2
@@ -371,8 +369,8 @@
       lc_check: false
       wait_timeout: 1800
       state: present
-  - name: get ec2_asg information
-    ec2_asg_info:
+  - name: get autoscaling_group information
+    autoscaling_group_info:
       name: '{{ resource_prefix }}-asg'
     register: output
   - assert:
@@ -397,7 +395,7 @@
 
   - name: update autoscaling group with mixed-instances policy with mixed instances
       types - check_mode
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_template:
         launch_template_name: '{{ resource_prefix }}-lt'
@@ -421,7 +419,7 @@
 
   - name: update autoscaling group with mixed-instances policy with mixed instances
       types
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_template:
         launch_template_name: '{{ resource_prefix }}-lt'
@@ -443,7 +441,7 @@
       - output.mixed_instances_policy[1] == 't2.nano'
 
   - name: update autoscaling group with mixed-instances policy with instances_distribution
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_template:
         launch_template_name: '{{ resource_prefix }}-lt'
@@ -503,7 +501,7 @@
       state: present
     register: out_tg2
   - name: update autoscaling group with tg1
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_template:
         launch_template_name: '{{ resource_prefix }}-lt'
@@ -520,7 +518,7 @@
       - output.target_group_arns[0] == out_tg1.target_group_arn
 
   - name: update autoscaling group add tg2
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_template:
         launch_template_name: '{{ resource_prefix }}-lt'
@@ -538,7 +536,7 @@
       - output.target_group_arns | length == 2
 
   - name: update autoscaling group remove tg1
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_template:
         launch_template_name: '{{ resource_prefix }}-lt'
@@ -556,7 +554,7 @@
       - output.target_group_arns[0] == out_tg2.target_group_arn
 
   - name: update autoscaling group remove tg2 and add tg1
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_template:
         launch_template_name: '{{ resource_prefix }}-lt'
@@ -574,7 +572,7 @@
       - output.target_group_arns[0] == out_tg1.target_group_arn
 
   - name: target group no change
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg'
       launch_template:
         launch_template_name: '{{ resource_prefix }}-lt'

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/env_cleanup.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/env_cleanup.yml
@@ -1,5 +1,5 @@
 - name: kill asg
-  ec2_asg:
+  autoscaling_group:
     name: '{{ resource_prefix }}-asg'
     state: absent
   register: removed
@@ -19,7 +19,7 @@
   - '{{ tg2_name }}'
 
 - name: remove the load balancer
-  ec2_elb_lb:
+  elb_classic_lb:
     name: '{{ load_balancer_name }}'
     state: absent
     security_group_ids:
@@ -44,7 +44,7 @@
   ignore_errors: true
   retries: 10
 - name: remove launch configs
-  ec2_lc:
+  autoscaling_launch_config:
     name: '{{ item }}'
     state: absent
   register: removed
@@ -64,7 +64,7 @@
   until: del_lt is not failed
   ignore_errors: true
 - name: remove the security group
-  ec2_group:
+  ec2_security_group:
     name: '{{ resource_prefix }}-sg'
     description: a security group for ansible tests
     vpc_id: '{{ testing_vpc.vpc.id }}'

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/env_setup.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/env_setup.yml
@@ -1,4 +1,4 @@
-- name: Run ec2_asg integration tests.
+- name: Run autoscaling_group integration tests.
   run_once: '{{ ec2_asg_setup_run_once }}'
   block:
 
@@ -35,7 +35,7 @@
       - '{{ testing_subnet.subnet.id }}'
 
   - name: create a security group with the vpc created in the ec2_setup
-    ec2_group:
+    ec2_security_group:
       name: '{{ resource_prefix }}-sg'
       description: a security group for ansible tests
       vpc_id: '{{ testing_vpc.vpc.id }}'

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/instance_detach.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/instance_detach.yml
@@ -2,7 +2,7 @@
   block:
     #----------------------------------------------------------------------
   - name: create a launch configuration
-    ec2_lc:
+    autoscaling_launch_config:
       name: '{{ resource_prefix }}-lc-detach-test'
       image_id: '{{ ec2_ami_id }}'
       region: '{{ aws_region }}'
@@ -19,7 +19,7 @@
     #----------------------------------------------------------------------
 
   - name: create a AutoScalingGroup to be used for instance_detach test - check_mode
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-detach-test'
       launch_config_name: '{{ resource_prefix }}-lc-detach-test'
       health_check_period: 60
@@ -38,7 +38,7 @@
       - '"autoscaling:CreateAutoScalingGroup" not in create_asg.resource_actions'
 
   - name: create a AutoScalingGroup to be used for instance_detach test
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-detach-test'
       launch_config_name: '{{ resource_prefix }}-lc-detach-test'
       health_check_period: 60
@@ -60,7 +60,7 @@
       - '"autoscaling:CreateAutoScalingGroup" in create_asg.resource_actions'
 
   - name: gather info about asg, get instance ids
-    ec2_asg_info:
+    autoscaling_group_info:
       name: '{{ resource_prefix }}-asg-detach-test'
     register: asg_info
   - set_fact:
@@ -84,7 +84,7 @@
     #----------------------------------------------------------------------
 
   - name: detach 2 instance from the asg and replace with other instances - check_mode
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-detach-test'
       launch_config_name: '{{ resource_prefix }}-lc-detach-test'
       health_check_period: 60
@@ -105,7 +105,7 @@
       - '"autoscaling:DetachInstances" not in detach_result.resource_actions'
 
   - name: detach 2 instance from the asg and replace with other instances
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-detach-test'
       launch_config_name: '{{ resource_prefix }}-lc-detach-test'
       health_check_period: 60
@@ -122,7 +122,7 @@
   - name: Pause for 30 seconds
     wait_for:
       timeout: 30
-  - ec2_asg_info:
+  - autoscaling_group_info:
       name: '{{ resource_prefix }}-asg-detach-test'
     register: asg_info_replaced
   - set_fact:
@@ -155,7 +155,7 @@
     # detach 2 instances from the asg and reduce the desired capacity from 3 to 1
   - name: detach 2 instance from the asg and reduce the desired capacity from 3 to
       1
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-detach-test'
       launch_config_name: '{{ resource_prefix }}-lc-detach-test'
       health_check_period: 60
@@ -172,7 +172,7 @@
   - name: Pause for 30 seconds to allow completion of above task
     wait_for:
       timeout: 30
-  - ec2_asg_info:
+  - autoscaling_group_info:
       name: '{{ resource_prefix }}-asg-detach-test'
     register: asg_info_decrement
   - set_fact:
@@ -215,7 +215,7 @@
     - '{{ instance_replace_3 }}'
 
   - name: kill asg created in this test - check_mode
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-detach-test'
       state: absent
     register: removed
@@ -227,7 +227,7 @@
       - '"autoscaling:DeleteAutoScalingGroup" not in removed.resource_actions'
 
   - name: kill asg created in this test
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-detach-test'
       state: absent
     register: removed
@@ -235,7 +235,7 @@
     ignore_errors: yes
     retries: 10
   - name: kill asg created in this test - check_mode (idempotent)
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-detach-test'
       state: absent
     register: removed
@@ -247,7 +247,7 @@
       - '"autoscaling:DeleteAutoScalingGroup" not in removed.resource_actions'
 
   - name: remove launch config created in this test
-    ec2_lc:
+    autoscaling_launch_config:
       name: '{{ resource_prefix }}-lc-detach-test'
       state: absent
     register: removed

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/tag_operations.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/tag_operations.yml
@@ -2,7 +2,7 @@
   block:
     #----------------------------------------------------------------------
   - name: create a launch configuration
-    ec2_lc:
+    autoscaling_launch_config:
       name: '{{ resource_prefix }}-lc-tag-test'
       image_id: '{{ ec2_ami_id }}'
       region: '{{ aws_region }}'
@@ -18,7 +18,7 @@
 
     #----------------------------------------------------------------------
   - name: create a AutoScalingGroup to be used for tag_operations test
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       launch_config_name: '{{ resource_prefix }}-lc-tag-test'
       health_check_period: 60
@@ -39,7 +39,7 @@
     #----------------------------------------------------------------------
 
   - name: Get asg info
-    ec2_asg_info:
+    autoscaling_group_info:
       name: '{{ resource_prefix }}-asg-tag-test'
     register: info_result
   - assert:
@@ -47,7 +47,7 @@
       - info_result.results[0].tags | length == 0
 
   - name: Tag asg - check_mode
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       tags:
       - tag_a: value 1
@@ -63,7 +63,7 @@
       - '"autoscaling:CreateOrUpdateTags" not in output.resource_actions'
 
   - name: Tag asg
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       tags:
       - tag_a: value 1
@@ -77,7 +77,7 @@
       - output is changed
 
   - name: Re-Tag asg (different order)
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       tags:
       - tag_b: value 2
@@ -91,7 +91,7 @@
       - output is not changed
 
   - name: Re-Tag asg new tags
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       tags:
       - tag_c: value 3
@@ -104,7 +104,7 @@
       - output is changed
 
   - name: Re-Tag asg update propagate_at_launch
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       tags:
       - tag_c: value 3
@@ -116,13 +116,13 @@
       - output is changed
 
   - name: Remove all tags
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       tags: []
       purge_tags: true
     register: add_empty
   - name: Get asg info
-    ec2_asg_info:
+    autoscaling_group_info:
       name: '{{ resource_prefix }}-asg-tag-test'
     register: info_result
   - set_fact:
@@ -135,7 +135,7 @@
       - '"autoscaling:DeleteTags" in add_empty.resource_actions'
 
   - name: Add 4 new tags - do not purge existing tags
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       tags:
       - lowercase spaced: hello cruel world
@@ -148,7 +148,7 @@
         propagate_at_launch: no
     register: add_result
   - name: Get asg info
-    ec2_asg_info:
+    autoscaling_group_info:
       name: '{{ resource_prefix }}-asg-tag-test'
     register: info_result
   - set_fact:
@@ -164,7 +164,7 @@
       - '"autoscaling:CreateOrUpdateTags" in add_result.resource_actions'
 
   - name: Add 4 new tags - do not purge existing tags - idempotency
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       tags:
       - lowercase spaced: hello cruel world
@@ -177,7 +177,7 @@
         propagate_at_launch: no
     register: add_result
   - name: Get asg info
-    ec2_asg_info:
+    autoscaling_group_info:
       name: '{{ resource_prefix }}-asg-tag-test'
     register: info_result
   - assert:
@@ -187,7 +187,7 @@
       - '"autoscaling:CreateOrUpdateTags" not in add_result.resource_actions'
 
   - name: Add 2 new tags - purge existing tags
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       tags:
       - tag_a: val_a
@@ -197,7 +197,7 @@
       purge_tags: true
     register: add_purge_result
   - name: Get asg info
-    ec2_asg_info:
+    autoscaling_group_info:
       name: '{{ resource_prefix }}-asg-tag-test'
     register: info_result
   - set_fact:
@@ -215,7 +215,7 @@
       - '"autoscaling:CreateOrUpdateTags" in add_purge_result.resource_actions'
 
   - name: Re-tag ASG - modify values
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       tags:
       - tag_a: new_val_a
@@ -224,7 +224,7 @@
         propagate_at_launch: yes
     register: add_purge_result
   - name: Get asg info
-    ec2_asg_info:
+    autoscaling_group_info:
       name: '{{ resource_prefix }}-asg-tag-test'
     register: info_result
   - set_fact:
@@ -247,7 +247,7 @@
       - '"autoscaling:CreateOrUpdateTags" in add_purge_result.resource_actions'
 
   - name: Add 2 more tags - do not purge existing tags
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       tags:
       - lowercase spaced: hello cruel world
@@ -256,7 +256,7 @@
         propagate_at_launch: yes
     register: add_result
   - name: Get asg info
-    ec2_asg_info:
+    autoscaling_group_info:
       name: '{{ resource_prefix }}-asg-tag-test'
     register: info_result
   - set_fact:
@@ -273,13 +273,13 @@
 
   - name: Add empty tags with purge set to false to assert that existing tags are
       retained
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       tags: []
       purge_tags: false
     register: add_empty
   - name: Get asg info
-    ec2_asg_info:
+    autoscaling_group_info:
       name: '{{ resource_prefix }}-asg-tag-test'
     register: info_result
   - set_fact:
@@ -295,13 +295,13 @@
       - '"autoscaling:CreateOrUpdateTags" not in add_empty.resource_actions'
 
   - name: Add empty tags with purge set to true to assert that existing tags are removed
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       tags: []
       purge_tags: true
     register: add_empty
   - name: Get asg info
-    ec2_asg_info:
+    autoscaling_group_info:
       name: '{{ resource_prefix }}-asg-tag-test'
     register: info_result
   - set_fact:
@@ -322,7 +322,7 @@
   always:
 
   - name: kill asg created in this test
-    ec2_asg:
+    autoscaling_group:
       name: '{{ resource_prefix }}-asg-tag-test'
       state: absent
     register: removed
@@ -330,7 +330,7 @@
     ignore_errors: yes
     retries: 10
   - name: remove launch config created in this test
-    ec2_lc:
+    autoscaling_launch_config:
       name: '{{ resource_prefix }}-lc-tag-test'
       state: absent
     register: removed

--- a/tests/integration/targets/cloudtrail/tasks/main.yml
+++ b/tests/integration/targets/cloudtrail/tasks/main.yml
@@ -127,14 +127,14 @@
       policy: "{{ lookup('template', 'sns-policy.j2') | to_json }}"
 
   - name: 'Create KMS Key'
-    aws_kms:
+    kms_key:
       state: present
       alias: '{{ kms_alias }}'
       enabled: yes
       policy: "{{ lookup('template', 'kms-policy.j2') | to_json }}"
     register: kms_key
   - name: 'Create second KMS Key'
-    aws_kms:
+    kms_key:
       state: present
       alias: '{{ kms_alias }}-2'
       enabled: yes
@@ -1543,12 +1543,12 @@
       force: yes
     ignore_errors: yes
   - name: 'Delete KMS Key'
-    aws_kms:
+    kms_key:
       state: absent
       alias: '{{ kms_alias }}'
     ignore_errors: yes
   - name: 'Delete second KMS Key'
-    aws_kms:
+    kms_key:
       state: absent
       alias: '{{ kms_alias }}-2'
     ignore_errors: yes

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/env_cleanup.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/env_cleanup.yml
@@ -24,7 +24,7 @@
   retries: 10
 
 - name: remove the security group
-  ec2_group:
+  ec2_security_group:
     name: '{{ resource_prefix }}-sg'
     description: a security group for ansible tests
     vpc_id: '{{ testing_vpc.vpc.id }}'

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/env_setup.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/env_setup.yml
@@ -46,7 +46,7 @@
     - '{{ testing_subnet_b.subnet.id }}'
 
 - name: create a security group with the vpc
-  ec2_group:
+  ec2_security_group:
     name: '{{ resource_prefix }}-sg'
     description: a security group for ansible tests
     vpc_id: '{{ testing_vpc.vpc.id }}'

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: run ec2_metric_alarm tests
+- name: run cloudwatch_metric_alarm tests
   module_defaults:
     group/aws:
       aws_access_key: '{{ aws_access_key }}'
@@ -31,12 +31,12 @@
     register: ec2_instance_results
 
   - name: ensure alarm doesn't exist for a clean test
-    ec2_metric_alarm:
+    cloudwatch_metric_alarm:
       state: absent
       name: '{{ alarm_full_name }}'
 
   - name: create ec2 metric alarm on ec2 instance (check mode)
-    ec2_metric_alarm:
+    cloudwatch_metric_alarm:
       dimensions:
         InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
       state: present
@@ -69,7 +69,7 @@
         - 'alarm_info_check.metric_alarms | length == 0'
 
   - name: create ec2 metric alarm on ec2 instance
-    ec2_metric_alarm:
+    cloudwatch_metric_alarm:
       dimensions:
         InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
       state: present
@@ -111,7 +111,7 @@
         - 'ec2_instance_metric_alarm.treat_missing_data == alarm_info.metric_alarms[0].treat_missing_data'
 
   - name: create ec2 metric alarm on ec2 instance (idempotent) (check mode)
-    ec2_metric_alarm:
+    cloudwatch_metric_alarm:
       dimensions:
         InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
       state: present
@@ -160,7 +160,7 @@
       - treat_missing_data
 
   - name: create ec2 metric alarm on ec2 instance (idempotent)
-    ec2_metric_alarm:
+    cloudwatch_metric_alarm:
       dimensions:
         InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
       state: present
@@ -208,7 +208,7 @@
       - treat_missing_data
 
   - name: update alarm (check mode)
-    ec2_metric_alarm:
+    cloudwatch_metric_alarm:
       dimensions:
         InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
       state: present
@@ -249,7 +249,7 @@
       - 'ec2_instance_metric_alarm_update_check.treat_missing_data == alarm_info.metric_alarms[0].treat_missing_data'
 
   - name: update alarm
-    ec2_metric_alarm:
+    cloudwatch_metric_alarm:
       dimensions:
         InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
       state: present
@@ -289,7 +289,7 @@
       - 'ec2_instance_metric_alarm_update.treat_missing_data == alarm_info.metric_alarms[0].treat_missing_data'
 
   - name: try to remove the alarm (check mode)
-    ec2_metric_alarm:
+    cloudwatch_metric_alarm:
       state: absent
       name: '{{ alarm_full_name }}'
     check_mode: true
@@ -312,7 +312,7 @@
         - 'alarm_info.metric_alarms | length > 0'
 
   - name: try to remove the alarm
-    ec2_metric_alarm:
+    cloudwatch_metric_alarm:
       state: absent
       name: '{{ alarm_full_name }}'
     register: ec2_instance_metric_alarm_deletion
@@ -334,7 +334,7 @@
         - 'alarm_info.metric_alarms | length == 0'
 
   - name: create ec2 metric alarm with no unit on ec2 instance
-    ec2_metric_alarm:
+    cloudwatch_metric_alarm:
       dimensions:
         InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
       state: present
@@ -375,7 +375,7 @@
       - 'ec2_instance_metric_alarm_no_unit.treat_missing_data == alarm_info_no_unit.metric_alarms[0].treat_missing_data'
 
   - name: try to remove the alarm
-    ec2_metric_alarm:
+    cloudwatch_metric_alarm:
       state: absent
       name: '{{ alarm_full_name }}'
     register: ec2_instance_metric_alarm_deletion_no_unit
@@ -398,7 +398,7 @@
 
   always:
   - name: try to delete the alarm
-    ec2_metric_alarm:
+    cloudwatch_metric_alarm:
       state: absent
       name: '{{ alarm_full_name }}'
     ignore_errors: true

--- a/tests/integration/targets/ec2_ami/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami/tasks/main.yml
@@ -46,7 +46,7 @@
       register: setup_subnet
 
     - name: create a security group to use for creating an ec2 instance
-      ec2_group:
+      ec2_security_group:
         name: '{{ ec2_ami_name }}_setup'
         description: 'created by Ansible integration tests'
         state: present
@@ -758,7 +758,7 @@
       ignore_errors: yes
 
     - name: remove setup security group
-      ec2_group:
+      ec2_security_group:
         name: '{{ ec2_ami_name }}_setup'
         description: 'created by Ansible integration tests'
         state: absent

--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -62,7 +62,7 @@
     register: vpc_igw
 
   - name: Create security group
-    ec2_group:
+    ec2_security_group:
       state: present
       name: '{{ resource_prefix }}-sg'
       description: a security group for ansible tests
@@ -1398,7 +1398,7 @@
     ignore_errors: true
 
   - name: Cleanup security group
-    ec2_group:
+    ec2_security_group:
       state: absent
       name: '{{ resource_prefix }}-sg'
     ignore_errors: true

--- a/tests/integration/targets/ec2_eni/tasks/main.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/main.yaml
@@ -36,7 +36,7 @@
     register: vpc_subnet_result
 
   - name: create a security group
-    ec2_group:
+    ec2_security_group:
       name: "{{ resource_prefix }}-sg"
       description: "Created by {{ resource_prefix }}"
       rules: []
@@ -131,7 +131,7 @@
         when: instance_id_1 is defined and instance_id_2 is defined
 
       - name: remove the security group
-        ec2_group:
+        ec2_security_group:
           name: "{{ resource_prefix }}-sg"
           description: "{{ resource_prefix }}"
           rules: []

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -74,7 +74,7 @@
     register: public_route_table
 
   - name: create a security group
-    ec2_group:
+    ec2_security_group:
       name: "{{ resource_prefix }}-sg"
       description: "Created by {{ resource_prefix }}"
       rules:

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/teardown.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/teardown.yml
@@ -53,7 +53,7 @@
     until: remove is successful
 
   - name: remove the security group
-    ec2_group:
+    ec2_security_group:
       group_id: "{{ vpc_sg_id }}"
       state: absent
     ignore_errors: true

--- a/tests/integration/targets/ec2_security_group/tasks/data_validation.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/data_validation.yml
@@ -1,13 +1,13 @@
 ---
 - block:
     - name: Create a group with only the default rule
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-input-tests'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
 
     - name: Run through some common weird port specs
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-input-tests'
         description: '{{ec2_group_description}}'
         rules:
@@ -26,7 +26,7 @@
           cidr_ip: "10.2.3.0/24"
   always:
     - name: tidy up input testing group
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-input-tests'
         vpc_id: '{{ vpc_result.vpc.id }}'
         state: absent

--- a/tests/integration/targets/ec2_security_group/tasks/diff_mode.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/diff_mode.yml
@@ -2,7 +2,7 @@
   # ============================================================
 
   - name: create a group with a rule (CHECK MODE + DIFF)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -23,7 +23,7 @@
         - check_mode_result.changed
 
   - name: create a group with a rule (DIFF)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -45,7 +45,7 @@
         - result.diff.0.after.ip_permissions_egress == check_mode_result.diff.0.after.ip_permissions_egress
 
   - name: add rules to make sorting occur (CHECK MODE + DIFF)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -74,7 +74,7 @@
         - check_mode_result.changed
 
   - name: add rules in a different order to test sorting consistency (DIFF)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -104,7 +104,7 @@
         - result.diff.0.after.ip_permissions_egress == check_mode_result.diff.0.after.ip_permissions_egress
 
   - name: purge rules (CHECK MODE + DIFF)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -123,7 +123,7 @@
         - check_mode_result.changed
 
   - name: purge rules (DIFF)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -143,7 +143,7 @@
         - result.diff.0.after.ip_permissions_egress == check_mode_result.diff.0.after.ip_permissions_egress
 
   - name: delete the security group (CHECK MODE + DIFF)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       state: absent
     register: check_mode_result
@@ -155,7 +155,7 @@
         - check_mode_result.changed
 
   - name: delete the security group (DIFF)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       state: absent
     register: result

--- a/tests/integration/targets/ec2_security_group/tasks/egress_tests.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/egress_tests.yml
@@ -1,7 +1,7 @@
 ---
 - block:
     - name: Create a group with only the default rule
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-egress-tests'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -17,7 +17,7 @@
           - result.ip_permissions_egress[0].ip_ranges[0].cidr_ip == '0.0.0.0/0'
 
     - name: Create a group with only the default rule
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-egress-tests'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -34,7 +34,7 @@
           - result.ip_permissions_egress[0].ip_ranges[0].cidr_ip == '0.0.0.0/0'
 
     - name: Pass empty egress rules without purging, should leave default rule in place
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-egress-tests'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -52,7 +52,7 @@
           - result.ip_permissions_egress[0].ip_ranges[0].cidr_ip == '0.0.0.0/0'
 
     - name: Purge rules, including the default
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-egress-tests'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -69,7 +69,7 @@
           - result.ip_permissions_egress|length == 0
 
     - name: Add a custom egress rule
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-egress-tests'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -87,7 +87,7 @@
           - result.ip_permissions_egress|length == 1
 
     - name: Add a second custom egress rule
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-egress-tests'
         description: '{{ec2_group_description}}'
         purge_rules_egress: false
@@ -106,7 +106,7 @@
           - result.ip_permissions_egress|length == 2
 
     - name: Purge the second rule (CHECK MODE) (DIFF MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-egress-tests'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -128,7 +128,7 @@
           - result.diff.0.after.ip_permissions_egress[0].ip_ranges[0].cidr_ip == '10.2.1.2/32'
 
     - name: Purge the second rule
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-egress-tests'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -147,7 +147,7 @@
           - result.ip_permissions_egress[0].ip_ranges[0].cidr_ip == '10.2.1.2/32'
 
     - name: add a rule for all TCP ports
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-egress-tests'
         description: '{{ec2_group_description}}'
         rules_egress:
@@ -159,7 +159,7 @@
       register: result
 
     - name: Re-add the default rule
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-egress-tests'
         description: '{{ec2_group_description}}'
         rules_egress:
@@ -170,7 +170,7 @@
       register: result
   always:
     - name: tidy up egress rule test security group
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-egress-tests'
         state: absent
         vpc_id: '{{ vpc_result.vpc.id }}'

--- a/tests/integration/targets/ec2_security_group/tasks/group_info.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/group_info.yml
@@ -5,7 +5,7 @@
 - block:
     # ======================== Setup =====================================
     - name: Create a group for testing group info retrieval below
-      ec2_group:
+      ec2_security_group:
         name: '{{ ec2_group_name }}-info-1'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ ec2_group_description }}'
@@ -19,7 +19,7 @@
       register: group_info_test_setup
 
     - name: Create another group for testing group info retrieval below
-      ec2_group:
+      ec2_security_group:
         name: '{{ ec2_group_name }}-info-2'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ ec2_group_description }}'
@@ -32,7 +32,7 @@
     # ========================= ec2_group_info tests ====================
 
     - name: Retrieve security group info based on SG name
-      ec2_group_info:
+      ec2_security_group_info:
         filters:
           group-name: '{{ ec2_group_name }}-info-2'
       register: result_1
@@ -44,7 +44,7 @@
           - (result_1.security_groups|first).group_name == '{{ ec2_group_name }}-info-2'
 
     - name: Retrieve security group info based on SG VPC
-      ec2_group_info:
+      ec2_security_group_info:
         filters:
           vpc-id: '{{ vpc_result.vpc.id }}'
       register: result_2
@@ -57,7 +57,7 @@
           - (result_2.security_groups|length) > 2
 
     - name: Retrieve security group info based on SG tags
-      ec2_group_info:
+      ec2_security_group_info:
         filters:
           "tag:test": "{{ resource_prefix }}_ec2_group_info_module"
       register: result_3
@@ -69,7 +69,7 @@
           - (result_3.security_groups|first).group_id == group_info_test_setup.group_id
 
     - name: Retrieve security group info based on SG ID
-      ec2_group_info:
+      ec2_security_group_info:
         filters:
           group-id: '{{ group_info_test_setup.group_id }}'
       register: result_4
@@ -84,13 +84,13 @@
   always:
     # ========================= Cleanup =================================
     - name: tidy up test security group 1
-      ec2_group:
+      ec2_security_group:
         name: '{{ ec2_group_name }}-info-1'
         state: absent
       ignore_errors: yes
 
     - name: tidy up test security group 2
-      ec2_group:
+      ec2_security_group:
         name: '{{ ec2_group_name }}-info-2'
         state: absent
       ignore_errors: yes

--- a/tests/integration/targets/ec2_security_group/tasks/icmp_verbs.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/icmp_verbs.yml
@@ -2,7 +2,7 @@
 - block:
     # ============================================================
     - name: Create simple rule using icmp verbs
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-icmp-1'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -17,7 +17,7 @@
       register: result
 
     - name: Retrieve security group info
-      ec2_group_info:
+      ec2_security_group_info:
         filters:
           group-name: '{{ ec2_group_name }}-icmp-1'
       register: result_1
@@ -30,7 +30,7 @@
           - (result_1.security_groups|first).ip_permissions[0].ip_protocol == "icmp"
 
     - name: Create ipv6 rule using icmp verbs
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-icmp-2'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -43,7 +43,7 @@
       register: result
 
     - name: Retrieve security group info
-      ec2_group_info:
+      ec2_security_group_info:
         filters:
           group-name: '{{ ec2_group_name }}-icmp-2'
       register: result_1
@@ -57,7 +57,7 @@
 
 
     - name: Create rule using security group referencing
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-icmp-3'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -71,7 +71,7 @@
       register: result
 
     - name: Retrieve security group info
-      ec2_group_info:
+      ec2_security_group_info:
         filters:
           group-name: '{{ ec2_group_name }}-icmp-3'
       register: result_1
@@ -82,7 +82,7 @@
           - (result_1.security_groups | first).ip_permissions[0].user_id_group_pairs is defined
 
     - name: Create list rule using 0 as icmp_type
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-icmp-4'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -101,7 +101,7 @@
       register: result
 
     - name: Retrieve security group info
-      ec2_group_info:
+      ec2_security_group_info:
         filters:
           group-name: '{{ ec2_group_name }}-icmp-4'
       register: result_1
@@ -114,7 +114,7 @@
 
     # ============================================================
     - name: Create a group with non-ICMP protocol
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-icmp-4'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -135,7 +135,7 @@
           - result is failed
 
     - name: Create a group with conflicting parameters
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-icmp-4'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -158,7 +158,7 @@
           - result is failed
 
     - name: Create a group with missing icmp parameters
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-icmp-4'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -179,7 +179,7 @@
 
   always:
     - name: tidy up egress rule test security group rules
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-auto-create-2'
         description: 'sg-group-referencing'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -188,7 +188,7 @@
       ignore_errors: yes
 
     - name: tidy up egress rule test security group rules
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-icmp-{{ item }}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -202,14 +202,14 @@
         - 4
 
     - name: tidy up egress rule test security group rules
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-auto-create-2'
         state: absent
         vpc_id: '{{ vpc_result.vpc.id }}'
       ignore_errors: yes
 
     - name: tidy up egress rule test security group
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-icmp-{{ item }}'
         state: absent
         vpc_id: '{{ vpc_result.vpc.id }}'

--- a/tests/integration/targets/ec2_security_group/tasks/ipv6_default_tests.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/ipv6_default_tests.yml
@@ -1,7 +1,7 @@
 ---
 # ============================================================
 - name: test state=present for ipv6 (expected changed=true) (CHECK MODE)
-  ec2_group:
+  ec2_security_group:
     name: '{{ec2_group_name}}'
     description: '{{ec2_group_description}}'
     state: present
@@ -20,7 +20,7 @@
 
 # ============================================================
 - name: test state=present for ipv6 (expected changed=true)
-  ec2_group:
+  ec2_security_group:
     name: '{{ec2_group_name}}'
     description: '{{ec2_group_description}}'
     state: present
@@ -39,7 +39,7 @@
 
 # ============================================================
 - name: test rules_egress state=present for ipv6 (expected changed=true) (CHECK MODE)
-  ec2_group:
+  ec2_security_group:
     name: '{{ec2_group_name}}'
     description: '{{ec2_group_description}}'
     state: present
@@ -63,7 +63,7 @@
 
 # ============================================================
 - name: test rules_egress state=present for ipv6 (expected changed=true)
-  ec2_group:
+  ec2_security_group:
     name: '{{ec2_group_name}}'
     description: '{{ec2_group_description}}'
     state: present
@@ -85,6 +85,6 @@
        - 'result.changed'
        - 'result.group_id.startswith("sg-")'
 - name: delete it
-  ec2_group:
+  ec2_security_group:
     name: '{{ec2_group_name}}'
     state: absent

--- a/tests/integration/targets/ec2_security_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/main.yml
@@ -44,7 +44,7 @@
 
     # ============================================================
     - name: test state=absent (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: absent
@@ -58,7 +58,7 @@
 
     # ===========================================================
     - name: test state=absent
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: absent
@@ -66,7 +66,7 @@
 
     # ============================================================
     - name: test state=present (expected changed=true) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -80,7 +80,7 @@
 
     # ============================================================
     - name: test state=present (expected changed=true)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -94,7 +94,7 @@
 
     # ============================================================
     - name: test state=present different description (expected changed=false) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}CHANGED'
         state: present
@@ -108,7 +108,7 @@
 
     # ============================================================
     - name: test state=present different description (expected changed=false)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}CHANGED'
         state: present
@@ -123,7 +123,7 @@
 
     # ============================================================
     - name: test state=present (expected changed=false)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -145,7 +145,7 @@
 
         # ============================================================
         - name: test state=present (expected changed=true) (CHECK MODE)
-          ec2_group:
+          ec2_security_group:
             name: '{{ ec2_group_name }}-2'
             description: '{{ ec2_group_description }}-2'
             state: present
@@ -160,7 +160,7 @@
 
         # ============================================================
         - name: test state=present (expected changed=true)
-          ec2_group:
+          ec2_security_group:
             name: '{{ ec2_group_name }}-2'
             description: '{{ ec2_group_description }}-2'
             state: present
@@ -175,7 +175,7 @@
 
         # ============================================================
         - name: test state=present for ipv6 (expected changed=true) (CHECK MODE)
-          ec2_group:
+          ec2_security_group:
             name: '{{ ec2_group_name }}-2'
             description: '{{ ec2_group_description }}-2'
             state: present
@@ -195,7 +195,7 @@
 
         # ============================================================
         - name: test state=present for ipv6 (expected changed=true)
-          ec2_group:
+          ec2_security_group:
             name: '{{ ec2_group_name }}-2'
             description: '{{ ec2_group_description }}-2'
             state: present
@@ -215,7 +215,7 @@
 
         # ============================================================
         - name: test state=present for ipv6 (expected changed=false) (CHECK MODE)
-          ec2_group:
+          ec2_security_group:
             name: '{{ ec2_group_name }}-2'
             description: '{{ ec2_group_description }}-2'
             state: present
@@ -235,7 +235,7 @@
 
         # ============================================================
         - name: test state=present for ipv6 (expected changed=false)
-          ec2_group:
+          ec2_security_group:
             name: '{{ ec2_group_name }}-2'
             description: '{{ ec2_group_description }}-2'
             state: present
@@ -254,7 +254,7 @@
 
         # ============================================================
         - name: test rules_egress state=present for ipv6 (expected changed=true) (CHECK MODE)
-          ec2_group:
+          ec2_security_group:
             name: '{{ ec2_group_name }}-2'
             description: '{{ ec2_group_description }}-2'
             state: present
@@ -282,7 +282,7 @@
 
         # ============================================================
         - name: test rules_egress state=present for ipv6 (expected changed=true)
-          ec2_group:
+          ec2_security_group:
             name: '{{ ec2_group_name }}-2'
             description: '{{ ec2_group_description }}-2'
             state: present
@@ -307,7 +307,7 @@
 
         # ============================================================
         - name: test state=absent (expected changed=true) (CHECK MODE)
-          ec2_group:
+          ec2_security_group:
             name: '{{ ec2_group_name }}-2'
             description: '{{ ec2_group_description }}-2'
             state: absent
@@ -324,7 +324,7 @@
 
         # ============================================================
         - name: test state=absent (expected changed=true)
-          ec2_group:
+          ec2_security_group:
             name: '{{ ec2_group_name }}-2'
             description: '{{ ec2_group_description }}-2'
             state: absent
@@ -338,7 +338,7 @@
 
     # ============================================================
     - name: test state=present for ipv4 (expected changed=true) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         rules:
@@ -356,7 +356,7 @@
 
     # ============================================================
     - name: test state=present for ipv4 (expected changed=true)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         rules:
@@ -376,7 +376,7 @@
 
     # ============================================================
     - name: add same rule to the existing group  (expected changed=false) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -396,7 +396,7 @@
 
     # ============================================================
     - name: add same rule to the existing group  (expected changed=false)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -420,7 +420,7 @@
 
     # ============================================================
     - name: add a rule that auto creates another security group (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -440,7 +440,7 @@
 
     # ============================================================
     - name: add a rule that auto creates another security group
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -464,7 +464,7 @@
 
     # ============================================================
     - name: test ip rules convert port numbers from string to int (expected changed=true) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -488,7 +488,7 @@
 
     # ============================================================
     - name: test ip rules convert port numbers from string to int (expected changed=true)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -515,7 +515,7 @@
 
     # ============================================================
     - name: test group rules convert port numbers from string to int (expected changed=true) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -539,7 +539,7 @@
 
     # ============================================================
     - name: test group rules convert port numbers from string to int (expected changed=true)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -564,7 +564,7 @@
 
     # ============================================================
     - name: test adding a range of ports and ports given as strings (expected changed=true) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -586,7 +586,7 @@
 
     # ============================================================
     - name: test adding a range of ports and ports given as strings (expected changed=true)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -608,7 +608,7 @@
 
     # ============================================================
     - name: test adding a rule with a IPv4 CIDR with host bits set (expected changed=true) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -629,7 +629,7 @@
 
     # ============================================================
     - name: test adding a rule with a IPv4 CIDR with host bits set (expected changed=true)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -650,7 +650,7 @@
 
     # ============================================================
     - name: test adding the same rule with a IPv4 CIDR with host bits set (expected changed=false) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -666,7 +666,7 @@
 
     # ============================================================
     - name: test adding the same rule with a IPv4 CIDR with host bits set (expected changed=false and a warning)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         state: present
@@ -696,7 +696,7 @@
       block:
 
         - name: test adding a rule with a IPv6 CIDR with host bits set (expected changed=true) (CHECK MODE)
-          ec2_group:
+          ec2_security_group:
             name: '{{ec2_group_name}}'
             description: '{{ec2_group_description}}'
             state: present
@@ -717,7 +717,7 @@
 
         # ============================================================
         - name: test adding a rule with a IPv6 CIDR with host bits set (expected changed=true)
-          ec2_group:
+          ec2_security_group:
             name: '{{ec2_group_name}}'
             description: '{{ec2_group_description}}'
             state: present
@@ -739,7 +739,7 @@
         # ============================================================
 
         - name: test adding a rule again with a IPv6 CIDR with host bits set (expected changed=false and a warning)
-          ec2_group:
+          ec2_security_group:
             name: '{{ec2_group_name}}'
             description: '{{ec2_group_description}}'
             state: present
@@ -763,7 +763,7 @@
 
     # ============================================================
     - name: test state=absent (expected changed=true) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         state: absent
       check_mode: true
@@ -776,7 +776,7 @@
 
     # ============================================================
     - name: test state=absent (expected changed=true)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         state: absent
       register: result
@@ -789,7 +789,7 @@
 
     # ============================================================
     - name: create security group in the VPC (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -809,7 +809,7 @@
 
     # ============================================================
     - name: create security group in the VPC
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -830,7 +830,7 @@
 
     # ============================================================
     - name: test adding tags (expected changed=true) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -857,7 +857,7 @@
 
     # ============================================================
     - name: test adding tags (expected changed=true)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -880,7 +880,7 @@
 
     # ============================================================
     - name: test that tags are present (expected changed=False) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -904,7 +904,7 @@
 
     # ============================================================
     - name: test that tags are present (expected changed=False)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -928,7 +928,7 @@
 
     # ============================================================
     - name: test purging tags (expected changed=True) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -950,7 +950,7 @@
 
     # ============================================================
     - name: test purging tags (expected changed=True)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -973,7 +973,7 @@
     # ============================================================
 
     - name: assert that tags are left as-is if not specified (expected changed=False)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -994,7 +994,7 @@
     # ============================================================
 
     - name: test purging all tags (expected changed=True)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -1015,7 +1015,7 @@
 
     # ============================================================
     - name: test adding a rule and egress rule descriptions (expected changed=true) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -1045,7 +1045,7 @@
 
     # =========================================================================================
     - name: add rules without descriptions ready for adding descriptions to existing rules
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -1067,7 +1067,7 @@
 
     # ============================================================
     - name: test adding a rule and egress rule descriptions (expected changed=true)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -1098,7 +1098,7 @@
 
     # ============================================================
     - name: test modifying rule and egress rule descriptions (expected changed=true) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -1128,7 +1128,7 @@
 
     # ============================================================
     - name: test modifying rule and egress rule descriptions (expected changed=true)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -1159,7 +1159,7 @@
     # ============================================================
 
     - name: test creating rule in default vpc with egress rule (expected changed=true)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-default-vpc'
         description: '{{ec2_group_description}} default VPC'
         purge_rules_egress: true
@@ -1186,7 +1186,7 @@
 
     # ============================================================
     - name: test that keeping the same rule descriptions (expected changed=false) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -1215,7 +1215,7 @@
 
     # ============================================================
     - name: test that keeping the same rule descriptions (expected changed=false)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -1245,7 +1245,7 @@
 
     # ============================================================
     - name: test removing rule descriptions (expected changed=true) (CHECK MODE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -1274,7 +1274,7 @@
 
     # ============================================================
     - name: test removing rule descriptions (expected changed=true)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         description: '{{ec2_group_description}}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -1305,7 +1305,7 @@
     # ============================================================
 
     - name: test state=absent (expected changed=true)
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}'
         state: absent
       register: result
@@ -1321,7 +1321,7 @@
     # Describe state of remaining resources
 
     - name: Retrieve security group info based on SG VPC
-      ec2_group_info:
+      ec2_security_group_info:
         filters:
           vpc-id: '{{ vpc_result.vpc.id }}'
       register: remaining_groups
@@ -1342,7 +1342,7 @@
     # Delete all remaining SGs
 
     - name: Delete rules from remaining SGs
-      ec2_group:
+      ec2_security_group:
         name: '{{ item.group_name }}'
         group_id: '{{ item.group_id }}'
         description: '{{ item.description }}'
@@ -1352,7 +1352,7 @@
       ignore_errors: yes
 
     - name: Delete remaining SGs
-      ec2_group:
+      ec2_security_group:
         state: absent
         group_id: '{{ item.group_id }}'
       loop: '{{ remaining_groups.security_groups }}'

--- a/tests/integration/targets/ec2_security_group/tasks/multi_account.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/multi_account.yml
@@ -25,7 +25,7 @@
         peer_owner_id: '{{ caller_facts.account }}'
         peer_region: '{{ aws_region }}'
     - name: Create group in second VPC
-      ec2_group:
+      ec2_security_group:
         name: '{{ ec2_group_name }}-external'
         description: '{{ ec2_group_description }}'
         vpc_id: '{{ vpc_result_2.vpc.id }}'
@@ -38,7 +38,7 @@
           rule_desc: 'http whoo'
       register: external
     - name: Create group in internal VPC
-      ec2_group:
+      ec2_security_group:
         name: '{{ ec2_group_name }}-internal'
         description: '{{ ec2_group_description }}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -49,7 +49,7 @@
           ports:
           - 80
     - name: Re-make same rule, expecting changed=false in internal VPC
-      ec2_group:
+      ec2_security_group:
         name: '{{ ec2_group_name }}-internal'
         description: '{{ ec2_group_description }}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -64,7 +64,7 @@
         that:
           - out is not changed
     - name: Try again with a bad group_id group in internal VPC
-      ec2_group:
+      ec2_security_group:
         name: '{{ ec2_group_name }}-internal'
         description: '{{ ec2_group_description }}'
         vpc_id: '{{ vpc_result.vpc.id }}'
@@ -100,14 +100,14 @@
         peer_region: '{{ aws_region }}'
       ignore_errors: yes
     - name: Clean up group in second VPC
-      ec2_group:
+      ec2_security_group:
         name: '{{ ec2_group_name }}-external'
         description: '{{ ec2_group_description }}'
         state: absent
         vpc_id: '{{ vpc_result_2.vpc.id }}'
       ignore_errors: yes
     - name: Clean up group in second VPC
-      ec2_group:
+      ec2_security_group:
         name: '{{ ec2_group_name }}-internal'
         description: '{{ ec2_group_description }}'
         state: absent

--- a/tests/integration/targets/ec2_security_group/tasks/multi_nested_target.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/multi_nested_target.yml
@@ -2,7 +2,7 @@
   # ============================================================
 
   - name: test state=present for multiple ipv6 and ipv4 targets (expected changed=true) (CHECK MODE)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -28,7 +28,7 @@
         - 'result.changed'
 
   - name: test state=present for multiple ipv6 and ipv4 targets (expected changed=true)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -56,7 +56,7 @@
         - 'result.ip_permissions[0].ipv6_ranges | length == 2 or result.ip_permissions[1].ipv6_ranges | length == 2'
 
   - name: test state=present for multiple ipv6 and ipv4 targets (expected changed=false) (CHECK MODE)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -82,7 +82,7 @@
         - 'not result.changed'
 
   - name: test state=present for multiple ipv6 and ipv4 targets (expected changed=false)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -107,7 +107,7 @@
         - 'not result.changed'
 
   - name: test state=present purging a nested ipv4 target (expected changed=true) (CHECK MODE)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -132,7 +132,7 @@
         - result.changed
 
   - name: test state=present purging a nested ipv4 target (expected changed=true)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -158,7 +158,7 @@
         - 'result.ip_permissions[0].ipv6_ranges | length == 2 or result.ip_permissions[1].ipv6_ranges | length == 2'
 
   - name: test state=present with both associated ipv6 targets nested (expected changed=false)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -181,7 +181,7 @@
         - not result.changed
 
   - name: test state=present add another nested ipv6 target (expected changed=true)
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       description: '{{ ec2_group_description }}'
       state: present
@@ -208,6 +208,6 @@
         - 'result.ip_permissions[0].ipv6_ranges | length == 3 or result.ip_permissions[1].ipv6_ranges | length == 3'
 
   - name: delete it
-    ec2_group:
+    ec2_security_group:
       name: '{{ ec2_group_name }}'
       state: absent

--- a/tests/integration/targets/ec2_security_group/tasks/numeric_protos.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/numeric_protos.yml
@@ -5,7 +5,7 @@
         group_tmp_name: '{{ec2_group_name}}-numbered-protos'
 
     - name: Create a group with numbered protocol (GRE)
-      ec2_group:
+      ec2_security_group:
         name: '{{ group_tmp_name }}'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ ec2_group_description }}'
@@ -18,7 +18,7 @@
       register: result
 
     - name: Create a group with a quoted proto
-      ec2_group:
+      ec2_security_group:
         name: '{{ group_tmp_name }}'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ ec2_group_description }}'
@@ -33,14 +33,14 @@
         that:
           - result is not changed
     - name: Add a tag with a numeric value
-      ec2_group:
+      ec2_security_group:
         name: '{{ group_tmp_name }}'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ ec2_group_description }}'
         tags:
           foo: 1
     - name: Read a tag with a numeric value
-      ec2_group:
+      ec2_security_group:
         name: '{{ group_tmp_name }}'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ ec2_group_description }}'
@@ -53,7 +53,7 @@
 
   always:
     - name: tidy up egress rule test security group
-      ec2_group:
+      ec2_security_group:
         name: '{{group_tmp_name}}'
         state: absent
         vpc_id: '{{ vpc_result.vpc.id }}'

--- a/tests/integration/targets/ec2_security_group/tasks/rule_group_create.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/rule_group_create.yml
@@ -1,7 +1,7 @@
 ---
 - block:
     - name: Create a group with self-referring rule
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-auto-create-1'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -14,14 +14,14 @@
       register: result
 
     - name: Create a second group rule
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-auto-create-2'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
         state: present
 
     - name: Create a series of rules with a recently created group as target
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-auto-create-1'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -44,7 +44,7 @@
           - result.warning is not defined
 
     - name: Create a group with only the default rule
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-auto-create-1'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -63,7 +63,7 @@
           - result is failed
 
     - name: Create a group with a target of a separate group
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-auto-create-1'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -82,7 +82,7 @@
           - result.warning is not defined
 
     - name: Create a 4th group
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-auto-create-4'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -94,7 +94,7 @@
           cidr_ip: 0.0.0.0/0
 
     - name: use recently created group in a rule
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-auto-create-5'
         vpc_id: '{{ vpc_result.vpc.id }}'
         description: '{{ec2_group_description}}'
@@ -111,7 +111,7 @@
 
   always:
     - name: tidy up egress rule test security group rules
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-auto-create-{{ item }}'
         description: '{{ec2_group_description}}'
         rules: []
@@ -119,7 +119,7 @@
       ignore_errors: yes
       with_items: [5, 4, 3, 2, 1]
     - name: tidy up egress rule test security group
-      ec2_group:
+      ec2_security_group:
         name: '{{ec2_group_name}}-auto-create-{{ item }}'
         state: absent
         vpc_id: '{{ vpc_result.vpc.id }}'

--- a/tests/integration/targets/ec2_snapshot/tasks/main.yml
+++ b/tests/integration/targets/ec2_snapshot/tasks/main.yml
@@ -23,7 +23,7 @@
 
   block:
     - name: Gather availability zones
-      aws_az_facts:
+      aws_az_info:
       register: azs
 
     # Create a new volume in detached mode without tags

--- a/tests/integration/targets/ec2_spot_instance/tasks/main.yaml
+++ b/tests/integration/targets/ec2_spot_instance/tasks/main.yaml
@@ -44,7 +44,7 @@
     register: vpc_subnet_result
 
   - name: create a security group
-    ec2_group:
+    ec2_security_group:
       name: "{{ resource_prefix }}-sg"
       description: "Created by {{ resource_prefix }}"
       rules: []
@@ -279,7 +279,7 @@
         with_items: "{{ spot_request_list.spot_request }}"
 
       - name: remove the security group
-        ec2_group:
+        ec2_security_group:
           name: "{{ resource_prefix }}-sg"
           description: "{{ resource_prefix }}"
           rules: []

--- a/tests/integration/targets/ec2_vpc_endpoint/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint/defaults/main.yml
@@ -2,6 +2,7 @@ vpc_name: '{{ resource_prefix }}-vpc'
 vpc_seed: '{{ resource_prefix }}'
 vpc_cidr: 10.{{ 256 | random(seed=vpc_seed) }}.22.0/24
 
-# S3 and EC2 should generally be available...
+# S3, Cloud Trail and EC2 should generally be available...
 endpoint_service_a: com.amazonaws.{{ aws_region }}.s3
 endpoint_service_b: com.amazonaws.{{ aws_region }}.ec2
+endpoint_service_c: com.amazonaws.{{ aws_region }}.cloudtrail

--- a/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
@@ -764,7 +764,7 @@
     register: interface_endpoint_create_subnet_check
 
   - name: Create a security group
-    ec2_group:
+    ec2_security_group:
       name: securitygroup-prodext
       description: "security group for Ansible interface endpoint"
       state: present

--- a/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
@@ -780,7 +780,7 @@
     ec2_vpc_endpoint:
       state: present
       vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_b }}'
+      service: '{{ endpoint_service_c }}'
       vpc_endpoint_type: Interface
       vpc_endpoint_subnets: "{{ interface_endpoint_create_subnet_check.subnet.id }}"
       vpc_endpoint_security_groups: "{{ interface_endpoint_create_sg_check.group_id }}"

--- a/tests/integration/targets/elb_application_lb/tasks/main.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/main.yml
@@ -20,7 +20,7 @@
     set_fact:
       vpc_id: '{{ vpc.vpc.id }}'
   - name: Get VPC's default security group
-    ec2_group_info:
+    ec2_security_group_info:
       filters:
         vpc-id: '{{ vpc_id }}'
     register: default_sg
@@ -84,7 +84,7 @@
         gateway_id: '{{ igw.gateway_id }}'
     register: route_table
   - name: Create a security group for Ansible ALB integration tests
-    ec2_group:
+    ec2_security_group:
       name: '{{ resource_prefix }}'
       description: security group for Ansible ALB integration tests
       state: present
@@ -96,7 +96,7 @@
         cidr_ip: 0.0.0.0/0
     register: sec_group
   - name: Create another security group for Ansible ALB integration tests
-    ec2_group:
+    ec2_security_group:
       name: '{{ resource_prefix }}-2'
       description: security group for Ansible ALB integration tests
       state: present
@@ -1291,7 +1291,7 @@
     when: tg is defined
     ignore_errors: true
   - name: Destroy sec groups
-    ec2_group:
+    ec2_security_group:
       name: '{{ item }}'
       description: security group for Ansible ALB integration tests
       state: absent

--- a/tests/integration/targets/elb_classic_lb/defaults/main.yml
+++ b/tests/integration/targets/elb_classic_lb/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-# defaults file for ec2_elb_lb
+# defaults file for elb_classic_lb
 elb_name: 'ansible-test-{{ tiny_prefix }}'
 
 vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'

--- a/tests/integration/targets/elb_classic_lb/tasks/cleanup_vpc.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/cleanup_vpc.yml
@@ -1,6 +1,6 @@
 ---
 - name: delete security groups
-  ec2_group:
+  ec2_security_group:
     name: '{{ item }}'
     state: absent
   ignore_errors: true

--- a/tests/integration/targets/elb_classic_lb/tasks/https_listeners.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/https_listeners.yml
@@ -25,7 +25,7 @@
   register: cert_create_result
 
 - name: upload certificates first time
-  aws_acm:
+  community.aws.acm_certificate:
     name_tag: '{{ item.name }}'
     certificate: '{{ lookup(''file'', item.cert ) }}'
     private_key: '{{ lookup(''file'', item.priv_key ) }}'
@@ -116,7 +116,7 @@
     state: absent
 
 - name: Delete the certificate created in this test
-  community.aws.aws_acm:
+  community.aws.acm_certificate:
     certificate_arn: '{{ cert_arn }}'
     state: absent
   # AWS doesn't always cleanup the associations properly

--- a/tests/integration/targets/elb_classic_lb/tasks/setup_vpc.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/setup_vpc.yml
@@ -54,7 +54,7 @@
   register: setup_subnet_4
 
 - name: create a security group
-  ec2_group:
+  ec2_security_group:
     name: '{{ resource_prefix }}-a'
     description: 'created by Ansible integration tests'
     state: present
@@ -67,7 +67,7 @@
   register: setup_sg_1
 
 - name: create a security group
-  ec2_group:
+  ec2_security_group:
     name: '{{ resource_prefix }}-b'
     description: 'created by Ansible integration tests'
     state: present
@@ -80,7 +80,7 @@
   register: setup_sg_2
 
 - name: create a security group
-  ec2_group:
+  ec2_security_group:
     name: '{{ resource_prefix }}-c'
     description: 'created by Ansible integration tests'
     state: present

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/setup.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/setup.yml
@@ -41,7 +41,7 @@
     subnet_id: '{{ setup_subnet.subnet.id }}'
 
 - name: create a security group to use for creating an ec2 instance
-  ec2_group:
+  ec2_security_group:
     name: '{{ resource_prefix }}_setup'
     description: 'created by Ansible integration tests'
     state: present

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/tear_down.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/tear_down.yml
@@ -3,7 +3,7 @@
     subnet_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/24'
 
 - name: remove setup security group
-  ec2_group:
+  ec2_security_group:
     name: '{{ resource_prefix }}_setup'
     description: 'created by Ansible integration tests'
     state: absent

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/main.yml
@@ -1,4 +1,4 @@
-- name: aws_kms integration tests
+- name: kms_key integration tests
   collections:
   - community.aws
   module_defaults:

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_grants.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_grants.yml
@@ -16,7 +16,7 @@
         "Deny"} }'
     register: iam_role_result
   - name: create a key
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       tags:
         Hello: World
@@ -49,7 +49,7 @@
     # ------------------------------------------------------------------------------------------
 
   - name: Add grant - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       purge_grants: yes
@@ -75,7 +75,7 @@
   - wait_for:
       timeout: 20
   - name: Add grant
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       purge_grants: yes
@@ -117,7 +117,7 @@
     wait_for:
       timeout: 45
   - name: Add grant (idempotence) - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       purge_grants: yes
@@ -139,7 +139,7 @@
       - not key.changed
 
   - name: Add grant (idempotence)
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       purge_grants: yes
@@ -177,7 +177,7 @@
       - key.description == ''
 
   - name: Add a second grant
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       grants:
@@ -218,7 +218,7 @@
     wait_for:
       timeout: 45
   - name: Add a second grant again
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       grants:
@@ -256,7 +256,7 @@
       - key.description == ''
 
   - name: Update the grants with purge_grants set
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       purge_grants: yes
@@ -295,7 +295,7 @@
       - key.description == ''
 
   - name: Update third grant to change encryption context equals to subset
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       grants:
@@ -338,7 +338,7 @@
     # ============================================================
     #   CLEAN-UP
   - name: finish off by deleting keys
-    aws_kms:
+    kms_key:
       state: absent
       alias: '{{ kms_key_alias }}'
       pending_window: 7

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_modify.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_modify.yml
@@ -16,7 +16,7 @@
         "Deny"} }'
     register: iam_role_result
   - name: create a key
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       tags:
         Hello: World
@@ -53,7 +53,7 @@
       kms_key_id: '{{ key.key_id }}'
       kms_key_arn: '{{ key.key_arn }}'
   - name: find facts about the key (by ID)
-    aws_kms_info:
+    kms_key_info:
       key_id: '{{ kms_key_id }}'
     register: new_key
   - name: check that a key was found
@@ -78,7 +78,7 @@
       - new_key.kms_keys[0].description == ''
 
   - name: Update policy - check mode
-    aws_kms:
+    kms_key:
       key_id: '{{ kms_key_id }}'
       policy: "{{ lookup('template', 'console-policy.j2') }}"
     register: key
@@ -88,7 +88,7 @@
       - key is changed
 
   - name: Update policy
-    aws_kms:
+    kms_key:
       key_id: '{{ kms_key_id }}'
       policy: "{{ lookup('template', 'console-policy.j2') }}"
     register: key
@@ -118,7 +118,7 @@
     wait_for:
       timeout: 45
   - name: Update policy (idempotence) - check mode
-    aws_kms:
+    kms_key:
       alias: alias/{{ kms_key_alias }}
       policy: "{{ lookup('template', 'console-policy.j2') }}"
     register: key
@@ -128,7 +128,7 @@
       - not key.changed
 
   - name: Update policy (idempotence)
-    aws_kms:
+    kms_key:
       alias: alias/{{ kms_key_alias }}
       policy: "{{ lookup('template', 'console-policy.j2') }}"
     register: key
@@ -156,7 +156,7 @@
     # ------------------------------------------------------------------------------------------
 
   - name: Update description - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       description: test key for testing
@@ -167,7 +167,7 @@
       - key.changed
 
   - name: Update description
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       description: test key for testing
@@ -197,7 +197,7 @@
     wait_for:
       timeout: 45
   - name: Update description (idempotence) - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       description: test key for testing
@@ -208,7 +208,7 @@
       - not key.changed
 
   - name: Update description (idempotence)
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       description: test key for testing
@@ -237,7 +237,7 @@
     # ------------------------------------------------------------------------------------------
 
   - name: update policy to remove access to key rotation status
-    aws_kms:
+    kms_key:
       alias: alias/{{ kms_key_alias }}
       policy: "{{ lookup('template', 'console-policy-no-key-rotation.j2') }}"
     register: key
@@ -267,7 +267,7 @@
     # ============================================================
     #   CLEAN-UP
   - name: finish off by deleting keys
-    aws_kms:
+    kms_key:
       state: absent
       alias: '{{ kms_key_alias }}'
       pending_window: 7

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_states.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_states.yml
@@ -8,10 +8,10 @@
     aws_caller_info:
     register: aws_caller_info
   - name: See whether key exists and its current state
-    aws_kms_info:
+    kms_key_info:
       alias: '{{ kms_key_alias }}'
   - name: create a key - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}-check'
       tags:
         Hello: World
@@ -20,7 +20,7 @@
     register: key_check
     check_mode: yes
   - name: find facts about the check mode key
-    aws_kms_info:
+    kms_key_info:
       alias: '{{ kms_key_alias }}-check'
     register: check_key
   - name: ensure that check mode worked as expected
@@ -30,7 +30,7 @@
       - key_check is changed
 
   - name: create a key
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       tags:
         Hello: World
@@ -64,7 +64,7 @@
     wait_for:
       timeout: 45
   - name: create a key (idempotence) - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       tags:
         Hello: World
@@ -77,7 +77,7 @@
       - key is not changed
 
   - name: create a key (idempotence)
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       tags:
         Hello: World
@@ -113,7 +113,7 @@
       kms_key_id: '{{ key.key_id }}'
       kms_key_arn: '{{ key.key_arn }}'
   - name: Enable key rotation - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       tags:
         Hello: World
@@ -127,7 +127,7 @@
       - key.changed
 
   - name: Enable key rotation
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       tags:
         Hello: World
@@ -161,7 +161,7 @@
     wait_for:
       timeout: 45
   - name: Enable key rotation (idempotence) - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       tags:
         Hello: World
@@ -175,7 +175,7 @@
       - not key.changed
 
   - name: Enable key rotation (idempotence)
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       tags:
         Hello: World
@@ -207,7 +207,7 @@
     # ------------------------------------------------------------------------------------------
 
   - name: Disable key - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       enabled: no
@@ -218,7 +218,7 @@
       - key.changed
 
   - name: Disable key
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       enabled: no
@@ -249,7 +249,7 @@
     wait_for:
       timeout: 45
   - name: Disable key (idempotence) - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       enabled: no
@@ -260,7 +260,7 @@
       - not key.changed
 
   - name: Disable key (idempotence)
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       enabled: no
@@ -289,7 +289,7 @@
     # ------------------------------------------------------------------------------------------
 
   - name: Delete key - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: absent
     register: key
@@ -299,7 +299,7 @@
       - key is changed
 
   - name: Delete key
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: absent
     register: key
@@ -336,7 +336,7 @@
       - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days >= 29
 
   - name: Delete key (idempotence) - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: absent
     register: key
@@ -346,7 +346,7 @@
       - not key.changed
 
   - name: Delete key (idempotence)
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: absent
     register: key
@@ -381,7 +381,7 @@
     # ------------------------------------------------------------------------------------------
 
   - name: Cancel key deletion - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
     register: key
@@ -391,7 +391,7 @@
       - key.changed
 
   - name: Cancel key deletion
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
     register: key
@@ -421,7 +421,7 @@
     wait_for:
       timeout: 45
   - name: Cancel key deletion (idempotence) - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
     register: key
@@ -431,7 +431,7 @@
       - not key.changed
 
   - name: Cancel key deletion (idempotence)
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
     register: key
@@ -460,7 +460,7 @@
     # ------------------------------------------------------------------------------------------
 
   - name: delete the key with a specific deletion window
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: absent
       pending_window: 7
@@ -484,7 +484,7 @@
     # ============================================================
     # test different key usage and specs
   - name: create kms key with different specs
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}-diff-spec-usage'
       purge_grants: yes
       key_spec: ECC_NIST_P256
@@ -509,7 +509,7 @@
     # ============================================================
     #   CLEAN-UP
   - name: finish off by deleting keys
-    aws_kms:
+    kms_key:
       state: absent
       alias: '{{ item }}'
       pending_window: 7

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_tagging.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_tagging.yml
@@ -8,7 +8,7 @@
     aws_caller_info:
     register: aws_caller_info
   - name: create a key
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       tags:
         Hello: World
@@ -41,7 +41,7 @@
     # ------------------------------------------------------------------------------------------
 
   - name: Tag encryption key
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       tags:
@@ -77,7 +77,7 @@
     wait_for:
       timeout: 45
   - name: Modify tags - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       purge_tags: yes
@@ -91,7 +91,7 @@
       - key.changed
 
   - name: Modify tags
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       purge_tags: yes
@@ -129,7 +129,7 @@
     wait_for:
       timeout: 45
   - name: Modify tags (idempotence) - check mode
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       purge_tags: yes
@@ -143,7 +143,7 @@
       - not key.changed
 
   - name: Modify tags (idempotence)
-    aws_kms:
+    kms_key:
       alias: '{{ kms_key_alias }}'
       state: present
       purge_tags: yes
@@ -180,7 +180,7 @@
     # ============================================================
     #   CLEAN-UP
   - name: finish off by deleting keys
-    aws_kms:
+    kms_key:
       state: absent
       alias: '{{ kms_key_alias }}'
       pending_window: 7

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -73,7 +73,7 @@
       - '"role" in result.msg'
 
   - name: test execute lambda with no function arn or name
-    execute_lambda:
+    lambda_execute:
     register: result
     ignore_errors: true
   - name: assert failure when called with no parameters
@@ -144,7 +144,7 @@
 
   # Test basic operation of Uploaded lambda
   - name: test lambda works (check mode)
-    execute_lambda:
+    lambda_execute:
       name: '{{lambda_function_name}}'
       payload:
         name: Mr Ansible Tests
@@ -157,7 +157,7 @@
       - "'result' not in result"
 
   - name: test lambda works
-    execute_lambda:
+    lambda_execute:
       name: '{{lambda_function_name}}'
       payload:
         name: Mr Ansible Tests
@@ -467,7 +467,7 @@
         great!!"
 
   - name: test lambda works
-    execute_lambda:
+    lambda_execute:
       name: '{{lambda_function_name}}'
       payload:
         name: Mr Ansible Tests

--- a/tests/integration/targets/lambda_policy/tasks/main.yml
+++ b/tests/integration/targets/lambda_policy/tasks/main.yml
@@ -8,7 +8,7 @@
   collections:
     - community.general
     - amazon.aws
-
+    - community.aws
   block:
   - name: create minimal lambda role
     iam_role:
@@ -77,7 +77,7 @@
       src: endpoint-test-swagger-api.yml.j2
       dest: '{{output_dir}}/endpoint-test-swagger-api.yml.j2'
   - name: deploy new API
-    aws_api_gateway:
+    api_gateway:
       api_file: '{{output_dir}}/endpoint-test-swagger-api.yml.j2'
       stage: lambdabased
     register: create_result
@@ -119,7 +119,7 @@
       that:
       - uri_result
   - name: deploy new API
-    aws_api_gateway:
+    api_gateway:
       api_file: '{{output_dir}}/endpoint-test-swagger-api.yml.j2'
       stage: lambdabased
     register: create_result
@@ -132,7 +132,7 @@
     register: result
     ignore_errors: true
   - name: destroy API for test cleanup if created
-    aws_api_gateway:
+    api_gateway:
       state: absent
       api_id: '{{api_id}}'
     register: destroy_result

--- a/tests/integration/targets/lookup_aws_ssm/tasks/main.yml
+++ b/tests/integration/targets/lookup_aws_ssm/tasks/main.yml
@@ -11,6 +11,7 @@
 - name: 'aws_ssm lookup plugin integration tests'
   collections:
   - amazon.aws
+  - community.aws
   module_defaults:
     group/aws:
       aws_access_key: '{{ aws_access_key }}'
@@ -65,7 +66,7 @@
       - lookup_value | list | length == 0
 
   - name: Create key/value pair in aws parameter store
-    aws_ssm_parameter_store:
+    ssm_parameter:
       name: '{{ simple_name }}'
       description: '{{ simple_description }}'
       value: '{{ simple_value }}'
@@ -80,19 +81,19 @@
   # ============================================================
 
   - name: Create nested key/value pair in aws parameter store (1)
-    aws_ssm_parameter_store:
+    ssm_parameter:
       name: '{{ path_name_a }}'
       description: '{{ path_description }}'
       value: '{{ path_value_a }}'
 
   - name: Create nested key/value pair in aws parameter store (2)
-    aws_ssm_parameter_store:
+    ssm_parameter:
       name: '{{ path_name_b }}'
       description: '{{ path_description }}'
       value: '{{ path_value_b }}'
 
   - name: Create nested key/value pair in aws parameter store (3)
-    aws_ssm_parameter_store:
+    ssm_parameter:
       name: '{{ path_name_c }}'
       description: '{{ path_description }}'
       value: '{{ path_value_c }}'
@@ -230,7 +231,7 @@
   always:
   # ============================================================
   - name: Delete remaining key/value pairs in aws parameter store
-    aws_ssm_parameter_store:
+    ssm_parameter:
       name: "{{item}}"
       state: absent
     ignore_errors: True

--- a/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_create_sgs.yml
+++ b/tests/integration/targets/rds_cluster/roles/rds_cluster/tasks/test_create_sgs.yml
@@ -37,7 +37,7 @@
     loop: '{{ subnets }}'
 
   - name: Create security groups
-    ec2_group:
+    ec2_security_group:
       name: '{{ item }}'
       description: Created by rds_cluster integration tests
       state: present
@@ -179,7 +179,7 @@
     ignore_errors: true
 
   - name: Remove security groups
-    ec2_group:
+    ec2_security_group:
       name: '{{ item }}'
       description: created by rds_cluster integration tests
       state: absent

--- a/tests/integration/targets/rds_instance/roles/rds_instance/tasks/test_sgroups.yml
+++ b/tests/integration/targets/rds_instance/roles/rds_instance/tasks/test_sgroups.yml
@@ -27,7 +27,7 @@
     - {cidr: 10.122.122.160/28, zone: '{{ aws_region }}c'}
 
   - name: Create security groups
-    ec2_group:
+    ec2_security_group:
       name: '{{ item }}'
       description: created by rds_instance integration tests
       state: present
@@ -275,7 +275,7 @@
     ignore_errors: yes
 
   - name: Remove security groups
-    ec2_group:
+    ec2_security_group:
       name: '{{ item }}'
       description: created by rds_instance integration tests
       state: absent

--- a/tests/integration/targets/rds_option_group/tasks/main.yml
+++ b/tests/integration/targets/rds_option_group/tasks/main.yml
@@ -59,7 +59,7 @@
 
 
   - name: Create security groups
-    ec2_group:
+    ec2_security_group:
       name: '{{ item }}'
       description: created by rds_instance integration tests
       state: present
@@ -921,7 +921,7 @@
     ignore_errors: yes
 
   - name: Remove security groups
-    ec2_group:
+    ec2_security_group:
       name: '{{ item }}'
       description: created by rds_instance integration tests
       state: absent

--- a/tests/integration/targets/s3_object/tasks/main.yml
+++ b/tests/integration/targets/s3_object/tasks/main.yml
@@ -207,7 +207,7 @@
     # 'file' lookup path or a remote path.  Keeping this working is dependent on
     # having a redirect for both the module and the action plugin
     - name: check that roles file lookups work as expected when using old name
-      aws_s3:
+      s3_object:
         bucket: "{{ bucket_name }}"
         mode: put
         src: hello.txt
@@ -766,7 +766,7 @@
           - result is changed
 
     - name: create an object from a template (idempotency)
-      aws_s3:
+      s3_object:
         bucket: "{{ bucket_name }}"
         object: put-template.txt
         mode: put
@@ -806,7 +806,7 @@
           - result is changed
 
     - name: create an object from binary data (idempotency)
-      aws_s3:
+      s3_object:
         bucket: "{{ bucket_name }}"
         object: put-binary.bin
         mode: put

--- a/tests/integration/targets/setup_ec2_instance_env/tasks/main.yml
+++ b/tests/integration/targets/setup_ec2_instance_env/tasks/main.yml
@@ -39,7 +39,7 @@
     register: testing_subnet_b
 
   - name: "create a security group with the vpc"
-    ec2_group:
+    ec2_security_group:
       state: present
       name: "{{ resource_prefix }}-sg"
       description: a security group for ansible tests
@@ -56,7 +56,7 @@
     register: sg
 
   - name: "create secondary security group with the vpc"
-    ec2_group:
+    ec2_security_group:
       name: "{{ resource_prefix }}-sg-2"
       description: a secondary security group for ansible tests
       vpc_id: "{{ testing_vpc.vpc.id }}"

--- a/tests/integration/targets/setup_ec2_vpc/tasks/cleanup.yml
+++ b/tests/integration/targets/setup_ec2_vpc/tasks/cleanup.yml
@@ -59,7 +59,7 @@
     # Cross-dependencies between rules in the SGs can cause us problems if we don't clear the rules
     # first
     - name: '(VPC Cleanup) Delete rules from remaining SGs'
-      ec2_group:
+      ec2_security_group:
         name: '{{ item.group_name }}'
         group_id: '{{ item.group_id }}'
         description: '{{ item.description }}'
@@ -69,7 +69,7 @@
       ignore_errors: yes
 
     - name: '(VPC Cleanup) Delete remaining SGs'
-      ec2_group:
+      security_group:
         state: absent
         group_id: '{{ item.group_id }}'
       loop: '{{ remaining_groups.security_groups }}'

--- a/tests/integration/targets/setup_ec2_vpc/tasks/cleanup.yml
+++ b/tests/integration/targets/setup_ec2_vpc/tasks/cleanup.yml
@@ -69,7 +69,7 @@
       ignore_errors: yes
 
     - name: '(VPC Cleanup) Delete remaining SGs'
-      security_group:
+      ec2_security_group:
         state: absent
         group_id: '{{ item.group_id }}'
       loop: '{{ remaining_groups.security_groups }}'


### PR DESCRIPTION
##### SUMMARY

A lot of modules were renamed prior to 5.0.0, update the integration tests to take this into account.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tests/integration

##### ADDITIONAL INFORMATION
