### PR TITLE
Add documentation for the use of strings with compose

### DIFF
--- a/changelogs/fragments/1283-aws_ec2_inventory_compose_doc_examples.yml
+++ b/changelogs/fragments/1283-aws_ec2_inventory_compose_doc_examples.yml
@@ -1,0 +1,2 @@
+trivial:
+- Add documentation for using string with compose feature in ec2 dynamic inventory.

--- a/docs/docsite/rst/aws_ec2_guide.rst
+++ b/docs/docsite/rst/aws_ec2_guide.rst
@@ -275,17 +275,10 @@ Some examples are shown below:
     # This sets the ec2_security_group_ids variable.
     ec2_security_group_ids: security_groups | map(attribute='group_id') | list |  join(',')
 
-    # This sets several host variables that can be used in conjunction with the SSM connection module.
-    # Strings must be wrapped in two sets of quotes, either ' then " or " then '.
-    ansible_aws_ssm_instance_id: instance_id
+    # Host variables that are strings need to be wrapped with two sets of quotes.
+    # See https://docs.ansible.com/ansible/latest/plugins/inventory.html#using-inventory-plugins for details.
     ansible_connection: '"community.aws.aws_ssm"'
     ansible_user: '"ssm-user"'
-    ansible_become: true
-    ansible_aws_ssm_region: '"us-west-2"'
-    ansible_aws_ssm_bucket_name: '"my-ansible-ssm-bucket"'
-    ansible_aws_ssm_bucket_sse_mode: '"AES256"'
-    ansible_aws_ssm_timeout: 600
-    ansible_aws_ssm_retries: 10
 
 
 ``include_filters`` and ``exclude_filters``

--- a/docs/docsite/rst/aws_ec2_guide.rst
+++ b/docs/docsite/rst/aws_ec2_guide.rst
@@ -275,6 +275,18 @@ Some examples are shown below:
     # This sets the ec2_security_group_ids variable.
     ec2_security_group_ids: security_groups | map(attribute='group_id') | list |  join(',')
 
+    # This sets several host variables that can be used in conjunction with the SSM connection module.
+    # Strings must be wrapped in two sets of quotes, either ' then " or " then '.
+    ansible_aws_ssm_instance_id: instance_id
+    ansible_connection: '"community.aws.aws_ssm"'
+    ansible_user: '"ssm-user"'
+    ansible_become: true
+    ansible_aws_ssm_region: '"us-west-2"'
+    ansible_aws_ssm_bucket_name: '"my-ansible-ssm-bucket"'
+    ansible_aws_ssm_bucket_sse_mode: '"AES256"'
+    ansible_aws_ssm_timeout: 600
+    ansible_aws_ssm_retries: 10
+
 
 ``include_filters`` and ``exclude_filters``
 -------------------------------------------


### PR DESCRIPTION
##### SUMMARY
Documentation for the use of strings with compose is documented in https://docs.ansible.com/ansible/latest/plugins/inventory.html#using-inventory-plugins. However, in the module, it is not well documented. This documentation and example provides documentation in the module docs.

Related to ansible-collections/amazon.aws#570

##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
aws_ec2 inventory