### PR TITLE
ec2_snapshot - stability - relax integration tests

### DIFF
--- a/changelogs/fragments/20230105-ec2_snapshot.yml
+++ b/changelogs/fragments/20230105-ec2_snapshot.yml
@@ -1,0 +1,2 @@
+trivial:
+- ec2_snapshot - tweak to ec2_snapshot tests for ``max_results`` and ``next_token_id``

--- a/tests/integration/targets/ec2_snapshot/tasks/main.yml
+++ b/tests/integration/targets/ec2_snapshot/tasks/main.yml
@@ -243,9 +243,6 @@
           "tag:Name": '{{ resource_prefix }}'
         max_results: 5
       register: info_result
-      until: "info_result.snapshots | length == 5"
-      retries: 10
-      delay: 30
 
     - assert:
         that:
@@ -257,11 +254,17 @@
         filters:
           "tag:Name": '{{ resource_prefix }}'
         next_token_id: "{{ info_result.next_token_id }}"
-      register: info_result
+        max_results: 5
+      register: info_result_2
 
+    # note: *MAX* 5 results, sometimes they'll throw us fewer...
+    # 8 is the absolute max it should find
     - assert:
         that:
-          - info_result.snapshots | length == 3
+          - (length_1 | int ) + (length_2 | int) <= 8
+      vars:
+        length_1: "{{ info_result.snapshots | length }}"
+        length_2: "{{ info_result_2.snapshots | length }}"
 
     # delete the tagged snapshot - check mode
     - name: Delete the tagged snapshot (check mode)


### PR DESCRIPTION
##### SUMMARY

When using pagination, you're not guaranteed to get "max_items", it's a maximum.  Sometimes you'll get less.  Relax the ec2_snapshot tests a little to take this into account.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_snapshot

##### ADDITIONAL INFORMATION
