### PR TITLE
Disable S3 tests related to removing bucket encryption

### DIFF
--- a/changelogs/fragments/1395-s3-encryption.yml
+++ b/changelogs/fragments/1395-s3-encryption.yml
@@ -1,0 +1,2 @@
+trivial:
+- s3_bucket - disabled tests related to disabling encryption on S3 buckets, this is no longer supported by AWS, and encryption is enabled by default (https://github.com/ansible-collections/amazon.aws/pull/1395).

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -70,6 +70,7 @@ options:
     description:
       - Describes the default server-side encryption to apply to new objects in the bucket.
         In order to remove the server-side encryption, the encryption needs to be set to 'none' explicitly.
+      - "Note: Since January 2023 Amazon S3 doesn't support disabling encryption on S3 buckets."
     choices: [ 'none', 'AES256', 'aws:kms' ]
     type: str
   encryption_key_id:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_bucket_key.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_bucket_key.yml
@@ -32,7 +32,7 @@
         bucket_key_enabled: true
       register: output
 
-    - name: Assert for 'Enable bucket key for bucket with aws:kms encryption'
+    - name: "Assert for 'Enable bucket key for bucket with aws:kms encryption'"
       assert:
         that:
           - output.changed
@@ -45,40 +45,43 @@
         bucket_key_enabled: true
       register: output
 
-    - name: Assert for 'Re-enable bucket key for bucket with aws:kms encryption (idempotent)''
+    - name: "Assert for 'Re-enable bucket key for bucket with aws:kms encryption (idempotent)'"
       assert:
         that:
           - not output.changed
           - output.encryption
 
-    # ============================================================
-
-    - name: Disable encryption from bucket
-      s3_bucket:
-        name: "{{ local_bucket_name }}"
-        encryption: none
-        bucket_key_enabled: false
-      register: output
-
-    - name: Assert for 'Disable encryption from bucket'
-      assert:
-        that:
-          - output.changed
-          - not output.encryption
-
-    - name: Disable encryption from bucket (idempotent)
-      s3_bucket:
-        name: "{{ local_bucket_name }}"
-        bucket_key_enabled: true
-      register: output
-
-    - name: Assert for 'Disable encryption from bucket (idempotent)'
-      assert:
-        that:
-          - output is not changed
-          - not output.encryption
-
-    # ============================================================
+    ## # ============================================================
+    ##
+    ## AWS S3 no longer supports disabling S3 encryption
+    ## https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-encryption-faq.html
+    ##
+    ## - name: Disable encryption from bucket
+    ##   s3_bucket:
+    ##     name: "{{ local_bucket_name }}"
+    ##     encryption: none
+    ##     bucket_key_enabled: false
+    ##   register: output
+    ##
+    ## - name: Assert for 'Disable encryption from bucket'
+    ##   assert:
+    ##     that:
+    ##       - output.changed
+    ##       - not output.encryption
+    ##
+    ## - name: Disable encryption from bucket (idempotent)
+    ##   s3_bucket:
+    ##     name: "{{ local_bucket_name }}"
+    ##     bucket_key_enabled: true
+    ##   register: output
+    ##
+    ## - name: Assert for 'Disable encryption from bucket (idempotent)'
+    ##   assert:
+    ##     that:
+    ##       - output is not changed
+    ##       - not output.encryption
+    ##
+    ## # ============================================================
 
     - name: Delete encryption test s3 bucket
       s3_bucket:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_kms.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_kms.yml
@@ -42,33 +42,36 @@
           - output.encryption
           - output.encryption.SSEAlgorithm == 'aws:kms'
 
-    # ============================================================
-
-    - name: Disable encryption from bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
-        state: present
-        encryption: "none"
-      register: output
-
-    - assert:
-        that:
-          - output.changed
-          - not output.encryption
-
-    - name: Disable encryption from bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
-        state: present
-        encryption: "none"
-      register: output
-
-    - assert:
-        that:
-          - output is not changed
-          - not output.encryption
-
-    # ============================================================
+    ## # ============================================================
+    ##
+    ## AWS S3 no longer supports disabling S3 encryption
+    ## https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-encryption-faq.html
+    ##
+    ## - name: Disable encryption from bucket
+    ##   s3_bucket:
+    ##     name: '{{ local_bucket_name }}'
+    ##     state: present
+    ##     encryption: "none"
+    ##   register: output
+    ##
+    ## - assert:
+    ##     that:
+    ##       - output.changed
+    ##       - not output.encryption
+    ##
+    ## - name: Disable encryption from bucket
+    ##   s3_bucket:
+    ##     name: '{{ local_bucket_name }}'
+    ##     state: present
+    ##     encryption: "none"
+    ##   register: output
+    ##
+    ## - assert:
+    ##     that:
+    ##       - output is not changed
+    ##       - not output.encryption
+    ##
+    ## # ============================================================
 
     - name: Delete encryption test s3 bucket
       s3_bucket:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_sse.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_sse.yml
@@ -25,7 +25,8 @@
 
     - assert:
         that:
-          - output.changed
+          # SSE is now enabled by default
+          # - output.changed
           - output.encryption
           - output.encryption.SSEAlgorithm == 'AES256'
 
@@ -42,33 +43,36 @@
           - output.encryption
           - output.encryption.SSEAlgorithm == 'AES256'
 
-    # ============================================================
-
-    - name: Disable encryption from bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
-        state: present
-        encryption: "none"
-      register: output
-
-    - assert:
-        that:
-          - output.changed
-          - not output.encryption
-
-    - name: Disable encryption from bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
-        state: present
-        encryption: "none"
-      register: output
-
-    - assert:
-        that:
-          - output is not changed
-          - not output.encryption
-
-    # ============================================================
+    ## # ============================================================
+    ##
+    ## AWS S3 no longer supports disabling S3 encryption
+    ## https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-encryption-faq.html
+    ##
+    ## - name: Disable encryption from bucket
+    ##   s3_bucket:
+    ##     name: '{{ local_bucket_name }}'
+    ##     state: present
+    ##     encryption: "none"
+    ##   register: output
+    ##
+    ## - assert:
+    ##     that:
+    ##       - output.changed
+    ##       - not output.encryption
+    ##
+    ## - name: Disable encryption from bucket
+    ##   s3_bucket:
+    ##     name: '{{ local_bucket_name }}'
+    ##     state: present
+    ##     encryption: "none"
+    ##   register: output
+    ##
+    ## - assert:
+    ##     that:
+    ##       - output is not changed
+    ##       - not output.encryption
+    ##
+    ## # ============================================================
 
     - name: Delete encryption test s3 bucket
       s3_bucket:


### PR DESCRIPTION
##### SUMMARY

Amazon now enables S3-SSE bucket encryption by default and it's not possible to disable it.  Disable the relevant tests but leave a minimal framework in place.

##### ISSUE TYPE

- Tests Pull Request

##### COMPONENT NAME

s3_bucket

##### ADDITIONAL INFORMATION
