### PR TITLE
ec2_metadata_facts: Add support to query instance tags in metadata

### DIFF
--- a/changelogs/fragments/1186-ec2_metadata_facts-query-instance-metadata-tags.yml
+++ b/changelogs/fragments/1186-ec2_metadata_facts-query-instance-metadata-tags.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_metadata_facts - added support to query instance tags in metadata (https://github.com/ansible-collections/amazon.aws/pull/1186).

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -259,6 +259,7 @@ ansible_facts:
             type: list
             elements: str
             sample: ["tagKey1", "tag_key2"]
+            version_added: 5.1.0
         ansible_ec2_instance_type:
             description: The type of the instance.
             type: str

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -252,6 +252,13 @@ ansible_facts:
             description: The purchasing option of the instance.
             type: str
             sample: "on-demand"
+        ansible_ec2_instance_tags_keys:
+            description:
+                - The list of tags keys of the instance.
+                - Returns empty list if access to tags (InstanceMetadataTags) in instance metadata is not enabled.
+            type: list
+            elements: str
+            sample: ["tagKey1", "tag_key2"]
         ansible_ec2_instance_type:
             description: The type of the instance.
             type: str
@@ -445,14 +452,16 @@ socket.setdefaulttimeout(5)
 class Ec2Metadata(object):
     ec2_metadata_token_uri = 'http://169.254.169.254/latest/api/token'
     ec2_metadata_uri = 'http://169.254.169.254/latest/meta-data/'
+    ec2_metadata_instance_tags_uri = 'http://169.254.169.254/latest/meta-data/tags/instance'
     ec2_sshdata_uri = 'http://169.254.169.254/latest/meta-data/public-keys/0/openssh-key'
     ec2_userdata_uri = 'http://169.254.169.254/latest/user-data/'
     ec2_dynamicdata_uri = 'http://169.254.169.254/latest/dynamic/'
 
-    def __init__(self, module, ec2_metadata_token_uri=None, ec2_metadata_uri=None, ec2_sshdata_uri=None, ec2_userdata_uri=None, ec2_dynamicdata_uri=None):
+    def __init__(self, module, ec2_metadata_token_uri=None, ec2_metadata_uri=None, ec2_metadata_instance_tags_uri= None, ec2_sshdata_uri=None, ec2_userdata_uri=None, ec2_dynamicdata_uri=None):
         self.module = module
         self.uri_token = ec2_metadata_token_uri or self.ec2_metadata_token_uri
         self.uri_meta = ec2_metadata_uri or self.ec2_metadata_uri
+        self.uri_instance_tags = ec2_metadata_instance_tags_uri or self.ec2_metadata_instance_tags_uri
         self.uri_user = ec2_userdata_uri or self.ec2_userdata_uri
         self.uri_ssh = ec2_sshdata_uri or self.ec2_sshdata_uri
         self.uri_dynamic = ec2_dynamicdata_uri or self.ec2_dynamicdata_uri
@@ -575,6 +584,10 @@ class Ec2Metadata(object):
         dyndata = self._mangle_fields(self._data, self.uri_dynamic)
         data.update(dyndata)
         data = self.fix_invalid_varnames(data)
+
+        instance_tags_keys = self._fetch(self.uri_instance_tags)
+        instance_tags_keys = instance_tags_keys.split('\n') if '\n' in instance_tags_keys else [instance_tags_keys]
+        data[self._prefix % 'instance_tags_keys'] = instance_tags_keys
 
         # Maintain old key for backwards compatibility
         if 'ansible_ec2_instance_identity_document_region' in data:

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -595,7 +595,7 @@ class Ec2Metadata(object):
         data = self.fix_invalid_varnames(data)
 
         instance_tags_keys = self._fetch(self.uri_instance_tags)
-        instance_tags_keys = instance_tags_keys.split('\n') if '\n' in instance_tags_keys else [instance_tags_keys]
+        instance_tags_keys = instance_tags_keys.split('\n')
         data[self._prefix % 'instance_tags_keys'] = instance_tags_keys
 
         # Maintain old key for backwards compatibility

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -595,7 +595,7 @@ class Ec2Metadata(object):
         data = self.fix_invalid_varnames(data)
 
         instance_tags_keys = self._fetch(self.uri_instance_tags)
-        instance_tags_keys = instance_tags_keys.split('\n')
+        instance_tags_keys = instance_tags_keys.split('\n') if instance_tags_keys != "None" else []
         data[self._prefix % 'instance_tags_keys'] = instance_tags_keys
 
         # Maintain old key for backwards compatibility

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -457,7 +457,16 @@ class Ec2Metadata(object):
     ec2_userdata_uri = 'http://169.254.169.254/latest/user-data/'
     ec2_dynamicdata_uri = 'http://169.254.169.254/latest/dynamic/'
 
-    def __init__(self, module, ec2_metadata_token_uri=None, ec2_metadata_uri=None, ec2_metadata_instance_tags_uri= None, ec2_sshdata_uri=None, ec2_userdata_uri=None, ec2_dynamicdata_uri=None):
+    def __init__(
+        self,
+        module,
+        ec2_metadata_token_uri=None,
+        ec2_metadata_uri=None,
+        ec2_metadata_instance_tags_uri=None,
+        ec2_sshdata_uri=None,
+        ec2_userdata_uri=None,
+        ec2_dynamicdata_uri=None,
+    ):
         self.module = module
         self.uri_token = ec2_metadata_token_uri or self.ec2_metadata_token_uri
         self.uri_meta = ec2_metadata_uri or self.ec2_metadata_uri

--- a/tests/integration/targets/ec2_metadata_facts/meta/main.yml
+++ b/tests/integration/targets/ec2_metadata_facts/meta/main.yml
@@ -1,7 +1,7 @@
 dependencies:
-- setup_ec2_facts
-- setup_sshkey
-#required for run_instances with MetadataOptions.InstanceMetadataTags
-- role: setup_botocore_pip
-  vars:
-    botocore_version: 1.23.30
+  - setup_ec2_facts
+  - setup_sshkey
+  #required for run_instances with MetadataOptions.InstanceMetadataTags
+  - role: setup_botocore_pip
+    vars:
+      botocore_version: '1.23.30'

--- a/tests/integration/targets/ec2_metadata_facts/meta/main.yml
+++ b/tests/integration/targets/ec2_metadata_facts/meta/main.yml
@@ -1,3 +1,7 @@
 dependencies:
 - setup_ec2_facts
 - setup_sshkey
+#required for run_instances with MetadataOptions.InstanceMetadataTags
+- role: setup_botocore_pip
+  vars:
+    botocore_version: 1.23.30

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -25,6 +25,11 @@
   - include_role:
       name: '../setup_ec2_facts'
 
+  - include_role:
+      name: '../setup_botocore_pip'
+    vars:
+      botocore_version: '1.23.30'
+
   - set_fact:
       availability_zone: '{{ ec2_availability_zone_names[0] }}'
 
@@ -123,7 +128,7 @@
       wait: True
     register: ec2_instance
     vars:
-      ansible_python_interpreter: '{{ botocore_virtualenv_interpreter }}'
+      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
   - set_fact:
       ec2_instance_id: "{{ ec2_instance.instances[0].instance_id }}"

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -119,6 +119,7 @@
           instance_metadata_tags: enabled
       tags:
         snake_case_key: a_snake_case_value
+        camelCaseKey: aCamelCaseValue
       wait: True
     register: ec2_instance
 

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -115,8 +115,11 @@
       network:
         assign_public_ip: true
         delete_on_termination: true
+      metadata_options:
+          instance_metadata_tags: enabled
+      tags:
+        snake_case_key: a_snake_case_value
       wait: True
-
     register: ec2_instance
 
   - set_fact:

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -122,6 +122,8 @@
         camelCaseKey: aCamelCaseValue
       wait: True
     register: ec2_instance
+    vars:
+      ansible_python_interpreter: '{{ botocore_virtualenv_interpreter }}'
 
   - set_fact:
       ec2_instance_id: "{{ ec2_instance.instances[0].instance_id }}"

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
@@ -15,4 +15,4 @@
         - ansible_ec2_security_groups == "{{ resource_prefix }}-sg"
         - ansible_ec2_user_data == "None"
         - ansible_ec2_instance_tags_keys is defined
-        - ansible_ec2_instance_tags_keys | length == 2
+        - ansible_ec2_instance_tags_keys | length == 3

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
@@ -14,3 +14,5 @@
         - ansible_ec2_placement_availability_zone == availability_zone
         - ansible_ec2_security_groups == "{{ resource_prefix }}-sg"
         - ansible_ec2_user_data == "None"
+        - ansible_ec2_instance_tags_keys is defined
+        - ansible_ec2_instance_tags_keys | length == 2


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #684 

Added support to be able to query instance tags using ec2_metadata_facts.

This PR adds a field in returned `ansible_facts` named  ansible_ec2_instance_tags_keys.

Sample
```
"ansible_ec2_instance_tags_keys": [
        "Name",
        "snake_case_key"
],
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_metadata_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
Support to enable instance metadata tags already exists in [amazon.aws.ec2_instance](https://github.com/ansible-collections/amazon.aws/blob/main/plugins/modules/ec2_instance.py#L346-L353)
