### PR TITLE
Refacterization of code to use 'fallback' instead of using os.environ

### DIFF
--- a/changelogs/fragments/1174-module_params.yml
+++ b/changelogs/fragments/1174-module_params.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- amazon.aws collection - refacterization of code to use argument specification ``fallback`` when falling back to environment variables for security credentials and AWS connection details (https://github.com/ansible-collections/amazon.aws/pull/1174).

--- a/plugins/doc_fragments/aws.py
+++ b/plugins/doc_fragments/aws.py
@@ -120,9 +120,11 @@ options:
     type: bool
     default: false
 notes:
-  - B(Caution:) Environment variables and configuration files are read from the
-    Ansible 'host' context and not the 'controller' context.  Files may need to
-    be explicitly copied to the 'host'.
+  - B(Caution:) For modules, environment variables and configuration files are
+    read from the Ansible 'host' context and not the 'controller' context.
+    As such, files may need to be explicitly copied to the 'host'.  For lookup
+    and connection plugins, environment variables and configuration files are
+    read from the Ansible 'controller' context and not the 'host' context.
   - The AWS SDK (boto3) that Ansible uses may also read defaults for credentials
     and other settings, such as the region, from its configuration files in the
     Ansible 'host' context (typically C(~/.aws/credentials)).

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -380,6 +380,7 @@ def _aws_common_argument_spec():
             deprecated_aliases=[
                 dict(name='ec2_access_key', date='2024-12-01', collection_name='amazon.aws'),
             ],
+            fallback=(env_fallback, ['AWS_ACCESS_KEY_ID', 'AWS_ACCESS_KEY', 'EC2_ACCESS_KEY']),
             no_log=False,
         ),
         secret_key=dict(
@@ -387,6 +388,7 @@ def _aws_common_argument_spec():
             deprecated_aliases=[
                 dict(name='ec2_secret_key', date='2024-12-01', collection_name='amazon.aws'),
             ],
+            fallback=(env_fallback, ['AWS_SECRET_ACCESS_KEY', 'AWS_SECRET_KEY', 'EC2_SECRET_KEY']),
             no_log=True,
         ),
         session_token=dict(
@@ -396,10 +398,12 @@ def _aws_common_argument_spec():
                 dict(name='security_token', date='2024-12-01', collection_name='amazon.aws'),
                 dict(name='aws_security_token', date='2024-12-01', collection_name='amazon.aws'),
             ],
+            fallback=(env_fallback, ['AWS_SESSION_TOKEN', 'AWS_SECURITY_TOKEN', 'EC2_SECURITY_TOKEN']),
             no_log=True,
         ),
         profile=dict(
             aliases=['aws_profile'],
+            fallback=(env_fallback, ['AWS_PROFILE', 'AWS_DEFAULT_PROFILE']),
         ),
 
         endpoint_url=dict(
@@ -408,16 +412,18 @@ def _aws_common_argument_spec():
                 dict(name='ec2_url', date='2024-12-01', collection_name='amazon.aws'),
                 dict(name='s3_url', date='2024-12-01', collection_name='amazon.aws'),
             ],
+            fallback=(env_fallback, ['AWS_URL', 'EC2_URL', 'S3_URL']),
         ),
         validate_certs=dict(
             type='bool',
             default=True,
         ),
         aws_ca_bundle=dict(
-            type='path'
+            type='path',
+            fallback=(env_fallback, ['AWS_CA_BUNDLE']),
         ),
         aws_config=dict(
-            type='dict'
+            type='dict',
         ),
         debug_botocore_endpoint_logs=dict(
             type='bool',
@@ -437,6 +443,7 @@ def aws_argument_spec():
             deprecated_aliases=[
                 dict(name='ec2_region', date='2024-12-01', collection_name='amazon.aws'),
             ],
+            fallback=(env_fallback, ['AWS_REGION', 'AWS_DEFAULT_REGION', 'EC2_REGION']),
         ),
     )
     spec = _aws_common_argument_spec()


### PR DESCRIPTION
##### SUMMARY

When the "ec2" module was [first added](https://github.com/ansible/ansible/pull/1571), it included support for pulling credentials out of the environment variables.  3.5 years later, in Ansible 2.1, support for configuring a 'fallback' directly in the argument specification was added, but we never got around to using it.

This PR finally cleans up the code and lets the argument parser directly handle fallback to environment variables.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/botocore.py
plugins/module_utils/modules.py

##### ADDITIONAL INFORMATION
