### PR TITLE
ec2_security_group - fix bug in handling of `ports: -1`

### DIFF
--- a/changelogs/fragments/20221103-ec2_security_group_-1.yml
+++ b/changelogs/fragments/20221103-ec2_security_group_-1.yml
@@ -1,0 +1,2 @@
+trivial:
+- 'ec2_security_group - fix unreleased bug in support for ``ports: -1`` (https://github.com/ansible-collections/amazon.aws/pull/1241).'

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -842,12 +842,14 @@ def ports_expand(ports):
     # takes a list of ports and returns a list of (port_from, port_to)
     ports_expanded = []
     for port in ports:
-        if not isinstance(port, string_types):
-            ports_expanded.append((port,) * 2)
-        elif '-' in port:
-            ports_expanded.append(tuple(int(p.strip()) for p in port.split('-', 1)))
-        else:
+        try:
             ports_expanded.append((int(port.strip()),) * 2)
+        except ValueError as e:
+            # Someone passed a range
+            if '-' in port:
+                ports_expanded.append(tuple(int(p.strip()) for p in port.split('-', 1)))
+            else:
+                raise e
 
     return ports_expanded
 

--- a/tests/integration/targets/ec2_security_group/tasks/numeric_protos.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/numeric_protos.yml
@@ -14,6 +14,9 @@
           to_port: -1
           from_port: -1
           cidr_ip: 0.0.0.0/0
+        - proto: -1
+          ports: -1
+          cidr_ip: 0.0.0.0/0
         state: present
       register: result
 
@@ -26,6 +29,9 @@
         - proto: '47'
           to_port: -1
           from_port: -1
+          cidr_ip: 0.0.0.0/0
+        - proto: -1
+          ports: -1
           cidr_ip: 0.0.0.0/0
         state: present
       register: result


### PR DESCRIPTION
##### SUMMARY

Before we defined a schema for rules YAML would guess that `-1` was an integer.  With ports is explicitly defined as a string it was trying to handle `-1` as a range, rather than an integer

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_security_group

##### ADDITIONAL INFORMATION
