### PR TITLE
rds_instance: fix 'typeError'when tagging gp3 db

### DIFF
--- a/changelogs/fragments/1437-rds_instance-gp3-tagging-bugfix.yml
+++ b/changelogs/fragments/1437-rds_instance-gp3-tagging-bugfix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- rds_instance - Fixed "TypeError" when tagging RDS DB with storage type 'gp3' (https://github.com/ansible-collections/amazon.aws/pull/1437).

--- a/changelogs/fragments/1437-rds_instance-gp3-tagging-bugfix.yml
+++ b/changelogs/fragments/1437-rds_instance-gp3-tagging-bugfix.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- rds_instance - Fixed "TypeError" when tagging RDS DB with storage type 'gp3' (https://github.com/ansible-collections/amazon.aws/pull/1437).
+- rds_instance - Fixed ``TypeError`` when tagging RDS DB with storage type ``gp3`` (https://github.com/ansible-collections/amazon.aws/pull/1437).

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1029,20 +1029,21 @@ def get_options_with_changing_values(client, module, parameters):
         new_allocated_storage = module.params.get('allocated_storage')
         current_allocated_storage = instance.get('PendingModifiedValues', {}).get('AllocatedStorage', instance['AllocatedStorage'])
 
-        if current_allocated_storage != new_allocated_storage:
-            parameters['AllocatedStorage'] = new_allocated_storage
-
-        if new_allocated_storage >= 400:
-            if new_iops < 12000:
-                module.fail_json(msg='IOPS must be at least 12000 when the allocated storage is larger than or equal to 400 GB.')
-
-            if new_storage_throughput < 500 and GP3_THROUGHPUT:
-                module.fail_json(msg='Storage Throughput must be at least 500 when the allocated storage is larger than or equal to 400 GB.')
-
-            if current_iops != new_iops:
-                parameters['Iops'] = new_iops
-                # must be always specified when changing iops
+        if new_allocated_storage:
+            if current_allocated_storage != new_allocated_storage:
                 parameters['AllocatedStorage'] = new_allocated_storage
+
+            if new_allocated_storage >= 400:
+                if new_iops < 12000:
+                    module.fail_json(msg='IOPS must be at least 12000 when the allocated storage is larger than or equal to 400 GB.')
+
+                if new_storage_throughput < 500 and GP3_THROUGHPUT:
+                    module.fail_json(msg='Storage Throughput must be at least 500 when the allocated storage is larger than or equal to 400 GB.')
+
+                if current_iops != new_iops:
+                    parameters['Iops'] = new_iops
+                    # must be always specified when changing iops
+                    parameters['AllocatedStorage'] = new_allocated_storage
 
     if parameters.get('NewDBInstanceIdentifier') and instance.get('PendingModifiedValues', {}).get('DBInstanceIdentifier'):
         if parameters['NewDBInstanceIdentifier'] == instance['PendingModifiedValues']['DBInstanceIdentifier'] and not apply_immediately:

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1031,19 +1031,23 @@ def get_options_with_changing_values(client, module, parameters):
 
         if new_allocated_storage:
             if current_allocated_storage != new_allocated_storage:
-                parameters['AllocatedStorage'] = new_allocated_storage
+                parameters["AllocatedStorage"] = new_allocated_storage
 
             if new_allocated_storage >= 400:
                 if new_iops < 12000:
-                    module.fail_json(msg='IOPS must be at least 12000 when the allocated storage is larger than or equal to 400 GB.')
+                    module.fail_json(
+                        msg="IOPS must be at least 12000 when the allocated storage is larger than or equal to 400 GB."
+                    )
 
                 if new_storage_throughput < 500 and GP3_THROUGHPUT:
-                    module.fail_json(msg='Storage Throughput must be at least 500 when the allocated storage is larger than or equal to 400 GB.')
+                    module.fail_json(
+                        msg="Storage Throughput must be at least 500 when the allocated storage is larger than or equal to 400 GB."
+                    )
 
                 if current_iops != new_iops:
-                    parameters['Iops'] = new_iops
+                    parameters["Iops"] = new_iops
                     # must be always specified when changing iops
-                    parameters['AllocatedStorage'] = new_allocated_storage
+                    parameters["AllocatedStorage"] = new_allocated_storage
 
     if parameters.get('NewDBInstanceIdentifier') and instance.get('PendingModifiedValues', {}).get('DBInstanceIdentifier'):
         if parameters['NewDBInstanceIdentifier'] == instance['PendingModifiedValues']['DBInstanceIdentifier'] and not apply_immediately:

--- a/tests/integration/targets/rds_instance_tagging/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_tagging/defaults/main.yml
@@ -1,4 +1,5 @@
 instance_id: ansible-test-{{ tiny_prefix }}
+instance_id_gp3: ansible-test-{{ tiny_prefix }}-gp3
 modified_instance_id: '{{ instance_id }}-updated'
 username: test
 password: test12345678

--- a/tests/integration/targets/rds_instance_tagging/tasks/test_tagging_gp3.yml
+++ b/tests/integration/targets/rds_instance_tagging/tasks/test_tagging_gp3.yml
@@ -48,7 +48,7 @@
   - assert:
       that:
       - result.changed
-      - result.db_instance_id_gp3entifier == '{{ instance_id_gp3 }}'
+      - result.db_instance_identifier == '{{ instance_id_gp3 }}'
       - result.tags | length == 2
       - result.tags.Name == '{{ instance_id_gp3 }}'
       - result.tags.Created_by == 'Ansible rds_instance tests'
@@ -85,7 +85,7 @@
   - assert:
       that:
       - not result.changed
-      - result.db_instance_id_gp3entifier
+      - result.db_instance_identifier == '{{ instance_id_gp3 }}'
       - result.tags | length == 2
 
   - name: Idempotence with minimal options
@@ -97,12 +97,12 @@
   - assert:
       that:
       - not result.changed
-      - result.db_instance_id_gp3entifier
+      - result.db_instance_identifier == '{{ instance_id_gp3 }}'
       - result.tags | length == 2
 
   - name: Test tags are not purged if purge_tags is False
     rds_instance:
-      db_instance_id_gp3entifier: '{{ instance_id_gp3 }}'
+      db_instance_identifier: '{{ instance_id_gp3 }}'
       state: present
       engine: mariadb
       username: '{{ username }}'
@@ -120,7 +120,7 @@
 
   - name: Add a tag and remove a tag - check_mode
     rds_instance:
-      db_instance_id_gp3entifier: '{{ instance_id_gp3 }}'
+      db_instance_identifier: '{{ instance_id_gp3 }}'
       state: present
       tags:
         Name: '{{ instance_id_gp3 }}-new'
@@ -135,7 +135,7 @@
 
   - name: Add a tag and remove a tag
     rds_instance:
-      db_instance_id_gp3entifier: '{{ instance_id_gp3 }}'
+      db_instance_identifier: '{{ instance_id_gp3 }}'
       state: present
       tags:
         Name: '{{ instance_id_gp3 }}-new'
@@ -151,7 +151,7 @@
 
   - name: Add a tag and remove a tag (idempotence) - check_mode
     rds_instance:
-      db_instance_id_gp3entifier: '{{ instance_id_gp3 }}'
+      db_instance_identifier: '{{ instance_id_gp3 }}'
       state: present
       tags:
         Name: '{{ instance_id_gp3 }}-new'
@@ -166,7 +166,7 @@
 
   - name: Add a tag and remove a tag (idempotence)
     rds_instance:
-      db_instance_id_gp3entifier: '{{ instance_id_gp3 }}'
+      db_instance_identifier: '{{ instance_id_gp3 }}'
       state: present
       tags:
         Name: '{{ instance_id_gp3 }}-new'

--- a/tests/integration/targets/rds_instance_tagging/tasks/test_tagging_gp3.yml
+++ b/tests/integration/targets/rds_instance_tagging/tasks/test_tagging_gp3.yml
@@ -1,19 +1,7 @@
-- name: rds_instance / tagging integration tests
-  collections:
-  - community.aws
-  module_defaults:
-    group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
-  block:
-  - name: Test tagging db with storage type gp3
-    import_tasks: test_tagging_gp3.yml
-
+- block:
   - name: Ensure the resource doesn't exist
     rds_instance:
-      id: '{{ instance_id }}'
+      id: '{{ instance_id_gp3 }}'
       state: absent
       skip_final_snapshot: true
     register: result
@@ -26,7 +14,7 @@
     # Test invalid bad options
   - name: Create a DB instance with an invalid engine
     rds_instance:
-      id: '{{ instance_id }}'
+      id: '{{ instance_id_gp3 }}'
       state: present
       engine: thisisnotavalidengine
       username: '{{ username }}'
@@ -44,7 +32,7 @@
     # Test creation, adding tags and enabling encryption
   - name: Create a mariadb instance
     rds_instance:
-      id: '{{ instance_id }}'
+      id: '{{ instance_id_gp3 }}'
       state: present
       engine: mariadb
       username: '{{ username }}'
@@ -53,23 +41,23 @@
       allocated_storage: '{{ allocated_storage }}'
       storage_encrypted: true
       tags:
-        Name: '{{ instance_id }}'
+        Name: '{{ instance_id_gp3 }}'
         Created_by: Ansible rds_instance tests
     register: result
 
   - assert:
       that:
       - result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
+      - result.db_instance_id_gp3entifier == '{{ instance_id_gp3 }}'
       - result.tags | length == 2
-      - result.tags.Name == '{{ instance_id }}'
+      - result.tags.Name == '{{ instance_id_gp3 }}'
       - result.tags.Created_by == 'Ansible rds_instance tests'
       - result.kms_key_id
       - result.storage_encrypted == true
 
-  - name: Test impotency omitting tags - check_mode
+  - name: Test idempotency omitting tags - check_mode
     rds_instance:
-      id: '{{ instance_id }}'
+      id: '{{ instance_id_gp3 }}'
       state: present
       engine: mariadb
       username: '{{ username }}'
@@ -83,9 +71,9 @@
       that:
       - not result.changed
 
-  - name: Test impotency omitting tags
+  - name: Test idempotency omitting tags
     rds_instance:
-      id: '{{ instance_id }}'
+      id: '{{ instance_id_gp3 }}'
       state: present
       engine: mariadb
       username: '{{ username }}'
@@ -97,24 +85,24 @@
   - assert:
       that:
       - not result.changed
-      - result.db_instance_identifier
+      - result.db_instance_id_gp3entifier
       - result.tags | length == 2
 
   - name: Idempotence with minimal options
     rds_instance:
-      id: '{{ instance_id }}'
+      id: '{{ instance_id_gp3 }}'
       state: present
     register: result
 
   - assert:
       that:
       - not result.changed
-      - result.db_instance_identifier
+      - result.db_instance_id_gp3entifier
       - result.tags | length == 2
 
   - name: Test tags are not purged if purge_tags is False
     rds_instance:
-      db_instance_identifier: '{{ instance_id }}'
+      db_instance_id_gp3entifier: '{{ instance_id_gp3 }}'
       state: present
       engine: mariadb
       username: '{{ username }}'
@@ -132,10 +120,10 @@
 
   - name: Add a tag and remove a tag - check_mode
     rds_instance:
-      db_instance_identifier: '{{ instance_id }}'
+      db_instance_id_gp3entifier: '{{ instance_id_gp3 }}'
       state: present
       tags:
-        Name: '{{ instance_id }}-new'
+        Name: '{{ instance_id_gp3 }}-new'
         Created_by: Ansible rds_instance tests
       purge_tags: true
     register: result
@@ -147,10 +135,10 @@
 
   - name: Add a tag and remove a tag
     rds_instance:
-      db_instance_identifier: '{{ instance_id }}'
+      db_instance_id_gp3entifier: '{{ instance_id_gp3 }}'
       state: present
       tags:
-        Name: '{{ instance_id }}-new'
+        Name: '{{ instance_id_gp3 }}-new'
         Created_by: Ansible rds_instance tests
       purge_tags: true
     register: result
@@ -159,14 +147,14 @@
       that:
       - result.changed
       - result.tags | length == 2
-      - result.tags.Name == '{{ instance_id }}-new'
+      - result.tags.Name == '{{ instance_id_gp3 }}-new'
 
   - name: Add a tag and remove a tag (idempotence) - check_mode
     rds_instance:
-      db_instance_identifier: '{{ instance_id }}'
+      db_instance_id_gp3entifier: '{{ instance_id_gp3 }}'
       state: present
       tags:
-        Name: '{{ instance_id }}-new'
+        Name: '{{ instance_id_gp3 }}-new'
         Created_by: Ansible rds_instance tests
       purge_tags: true
     register: result
@@ -178,10 +166,10 @@
 
   - name: Add a tag and remove a tag (idempotence)
     rds_instance:
-      db_instance_identifier: '{{ instance_id }}'
+      db_instance_id_gp3entifier: '{{ instance_id_gp3 }}'
       state: present
       tags:
-        Name: '{{ instance_id }}-new'
+        Name: '{{ instance_id_gp3 }}-new'
         Created_by: Ansible rds_instance tests
       purge_tags: true
     register: result
@@ -190,12 +178,12 @@
       that:
       - not result.changed
       - result.tags | length == 2
-      - result.tags.Name == '{{ instance_id }}-new'
+      - result.tags.Name == '{{ instance_id_gp3 }}-new'
 
   always:
   - name: Remove DB instance
     rds_instance:
-      id: '{{ instance_id }}'
+      id: '{{ instance_id_gp3 }}'
       state: absent
       skip_final_snapshot: true
       wait: false


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This PR fixes bug causing error when managing tags on a `gp3` rds database instance, caused by a conditional statement comparing `allocated_storage` even when it is not provided. 
currently code returns `TypeError: '>=' not supported between instances of 'NoneType' and 'int'`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rds_instance
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
