### PR TITLE
route53_health_check: bump up version_added for measure_latency

### DIFF
--- a/changelogs/fragments/1222-route53_health_check-bump-up-version_added.yml
+++ b/changelogs/fragments/1222-route53_health_check-bump-up-version_added.yml
@@ -1,0 +1,2 @@
+trivial:
+- route53_health_check - bump ``version_Added`` for ``measure_latency`` to ``5.2.0``.

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -120,7 +120,7 @@ options:
         See U(https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/monitoring-health-check-latency.html)
     type: bool
     required: False
-    version_added: 5.1.0
+    version_added: 5.2.0
 author:
   - "zimbatm (@zimbatm)"
 notes:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
With amazon.aws 5.1.0 release before merging #1201 , changing version_added for measure_latency to 5.2.0
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
route53_health_check