### PR TITLE
More integration test timing

### DIFF
--- a/changelogs/fragments/20221103-tests.yml
+++ b/changelogs/fragments/20221103-tests.yml
@@ -1,0 +1,3 @@
+trivial:
+- ec2_eip - mark tests as unstable, they keep failing when run in parallel with other tests
+- rds_instance_states - increase time allowed for integration test

--- a/tests/integration/targets/ec2_eip/aliases
+++ b/tests/integration/targets/ec2_eip/aliases
@@ -1,5 +1,4 @@
-# https://github.com/ansible-collections/community.aws/issues/159
-# unstable
+unstable
 
 cloud/aws
 ec2_eip_info

--- a/tests/integration/targets/rds_instance_states/aliases
+++ b/tests/integration/targets/rds_instance_states/aliases
@@ -1,4 +1,4 @@
 cloud/aws
 rds_instance_info
-time=15m
+time=30m
 rds_instance


### PR DESCRIPTION
##### SUMMARY

ec2_eip is unstable
rds_instance_states is taking longer with the new DB type.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tests/integration

##### ADDITIONAL INFORMATION
