### PR TITLE
ec2_key/tests: add unit-tests 

### DIFF
--- a/changelogs/fragments/unit-tests_test_ec2_key_only.yaml
+++ b/changelogs/fragments/unit-tests_test_ec2_key_only.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- "ec2_key - Add unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1288)."

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -365,16 +365,16 @@ def main():
     if key_type:
         module.require_botocore_at_least('1.21.23', reason='to set the key_type for a keypair')
     try:
-      if state == 'absent':
-          result = delete_key_pair(module.check_mode, ec2_client, name)
+        if state == 'absent':
+            result = delete_key_pair(module.check_mode, ec2_client, name)
 
-      elif state == 'present':
-          # check if key already exists
-          key = find_key_pair(ec2_client, name)
-          if key:
-              result = handle_existing_key_pair_update(module, ec2_client, name, key)
-          else:
-              result = create_new_key_pair(ec2_client, name, key_material, key_type, tags, module.check_mode)
+        elif state == 'present':
+            # check if key already exists
+            key = find_key_pair(ec2_client, name)
+            if key:
+                result = handle_existing_key_pair_update(module, ec2_client, name, key)
+            else:
+                result = create_new_key_pair(ec2_client, name, key_material, key_type, tags, module.check_mode)
 
     except Ec2KeyFailure as e:
         if e.original_e:

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -209,13 +209,11 @@ def get_key_fingerprint(module, ec2_client, key_material):
     http://blog.jbrowne.com/?p=23
     https://forums.aws.amazon.com/thread.jspa?messageID=352828
     '''
-
     # find an unused name
     name_in_use = True
     while name_in_use:
         random_name = "ansible-" + str(uuid.uuid4())
         name_in_use = find_key_pair(ec2_client, random_name)
-
     temp_key = _import_key_pair(ec2_client, random_name, key_material)
     delete_key_pair(module, ec2_client, random_name, finish_task=False)
     return temp_key['KeyFingerprint']

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -236,14 +236,15 @@ def get_key_fingerprint(module, ec2_client, key_material):
 def find_key_pair(ec2_client, name):
 
     try:
-        key = ec2_client.describe_key_pairs(aws_retry=True, KeyNames=[name])['KeyPairs'][0]
+        key = ec2_client.describe_key_pairs(aws_retry=True, KeyNames=[name])
     except is_boto3_error_code('InvalidKeyPair.NotFound'):
         return None
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as err:  # pylint: disable=duplicate-except
         raise Ec2KeyFailure(err, "error finding keypair")
     except IndexError:
         key = None
-    return key
+
+    return key['KeyPairs'][0]
 
 
 def create_new_key_pair(module, ec2_client, name, key_material, key_type):

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -196,7 +196,6 @@ def _import_key_pair(ec2_client, name, key_material, tag_spec=None):
 
 
 def extract_key_data(key, key_type=None):
-
     data = {
         'name': key['KeyName'],
         'fingerprint': key['KeyFingerprint'],

--- a/tests/unit/plugins/modules/test_ec2_key.py
+++ b/tests/unit/plugins/modules/test_ec2_key.py
@@ -274,7 +274,7 @@ def test_create_new_key_pair_key_material(m_import_key_pair, m_extract_key_data)
 
     expected_result = {'changed': True, 'key': m_extract_key_data.return_value, 'msg': 'key pair created'}
 
-    result = ec2_key.create_new_key_pair(module, ec2_client, name, key_material, key_type, tags)
+    result = ec2_key.create_new_key_pair(ec2_client, name, key_material, key_type, tags, module.check_mode)
 
     assert result == expected_result
     assert m_import_key_pair.call_count == 1
@@ -310,7 +310,7 @@ def test_create_new_key_pair_no_key_material(m_create_key_pair, m_extract_key_da
 
     expected_result = {'changed': True, 'key': m_extract_key_data.return_value, 'msg': 'key pair created'}
 
-    result = ec2_key.create_new_key_pair(module, ec2_client, name, key_material, key_type, tags)
+    result = ec2_key.create_new_key_pair(ec2_client, name, key_material, key_type, tags, module.check_mode)
 
     assert result == expected_result
     assert m_create_key_pair.call_count == 1
@@ -374,15 +374,15 @@ def test_update_key_pair_by_key_material_update_needed(m_get_key_fingerprint, m_
 
     expected_result = {'changed': True, 'key': m_extract_key_data.return_value, 'msg': "key pair updated"}
 
-    result = ec2_key.update_key_pair_by_key_material(module, ec2_client, name, key, key_material, tag_spec)
+    result = ec2_key.update_key_pair_by_key_material(module.check_mode, ec2_client, name, key, key_material, tag_spec)
 
     assert result == expected_result
     assert m_get_key_fingerprint.call_count == 1
     assert m_delete_key_pair.call_count == 1
     assert m__import_key_pair.call_count == 1
     assert m_extract_key_data.call_count == 1
-    m_get_key_fingerprint.assert_called_with(module, ec2_client, key_material)
-    m_delete_key_pair.assert_called_with(module, ec2_client, name, finish_task=False)
+    m_get_key_fingerprint.assert_called_with(module.check_mode, ec2_client, key_material)
+    m_delete_key_pair.assert_called_with(module.check_mode, ec2_client, name, finish_task=False)
     m__import_key_pair.assert_called_with(ec2_client, name, key_material, tag_spec)
     m_extract_key_data.assert_called_with(key)
 
@@ -418,13 +418,13 @@ def test_update_key_pair_by_key_type_update_needed(m_delete_key_pair, m__create_
 
     expected_result = {'changed': True, 'key': m_extract_key_data.return_value, 'msg': "key pair updated"}
 
-    result = ec2_key.update_key_pair_by_key_type(module, ec2_client, name, key_type, tag_spec)
+    result = ec2_key.update_key_pair_by_key_type(module.check_mode, ec2_client, name, key_type, tag_spec)
 
     assert result == expected_result
     assert m_delete_key_pair.call_count == 1
     assert m__create_key_pair.call_count == 1
     assert m_extract_key_data.call_count == 1
-    m_delete_key_pair.assert_called_with(module, ec2_client, name, finish_task=False)
+    m_delete_key_pair.assert_called_with(module.check_mode, ec2_client, name, finish_task=False)
     m__create_key_pair.assert_called_with(ec2_client, name, tag_spec, key_type)
     m_extract_key_data.assert_called_with(m__create_key_pair.return_value, key_type)
 
@@ -573,7 +573,7 @@ def test_delete_key_pair_key_exists(m_find_key_pair, m_delete_key_pair):
 
     expected_result = {'changed': True, 'key': None, 'msg': 'key deleted'}
 
-    result = ec2_key.delete_key_pair(module, ec2_client, name)
+    result = ec2_key.delete_key_pair(module.check_mode, ec2_client, name)
 
     assert m_find_key_pair.call_count == 1
     m_find_key_pair.assert_called_with(ec2_client, name)
@@ -596,7 +596,7 @@ def test_delete_key_pair_key_not_exist(m_find_key_pair, m_delete_key_pair):
 
     expected_result = {'key': None, 'msg': 'key did not exist'}
 
-    result = ec2_key.delete_key_pair(module, ec2_client, name)
+    result = ec2_key.delete_key_pair(module.check_mode, ec2_client, name)
 
     assert m_find_key_pair.call_count == 1
     m_find_key_pair.assert_called_with(ec2_client, name)

--- a/tests/unit/plugins/modules/test_ec2_key.py
+++ b/tests/unit/plugins/modules/test_ec2_key.py
@@ -95,3 +95,37 @@ def test_extract_key_data_create_key_pair():
     result = ec2_key.extract_key_data(key, key_type)
 
     assert result == expected_result
+
+
+@patch(module_name + '.delete_key_pair')
+@patch(module_name + '._import_key_pair')
+@patch(module_name + '.find_key_pair')
+def test_get_key_fingerprint(m_find_key_pair, m_import_key_pair, m_delete_key_pair):
+
+    module = MagicMock()
+    ec2_client = MagicMock()
+
+    m_find_key_pair.return_value = None
+
+    m_import_key_pair.return_value = {
+        'KeyFingerprint': 'd7:ff:a6:63:18:64:9c:57:a1:ee:ca:a4:ad:c2:81:62',
+        'KeyName': 'my_keypair',
+        'KeyPairId': 'key-043046ef2a9a80b56'
+    }
+
+    m_delete_key_pair.return_value = {
+        'changed': True,
+        'key': None,
+        'msg': 'key deleted'
+    }
+
+    expected_result = 'd7:ff:a6:63:18:64:9c:57:a1:ee:ca:a4:ad:c2:81:62'
+
+    key_material = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
+
+    result = ec2_key.get_key_fingerprint(module, ec2_client, key_material)
+
+    assert result == expected_result
+    assert m_find_key_pair.call_count == 1
+    assert m_import_key_pair.call_count == 1
+    assert m_delete_key_pair.call_count == 1

--- a/tests/unit/plugins/modules/test_ec2_key.py
+++ b/tests/unit/plugins/modules/test_ec2_key.py
@@ -1,0 +1,49 @@
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from unittest.mock import call
+
+import pytest
+import botocore
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+import datetime
+from dateutil.tz import tzutc
+
+from ansible_collections.amazon.aws.plugins.modules import ec2_key
+
+module_name = "ansible_collections.amazon.aws.plugins.modules.ec2_key"
+
+
+def test_find_key_pair():
+    ec2_client = MagicMock()
+    name = 'my_keypair'
+
+    ec2_client.describe_key_pairs.return_value = {
+        'KeyPairs': [
+            {
+                'CreateTime': datetime.datetime(2022, 9, 15, 20, 10, 15, tzinfo=tzutc()),
+                'KeyFingerprint': '11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa',
+                'KeyName': 'my_keypair',
+                'KeyPairId': 'key-043046ef2a9a80b56',
+                'KeyType': 'rsa',
+                'Tags': []
+            }
+        ],
+    }
+
+    ec2_key.find_key_pair(ec2_client, name)
+
+    assert ec2_client.describe_key_pairs.call_count == 1
+    ec2_client.describe_key_pairs.assert_called_with(aws_retry=True, KeyNames=[name])
+
+
+def test_api_failure_find_key_pair():
+    ec2_client = MagicMock()
+    name = 'non_existing_keypair'
+
+    ec2_client.describe_key_pairs.side_effect = botocore.exceptions.BotoCoreError
+
+    with pytest.raises(ec2_key.Ec2KeyFailure):
+        ec2_key.find_key_pair(ec2_client, name)

--- a/tests/unit/plugins/modules/test_ec2_key.py
+++ b/tests/unit/plugins/modules/test_ec2_key.py
@@ -47,3 +47,29 @@ def test_api_failure_find_key_pair():
 
     with pytest.raises(ec2_key.Ec2KeyFailure):
         ec2_key.find_key_pair(ec2_client, name)
+
+
+def test_extract_key_data():
+
+    key = {
+        "CreateTime": datetime.datetime(2022, 9, 15, 20, 10, 15, tzinfo=tzutc()),
+        "KeyFingerprint": "11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa",
+        "KeyName": "my_keypair",
+        "KeyPairId": "key-043046ef2a9a80b56",
+        "Tags": [],
+    }
+
+    key_type = "rsa"
+
+    expected_result = {
+        "name": "my_keypair",
+        "fingerprint": "11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa",
+        "id": "key-043046ef2a9a80b56",
+        "tags": {},
+        "type": "rsa"
+    }
+
+    result = ec2_key.extract_key_data(key, key_type)
+
+    assert result == expected_result
+

--- a/tests/unit/plugins/modules/test_ec2_key.py
+++ b/tests/unit/plugins/modules/test_ec2_key.py
@@ -7,9 +7,11 @@ from unittest.mock import call
 
 import pytest
 import botocore
-from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 import datetime
 from dateutil.tz import tzutc
+from ansible.module_utils._text import to_bytes
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 
 from ansible_collections.amazon.aws.plugins.modules import ec2_key
 
@@ -18,8 +20,7 @@ module_name = "ansible_collections.amazon.aws.plugins.modules.ec2_key"
 
 def raise_botocore_exception_clienterror(action):
 
-    if action == 'create_key_pair':
-        params = {
+    params = {
             'Error': {
                 'Code': 1,
                 'Message': 'error creating key'
@@ -29,62 +30,56 @@ def raise_botocore_exception_clienterror(action):
             }
         }
 
+    if action == 'create_key_pair':
+        params['Error']['Message'] = 'error creating key'
+
     elif action == 'describe_key_pair':
-        params = {
-            'Error': {
-                'Code': 'InvalidKeyPair.NotFound',
-                'Message': 'The key pair does not exist'
-            },
-            'ResponseMetadata': {
-                'RequestId': '01234567-89ab-cdef-0123-456789abcdef'
-            }
-        }
+        params['Error']['Code'] = 'InvalidKeyPair.NotFound'
+        params['Error']['Message'] = 'The key pair does not exist'
+
+    elif action == 'import_key_pair':
+        params['Error']['Message'] = 'error importing key'
 
     return botocore.exceptions.ClientError(params, action)
 
 
-def test_find_key_pair():
+def test__import_key_pair():
     ec2_client = MagicMock()
     name = 'my_keypair'
+    key_material = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
 
-    ec2_client.describe_key_pairs.return_value = {
-        'KeyPairs': [
-            {
-                'CreateTime': datetime.datetime(2022, 9, 15, 20, 10, 15, tzinfo=tzutc()),
-                'KeyFingerprint': '11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa',
-                'KeyName': 'my_keypair',
-                'KeyPairId': 'key-043046ef2a9a80b56',
-                'KeyType': 'rsa',
-                'Tags': []
-            }
-        ],
+    expected_params = {
+        'KeyName': name,
+        'PublicKeyMaterial': to_bytes(key_material),
     }
 
-    ec2_key.find_key_pair(ec2_client, name)
+    ec2_client.import_key_pair.return_value = {
+        'KeyFingerprint': 'd7:ff:a6:63:18:64:9c:57:a1:ee:ca:a4:ad:c2:81:62',
+        'KeyName': 'my_keypair',
+        'KeyPairId': 'key-012345678905a208d'
+    }
 
-    assert ec2_client.describe_key_pairs.call_count == 1
-    ec2_client.describe_key_pairs.assert_called_with(aws_retry=True, KeyNames=[name])
+    result = ec2_key._import_key_pair(ec2_client, name, key_material)
+
+    assert result == ec2_client.import_key_pair.return_value
+    assert ec2_client.import_key_pair.call_count == 1
+    assert ec2_client.import_key_pair.called_with(aws_retry=True, **expected_params)
 
 
-def test_api_failure_find_key_pair():
+def test_api_failure__import_key_pair():
     ec2_client = MagicMock()
-    name = 'non_existing_keypair'
+    name = 'my_keypair'
+    key_material = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
 
-    ec2_client.describe_key_pairs.side_effect = botocore.exceptions.BotoCoreError
+    expected_params = {
+        'KeyName': name,
+        'PublicKeyMaterial': to_bytes(key_material),
+    }
+
+    ec2_client.import_key_pair.side_effect = raise_botocore_exception_clienterror('import_key_pair')
 
     with pytest.raises(ec2_key.Ec2KeyFailure):
-        ec2_key.find_key_pair(ec2_client, name)
-
-
-def test_invalid_key_pair_find_key_pair():
-    ec2_client = MagicMock()
-    name = 'non_existing_keypair'
-
-    ec2_client.describe_key_pairs.side_effect = raise_botocore_exception_clienterror('describe_key_pair')
-
-    result = ec2_key.find_key_pair(ec2_client, name)
-
-    assert result == None
+        ec2_key._import_key_pair(ec2_client, name, key_material)
 
 
 def test_extract_key_data_describe_key_pairs():
@@ -119,7 +114,6 @@ def test_extract_key_data_create_key_pair():
     'KeyName': 'my_keypair',
     'KeyPairId': 'key-043046ef2a9a80b56'
     }
-
 
     key_type = "rsa"
 
@@ -170,13 +164,57 @@ def test_get_key_fingerprint(m_find_key_pair, m_import_key_pair, m_delete_key_pa
     assert m_delete_key_pair.call_count == 1
 
 
+def test_find_key_pair():
+    ec2_client = MagicMock()
+    name = 'my_keypair'
+
+    ec2_client.describe_key_pairs.return_value = {
+        'KeyPairs': [
+            {
+                'CreateTime': datetime.datetime(2022, 9, 15, 20, 10, 15, tzinfo=tzutc()),
+                'KeyFingerprint': '11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa',
+                'KeyName': 'my_keypair',
+                'KeyPairId': 'key-043046ef2a9a80b56',
+                'KeyType': 'rsa',
+                'Tags': []
+            }
+        ],
+    }
+
+    ec2_key.find_key_pair(ec2_client, name)
+
+    assert ec2_client.describe_key_pairs.call_count == 1
+    ec2_client.describe_key_pairs.assert_called_with(aws_retry=True, KeyNames=[name])
+
+
+def test_api_failure_find_key_pair():
+    ec2_client = MagicMock()
+    name = 'non_existing_keypair'
+
+    ec2_client.describe_key_pairs.side_effect = botocore.exceptions.BotoCoreError
+
+    with pytest.raises(ec2_key.Ec2KeyFailure):
+        ec2_key.find_key_pair(ec2_client, name)
+
+
+def test_invalid_key_pair_find_key_pair():
+    ec2_client = MagicMock()
+    name = 'non_existing_keypair'
+
+    ec2_client.describe_key_pairs.side_effect = raise_botocore_exception_clienterror('describe_key_pair')
+
+    result = ec2_key.find_key_pair(ec2_client, name)
+
+    assert result == None
+
+
 def test__create_key_pair():
     ec2_client = MagicMock()
     name = 'my_keypair'
     tag_spec = None
     key_type = None
 
-    params = { 'KeyName': name }
+    expected_params = { 'KeyName': name }
 
     ec2_client.create_key_pair.return_value = {
         'KeyFingerprint': 'd7:ff:a6:63:18:64:9c:57:a1:ee:ca:a4:ad:c2:81:62',
@@ -189,7 +227,7 @@ def test__create_key_pair():
 
     assert result == ec2_client.create_key_pair.return_value
     assert ec2_client.create_key_pair.call_count == 1
-    assert ec2_client.create_key_pair.called_with(aws_retry=True, **params)
+    assert ec2_client.create_key_pair.called_with(aws_retry=True, **expected_params)
 
 
 def test_api_failure__create_key_pair():

--- a/tests/unit/plugins/modules/test_ec2_key.py
+++ b/tests/unit/plugins/modules/test_ec2_key.py
@@ -3,7 +3,7 @@
 
 from unittest.mock import MagicMock
 from unittest.mock import patch
-from unittest.mock import call
+from unittest.mock import call, ANY
 
 import pytest
 import botocore
@@ -21,14 +21,14 @@ module_name = "ansible_collections.amazon.aws.plugins.modules.ec2_key"
 def raise_botocore_exception_clienterror(action):
 
     params = {
-            'Error': {
-                'Code': 1,
-                'Message': 'error creating key'
-            },
-            'ResponseMetadata': {
-                'RequestId': '01234567-89ab-cdef-0123-456789abcdef'
-            }
+        'Error': {
+            'Code': 1,
+            'Message': 'error creating key'
+        },
+        'ResponseMetadata': {
+            'RequestId': '01234567-89ab-cdef-0123-456789abcdef'
         }
+    }
 
     if action == 'create_key_pair':
         params['Error']['Message'] = 'error creating key'
@@ -49,7 +49,7 @@ def raise_botocore_exception_clienterror(action):
 def test__import_key_pair():
     ec2_client = MagicMock()
     name = 'my_keypair'
-    key_material = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
+    key_material = "ssh-rsa AAAAB3NzaC1yc2EAA email@example.com"
 
     expected_params = {
         'KeyName': name,
@@ -72,7 +72,7 @@ def test__import_key_pair():
 def test_api_failure__import_key_pair():
     ec2_client = MagicMock()
     name = 'my_keypair'
-    key_material = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
+    key_material = "ssh-rsa AAAAB3NzaC1yc2EAA email@example.com"
 
     expected_params = {
         'KeyName': name,
@@ -113,9 +113,9 @@ def test_extract_key_data_describe_key_pairs():
 def test_extract_key_data_create_key_pair():
 
     key = {
-    'KeyFingerprint': '11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa',
-    'KeyName': 'my_keypair',
-    'KeyPairId': 'key-043046ef2a9a80b56'
+        'KeyFingerprint': '11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa',
+        'KeyName': 'my_keypair',
+        'KeyPairId': 'key-043046ef2a9a80b56'
     }
 
     key_type = "rsa"
@@ -157,7 +157,7 @@ def test_get_key_fingerprint(m_find_key_pair, m_import_key_pair, m_delete_key_pa
 
     expected_result = 'd7:ff:a6:63:18:64:9c:57:a1:ee:ca:a4:ad:c2:81:62'
 
-    key_material = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
+    key_material = "ssh-rsa AAAAB3NzaC1yc2EAA email@example.com"
 
     result = ec2_key.get_key_fingerprint(module, ec2_client, key_material)
 
@@ -208,7 +208,7 @@ def test_invalid_key_pair_find_key_pair():
 
     result = ec2_key.find_key_pair(ec2_client, name)
 
-    assert result == None
+    assert result is None
 
 
 def test__create_key_pair():
@@ -217,7 +217,7 @@ def test__create_key_pair():
     tag_spec = None
     key_type = None
 
-    expected_params = { 'KeyName': name }
+    expected_params = {'KeyName': name}
 
     ec2_client.create_key_pair.return_value = {
         'KeyFingerprint': 'd7:ff:a6:63:18:64:9c:57:a1:ee:ca:a4:ad:c2:81:62',
@@ -252,7 +252,7 @@ def test_create_new_key_pair_key_material(m_import_key_pair, m_extract_key_data)
     ec2_client = MagicMock()
 
     name = 'my_keypair'
-    key_material = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
+    key_material = "ssh-rsa AAAAB3NzaC1yc2EAA email@example.com"
     key_type = 'rsa'
     tags = None
 
@@ -320,7 +320,6 @@ def test_create_new_key_pair_no_key_material(m_create_key_pair, m_extract_key_da
 def test__delete_key_pair():
     ec2_client = MagicMock()
 
-
     key_name = 'my_keypair'
     ec2_key._delete_key_pair(ec2_client, key_name)
 
@@ -347,14 +346,13 @@ def test_update_key_pair_by_key_material_update_needed(m_get_key_fingerprint, m_
     ec2_client = MagicMock()
 
     name = 'my_keypair'
-    key_material = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQD3F6tyPEFEzV0LX3X8BsXdMsQz1x2cEikKDEY0aIj41qgxMCP/iteneqXSIFZBp5vizPvaoIR3Um9xK7PGoW8giupGn+EPuxIA4cDM4vzOqOkiMPhz5XK0whEjkVzTo4+S0puvDZuwIsdiW9mxhJc7tgBNL0cYlWSYVkz4G/fslNfRPW5mYAM49f4fhtxPb5ok4Q2Lg9dPKVHO/Bgeu5woMc7RY0p1ej6D4CKFE6lymSDJpW0YHX/wqE9+cfEauh7xZcG0q9t2ta6F6fmX0agvpFyZo8aFbXeUBr7osSCJNgvavWbM/06niWrOvYX2xwWdhXmXSrbX8ZbabVohBK41 email@example.com"
+    key_material = "ssh-rsa AAAAB3NzaC1yc2EAA email@example.com"
     tag_spec = None
     key = {
-        "Name": "my_keypair",
+        "KeyName": "my_keypair",
         "KeyFingerprint": "11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa",
-        "Id": "key-043046ef2a9a80b56",
+        "KeyPairId": "key-043046ef2a9a80b56",
         "Tags": {},
-        "Type": "rsa"
     }
 
     module.check_mode = False
@@ -363,17 +361,15 @@ def test_update_key_pair_by_key_material_update_needed(m_get_key_fingerprint, m_
     m_delete_key_pair.return_value = None
     m__import_key_pair.return_value = {
         'KeyFingerprint': '11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa',
-        'Name': 'my_keypair',
-        'Id': 'key-043046ef2a9a80b56',
+        'KeyName': 'my_keypair',
+        'KeyPairId': 'key-043046ef2a9a80b56',
         'Tags': {},
-        'Type': 'rsa'
     }
     m_extract_key_data.return_value = {
         "name": "my_keypair",
         "fingerprint": "d7:ff:a6:63:18:64:9c:57:a1:ee:ca:a4:ad:c2:81:62",
         "id": "key-012345678905a208d",
         "tags": {},
-        "type": "rsa"
     }
 
     expected_result = {'changed': True, 'key': m_extract_key_data.return_value, 'msg': "key pair updated"}
@@ -389,6 +385,167 @@ def test_update_key_pair_by_key_material_update_needed(m_get_key_fingerprint, m_
     m_delete_key_pair.assert_called_with(module, ec2_client, name, finish_task=False)
     m__import_key_pair.assert_called_with(ec2_client, name, key_material, tag_spec)
     m_extract_key_data.assert_called_with(key)
+
+
+@patch(module_name + '.extract_key_data')
+@patch(module_name + '._create_key_pair')
+@patch(module_name + '.delete_key_pair')
+def test_update_key_pair_by_key_type_update_needed(m_delete_key_pair, m__create_key_pair, m_extract_key_data):
+    module = MagicMock()
+    ec2_client = MagicMock()
+
+    name = 'my_keypair'
+    key_type = 'rsa'
+    tag_spec = None
+
+    module.check_mode = False
+
+    m_delete_key_pair.return_value = None
+    m__create_key_pair.return_value = {
+        'KeyFingerprint': '11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa',
+        'Name': 'my_keypair',
+        'Id': 'key-043046ef2a9a80b56',
+        'Tags': {},
+        'Type': 'rsa'
+    }
+    m_extract_key_data.return_value = {
+        "name": "my_keypair",
+        "fingerprint": "11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa",
+        "id": "key-043046ef2a9a80b56",
+        "tags": {},
+        "type": "rsa"
+    }
+
+    expected_result = {'changed': True, 'key': m_extract_key_data.return_value, 'msg': "key pair updated"}
+
+    result = ec2_key.update_key_pair_by_key_type(module, ec2_client, name, key_type, tag_spec)
+
+    assert result == expected_result
+    assert m_delete_key_pair.call_count == 1
+    assert m__create_key_pair.call_count == 1
+    assert m_extract_key_data.call_count == 1
+    m_delete_key_pair.assert_called_with(module, ec2_client, name, finish_task=False)
+    m__create_key_pair.assert_called_with(ec2_client, name, tag_spec, key_type)
+    m_extract_key_data.assert_called_with(m__create_key_pair.return_value, key_type)
+
+
+@patch(module_name + '.update_key_pair_by_key_material')
+def test_handle_existing_key_pair_update_key_matrial_with_force(m_update_key_pair_by_key_material):
+    module = MagicMock()
+    ec2_client = MagicMock()
+
+    name = 'my_keypair'
+    key = {
+        "KeyName": "my_keypair",
+        "KeyFingerprint": "11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa",
+        "KeyPairId": "key-043046ef2a9a80b56",
+        "Tags": {},
+        "KeyType": "rsa"
+    }
+
+    module.params = {
+        'key_material': "ssh-rsa AAAAB3NzaC1yc2EAA email@example.com",
+        'force': True,
+        'key_type': 'rsa',
+        'tags': None,
+        'purge_tags': True,
+        'tag_spec': None
+    }
+
+    key_data = {
+        "name": "my_keypair",
+        "fingerprint": "d7:ff:a6:63:18:64:9c:57:a1:ee:ca:a4:ad:c2:81:62",
+        "id": "key-012345678905a208d",
+        "tags": {},
+    }
+
+    m_update_key_pair_by_key_material.return_value = {'changed': True, 'key': key_data, 'msg': "key pair updated"}
+
+    expected_result = {'changed': True, 'key': key_data, 'msg': "key pair updated"}
+
+    result = ec2_key.handle_existing_key_pair_update(module, ec2_client, name, key)
+
+    assert result == expected_result
+    assert m_update_key_pair_by_key_material.call_count == 1
+
+
+@patch(module_name + '.update_key_pair_by_key_type')
+def test_handle_existing_key_pair_update_key_type(m_update_key_pair_by_key_type):
+    module = MagicMock()
+    ec2_client = MagicMock()
+
+    name = 'my_keypair'
+    key = {
+        "KeyName": "my_keypair",
+        "KeyFingerprint": "11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa",
+        "KeyPairId": "key-043046ef2a9a80b56",
+        "Tags": {},
+        "KeyType": "ed25519"
+    }
+
+    module.params = {
+        'key_material': "ssh-rsa AAAAB3NzaC1yc2EAA email@example.com",
+        'force': False,
+        'key_type': 'rsa',
+        'tags': None,
+        'purge_tags': True,
+        'tag_spec': None
+    }
+
+    key_data = {
+        "name": "my_keypair",
+        "fingerprint": "d7:ff:a6:63:18:64:9c:57:a1:ee:ca:a4:ad:c2:81:62",
+        "id": "key-012345678905a208d",
+        "tags": {},
+    }
+
+    m_update_key_pair_by_key_type.return_value = {'changed': True, 'key': key_data, 'msg': "key pair updated"}
+
+    expected_result = {'changed': True, 'key': key_data, 'msg': "key pair updated"}
+
+    result = ec2_key.handle_existing_key_pair_update(module, ec2_client, name, key)
+
+    assert result == expected_result
+    assert m_update_key_pair_by_key_type.call_count == 1
+
+
+@patch(module_name + '.extract_key_data')
+def test_handle_existing_key_pair_else(m_extract_key_data):
+    module = MagicMock()
+    ec2_client = MagicMock()
+
+    name = 'my_keypair'
+    key = {
+        "KeyName": "my_keypair",
+        "KeyFingerprint": "11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa",
+        "KeyPairId": "key-043046ef2a9a80b56",
+        "Tags": {},
+        "KeyType": "rsa"
+    }
+
+    module.params = {
+        'key_material': "ssh-rsa AAAAB3NzaC1yc2EAA email@example.com",
+        'force': False,
+        'key_type': 'rsa',
+        'tags': None,
+        'purge_tags': True,
+        'tag_spec': None
+    }
+
+    m_extract_key_data.return_value = {
+        "name": "my_keypair",
+        "fingerprint": "11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa",
+        "id": "key-043046ef2a9a80b56",
+        "tags": {},
+        "type": "rsa"
+    }
+
+    expected_result = {'changed': False, 'key': m_extract_key_data.return_value, 'msg': 'key pair alreday exists'}
+
+    result = ec2_key.handle_existing_key_pair_update(module, ec2_client, name, key)
+
+    assert result == expected_result
+    assert m_extract_key_data.call_count == 1
 
 
 @patch(module_name + '._delete_key_pair')
@@ -446,3 +603,12 @@ def test_delete_key_pair_key_not_exist(m_find_key_pair, m_delete_key_pair):
     assert m_delete_key_pair.call_count == 0
     assert result == expected_result
 
+
+@patch(module_name + ".AnsibleAWSModule")
+def test_main_success(m_AnsibleAWSModule):
+    m_module = MagicMock()
+    m_AnsibleAWSModule.return_value = m_module
+
+    ec2_key.main()
+
+    m_module.client.assert_called_with("ec2", retry_decorator=ANY)

--- a/tests/unit/plugins/modules/test_ec2_key.py
+++ b/tests/unit/plugins/modules/test_ec2_key.py
@@ -49,7 +49,7 @@ def test_api_failure_find_key_pair():
         ec2_key.find_key_pair(ec2_client, name)
 
 
-def test_extract_key_data():
+def test_extract_key_data_describe_key_pairs():
 
     key = {
         "CreateTime": datetime.datetime(2022, 9, 15, 20, 10, 15, tzinfo=tzutc()),
@@ -73,3 +73,25 @@ def test_extract_key_data():
 
     assert result == expected_result
 
+def test_extract_key_data_create_key_pair():
+
+    key = {
+    'KeyFingerprint': '11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa',
+    'KeyName': 'my_keypair',
+    'KeyPairId': 'key-043046ef2a9a80b56'
+    }
+
+
+    key_type = "rsa"
+
+    expected_result = {
+        "name": "my_keypair",
+        "fingerprint": "11:12:13:14:bb:26:85:b2:e8:39:27:bc:ee:aa:ff:ee:dd:cc:bb:aa",
+        "id": "key-043046ef2a9a80b56",
+        "tags": {},
+        "type": "rsa"
+    }
+
+    result = ec2_key.extract_key_data(key, key_type)
+
+    assert result == expected_result


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Add the unit-test coverage of the ec2_key module.
- Refactor the module to reduce complexity and allow unit testing.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_key

Latest unit-test coverage (86%): https://890cb34819f4a5031a6a-ac7bf798a2c5290001623a42300937df.ssl.cf5.rackcdn.com/1288/8f1100d82dc058131d0476ff7f82ee7f6eac5b7b/check/cloud-tox-py3/8b0e4b4/docs/coverage/plugins_modules_ec2_key_py.html