### PR TITLE
Add rust and openssl-devel to bindeps - prep for fedora37 Zuul

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,4 +1,7 @@
 # Needed by the ec2_key integration tests (generating EC2 format fingerprint)
 openssl [test platform:rpm]
+openssl-devel [test platform:rpm]
 gcc [test platform:rpm]
 python3-devel [test platform:rpm]
+cargo [test platform:rpm]
+rust [test platform:rpm]

--- a/changelogs/fragments/1341-fedora-37.yml
+++ b/changelogs/fragments/1341-fedora-37.yml
@@ -1,0 +1,2 @@
+trivial:
+- Update bindeps for fedora-37 on Zuul nodes


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1748

##### SUMMARY

Add rust and openssl-devel to bindeps - prep for fedora37 Zuul

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME
bindeps.txt

##### ADDITIONAL INFORMATION
