### PR TITLE
Partial revertion of environment variable fallback (#1224)

### DIFF
--- a/changelogs/fragments/1353-revert-env-fallback.yml
+++ b/changelogs/fragments/1353-revert-env-fallback.yml
@@ -1,0 +1,7 @@
+bugfixes:
+- revert breaking change introduced in 5.2.0 when passing credentials through a mix of environment variables and parameters (https://github.com/ansible-collections/amazon.aws/issues/1353).
+deprecated_features:
+- support for passing both profile and security tokens through a mix of environment variables and parameters has been deprecated and support will be removed in release 6.0.0.
+  After release 6.0.0 it will only be possible to pass either a profile or security tokens, both both at the same time.
+  Support for passing profile and security tokens together was originally deprecated in release 1.2.0, however only partially implemented in release 5.0.0
+  ().

--- a/changelogs/fragments/1353-revert-env-fallback.yml
+++ b/changelogs/fragments/1353-revert-env-fallback.yml
@@ -2,6 +2,6 @@ bugfixes:
 - revert breaking change introduced in 5.2.0 when passing credentials through a mix of environment variables and parameters (https://github.com/ansible-collections/amazon.aws/issues/1353).
 deprecated_features:
 - support for passing both profile and security tokens through a mix of environment variables and parameters has been deprecated and support will be removed in release 6.0.0.
-  After release 6.0.0 it will only be possible to pass either a profile or security tokens, both both at the same time.
+  After release 6.0.0 it will only be possible to pass either a profile or security tokens, regardless of mechanism used to pass them.  To explicitly block a parameter coming from an environment variable pass an empty string as the parameter value```
   Support for passing profile and security tokens together was originally deprecated in release 1.2.0, however only partially implemented in release 5.0.0
-  ().
+  (https://github.com/ansible-collections/amazon.aws/pull/1355).

--- a/plugins/doc_fragments/aws.py
+++ b/plugins/doc_fragments/aws.py
@@ -19,7 +19,9 @@ options:
         U(https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys).
       - The C(AWS_ACCESS_KEY_ID), C(AWS_ACCESS_KEY) or C(EC2_ACCESS_KEY)
         environment variables may also be used in decreasing order of
-        preference.
+        preference.  Prior to release 6.0.0 these environment variables will be
+        ignored if the I(profile) parameter is passed.  After release 6.0.0
+        I(access_key) will always fall back to the environment variables if set.
       - The I(aws_access_key) and I(profile) options are mutually exclusive.
       - The I(aws_access_key_id) alias was added in release 5.1.0 for
         consistency with the AWS botocore SDK.
@@ -36,7 +38,9 @@ options:
         U(https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys).
       - The C(AWS_SECRET_ACCESS_KEY), C(AWS_SECRET_KEY), or C(EC2_SECRET_KEY)
         environment variables may also be used in decreasing order of
-        preference.
+        preference.  Prior to release 6.0.0 these environment variables will be
+        ignored if the I(profile) parameter is passed.  After release 6.0.0
+        I(secret_key) will always fall back to the environment variables if set.
       - The I(secret_key) and I(profile) options are mutually exclusive.
       - The I(aws_secret_access_key) alias was added in release 5.1.0 for
         consistency with the AWS botocore SDK.
@@ -53,6 +57,9 @@ options:
         U(https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys).
       - The C(AWS_SESSION_TOKEN), C(AWS_SECURITY_TOKEN) or C(EC2_SECURITY_TOKEN)
         environment variables may also be used in decreasing order of preference.
+        Prior to release 6.0.0 these environment variables will be
+        ignored if the I(profile) parameter is passed.  After release 6.0.0
+        I(session_token) will always fall back to the environment variables if set.
       - The I(security_token) and I(profile) options are mutually exclusive.
       - Aliases I(aws_session_token) and I(session_token) were added in release
         3.2.0, with the parameter being renamed from I(security_token) to
@@ -70,7 +77,10 @@ options:
       - A named AWS profile to use for authentication.
       - See the AWS documentation for more information about named profiles
         U(https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-profiles.html).
-      - The C(AWS_PROFILE) environment variable may also be used.
+      - The C(AWS_PROFILE) environment variable may also be used.  Prior to release 6.0.0 the
+        C(AWS_PROFILE) environment variable will be ignored if any of I(access_key), I(secret_key),
+        or I(session_token) are passed.  After release 6.0.0 I(profile) will always fall back to the
+        C(AWS_PROFILE) environment variable if set.
       - The I(profile) option is mutually exclusive with the I(aws_access_key),
         I(aws_secret_key) and I(security_token) options.
     type: str

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -380,7 +380,6 @@ def _aws_common_argument_spec():
             deprecated_aliases=[
                 dict(name='ec2_access_key', date='2024-12-01', collection_name='amazon.aws'),
             ],
-            fallback=(env_fallback, ['AWS_ACCESS_KEY_ID', 'AWS_ACCESS_KEY', 'EC2_ACCESS_KEY']),
             no_log=False,
         ),
         secret_key=dict(
@@ -388,7 +387,6 @@ def _aws_common_argument_spec():
             deprecated_aliases=[
                 dict(name='ec2_secret_key', date='2024-12-01', collection_name='amazon.aws'),
             ],
-            fallback=(env_fallback, ['AWS_SECRET_ACCESS_KEY', 'AWS_SECRET_KEY', 'EC2_SECRET_KEY']),
             no_log=True,
         ),
         session_token=dict(
@@ -398,12 +396,10 @@ def _aws_common_argument_spec():
                 dict(name='security_token', date='2024-12-01', collection_name='amazon.aws'),
                 dict(name='aws_security_token', date='2024-12-01', collection_name='amazon.aws'),
             ],
-            fallback=(env_fallback, ['AWS_SESSION_TOKEN', 'AWS_SECURITY_TOKEN', 'EC2_SECURITY_TOKEN']),
             no_log=True,
         ),
         profile=dict(
             aliases=['aws_profile'],
-            fallback=(env_fallback, ['AWS_PROFILE', 'AWS_DEFAULT_PROFILE']),
         ),
 
         endpoint_url=dict(


### PR DESCRIPTION
fixes #1353

##### SUMMARY

#1224 exposed that the removal of support for passing both profiles and security tokens was only partially implemented in release 5.0.0 (#834)

Since we had already announced that support would be dropped for passing both (back in 2020 with release 1.2.0),  I think it's reasonable to still fully drop support in 6.0.0.  The documentation was originally very fuzzy about when we'd fallback and use which variables.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/module_utils/botocore.py
plugins/module_utils/modules.py

##### ADDITIONAL INFORMATION
