### PR TITLE
Fix ec2_metadata_facts integration test

### DIFF
--- a/changelogs/fragments/20221107-metadata_test.yml
+++ b/changelogs/fragments/20221107-metadata_test.yml
@@ -1,0 +1,2 @@
+trivial:
+- ec2_metadata_facts - update integration test so ICMP SG rule is actually added.

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -89,6 +89,7 @@
         - proto: icmp
           from_port: -1
           to_port: -1
+          cidr_ip: 0.0.0.0/0
       state: present
       vpc_id: "{{ vpc_result.vpc.id }}"
     register: vpc_sg_result


### PR DESCRIPTION
##### SUMMARY

With #1214 security_group now validates the rules its passed, requiring a "source" be passed (SG/CIDR).  Previously it just dropped the rule on the floor.  This has however broken the ec2_metadata_facts integration test

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_metadata_facts

##### ADDITIONAL INFORMATION
