### PR TITLE
ec2_vol - improve integration test stability

### DIFF
--- a/changelogs/fragments/20230106-ec2_vol.yml
+++ b/changelogs/fragments/20230106-ec2_vol.yml
@@ -1,0 +1,2 @@
+trivial:
+- ec2_vol - tweak integration tests to use instance_id rather than tags when waiting for the instance.

--- a/tests/integration/targets/ec2_vol/tasks/main.yml
+++ b/tests/integration/targets/ec2_vol/tasks/main.yml
@@ -212,9 +212,8 @@
 
     - name: Wait for instance to start
       ec2_instance:
-        name: "{{ instance_name }}"
         state: running
-        image_id: "{{ ec2_ami_id }}"
+        instance_ids: "{{ test_instance.instance_ids }}"
         wait: True
 
     - name: attach existing volume to an instance (check_mode)
@@ -894,9 +893,8 @@
 
     - name: Wait for instance to start
       ec2_instance:
-        name: "{{ instance_name }}-2"
         state: running
-        image_id: "{{ ec2_ami_id }}"
+        instance_ids: "{{ test_instance_2.instance_ids }}"
         wait: True
 
     - name: attach existing volume to second instance


### PR DESCRIPTION
##### SUMMARY

When searching for EC2 resources (without an ID), the search results sometimes come back empty when they shouldn't.

##### ISSUE TYPE

- Tests Pull Request

##### COMPONENT NAME

ec2_vol

##### ADDITIONAL INFORMATION
