### PR TITLE
ec2_vpc_endpoint - Remove policy_file parameter

### DIFF
--- a/changelogs/fragments/20221024-ec2_vpc_endpoint.yml
+++ b/changelogs/fragments/20221024-ec2_vpc_endpoint.yml
@@ -1,0 +1,2 @@
+breaking_changes:
+- ec2_vpc_endpoint - the ``policy_file`` parameter has been removed.  I(policy) with a file lookup can be used instead (https://github.com/ansible-collections/amazon.aws/issues/1178).

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,6 +1,5 @@
 plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
 plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
-plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,6 +1,5 @@
 plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
 plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
-plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,6 +1,5 @@
 plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
 plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
-plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,6 +1,5 @@
 plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
 plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
-plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,6 +1,5 @@
 plugins/modules/ec2_eip.py validate-modules:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1176
 plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
-plugins/modules/ec2_vpc_endpoint.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1178
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,5 +1,4 @@
 plugins/modules/ec2_vpc_dhcp_option.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_vpc_endpoint.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_vpc_endpoint_info.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/ec2_instance.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/iam_policy.py pylint:ansible-deprecated-no-version


### PR DESCRIPTION
##### SUMMARY

fixes: #1178 

Drops the previously deprecated policy_file parameter.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vpc_endpoint

##### ADDITIONAL INFORMATION
