### PR TITLE
ec2_snapshot_info/tests: add unit-tests

### DIFF
--- a/changelogs/fragments/unit-tests_test_ec2_snapshot_info_only.yaml
+++ b/changelogs/fragments/unit-tests_test_ec2_snapshot_info_only.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "ec2_snapshot_info - Add unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1211)."

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -238,21 +238,26 @@ def list_ec2_snapshots(connection, module):
     if module.params.get('snapshot_ids'):
         snapshot_ids = module.params.get("snapshot_ids")
         params['SnapshotIds'] = snapshot_ids
+
     if module.params.get('owner_ids'):
         owner_ids = [str(owner_id) for owner_id in module.params.get("owner_ids")]
         params['OwnerIds'] = owner_ids
+
     if module.params.get('restorable_by_user_ids'):
         restorable_by_user_ids = [str(user_id) for user_id in module.params.get("restorable_by_user_ids")]
         params['RestorableByUserIds'] = restorable_by_user_ids
+
     if module.params.get('filters'):
         filters = ansible_dict_to_boto3_filter_list(module.params.get("filters"))
         params['Filters'] = filters
+
     if module.params.get('max_results'):
         max_results = module.params.get('max_results')
         params['MaxResults'] = max_results
-    if module.params.get('next_token'):
-        next_token = module.params.get('next_token')
-        params['NextToken'] = next_token
+
+    if module.params.get('next_token_id'):
+        next_token_id = module.params.get('next_token_id')
+        params['NextToken'] = next_token_id
 
     try:
         snapshots = _describe_snapshots(connection, module, **params)

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -270,7 +270,7 @@ def list_ec2_snapshots(connection, module, request_args):
     if snapshots.get('NextToken'):
         result.update(camel_dict_to_snake_dict({'NextTokenId': snapshots.get('NextToken')}))
 
-    module.exit_json(**result)
+    return result
 
 
 def main():
@@ -305,7 +305,9 @@ def main():
         snapshot_ids=module.params["snapshot_ids"],
     )
 
-    list_ec2_snapshots(connection, module, request_args)
+    result = list_ec2_snapshots(connection, module, request_args)
+
+    module.exit_json(**result)
 
 
 if __name__ == '__main__':

--- a/tests/unit/plugins/modules/test_ec2_snapshot_info.py
+++ b/tests/unit/plugins/modules/test_ec2_snapshot_info.py
@@ -2,18 +2,12 @@
 
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-from ansible_collections.amazon.aws.plugins.modules import ec2_snapshot_info
-from unittest.mock import MagicMock, Mock, patch, ANY, call
-import botocore.exceptions
 
+from unittest.mock import MagicMock, Mock, patch, ANY, call
+
+from ansible_collections.amazon.aws.plugins.modules import ec2_snapshot_info
 
 module_name = "ansible_collections.amazon.aws.plugins.modules.ec2_snapshot_info"
-
-
-def a_boto_exception():
-    return botocore.exceptions.UnknownServiceError(
-        service_name="Whoops", known_service_names="Oula"
-    )
 
 
 def test__describe_snapshots():
@@ -46,9 +40,11 @@ def test__describe_snapshots():
         "SnapshotIds": [ "snap-0f00cba1234567890" ]
     }
 
-    snapshots = ec2_snapshot_info._describe_snapshots(connection, module, **params)
+    snapshot_info = ec2_snapshot_info._describe_snapshots(connection, module, **params)
     connection.describe_snapshots.called_with(aws_retry=True,  SnapshotIds=[ "snap-0f00cba1234567890" ])
     assert connection.describe_snapshots.call_count == 1
+    assert len(snapshot_info['Snapshots']) > 0
+    assert 'SnapshotId' in snapshot_info['Snapshots'][0]
 
 
 @patch(module_name + "._describe_snapshots")

--- a/tests/unit/plugins/modules/test_ec2_snapshot_info.py
+++ b/tests/unit/plugins/modules/test_ec2_snapshot_info.py
@@ -10,7 +10,7 @@ from ansible_collections.amazon.aws.plugins.modules import ec2_snapshot_info
 module_name = "ansible_collections.amazon.aws.plugins.modules.ec2_snapshot_info"
 
 
-def test__describe_snapshots():
+def test_describe_snapshots():
     module = MagicMock()
     connection = MagicMock()
 
@@ -37,11 +37,12 @@ def test__describe_snapshots():
         ]}
 
     params = {
-        "SnapshotIds": [ "snap-0f00cba1234567890" ]
+        "SnapshotIds": ["snap-0f00cba1234567890"]
     }
 
     snapshot_info = ec2_snapshot_info._describe_snapshots(connection, module, **params)
-    connection.describe_snapshots.called_with(aws_retry=True,  SnapshotIds=[ "snap-0f00cba1234567890" ])
+
+    connection.describe_snapshots.assert_called_with(aws_retry=True, SnapshotIds=["snap-0f00cba1234567890"])
     assert connection.describe_snapshots.call_count == 1
     assert len(snapshot_info['Snapshots']) > 0
     assert 'SnapshotId' in snapshot_info['Snapshots'][0]
@@ -75,7 +76,7 @@ def test_get_snapshot_info_by_id(mock__describe_snapshots):
         ]}
 
     module.params = {
-        "snapshot_ids": [ "snap-0f00cba1234567890" ]
+        "snapshot_ids": ["snap-0f00cba1234567890"]
     }
 
     ec2_snapshot_info.list_ec2_snapshots(connection, module)
@@ -83,7 +84,7 @@ def test_get_snapshot_info_by_id(mock__describe_snapshots):
     assert mock__describe_snapshots.call_count == 1
     mock__describe_snapshots.assert_has_calls(
         [
-            call(connection, module, SnapshotIds=[ "snap-0f00cba1234567890" ]),
+            call(connection, module, SnapshotIds=["snap-0f00cba1234567890"]),
         ]
     )
 

--- a/tests/unit/plugins/modules/test_ec2_snapshot_info.py
+++ b/tests/unit/plugins/modules/test_ec2_snapshot_info.py
@@ -1,0 +1,102 @@
+# (c) 2022 Red Hat Inc.
+
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from ansible_collections.amazon.aws.plugins.modules import ec2_snapshot_info
+from unittest.mock import MagicMock, Mock, patch, ANY, call
+import botocore.exceptions
+
+
+module_name = "ansible_collections.amazon.aws.plugins.modules.ec2_snapshot_info"
+
+
+def a_boto_exception():
+    return botocore.exceptions.UnknownServiceError(
+        service_name="Whoops", known_service_names="Oula"
+    )
+
+
+def test__describe_snapshots():
+    module = MagicMock()
+    connection = MagicMock()
+
+    connection.describe_snapshots.return_value = {
+        "Snapshots": [
+            {
+                "Description": "Created by CreateImage(i-083b9dd1234567890) for ami-01486e111234567890",
+                "Encrypted": False,
+                "OwnerId": "123456789000",
+                "Progress": "100%",
+                "SnapshotId": "snap-0f00cba1234567890",
+                "StartTime": "2021-09-30T01:04:49.724000+00:00",
+                "State": "completed",
+                "StorageTier": "standard",
+                "Tags": [
+                    {
+                        'Key': 'TagKey',
+                        'Value': 'TagValue'
+                    },
+                ],
+                "VolumeId": "vol-0ae6c5e1234567890",
+                "VolumeSize": 10
+            }
+        ]}
+
+    params = {
+        "SnapshotIds": [ "snap-0f00cba1234567890" ]
+    }
+
+    snapshots = ec2_snapshot_info._describe_snapshots(connection, module, **params)
+    connection.describe_snapshots.called_with(aws_retry=True,  SnapshotIds=[ "snap-0f00cba1234567890" ])
+    assert connection.describe_snapshots.call_count == 1
+
+
+@patch(module_name + "._describe_snapshots")
+def test_get_snapshot_info_by_id(mock__describe_snapshots):
+    module = MagicMock()
+    connection = MagicMock()
+
+    mock__describe_snapshots.return_value = {
+        "Snapshots": [
+            {
+                "Description": "Created by CreateImage(i-083b9dd1234567890) for ami-01486e111234567890",
+                "Encrypted": False,
+                "OwnerId": "123456789000",
+                "Progress": "100%",
+                "SnapshotId": "snap-0f00cba1234567890",
+                "StartTime": "2021-09-30T01:04:49.724000+00:00",
+                "State": "completed",
+                "StorageTier": "standard",
+                "Tags": [
+                    {
+                        'Key': 'TagKey',
+                        'Value': 'TagValue'
+                    },
+                ],
+                "VolumeId": "vol-0ae6c5e1234567890",
+                "VolumeSize": 10
+            }
+        ]}
+
+    module.params = {
+        "snapshot_ids": [ "snap-0f00cba1234567890" ]
+    }
+
+    ec2_snapshot_info.list_ec2_snapshots(connection, module)
+
+    assert mock__describe_snapshots.call_count == 1
+    mock__describe_snapshots.assert_has_calls(
+        [
+            call(connection, module, SnapshotIds=[ "snap-0f00cba1234567890" ]),
+        ]
+    )
+
+
+@patch(module_name + ".AnsibleAWSModule")
+def test_main_success(m_AnsibleAWSModule):
+    m_module = MagicMock()
+    m_AnsibleAWSModule.return_value = m_module
+
+    ec2_snapshot_info.main()
+
+    m_module.client.assert_called_with("ec2", retry_decorator=ANY)


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/1234
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/1235

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Add the unit-test coverage of the ec2_snapshot_info module.
- break up `list_ec2_snapshots` to move `connection.describe_snapshots` to  separate method.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->



##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_snapshot_info

##### ADDITIONAL INFO
latest CI run coverage report  [plugins_modules_ec2_snapshot_info_py.html](https://e339f4533846914e22f6-06965a640df6d8f2fba9bf6cab32ee3a.ssl.cf5.rackcdn.com/1211/7c239aa4cd8f4b111c9afa4563d4d96c76091a1f/check/cloud-tox-py3/7416aa0/docs/coverage/plugins_modules_ec2_snapshot_info_py.html)