### PR TITLE
Various lint fixups

### DIFF
--- a/changelogs/fragments/20230204-sanity.yml
+++ b/changelogs/fragments/20230204-sanity.yml
@@ -1,4 +1,4 @@
 minor_changes:
-- ec2_instance - remove unused import ().
-- ec2_vpc_nat_gateway - ensure allocation_id is defined before potential access ().
-- lambda_layer - raise LambdaLayerFailure rather than just creating it ().
+- ec2_instance - remove unused import (https://github.com/ansible-collections/amazon.aws/pull/1350).
+- ec2_vpc_nat_gateway - ensure allocation_id is defined before potential access (https://github.com/ansible-collections/amazon.aws/pull/1350).
+- lambda_layer - raise ``LambdaLayerFailure`` rather than just creating it (https://github.com/ansible-collections/amazon.aws/pull/1350).

--- a/changelogs/fragments/20230204-sanity.yml
+++ b/changelogs/fragments/20230204-sanity.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- ec2_instance - remove unused import ().
+- ec2_vpc_nat_gateway - ensure allocation_id is defined before potential access ().
+- lambda_layer - raise LambdaLayerFailure rather than just creating it ().

--- a/plugins/module_utils/s3.py
+++ b/plugins/module_utils/s3.py
@@ -18,8 +18,6 @@ except ImportError:
 
 from ansible.module_utils.basic import to_text
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import boto3_conn
-
 
 def s3_head_objects(client, parts, bucket, obj, versionId):
     args = {"Bucket": bucket, "Key": obj}

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -943,8 +943,6 @@ instances:
 '''
 
 from collections import namedtuple
-import string
-import textwrap
 import time
 import uuid
 
@@ -958,7 +956,6 @@ from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 from ansible.module_utils.six import string_types
-from ansible.module_utils.six.moves.urllib import parse as urlparse
 
 from ansible_collections.amazon.aws.plugins.module_utils.arn import parse_aws_arn
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code

--- a/plugins/modules/ec2_vpc_nat_gateway.py
+++ b/plugins/modules/ec2_vpc_nat_gateway.py
@@ -837,6 +837,7 @@ def remove(client, module, nat_gateway_id, wait=False, release_eip=False, connec
         Tuple (bool, str, list)
     """
 
+    allocation_id = None
     params = {
         'NatGatewayId': nat_gateway_id
     }

--- a/plugins/modules/lambda_layer.py
+++ b/plugins/modules/lambda_layer.py
@@ -299,7 +299,7 @@ def delete_layer_version(lambda_client, params, check_mode=False):
                 try:
                     lambda_client.delete_layer_version(LayerName=name, VersionNumber=layer["version"])
                 except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
-                    LambdaLayerFailure(e, "Failed to delete layer version LayerName={0}, VersionNumber={1}.".format(name, version))
+                    raise LambdaLayerFailure(e, "Failed to delete layer version LayerName={0}, VersionNumber={1}.".format(name, version))
     return {"changed": changed, "layer_versions": deleted_versions}
 
 

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -348,7 +348,6 @@ acl:
 '''
 
 import json
-import os
 import time
 
 try:
@@ -359,7 +358,6 @@ except ImportError:
 from ansible.module_utils.basic import to_text
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 from ansible.module_utils.six import string_types
-from ansible.module_utils.six.moves.urllib.parse import urlparse
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule

--- a/tests/unit/module_utils/botocore/test_merge_botocore_config.py
+++ b/tests/unit/module_utils/botocore/test_merge_botocore_config.py
@@ -3,11 +3,8 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import pprint
 import pytest
 from unittest.mock import MagicMock
-from unittest.mock import sentinel
-from unittest.mock import call
 
 try:
     import botocore
@@ -16,7 +13,6 @@ except ImportError:
     pass
 
 import ansible_collections.amazon.aws.plugins.module_utils.botocore as utils_botocore
-from ansible_collections.amazon.aws.plugins.module_utils.exceptions import AnsibleBotocoreError
 
 MINIMAL_CONFIG = {
     "user_agent_extra": "Ansible/unit-test",

--- a/tests/unit/module_utils/test_acm.py
+++ b/tests/unit/module_utils/test_acm.py
@@ -5,10 +5,10 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 
-from pydoc import describe
-from sre_constants import ANY
-from unittest import result
 import pytest
+import random
+from unittest.mock import MagicMock
+from unittest.mock import ANY
 
 try:
     import botocore
@@ -20,8 +20,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.acm import (
     ACMServiceManager,
     acm_catch_boto_exception
 )
-from unittest.mock import MagicMock, patch, call, ANY
-import random
 
 
 MODULE_NAME = "ansible_collections.amazon.aws.plugins.module_utils.acm"

--- a/tests/unit/plugins/modules/test_ec2_eni_info.py
+++ b/tests/unit/plugins/modules/test_ec2_eni_info.py
@@ -3,8 +3,10 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from unittest.mock import MagicMock, patch, ANY, call
 import pytest
+from unittest.mock import MagicMock
+from unittest.mock import call
+from unittest.mock import patch
 
 from ansible_collections.amazon.aws.plugins.modules import ec2_eni_info
 

--- a/tests/unit/plugins/modules/test_ec2_key.py
+++ b/tests/unit/plugins/modules/test_ec2_key.py
@@ -1,17 +1,16 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from unittest.mock import MagicMock
-from unittest.mock import patch
-from unittest.mock import call, ANY
-
-import pytest
-import botocore
 import datetime
 from dateutil.tz import tzutc
-from ansible.module_utils._text import to_bytes
+import pytest
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from unittest.mock import ANY
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+import botocore
+
+from ansible.module_utils._text import to_bytes
 
 from ansible_collections.amazon.aws.plugins.modules import ec2_key
 

--- a/tests/unit/plugins/modules/test_ec2_metadata_facts.py
+++ b/tests/unit/plugins/modules/test_ec2_metadata_facts.py
@@ -1,12 +1,10 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from unittest.mock import Mock, MagicMock
-from unittest.mock import patch
-from unittest.mock import call
-
 import io
 import pytest
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
 from ansible_collections.amazon.aws.plugins.modules import ec2_metadata_facts
 

--- a/tests/unit/plugins/modules/test_ec2_snapshot_info.py
+++ b/tests/unit/plugins/modules/test_ec2_snapshot_info.py
@@ -3,8 +3,11 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from unittest.mock import MagicMock, Mock, patch, ANY, call
 import pytest
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from unittest.mock import ANY
+from unittest.mock import call
 
 from ansible_collections.amazon.aws.plugins.modules import ec2_snapshot_info
 

--- a/tests/unit/plugins/modules/test_kms_key.py
+++ b/tests/unit/plugins/modules/test_kms_key.py
@@ -4,9 +4,9 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import pytest
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
-from unittest.mock import MagicMock, call, patch
 from ansible_collections.amazon.aws.plugins.modules import kms_key
 
 

--- a/tests/unit/plugins/modules/test_rds_instance_info.py
+++ b/tests/unit/plugins/modules/test_rds_instance_info.py
@@ -2,12 +2,15 @@
 #
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-from ansible_collections.amazon.aws.plugins.modules import rds_instance_info
-from unittest.mock import MagicMock, Mock, patch, ANY, call
-import ansible.module_utils.basic
-import botocore.exceptions
 import pytest
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from unittest.mock import ANY
+from unittest.mock import call
 
+import botocore.exceptions
+
+from ansible_collections.amazon.aws.plugins.modules import rds_instance_info
 
 mod_name = "ansible_collections.amazon.aws.plugins.modules.rds_instance_info"
 

--- a/tests/unit/plugins/modules/test_s3_object.py
+++ b/tests/unit/plugins/modules/test_s3_object.py
@@ -3,15 +3,13 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from unittest.mock import MagicMock, Mock, patch, ANY, call
+from unittest.mock import MagicMock
+from unittest.mock import patch
 import pytest
 
 import botocore.exceptions
 
 from ansible_collections.amazon.aws.plugins.modules import s3_object
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    get_aws_connection_info,
-)
 
 module_name = "ansible_collections.amazon.aws.plugins.modules.s3_object"
 utils = "ansible_collections.amazon.aws.plugins.module_utils.ec2"


### PR DESCRIPTION
##### SUMMARY

Minor linting fixups

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_instance
ec2_vpc_nat_gateway
lambda_layer
s3_bucket
plugins/module_utils/s3.py

##### ADDITIONAL INFORMATION

S3 unused imports aren't in changelog because they're related to unreleased refactoring.

See Also: https://github.com/ansible-collections/news-for-maintainers/issues/34
