### PR TITLE
ec2_eni_info/tests: add unit-tests

### DIFF
--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -218,7 +218,7 @@ def build_request_args(eni_id, filters):
 
 def get_network_interfaces(connection, module, request_args):
     try:
-        network_interfaces_result = connection.describe_network_interfaces(aws_retry=True, **request_args)['NetworkInterfaces']
+        network_interfaces_result = connection.describe_network_interfaces(aws_retry=True, **request_args)
     except is_boto3_error_code('InvalidNetworkInterfaceID.NotFound'):
         module.exit_json(network_interfaces=[])
     except (ClientError, NoCredentialsError) as e:  # pylint: disable=duplicate-except
@@ -233,7 +233,7 @@ def list_eni(connection, module, request_args):
 
     # Modify boto3 tags list to be ansible friendly dict and then camel_case
     camel_network_interfaces = []
-    for network_interface in network_interfaces_result:
+    for network_interface in network_interfaces_result['NetworkInterfaces']:
         network_interface['TagSet'] = boto3_tag_list_to_ansible_dict(network_interface['TagSet'])
         network_interface['Tags'] = network_interface['TagSet']
         if 'Name' in network_interface['Tags']:

--- a/tests/unit/plugins/modules/test_ec2_eni_info.py
+++ b/tests/unit/plugins/modules/test_ec2_eni_info.py
@@ -3,7 +3,7 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from unittest.mock import MagicMock, patch, ANY
+from unittest.mock import MagicMock, patch, ANY, call
 import pytest
 
 from ansible_collections.amazon.aws.plugins.modules import ec2_eni_info
@@ -23,33 +23,33 @@ def test_get_network_interfaces():
     connection.describe_network_interfaces.return_value = {
         'NetworkInterfaces': [
             {
-            "AvailabilityZone": "us-east-2b",
-            "Description": "",
-            "Groups": [
-                {
-                "GroupId": "sg-05db20a1234567890",
-                "GroupName": "TestGroup1"
-                }
-            ],
-            "InterfaceType": "interface",
-            "Ipv6Addresses": [],
-            "MacAddress": "00:11:66:77:11:bb",
-            "NetworkInterfaceId": "eni-1234567890",
-            "OwnerId": "1234567890",
-            "PrivateIpAddress": "11.22.33.44",
-            "PrivateIpAddresses": [
-                {
-                "Primary": "True",
-                "PrivateIpAddress": "11.22.33.44"
-                }
-            ],
-            "RequesterManaged": False,
-            "SourceDestCheck": True,
-            "Status": "available",
-            "SubnetId": "subnet-07d906b8358869bda",
-            "TagSet": [],
-            "VpcId": "vpc-0cb60952be96c9cd8"
-            },
+                "AvailabilityZone": "us-east-2b",
+                "Description": "",
+                "Groups": [
+                    {
+                    "GroupId": "sg-05db20a1234567890",
+                    "GroupName": "TestGroup1"
+                    }
+                ],
+                "InterfaceType": "interface",
+                "Ipv6Addresses": [],
+                "MacAddress": "00:11:66:77:11:bb",
+                "NetworkInterfaceId": "eni-1234567890",
+                "OwnerId": "1234567890",
+                "PrivateIpAddress": "11.22.33.44",
+                "PrivateIpAddresses": [
+                    {
+                    "Primary": "True",
+                    "PrivateIpAddress": "11.22.33.44"
+                    }
+                ],
+                "RequesterManaged": False,
+                "SourceDestCheck": True,
+                "Status": "available",
+                "SubnetId": "subnet-07d906b8358869bda",
+                "TagSet": [],
+                "VpcId": "vpc-0cb60952be96c9cd8"
+            }
         ]
     }
 
@@ -60,6 +60,106 @@ def test_get_network_interfaces():
     connection.describe_network_interfaces.call_count == 1
     connection.describe_network_interfaces.assert_called_with(aws_retry=True, **request_args)
     assert len(network_interfaces_result['NetworkInterfaces']) == 1
+
+
+@patch(module_name + '.get_network_interfaces')
+@patch(module_name + '.build_request_args')
+def test_list_eni(m_build_request_args, m_get_network_interfaces):
+    connection = MagicMock()
+    module = MagicMock()
+
+    m_build_request_args.return_value ={
+        'Filters': [{
+            'Name': 'owner-id',
+            'Values': [
+                '1234567890'
+            ]
+        }]
+    }
+
+    m_get_network_interfaces.return_value = {
+        'NetworkInterfaces': [
+            {
+                "AvailabilityZone": "us-east-2b",
+                "Description": "",
+                "Groups": [
+                    {
+                    "GroupId": "sg-05db20a1234567890",
+                    "GroupName": "TestGroup1"
+                    }
+                ],
+                "InterfaceType": "interface",
+                "Ipv6Addresses": [],
+                "MacAddress": "00:11:66:77:11:bb",
+                "NetworkInterfaceId": "eni-1234567890",
+                "OwnerId": "1234567890",
+                "PrivateIpAddress": "11.22.33.44",
+                "PrivateIpAddresses": [
+                    {
+                    "Primary": "True",
+                    "PrivateIpAddress": "11.22.33.44"
+                    }
+                ],
+                "RequesterManaged": False,
+                "SourceDestCheck": True,
+                "Status": "available",
+                "SubnetId": "subnet-07d906b8358869bda",
+                "TagSet": [],
+                "VpcId": "vpc-0cb60952be96c9cd8"
+            },
+            {
+                "AvailabilityZone": "us-east-2b",
+                "Description": "",
+                "Groups": [
+                    {
+                    "GroupId": "sg-05db20a1234567890",
+                    "GroupName": "TestGroup1"
+                    }
+                ],
+                "InterfaceType": "interface",
+                "Ipv6Addresses": [],
+                "MacAddress": "00:11:66:77:11:bb",
+                "NetworkInterfaceId": "eni-0987654321",
+                "OwnerId": "1234567890",
+                "PrivateIpAddress": "11.22.33.44",
+                "PrivateIpAddresses": [
+                    {
+                    "Primary": "True",
+                    "PrivateIpAddress": "11.22.33.44"
+                    }
+                ],
+                "RequesterManaged": False,
+                "SourceDestCheck": True,
+                "Status": "available",
+                "SubnetId": "subnet-07d906b8358869bda",
+                "TagSet": [{
+                        'Key': 'Name',
+                        'Value': 'my-test-eni-name'
+                    },],
+                "VpcId": "vpc-0cb60952be96c9cd8"
+            },
+        ]
+    }
+
+    request_args = ec2_eni_info.build_request_args()
+
+    camel_network_interfaces = ec2_eni_info.list_eni(connection, module, request_args)
+
+    m_get_network_interfaces.call_count == 1
+    m_get_network_interfaces.assert_has_calls(
+        [
+            call(connection, module, request_args),
+        ]
+    )
+    assert len(camel_network_interfaces) == 2
+
+    assert camel_network_interfaces[0].get('id', None) == 'eni-1234567890'
+    assert camel_network_interfaces[0].get('tags', None) == {}
+    assert camel_network_interfaces[0].get('name', None) == None
+
+    assert camel_network_interfaces[1].get('id', None) == 'eni-0987654321'
+    assert camel_network_interfaces[1].get('tags', None) == {'Name' : 'my-test-eni-name'}
+    assert camel_network_interfaces[1].get('name', None) == 'my-test-eni-name'
 
 
 @patch(module_name + ".AnsibleAWSModule")

--- a/tests/unit/plugins/modules/test_ec2_eni_info.py
+++ b/tests/unit/plugins/modules/test_ec2_eni_info.py
@@ -16,6 +16,52 @@ def test_build_request_args(eni_id, filters, expected):
     assert ec2_eni_info.build_request_args(eni_id, filters) == expected
 
 
+def test_get_network_interfaces():
+    connection = MagicMock()
+    module = MagicMock()
+
+    connection.describe_network_interfaces.return_value = {
+        'NetworkInterfaces': [
+            {
+            "AvailabilityZone": "us-east-2b",
+            "Description": "",
+            "Groups": [
+                {
+                "GroupId": "sg-05db20a1234567890",
+                "GroupName": "TestGroup1"
+                }
+            ],
+            "InterfaceType": "interface",
+            "Ipv6Addresses": [],
+            "MacAddress": "00:11:66:77:11:bb",
+            "NetworkInterfaceId": "eni-1234567890",
+            "OwnerId": "1234567890",
+            "PrivateIpAddress": "11.22.33.44",
+            "PrivateIpAddresses": [
+                {
+                "Primary": "True",
+                "PrivateIpAddress": "11.22.33.44"
+                }
+            ],
+            "RequesterManaged": False,
+            "SourceDestCheck": True,
+            "Status": "available",
+            "SubnetId": "subnet-07d906b8358869bda",
+            "TagSet": [],
+            "VpcId": "vpc-0cb60952be96c9cd8"
+            },
+        ]
+    }
+
+    request_args = {'NetworkInterfaceIds': ['eni-1234567890']}
+
+    network_interfaces_result = ec2_eni_info.get_network_interfaces(connection, module, request_args)
+
+    connection.describe_network_interfaces.call_count == 1
+    connection.describe_network_interfaces.assert_called_with(aws_retry=True, **request_args)
+    assert len(network_interfaces_result['NetworkInterfaces']) == 1
+
+
 @patch(module_name + ".AnsibleAWSModule")
 def test_main_success(m_AnsibleAWSModule):
     m_module = MagicMock()

--- a/tests/unit/plugins/modules/test_ec2_eni_info.py
+++ b/tests/unit/plugins/modules/test_ec2_eni_info.py
@@ -1,0 +1,26 @@
+# (c) 2022 Red Hat Inc.
+
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock, patch, ANY
+import pytest
+
+from ansible_collections.amazon.aws.plugins.modules import ec2_eni_info
+
+module_name = "ansible_collections.amazon.aws.plugins.modules.ec2_eni_info"
+
+
+@pytest.mark.parametrize("eni_id,filters,expected", [('', {}, {}), ('eni-1234567890', {}, {'NetworkInterfaceIds': ['eni-1234567890']})])
+def test_build_request_args(eni_id, filters, expected):
+    assert ec2_eni_info.build_request_args(eni_id, filters) == expected
+
+
+@patch(module_name + ".AnsibleAWSModule")
+def test_main_success(m_AnsibleAWSModule):
+    m_module = MagicMock()
+    m_AnsibleAWSModule.return_value = m_module
+
+    ec2_eni_info.main()
+
+    m_module.client.assert_called_with("ec2", retry_decorator=ANY)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Add the unit-test coverage of the ec2_eni_info module.
- break up list_eni to move connection.describe_network_interfaces to separate method.
- refactor ec2_eni_info module
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_eni_info
