### PR TITLE
Move RetryingBotoClientWrapper into module_utils.retries

### DIFF
--- a/changelogs/fragments/1230-move-RetryingBotoClientWrapper.yml
+++ b/changelogs/fragments/1230-move-RetryingBotoClientWrapper.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Move RetryingBotoClientWrapper into module_utils.retries for reuse with other plugin types (https://github.com/ansible-collections/amazon.aws/pull/1230).

--- a/changelogs/fragments/1230-move-RetryingBotoClientWrapper.yml
+++ b/changelogs/fragments/1230-move-RetryingBotoClientWrapper.yml
@@ -1,2 +1,4 @@
 minor_changes:
-- Move RetryingBotoClientWrapper into module_utils.retries for reuse with other plugin types (https://github.com/ansible-collections/amazon.aws/pull/1230).
+- "module_utils - move RetryingBotoClientWrapper into module_utils.retries for reuse with other plugin types (https://github.com/ansible-collections/amazon.aws/pull/1230)."
+bugfixes:
+- "module_utils - fixes ``TypeError: deciding_wrapper() got multiple values for argument 'aws_retry'`` when passing positional arguments to functions wrapped by AnsibleAWSModule.client (https://github.com/ansible-collections/amazon.aws/pull/1230)."

--- a/plugins/module_utils/retries.py
+++ b/plugins/module_utils/retries.py
@@ -29,6 +29,8 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
+from functools import wraps
+
 try:
     from botocore.exceptions import ClientError
     HAS_BOTO3 = True
@@ -76,3 +78,36 @@ class AWSRetry(CloudRetry):
             retry_on.extend(catch_extra_error_codes)
 
         return response_code in retry_on
+
+
+class RetryingBotoClientWrapper(object):
+    __never_wait = (
+        'get_paginator', 'can_paginate',
+        'get_waiter', 'generate_presigned_url',
+    )
+
+    def __init__(self, client, retry):
+        self.client = client
+        self.retry = retry
+
+    def _create_optional_retry_wrapper_function(self, unwrapped):
+        retrying_wrapper = self.retry(unwrapped)
+
+        @wraps(unwrapped)
+        def deciding_wrapper(aws_retry=False, *args, **kwargs):
+            if aws_retry:
+                return retrying_wrapper(*args, **kwargs)
+            else:
+                return unwrapped(*args, **kwargs)
+        return deciding_wrapper
+
+    def __getattr__(self, name):
+        unwrapped = getattr(self.client, name)
+        if name in self.__never_wait:
+            return unwrapped
+        elif callable(unwrapped):
+            wrapped = self._create_optional_retry_wrapper_function(unwrapped)
+            setattr(self, name, wrapped)
+            return wrapped
+        else:
+            return unwrapped

--- a/plugins/module_utils/retries.py
+++ b/plugins/module_utils/retries.py
@@ -94,7 +94,7 @@ class RetryingBotoClientWrapper(object):
         retrying_wrapper = self.retry(unwrapped)
 
         @wraps(unwrapped)
-        def deciding_wrapper(aws_retry=False, *args, **kwargs):
+        def deciding_wrapper(*args, aws_retry=False, **kwargs):
             if aws_retry:
                 return retrying_wrapper(*args, **kwargs)
             else:

--- a/plugins/module_utils/waiters.py
+++ b/plugins/module_utils/waiters.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     pass  # caught by HAS_BOTO3
 
-from ansible_collections.amazon.aws.plugins.module_utils.modules import _RetryingBotoClientWrapper
+from ansible_collections.amazon.aws.plugins.module_utils.retries import RetryingBotoClientWrapper
 
 
 ec2_data = {
@@ -1256,7 +1256,7 @@ waiters_by_name = {
 
 
 def get_waiter(client, waiter_name):
-    if isinstance(client, _RetryingBotoClientWrapper):
+    if isinstance(client, RetryingBotoClientWrapper):
         return get_waiter(client.client, waiter_name)
     try:
         return waiters_by_name[(client.__class__.__name__, waiter_name)](client)

--- a/tests/unit/module_utils/retries/test_botocore_exception_maybe.py
+++ b/tests/unit/module_utils/retries/test_botocore_exception_maybe.py
@@ -1,0 +1,21 @@
+# (c) 2022 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+try:
+    import botocore
+except ImportError:
+    pass
+
+import ansible_collections.amazon.aws.plugins.module_utils.retries as util_retries
+
+
+def test_botocore_exception_maybe(monkeypatch):
+    none_type = type(None)
+    assert util_retries._botocore_exception_maybe() is botocore.exceptions.ClientError
+    monkeypatch.setattr(util_retries, 'HAS_BOTO3', False)
+    assert util_retries._botocore_exception_maybe() is none_type

--- a/tests/unit/module_utils/retries/test_retry_wrapper.py
+++ b/tests/unit/module_utils/retries/test_retry_wrapper.py
@@ -1,0 +1,269 @@
+# (c) 2022 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+from unittest.mock import call
+from unittest.mock import sentinel
+from unittest.mock import MagicMock
+
+try:
+    import botocore
+except ImportError:
+    pass
+
+import ansible_collections.amazon.aws.plugins.module_utils.retries as util_retries
+import ansible_collections.amazon.aws.plugins.module_utils.botocore as util_botocore
+
+
+@pytest.fixture
+def fake_client():
+    retryable_response = {'Error': {'Code': 'RequestLimitExceeded', 'Message': 'Something went wrong'}}
+    retryable_exception = botocore.exceptions.ClientError(retryable_response, 'fail_retryable')
+    not_retryable_response = {'Error': {'Code': 'AnotherProblem', 'Message': 'Something went wrong'}}
+    not_retryable_exception = botocore.exceptions.ClientError(not_retryable_response, 'fail_not_retryable')
+
+    client = MagicMock()
+
+    client.fail_retryable.side_effect = retryable_exception
+    client.fail_not_retryable.side_effect = not_retryable_exception
+    client.my_attribute = sentinel.ATTRIBUTE
+    client.successful.return_value = sentinel.RETURNED_SUCCESSFUL
+
+    return client
+
+
+@pytest.fixture
+def quick_backoff():
+    # Because RetryingBotoClientWrapper will wrap resources using the this decorator,
+    # we're going to rely on AWSRetry.jittered_backoff rather than trying to mock out
+    # a decorator use a really short delay to keep the tests quick, and we only need
+    # to actually retry once
+    retry = util_retries.AWSRetry.jittered_backoff(retries=2, delay=0.1)
+    return retry
+
+
+def test_retry_wrapper_non_callable(fake_client, quick_backoff):
+    wrapped_client = util_retries.RetryingBotoClientWrapper(fake_client, quick_backoff)
+
+    # non-callable's shouldn't be wrapped, we should just get them back
+    assert wrapped_client.my_attribute is sentinel.ATTRIBUTE
+
+
+def test_retry_wrapper_callable(fake_client, quick_backoff):
+    # Minimal test: not testing the aws_retry=True behaviour
+    # (In general) callables should be wrapped
+    wrapped_client = util_retries.RetryingBotoClientWrapper(fake_client, quick_backoff)
+
+    assert isinstance(fake_client.fail_retryable, MagicMock)
+    assert not isinstance(wrapped_client.fail_retryable, MagicMock)
+    assert callable(wrapped_client.fail_retryable)
+    with pytest.raises(botocore.exceptions.ClientError) as e:
+        wrapped_client.fail_retryable()
+    boto3_code = util_botocore.is_boto3_error_code('RequestLimitExceeded', e=e.value)
+    boto3_message = util_botocore.is_boto3_error_message('Something went wrong', e=e.value)
+    assert boto3_code is botocore.exceptions.ClientError
+    assert boto3_message is botocore.exceptions.ClientError
+    assert fake_client.fail_retryable.called
+    assert fake_client.fail_retryable.call_count == 1
+
+    assert isinstance(fake_client.fail_not_retryable, MagicMock)
+    assert not isinstance(wrapped_client.fail_not_retryable, MagicMock)
+    assert callable(wrapped_client.fail_not_retryable)
+    with pytest.raises(botocore.exceptions.ClientError) as e:
+        wrapped_client.fail_not_retryable()
+    boto3_code = util_botocore.is_boto3_error_code('AnotherProblem', e=e.value)
+    boto3_message = util_botocore.is_boto3_error_message('Something went wrong', e=e.value)
+    assert boto3_code is botocore.exceptions.ClientError
+    assert boto3_message is botocore.exceptions.ClientError
+    assert fake_client.fail_not_retryable.called
+    assert fake_client.fail_not_retryable.call_count == 1
+
+    assert isinstance(fake_client.successful, MagicMock)
+    assert not isinstance(wrapped_client.successful, MagicMock)
+    assert callable(fake_client.successful)
+    assert wrapped_client.successful() is sentinel.RETURNED_SUCCESSFUL
+    assert fake_client.successful.called
+    assert fake_client.successful.call_count == 1
+
+
+def test_retry_wrapper_never_wrap(fake_client, quick_backoff):
+    wrapped_client = util_retries.RetryingBotoClientWrapper(fake_client, quick_backoff)
+
+    assert isinstance(fake_client.get_paginator, MagicMock)
+    assert isinstance(wrapped_client.get_paginator, MagicMock)
+    assert wrapped_client.get_paginator is fake_client.get_paginator
+
+
+def test_retry_wrapper_no_retry_no_args(fake_client, quick_backoff):
+    # Minimal test: not testing the aws_retry=True behaviour
+    # (In general) callables should be wrapped
+    wrapped_client = util_retries.RetryingBotoClientWrapper(fake_client, quick_backoff)
+    call_args = call()
+
+    assert isinstance(fake_client.fail_retryable, MagicMock)
+    assert not isinstance(wrapped_client.fail_retryable, MagicMock)
+    assert callable(wrapped_client.fail_retryable)
+    with pytest.raises(botocore.exceptions.ClientError) as e:
+        wrapped_client.fail_retryable(aws_retry=False)
+    boto3_code = util_botocore.is_boto3_error_code('RequestLimitExceeded', e=e.value)
+    boto3_message = util_botocore.is_boto3_error_message('Something went wrong', e=e.value)
+    assert boto3_code is botocore.exceptions.ClientError
+    assert boto3_message is botocore.exceptions.ClientError
+    assert fake_client.fail_retryable.called
+    assert fake_client.fail_retryable.call_count == 1
+    assert fake_client.fail_retryable.call_args_list == [call_args]
+
+    assert isinstance(fake_client.fail_not_retryable, MagicMock)
+    assert not isinstance(wrapped_client.fail_not_retryable, MagicMock)
+    assert callable(wrapped_client.fail_not_retryable)
+    with pytest.raises(botocore.exceptions.ClientError) as e:
+        wrapped_client.fail_not_retryable(aws_retry=False)
+    boto3_code = util_botocore.is_boto3_error_code('AnotherProblem', e=e.value)
+    boto3_message = util_botocore.is_boto3_error_message('Something went wrong', e=e.value)
+    assert boto3_code is botocore.exceptions.ClientError
+    assert boto3_message is botocore.exceptions.ClientError
+    assert fake_client.fail_not_retryable.called
+    assert fake_client.fail_not_retryable.call_count == 1
+    assert fake_client.fail_not_retryable.call_args_list == [call_args]
+
+    assert isinstance(fake_client.successful, MagicMock)
+    assert not isinstance(wrapped_client.successful, MagicMock)
+    assert callable(fake_client.successful)
+    assert wrapped_client.successful(aws_retry=False) is sentinel.RETURNED_SUCCESSFUL
+    assert fake_client.successful.called
+    assert fake_client.successful.call_count == 1
+    assert fake_client.successful.call_args_list == [call_args]
+
+
+def test_retry_wrapper_retry_no_args(fake_client, quick_backoff):
+    # Minimal test: not testing the aws_retry=True behaviour
+    # (In general) callables should be wrapped
+    wrapped_client = util_retries.RetryingBotoClientWrapper(fake_client, quick_backoff)
+    call_args = call()
+
+    assert isinstance(fake_client.fail_retryable, MagicMock)
+    assert not isinstance(wrapped_client.fail_retryable, MagicMock)
+    assert callable(wrapped_client.fail_retryable)
+    with pytest.raises(botocore.exceptions.ClientError) as e:
+        wrapped_client.fail_retryable(aws_retry=True)
+    boto3_code = util_botocore.is_boto3_error_code('RequestLimitExceeded', e=e.value)
+    boto3_message = util_botocore.is_boto3_error_message('Something went wrong', e=e.value)
+    assert boto3_code is botocore.exceptions.ClientError
+    assert boto3_message is botocore.exceptions.ClientError
+    assert fake_client.fail_retryable.called
+    assert fake_client.fail_retryable.call_count == 2
+    assert fake_client.fail_retryable.call_args_list == [call_args, call_args]
+
+    assert isinstance(fake_client.fail_not_retryable, MagicMock)
+    assert not isinstance(wrapped_client.fail_not_retryable, MagicMock)
+    assert callable(wrapped_client.fail_not_retryable)
+    with pytest.raises(botocore.exceptions.ClientError) as e:
+        wrapped_client.fail_not_retryable(aws_retry=True)
+    boto3_code = util_botocore.is_boto3_error_code('AnotherProblem', e=e.value)
+    boto3_message = util_botocore.is_boto3_error_message('Something went wrong', e=e.value)
+    assert boto3_code is botocore.exceptions.ClientError
+    assert boto3_message is botocore.exceptions.ClientError
+    assert fake_client.fail_not_retryable.called
+    assert fake_client.fail_not_retryable.call_count == 1
+    assert fake_client.fail_not_retryable.call_args_list == [call_args]
+
+    assert isinstance(fake_client.successful, MagicMock)
+    assert not isinstance(wrapped_client.successful, MagicMock)
+    assert callable(fake_client.successful)
+    assert wrapped_client.successful(aws_retry=True) is sentinel.RETURNED_SUCCESSFUL
+    assert fake_client.successful.called
+    assert fake_client.successful.call_count == 1
+    assert fake_client.successful.call_args_list == [call_args]
+
+
+def test_retry_wrapper_no_retry_args(fake_client, quick_backoff):
+    # Minimal test: not testing the aws_retry=True behaviour
+    # (In general) callables should be wrapped
+    wrapped_client = util_retries.RetryingBotoClientWrapper(fake_client, quick_backoff)
+    args = [sentinel.ARG_1, sentinel.ARG_2]
+    kwargs = {'kw1': sentinel.KWARG_1, 'kw2': sentinel.KWARG_2}
+    # aws_retry=False shouldn't be passed to the 'wrapped' call
+    call_args = call(*args, **kwargs)
+
+    assert isinstance(fake_client.fail_retryable, MagicMock)
+    assert not isinstance(wrapped_client.fail_retryable, MagicMock)
+    assert callable(wrapped_client.fail_retryable)
+    with pytest.raises(botocore.exceptions.ClientError) as e:
+        wrapped_client.fail_retryable(*args, aws_retry=False, **kwargs)
+    boto3_code = util_botocore.is_boto3_error_code('RequestLimitExceeded', e=e.value)
+    boto3_message = util_botocore.is_boto3_error_message('Something went wrong', e=e.value)
+    assert boto3_code is botocore.exceptions.ClientError
+    assert boto3_message is botocore.exceptions.ClientError
+    assert fake_client.fail_retryable.called
+    assert fake_client.fail_retryable.call_count == 1
+    assert fake_client.fail_retryable.call_args_list == [call_args]
+
+    assert isinstance(fake_client.fail_not_retryable, MagicMock)
+    assert not isinstance(wrapped_client.fail_not_retryable, MagicMock)
+    assert callable(wrapped_client.fail_not_retryable)
+    with pytest.raises(botocore.exceptions.ClientError) as e:
+        wrapped_client.fail_not_retryable(*args, aws_retry=False, **kwargs)
+    boto3_code = util_botocore.is_boto3_error_code('AnotherProblem', e=e.value)
+    boto3_message = util_botocore.is_boto3_error_message('Something went wrong', e=e.value)
+    assert boto3_code is botocore.exceptions.ClientError
+    assert boto3_message is botocore.exceptions.ClientError
+    assert fake_client.fail_not_retryable.called
+    assert fake_client.fail_not_retryable.call_count == 1
+    assert fake_client.fail_not_retryable.call_args_list == [call_args]
+
+    assert isinstance(fake_client.successful, MagicMock)
+    assert not isinstance(wrapped_client.successful, MagicMock)
+    assert callable(fake_client.successful)
+    assert wrapped_client.successful(*args, aws_retry=False, **kwargs) is sentinel.RETURNED_SUCCESSFUL
+    assert fake_client.successful.called
+    assert fake_client.successful.call_count == 1
+    assert fake_client.successful.call_args_list == [call_args]
+
+
+def test_retry_wrapper_retry_no_args(fake_client, quick_backoff):
+    # Minimal test: not testing the aws_retry=True behaviour
+    # (In general) callables should be wrapped
+    wrapped_client = util_retries.RetryingBotoClientWrapper(fake_client, quick_backoff)
+    args = [sentinel.ARG_1, sentinel.ARG_2]
+    kwargs = {'kw1': sentinel.KWARG_1, 'kw2': sentinel.KWARG_2}
+    # aws_retry=True shouldn't be passed to the 'wrapped' call
+    call_args = call(*args, **kwargs)
+
+    assert isinstance(fake_client.fail_retryable, MagicMock)
+    assert not isinstance(wrapped_client.fail_retryable, MagicMock)
+    assert callable(wrapped_client.fail_retryable)
+    with pytest.raises(botocore.exceptions.ClientError) as e:
+        wrapped_client.fail_retryable(*args, aws_retry=True, **kwargs)
+    boto3_code = util_botocore.is_boto3_error_code('RequestLimitExceeded', e=e.value)
+    boto3_message = util_botocore.is_boto3_error_message('Something went wrong', e=e.value)
+    assert boto3_code is botocore.exceptions.ClientError
+    assert boto3_message is botocore.exceptions.ClientError
+    assert fake_client.fail_retryable.called
+    assert fake_client.fail_retryable.call_count == 2
+    assert fake_client.fail_retryable.call_args_list == [call_args, call_args]
+
+    assert isinstance(fake_client.fail_not_retryable, MagicMock)
+    assert not isinstance(wrapped_client.fail_not_retryable, MagicMock)
+    assert callable(wrapped_client.fail_not_retryable)
+    with pytest.raises(botocore.exceptions.ClientError) as e:
+        wrapped_client.fail_not_retryable(*args, aws_retry=True, **kwargs)
+    boto3_code = util_botocore.is_boto3_error_code('AnotherProblem', e=e.value)
+    boto3_message = util_botocore.is_boto3_error_message('Something went wrong', e=e.value)
+    assert boto3_code is botocore.exceptions.ClientError
+    assert boto3_message is botocore.exceptions.ClientError
+    assert fake_client.fail_not_retryable.called
+    assert fake_client.fail_not_retryable.call_count == 1
+    assert fake_client.fail_not_retryable.call_args_list == [call_args]
+
+    assert isinstance(fake_client.successful, MagicMock)
+    assert not isinstance(wrapped_client.successful, MagicMock)
+    assert callable(fake_client.successful)
+    assert wrapped_client.successful(*args, aws_retry=True, **kwargs) is sentinel.RETURNED_SUCCESSFUL
+    assert fake_client.successful.called
+    assert fake_client.successful.call_count == 1
+    assert fake_client.successful.call_args_list == [call_args]

--- a/tests/unit/plugins/modules/test_cloudformation.py
+++ b/tests/unit/plugins/modules/test_cloudformation.py
@@ -13,7 +13,7 @@ import pytest
 from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import maybe_sleep, placeboify  # pylint: disable=unused-import
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import boto_exception
-from ansible_collections.amazon.aws.plugins.module_utils.modules import _RetryingBotoClientWrapper
+from ansible_collections.amazon.aws.plugins.module_utils.retries import RetryingBotoClientWrapper
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 
 from ansible_collections.amazon.aws.plugins.modules import cloudformation as cfn_module
@@ -84,7 +84,7 @@ class FakeModule(object):
 def _create_wrapped_client(placeboify):
     connection = placeboify.client('cloudformation')
     retry_decorator = AWSRetry.jittered_backoff()
-    wrapped_conn = _RetryingBotoClientWrapper(connection, retry_decorator)
+    wrapped_conn = RetryingBotoClientWrapper(connection, retry_decorator)
     return wrapped_conn
 
 


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.aws/pull/1579

##### SUMMARY

Move RetryingBotoClientWrapper into module_utils.retries
This means we can use it later with non-module plugins

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/modules.py
plugins/module_utils/retries.py
plugins/module_utils/waiters.py

##### ADDITIONAL INFORMATION
