### PR TITLE
Remove an unreachable code fragment in ec2_security_group 

### DIFF
--- a/changelogs/fragments/1348-remove-unreachable-code.yml
+++ b/changelogs/fragments/1348-remove-unreachable-code.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_security_group - file included unreachable code. Fix now removes unreachable code by removing an inapproproate logic.(https://github.com/ansible-collections/amazon.aws/pull/1348).

--- a/changelogs/fragments/1348-remove-unreachable-code.yml
+++ b/changelogs/fragments/1348-remove-unreachable-code.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- ec2_security_group - file included unreachable code. Fix now removes unreachable code by removing an inapproproate logic.(https://github.com/ansible-collections/amazon.aws/pull/1348).
+- ec2_security_group - file included unreachable code. Fix now removes unreachable code by removing an inapproproate logic (https://github.com/ansible-collections/amazon.aws/pull/1348).

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -1450,7 +1450,7 @@ def ensure_present(module, client, group, groups):
         revoke_ingress = []
 
     if purge_rules_egress and module.params.get('rules_egress') is not None:
-        if module.params.get('rules_egress') is []:
+        if module.params.get('rules_egress') == []:
             revoke_egress = [
                 to_permission(r) for r in set(present_egress) - set(named_tuple_egress_list)
                 if r != Rule((None, None), '-1', '0.0.0.0/0', 'ipv4', None)

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -1450,16 +1450,10 @@ def ensure_present(module, client, group, groups):
         revoke_ingress = []
 
     if purge_rules_egress and module.params.get('rules_egress') is not None:
-        if module.params.get('rules_egress') == []:
-            revoke_egress = [
-                to_permission(r) for r in set(present_egress) - set(named_tuple_egress_list)
-                if r != Rule((None, None), '-1', '0.0.0.0/0', 'ipv4', None)
-            ]
-        else:
-            revoke_egress = []
-            for p in present_egress:
-                if not any(rule_cmp(p, b) for b in named_tuple_egress_list):
-                    revoke_egress.append(to_permission(p))
+        revoke_egress = []
+        for p in present_egress:
+            if not any(rule_cmp(p, b) for b in named_tuple_egress_list):
+                revoke_egress.append(to_permission(p))
     else:
         revoke_egress = []
 


### PR DESCRIPTION
In file: ec2_security_group.py, method: ensure_present, a logical expression uses the identity operator. A new object is created inside the identity check operation and then used for matching identity. Since this is a distinct, new object, it will not have identity and match with anything else. As a result, the identity check will have a logical short circuit and the program may have unintended behavior. 

I suggested that the logical operation should be done properly.