### PR TITLE
ec2_vpc_dhcp_option - retry describe_dhcp_options on InvalidDhcpOptioID.NotFound

### DIFF
--- a/changelogs/fragments/1320-ec2_vpc_dhcp_options-retrys.yaml
+++ b/changelogs/fragments/1320-ec2_vpc_dhcp_options-retrys.yaml
@@ -1,0 +1,3 @@
+bugfixes:
+- ec2_vpc_dhcp_option - retry ``describe_dhcp_options`` after creation when ``InvalidDhcpOptionID.NotFound`` is raised
+  (https://github.com/ansible-collections/amazon.aws/pull/1320).

--- a/plugins/modules/ec2_vpc_dhcp_option.py
+++ b/plugins/modules/ec2_vpc_dhcp_option.py
@@ -410,7 +410,13 @@ def get_dhcp_options_info(client, module, dhcp_options_id):
         return None
 
     try:
-        dhcp_option_info = client.describe_dhcp_options(aws_retry=True, DhcpOptionsIds=[dhcp_options_id])
+        dhcp_option_info = AWSRetry.jittered_backoff(
+            catch_extra_error_codes=["InvalidDhcpOptionID.NotFound"]
+        )(
+            client.describe_dhcp_options,
+        )(
+            DhcpOptionsIds=[dhcp_options_id],
+        )
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Unable to describe dhcp options")
 

--- a/tests/integration/targets/ec2_vpc_net/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_net/tasks/main.yml
@@ -448,7 +448,7 @@
     - name: create a DHCP option set to use in next test
       ec2_vpc_dhcp_option:
         dns_servers:
-          - 4.4.4.4
+          - 8.8.4.4
           - 8.8.8.8
         tags:
           Name: "{{ vpc_name }}"
@@ -456,7 +456,7 @@
     - name: assert the DHCP option set was successfully created
       assert:
         that:
-          - new_dhcp is changed
+          - new_dhcp is successful
 
     - name: modify the DHCP options set for a VPC (check_mode)
       ec2_vpc_net:


### PR DESCRIPTION
##### SUMMARY

Integration tests have been flakey because of 

```
botocore.exceptions.ClientError: An error occurred (InvalidDhcpOptionID.NotFound) when calling the DescribeDhcpOptions operation: The dhcpOption ID 'dopt-005de86cff685951b' does not exist
```

While we're returned the ID, creation and propagation isn't always instant.  Allow for retries after creation of an optionset.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_vpc_dhcp_options

##### ADDITIONAL INFORMATION

Examples:

https://99b800ba2f338f8fe26c-b9e663698c5137b7c40d5b983da05750.ssl.cf5.rackcdn.com/1310/8b18a5ca6e49e02b0004c86cc3467e10b0757555/gate/integration-amazon.aws-16/23f54a3/job-output.txt

https://530531024c51fb0860cd-d325a0cf1bd8249f2d5115b3e7ba100c.ssl.cf5.rackcdn.com/1310/8b18a5ca6e49e02b0004c86cc3467e10b0757555/gate/integration-amazon.aws-16/3594443/job-output.txt

(note the failing ec2_vpc_net test is actually the DHCP option creation failing.  First time we get the exception, second time the option already exists so isn't "changed")