### PR TITLE
route53_info: fix "key error" for health_check operations

### DIFF
--- a/changelogs/fragments/1419-route53_info-fix-keyerror-for-healthcheck-operations.yml
+++ b/changelogs/fragments/1419-route53_info-fix-keyerror-for-healthcheck-operations.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- route53_info - Fixed "Key Error" when getting status or failure_reason of a health check (https://github.com/ansible-collections/amazon.aws/pull/1419).
+- route53_info - Add new return key `health_check_observations` for health check operations (https://github.com/ansible-collections/amazon.aws/pull/1419).

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -860,7 +860,7 @@ def main():
     try:
         results = invocations[module.params.get('query')]()
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json(msg=to_native(e))
+        module.fail_json_aws(e, msg="Query failed")
 
     module.exit_json(**results)
 

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -656,7 +656,7 @@ def get_health_check():
 
     if module.params.get('health_check_method') == 'details':
         results = client.get_health_check(**params)
-        results['health_check'] = camel_dict_to_snake_dict(results['HealthCheck'])
+        results["health_check"] = camel_dict_to_snake_dict(results["HealthCheck"])
         module.deprecate(
             "The 'CamelCase' return values with key 'HealthCheck' is deprecated \
                 and will be replaced by 'snake_case' return values with key 'health_check'. \
@@ -667,13 +667,15 @@ def get_health_check():
 
     elif module.params.get('health_check_method') == 'failure_reason':
         response = client.get_health_check_last_failure_reason(**params)
-        results = {'health_check_observations': []}
-        results['health_check_observations'] = [camel_dict_to_snake_dict(health_check) for health_check in response['HealthCheckObservations']]
+        results["health_check_observations"] = [
+            camel_dict_to_snake_dict(health_check) for health_check in response["HealthCheckObservations"]
+        ]
 
     elif module.params.get('health_check_method') == 'status':
         response = client.get_health_check_status(**params)
-        results = {'health_check_observations': []}
-        results['health_check_observations'] = [camel_dict_to_snake_dict(health_check) for health_check in response['HealthCheckObservations']]
+        results["health_check_observations"] = [
+            camel_dict_to_snake_dict(health_check) for health_check in response["HealthCheckObservations"]
+        ]
 
     return results
 

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -472,6 +472,7 @@ health_check_observations:
                     description: A description of the status of the health check endpoint as reported by one of the Amazon Route 53 health checkers.
                     type: str
                     sample: 'Failure: Resolved IP: 12.345.67.89. The connection was closed by the endpoint.'
+    version_added: 5.4.0
 ResourceRecordSets:
     description: A deprecated CamelCased list of resource record sets returned by list_resource_record_sets in boto3. \
                  This list contains same elements/parameters as it's snake_cased version mentioned above. \
@@ -648,6 +649,7 @@ def get_count():
 
 def get_health_check():
     params = dict()
+    results = dict()
 
     if not module.params.get('health_check_id'):
         module.fail_json(msg="health_check_id is required")

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -376,7 +376,7 @@ delegation_sets:
     version_added: 4.1.0
     version_added_collection: community.aws
 health_check:
-    description: A dict of Route53 health check details returned by get_health_check_status in boto3.
+    description: A dict of Route53 health check details returned by get_health_check in boto3.
     type: dict
     returned: when I(query=health_check) and I(health_check_method=details)
     contains:
@@ -446,6 +446,32 @@ health_check:
                     sample: HTTPS
     version_added: 4.1.0
     version_added_collection: community.aws
+health_check_observations:
+    description: A dict of Route53 health check details returned by get_health_check_status and get_health_check_last_failure_reason in boto3.
+    type: list
+    elements: dict
+    returned: when I(query=health_check) and I(health_check_method=status) or I(health_check_method=failure_reason)
+    contains:
+        ip_address:
+            description: The IP address of the Amazon Route 53 health checker that provided the failure reason in StatusReport.
+            type: str
+            sample: '12.345.67.89'
+        region:
+            description: The region of the Amazon Route 53 health checker that provided the status in StatusReport.
+            type: str
+            sample: 'us-west-1'
+        status_report:
+            description: A complex type that contains the last failure reason and the time of the failed health check.
+            type: dict
+            contains:
+                checked_time:
+                    description: The date and time that the health checker performed the health check in ISO 8601 format and Coordinated Universal Time (UTC).
+                    type: str
+                    sample: '2023-03-08T23:10:08.452000+00:00'
+                status:
+                    description: A description of the status of the health check endpoint as reported by one of the Amazon Route 53 health checkers.
+                    type: str
+                    sample: 'Failure: Resolved IP: 12.345.67.89. The connection was closed by the endpoint.'
 ResourceRecordSets:
     description: A deprecated CamelCased list of resource record sets returned by list_resource_record_sets in boto3. \
                  This list contains same elements/parameters as it's snake_cased version mentioned above. \
@@ -482,7 +508,7 @@ DelegationSets:
     elements: dict
     returned: when I(query=reusable_delegation_set)
 HealthCheck:
-    description: A deprecated CamelCased dict of Route53 health check details returned by get_health_check_status in boto3. \
+    description: A deprecated CamelCased dict of Route53 health check details returned by get_health_check in boto3. \
                  This dict contains same elements/parameters as it's snake_cased version mentioned above. \
                  This field is deprecated and will be removed in 6.0.0 version release.
     type: dict
@@ -630,16 +656,24 @@ def get_health_check():
 
     if module.params.get('health_check_method') == 'details':
         results = client.get_health_check(**params)
-    elif module.params.get('health_check_method') == 'failure_reason':
-        results = client.get_health_check_last_failure_reason(**params)
-    elif module.params.get('health_check_method') == 'status':
-        results = client.get_health_check_status(**params)
+        results['health_check'] = camel_dict_to_snake_dict(results['HealthCheck'])
+        module.deprecate(
+            "The 'CamelCase' return values with key 'HealthCheck' is deprecated \
+                and will be replaced by 'snake_case' return values with key 'health_check'. \
+                Both case values are returned for now.",
+            date="2025-01-01",
+            collection_name="amazon.aws",
+        )
 
-    results['health_check'] = camel_dict_to_snake_dict(results['HealthCheck'])
-    module.deprecate("The 'CamelCase' return values with key 'HealthCheck' is deprecated and \
-                    will be replaced by 'snake_case' return values with key 'health_check'. \
-                    Both case values are returned for now.",
-                     date='2025-01-01', collection_name='amazon.aws')
+    elif module.params.get('health_check_method') == 'failure_reason':
+        response = client.get_health_check_last_failure_reason(**params)
+        results = {'health_check_observations': []}
+        results['health_check_observations'] = [camel_dict_to_snake_dict(health_check) for health_check in response['HealthCheckObservations']]
+
+    elif module.params.get('health_check_method') == 'status':
+        response = client.get_health_check_status(**params)
+        results = {'health_check_observations': []}
+        results['health_check_observations'] = [camel_dict_to_snake_dict(health_check) for health_check in response['HealthCheckObservations']]
 
     return results
 

--- a/tests/integration/targets/route53_health_check/tasks/main.yml
+++ b/tests/integration/targets/route53_health_check/tasks/main.yml
@@ -1725,6 +1725,33 @@
       - create_check is changed
       - health_check_info.health_check.health_check_config.measure_latency == true
 
+  # test route53_info for health_check_method=status
+  - name: Get health check status
+    amazon.aws.route53_info:
+      query: health_check
+      health_check_id: "{{ create_check.health_check.id }}"
+      health_check_method: status
+    register: health_check_status_info
+
+  - assert:
+      that:
+      - health_check_status_info is not failed
+      - '"health_check_observations" in health_check_status_info'
+
+  # test route53_info for health_check_method=failure_reason
+  - name: Get health check failure_reason
+    amazon.aws.route53_info:
+      query: health_check
+      health_check_id: "{{ create_check.health_check.id }}"
+      health_check_method: failure_reason
+    register: health_check_failure_reason_info
+
+  - assert:
+      that:
+      - health_check_failure_reason_info is not failed
+      - '"health_check_observations" in health_check_failure_reason_info'
+
+
   - name: 'Update above health check to disable latency graphs - immutable, no change'
     route53_health_check:
       state: present

--- a/tests/integration/targets/route53_health_check/tasks/main.yml
+++ b/tests/integration/targets/route53_health_check/tasks/main.yml
@@ -1725,6 +1725,9 @@
       - create_check is changed
       - health_check_info.health_check.health_check_config.measure_latency == true
 
+  - pause:
+      seconds: 20
+
   # test route53_info for health_check_method=status
   - name: Get health check status
     amazon.aws.route53_info:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1396 

This pull request
1. Add new return key `health_check_observations` for health check operations, returned when `I(query=health_check) and I(health_check_method=status) or I(health_check_method=failure_reason)`
2. Fixes "Key Error" when getting `status` or `failure_reason` of a health check. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
route53_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
