### PR TITLE
module_utils/botocore - add BOTOCORE_BASE_EXCEPTIONS

### DIFF
--- a/plugins/module_utils/botocore.py
+++ b/plugins/module_utils/botocore.py
@@ -40,9 +40,11 @@ try:
     import boto3
     import botocore
     HAS_BOTO3 = True
+    BOTOCORE_BASE_EXCEPTIONS = (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError)
 except ImportError:
     BOTO3_IMP_ERR = traceback.format_exc()
     HAS_BOTO3 = False
+    BOTOCORE_BASE_EXCEPTIONS = (type("NeverRaisedException", (Exception,), {}),)
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils.ansible_release import __version__


### PR DESCRIPTION
##### SUMMARY

With improvements to module_utils.botocore and AnsibleAWSModule the primary usecase for importing "botocore" is to be able to catch ClientException and BotoCoreError.

By dropping these two into a constant in module_utils.botocore we can remove the need to import botocore in most of our modules

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/botocore.py

(For examples of use)
plugins/module_utils/acm.py
plugins/module_utils/iam.py

##### ADDITIONAL INFORMATION

