### PR TITLE
rds_instance: disable aurora integration tests

### DIFF
--- a/changelogs/fragments/rds_instance_disable_aurora_integration_tests.yaml
+++ b/changelogs/fragments/rds_instance_disable_aurora_integration_tests.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+- "rds_instance - Disable the Aurora tests temporarily (https://github.com/ansible-collections/amazon.aws/pull/1192)." 

--- a/tests/integration/targets/rds_instance/inventory
+++ b/tests/integration/targets/rds_instance/inventory
@@ -10,7 +10,9 @@ tagging
 replica
 upgrade
 snapshot
-aurora
+# Disabled until https://github.com/ansible-collections/amazon.aws/pull/941
+# is merged
+#aurora
 
 # TODO: uncomment after adding iam:CreatePolicy and iam:DeletePolicy
 # iam_roles


### PR DESCRIPTION
Follow up to a recent behaviour change, the Aurora clusters are created
with `engine_mode=serverless` by default. When we try
to add a new instance with `rds_instance`, we get the following errror:

```
Unable to create DB instance: An error occurred (InvalidParameterValue) when calling the CreateDBInstance operation: Instances cannot be added to Aurora Serverless clusters.
```

e.g: https://ansible.softwarefactory-project.io/zuul/build/f1f7cb085f0c4038b905a216a118c229/logs

Address the problem, we will need to add the `engine_mode` parameter to `rds_cluster`
through https://github.com/ansible-collections/amazon.aws/pull/941 and adjust
the test-suite.

This commit temporarily disable the aurora integration tests for now.
