### PR TITLE
Fix inventory test error handling

### DIFF
--- a/changelogs/fragments/1269-inventory_tests.yml
+++ b/changelogs/fragments/1269-inventory_tests.yml
@@ -1,0 +1,3 @@
+trivial:
+- aws_ec2 - fix broken integration test (https://github.com/ansible-collections/amazon.aws/pull/1269).
+- aws_ec2/aws_rds - ensure test actually fails when a playbook fails (https://github.com/ansible-collections/amazon.aws/pull/1269).

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostvars_prefix_suffix.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostvars_prefix_suffix.yml
@@ -21,7 +21,7 @@
         - name: create a new host
           ec2_instance:
             image_id: '{{ image_id }}'
-            name: '{{ resource_prefix }}'
+            name: '{{ resource_prefix }}_1'
             tags:
               tag_instance1: foo
             purge_tags: true
@@ -36,16 +36,16 @@
         - name: assert the hostvars are defined with prefix and/or suffix
           assert:
             that:
-              - "hostvars['{{ resource_prefix }}'].{{ vars_prefix }}instance_type{{ vars_suffix }} == 't2.micro'"
-              - "'{{ vars_prefix }}instance_type{{ vars_suffix }}' in hostvars['{{ resource_prefix }}']"
-              - "'{{ vars_prefix }}image_id{{ vars_suffix }}' in hostvars['{{ resource_prefix }}']"
-              - "'{{ vars_prefix }}instance_id{{ vars_suffix }}' in hostvars['{{ resource_prefix }}']"
-              - "'instance_type' not in hostvars['{{ resource_prefix }}']"
-              - "'image_id' not in hostvars['{{ resource_prefix }}']"
-              - "'instance_id' not in hostvars['{{ resource_prefix }}']"
-              - "'ansible_diff_mode' in hostvars['{{ resource_prefix }}']"
-              - "'ansible_forks' in hostvars['{{ resource_prefix }}']"
-              - "'ansible_version' in hostvars['{{ resource_prefix }}']"
+              - "hostvars['{{ resource_prefix }}_1'].{{ vars_prefix }}instance_type{{ vars_suffix }} == 't2.micro'"
+              - "'{{ vars_prefix }}instance_type{{ vars_suffix }}' in hostvars['{{ resource_prefix }}_1']"
+              - "'{{ vars_prefix }}image_id{{ vars_suffix }}' in hostvars['{{ resource_prefix }}_1']"
+              - "'{{ vars_prefix }}instance_id{{ vars_suffix }}' in hostvars['{{ resource_prefix }}_1']"
+              - "'instance_type' not in hostvars['{{ resource_prefix }}_1']"
+              - "'image_id' not in hostvars['{{ resource_prefix }}_1']"
+              - "'instance_id' not in hostvars['{{ resource_prefix }}_1']"
+              - "'ansible_diff_mode' in hostvars['{{ resource_prefix }}_1']"
+              - "'ansible_forks' in hostvars['{{ resource_prefix }}_1']"
+              - "'ansible_version' in hostvars['{{ resource_prefix }}_1']"
           vars:
             vars_prefix: "{{ hostvars_prefix | default('') }}"
             vars_suffix: "{{ hostvars_suffix | default('') }}"

--- a/tests/integration/targets/inventory_aws_rds/runme.sh
+++ b/tests/integration/targets/inventory_aws_rds/runme.sh
@@ -2,6 +2,13 @@
 
 set -eux
 
+function cleanup() {
+    ansible-playbook playbooks/setup_instance.yml -e "operation=delete" "$@"
+    exit 1
+}
+
+trap 'cleanup "${@}"'  ERR
+
 # ensure test config is empty
 ansible-playbook playbooks/empty_inventory_config.yml "$@"
 
@@ -17,8 +24,6 @@ ansible-playbook playbooks/test_invalid_aws_rds_inventory_config.yml "$@"
 
 # delete existing resources
 ansible-playbook playbooks/setup_instance.yml -e "operation=delete" -e "aws_api_wait=true" "$@"
-
-{
 
 # generate inventory config and test using it
 ansible-playbook playbooks/create_inventory_config.yml "$@" &&
@@ -63,7 +68,4 @@ rm -rf "${AWS_RDS_CACHE_DIR}" &&
 # cleanup inventory config
 ansible-playbook playbooks/empty_inventory_config.yml "$@"
 
-} || {
-    ansible-playbook playbooks/setup_instance.yml -e "operation=delete" "$@"
-    exit 1
-}
+ansible-playbook playbooks/setup_instance.yml -e "operation=delete" "$@"


### PR DESCRIPTION
##### SUMMARY

The inventory tests were ignoring errors.

- Fix a broken test (aws_ec2)
- Ensure that when errors are thrown the test actually fails

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/inventory/aws_ec2.py
plugins/inventory/aws_rds.py

##### ADDITIONAL INFORMATION

See for example: https://ansible.softwarefactory-project.io/zuul/build/44fb0537b2a94472a8db8fe3d38e5f2e - https://9579ab6a3b03fcb3c00a-69908a85d5fb5681d7c2fae55d6bef4c.ssl.cf2.rackcdn.com/1218/0488965660f26bad143f612c7290f0a6ecdffcf7/gate/integration-amazon.aws-1/44fb053/job-output.txt

Tests "passed", but there were failures being ignored

```
2022-11-14 12:08:36.997752 | controller | TASK [meta] ********************************************************************
2022-11-14 12:08:36.997757 | controller | task path: /home/zuul/.ansible/collections/ansible_collections/amazon/aws/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostvars_prefix_suffix.yml:34
2022-11-14 12:08:36.997763 | controller | setting up inventory plugins
2022-11-14 12:08:36.997768 | controller | Parsed /home/zuul/.ansible/collections/ansible_collections/amazon/aws/tests/integration/targets/inventory_aws_ec2/test.aws_ec2.yml inventory source with ansible_collections.amazon.aws.plugins.inventory.aws_ec2 plugin
2022-11-14 12:08:36.997778 | controller | META: inventory successfully refreshed
2022-11-14 12:08:36.997784 | controller |
2022-11-14 12:08:36.997790 | controller | TASK [assert the hostvars are defined with prefix and/or suffix] ***************
2022-11-14 12:08:36.997794 | controller | task path: /home/zuul/.ansible/collections/ansible_collections/amazon/aws/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostvars_prefix_suffix.yml:36
2022-11-14 12:08:37.221690 | controller | fatal: [127.0.0.1]: FAILED! => {
2022-11-14 12:08:37.221731 | controller |     "msg": "The conditional check 'hostvars['ansible-test-76941238-ip-172-16-11-90'].aws_ec2_instance_type == 't2.micro'' failed. The error was: error while evaluating conditional (hostvars['ansible-test-76941238-ip-172-16-11-90'].aws_ec2_instance_type == 't2.micro'): \"hostvars['ansible-test-76941238-ip-172-16-11-90']\" is undefined. \"hostvars['ansible-test-76941238-ip-172-16-11-90']\" is undefined"
2022-11-14 12:08:37.221741 | controller | }
2022-11-14 12:08:37.221749 | controller |
2022-11-14 12:08:37.221756 | controller | PLAY RECAP *********************************************************************
2022-11-14 12:08:37.221765 | controller | 127.0.0.1                  : ok=11   changed=1    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0
2022-11-14 12:08:37.221772 | controller |
2022-11-14 12:08:37.221780 | controller | AWS ACTIONS: ['ec2:CreateTags', 'ec2:DeleteTags', 'ec2:DescribeImages', 'ec2:DescribeInstanceAttribute', 'ec2:DescribeInstances', 'ec2:DescribeSecurityGroups', 'ec2:DescribeSubnets', 'ec2:DescribeTags', 'ec2:DescribeVpcClassicLink', 'ec2:DescribeVpcs', 'sts:GetCallerIdentity']
2022-11-14 12:08:37.342789 | controller | + ansible-playbook playbooks/create_inventory_config.yml -e 'template='\''inventory_with_hostvars_prefix_suffix.yml.j2'\''' -e 'hostvars_suffix='\''_aws_ec2'\''' -vvvv -e @/home/zuul/.ansible/collections/ansible_collections/amazon/aws/tests/integration/config-file-4he3xb2k.json
```