### PR TITLE
Add full path to the awx_ec2 inv example

### DIFF
--- a/changelogs/fragments/20230220-inventory_docs_ec2_aws.yml
+++ b/changelogs/fragments/20230220-inventory_docs_ec2_aws.yml
@@ -1,0 +1,2 @@
+trivial:
+- inventory:aws_ec2 - update docs. Add full path to the awx_ec2 inv example and update description to add a file name example.

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -13,7 +13,7 @@ extends_documentation_fragment:
   - amazon.aws.assume_role.plugins
 description:
   - Get inventory hosts from Amazon Web Services EC2.
-  - The inventory file is an YAML configuration file and must ends with C(aws_ec2.{yml|yaml}). Example: C(my_inventory.aws_ec2.yml).
+  - "The inventory file is an YAML configuration file and must ends with C(aws_ec2.{yml|yaml}). Example: C(my_inventory.aws_ec2.yml)."
 notes:
   - If no credentials are provided and the control node has an associated IAM instance profile then the
     role will be used for authentication.

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -13,7 +13,7 @@ extends_documentation_fragment:
   - amazon.aws.assume_role.plugins
 description:
   - Get inventory hosts from Amazon Web Services EC2.
-  - The inventory file is an YAML configuration file and must ends with C(.aws_ec2.{yml|yaml}). Example: C(my_inventory.aws_ec2.yml).
+  - The inventory file is an YAML configuration file and must ends with C(aws_ec2.{yml|yaml}). Example: C(my_inventory.aws_ec2.yml).
 notes:
   - If no credentials are provided and the control node has an associated IAM instance profile then the
     role will be used for authentication.

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -13,7 +13,7 @@ extends_documentation_fragment:
   - amazon.aws.assume_role.plugins
 description:
   - Get inventory hosts from Amazon Web Services EC2.
-  - "The inventory file is an YAML configuration file and must ends with C(aws_ec2.{yml|yaml}). Example: C(my_inventory.aws_ec2.yml)."
+  - "The inventory file is a YAML configuration file and must end with C(aws_ec2.{yml|yaml}). Example: C(my_inventory.aws_ec2.yml)."
 notes:
   - If no credentials are provided and the control node has an associated IAM instance profile then the
     role will be used for authentication.

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -13,7 +13,7 @@ extends_documentation_fragment:
   - amazon.aws.assume_role.plugins
 description:
   - Get inventory hosts from Amazon Web Services EC2.
-  - Uses a YAML configuration file that ends with C(aws_ec2.{yml|yaml}).
+  - The inventory file is an YAML configuration file and must ends with C(.aws_ec2.{yml|yaml}). Example: C(my_inventory.aws_ec2.yml).
 notes:
   - If no credentials are provided and the control node has an associated IAM instance profile then the
     role will be used for authentication.

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -138,12 +138,12 @@ options:
 EXAMPLES = r"""
 # Minimal example using environment vars or instance role credentials
 # Fetch all hosts in us-east-1, the hostname is the public DNS if it exists, otherwise the private IP address
-plugin: aws_ec2
+plugin: amazon.aws.aws_ec2
 regions:
   - us-east-1
 
 # Example using filters, ignoring permission errors, and specifying the hostname precedence
-plugin: aws_ec2
+plugin: amazon.aws.aws_ec2
 # The values for profile, access key, secret key and token can be hardcoded like:
 boto_profile: aws_profile
 # or you could use Jinja as:
@@ -180,7 +180,7 @@ hostnames:
 allow_duplicated_hosts: False
 
 # Example using constructed features to create groups and set ansible_host
-plugin: aws_ec2
+plugin: amazon.aws.aws_ec2
 regions:
   - us-east-1
   - us-west-1
@@ -216,7 +216,7 @@ compose:
   ansible_host: private_ip_address
 
 # Example using include_filters and exclude_filters to compose the inventory.
-plugin: aws_ec2
+plugin: amazon.aws.aws_ec2
 regions:
   - us-east-1
   - us-west-1
@@ -230,7 +230,7 @@ exclude_filters:
   - 'my_first_tag'
 
 # Example using groups to assign the running hosts to a group based on vpc_id
-plugin: aws_ec2
+plugin: amazon.aws.aws_ec2
 boto_profile: aws_profile
 # Populate inventory with instances in these regions
 regions:
@@ -246,7 +246,7 @@ compose:
 groups:
   libvpc: vpc_id == 'vpc-####'
 # Define prefix and suffix for host variables coming from AWS.
-plugin: aws_ec2
+plugin: amazon.aws.aws_ec2
 regions:
   - us-east-1
 hostvars_prefix: 'aws_'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The current example does not work, since it uses the default `namespace` and `collection` names.

This fixes the problem and allows anyone who installs the collection to use it outside of the collection scope.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- inventory: `aws_ec2`
