### PR TITLE
rds_param_group: WARN on updating DBParameterGroupFamily (engine)

### DIFF
--- a/changelogs/fragments/1169-rds_param_group-fail-on-updating-engine.yml
+++ b/changelogs/fragments/1169-rds_param_group-fail-on-updating-engine.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- rds_param_group - added a check to fail the task while modifying/updating rds_param_group if trying to change DB parameter group family. (https://github.com/ansible-collections/amazon.aws/pull/1169).

--- a/plugins/modules/rds_param_group.py
+++ b/plugins/modules/rds_param_group.py
@@ -35,6 +35,8 @@ options:
       - The type of database for this group.
       - Please use following command to get list of all supported db engines and their respective versions.
       - '# aws rds describe-db-engine-versions --query "DBEngineVersions[].DBParameterGroupFamily"'
+      - The DB parameter group family can't be changed when updating a DB parameter group.
+        See U(https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbparametergroup.html)
       - Required for I(state=present).
     type: str
   immediate:
@@ -266,6 +268,11 @@ def ensure_present(module, connection):
                 module.fail_json_aws(e, msg="Couldn't create parameter group")
     else:
         group = response['DBParameterGroups'][0]
+        db_parameter_group_family = group['DBParameterGroupFamily']
+
+        if module.params.get('engine') != db_parameter_group_family:
+            module.fail_json(msg="The DB parameter group family (engine) can't be changed when updating a DB parameter group.")
+
         if tags:
             changed = update_tags(module, connection, group, tags)
 

--- a/plugins/modules/rds_param_group.py
+++ b/plugins/modules/rds_param_group.py
@@ -35,7 +35,7 @@ options:
       - The type of database for this group.
       - Please use following command to get list of all supported db engines and their respective versions.
       - '# aws rds describe-db-engine-versions --query "DBEngineVersions[].DBParameterGroupFamily"'
-      - The DB parameter group family can't be changed when updating a DB parameter group.
+      - The DB parameter group family is immutable and can't be changed when updating a DB parameter group.
         See U(https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbparametergroup.html)
       - Required for I(state=present).
     type: str
@@ -271,7 +271,7 @@ def ensure_present(module, connection):
         db_parameter_group_family = group['DBParameterGroupFamily']
 
         if module.params.get('engine') != db_parameter_group_family:
-            module.fail_json(msg="The DB parameter group family (engine) can't be changed when updating a DB parameter group.")
+            module.warn("The DB parameter group family (engine) can't be changed when updating a DB parameter group.")
 
         if tags:
             changed = update_tags(module, connection, group, tags)

--- a/tests/integration/targets/rds_param_group/defaults/main.yml
+++ b/tests/integration/targets/rds_param_group/defaults/main.yml
@@ -2,6 +2,7 @@ rds_param_group:
   name: '{{ resource_prefix}}rds-param-group'
   description: Test group for rds_param_group Ansible module
   engine: postgres9.6
+  engine_to_modify_to: postgres10
 
 rds_long_param_list:
   application_name: Test

--- a/tests/integration/targets/rds_param_group/tasks/main.yml
+++ b/tests/integration/targets/rds_param_group/tasks/main.yml
@@ -123,6 +123,26 @@
       - result.tags["Test"] == '123'
 
     # ============================================================
+
+  - name: test modifying rds parameter group engine/family
+    rds_param_group:
+      name: '{{ rds_param_group.name }}'
+      engine: '{{ rds_param_group.engine_to_modify_to }}'
+      description: '{{ rds_param_group.description }}'
+      state: present
+      tags:
+        Environment: test
+        Test: 123
+    register: result
+    ignore_errors: true
+
+  - name: adding numeric tag just silently converts
+    assert:
+      that:
+      - not result.changed
+      - result.failed
+
+    # ============================================================
   - name: test tagging existing group - CHECK_MODE
     rds_param_group:
       name: '{{ rds_param_group.name }}'

--- a/tests/integration/targets/rds_param_group/tasks/main.yml
+++ b/tests/integration/targets/rds_param_group/tasks/main.yml
@@ -136,7 +136,7 @@
     register: result
     ignore_errors: true
 
-  - name: adding numeric tag just silently converts
+  - name: verify that modifying rds param group engine/family failed
     assert:
       that:
       - not result.changed

--- a/tests/integration/targets/rds_param_group/tasks/main.yml
+++ b/tests/integration/targets/rds_param_group/tasks/main.yml
@@ -135,11 +135,13 @@
         Test: 123
     register: result
 
-  - name: verify that modifying rds param group engine/family failed
+  - name: verify that modifying rds param group engine/family displays warning
     assert:
       that:
       - not result.changed
       - not result.failed
+      - result.warnings is defined
+      - result.warnings | length > 0
 
     # ============================================================
   - name: test tagging existing group - CHECK_MODE

--- a/tests/integration/targets/rds_param_group/tasks/main.yml
+++ b/tests/integration/targets/rds_param_group/tasks/main.yml
@@ -124,7 +124,7 @@
 
     # ============================================================
 
-  - name: test modifying rds parameter group engine/family
+  - name: test modifying rds parameter group engine/family (warning displayed)
     rds_param_group:
       name: '{{ rds_param_group.name }}'
       engine: '{{ rds_param_group.engine_to_modify_to }}'
@@ -134,13 +134,12 @@
         Environment: test
         Test: 123
     register: result
-    ignore_errors: true
 
   - name: verify that modifying rds param group engine/family failed
     assert:
       that:
       - not result.changed
-      - result.failed
+      - not result.failed
 
     # ============================================================
   - name: test tagging existing group - CHECK_MODE


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1074 

Added a check to `WARN` the task while modifying/updating rds_param_group if task tries to change `DB parameter group family`.

As [AWS Documentation](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbparametergroup.html) specifies that, 
```
The DB parameter group family can't be changed when updating a DB parameter group.
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rds_param_group
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Paste verbatim command output below, e.g. before and after your change -->
Steps to reproduce
1. Create rds Param group
```
- name: Create a param group
  hosts: localhost
  gather_facts: false
  tasks:
    - name: create test rds db parameter group
      amazon.aws.rds_param_group:
        name: "test-parameter-group"
        description: test rpg
        state: present
        engine: "aurora-postgresql13"
```
2. Try to change engine (family), with the fix in PR task should throw warning.
```
- name: Create a param group
  hosts: localhost
  gather_facts: false
  tasks:
    - name: create test rds db parameter group
      amazon.aws.rds_param_group:
        name: "test-parameter-group"
        description: test rpg
        state: present
        engine: "aurora-postgresql14"
```