### PR TITLE
add pytest-forked to test requirements

### DIFF
--- a/changelogs/fragments/20221026-pytest-forked.yml
+++ b/changelogs/fragments/20221026-pytest-forked.yml
@@ -1,0 +1,2 @@
+trivial:
+- test-requirements - add pytest-forked to requirements for unit tests

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -5,9 +5,10 @@ coverage==4.5.4
 placebo
 mock
 pytest
-pytest-xdist
-# We should avoid these two modules with py3
+pytest-forked
 pytest-mock
+pytest-xdist
+
 # Needed for ansible.utils.ipaddr in tests
 netaddr
 # Sometimes needed where we don't have features we need in modules


### PR DESCRIPTION
##### SUMMARY

ansible-test is using `pytest --forked` we need the sub-module installed

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

test-requirements.txt

##### ADDITIONAL INFORMATION

See also: https://github.com/ansible/ansible/pull/76679