### PR TITLE
[6.0.0] s3_object - Remove support for creation/deletion of buckets.

### DIFF
--- a/changelogs/fragments/1112-s3_object-delete-create.yml
+++ b/changelogs/fragments/1112-s3_object-delete-create.yml
@@ -1,0 +1,4 @@
+removed_features:
+- s3_object - support for creating and deleting buckets using the ``s3_object`` module has been removed.
+  S3 buckets can be created and deleted using the ``amazon.aws.s3_bucket`` module
+  (https://github.com/ansible-collections/amazon.aws/issues/1112).

--- a/tests/integration/targets/s3_object/tasks/copy_object.yml
+++ b/tests/integration/targets/s3_object/tasks/copy_object.yml
@@ -6,9 +6,14 @@
         dst: "{{ bucket_name }}-copydst"
 
   - name: create bucket source
-    s3_object:
-      bucket: "{{ copy_bucket.src }}"
-      mode: create
+    s3_bucket:
+      name: "{{ copy_bucket.src }}"
+      state: present
+
+  - name: create bucket destination
+    s3_bucket:
+      name: "{{ copy_bucket.dst }}"
+      state: present
 
   - name: Create content
     set_fact:
@@ -26,7 +31,9 @@
     retries: 3
     delay: 3
     register: put_result
-    until: "put_result.msg == 'PUT operation complete'"
+    until:
+      - '"not found" not in put_result.msg'
+    ignore_errors: True
 
   - name: Copy the content of the source bucket into dest bucket
     s3_object:
@@ -36,6 +43,12 @@
       copy_src:
         bucket: "{{ copy_bucket.src }}"
         object: source.txt
+    retries: 3
+    delay: 3
+    register: put_result
+    until:
+      - '"not found" not in put_result.msg'
+    ignore_errors: True
 
   - name: Get the content copied into {{ copy_bucket.dst }}
     s3_object:

--- a/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
+++ b/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
@@ -124,9 +124,3 @@
         name: "{{ bucket_name }}-acl-disabled"
         state: absent
       register: delete_result
-
-    - name: Ensure bucket deletion
-      assert:
-        that:
-          - delete_result is changed
-          - delete_result is not failed

--- a/tests/integration/targets/s3_object/tasks/delete_bucket.yml
+++ b/tests/integration/targets/s3_object/tasks/delete_bucket.yml
@@ -19,7 +19,7 @@
       ignore_errors: true
 
     - name: delete the bucket
-      s3_object:
-        bucket: "{{ item }}"
-        mode: delete
+      s3_bucket:
+        name: "{{ item }}"
+        state: absent
       ignore_errors: true

--- a/tests/integration/targets/s3_object/tasks/main.yml
+++ b/tests/integration/targets/s3_object/tasks/main.yml
@@ -31,49 +31,15 @@
       set_fact:
         content: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits,punctuation') }}"
 
-    - name: test create bucket without permissions
-      module_defaults: { group/aws: {} }
-      s3_object:
-        bucket: "{{ bucket_name }}"
-        mode: create
-      register: result
-      ignore_errors: true
-
-    - assert:
-        that:
-          - result is failed
-          - "result.msg != 'MODULE FAILURE'"
-
-    - name: test create bucket with an invalid name
-      s3_object:
-        bucket: "{{ bucket_name }}-"
-        mode: create
-      register: result
-      ignore_errors: true
-
-    - assert:
-        that:
-          - result is failed
-
     - name: test create bucket
-      s3_object:
-        bucket: "{{ bucket_name }}"
-        mode: create
+      s3_bucket:
+        name: "{{ bucket_name }}"
+        state: present
       register: result
 
     - assert:
         that:
           - result is changed
-
-    - name: trying to create a bucket name that already exists
-      s3_object:
-        bucket: "{{ bucket_name }}"
-        mode: create
-      register: result
-
-    - assert:
-        that:
-          - result is not changed
 
     - name: Create local upload.txt
       copy:
@@ -582,9 +548,9 @@
       delay: 3
 
     - name: test delete bucket
-      s3_object:
-        bucket: "{{ bucket_name }}"
-        mode: delete
+      s3_bucket:
+        name: "{{ bucket_name }}"
+        state: absent
       register: result
       retries: 3
       delay: 3
@@ -593,36 +559,6 @@
     - assert:
         that:
           - result is changed
-
-    - name: test create a bucket with a dot in the name
-      s3_object:
-        bucket: "{{ bucket_name_with_dot }}"
-        mode: create
-      register: result
-
-    - assert:
-        that:
-          - result is changed
-
-    - name: test delete a bucket with a dot in the name
-      s3_object:
-        bucket: "{{ bucket_name_with_dot }}"
-        mode: delete
-      register: result
-
-    - assert:
-        that:
-          - result is changed
-
-    - name: test delete a nonexistent bucket
-      s3_object:
-        bucket: "{{ bucket_name_with_dot }}"
-        mode: delete
-      register: result
-
-    - assert:
-        that:
-          - result is not changed
 
     - name: make tempfile 4 GB for OSX
       command:
@@ -637,9 +573,9 @@
     - name: test multipart download - platform specific
       block:
         - name: make a bucket to upload the file
-          s3_object:
-            bucket: "{{ bucket_name }}"
-            mode: create
+          s3_bucket:
+            name: "{{ bucket_name }}"
+            state: present
 
         - name: upload the file to the bucket
           s3_object:

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -2,4 +2,3 @@ plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # ht
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
-plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -2,4 +2,3 @@ plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # ht
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
-plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -2,4 +2,3 @@ plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # ht
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
-plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -2,4 +2,3 @@ plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # ht
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
-plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -2,4 +2,3 @@ plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # ht
 plugins/modules/ec2_vpc_endpoint_info.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1179
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111
-plugins/modules/s3_object.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1112

--- a/tests/unit/plugins/modules/test_s3_object.py
+++ b/tests/unit/plugins/modules/test_s3_object.py
@@ -79,30 +79,6 @@ def test_s3_object_do_delobj_failure_noobj(m_delete_key):
     module.fail_json.assert_called_with(msg="object parameter is required")
 
 
-@patch(module_name + ".delete_bucket")
-def test_s3_object_do_delete_success(m_delete_bucket):
-    module = MagicMock()
-    s3 = MagicMock()
-    var_dict = {"bucket": "a987e6b6026ab04e4717"}
-    s3_object.s3_object_do_delete(module, s3, var_dict)
-    assert m_delete_bucket.call_count == 1
-    module.exit_json.assert_called_with(
-        msg="Bucket a987e6b6026ab04e4717 and all keys have been deleted.",
-        changed=True,
-    )
-
-
-@patch(module_name + ".delete_bucket")
-def test_s3_object_do_delete_failure_nobucket(m_delete_bucket):
-    module = MagicMock()
-    s3 = MagicMock()
-
-    var_dict = {}
-    s3_object.s3_object_do_delete(module, s3, var_dict)
-    assert m_delete_bucket.call_count == 0
-    module.fail_json.assert_called_with(msg="Bucket parameter is required.")
-
-
 @patch(module_name + ".paginated_list")
 @patch(module_name + ".list_keys")
 def test_s3_object_do_list_success(m_paginated_list, m_list_keys):


### PR DESCRIPTION
##### SUMMARY

We previously deprecated support for creation/deletion of buckets using the s3_object module (s3_bucket performs the action much better).  It is slated for removal in 6.0.0
 
Fixes #1112 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

s3_object

##### ADDITIONAL INFORMATION

