### PR TITLE
ec2_eni_info - update docs default entry for filters

### DIFF
--- a/changelogs/fragments/20230103-sanity-ec2_eni_info.yml
+++ b/changelogs/fragments/20230103-sanity-ec2_eni_info.yml
@@ -1,0 +1,2 @@
+trivial:
+- ec2_eni_info - update docs to reflect default value for ``filters`` parameter.

--- a/plugins/modules/ec2_eni_info.py
+++ b/plugins/modules/ec2_eni_info.py
@@ -24,6 +24,7 @@ options:
         See U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeNetworkInterfaces.html) for possible filters.
       - This option is mutually exclusive of I(eni_id).
     type: dict
+    default: {}
 extends_documentation_fragment:
   - amazon.aws.aws
   - amazon.aws.ec2


### PR DESCRIPTION
##### SUMMARY

Devel is currently reporting a sanity failure:
```
2023-01-02 21:42:04.487975 | controller | ERROR: plugins/modules/ec2_eni_info.py:0:0: doc-default-does-not-match-spec: Argument 'filters' in argument_spec defines default as ({}) but documentation defines default as (None)
```

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

ec2_eni_info

##### ADDITIONAL INFORMATION
