### PR TITLE
[6.0.0] Bump botocore requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ after 2023-05-31.
 
 Starting with the 2.0.0 releases of amazon.aws and community.aws, it is generally the collection's policy to support the versions of `botocore` and `boto3` that were released 12 months prior to the most recent major collection release, following semantic versioning (for example, 2.0.0, 3.0.0).
 
-Version 5.0.0 of this collection supports `boto3 >= 1.18.0` and `botocore >= 1.21.0`
+Version 6.0.0 of this collection supports `boto3 >= 1.22.0` and `botocore >= 1.25.0`
 
 All support for the original AWS SDK `boto` was removed in release 4.0.0.
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ this collection requires Python 3.6 or greater.
 
 Amazon have also announced the end of support for
 [Python less than 3.7](https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/).
-As such support for Python less than 3.7 by this collection has been deprecated and will be removed in a release
-after 2023-05-31.
+As such support for Python less than 3.7 by this collection has been deprecated and will be removed in release 7.0.0.
+Additionally, support for Python less than 3.8 is expected to be removed in a release after 2024-12-01 based on currently
+available schedules.
 
 ## AWS SDK version compatibility
 

--- a/changelogs/fragments/python37.yml
+++ b/changelogs/fragments/python37.yml
@@ -1,0 +1,9 @@
+deprecated_features:
+- amazon.aws collection - due to the AWS SDKs announcing the end of support
+  for Python less than 3.7 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
+  support for Python less than 3.7 by this collection has been deprecated and will be removed in release 7.0.0.
+  (https://github.com/ansible-collections/amazon.aws/pull/1342).
+- amazon.aws collection - due to the AWS SDKs Python support policies
+  (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
+  support for Python less than 3.8 by this collection is expected to be removed in a release after 2024-12-01
+  (https://github.com/ansible-collections/amazon.aws/pull/1342).

--- a/changelogs/fragments/release-6-botocore.yml
+++ b/changelogs/fragments/release-6-botocore.yml
@@ -1,0 +1,6 @@
+breaking_changes:
+- The amazon.aws collection has dropped support for ``botocore<1.25.0`` and
+  ``boto3<1.22.0``. Most modules will continue to work with older versions of the AWS SDK, however
+  compatability with older versions of the SDK is not guaranteed and will not be tested. When using
+  older versions of the SDK a warning will be emitted by Ansible
+  (https://github.com/ansible-collections/amazon.aws/pull/1342).

--- a/plugins/module_utils/botocore.py
+++ b/plugins/module_utils/botocore.py
@@ -55,8 +55,8 @@ from .retries import AWSRetry
 from .version import LooseVersion
 from .common import get_collection_info
 
-MINIMUM_BOTOCORE_VERSION = '1.21.0'
-MINIMUM_BOTO3_VERSION = '1.18.0'
+MINIMUM_BOTOCORE_VERSION = '1.25.0'
+MINIMUM_BOTO3_VERSION = '1.22.0'
 
 
 def _get_user_agent_string():

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -359,7 +359,6 @@ options:
         type: str
         description:
           - Wether the instance metadata endpoint is available via IPv6 (C(enabled)) or not (C(disabled)).
-          - Requires botocore >= 1.21.29
         choices: [enabled, disabled]
         default: 'disabled'
       instance_metadata_tags:
@@ -367,7 +366,6 @@ options:
         type: str
         description:
           - Wether the instance tags are availble (C(enabled)) via metadata endpoint or not (C(disabled)).
-          - Requires botocore >= 1.23.30
         choices: [enabled, disabled]
         default: 'disabled'
 
@@ -1290,22 +1288,10 @@ def build_top_level_options(params):
             'metadata_options').get('http_tokens')
         spec['MetadataOptions']['HttpPutResponseHopLimit'] = params.get(
             'metadata_options').get('http_put_response_hop_limit')
-
-        if not module.botocore_at_least('1.23.30'):
-            # fail only if enabled is requested
-            if params.get('metadata_options').get('instance_metadata_tags') == 'enabled':
-                module.require_botocore_at_least('1.23.30', reason='to set instance_metadata_tags')
-        else:
-            spec['MetadataOptions']['InstanceMetadataTags'] = params.get(
-                'metadata_options').get('instance_metadata_tags')
-
-        if not module.botocore_at_least('1.21.29'):
-            # fail only if enabled is requested
-            if params.get('metadata_options').get('http_protocol_ipv6') == 'enabled':
-                module.require_botocore_at_least('1.21.29', reason='to set http_protocol_ipv6')
-        else:
-            spec['MetadataOptions']['HttpProtocolIpv6'] = params.get(
-                'metadata_options').get('http_protocol_ipv6')
+        spec['MetadataOptions']['HttpProtocolIpv6'] = params.get(
+            'metadata_options').get('http_protocol_ipv6')
+        spec['MetadataOptions']['InstanceMetadataTags'] = params.get(
+            'metadata_options').get('instance_metadata_tags')
 
     return spec
 

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -41,7 +41,6 @@ options:
         EC2 Instance Connect, and EC2 Serial Console.
       - By default Amazon will create an RSA key.
       - Mutually exclusive with parameter I(key_material).
-      - Requires at least botocore version 1.21.23.
     type: str
     choices:
       - rsa
@@ -362,8 +361,6 @@ def main():
 
     result = {}
 
-    if key_type:
-        module.require_botocore_at_least('1.21.23', reason='to set the key_type for a keypair')
     try:
         if state == 'absent':
             result = delete_key_pair(module.check_mode, ec2_client, name)

--- a/plugins/modules/lambda.py
+++ b/plugins/modules/lambda.py
@@ -111,7 +111,6 @@ options:
     description:
       - The instruction set architecture that the function supports.
       - Requires one of I(s3_bucket) or I(zip_file).
-      - Requires botocore >= 1.21.51.
     type: str
     choices: ['x86_64', 'arm64']
     aliases: ['architectures']
@@ -239,7 +238,6 @@ configuration:
     contains:
         architectures:
             description: The architectures supported by the function.
-            returned: successful run where botocore >= 1.21.51
             type: list
             elements: str
             sample: ['arm64']
@@ -642,10 +640,6 @@ def main():
 
     check_mode = module.check_mode
     changed = False
-
-    if architectures:
-        module.require_botocore_at_least(
-            '1.21.51', reason='to configure the architectures that the function supports.')
 
     try:
         client = module.client('lambda', retry_decorator=AWSRetry.jittered_backoff())

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -410,7 +410,7 @@ options:
         - The storage throughput when the I(storage_type) is C(gp3).
         - When the allocated storage is below 400 GB, the storage throughput will always be 125 mb/s.
         - When the allocated storage is large than or equal 400 GB, the througput starts at 500 mb/s.
-        - Requires boto3 >= 1.26.0.
+        - Requires botocore >= 1.29.0.
       type: int
       version_added: 5.2.0
     tde_credential_arn:
@@ -1010,7 +1010,7 @@ def get_options_with_changing_values(client, module, parameters):
             parameters['Iops'] = new_iops
 
     if instance.get('StorageType') == 'gp3':
-        if module.boto3_at_least('1.26.0'):
+        if module.botocore_at_least('1.29.0'):
             GP3_THROUGHPUT = True
             current_storage_throughput = instance.get('PendingModifiedValues', {}).get('StorageThroughput', instance['StorageThroughput'])
             new_storage_throughput = module.params.get('storage_throughput') or current_storage_throughput
@@ -1018,7 +1018,7 @@ def get_options_with_changing_values(client, module, parameters):
                 parameters['StorageThroughput'] = new_storage_throughput
         else:
             GP3_THROUGHPUT = False
-            module.warn('gp3 volumes require boto3 >= 1.26.0. storage_throughput will be ignored.')
+            module.warn('gp3 volumes require botocore >= 1.29.0. storage_throughput will be ignored.')
 
         current_iops = instance.get('PendingModifiedValues', {}).get('Iops', instance['Iops'])
         # when you just change from gp2 to gp3, you may not add the iops parameter

--- a/plugins/modules/s3_object_info.py
+++ b/plugins/modules/s3_object_info.py
@@ -85,7 +85,6 @@ options:
       object_attributes:
         description:
           - Retreive S3 object attributes.
-          - Requires minimum botocore version 1.24.7.
         required: false
         type: bool
         default: false
@@ -723,9 +722,6 @@ def main():
     # check if specified object exists
     if object_name:
         object_check(connection, module, bucket_name, object_name)
-
-    if requested_object_details and requested_object_details['object_attributes']:
-        module.require_botocore_at_least('1.24.7', reason='required for s3.get_object_attributes')
 
     if requested_object_details:
         if object_name:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # - tests/unit/constraints.txt
 # - tests/integration/constraints.txt
 # - tests/integration/targets/setup_botocore_pip
-botocore>=1.21.0
-boto3>=1.18.0
+botocore>=1.25.0
+boto3>=1.22.0

--- a/tests/integration/constraints.txt
+++ b/tests/integration/constraints.txt
@@ -1,7 +1,7 @@
 # Specifically run tests against the oldest versions that we support
-boto3==1.18.0
-botocore==1.21.0
+boto3==1.22.0
+botocore==1.25.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.20.0
+awscli==1.23.0

--- a/tests/integration/targets/ec2_instance_hibernation_options/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_hibernation_options/meta/main.yml
@@ -4,6 +4,3 @@ dependencies:
 - role: setup_ec2_instance_env
   vars:
     ec2_instance_test_name: hibernation_options
-- role: setup_botocore_pip
-  vars:
-    boto3_version: "1.20.30"

--- a/tests/integration/targets/ec2_instance_metadata_options/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/meta/main.yml
@@ -1,9 +1,6 @@
 # this just makes sure they're in the right place
 dependencies:
 - role: setup_ec2_facts
-- role: setup_botocore_pip
-  vars:
-    botocore_version: 1.23.30
 - role: setup_ec2_instance_env
   vars:
     ec2_instance_test_name: metadata

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -1,38 +1,4 @@
-- name: test with boto3 version that does not support instance_metadata_tags
-  module_defaults:
-    group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
-      region: "{{ aws_region }}"
-  block:
-  - name: "fail create t3.nano instance with metadata_options"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-t3nano-enabled-required"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      instance_type: t3.nano
-      metadata_options:
-          http_endpoint: enabled
-          http_tokens: required
-          instance_metadata_tags: enabled
-      wait: false
-    ignore_errors: yes
-    register: instance_creation
-
-  - name: verify fail instance with metadata_options because insufficient boto3 requirements
-    assert:
-      that:
-        - instance_creation is failed
-        - instance_creation is not changed
-        - "'This is required to set instance_metadata_tags' in instance_creation.msg"
-
 - name: test with boto3 version that supports instance_metadata_tags
-  vars:
-    ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
   module_defaults:
     group/aws:
       aws_access_key: "{{ aws_access_key }}"

--- a/tests/integration/targets/ec2_key/meta/main.yml
+++ b/tests/integration/targets/ec2_key/meta/main.yml
@@ -1,5 +1,2 @@
 dependencies:
   - setup_sshkey
-  - role: setup_botocore_pip
-    vars:
-      botocore_version: "1.21.23"

--- a/tests/integration/targets/ec2_key/tasks/main.yml
+++ b/tests/integration/targets/ec2_key/tasks/main.yml
@@ -389,27 +389,11 @@
            - 'result.key == None'
 
     # ============================================================
-    - name: test create ED25519 key pair type with botocore <= 1.21.23
-      ec2_key:
-        name: '{{ ec2_key_name }}'
-        key_type: ed25519
-      ignore_errors: true
-      register: result
-
-    - name: assert that task failed
-      assert:
-        that:
-          - 'result.failed'
-          - '"Failed to import the required Python library (botocore>=1.21.23)" in result.msg'
-          - '"This is required to set the key_type for a keypair" in result.msg'
-
     - name: test create ED25519 key pair type
       ec2_key:
         name: '{{ ec2_key_name }}'
         key_type: ed25519
       register: result
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: assert that task succeed
       assert:
@@ -422,8 +406,6 @@
         name: '{{ ec2_key_name }}'
         key_type: rsa
       register: result
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: assert that task succeed
       assert:

--- a/tests/integration/targets/ec2_metadata_facts/meta/main.yml
+++ b/tests/integration/targets/ec2_metadata_facts/meta/main.yml
@@ -1,7 +1,3 @@
 dependencies:
   - setup_ec2_facts
   - setup_sshkey
-  #required for run_instances with MetadataOptions.InstanceMetadataTags
-  - role: setup_botocore_pip
-    vars:
-      botocore_version: '1.23.30'

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -32,11 +32,6 @@
   - include_role:
       name: '../setup_ec2_facts'
 
-  - include_role:
-      name: '../setup_botocore_pip'
-    vars:
-      botocore_version: '1.23.30'
-
   - set_fact:
       availability_zone: '{{ ec2_availability_zone_names[0] }}'
 
@@ -134,8 +129,6 @@
         snake_case_key: a_snake_case_value
         camelCaseKey: aCamelCaseValue
     register: ec2_instance
-    vars:
-      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
   - set_fact:
       ec2_ami_id_py2: "{{ lookup('aws_ssm', '/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2', **connection_args) }}"
@@ -160,8 +153,6 @@
         camelCaseKey: aCamelCaseValue
       wait: True
     register: ec2_instance_py2
-    vars:
-      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
   - set_fact:
       ec2_instance_id: "{{ ec2_instance.instances[0].instance_id }}"

--- a/tests/integration/targets/lambda/meta/main.yml
+++ b/tests/integration/targets/lambda/meta/main.yml
@@ -1,5 +1,2 @@
 dependencies:
-- role: setup_botocore_pip
-  vars:
-    botocore_version: 1.21.51
 - role: setup_remote_tmp_dir

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -157,8 +157,6 @@
       role: '{{ lambda_role_name }}'
       zip_file: '{{ zip_res.dest }}'
       architecture: arm64
-    vars:
-      ansible_python_interpreter: '{{ botocore_virtualenv_interpreter }}'
     register: result
     check_mode: yes
   - name: assert lambda upload succeeded
@@ -174,8 +172,6 @@
       role: '{{ lambda_role_name }}'
       zip_file: '{{ zip_res.dest }}'
       architecture: arm64
-    vars:
-      ansible_python_interpreter: '{{ botocore_virtualenv_interpreter }}'
     register: result
   - name: assert lambda upload succeeded
     assert:
@@ -329,8 +325,6 @@
       query: all
     register: lambda_infos_all
     check_mode: yes
-    vars:
-      ansible_python_interpreter: '{{ botocore_virtualenv_interpreter }}'
   - name: lambda_info | Assert successfull retrieval of all information 1
     vars:
       lambda_info: "{{ lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first }}"

--- a/tests/integration/targets/lambda_event/meta/main.yml
+++ b/tests/integration/targets/lambda_event/meta/main.yml
@@ -1,5 +1,2 @@
 dependencies:
 - role: setup_remote_tmp_dir
-- role: setup_botocore_pip
-  vars:
-    botocore_version: 1.21.51

--- a/tests/integration/targets/lambda_event/tasks/setup.yml
+++ b/tests/integration/targets/lambda_event/tasks/setup.yml
@@ -70,8 +70,6 @@
     zip_file: '{{ zip_res.dest }}'
     architecture: x86_64
   register: result
-  vars:
-    ansible_python_interpreter: '{{ botocore_virtualenv_interpreter }}'
 
 - name: assert lambda upload succeeded
   assert:

--- a/tests/integration/targets/s3_object/meta/main.yml
+++ b/tests/integration/targets/s3_object/meta/main.yml
@@ -1,6 +1,2 @@
 dependencies:
   - setup_remote_tmp_dir
-  # required for s3.get_object_attributes
-  - role: setup_botocore_pip
-    vars:
-      botocore_version: '1.24.7'

--- a/tests/integration/targets/s3_object/tasks/main.yml
+++ b/tests/integration/targets/s3_object/tasks/main.yml
@@ -120,8 +120,6 @@
             - Checksum
             - ObjectParts
       register: info_detail_result
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - assert:
         that:

--- a/tests/unit/constraints.txt
+++ b/tests/unit/constraints.txt
@@ -1,7 +1,7 @@
 # Specifically run tests against the oldest versions that we support
-boto3==1.18.0
-botocore==1.21.0
+boto3==1.22.0
+botocore==1.25.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.20.0
+awscli==1.23.0

--- a/tests/unit/module_utils/modules/ansible_aws_module/test_minimal_versions.py
+++ b/tests/unit/module_utils/modules/ansible_aws_module/test_minimal_versions.py
@@ -25,10 +25,10 @@ class TestMinimalVersionTestSuite:
     # Prepare some data for use in our testing
     # ========================================================
     def setup_method(self):
-        self.MINIMAL_BOTO3 = '1.18.0'
-        self.MINIMAL_BOTOCORE = '1.21.0'
-        self.OLD_BOTO3 = '1.17.999'
-        self.OLD_BOTOCORE = '1.20.999'
+        self.MINIMAL_BOTO3 = '1.22.0'
+        self.MINIMAL_BOTOCORE = '1.25.0'
+        self.OLD_BOTO3 = '1.21.999'
+        self.OLD_BOTOCORE = '1.24.999'
 
     # ========================================================
     #   Test we don't warn when using valid versions


### PR DESCRIPTION
##### SUMMARY

In line with our botocore version policy bump the minimum requirements

> Starting with the 2.0.0 releases of amazon.aws and community.aws, it is generally the collection's policy to 
> support the versions of botocore and boto3 that were released 12 months prior to the most recent major 
> collection release, following semantic versioning (for example, 2.0.0, 3.0.0).


##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/botocore.py
requirements.txt

##### ADDITIONAL INFORMATION

Based on a target release date for 6.0.0 of late April I've bumped this to botocore 1.25.0

boto3 - 1.22.0 - "Mon Apr 25 18:07:20 2022 +0000"
botocore - 1.25.0 - "Mon Apr 25 18:07:02 2022 +0000"