### PR TITLE
DNM: module_utils.modules: expose module.params as a readonly dict

### DIFF
--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -54,6 +54,7 @@ import logging
 import os
 import re
 import traceback
+from types import MappingProxyType
 
 try:
     from cStringIO import StringIO
@@ -163,7 +164,7 @@ class AnsibleAWSModule:
 
     @property
     def params(self):
-        return self._module.params
+        return MappingProxyType(self._module.params)
 
     def _get_resource_action_list(self):
         actions = []


### PR DESCRIPTION
Depended-On: #1187
Depended-On: https://github.com/ansible-collections/community.aws/pull/1567

Use a MappingProxyType with no backend to ensure the `module.params` dict is readonly.
