### PR TITLE
ec2_instance should allow setting and changing PlacementGroup and PartitionNumber

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: amazon
 name: aws
-version: 6.0.0-dev0
+version: 6.0.1
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1514,7 +1514,7 @@ def change_placement(instance, params):
         desired_placement.update({'PartitionNumber':params.get('partition_number')})
          
     if (( desired_placement['GroupName'] != current_placement['GroupName']) or
-        ( desired_placement['PartitionNumber'] and ( desired_placement['PartitionNumber'] != current_placement['PartitionNumber']))):
+        ( 'PartitionNumber' in desired_placement and ( desired_placement['PartitionNumber'] != current_placement['PartitionNumber']))):
 
         try:
             client.modify_instance_placement(
@@ -1523,7 +1523,7 @@ def change_placement(instance, params):
                 **desired_placement
             )
         except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
-            module.fail_json_aws(e, msg="Could not change placement instance {0} to {1} - {2}".format(instance['InstanceId'],
+            module.fail_json_aws(e, msg="Could not change placement instance {0} to {1}".format(instance['InstanceId'],
             desired_placement_group,desired_partition_number))
         return True
     return False


### PR DESCRIPTION
##### SUMMARY
I needed the ability to set PlacementGroup and PartitionNumber for the Placement of a new instance as well as changing them for a stopped existing instance. This is an attempt to implement that for your review.

Fixes #1263

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_instance

##### ADDITIONAL INFORMATION
