### PR TITLE
route53_health_check: add support for enabling latency graphs

### DIFF
--- a/changelogs/fragments/1201-route53_health_check-add-support-for-latency-graphs.yml
+++ b/changelogs/fragments/1201-route53_health_check-add-support-for-latency-graphs.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- route53_health_check -  added support for enabling Latency graphs (MeasureLatency) during creation of a Route53 Health Check. (https://github.com/ansible-collections/amazon.aws/pull/1201).

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -116,7 +116,7 @@ options:
   measure_latency:
     description:
       - To enable/disable latency graphs to monitor the latency between health checkers in multiple Amazon Web Services regions and your endpoint.
-      - Value of measure_latency is immutable and can not be modified after creating a health check.
+      - Value of I(measure_latency) is immutable and can not be modified after creating a health check.
         See U(https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/monitoring-health-check-latency.html)
     type: bool
     required: False

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -113,6 +113,14 @@ options:
     aliases: ['id']
     version_added: 4.1.0
     version_added_collection: community.aws
+  measure_latency:
+    description:
+      - To enable/disable latency graphs to monitor the latency between health checkers in multiple Amazon Web Services regions and your endpoint.
+      - Value of measure_latency is immutable and can not be modified after creating a health check.
+        See U(https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/monitoring-health-check-latency.html)
+    type: bool
+    required: False
+    version_added: 5.1.0
 author:
   - "zimbatm (@zimbatm)"
 notes:
@@ -156,6 +164,16 @@ EXAMPLES = '''
     port: 443
     type: HTTPS
     use_unique_names: true
+
+- name: create a TCP health check with latency graphs enabled
+  amazon.aws.route53_health_check:
+    state: present
+    health_check_name: ansible
+    fqdn: ansible.com
+    port: 443
+    type: HTTPS
+    use_unique_names: true
+    measure_latency: true
 
 - name: Delete health-check
   amazon.aws.route53_health_check:
@@ -392,6 +410,9 @@ def create_health_check(ip_addr_in, fqdn_in, type_in, request_interval_in, port_
         failure_threshold = 3
     health_check['FailureThreshold'] = failure_threshold
 
+    if module.params.get('measure_latency') is not None:
+        health_check['MeasureLatency'] = module.params.get('measure_latency')
+
     if missing_args:
         module.fail_json(msg='missing required arguments for creation: {0}'.format(
             ', '.join(missing_args)),
@@ -513,6 +534,7 @@ def main():
         health_check_id=dict(type='str', aliases=['id'], required=False),
         health_check_name=dict(type='str', aliases=['name'], required=False),
         use_unique_names=dict(type='bool', required=False),
+        measure_latency=dict(type='bool', required=False),
     )
 
     args_one_of = [

--- a/tests/integration/targets/route53_health_check/tasks/main.yml
+++ b/tests/integration/targets/route53_health_check/tasks/main.yml
@@ -1696,11 +1696,66 @@
       - delete_complex is successful
       - delete_complex is not changed
 
+  # Minimum possible definition
+  - name: 'Create a TCP health check with latency graphs enabled'
+    route53_health_check:
+      state: present
+      health_check_name: '{{ tiny_prefix }}-hc-latency-graph'
+      use_unique_names: true
+      ip_address: '{{ ip_address }}'
+      port: '{{ port }}'
+      type: '{{ type }}'
+      measure_latency: true
+    register: create_check
+
+  - name: Get health check info
+    amazon.aws.route53_info:
+      query: health_check
+      health_check_id: "{{ create_check.health_check.id }}"
+      health_check_method: details
+    register: health_check_info
+
+  - name: 'Check result - Create a TCP health check with latency graphs enabled'
+    assert:
+      that:
+      - create_check is successful
+      - create_check is changed
+      - health_check_info.health_check.health_check_config.measure_latency == true
+
+  - name: 'Update above health check to disable latency graphs - immutable, no change'
+    route53_health_check:
+      state: present
+      health_check_name: '{{ tiny_prefix }}-hc-latency-graph'
+      use_unique_names: true
+      ip_address: '{{ ip_address }}'
+      port: '{{ port }}'
+      type: '{{ type }}'
+      measure_latency: false
+    register: update_check
+
+  - name: 'Check result - Update TCP health check to disable latency graphs'
+    assert:
+      that:
+      - update_check is successful
+      - update_check is not changed
+      - health_check_info.health_check.health_check_config.measure_latency == true
+
   always:
 
     ################################################
     # TEARDOWN STARTS HERE
     ################################################
+
+  - name: 'Delete TCP health check with latency graphs enabled'
+    route53_health_check:
+      state: absent
+      health_check_name: '{{ tiny_prefix }}-hc-latency-graph'
+      use_unique_names: true
+      ip_address: '{{ ip_address }}'
+      port: '{{ port }}'
+      type: '{{ type }}'
+      measure_latency: true
+    ignore_errors: true
 
   - name: 'Delete TCP health check'
     route53_health_check:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1189 
Add support for enabling Latency graphs (MeasureLatency) during creation of a Route53 Health Check.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
route53_health_check

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

[You can't change the value of MeasureLatency after you create a health check.](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/route53.html#Route53.Client.update_health_check)