### PR TITLE
add .gitignore for inventory automatically created by integration tests

### DIFF
--- a/changelogs/fragments/1276-gitignore-inventory.yml
+++ b/changelogs/fragments/1276-gitignore-inventory.yml
@@ -1,0 +1,2 @@
+trivial:
+- gitignore - ignore integration test 'inventory' files (https://github.com/ansible-collections/amazon.aws/pull/1276)

--- a/tests/integration/.gitignore
+++ b/tests/integration/.gitignore
@@ -1,0 +1,1 @@
+/inventory


### PR DESCRIPTION
##### SUMMARY

Helps fix #924 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests

##### ADDITIONAL INFORMATION

When running integration tests, a file is generated at `tests/integration/inventory`. This file contains paths specific to the test machine. I assume this shouldn't be committed. So I've added a .gitignore for it.

The leading slash is to make it *not* apply recursively. ([Stack Overflow](https://stackoverflow.com/a/2476760/5443120))