### PR TITLE
ec2_vpc_route_table - fix integration test after 1308

### DIFF
--- a/changelogs/fragments/20230109-ec2_vpc_route_table.yml
+++ b/changelogs/fragments/20230109-ec2_vpc_route_table.yml
@@ -1,0 +1,2 @@
+trivial:
+- ec2_vpc_route_table - fix integration test after https://github.com/ansible-collections/amazon.aws/pull/1308.

--- a/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -714,7 +714,6 @@
     register: result
   - name: Get endpoint infos to verify that it wasn't purged from the route table
     ec2_vpc_endpoint_info:
-      query: endpoints
       vpc_endpoint_ids:
       - '{{ vpc_endpoint.result.vpc_endpoint_id }}'
     register: endpoint_details


### PR DESCRIPTION
##### SUMMARY

#1308 means `query` is no longer needed (and no longer supported)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_vpc_route_table

##### ADDITIONAL INFORMATION
