### PR TITLE
[6.0.0] ec2_vpc_dhcp_options - drop new_options

### DIFF
--- a/changelogs/fragments/1327-ec2_vpc_dhcp_options.yml
+++ b/changelogs/fragments/1327-ec2_vpc_dhcp_options.yml
@@ -1,0 +1,4 @@
+breaking_changes:
+- ec2_vpc_dhcp_options - the ``new_options`` return value has been deprecated after being renamed
+  to ``dhcp_config``.  Please use the ``dhcp_config`` or ``dhcp_options`` return values
+  (https://github.com/ansible-collections/amazon.aws/pull/1327).

--- a/plugins/modules/ec2_vpc_dhcp_option.py
+++ b/plugins/modules/ec2_vpc_dhcp_option.py
@@ -473,14 +473,12 @@ def main():
 
     client = module.client('ec2', retry_decorator=AWSRetry.jittered_backoff())
 
-    module.deprecate("The 'new_config' return key is deprecated and will be replaced by 'dhcp_config'. Both values are returned for now.",
-                     version='6.0.0', collection_name='amazon.aws')
     if state == 'absent':
         if not dhcp_options_id:
             # Look up the option id first by matching the supplied options
             dhcp_options_id = match_dhcp_options(client, module, new_config)
         changed = remove_dhcp_options_by_id(client, module, dhcp_options_id)
-        module.exit_json(changed=changed, new_options={}, dhcp_options={})
+        module.exit_json(changed=changed, dhcp_options={}, dhcp_config={})
 
     if not dhcp_options_id:
         # If we were given a vpc_id then we need to look at the configuration on that
@@ -498,7 +496,8 @@ def main():
                                                    tags=tags, purge_tags=purge_tags)
                     return_config = normalize_ec2_vpc_dhcp_config(new_config)
                     results = get_dhcp_options_info(client, module, dhcp_options_id)
-                    module.exit_json(changed=changed, new_options=return_config, dhcp_options_id=dhcp_options_id, dhcp_options=results)
+                    module.exit_json(changed=changed, dhcp_options_id=dhcp_options_id,
+                                     dhcp_options=results, dhcp_config=return_config)
         # If no vpc_id was given, or the options don't match then look for an existing set using tags
         found, dhcp_options_id = match_dhcp_options(client, module, new_config)
 
@@ -532,7 +531,7 @@ def main():
 
     return_config = normalize_ec2_vpc_dhcp_config(new_config)
     results = get_dhcp_options_info(client, module, dhcp_options_id)
-    module.exit_json(changed=changed, new_options=return_config, dhcp_options_id=dhcp_options_id, dhcp_options=results, dhcp_config=return_config)
+    module.exit_json(changed=changed, dhcp_options_id=dhcp_options_id, dhcp_options=results, dhcp_config=return_config)
 
 
 if __name__ == '__main__':

--- a/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml
@@ -3,7 +3,6 @@
 # Known issues:
 #
 # there is no way to associate the `default` option set in the module
-# The module doesn't store/return tags in the new_options dictionary
 # always reassociated (changed=True) when vpc_id is provided without options
 #
 # ============================================================
@@ -172,13 +171,13 @@
   - assert:
       that:
         - dhcp_options.changed
-        - dhcp_options.new_options
-        - dhcp_options.new_options.keys() | list | sort == ['domain-name', 'domain-name-servers', 'netbios-name-servers', 'netbios-node-type', 'ntp-servers']
-        - dhcp_options.new_options['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
-        - dhcp_options.new_options['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.new_options['netbios-node-type'] == '2'
-        - dhcp_options.new_options['domain-name'] == ['{{ aws_domain_name }}']
-        - dhcp_options.new_options['domain-name-servers'] == ['AmazonProvidedDNS']
+        - dhcp_options.dhcp_config
+        - dhcp_options.dhcp_config.keys() | list | sort == ['domain-name', 'domain-name-servers', 'netbios-name-servers', 'netbios-node-type', 'ntp-servers']
+        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+        - dhcp_options.dhcp_config['netbios-node-type'] == '2'
+        - dhcp_options.dhcp_config['domain-name'] == ['{{ aws_domain_name }}']
+        - dhcp_options.dhcp_config['domain-name-servers'] == ['AmazonProvidedDNS']
         # We return the list of dicts that boto gives us, in addition to the user-friendly config dict
         - dhcp_options_config['ntp-servers'] | map(attribute='value') | list | sort == ['10.0.0.2', '10.0.1.2']
         - dhcp_options_config['netbios-name-servers'] | map(attribute='value') | list | sort == ['10.0.0.1', '10.0.1.1']
@@ -276,12 +275,11 @@
   - assert:
       that:
         - dhcp_options.changed
-        - dhcp_options.new_options
-        # FIXME extra keys are returned unpredictably
-        - dhcp_options.new_options.keys() | list | sort == ['netbios-name-servers', 'netbios-node-type', 'ntp-servers']
-        - dhcp_options.new_options['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
-        - dhcp_options.new_options['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.new_options['netbios-node-type'] == '2'
+        - dhcp_options.dhcp_config
+        - dhcp_options.dhcp_config.keys() | list | sort == ['netbios-name-servers', 'netbios-node-type', 'ntp-servers']
+        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+        - dhcp_options.dhcp_config['netbios-node-type'] == '2'
         - original_dhcp_options_id != dhcp_options.dhcp_options_id
         # We return the list of dicts that boto gives us, in addition to the user-friendly config dict
         - new_dhcp_options.dhcp_config[0]['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
@@ -358,12 +356,12 @@
   - assert:
       that:
         - dhcp_options.changed
-        - dhcp_options.new_options
-        - dhcp_options.new_options.keys() | list | sort == ['domain-name', 'domain-name-servers', 'netbios-name-servers', 'netbios-node-type', 'ntp-servers']
-        - dhcp_options.new_options['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
-        - dhcp_options.new_options['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.new_options['netbios-node-type'] == '1'
-        - dhcp_options.new_options['domain-name'] == ['{{ aws_domain_name }}']
+        - dhcp_options.dhcp_config
+        - dhcp_options.dhcp_config.keys() | list | sort == ['domain-name', 'domain-name-servers', 'netbios-name-servers', 'netbios-node-type', 'ntp-servers']
+        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+        - dhcp_options.dhcp_config['netbios-node-type'] == '1'
+        - dhcp_options.dhcp_config['domain-name'] == ['{{ aws_domain_name }}']
         - original_dhcp_options_id != dhcp_options.dhcp_options_id
 
   - set_fact:
@@ -440,10 +438,10 @@
 
   - assert:
       that:
-        - dhcp_options.new_options
-        - dhcp_options.new_options.keys() | list | sort is superset(['domain-name', 'domain-name-servers'])
-        - dhcp_options.new_options['domain-name'] == ['{{ aws_domain_name }}']
-        - dhcp_options.new_options['domain-name-servers'] == ['AmazonProvidedDNS']
+        - dhcp_options.dhcp_config
+        - dhcp_options.dhcp_config.keys() | list | sort is superset(['domain-name', 'domain-name-servers'])
+        - dhcp_options.dhcp_config['domain-name'] == ['{{ aws_domain_name }}']
+        - dhcp_options.dhcp_config['domain-name-servers'] == ['AmazonProvidedDNS']
         - original_dhcp_options_id != dhcp_options.dhcp_options_id
 
   - set_fact:
@@ -525,9 +523,9 @@
   - assert:
       that:
         - dhcp_options.changed
-        - dhcp_options.new_options.keys() | list | sort is superset(['ntp-servers', 'netbios-name-servers'])
-        - dhcp_options.new_options['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
-        - dhcp_options.new_options['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+        - dhcp_options.dhcp_config.keys() | list | sort is superset(['ntp-servers', 'netbios-name-servers'])
+        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
         - original_dhcp_options_id != dhcp_options.dhcp_options_id
         # We return the list of dicts that boto gives us, in addition to the user-friendly config dict
         - dhcp_options_config['ntp-servers'] | map(attribute='value') | list | sort == ['10.0.0.2', '10.0.1.2']
@@ -572,9 +570,9 @@
   - assert:
       that:
         - not dhcp_options.changed
-        - dhcp_options.new_options.keys() | list | sort == ['netbios-name-servers', 'ntp-servers']
-        - dhcp_options.new_options['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.new_options['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+        - dhcp_options.dhcp_config.keys() | list | sort == ['netbios-name-servers', 'ntp-servers']
+        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
 
   - name: test no changes with the same tags
     ec2_vpc_dhcp_option:
@@ -601,9 +599,9 @@
   - assert:
       that:
         - not dhcp_options.changed
-        - dhcp_options.new_options.keys() | list | sort == ['netbios-name-servers', 'ntp-servers']
-        - dhcp_options.new_options['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.new_options['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+        - dhcp_options.dhcp_config.keys() | list | sort == ['netbios-name-servers', 'ntp-servers']
+        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
         - new_dhcp_options_id == dhcp_options.dhcp_options_id
         - dhcp_options.dhcp_options.tags.keys() | length == 2
         - dhcp_options.dhcp_options.tags['CreatedBy'] == 'ansible-test'
@@ -632,9 +630,9 @@
   - assert:
       that:
         - not dhcp_options.changed
-        - dhcp_options.new_options.keys() | list | sort is superset(['netbios-name-servers', 'ntp-servers'])
-        - dhcp_options.new_options['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.new_options['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+        - dhcp_options.dhcp_config.keys() | list | sort is superset(['netbios-name-servers', 'ntp-servers'])
+        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
 
   - name: test no changes without specifying tags
     ec2_vpc_dhcp_option:
@@ -659,9 +657,9 @@
   - assert:
       that:
         - not dhcp_options.changed
-        - dhcp_options.new_options.keys() | list | sort is superset(['netbios-name-servers', 'ntp-servers'])
-        - dhcp_options.new_options['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.new_options['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+        - dhcp_options.dhcp_config.keys() | list | sort is superset(['netbios-name-servers', 'ntp-servers'])
+        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
         - new_dhcp_options_id == dhcp_options.dhcp_options_id
         - dhcp_options_info.dhcp_options[0].tags is defined
         - dhcp_options_info.dhcp_options[0].tags.keys() | length == 2
@@ -694,9 +692,9 @@
   - assert:
       that:
         - dhcp_options.changed
-        - dhcp_options.new_options.keys() | list | sort is superset(['netbios-name-servers', 'ntp-servers'])
-        - dhcp_options.new_options['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.new_options['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+        - dhcp_options.dhcp_config.keys() | list | sort is superset(['netbios-name-servers', 'ntp-servers'])
+        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
         - new_dhcp_options_id == dhcp_options.dhcp_options_id
         - dhcp_options.dhcp_options.tags.keys() | length == 3
         - dhcp_options.dhcp_options.tags['another'] == 'tag'

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,3 +1,2 @@
-plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,3 +1,2 @@
-plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,3 +1,2 @@
-plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,3 +1,2 @@
-plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,3 +1,2 @@
-plugins/modules/ec2_vpc_dhcp_option.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1177
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,5 +1,3 @@
-plugins/modules/ec2_vpc_dhcp_option.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
-plugins/modules/ec2_instance.py pylint:ansible-deprecated-no-version  # We use dates for deprecations, Ansible 2.9 only supports this for compatability
 plugins/modules/iam_policy.py pylint:ansible-deprecated-no-version
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/modules/iam_user.py pylint:ansible-deprecated-no-version


### PR DESCRIPTION
##### SUMMARY

new_options was temporary, has been deprecated and should now be removed.

fixes: #1177 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vpc_dhcp_options

##### ADDITIONAL INFORMATION
