### PR TITLE
ec2_eip - Remove deprecated instance_id alias

### DIFF
--- a/changelogs/fragments/20221024-ec2_eip-instance_id.yml
+++ b/changelogs/fragments/20221024-ec2_eip-instance_id.yml
@@ -1,0 +1,3 @@
+breaking_changes:
+- ec2_eip - the previously deprecated ``instance_id`` alias for the ``device_id`` parameter has been removed.
+  Please use the ``device_id`` parameter name instead (https://github.com/ansible-collections/amazon.aws/issues/1176).

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -20,10 +20,11 @@ description:
 options:
   device_id:
     description:
-      - The id of the device for the EIP. Can be an EC2 Instance id or Elastic Network Interface (ENI) id.
-      - The I(instance_id) alias has been deprecated and will be removed in release 6.0.0.
+      - The id of the device for the EIP.
+      - Can be an EC2 Instance id or Elastic Network Interface (ENI) id.
+      - When specifying an ENI id, I(in_vpc) must be C(true)
+      - The C(instance_id) alias was removed in release 6.0.0.
     required: false
-    aliases: [ instance_id ]
     type: str
   public_ip:
     description:
@@ -523,12 +524,21 @@ def generate_tag_dict(module, tag_name, tag_value):
         module.fail_json(msg="parameters are required together: ('tag_name', 'tag_value')")
 
 
+def check_is_instance(device_id, in_vpc):
+    if not device_id:
+        return False
+    if device_id.startswith('i-'):
+        return True
+
+    if device_id.startswith('eni-') and not in_vpc:
+        module.fail_json(msg="If you are specifying an ENI, in_vpc must be true")
+
+    return False
+
+
 def main():
     argument_spec = dict(
-        device_id=dict(required=False, aliases=['instance_id'],
-                       deprecated_aliases=[dict(name='instance_id',
-                                           version='6.0.0',
-                                           collection_name='amazon.aws')]),
+        device_id=dict(required=False),
         public_ip=dict(required=False, aliases=['ip']),
         state=dict(required=False, default='present',
                    choices=['present', 'absent']),
@@ -556,7 +566,6 @@ def main():
     ec2 = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 
     device_id = module.params.get('device_id')
-    instance_id = module.params.get('instance_id')
     public_ip = module.params.get('public_ip')
     private_ip_address = module.params.get('private_ip_address')
     state = module.params.get('state')
@@ -571,16 +580,7 @@ def main():
     tags = module.params.get('tags')
     purge_tags = module.params.get('purge_tags')
 
-    if instance_id:
-        is_instance = True
-        device_id = instance_id
-    else:
-        if device_id and device_id.startswith('i-'):
-            is_instance = True
-        elif device_id:
-            if device_id.startswith('eni-') and not in_vpc:
-                module.fail_json(msg="If you are specifying an ENI, in_vpc must be true")
-            is_instance = False
+    is_instance = check_is_instance(device_id, in_vpc)
 
     # Tags for *searching* for an EIP.
     tag_dict = generate_tag_dict(module, tag_name, tag_value)

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,4 +1,3 @@
-plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
 plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
 plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,4 +1,3 @@
-plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
 plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
 plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,4 +1,3 @@
-plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
 plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
 plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,4 +1,3 @@
-plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
 plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
 plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,4 +1,3 @@
-plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
 plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
 plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179


### PR DESCRIPTION
##### SUMMARY

fixes: #1176

Removes deprecated instance_id alias

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_eip

##### ADDITIONAL INFORMATION
