### PR TITLE
ec2_instance - avoid manipulating module.params

### DIFF
--- a/changelogs/fragments/1337-ec2_instance.yml
+++ b/changelogs/fragments/1337-ec2_instance.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_instance - updated to avoid manipulating ``module.params`` (https://github.com/ansible-collections/amazon.aws/pull/1337).

--- a/tests/unit/plugins/modules/ec2_instance/test_build_run_instance_spec.py
+++ b/tests/unit/plugins/modules/ec2_instance/test_build_run_instance_spec.py
@@ -130,12 +130,20 @@ def test_build_run_instance_spec_exact_count(params_object, ec2_instance):
     # The "exact_count" logic relies on enforce_count doing the math to figure out how many
     # instances to start/stop.  The enforce_count call is responsible for ensuring that 'to_launch'
     # is set and is a positive integer.
-    params_object['exact_count'] = sentinel.EXACT_COUNT
+    params_object['exact_count'] = 42
     params_object['to_launch'] = sentinel.TO_LAUNCH
     instance_spec = ec2_instance.build_run_instance_spec(params_object)
 
     _assert_defaults(instance_spec, ['MaxCount', 'MinCount'])
     assert 'MaxCount' in instance_spec
     assert 'MinCount' in instance_spec
-    assert instance_spec['MaxCount'] == sentinel.TO_LAUNCH
-    assert instance_spec['MinCount'] == sentinel.TO_LAUNCH
+    assert instance_spec['MaxCount'] == 42
+    assert instance_spec['MinCount'] == 42
+
+    instance_spec = ec2_instance.build_run_instance_spec(params_object, 7)
+
+    _assert_defaults(instance_spec, ['MaxCount', 'MinCount'])
+    assert 'MaxCount' in instance_spec
+    assert 'MinCount' in instance_spec
+    assert instance_spec['MaxCount'] == 35
+    assert instance_spec['MinCount'] == 35


### PR DESCRIPTION
##### SUMMARY

Directly manipulating module.params results in the Ansible output incorrectly representing what was passed to the module, as such we shouldn't be doing this.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_instance

##### ADDITIONAL INFORMATION
