### PR TITLE
s3_bucket.py - deal gracefuly with empty bucket policy

### DIFF
--- a/changelogs/fragments/1368-empty_bucket_policy.yml
+++ b/changelogs/fragments/1368-empty_bucket_policy.yml
@@ -1,2 +1,2 @@
-bugfix:
+bugfixes:
 - s3_bucket - empty bucket policy was throwing a JSONDecodeError - deal with it gracefully instead (https://github.com/ansible-collections/amazon.aws/pull/1368)

--- a/changelogs/fragments/1368-empty_bucket_policy.yml
+++ b/changelogs/fragments/1368-empty_bucket_policy.yml
@@ -1,0 +1,2 @@
+bugfix:
+- s3_bucket - deal gracefully with empty bucket policy (i.e. from wasabi cloud storage)"

--- a/changelogs/fragments/1368-empty_bucket_policy.yml
+++ b/changelogs/fragments/1368-empty_bucket_policy.yml
@@ -1,2 +1,2 @@
 bugfix:
-- s3_bucket - deal gracefully with empty bucket policy (i.e. from wasabi cloud storage)"
+- s3_bucket - empty bucket policy was throwing a JSONDecodeError - deal with it gracefully instead (https://github.com/ansible-collections/amazon.aws/pull/1368)

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -698,7 +698,7 @@ def delete_bucket_policy(s3_client, bucket_name):
 def get_bucket_policy(s3_client, bucket_name):
     try:
         current_policy_string = s3_client.get_bucket_policy(Bucket=bucket_name).get('Policy')
-        if(len(current_policy_string) == 0)
+        if(len(current_policy_string) == 0):
             return None
         current_policy = json.loads(current_policy_string)
     except is_boto3_error_code('NoSuchBucketPolicy'):

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -698,7 +698,7 @@ def delete_bucket_policy(s3_client, bucket_name):
 def get_bucket_policy(s3_client, bucket_name):
     try:
         current_policy_string = s3_client.get_bucket_policy(Bucket=bucket_name).get('Policy')
-        if(len(current_policy_string) == 0):
+        if not current_policy_string:
             return None
         current_policy = json.loads(current_policy_string)
     except is_boto3_error_code('NoSuchBucketPolicy'):

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -697,7 +697,10 @@ def delete_bucket_policy(s3_client, bucket_name):
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=['NoSuchBucket', 'OperationAborted'])
 def get_bucket_policy(s3_client, bucket_name):
     try:
-        current_policy = json.loads(s3_client.get_bucket_policy(Bucket=bucket_name).get('Policy'))
+        current_policy_string = s3_client.get_bucket_policy(Bucket=bucket_name).get('Policy')
+        if(len(current_policy_string) == 0)
+            return None
+        current_policy = json.loads(current_policy_string)
     except is_boto3_error_code('NoSuchBucketPolicy'):
         return None
 


### PR DESCRIPTION
When using wasabi object storage, the bucket policy can be blank. This was throwing a json decode error. Fix by checking for empty string and returning None.

##### SUMMARY
Deals gracefully with empty bucket policy (encountered on wasabi storage).

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
s3_bucket

##### ADDITIONAL INFORMATION
Recreate by attempting to create a new bucket on wasabi:
ENV:
S3_URL=https://s3.us-west-1.wasabisys.com

- name: create bucket
   s3_bucket:
     name: "thisbucketwillfail"
