### PR TITLE
Bump December deprecation dates over to a firm 6.0.0 version

### DIFF
--- a/changelogs/fragments/1180-december-deprecations.yml
+++ b/changelogs/fragments/1180-december-deprecations.yml
@@ -1,0 +1,2 @@
+trivial:
+- various modules - bump 2022-12-01 deprecations over to version 6.0.0 (https://github.com/ansible-collections/amazon.aws/pull/1180).

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -21,7 +21,7 @@ options:
   device_id:
     description:
       - The id of the device for the EIP. Can be an EC2 Instance id or Elastic Network Interface (ENI) id.
-      - The I(instance_id) alias has been deprecated and will be removed after 2022-12-01.
+      - The I(instance_id) alias has been deprecated and will be removed in release 6.0.0.
     required: false
     aliases: [ instance_id ]
     type: str
@@ -527,7 +527,7 @@ def main():
     argument_spec = dict(
         device_id=dict(required=False, aliases=['instance_id'],
                        deprecated_aliases=[dict(name='instance_id',
-                                           date='2022-12-01',
+                                           version='6.0.0',
                                            collection_name='amazon.aws')]),
         public_ip=dict(required=False, aliases=['ip']),
         state=dict(required=False, default='present',

--- a/plugins/modules/ec2_vpc_dhcp_option.py
+++ b/plugins/modules/ec2_vpc_dhcp_option.py
@@ -472,7 +472,7 @@ def main():
     client = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 
     module.deprecate("The 'new_config' return key is deprecated and will be replaced by 'dhcp_config'. Both values are returned for now.",
-                     date='2022-12-01', collection_name='amazon.aws')
+                     version='6.0.0', collection_name='amazon.aws')
     if state == 'absent':
         if not dhcp_options_id:
             # Look up the option id first by matching the supplied options

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -67,7 +67,7 @@ options:
         on how to use it properly. Cannot be used with I(policy).
       - Option when creating an endpoint. If not provided AWS will
         utilise a default policy which provides full access to the service.
-      - This option has been deprecated and will be removed after 2022-12-01
+      - This option has been deprecated and will be removed in release 6.0.0
         to maintain the existing functionality please use the I(policy) option
         and a file lookup.
     required: false
@@ -445,9 +445,8 @@ def main():
     state = module.params.get('state')
 
     if module.params.get('policy_file'):
-        module.deprecate('The policy_file option has been deprecated and'
-                         ' will be removed after 2022-12-01',
-                         date='2022-12-01', collection_name='amazon.aws')
+        module.deprecate('The policy_file option has been deprecated',
+                         version='6.0.0', collection_name='amazon.aws')
 
     if module.params.get('vpc_endpoint_type'):
         if module.params.get('vpc_endpoint_type') == 'Gateway':

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -19,7 +19,7 @@ options:
       - I(query=endpoints) returns information about AWS VPC endpoints.
       - Retrieving information about services using I(query=services) has been
         deprecated in favour of the M(amazon.aws.ec2_vpc_endpoint_service_info) module.
-      - The I(query) option has been deprecated and will be removed after 2022-12-01.
+      - The I(query) option has been deprecated and will be removed in release 6.0.0.
     required: False
     choices:
       - services
@@ -269,17 +269,17 @@ def main():
     query = module.params.get('query')
     if query == 'endpoints':
         module.deprecate('The query option has been deprecated and'
-                         ' will be removed after 2022-12-01.  Searching for'
+                         ' will be removed in release 6.0.0.  Searching for'
                          ' `endpoints` is now the default and after'
-                         ' 2022-12-01 this module will only support fetching'
+                         ' release 6.0.0 this module will only support fetching'
                          ' endpoints.',
-                         date='2022-12-01', collection_name='amazon.aws')
+                         version='6.0.0', collection_name='amazon.aws')
     elif query == 'services':
         module.deprecate('Support for fetching service information with this '
-                         'module has been deprecated and will be removed after'
-                         ' 2022-12-01.  '
+                         'module has been deprecated and will be removed in '
+                         'release 6.0.0.  '
                          'Please use the ec2_vpc_endpoint_service_info module '
-                         'instead.', date='2022-12-01',
+                         'instead.', version='6.0.0',
                          collection_name='amazon.aws')
     else:
         query = 'endpoints'

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,3 +1,7 @@
+plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
+plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
+plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
+plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
 plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,3 +1,7 @@
+plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
+plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
+plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
+plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
 plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,3 +1,7 @@
+plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
+plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
+plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
+plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
 plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,3 +1,7 @@
+plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
+plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
+plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
+plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
 plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,3 +1,7 @@
+plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
+plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
+plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
+plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
 plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112


### PR DESCRIPTION
##### SUMMARY

We're now close enough to 2022-12-01 and have only just released 5.0.0, so let's bump the date over to a specific version to make tracking easier.  Only down side is that this means we shouldn't release 6.0.0 until after 2022-12-01, however there's nothing groundbreaking currently in the pipeline

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/modules/ec2_eip.py
plugins/modules/ec2_vpc_dhcp_option.py
plugins/modules/ec2_vpc_endpoint.py
plugins/modules/ec2_vpc_endpoint_info.py

##### ADDITIONAL INFORMATION
