### PR TITLE
Corrected wrong parameter for SSH private key file. Improved value de…

### DIFF
--- a/docs/docsite/rst/aws_ec2_guide.rst
+++ b/docs/docsite/rst/aws_ec2_guide.rst
@@ -270,7 +270,7 @@ Some examples are shown below:
     # This defines combinations of host servers, IP addresses, and related SSH private keys.
     ansible_host: private_ip_address
     ansible_user: centos
-    ansible_private_ssh_key_file: key_name
+    ansible_ssh_private_key_file: /path/to/private_key_file
 
     # This sets the ec2_security_group_ids variable.
     ec2_security_group_ids: security_groups | map(attribute='group_id') | list |  join(',')


### PR DESCRIPTION
The `compose` section for the *Allowed Options* in the *Dynamic inventory plugin* guide contains the wrong key `ansible_private_ssh_key_file`, it needs to be `ansible_ssh_private_key_file`.

##### SUMMARY
Minor documentation improvement, corrects wrong key for SSH private key file and adds better description for value.

Fixes #1361 

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
aws_ec2_guide.rst

##### ADDITIONAL INFORMATION

```paste below
fixes: #1361 
```
