### PR TITLE
[stable-5] aws_rds - RDS inventory plugin didn't read config

### DIFF
--- a/changelogs/fragments/1304-aws_rds-config.yml
+++ b/changelogs/fragments/1304-aws_rds-config.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- aws_rds - fixes bug in RDS inventory plugin where config file was ignored (https://github.com/ansible-collections/amazon.aws/issues/1304).

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -360,6 +360,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
         if not HAS_BOTO3:
             raise AnsibleError(missing_required_lib('botocore and boto3'))
 
+        self._read_config_data(path)
         self._set_credentials()
 
         # get user specifications


### PR DESCRIPTION
##### SUMMARY

fixes #1304 

Partial reversion of #958 (ish)

_read_config_data() has side effects, namely that it sets all of the options data,  as well as returning data.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

aws_rds

##### ADDITIONAL INFORMATION
