### PR TITLE
route53_health_check: Add health_check info on updating health check

### DIFF
--- a/changelogs/fragments/1200-route53_health_check-return-health-check-info-on-updating.yml
+++ b/changelogs/fragments/1200-route53_health_check-return-health-check-info-on-updating.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- route53_health_check - minor fix for returning health check info while updating a Route53 health check (https://github.com/ansible-collections/amazon.aws/pull/1200).

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -627,10 +627,7 @@ def main():
                         tags['Name'] = health_check_name
 
             else:
-                if update_delete_by_id:
-                    changed, action, check_id = update_health_check(existing_check)
-                else:
-                    changed, action, check_id = update_health_check(existing_check)
+                changed, action, check_id = update_health_check(existing_check)
 
         if check_id:
             changed |= manage_tags(module, client, 'healthcheck', check_id,

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -425,6 +425,7 @@ def update_health_check(existing_check):
 
     changes = dict()
     existing_config = existing_check.get('HealthCheckConfig')
+    check_id = existing_check.get('Id')
 
     resource_path = module.params.get('resource_path', None)
     if resource_path and resource_path != existing_config.get('ResourcePath'):
@@ -458,11 +459,10 @@ def update_health_check(existing_check):
 
     # No changes...
     if not changes:
-        return False, None
+        return False, None, check_id
     if module.check_mode:
-        return True, 'update'
+        return True, 'update', check_id
 
-    check_id = existing_check.get('Id')
     # This makes sure we're starting from the version we think we are...
     version_id = existing_check.get('HealthCheckVersion', 1)
     try:
@@ -474,7 +474,7 @@ def update_health_check(existing_check):
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg='Failed to update health check.', id=check_id)
 
-    return True, 'update'
+    return True, 'update', check_id
 
 
 def describe_health_check(id):
@@ -616,7 +616,7 @@ def main():
                 existing_checks_with_name = get_existing_checks_with_name()
                 # update the health_check if another health check with same name exists
                 if health_check_name in existing_checks_with_name:
-                    changed, action = update_health_check(existing_checks_with_name[health_check_name])
+                    changed, action, check_id = update_health_check(existing_checks_with_name[health_check_name])
                 else:
                     # create a new health_check if another health check with same name does not exists
                     changed, action, check_id = create_health_check(ip_addr_in, fqdn_in, type_in, request_interval_in, port_in)
@@ -628,9 +628,9 @@ def main():
 
             else:
                 if update_delete_by_id:
-                    changed, action = update_health_check(existing_check)
+                    changed, action, check_id = update_health_check(existing_check)
                 else:
-                    changed, action = update_health_check(existing_check)
+                    changed, action, check_id = update_health_check(existing_check)
 
         if check_id:
             changed |= manage_tags(module, client, 'healthcheck', check_id,

--- a/tests/integration/targets/route53_health_check/defaults/main.yml
+++ b/tests/integration/targets/route53_health_check/defaults/main.yml
@@ -13,6 +13,7 @@
 fqdn: '{{ tiny_prefix }}.route53-health.ansible.test'
 fqdn_1: '{{ tiny_prefix }}-1.route53-health.ansible.test'
 port: 8080
+updated_port: 8181
 type: 'TCP'
 request_interval: 30
 

--- a/tests/integration/targets/route53_health_check/tasks/create_multiple_health_checks.yml
+++ b/tests/integration/targets/route53_health_check/tasks/create_multiple_health_checks.yml
@@ -117,7 +117,7 @@
         - '"route53:UpdateHealthCheck" not in create_idem.results[0].resource_actions'
         - '"route53:UpdateHealthCheck" not in create_idem.results[1].resource_actions'
 
-    - name: 'Update HTTP health checks with different resource_path'
+    - name: 'Update HTTP health check - update port'
       route53_health_check:
         state: present
         name: '{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found'
@@ -130,7 +130,7 @@
       with_items:
         - '{{ resource_path }}'
 
-    - name: 'Check result - Update TCP health check - set threshold'
+    - name: 'Check result - Update TCP health check - update port'
       assert:
         that:
         - update_health_check is successful
@@ -159,7 +159,7 @@
 
   always:
     # Cleanup starts here
-      - name: 'Delete multiple HTTP health checks with different resource_path'
+      - name: 'Delete HTTP health check'
         route53_health_check:
           state: absent
           name: '{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found'
@@ -172,7 +172,7 @@
         with_items:
           - '{{ resource_path }}'
 
-      - name: 'Delete multiple HTTP health checks with different resource_path'
+      - name: 'Delete HTTP health check'
         route53_health_check:
           state: absent
           name: '{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found'

--- a/tests/integration/targets/route53_health_check/tasks/create_multiple_health_checks.yml
+++ b/tests/integration/targets/route53_health_check/tasks/create_multiple_health_checks.yml
@@ -117,8 +117,61 @@
         - '"route53:UpdateHealthCheck" not in create_idem.results[0].resource_actions'
         - '"route53:UpdateHealthCheck" not in create_idem.results[1].resource_actions'
 
+    - name: 'Update HTTP health checks with different resource_path'
+      route53_health_check:
+        state: present
+        name: '{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found'
+        ip_address: '{{ ip_address }}'
+        port: '{{ updated_port }}'
+        type: '{{ type_http }}'
+        resource_path: '{{ item }}'
+        use_unique_names: true
+      register: update_health_check
+      with_items:
+        - '{{ resource_path }}'
+
+    - name: 'Check result - Update TCP health check - set threshold'
+      assert:
+        that:
+        - update_health_check is successful
+        - update_health_check is changed
+        - '"id" in _health_check'
+        - _health_check.id == health_check_1_id
+        - '"health_check_version" in _health_check'
+        - '"tags" in _health_check'
+        - '"health_check_config" in _health_check'
+        - '"type" in _check_config'
+        - '"disabled" in _check_config'
+        - '"failure_threshold" in _check_config'
+        - '"request_interval" in _check_config'
+        - '"fully_qualified_domain_name" not in _check_config'
+        - '"ip_address" in _check_config'
+        - '"port" in _check_config'
+        - '"search_string" not in _check_config'
+        - _check_config.disabled == false
+        - _check_config.type == 'HTTP'
+        - _check_config.request_interval == 30
+        - _check_config.ip_address == ip_address
+        - _check_config.port == updated_port
+      vars:
+        _health_check: '{{ update_health_check.results[0].health_check }}'
+        _check_config: '{{ update_health_check.results[0].health_check.health_check_config }}'
+
   always:
     # Cleanup starts here
+      - name: 'Delete multiple HTTP health checks with different resource_path'
+        route53_health_check:
+          state: absent
+          name: '{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found'
+          ip_address: '{{ ip_address }}'
+          port: '{{ updated_port }}'
+          type: '{{ type_http }}'
+          resource_path: '{{ item }}'
+          use_unique_names: true
+        register: delete_result
+        with_items:
+          - '{{ resource_path }}'
+
       - name: 'Delete multiple HTTP health checks with different resource_path'
         route53_health_check:
           state: absent
@@ -130,5 +183,4 @@
           use_unique_names: true
         register: delete_result
         with_items:
-          - '{{ resource_path }}'
           - '{{ resource_path_1 }}'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1190 
Added health check info in output when updating a Route53 health check with `use_unique_names: true`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
route53_health_check