### PR TITLE
rds/tests: mariadb 10.3.31 is not available anymore

### DIFF
--- a/tests/integration/targets/rds_instance_complex/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_complex/defaults/main.yml
@@ -13,4 +13,4 @@ storage_type: io1
 iops: 1000
 
 # For mariadb tests
-mariadb_engine_version: 10.3.31
+mariadb_engine_version: 10.6.10

--- a/tests/integration/targets/rds_instance_modify/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_modify/defaults/main.yml
@@ -6,4 +6,4 @@ db_instance_class: db.t3.micro
 allocated_storage: 20
 
 # For mariadb tests
-mariadb_engine_version: 10.3.31
+mariadb_engine_version: 10.6.10

--- a/tests/integration/targets/rds_instance_snapshot/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_snapshot/defaults/main.yml
@@ -8,7 +8,8 @@ password: "{{ lookup('password', '/dev/null') }}"
 db_instance_class: db.t3.micro
 allocated_storage: 10
 engine: 'mariadb'
-mariadb_engine_version: 10.3.31
+mariadb_engine_version: 10.6.10
+
 
 # Create snapshot
 snapshot_id: '{{ instance_id }}-snapshot'

--- a/tests/integration/targets/rds_instance_upgrade/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_upgrade/defaults/main.yml
@@ -6,5 +6,5 @@ db_instance_class: db.t3.micro
 allocated_storage: 20
 
 # For mariadb tests
-mariadb_engine_version: 10.3.31
+mariadb_engine_version: 10.4.26
 mariadb_engine_version_2: 10.4.21


### PR DESCRIPTION
MariaDB 10.3.31 is not available anymore. This results in the following exception:

```
botocore.exceptions.ClientError: An error occurred (InvalidParameterCombination) when calling the CreateDBInstance operation: Cannot find version 10.3.31 for mariadb
```

To get a list of the version available:

```console
$ aws rds describe-db-engine-versions --engine mariadb --query "DBEngineVersions[].EngineVersion"
```
