### PR TITLE
ec2_security_group - Deprecate automatic flattening of lists passed to cidr_ip and cidr_ipv6

### DIFF
--- a/changelogs/fragments/20221027-ec2_security_group-nested.yml
+++ b/changelogs/fragments/20221027-ec2_security_group-nested.yml
@@ -1,4 +1,4 @@
 deprecated_features:
 - >
   ec2_security_group - support for passing nested lists to ``cidr_ip`` and ``cidr_ipv6`` has been deprecated.
-  Nested lists can be passed through the ``flatten`` filter instead ``cidr_ip: '{{ my_cidrs | flatten }}'`` ().
+  Nested lists can be passed through the ``flatten`` filter instead ``cidr_ip: '{{ my_cidrs | flatten }}'`` (https://github.com/ansible-collections/amazon.aws/pull/1213).

--- a/changelogs/fragments/20221027-ec2_security_group-nested.yml
+++ b/changelogs/fragments/20221027-ec2_security_group-nested.yml
@@ -1,0 +1,4 @@
+deprecated_features:
+- >
+  ec2_security_group - support for passing nested lists to ``cidr_ip`` and ``cidr_ipv6`` has been deprecated.
+  Nested lists can be passed through the ``flatten`` filter instead ``cidr_ip: '{{ my_cidrs | flatten }}'`` ().

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -56,12 +56,16 @@ options:
             - The IPv4 CIDR range traffic is coming from.
             - You can specify only one of I(cidr_ip), I(cidr_ipv6), I(ip_prefix), I(group_id)
               and I(group_name).
+            - Support for passing nested lists of strings to I(cidr_ip) has been deprecated and will
+              be removed in a release after 2024-12-01.
         cidr_ipv6:
             type: str
             description:
             - The IPv6 CIDR range traffic is coming from.
             - You can specify only one of I(cidr_ip), I(cidr_ipv6), I(ip_prefix), I(group_id)
               and I(group_name).
+            - Support for passing nested lists of strings to I(cidr_ipv6) has been deprecated and will
+              be removed in a release after 2024-12-01.
         ip_prefix:
             type: str
             description:
@@ -142,12 +146,16 @@ options:
             - The IPv4 CIDR range traffic is going to.
             - You can specify only one of I(cidr_ip), I(cidr_ipv6), I(ip_prefix), I(group_id)
               and I(group_name).
+            - Support for passing nested lists of strings to I(cidr_ip) has been deprecated and will
+              be removed in a release after 2024-12-01.
         cidr_ipv6:
             type: str
             description:
             - The IPv6 CIDR range traffic is going to.
             - You can specify only one of I(cidr_ip), I(cidr_ipv6), I(ip_prefix), I(group_id)
               and I(group_name).
+            - Support for passing nested lists of strings to I(cidr_ipv6) has been deprecated and will
+              be removed in a release after 2024-12-01.
         ip_prefix:
             type: str
             description:
@@ -1213,6 +1221,9 @@ def flatten_nested_targets(module, rules):
     def _flatten(targets):
         for target in targets:
             if isinstance(target, list):
+                module.deprecate('Support for nested lists in cidr_ip and cidr_ipv6 has been '
+                                 'deprecated.  The flatten filter can be used instead.',
+                                 date='2024-12-01', collection_name='amazon.aws')
                 for t in _flatten(target):
                     yield t
             elif isinstance(target, string_types):


### PR DESCRIPTION
##### SUMMARY

`ec2_security_group` currently has its own "flatten" implementation built into the evaluation of `cidr_ip` and `cidr_ipv6`, which allows folks to do things like:

```
  - ec2_security_group:
      name: '{{ ec2_group_name }}'
      description: '{{ ec2_group_description }}'
      state: present
      rules:
      - proto: "tcp"
        from_port: 8182
        to_port: 8182
        cidr_ipv6:
          - "64:ff9b::/96"
          - ["2620::/32"]
      - proto: "tcp"
        ports: 5665
        cidr_ip:
          - 172.16.1.0/24
          - 172.16.17.0/24
          - ["10.0.0.0/24", "10.20.0.0/24"]
```

Support for this was originally added prior to the addition of the `flatten` filter in Ansible 2.5.  Behaviour like this isn't consistent with our other modules and adds additional complexity to an already very complex module.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_security_group

##### ADDITIONAL INFORMATION
