### PR TITLE
clean up 1129-disable-rds_cluster.yml changelog fragment

### DIFF
--- a/changelogs/fragments/1129-disable-rds_cluster.yml
+++ b/changelogs/fragments/1129-disable-rds_cluster.yml
@@ -1,2 +1,0 @@
-trivial:
-- rds_cluster - disable integration tests (https://github.com/ansible-collections/amazon.aws/pull/1229)


### PR DESCRIPTION
The patch has been reverted in ac164b64d69169067650b3be1d0af3bd0bc72157 and we
don't need the changelog fragment anymore.
