### PR TITLE
S3_bucket : Handle setting of permissions while acl is disabled

### DIFF
--- a/changelogs/fragments/1168-s3_bucket_acl_disabled.yml
+++ b/changelogs/fragments/1168-s3_bucket_acl_disabled.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- s3_bucket - Handle setting of permissions while acl is disabled.(https://github.com/ansible-collections/amazon.aws/pull/1168).

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -396,6 +396,7 @@ from ssl import SSLError
 import base64
 import time
 
+
 try:
     import botocore
 except ImportError:
@@ -607,6 +608,8 @@ def create_dirkey(module, s3, bucket, obj, encrypt, expiry):
             s3.put_object_acl(ACL=acl, Bucket=bucket, Key=obj)
     except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
         module.warn("PutObjectAcl is not implemented by your storage provider. Set the permissions parameters to the empty list to avoid this warning")
+    except is_boto3_error_code('AccessControlListNotSupported'):
+            module.warn("PutObjectAcl operation : The bucket does not allow ACLs.")
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Failed while creating object %s." % obj)
 
@@ -696,6 +699,8 @@ def upload_s3file(module, s3, bucket, obj, expiry, metadata, encrypt, headers, s
                 s3.put_object_acl(ACL=acl, Bucket=bucket, Key=obj)
         except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
             module.warn("PutObjectAcl is not implemented by your storage provider. Set the permission parameters to the empty list to avoid this warning")
+        except is_boto3_error_code('AccessControlListNotSupported'):
+            module.warn("PutObjectAcl operation : The bucket does not allow ACLs.")
         except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
             module.fail_json_aws(e, msg="Unable to set object ACL")
 
@@ -831,6 +836,8 @@ def copy_object_to_bucket(module, s3, bucket, obj, encrypt, metadata, validate, 
             module.exit_json(msg="Object copied from bucket %s to bucket %s." % (bucketsrc['Bucket'], bucket), tags=tags, changed=True)
     except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
         module.warn("PutObjectAcl is not implemented by your storage provider. Set the permissions parameters to the empty list to avoid this warning")
+    except is_boto3_error_code('AccessControlListNotSupported'):
+            module.warn("PutObjectAcl operation : The bucket does not allow ACLs.")
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Failed while copying object %s from bucket %s." % (obj, module.params['copy_src'].get('Bucket')))
 
@@ -1203,6 +1210,7 @@ def main():
         # these were separated above into the variables bucket_acl and object_acl
 
         if bucket and not obj:
+            
             if bucketrtn:
                 module.exit_json(msg="Bucket already exists.", changed=False)
             else:

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -1081,7 +1081,7 @@ def main():
     # check if bucket exists, if yes, check if ACL is disabled
     acl_disabled = False
     exists = bucket_check(module, s3, bucket)
-    import q
+
     if exists:
         try:
             ownership_controls = s3.get_bucket_ownership_controls(Bucket=bucket)['OwnershipControls']

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -1085,7 +1085,6 @@ def main():
     if exists:
         try:
             ownership_controls = s3.get_bucket_ownership_controls(Bucket=bucket)['OwnershipControls']
-            q(ownership_controls)
             if ownership_controls.get('Rules'):
                 object_ownership = ownership_controls['Rules'][0]['ObjectOwnership']
                 if object_ownership == 'BucketOwnerEnforced':

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -609,7 +609,7 @@ def create_dirkey(module, s3, bucket, obj, encrypt, expiry):
     except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
         module.warn("PutObjectAcl is not implemented by your storage provider. Set the permissions parameters to the empty list to avoid this warning")
     except is_boto3_error_code('AccessControlListNotSupported'):
-            module.warn("PutObjectAcl operation : The bucket does not allow ACLs.")
+        module.warn("PutObjectAcl operation : The bucket does not allow ACLs.")
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Failed while creating object %s." % obj)
 
@@ -837,7 +837,7 @@ def copy_object_to_bucket(module, s3, bucket, obj, encrypt, metadata, validate, 
     except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
         module.warn("PutObjectAcl is not implemented by your storage provider. Set the permissions parameters to the empty list to avoid this warning")
     except is_boto3_error_code('AccessControlListNotSupported'):
-            module.warn("PutObjectAcl operation : The bucket does not allow ACLs.")
+        module.warn("PutObjectAcl operation : The bucket does not allow ACLs.")
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Failed while copying object %s from bucket %s." % (obj, module.params['copy_src'].get('Bucket')))
 
@@ -1210,7 +1210,6 @@ def main():
         # these were separated above into the variables bucket_acl and object_acl
 
         if bucket and not obj:
-            
             if bucketrtn:
                 module.exit_json(msg="Bucket already exists.", changed=False)
             else:

--- a/tests/integration/inventory
+++ b/tests/integration/inventory
@@ -1,0 +1,2 @@
+[testgroup]
+testhost ansible_connection="local" ansible_pipelining="yes" ansible_python_interpreter="/usr/bin/python"

--- a/tests/integration/inventory
+++ b/tests/integration/inventory
@@ -1,2 +1,0 @@
-[testgroup]
-testhost ansible_connection="local" ansible_pipelining="yes" ansible_python_interpreter="/usr/bin/python"

--- a/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
+++ b/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
@@ -85,17 +85,39 @@
           - upload_file_result.msg != "PUT operation complete"
           - '"s3:PutObject" not in upload_file_result.resource_actions'
 
+    - name: Create an object in the bucket with permissions (permission not set)
+      amazon.aws.s3_object:
+        bucket: "{{ bucket_name }}-acl-disabled"
+        object: "/test_directory"
+        permission: bucket-owner-full-control
+        mode: create
+      register: permission_result
+
+    - assert:
+        that:
+          - permission_result is changed
+          - upload_file_result is not failed
+          - '"PutObjectAcl operation : The bucket does not allow ACLs." in permission_result.warnings'
+          - '"Virtual directory test_directory/ created" in permission_result.msg'
+
   always:
 
     - name: Delete the file in the bucket
       amazon.aws.s3_object:
         bucket: "{{ bucket_name }}-acl-disabled"
-        src: "{{ remote_tmp_dir }}/acl_disabled_upload_test.txt"
-        object: "acl_disabled_upload_test.txt"
+        object: "{{ item }}"
         mode: delobj
       retries: 3
       delay: 3
       ignore_errors: true
+      loop:
+        - "acl_disabled_upload_test.txt"
+        - "test_directory/"
+
+    - name: List keys simple
+      amazon.aws.s3_object:
+        bucket: "{{ bucket_name }}-acl-disabled"
+        mode: list
 
     - name: Delete bucket created in this test
       s3_bucket:

--- a/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
+++ b/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
@@ -85,21 +85,6 @@
           - upload_file_result.msg != "PUT operation complete"
           - '"s3:PutObject" not in upload_file_result.resource_actions'
 
-    - name: Create an object in the bucket with permission for the object
-      amazon.aws.s3_object:
-        bucket: "{{ bucket_name }}-acl-disabled"
-        object: "/test_directory"
-        permission: bucket-owner-full-control
-        mode: create
-      register: upload_file_result
-
-    - assert:
-        that:
-          - upload_file_result is not changed
-          - upload_file_result is not failed
-          - '"s3:PutObject" not in upload_file_result.resource_actions'
-
-
   always:
 
     - name: Delete the file in the bucket

--- a/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
+++ b/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
@@ -85,17 +85,35 @@
           - upload_file_result.msg != "PUT operation complete"
           - '"s3:PutObject" not in upload_file_result.resource_actions'
 
+    - name: Create an object in the bucket with permission for the object
+      amazon.aws.s3_object:
+        bucket: "{{ bucket_name }}-acl-disabled"
+        object: "/test_directory"
+        permission: bucket-owner-full-control
+        mode: create
+      register: upload_file_result
+
+    - assert:
+        that:
+          - upload_file_result is not changed
+          - upload_file_result is not failed
+          - '"s3:PutObject" not in upload_file_result.resource_actions'
+
+
   always:
 
     - name: Delete the file in the bucket
       amazon.aws.s3_object:
         bucket: "{{ bucket_name }}-acl-disabled"
         src: "{{ remote_tmp_dir }}/acl_disabled_upload_test.txt"
-        object: "acl_disabled_upload_test.txt"
+        object: "{{ item }}"
         mode: delobj
       retries: 3
       delay: 3
       ignore_errors: true
+      loop:
+        - "acl_disabled_upload_test.txt"
+        - "/test_directory"
 
     - name: Delete bucket created in this test
       s3_bucket:

--- a/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
+++ b/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
@@ -91,14 +91,11 @@
       amazon.aws.s3_object:
         bucket: "{{ bucket_name }}-acl-disabled"
         src: "{{ remote_tmp_dir }}/acl_disabled_upload_test.txt"
-        object: "{{ item }}"
+        object: "acl_disabled_upload_test.txt"
         mode: delobj
       retries: 3
       delay: 3
       ignore_errors: true
-      loop:
-        - "acl_disabled_upload_test.txt"
-        - "/test_directory"
 
     - name: Delete bucket created in this test
       s3_bucket:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

As per [boto3 aws documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3.html#S3.Client.get_bucket_ownership_controls) 

`When ObjectOwnership is BucketOwnerEnforced - Access control lists (ACLs) are disabled and no longer affect permissions.`

Fixes #1137 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
