### PR TITLE
Add support to AnsibleAWSModule.client to override the default parameters

### DIFF
--- a/changelogs/fragments/1303-client-override.yml
+++ b/changelogs/fragments/1303-client-override.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- AnsibleAWSModule - add support to the ``client`` and ``resource`` methods for overriding the default parameters (https://github.com/ansible-collections/amazon.aws/pull/1303).

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -203,16 +203,18 @@ class AnsibleAWSModule:
     def md5(self, *args, **kwargs):
         return self._module.md5(*args, **kwargs)
 
-    def client(self, service, retry_decorator=None):
+    def client(self, service, retry_decorator=None, **extra_params):
         region, endpoint_url, aws_connect_kwargs = get_aws_connection_info(self, boto3=True)
-        conn = boto3_conn(self, conn_type='client', resource=service,
-                          region=region, endpoint=endpoint_url, **aws_connect_kwargs)
+        kw_args = dict(region=region, endpoint=endpoint_url, **aws_connect_kwargs)
+        kw_args.update(extra_params)
+        conn = boto3_conn(self, conn_type='client', resource=service, **kw_args)
         return conn if retry_decorator is None else RetryingBotoClientWrapper(conn, retry_decorator)
 
-    def resource(self, service):
+    def resource(self, service, **extra_params):
         region, endpoint_url, aws_connect_kwargs = get_aws_connection_info(self, boto3=True)
-        return boto3_conn(self, conn_type='resource', resource=service,
-                          region=region, endpoint=endpoint_url, **aws_connect_kwargs)
+        kw_args = dict(region=region, endpoint=endpoint_url, **aws_connect_kwargs)
+        kw_args.update(extra_params)
+        return boto3_conn(self, conn_type='resource', resource=service, **kw_args)
 
     @property
     def region(self):

--- a/plugins/plugin_utils/base.py
+++ b/plugins/plugin_utils/base.py
@@ -36,17 +36,17 @@ class AWSPluginBase:
             self._do_fail(to_native(message))
         self._do_fail(f"{message}: {to_native(exception)}")
 
-    def client(self, service, retry_decorator=None, **params):
+    def client(self, service, retry_decorator=None, **extra_params):
         region, endpoint_url, aws_connect_kwargs = get_aws_connection_info(self)
         kw_args = dict(region=region, endpoint=endpoint_url, **aws_connect_kwargs)
-        kw_args.update(params)
+        kw_args.update(extra_params)
         conn = boto3_conn(self, conn_type='client', resource=service, **kw_args)
         return conn if retry_decorator is None else RetryingBotoClientWrapper(conn, retry_decorator)
 
-    def resource(self, service, **params):
+    def resource(self, service, **extra_params):
         region, endpoint_url, aws_connect_kwargs = get_aws_connection_info(self)
         kw_args = dict(region=region, endpoint=endpoint_url, **aws_connect_kwargs)
-        kw_args.update(params)
+        kw_args.update(extra_params)
         return boto3_conn(self, conn_type='resource', resource=service, **kw_args)
 
     @property

--- a/tests/unit/module_utils/modules/ansible_aws_module/test_passthrough.py
+++ b/tests/unit/module_utils/modules/ansible_aws_module/test_passthrough.py
@@ -155,6 +155,16 @@ def test_client_wrapper(monkeypatch, stdin):
                                         region=sentinel.CONN_REGION,
                                         endpoint=sentinel.CONN_URL,)
 
+    # Check that we can override parameters
+    wrapped_conn = aws_module.client(sentinel.PARAM_SERVICE, sentinel.PARAM_WRAPPER, region=sentinel.PARAM_REGION)
+    assert wrapped_conn.client is sentinel.BOTO3_CONN
+    assert wrapped_conn.retry is sentinel.PARAM_WRAPPER
+    assert get_aws_connection_info.call_args == call(aws_module, boto3=True)
+    assert boto3_conn.call_args == call(aws_module, conn_type='client',
+                                        resource=sentinel.PARAM_SERVICE,
+                                        region=sentinel.PARAM_REGION,
+                                        endpoint=sentinel.CONN_URL,)
+
 
 @pytest.mark.parametrize("stdin", [{}], indirect=["stdin"])
 def test_resource(monkeypatch, stdin):
@@ -172,4 +182,12 @@ def test_resource(monkeypatch, stdin):
     assert boto3_conn.call_args == call(aws_module, conn_type='resource',
                                         resource=sentinel.PARAM_SERVICE,
                                         region=sentinel.CONN_REGION,
+                                        endpoint=sentinel.CONN_URL,)
+
+    # Check that we can override parameters
+    assert aws_module.resource(sentinel.PARAM_SERVICE, region=sentinel.PARAM_REGION) is sentinel.BOTO3_CONN
+    assert get_aws_connection_info.call_args == call(aws_module, boto3=True)
+    assert boto3_conn.call_args == call(aws_module, conn_type='resource',
+                                        resource=sentinel.PARAM_SERVICE,
+                                        region=sentinel.PARAM_REGION,
                                         endpoint=sentinel.CONN_URL,)


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/community.aws/pull/1635

##### SUMMARY

When refactoring the inventory plugins it was helpful to be able to override region, however looking at the S3 code, it's also helpful to be able to override other things too.  Pull this in as a small change while I work on the rest of it.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/modules.py

##### ADDITIONAL INFORMATION
