### PR TITLE
lambda - Fix flaky integration tests which assume there are no other functions in the account

### DIFF
--- a/changelogs/fragments/1277-lambda-int-test-other-lambdas.yml
+++ b/changelogs/fragments/1277-lambda-int-test-other-lambdas.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lambda - fix flaky integration test which assumes there are no other lambdas in the account (https://github.com/ansible-collections/amazon.aws/issues/1277)

--- a/tests/integration/inventory
+++ b/tests/integration/inventory
@@ -1,0 +1,2 @@
+[testgroup]
+testhost ansible_connection="local" ansible_pipelining="yes" ansible_python_interpreter="/home/matthew/.pyenv/versions/3.10.1/bin/python3.10"

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -316,21 +316,23 @@
     vars:
       ansible_python_interpreter: '{{ botocore_virtualenv_interpreter }}'
   - name: lambda_info | Assert successfull retrieval of all information 1
+    vars:
+      lambda_info: "{{ lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first }}"
     assert:
       that:
       - lambda_infos_all is not failed
       - lambda_infos_all.functions | length > 0
       - lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | length == 1
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).runtime == lambda_python_runtime
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).description == ""
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).function_arn is defined
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).handler == lambda_python_handler
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).versions is defined
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).aliases is defined
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).policy is defined
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).mappings is defined
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).tags is defined
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).architectures == ['arm64']
+      - lambda_info.runtime == lambda_python_runtime
+      - lambda_info.description == ""
+      - lambda_info.function_arn is defined
+      - lambda_info.handler == lambda_python_handler
+      - lambda_info.versions is defined
+      - lambda_info.aliases is defined
+      - lambda_info.policy is defined
+      - lambda_info.mappings is defined
+      - lambda_info.tags is defined
+      - lambda_info.architectures == ['arm64']
 
   - name: lambda_info | Ensure default query value is 'config' when function name
       omitted
@@ -338,20 +340,22 @@
     register: lambda_infos_query_config
     check_mode: yes
   - name: lambda_info | Assert successfull retrieval of all information 2
+    vars:
+      lambda_info: "{{ lambda_infos_query_config.functions | selectattr('function_name', 'eq', lambda_function_name) | first }}"
     assert:
       that:
       - lambda_infos_query_config is not failed
       - lambda_infos_query_config.functions | length > 0
-      - lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | length == 1
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).runtime == lambda_python_runtime
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).description == ""
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).function_arn is defined
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).handler == lambda_python_handler
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).versions is not defined
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).aliases is not defined
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).policy is not defined
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).mappings is not defined
-      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).tags is not defined
+      - lambda_infos_query_config.functions | selectattr('function_name', 'eq', lambda_function_name) | length == 1
+      - lambda_info.runtime == lambda_python_runtime
+      - lambda_info.description == ""
+      - lambda_info.function_arn is defined
+      - lambda_info.handler == lambda_python_handler
+      - lambda_info.versions is not defined
+      - lambda_info.aliases is not defined
+      - lambda_info.policy is not defined
+      - lambda_info.mappings is not defined
+      - lambda_info.tags is not defined
 
   - name: lambda_info | Ensure default query value is 'all' when function name specified
     lambda_info:

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -337,12 +337,6 @@
     lambda_info:
     register: lambda_infos_query_config
     check_mode: yes
-  - name: debug
-    debug:
-      var: lambda_infos_all
-  - name: debug function name
-    debug:
-      var: lambda_function_name
   - name: lambda_info | Assert successfull retrieval of all information 2
     assert:
       that:

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -320,17 +320,17 @@
       that:
       - lambda_infos_all is not failed
       - lambda_infos_all.functions | length > 0
-      - lambda_function_name in lambda_infos_all.function
-      - lambda_infos_all.function[lambda_function_name].runtime == lambda_python_runtime
-      - lambda_infos_all.function[lambda_function_name].description == ""
-      - lambda_infos_all.function[lambda_function_name].function_arn is defined
-      - lambda_infos_all.function[lambda_function_name].handler == lambda_python_handler
-      - lambda_infos_all.function[lambda_function_name].versions is defined
-      - lambda_infos_all.function[lambda_function_name].aliases is defined
-      - lambda_infos_all.function[lambda_function_name].policy is defined
-      - lambda_infos_all.function[lambda_function_name].mappings is defined
-      - lambda_infos_all.function[lambda_function_name].tags is defined
-      - lambda_infos_all.function[lambda_function_name].architectures == ['arm64']
+      - lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | length == 1
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).runtime == lambda_python_runtime
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).description == ""
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).function_arn is defined
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).handler == lambda_python_handler
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).versions is defined
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).aliases is defined
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).policy is defined
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).mappings is defined
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).tags is defined
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).architectures == ['arm64']
 
   - name: lambda_info | Ensure default query value is 'config' when function name
       omitted
@@ -348,16 +348,16 @@
       that:
       - lambda_infos_query_config is not failed
       - lambda_infos_query_config.functions | length > 0
-      - lambda_function_name in lambda_infos_query_config.function
-      - lambda_infos_all.function[lambda_function_name].runtime == lambda_python_runtime
-      - lambda_infos_all.function[lambda_function_name].description == ""
-      - lambda_infos_all.function[lambda_function_name].function_arn is defined
-      - lambda_infos_all.function[lambda_function_name].handler == lambda_python_handler
-      - lambda_infos_all.function[lambda_function_name].versions is not defined
-      - lambda_infos_all.function[lambda_function_name].aliases is not defined
-      - lambda_infos_all.function[lambda_function_name].policy is not defined
-      - lambda_infos_all.function[lambda_function_name].mappings is not defined
-      - lambda_infos_all.function[lambda_function_name].tags is not defined
+      - lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | length == 1
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).runtime == lambda_python_runtime
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).description == ""
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).function_arn is defined
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).handler == lambda_python_handler
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).versions is not defined
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).aliases is not defined
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).policy is not defined
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).mappings is not defined
+      - (lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first).tags is not defined
 
   - name: lambda_info | Ensure default query value is 'all' when function name specified
     lambda_info:

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -315,49 +315,55 @@
     check_mode: yes
     vars:
       ansible_python_interpreter: '{{ botocore_virtualenv_interpreter }}'
-  - name: lambda_info | Assert successfull retrieval of all information
+  - name: lambda_info | Assert successfull retrieval of all information 1
     assert:
       that:
       - lambda_infos_all is not failed
       - lambda_infos_all.functions | length > 0
-      - lambda_infos_all.functions[0].function_name == lambda_function_name
-      - lambda_infos_all.functions[0].runtime == lambda_python_runtime
-      - lambda_infos_all.functions[0].description == ""
-      - lambda_infos_all.functions[0].function_arn is defined
-      - lambda_infos_all.functions[0].handler == lambda_python_handler
-      - lambda_infos_all.functions[0].versions is defined
-      - lambda_infos_all.functions[0].aliases is defined
-      - lambda_infos_all.functions[0].policy is defined
-      - lambda_infos_all.functions[0].mappings is defined
-      - lambda_infos_all.functions[0].tags is defined
-      - lambda_infos_all.functions[0].architectures == ['arm64']
+      - lambda_function_name in lambda_infos_all.function
+      - lambda_infos_all.function[lambda_function_name].runtime == lambda_python_runtime
+      - lambda_infos_all.function[lambda_function_name].description == ""
+      - lambda_infos_all.function[lambda_function_name].function_arn is defined
+      - lambda_infos_all.function[lambda_function_name].handler == lambda_python_handler
+      - lambda_infos_all.function[lambda_function_name].versions is defined
+      - lambda_infos_all.function[lambda_function_name].aliases is defined
+      - lambda_infos_all.function[lambda_function_name].policy is defined
+      - lambda_infos_all.function[lambda_function_name].mappings is defined
+      - lambda_infos_all.function[lambda_function_name].tags is defined
+      - lambda_infos_all.function[lambda_function_name].architectures == ['arm64']
 
   - name: lambda_info | Ensure default query value is 'config' when function name
       omitted
     lambda_info:
     register: lambda_infos_query_config
     check_mode: yes
-  - name: lambda_info | Assert successfull retrieval of all information
+  - name: debug
+    debug:
+      var: lambda_infos_all
+  - name: debug function name
+    debug:
+      var: lambda_function_name
+  - name: lambda_info | Assert successfull retrieval of all information 2
     assert:
       that:
       - lambda_infos_query_config is not failed
       - lambda_infos_query_config.functions | length > 0
-      - lambda_infos_query_config.functions[0].function_name == lambda_function_name
-      - lambda_infos_query_config.functions[0].runtime == lambda_python_runtime
-      - lambda_infos_query_config.functions[0].description == ""
-      - lambda_infos_query_config.functions[0].function_arn is defined
-      - lambda_infos_query_config.functions[0].handler == lambda_python_handler
-      - lambda_infos_query_config.functions[0].versions is not defined
-      - lambda_infos_query_config.functions[0].aliases is not defined
-      - lambda_infos_query_config.functions[0].policy is not defined
-      - lambda_infos_query_config.functions[0].mappings is not defined
-      - lambda_infos_query_config.functions[0].tags is not defined
+      - lambda_function_name in lambda_infos_query_config.function
+      - lambda_infos_all.function[lambda_function_name].runtime == lambda_python_runtime
+      - lambda_infos_all.function[lambda_function_name].description == ""
+      - lambda_infos_all.function[lambda_function_name].function_arn is defined
+      - lambda_infos_all.function[lambda_function_name].handler == lambda_python_handler
+      - lambda_infos_all.function[lambda_function_name].versions is not defined
+      - lambda_infos_all.function[lambda_function_name].aliases is not defined
+      - lambda_infos_all.function[lambda_function_name].policy is not defined
+      - lambda_infos_all.function[lambda_function_name].mappings is not defined
+      - lambda_infos_all.function[lambda_function_name].tags is not defined
 
   - name: lambda_info | Ensure default query value is 'all' when function name specified
     lambda_info:
       name: '{{ lambda_function_name }}'
     register: lambda_infos_query_all
-  - name: lambda_info | Assert successfull retrieval of all information
+  - name: lambda_info | Assert successfull retrieval of all information 3
     assert:
       that:
       - lambda_infos_query_all is not failed
@@ -644,7 +650,7 @@
     assert:
       that:
       - result is not failed
-  
+
   # Test creation with layers
   - name: Create temporary directory for testing
     tempfile:


### PR DESCRIPTION
##### SUMMARY

The integration tests for lambda assume that there are no other lambdas in the account.
So when we index into `[0]`, that's not necessarily the lambda we just created.

Note that this fix doesn't work. One of the assertions is failing.

```
TASK [lambda : lambda_info | Assert successfull retrieval of all information 2] ***
fatal: [testhost]: FAILED! => {
    "assertion": "lambda_infos_all.function[lambda_function_name].versions is not defined",
    "changed": false,
    "evaluated_to": false,
    "msg": "Assertion failed"
}
```

That attribute is defined. It's a list of 2 versions. I don't know why.
I'm just creating this PR anyway, so someone else can pickup where I left off.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
lambda_info

##### ADDITIONAL INFORMATION

Fixes #1277