### PR TITLE
ec2_vpc_subnet_info - example fix

### DIFF
--- a/changelogs/fragments/1357-subnet-example.yml
+++ b/changelogs/fragments/1357-subnet-example.yml
@@ -1,0 +1,2 @@
+trivial:
+- ec2_vpc_subnet_info - fix example (https://github.com/ansible-collections/amazon.aws/pull/1357).

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -65,7 +65,7 @@ EXAMPLES = '''
   register: subnet_info
 
 - set_fact:
-    subnet_ids: "{{ subnet_info.subnets|map(attribute='id')|list }}"
+    subnet_ids: "{{ subnet_info.results | sum(attribute='subnets', start=[]) | map(attribute='subnet_id') }}"
 '''
 
 RETURN = '''


### PR DESCRIPTION
##### SUMMARY
example is wrong. result returns in a list under key `results`

##### ISSUE TYPE

- Docs Pull Request


##### COMPONENT NAME
ec2_vpc_subnet_info
