### PR TITLE
route53_health_check: rescind deprecation message for `health_check_name`

### DIFF
--- a/changelogs/fragments/1335-route53_health_check-rescind-deprecation-message.yml
+++ b/changelogs/fragments/1335-route53_health_check-rescind-deprecation-message.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - route53_health_check - Drop deprecation warning (https://github.com/ansible-collections/community.aws/pull/1335).

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -594,13 +594,6 @@ def main():
     action = None
     check_id = None
 
-    if module.params.get('use_unique_names') or module.params.get('health_check_id'):
-        module.deprecate(
-            'The health_check_name is currently non required parameter.'
-            ' This behavior will change and health_check_name '
-            ' will change to required=True and use_unique_names will change to default=True in release 6.0.0.',
-            version='6.0.0', collection_name='amazon.aws')
-
     # If update or delete Health Check based on ID
     update_delete_by_id = False
     if module.params.get('health_check_id'):

--- a/tests/sanity/ignore-2.11.txt
+++ b/tests/sanity/ignore-2.11.txt
@@ -1,2 +1,1 @@
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
-plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.12.txt
+++ b/tests/sanity/ignore-2.12.txt
@@ -1,2 +1,1 @@
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
-plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.13.txt
+++ b/tests/sanity/ignore-2.13.txt
@@ -1,2 +1,1 @@
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
-plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.14.txt
+++ b/tests/sanity/ignore-2.14.txt
@@ -1,2 +1,1 @@
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
-plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111

--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,2 +1,1 @@
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
-plugins/modules/route53_health_check.py pylint:collection-deprecated-version # https://github.com/ansible-collections/amazon.aws/issues/1111


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Rescind deprecation message as nonessential due to below reasons
- `health_check_id` and `health_check_name` being mutually exclusive
- module currently provides functionality to update/delete by `name` and `id` both, which would not be the case if the deprecation changes are made.
- can [update by ID / delete by ID](https://github.com/ansible-collections/amazon.aws/blob/main/tests/integration/targets/route53_health_check/tasks/update_delete_by_id.yml)
can [update by name+use_unique_names](https://github.com/ansible-collections/amazon.aws/blob/main/tests/integration/targets/route53_health_check/tasks/create_multiple_health_checks.yml#L119-L157) / [delete by name+use_unique_names](https://github.com/ansible-collections/amazon.aws/blob/main/tests/integration/targets/route53_health_check/tasks/main.yml#L1752-L1761)
can [create single health check](https://github.com/ansible-collections/amazon.aws/blob/main/tests/integration/targets/route53_health_check/tasks/main.yml#L60-L66) without name and use_unique_names
can [create multiple health checks](https://github.com/ansible-collections/amazon.aws/blob/main/tests/integration/targets/route53_health_check/tasks/create_multiple_health_checks.yml#L26-L43) with name+use_unique_names
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
route53_health_check