### PR TITLE
Add 'base' connection plugin code

### DIFF
--- a/changelogs/fragments/refactor_connection_plugins.yml
+++ b/changelogs/fragments/refactor_connection_plugins.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- plugin_utils - Added ``AWSConnectionBase`` to support refactoring connection plugins (https://github.com/ansible-collections/amazon.aws/pull/1340).

--- a/plugins/plugin_utils/connection.py
+++ b/plugins/plugin_utils/connection.py
@@ -1,0 +1,19 @@
+# (c) 2023 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible.errors import AnsibleConnectionFailure
+from ansible.plugins.connection import ConnectionBase
+
+from ansible_collections.amazon.aws.plugins.plugin_utils.base import AWSPluginBase
+
+
+class AWSConnectionBase(AWSPluginBase, ConnectionBase):
+
+    def _do_fail(self, message):
+        raise AnsibleConnectionFailure(message)
+
+    def __init__(self, *args, boto3_version=None, botocore_version=None, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.require_aws_sdk(botocore_version=botocore_version, boto3_version=boto3_version)

--- a/tests/unit/plugin_utils/connection/test_connection_base.py
+++ b/tests/unit/plugin_utils/connection/test_connection_base.py
@@ -1,0 +1,41 @@
+# (c) 2023 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+from unittest.mock import call
+from unittest.mock import MagicMock
+from unittest.mock import sentinel
+
+from ansible.errors import AnsibleConnectionFailure
+
+import ansible_collections.amazon.aws.plugins.plugin_utils.connection as utils_connection
+
+
+def test_fail(monkeypatch):
+    monkeypatch.setattr(utils_connection.AWSConnectionBase, "__abstractmethods__", set())
+    monkeypatch.setattr(utils_connection.ConnectionBase, "__init__", MagicMock(name="__init__"))
+
+    connection_plugin = utils_connection.AWSConnectionBase()  # pylint: disable=abstract-class-instantiated
+    with pytest.raises(AnsibleConnectionFailure, match=str(sentinel.ERROR_MSG)):
+        connection_plugin._do_fail(sentinel.ERROR_MSG)
+
+
+def test_init(monkeypatch):
+    kwargs = {"example": sentinel.KWARG}
+    require_aws_sdk = MagicMock(name="require_aws_sdk")
+    require_aws_sdk.return_value = sentinel.RETURNED_SDK
+
+    monkeypatch.setattr(utils_connection.AWSConnectionBase, "__abstractmethods__", set())
+    monkeypatch.setattr(utils_connection.ConnectionBase, "__init__", MagicMock(name="__init__"))
+    monkeypatch.setattr(utils_connection.AWSConnectionBase, "require_aws_sdk", require_aws_sdk)
+
+    connection_plugin = utils_connection.AWSConnectionBase(sentinel.PARAM_TERMS, sentinel.PARAM_VARS, **kwargs)  # pylint: disable=abstract-class-instantiated
+    assert require_aws_sdk.call_args == call(botocore_version=None, boto3_version=None)
+
+    connection_plugin = utils_connection.AWSConnectionBase(  # pylint: disable=abstract-class-instantiated
+        sentinel.PARAM_ONE, sentinel.PARAM_TWO,
+        boto3_version=sentinel.PARAM_BOTO3, botocore_version=sentinel.PARAM_BOTOCORE,
+        **kwargs)
+    assert require_aws_sdk.call_args == call(botocore_version=sentinel.PARAM_BOTOCORE, boto3_version=sentinel.PARAM_BOTO3)


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1748

##### SUMMARY

Adds a plugin_utils.connection.AWSConnectionBase to support future work on aws_ssm plugin.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugin_utils/connection.py

##### ADDITIONAL INFORMATION