### PR TITLE
Add backup_plan and backup_plan_info modules

### DIFF
--- a/changelogs/fragments/1446-backup_plan-add-new-module.yml
+++ b/changelogs/fragments/1446-backup_plan-add-new-module.yml
@@ -1,0 +1,3 @@
+trivial:
+- backup_plan - Added a new module that manages AWS Backup plans. (https://github.com/ansible-collections/amazon.aws/pull/1446).
+- backup_plan_info - Added a new module that describes AWS Backup plans. (https://github.com/ansible-collections/amazon.aws/pull/1446).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -7,6 +7,7 @@ action_groups:
   - aws_az_info
   - aws_caller_info
   - aws_s3
+  - backup_plan
   - backup_tag
   - backup_tag_info
   - backup_selection

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -8,6 +8,7 @@ action_groups:
   - aws_caller_info
   - aws_s3
   - backup_plan
+  - backup_plan_info
   - backup_tag
   - backup_tag_info
   - backup_selection

--- a/plugins/module_utils/backup.py
+++ b/plugins/module_utils/backup.py
@@ -66,8 +66,8 @@ def get_plan_details(module, client, backup_plan_name: str):
 
     try:
         resource = result.get("BackupPlanArn", None)
-        # tag_dict = get_backup_resource_tags(module, client, resource)
-        # result.update({"tags": tag_dict})
+        tag_dict = get_backup_resource_tags(module, client, resource)
+        result.update({"tags": tag_dict})
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Failed to get the backup plan tags")
 

--- a/plugins/module_utils/backup.py
+++ b/plugins/module_utils/backup.py
@@ -73,10 +73,8 @@ def get_plan_details(module, client, backup_plan_name: str):
 
     snaked_backup_plan.append(camel_dict_to_snake_dict(result, ignore_list="tags"))
 
-    # Turn the boto3 result in to ansible friendly tag dictionary
+    # Remove AWS API response and add top-level plan name
     for v in snaked_backup_plan:
-        # if "tags_list" in v:
-        #    v["tags"] = boto3_tag_list_to_ansible_dict(v["tags_list"], "key", "value")
         if "response_metadata" in v:
             del v["response_metadata"]
         v["backup_plan_name"] = v["backup_plan"]["backup_plan_name"]

--- a/plugins/module_utils/backup.py
+++ b/plugins/module_utils/backup.py
@@ -71,7 +71,7 @@ def get_plan_details(module, client, backup_plan_name: str):
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Failed to get the backup plan tags")
 
-    snaked_backup_plan.append(camel_dict_to_snake_dict(result))
+    snaked_backup_plan.append(camel_dict_to_snake_dict(result, ignore_list="tags"))
 
     # Turn the boto3 result in to ansible friendly tag dictionary
     for v in snaked_backup_plan:

--- a/plugins/modules/backup_plan.py
+++ b/plugins/modules/backup_plan.py
@@ -9,37 +9,154 @@ DOCUMENTATION = r"""
 ---
 module: backup_plan
 version_added: 6.0.0
-short_description: create, delete and modify AWS Backup plans
+short_description: Manage AWS Backup Plans
 description:
-  - Manage AWS Backup plans.
+  - Creates, updates, or deletes AWS Backup Plans
   - For more information see the AWS documentation for Backup plans U(https://docs.aws.amazon.com/aws-backup/latest/devguide/about-backup-plans.html).
 author:
   - Kristof Imre Szabo (@krisek)
   - Alina Buzachis (@alinabuzachis)
+  - Helen Bailey (@hakbailey)
 options:
+  state:
+    description:
+      - Create/update or delete a backup plan.
+    type: str
+    default: present
+    choices: ['present', 'absent']
   backup_plan_name:
     description:
       - The display name of a backup plan. Must contain 1 to 50 alphanumeric or '-_.' characters.
-    required: true
     type: str
+    required: true
     aliases: ['name']
   rules:
     description:
       - An array of BackupRule objects, each of which specifies a scheduled task that is used to back up a selection of resources.
-    required: false
+      - Required when I(state=present).
     type: list
+    elements: dict
+    suboptions:
+      rule_name:
+        description: Name of the rule.
+        type: str
+        required: true
+      target_backup_vault_name:
+        description: Name of the Backup Vault this rule should target.
+        type: str
+        required: true
+      schedule_expression:
+        description: A CRON expression in UTC specifying when Backup initiates a backup
+          job. AWS default is used if not supplied.
+        type: str
+        default: 'cron(0 5 ? * * *)'
+      start_window_minutes:
+        description:
+          - A value in minutes after a backup is scheduled before a job will be
+            canceled if it doesn't start successfully. If this value is included, it
+            must be at least 60 minutes to avoid errors.
+          - AWS default if not supplied is 480.
+        type: int
+        default: 480
+      completion_window_minutes:
+        description:
+          - A value in minutes after a backup job is successfully started before it
+            must be completed or it will be canceled by Backup.
+          - AWS default if not supplied is 10080
+        type: int
+        default: 10080
+      lifecycle:
+        description:
+          - The lifecycle defines when a protected resource is transitioned to cold
+            storage and when it expires. Backup will transition and expire backups
+            automatically according to the lifecycle that you define.
+          - Backups transitioned to cold storage must be stored in cold storage for a
+            minimum of 90 days. Therefore, the "retention" setting must be 90 days
+            greater than the "transition to cold after days" setting. The "transition
+            to cold after days" setting cannot be changed after a backup has been
+            transitioned to cold.
+        type: dict
+        suboptions:
+          move_to_cold_storage_after_days:
+            description: Specifies the number of days after creation that a recovery point is moved to cold storage.
+            type: int
+          delete_after_days:
+            description: Specifies the number of days after creation that a recovery
+              point is deleted. Must be greater than 90 days plus
+              move_to_cold_storage_after_days.
+            type: int
+      recovery_point_tags:
+        description: To help organize your resources, you can assign your own metadata to the resources that you create.
+        type: dict
+      copy_actions:
+        description: An array of copy_action objects, which contains the details of the copy operation.
+        type: list
+        elements: dict
+        suboptions:
+          destination_backup_vault_arn:
+            description: An Amazon Resource Name (ARN) that uniquely identifies the destination backup vault for the copied backup.
+            type: str
+            required: true
+          lifecycle:
+            description:
+              - Contains an array of Transition objects specifying how long in days
+                before a recovery point transitions to cold storage or is deleted.
+              - Backups transitioned to cold storage must be stored in cold storage for
+                a minimum of 90 days. Therefore, on the console, the "retention"
+                setting must be 90 days greater than the "transition to cold after
+                days" setting. The "transition to cold after days" setting cannot be
+                changed after a backup has been transitioned to cold.
+            type: dict
+            suboptions:
+              move_to_cold_storage_after_days:
+                description: Specifies the number of days after creation that a
+                  recovery point is moved to cold storage.
+                type: int
+              delete_after_days:
+                description: Specifies the number of days after creation that a
+                  recovery point is deleted. Must be greater than 90 days plus
+                  move_to_cold_storage_after_days.
+                type: int
+      enable_continuous_backup:
+        description:
+          - Specifies whether Backup creates continuous backups. True causes Backup to
+            create continuous backups capable of point-in-time restore (PITR). False
+            (or not specified) causes Backup to create snapshot backups.
+          - AWS default if not supplied is false.
+        type: bool
+        default: false
   advanced_backup_settings:
     description:
-      -  Specifies a list of BackupOptions for each resource type. These settings are only available for Windows Volume Shadow Copy Service (VSS) backup jobs.
+      - Specifies a list of advanced backup settings for each resource type.
+      - These settings are only available for Windows Volume Shadow Copy Service (VSS) backup jobs.
     required: false
     type: list
-  state:
-    description:
-      - Create, delete a backup plan.
-    required: false
-    default: present
-    choices: ['present', 'absent']
+    elements: dict
+    suboptions:
+      resource_type:
+        description:
+          - Specifies an object containing resource type and backup options.
+          - The only supported resource type is Amazon EC2 instances with Windows Volume Shadow Copy Service (VSS).
+        type: str
+        choices: ['EC2']
+      backup_options:
+        description:
+          - Specifies the backup option for a selected resource.
+          - This option is only available for Windows VSS backup jobs.
+        type: dict
+        choices: [{'WindowsVSS': 'enabled'}, {'WindowsVSS': 'disabled'}]
+  creator_request_id:
+    description: Identifies the request and allows failed requests to be retried
+      without the risk of running the operation twice. If the request includes a
+      CreatorRequestId that matches an existing backup plan, that plan is returned.
     type: str
+  tags:
+    description: To help organize your resources, you can assign your own metadata to
+      the resources that you create. Each tag is a key-value pair. The specified tags
+      are assigned to all backups created with this plan.
+    type: dict
+    aliases: ['resource_tags', 'backup_plan_tags']
+
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules
@@ -48,275 +165,467 @@ extends_documentation_fragment:
 """
 
 EXAMPLES = r"""
-- name: create backup plan
+- name: Create an AWSbackup plan
   amazon.aws.backup_plan:
     state: present
     backup_plan_name: elastic
     rules:
-      - RuleName: every_morning
-        TargetBackupVaultName: elastic
-        ScheduleExpression: "cron(0 5 ? * * *)"
-        StartWindowMinutes: 120
-        CompletionWindowMinutes: 10080
-        Lifecycle:
-          DeleteAfterDays: 7
-        EnableContinuousBackup: true
-
+      - rule_name: daily
+        target_backup_vault_name: "{{ backup_vault_name }}"
+        schedule_expression: 'cron(0 5 ? * * *)'
+        start_window_minutes: 60
+        completion_window_minutes: 1440
+- name: Delete an AWS Backup plan
+  amazon.aws.backup_plan:
+    backup_plan_name: elastic
+    state: absent
 """
+
 RETURN = r"""
+exists:
+  description: Whether the resource exists.
+  returned: always
+  type: bool
+  sample: true
 backup_plan_arn:
-    description: ARN of the backup plan.
-    type: str
-    sample: arn:aws:backup:eu-central-1:111122223333:backup-plan:1111f877-1ecf-4d79-9718-a861cd09df3b
+  description: ARN of the backup plan.
+  returned: always
+  type: str
+  sample: arn:aws:backup:eu-central-1:111122223333:backup-plan:1111f877-1ecf-4d79-9718-a861cd09df3b
 backup_plan_id:
-    description: Id of the backup plan.
-    type: str
-    sample: 1111f877-1ecf-4d79-9718-a861cd09df3b
+  description: ID of the backup plan.
+  returned: always
+  type: str
+  sample: 1111f877-1ecf-4d79-9718-a861cd09df3b
 backup_plan_name:
-    description: Name of the backup plan.
-    type: str
-    sample: elastic
+  description: Name of the backup plan.
+  returned: always
+  type: str
+  sample: elastic
 creation_date:
-    description: Creation date of the backup plan.
-    type: str
-    sample: '2023-01-24T10:08:03.193000+01:00'
-last_execution_date:
-    description: Last execution date of the backup plan.
-    type: str
-    sample: '2023-03-24T06:30:08.250000+01:00'
-tags:
-    description: Tags of the backup plan
-    type: str
+  description: Creation date of the backup plan.
+  returned: on create/update
+  type: str
+  sample: '2023-01-24T10:08:03.193000+01:00'
+deletion_date:
+  description: Date the backup plan was deleted.
+  returned: on delete
+  type: str
+  sample: '2023-05-05T16:24:51.987000-04:00'
 version_id:
-    description: Version id of the backup plan
-    type: str
+  description: Version ID of the backup plan.
+  returned: always
+  type: str
+  sample: ODM3MjVjNjItYWFkOC00NjExLWIwZTYtZDNiNGI5M2I0ZTY1
 backup_plan:
-    description: backup plan details
-    returned: always
-    type: complex
-    contains:
-        backup_plan_arn:
-            description: backup plan arn
-            returned: always
-            type: str
-            sample: arn:aws:backup:eu-central-1:111122223333:backup-plan:1111f877-1ecf-4d79-9718-a861cd09df3b
+  description: Backup plan details.
+  returned: on create/update
+  type: dict
+  contains:
     backup_plan_name:
-        description: backup plan name
-        returned: always
-        type: str
-        sample:  elastic
-    advanced_backup_settings:
-        description: Advanced backup settings of the backup plan
-        type: list
-        elements: dict
-        contains:
-            resource_type:
-                description: Resource type of the advanced setting
-                type: str
-            backup_options:
-                description: Options of the advanced setting
-                type: dict
+      description: Name of the backup plan.
+      returned: always
+      type: str
+      sample: elastic
     rules:
-        description:
+      description:
         - An array of BackupRule objects, each of which specifies a scheduled task that is used to back up a selection of resources.
-        type: list
-
+      returned: always
+      type: list
+      elements: dict
+    advanced_backup_settings:
+      description: Advanced backup settings of the backup plan.
+      returned: when configured
+      type: list
+      elements: dict
+      contains:
+        resource_type:
+          description: Resource type of the advanced settings.
+          type: str
+        backup_options:
+          description: Backup options of the advanced settings.
+          type: dict
+    tags:
+      description: Tags of the backup plan.
+      returned: on create/update
+      type: str
 """
 
+import json
+from datetime import datetime
+from typing import Optional
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import compare_aws_tags
+from ansible_collections.amazon.aws.plugins.module_utils.backup import (
+    get_plan_details
+)
+from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 
 try:
     from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-import json
-from typing import Optional
-from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.backup import get_plan_details
+ARGUMENT_SPEC = dict(
+    state=dict(type="str", choices=["present", "absent"], default="present"),
+    backup_plan_name=dict(required=True, type="str", aliases=["name"]),
+    rules=dict(
+        type="list",
+        elements="dict",
+        options=dict(
+            rule_name=dict(required=True, type="str"),
+            target_backup_vault_name=dict(required=True, type="str"),
+            schedule_expression=dict(type="str", default="cron(0 5 ? * * *)"),
+            start_window_minutes=dict(type="int", default=480),
+            completion_window_minutes=dict(type="int", default=10080),
+            lifecycle=dict(
+                type="dict",
+                options=dict(
+                    move_to_cold_storage_after_days=dict(type="int"),
+                    delete_after_days=dict(type="int"),
+                ),
+            ),
+            recovery_point_tags=dict(type="dict"),
+            copy_actions=dict(
+                type="list",
+                elements="dict",
+                options=dict(
+                    destination_backup_vault_arn=dict(required=True, type="str"),
+                    lifecycle=dict(
+                        type="dict",
+                        options=dict(
+                            move_to_cold_storage_after_days=dict(type="int"),
+                            delete_after_days=dict(type="int"),
+                        ),
+                    ),
+                ),
+            ),
+            enable_continuous_backup=dict(type="bool", default=False),
+        ),
+    ),
+    advanced_backup_settings=dict(
+        type="list",
+        elements="dict",
+        options=dict(
+            resource_type=dict(type="str", choices=["EC2"]),
+            backup_options=dict(
+                type="dict",
+                choices=[{"WindowsVSS": "enabled"}, {"WindowsVSS": "disabled"}],
+            ),
+        ),
+    ),
+    creator_request_id=dict(type="str"),
+    tags=dict(type="dict", aliases=["backup_plan_tags", "resource_tags"]),
+    purge_tags=dict(default=True, type="bool"),
+)
+
+REQUIRED_IF = [
+    ("state", "present", ["backup_plan_name", "rules"]),
+    ("state", "absent", ["backup_plan_name"]),
+]
+
+SUPPORTS_CHECK_MODE = True
 
 
-def create_backup_plan(module: AnsibleAWSModule, client, params: dict):
+def format_client_params(
+    module: AnsibleAWSModule,
+    plan: dict,
+    tags: Optional[dict] = None,
+    backup_plan_id: Optional[str] = None,
+    operation: Optional[str] = None,
+) -> dict:
     """
-    Creates a Backup Plan
+    Formats plan details to match boto3 backup client param expectations.
+
+    module : AnsibleAWSModule object
+    plan: Dict of plan details including name, rules, and advanced settings
+    tags: Dict of plan tags
+    backup_plan_id: ID of backup plan to update, only needed for update operation
+    operation: Operation to add specific params for, either create or update
+    """
+    params = {
+        "BackupPlan": snake_dict_to_camel_dict(
+            {k: v for k, v in plan.items() if v != "backup_plan_name"},
+            capitalize_first=True,
+        )
+    }
+
+    if operation == "create":  # Add create-specific params
+        if tags:
+            params["BackupPlanTags"] = tags
+        creator_request_id = module.params["creator_request_id"]
+        if creator_request_id:
+            params["CreatorRequestId"] = creator_request_id
+
+    elif operation == "update":  # Add update-specific params
+        params["BackupPlanId"] = backup_plan_id
+
+    return params
+
+
+def format_check_mode_response(
+    plan_name: str, plan: dict, tags: dict, delete: bool = False
+) -> dict:
+    """
+    Formats plan details in check mode to match result expectations.
+
+    plan_name: Name of backup plan
+    plan: Dict of plan details including name, rules, and advanced settings
+    tags: Optional dict of plan tags
+    delete: Whether the response is for a delete action
+    """
+    timestamp = datetime.now().isoformat()
+    if delete:
+        return {
+            "backup_plan_name": plan_name,
+            "backup_plan_id": "",
+            "backup_plan_arn": "",
+            "deletion_date": timestamp,
+            "version_id": "",
+        }
+    else:
+        return {
+            "backup_plan_name": plan_name,
+            "backup_plan_id": "",
+            "backup_plan_arn": "",
+            "creation_date": timestamp,
+            "version_id": "",
+            "backup_plan": {
+                "backup_plan_name": plan_name,
+                "rules": plan["rules"],
+                "advanced_backup_settings": plan["advanced_backup_settings"],
+                "tags": tags,
+            },
+        }
+
+
+def create_backup_plan(module: AnsibleAWSModule, client, create_params: dict) -> dict:
+    """
+    Creates a backup plan.
 
     module : AnsibleAWSModule object
     client : boto3 backup client connection object
-    params : The parameters to create a backup plan
+    create_params : The boto3 backup client parameters to create a backup plan
     """
-    params = {k: v for k, v in params.items() if v is not None}
     try:
-        response = client.create_backup_plan(**params)
+        response = client.create_backup_plan(**create_params)
     except (
         BotoCoreError,
         ClientError,
     ) as err:
-        module.fail_json_aws(err, msg="Failed to create Backup Plan")
-
+        module.fail_json_aws(err, msg="Failed to create backup plan {err}")
     return response
 
 
-def plan_update_needed(client, backup_plan_id: str, backup_plan_data: dict) -> bool:
+def plan_update_needed(existing_plan: dict, new_plan: dict) -> bool:
+    """
+    Determines whether existing and new plan rules/settings match.
+
+    existing_plan: Dict of existing plan details including rules and advanced settings,
+        in snake-case format
+    new_plan: Dict of existing plan details including rules and advanced settings, in
+        snake-case format
+    """
     update_needed = False
 
-    # we need to get current rules to manage the plan
-    full_plan = client.get_backup_plan(BackupPlanId=backup_plan_id)
-
-    configured_rules = json.dumps(
+    # Check whether rules match
+    existing_rules = json.dumps(
         [
-            {key: val for key, val in rule.items() if key != "RuleId"}
-            for rule in full_plan.get("BackupPlan", {}).get("Rules", [])
+            {key: val for key, val in rule.items() if key != "rule_id"}
+            for rule in existing_plan["backup_plan"]["rules"]
         ],
         sort_keys=True,
     )
-    supplied_rules = json.dumps(backup_plan_data["BackupPlan"]["Rules"], sort_keys=True)
-
-    if configured_rules != supplied_rules:
-        # rules to be updated
+    new_rules = json.dumps(new_plan["rules"], sort_keys=True)
+    if not existing_rules or existing_rules != new_rules:
         update_needed = True
 
-    configured_advanced_backup_settings = json.dumps(
-        full_plan.get("BackupPlan", {}).get("AdvancedBackupSettings", None),
+    # Check whether advanced backup settings match
+    existing_advanced_backup_settings = json.dumps(
+        existing_plan["backup_plan"].get("advanced_backup_settings", []),
         sort_keys=True,
     )
-    supplied_advanced_backup_settings = json.dumps(
-        backup_plan_data["BackupPlan"]["AdvancedBackupSettings"], sort_keys=True
+    new_advanced_backup_settings = json.dumps(
+        new_plan.get("advanced_backup_settings", []), sort_keys=True
     )
-    if configured_advanced_backup_settings != supplied_advanced_backup_settings:
-        # advanced settings to be updated
+    if existing_advanced_backup_settings != new_advanced_backup_settings:
         update_needed = True
+
     return update_needed
 
 
-def update_backup_plan(
-    module: AnsibleAWSModule, client, backup_plan_id: str, backup_plan_data: dict
-):
+def update_backup_plan(module: AnsibleAWSModule, client, update_params: dict) -> dict:
+    """
+    Updates a backup plan.
+
+    module : AnsibleAWSModule object
+    client : boto3 backup client connection object
+    update_params : The boto3 backup client parameters to update a backup plan
+    """
     try:
-        response = client.update_backup_plan(
-            BackupPlanId=backup_plan_id,
-            BackupPlan=backup_plan_data["BackupPlan"],
-        )
+        response = client.update_backup_plan(**update_params)
     except (
         BotoCoreError,
         ClientError,
     ) as err:
-        module.fail_json_aws(err, msg="Failed to create Backup Plan")
+        module.fail_json_aws(err, msg="Failed to update backup plan {err}")
     return response
 
 
-def delete_backup_plan(module: AnsibleAWSModule, client, backup_plan_id: str):
+def tag_backup_plan(
+    module: AnsibleAWSModule,
+    client,
+    new_tags: Optional[dict],
+    plan_arn: str,
+    current_tags: Optional[dict] = None,
+):
     """
-    Delete a Backup Plan
+    Creates, updates, and/or removes tags on a Backup Plan resource.
 
     module : AnsibleAWSModule object
     client : boto3 client connection object
-    backup_plan_id : Backup Plan ID
+    new_tags : Dict of tags converted from ansible_dict to boto3 list of dicts
+    plan_arn : The ARN of the Backup Plan to operate on
+    curr_tags : Dict of the current tags on resource, if any
+    """
+
+    if not new_tags and not current_tags:
+        return False
+
+    if module.check_mode:
+        return True
+
+    new_tags = new_tags or {}
+    current_tags = current_tags or {}
+    tags_to_add, tags_to_remove = compare_aws_tags(
+        current_tags, new_tags, purge_tags=module.params["purge_tags"]
+    )
+
+    if not tags_to_add and not tags_to_remove:
+        return False
+
+    if tags_to_remove:
+        try:
+            client.untag_resource(ResourceArn=plan_arn, TagKeyList=tags_to_remove)
+        except (BotoCoreError, ClientError) as err:
+            module.fail_json_aws(err, msg="Failed to remove tags from the plan")
+
+    if tags_to_add:
+        try:
+            client.tag_resource(ResourceArn=plan_arn, Tags=tags_to_add)
+        except (BotoCoreError, ClientError) as err:
+            module.fail_json_aws(err, msg="Failed to add tags to the plan")
+
+    return True
+
+
+def delete_backup_plan(module: AnsibleAWSModule, client, backup_plan_id: str) -> dict:
+    """
+    Deletes a Backup Plan
+
+    module : AnsibleAWSModule object
+    client : boto3 backup client connection object
+    backup_plan_id : ID (*not* name or ARN) of Backup plan to delete
     """
     try:
-        client.delete_backup_plan(BackupPlanId=backup_plan_id)
+        response = client.delete_backup_plan(BackupPlanId=backup_plan_id)
     except (BotoCoreError, ClientError) as err:
         module.fail_json_aws(err, msg="Failed to delete the Backup Plan")
+    return response
 
 
 def main():
-    argument_spec = dict(
-        state=dict(default="present", choices=["present", "absent"]),
-        backup_plan_name=dict(required=True, type="str"),
-        rules=dict(type="list"),
-        advanced_backup_settings=dict(default=[], type="list"),
-        creator_request_id=dict(type="str"),
-        tags=dict(required=False, type="dict", aliases=["resource_tags"]),
-        purge_tags=dict(default=True, type="bool"),
+    module = AnsibleAWSModule(
+        argument_spec=ARGUMENT_SPEC,
+        required_if=REQUIRED_IF,
+        supports_check_mode=SUPPORTS_CHECK_MODE,
     )
 
-    required_if = [
-        ("state", "present", ["backup_plan_name", "rules"]),
-        ("state", "absent", ["backup_plan_name"]),
-    ]
+    # Set initial result values
+    result = dict(changed=False, exists=False)
 
-    module = AnsibleAWSModule(argument_spec=argument_spec, required_if=required_if, supports_check_mode=True)
+    # Get supplied params from module
+    client = module.client("backup")
+    state = module.params["state"]
+    plan_name = module.params["backup_plan_name"]
+    plan = {
+        "backup_plan_name": module.params["backup_plan_name"],
+        "rules": [
+            {k: v for k, v in rule.items() if v is not None}
+            for rule in module.params["rules"] or []
+        ],
+        "advanced_backup_settings": [
+            {k: v for k, v in setting.items() if v is not None}
+            for setting in module.params["advanced_backup_settings"] or []
+        ],
+    }
+    tags = module.params["tags"]
 
-    # collect parameters
-    state = module.params.get("state")
-    backup_plan_name = module.params["backup_plan_name"]
-    purge_tags = module.params["purge_tags"]
-    try:
-        client = module.client("backup", retry_decorator=AWSRetry.jittered_backoff())
-    except (ClientError, BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to connect to AWS")
+    # Get existing backup plan details and ID if present
+    existing_plan = get_plan_details(module, client, plan_name)
+    if existing_plan:
+        existing_plan_id = existing_plan[0]["backup_plan_id"]
+        existing_plan = existing_plan[0]
+    else:
+        existing_plan = existing_plan_id = None
 
-    results = {"changed": False, "exists": False}
+    if state == "present":  # Create or update plan
+        if existing_plan_id is None:  # Plan does not exist, create it
+            if module.check_mode:  # Use supplied params as result data in check mode
+                backup_plan = format_check_mode_response(plan_name, plan, tags)
+            else:
+                client_params = format_client_params(
+                    module, plan, tags=tags, operation="create"
+                )
+                response = create_backup_plan(module, client, client_params)
+                backup_plan = get_plan_details(module, client, plan_name)[0]
+            result["exists"] = True
+            result["changed"] = True
+            result.update(backup_plan)
 
-    current_plan = get_plan_details(module, client, backup_plan_name)
-
-    if state == "present":
-        new_plan_data = {
-            "BackupPlan": {
-                "BackupPlanName": backup_plan_name,
-                "Rules": module.params["rules"],
-                "AdvancedBackupSettings": module.params.get("advanced_backup_settings"),
-            },
-            "BackupPlanTags": module.params.get("tags"),
-            "CreatorRequestId": module.params.get("creator_request_id"),
-        }
-
-        if not current_plan:  # Plan does not exist, create it
-            results["exists"] = True
-            results["changed"] = True
-
+        else:  # Plan exists, update as needed
+            result["exists"] = True
+            if plan_update_needed(existing_plan, plan):
+                if not module.check_mode:
+                    client_params = format_client_params(
+                        module,
+                        plan,
+                        backup_plan_id=existing_plan_id,
+                        operation="update",
+                    )
+                    update_backup_plan(module, client, client_params)
+                result["changed"] = True
+            if tag_backup_plan(
+                module,
+                client,
+                tags,
+                existing_plan["backup_plan_arn"],
+                existing_plan["tags"],
+            ):
+                result["changed"] = True
             if module.check_mode:
-                module.exit_json(**results, msg="Would have created backup plan if not in check mode")
+                backup_plan = format_check_mode_response(plan_name, plan, tags)
+            else:
+                backup_plan = get_plan_details(module, client, plan_name)[0]
+            result.update(backup_plan)
 
-            create_backup_plan(module, client, new_plan_data)
-
-            # TODO: add tags
-            # ensure_tags(
-            #     client,
-            #     module,
-            #     response["BackupPlanArn"],
-            #     purge_tags=module.params.get("purge_tags"),
-            #     tags=module.params.get("tags"),
-            #     resource_type="BackupPlan",
-            # )
-
-        else:  # Plan exists, update if needed
-            results["exists"] = True
-            current_plan_id = current_plan[0]["backup_plan_id"]
-            if plan_update_needed(client, current_plan_id, new_plan_data):
-                results["changed"] = True
-
-                if module.check_mode:
-                    module.exit_json(**results, msg="Would have updated backup plan if not in check mode")
-
-                update_backup_plan(module, client, current_plan_id, new_plan_data)
-
-            if purge_tags:
-                pass
-                # TODO: Update plan tags
-                # ensure_tags(
-                #     client,
-                #     module,
-                #     response["BackupPlanArn"],
-                #     purge_tags=module.params.get("purge_tags"),
-                #     tags=module.params.get("tags"),
-                #     resource_type="BackupPlan",
-                # )
-
-        new_plan = get_plan_details(module, client, backup_plan_name)
-        results = results | new_plan[0]
-
-    elif state == "absent":
-        if not current_plan:  # Plan does not exist, can't delete it
-            module.exit_json(**results)
+    elif state == "absent":  # Delete plan
+        if existing_plan_id is None:  # Plan does not exist, can't delete it
+            module.debug(msg=f"Backup plan {plan_name} not found.")
         else:  # Plan exists, delete it
-            results["changed"] = True
-
             if module.check_mode:
-                module.exit_json(**results, msg="Would have deleted backup plan if not in check mode")
+                response = format_check_mode_response(
+                    plan_name, existing_plan, tags, True
+                )
+            else:
+                response = delete_backup_plan(module, client, existing_plan_id)
+            result["changed"] = True
+            result["exists"] = False
+            result.update(camel_dict_to_snake_dict(response))
 
-            delete_backup_plan(module, client, current_plan[0]["backup_plan_id"])
-
-    module.exit_json(**results)
+    module.exit_json(**result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/backup_plan.py
+++ b/plugins/modules/backup_plan.py
@@ -1,0 +1,235 @@
+#!/usr/bin/python
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+from __future__ import absolute_import, division, print_function
+import json
+from ansible.module_utils.resource_tags import ensure_tags
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+__metaclass__ = type
+DOCUMENTATION = '''
+module: backup_plan
+short_description: create, delete backup plans
+version_added: 1.0.0
+description:
+  - Read the AWS documentation for backup plans
+    U(https://docs.aws.amazon.com/aws-backup/latest/devguide/about-backup-plans.html).
+options:
+  backup_plan_name:
+    description:
+      - The display name of a backup plan. Must contain 1 to 50 alphanumeric or '-_.' characters.
+    required: true
+    type: str
+  rules:
+    description:
+      - An array of BackupRule objects, each of which specifies a scheduled task that is used to back up a selection of resources.
+    required: false
+    type: list
+  advanced_backup_settings:
+    description:
+      -  Specifies a list of BackupOptions for each resource type. These settings are only available for Windows Volume Shadow Copy Service (VSS) backup jobs.
+    required: false
+    type: list
+  state:
+    description:
+      - Create, delete a backup plan.
+    required: false
+    default: present
+    choices: ['present', 'absent']
+    type: str
+notes: []
+author:
+  - Kristof Imre Szabo (@krisek)
+extends_documentation_fragment:
+  - amazon.aws.aws
+  - amazon.aws.ec2
+  - amazon.aws.boto3
+  - amazon.aws.tags
+'''
+EXAMPLES = '''
+- name: create backup plan
+  backup_plan:
+    backup_plan_name: elastic
+    rules:
+    - RuleName: every_morning
+      TargetBackupVaultName: elastic
+      ScheduleExpression: "cron(0 5 ? * * *)"
+      StartWindowMinutes: 120
+      CompletionWindowMinutes: 10080
+      Lifecycle:
+        DeleteAfterDays: 7
+      EnableContinuousBackup: true
+  register: elastic_plan
+- name: show results
+  ansible.builtin.debug:
+    var: elastic_plan
+'''
+RETURN = '''
+backup_plan_name:
+  description: backup plan name
+  returned: always
+  type: str
+  sample: elastic
+backup_plan_id:
+  description: backup plan id
+  returned: always
+  type: str
+  sample: 1111f877-1ecf-4d79-9718-a861cd09df3b
+backup_plan:
+  description: backup plan details
+  returned: always
+  type: complex
+  contains:
+    backup_plan_arn:
+      description: backup plan arn
+      returned: always
+      type: str
+      sample: arn:aws:backup:eu-central-1:111122223333:backup-plan:1111f877-1ecf-4d79-9718-a861cd09df3b
+    backup_plan_id:
+      description: backup plan id
+      returned: always
+      type: str
+      sample: 1111f877-1ecf-4d79-9718-a861cd09df3b
+    backup_plan_name:
+      description: backup plan name
+      returned: always
+      type: str
+      sample:  elastic
+    creation_date:
+      description: backup plan creation date
+      returned: always
+      type: str
+      sample: '2023-01-24T10:08:03.193000+01:00'
+    last_execution_date:
+      description: backup plan last execution date
+      returned: always
+      type: str
+      sample: '2023-03-24T06:30:08.250000+01:00'
+    tags:
+      description: backup plan tags
+      returned: always
+      type: str
+      sample:
+    version_id:
+      description: backup plan version id
+      returned: always
+      type: str
+'''
+try:
+    import botocore
+except ImportError:
+    pass  # Handled by AnsibleAWSModule
+
+
+def main():
+    argument_spec = dict(
+        backup_plan_name=dict(type='str', required=True),
+        rules=dict(type='list', required=False),
+        advanced_backup_settings=dict(type='list', required=False),
+        tags=dict(required=False, type='dict', aliases=['resource_tags']),
+        purge_tags=dict(default=True, type='bool'),
+        state=dict(default='present', choices=['present', 'absent'])
+    )
+    required_if = [
+        ('state', 'present', ['backup_plan_name', 'rules']),
+        ('state', 'absent', ['backup_plan_name']),
+    ]
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec, required_if=required_if)
+    state = module.params.get('state')
+    backup_plan_name = module.params.get('backup_plan_name')
+    rules = module.params.get('rules')
+    advanced_backup_settings = module.params.get('advanced_backup_settings')
+    try:
+        client = module.client(
+            'backup', retry_decorator=AWSRetry.jittered_backoff())
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg='Failed to connect to AWS')
+    changed = False
+    # try to check if backup_plan is there
+    paginator = client.get_paginator('list_backup_plans')
+    backup_plans = []
+    for page in paginator.paginate():
+        backup_plans.extend(page['BackupPlansList'])
+    exist = False
+    response = {}
+    for backup_plan in backup_plans:
+        if backup_plan['BackupPlanName'] == backup_plan_name:
+            exist = True
+            response = backup_plan
+    if state == 'present':
+        if (exist):  # state is present and backup plan exists => got to update
+            # we need to get rules to manage the plan
+            full_plan = client.get_backup_plan(
+                BackupPlanId=response['BackupPlanId'])
+
+            update_needed = False
+            configured_rules = [{key: val for key, val in rule.items(
+            ) if key != 'RuleId'} for rule in full_plan.get('BackupPlan', {}).get('Rules', [])]
+
+            if json.dumps(configured_rules, sort_keys=True) != json.dumps(rules, sort_keys=True):
+                # rules to be updated
+                update_needed = True
+            advanced_backup_settings_from_aws = json.dumps(full_plan.get('BackupPlan', {}).get('AdvancedBackupSettings', None), sort_keys=True)
+            advanced_backup_settings_from_param = json.dumps(advanced_backup_settings, sort_keys=True)
+            if  advanced_backup_settings_from_aws != advanced_backup_settings_from_param:
+                # advanced settings to be updated
+                update_needed = True
+            if update_needed:
+                backup_plan_data = {
+                    'BackupPlanName': backup_plan_name
+                }
+                if rules:
+                    backup_plan_data['Rules'] = rules
+                if advanced_backup_settings:
+                    backup_plan_data['AdvancedBackupSettings'] = advanced_backup_settings
+                update_response = client.update_backup_plan(
+                    aws_retry=True, BackupPlanId=response.get('BackupPlanId'), BackupPlan=backup_plan_data)
+                changed = True
+            if ensure_tags(client, module, response['BackupPlanArn'],
+                           purge_tags=module.params.get('purge_tags'),
+                           tags=module.params.get('tags'),
+                           resource_type='BackupPlan',
+                           ):
+                changed = True
+        else:  # state is present but backup plan doesnt exist => got to create
+            backup_plan_data = {
+                'BackupPlanName': backup_plan_name
+            }
+            if rules:
+                backup_plan_data['Rules'] = rules
+            if advanced_backup_settings:
+                backup_plan_data['AdvancedBackupSettings'] = advanced_backup_settings
+            response = client.create_backup_plan(
+                aws_retry=True, BackupPlan=backup_plan_data)
+            ensure_tags(client, module, response['BackupPlanArn'],
+                        purge_tags=module.params.get('purge_tags'),
+                        tags=module.params.get('tags'),
+                        resource_type='BackupPlan',
+                        )
+            changed = True
+    elif state == 'absent':
+
+        if exist:
+            try:
+                response_delete = client.delete_backup_plan(
+                    aws_retry=True, BackupPlanId=response.get('BackupPlanId'))
+                if (response_delete['ResponseMetadata']['HTTPStatusCode'] == 200):
+                    changed = True
+            except Exception as e:
+                module.exit_json(changed=changed, failed=True)
+
+    formatted_results = camel_dict_to_snake_dict(response)
+    # Turn the resource tags from boto3 into an ansible friendly tag dictionary
+    formatted_results['tags'] = boto3_tag_list_to_ansible_dict(
+        formatted_results.get('tags', []))
+    module.exit_json(changed=changed, backup_plan=formatted_results, backup_plan_name=response.get(
+        'BackupPlanName'), backup_plan_id=response.get('BackupPlanId'))
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/backup_plan.py
+++ b/plugins/modules/backup_plan.py
@@ -208,6 +208,7 @@ def main():
             if advanced_backup_settings:
                 backup_plan_data["AdvancedBackupSettings"] = advanced_backup_settings
             response = client.create_backup_plan(aws_retry=True, BackupPlan=backup_plan_data)
+            response["BackupPlanName"] = backup_plan_name
             ensure_tags(
                 client,
                 module,

--- a/plugins/modules/backup_plan.py
+++ b/plugins/modules/backup_plan.py
@@ -1,7 +1,9 @@
 #!/usr/bin/python
-# Copyright: Ansible Project
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-from __future__ import absolute_import, division, print_function
+
 import json
 from ansible.module_utils.resource_tags import ensure_tags
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
@@ -10,14 +12,14 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
-__metaclass__ = type
-DOCUMENTATION = '''
+
+DOCUMENTATION = r"""
 module: backup_plan
-short_description: create, delete backup plans
-version_added: 1.0.0
+short_description: create, delete and modify AWS Backup plans
+version_added: 6.0.0
 description:
-  - Read the AWS documentation for backup plans
-    U(https://docs.aws.amazon.com/aws-backup/latest/devguide/about-backup-plans.html).
+  - Manages AWS Backup plans.
+  - For more information see the AWS documentation for backup plans U(https://docs.aws.amazon.com/aws-backup/latest/devguide/about-backup-plans.html).
 options:
   backup_plan_name:
     description:
@@ -45,12 +47,12 @@ notes: []
 author:
   - Kristof Imre Szabo (@krisek)
 extends_documentation_fragment:
-  - amazon.aws.aws
-  - amazon.aws.ec2
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
   - amazon.aws.boto3
   - amazon.aws.tags
-'''
-EXAMPLES = '''
+"""
+EXAMPLES = """
 - name: create backup plan
   backup_plan:
     backup_plan_name: elastic
@@ -67,8 +69,8 @@ EXAMPLES = '''
 - name: show results
   ansible.builtin.debug:
     var: elastic_plan
-'''
-RETURN = '''
+"""
+RETURN = """
 backup_plan_name:
   description: backup plan name
   returned: always
@@ -118,7 +120,7 @@ backup_plan:
       description: backup plan version id
       returned: always
       type: str
-'''
+"""
 try:
     import botocore
 except ImportError:
@@ -127,109 +129,113 @@ except ImportError:
 
 def main():
     argument_spec = dict(
-        backup_plan_name=dict(type='str', required=True),
-        rules=dict(type='list', required=False),
-        advanced_backup_settings=dict(type='list', required=False),
-        tags=dict(required=False, type='dict', aliases=['resource_tags']),
-        purge_tags=dict(default=True, type='bool'),
-        state=dict(default='present', choices=['present', 'absent'])
+        backup_plan_name=dict(type="str", required=True),
+        rules=dict(type="list", required=False),
+        advanced_backup_settings=dict(type="list", required=False),
+        tags=dict(required=False, type="dict", aliases=["resource_tags"]),
+        purge_tags=dict(default=True, type="bool"),
+        state=dict(default="present", choices=["present", "absent"]),
     )
     required_if = [
-        ('state', 'present', ['backup_plan_name', 'rules']),
-        ('state', 'absent', ['backup_plan_name']),
+        ("state", "present", ["backup_plan_name", "rules"]),
+        ("state", "absent", ["backup_plan_name"]),
     ]
-    module = AnsibleAWSModule(
-        argument_spec=argument_spec, required_if=required_if)
-    state = module.params.get('state')
-    backup_plan_name = module.params.get('backup_plan_name')
-    rules = module.params.get('rules')
-    advanced_backup_settings = module.params.get('advanced_backup_settings')
+    module = AnsibleAWSModule(argument_spec=argument_spec, required_if=required_if)
+    state = module.params.get("state")
+    backup_plan_name = module.params.get("backup_plan_name")
+    rules = module.params.get("rules")
+    advanced_backup_settings = module.params.get("advanced_backup_settings")
     try:
-        client = module.client(
-            'backup', retry_decorator=AWSRetry.jittered_backoff())
+        client = module.client("backup", retry_decorator=AWSRetry.jittered_backoff())
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg='Failed to connect to AWS')
+        module.fail_json_aws(e, msg="Failed to connect to AWS")
     changed = False
     # try to check if backup_plan is there
-    paginator = client.get_paginator('list_backup_plans')
+    paginator = client.get_paginator("list_backup_plans")
     backup_plans = []
     for page in paginator.paginate():
-        backup_plans.extend(page['BackupPlansList'])
+        backup_plans.extend(page["BackupPlansList"])
     exist = False
     response = {}
     for backup_plan in backup_plans:
-        if backup_plan['BackupPlanName'] == backup_plan_name:
+        if backup_plan["BackupPlanName"] == backup_plan_name:
             exist = True
             response = backup_plan
-    if state == 'present':
-        if (exist):  # state is present and backup plan exists => got to update
+    if state == "present":
+        if exist:  # state is present and backup plan exists => got to update
             # we need to get rules to manage the plan
             full_plan = client.get_backup_plan(
-                BackupPlanId=response['BackupPlanId'])
+                BackupPlanId=response["BackupPlanId"])
 
             update_needed = False
-            configured_rules = [{key: val for key, val in rule.items(
-            ) if key != 'RuleId'} for rule in full_plan.get('BackupPlan', {}).get('Rules', [])]
+            configured_rules = [
+                {key: val for key, val in rule.items() if key != "RuleId"}
+                for rule in full_plan.get("BackupPlan", {}).get("Rules", [])
+            ]
 
             if json.dumps(configured_rules, sort_keys=True) != json.dumps(rules, sort_keys=True):
                 # rules to be updated
                 update_needed = True
-            advanced_backup_settings_from_aws = json.dumps(full_plan.get('BackupPlan', {}).get('AdvancedBackupSettings', None), sort_keys=True)
+            advanced_backup_settings_from_aws = json.dumps(
+                full_plan.get("BackupPlan", {}).get("AdvancedBackupSettings", None), sort_keys=True
+            )
             advanced_backup_settings_from_param = json.dumps(advanced_backup_settings, sort_keys=True)
-            if  advanced_backup_settings_from_aws != advanced_backup_settings_from_param:
+            if advanced_backup_settings_from_aws != advanced_backup_settings_from_param:
                 # advanced settings to be updated
                 update_needed = True
             if update_needed:
-                backup_plan_data = {
-                    'BackupPlanName': backup_plan_name
-                }
+                backup_plan_data = {"BackupPlanName": backup_plan_name}
                 if rules:
-                    backup_plan_data['Rules'] = rules
+                    backup_plan_data["Rules"] = rules
                 if advanced_backup_settings:
-                    backup_plan_data['AdvancedBackupSettings'] = advanced_backup_settings
+                    backup_plan_data["AdvancedBackupSettings"] = advanced_backup_settings
                 update_response = client.update_backup_plan(
-                    aws_retry=True, BackupPlanId=response.get('BackupPlanId'), BackupPlan=backup_plan_data)
+                    aws_retry=True, BackupPlanId=response.get("BackupPlanId"), BackupPlan=backup_plan_data)
                 changed = True
-            if ensure_tags(client, module, response['BackupPlanArn'],
-                           purge_tags=module.params.get('purge_tags'),
-                           tags=module.params.get('tags'),
-                           resource_type='BackupPlan',
+            if ensure_tags(client, module, response["BackupPlanArn"],
+                           purge_tags=module.params.get("purge_tags"),
+                           tags=module.params.get("tags"),
+                           resource_type="BackupPlan",
                            ):
                 changed = True
         else:  # state is present but backup plan doesnt exist => got to create
-            backup_plan_data = {
-                'BackupPlanName': backup_plan_name
-            }
+            backup_plan_data = {"BackupPlanName": backup_plan_name}
             if rules:
-                backup_plan_data['Rules'] = rules
+                backup_plan_data["Rules"] = rules
             if advanced_backup_settings:
-                backup_plan_data['AdvancedBackupSettings'] = advanced_backup_settings
+                backup_plan_data["AdvancedBackupSettings"] = advanced_backup_settings
             response = client.create_backup_plan(
                 aws_retry=True, BackupPlan=backup_plan_data)
-            ensure_tags(client, module, response['BackupPlanArn'],
-                        purge_tags=module.params.get('purge_tags'),
-                        tags=module.params.get('tags'),
-                        resource_type='BackupPlan',
-                        )
+            ensure_tags(
+                client,
+                module,
+                response["BackupPlanArn"],
+                purge_tags=module.params.get("purge_tags"),
+                tags=module.params.get("tags"),
+                resource_type="BackupPlan",
+            )
             changed = True
-    elif state == 'absent':
+    elif state == "absent":
 
         if exist:
             try:
-                response_delete = client.delete_backup_plan(
-                    aws_retry=True, BackupPlanId=response.get('BackupPlanId'))
-                if (response_delete['ResponseMetadata']['HTTPStatusCode'] == 200):
+                response_delete = client.delete_backup_plan(aws_retry=True, BackupPlanId=response.get("BackupPlanId"))
+                if (response_delete["ResponseMetadata"]["HTTPStatusCode"] == 200):
                     changed = True
-            except Exception as e:
-                module.exit_json(changed=changed, failed=True)
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                module.fail_json_aws(e, msg="Failed to delete plan")
 
     formatted_results = camel_dict_to_snake_dict(response)
     # Turn the resource tags from boto3 into an ansible friendly tag dictionary
-    formatted_results['tags'] = boto3_tag_list_to_ansible_dict(
-        formatted_results.get('tags', []))
-    module.exit_json(changed=changed, backup_plan=formatted_results, backup_plan_name=response.get(
-        'BackupPlanName'), backup_plan_id=response.get('BackupPlanId'))
+    formatted_results["tags"] = boto3_tag_list_to_ansible_dict(
+        formatted_results.get("tags", []))
+    module.exit_json(
+        changed=changed,
+        backup_plan=formatted_results,
+        backup_plan_name=response.get("BackupPlanName"),
+        backup_plan_id=response.get("BackupPlanId")
+    )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/plugins/modules/backup_plan.py
+++ b/plugins/modules/backup_plan.py
@@ -258,9 +258,7 @@ from typing import Optional
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import compare_aws_tags
-from ansible_collections.amazon.aws.plugins.module_utils.backup import (
-    get_plan_details
-)
+from ansible_collections.amazon.aws.plugins.module_utils.backup import get_plan_details
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 
 try:
@@ -365,9 +363,7 @@ def format_client_params(
     return params
 
 
-def format_check_mode_response(
-    plan_name: str, plan: dict, tags: dict, delete: bool = False
-) -> dict:
+def format_check_mode_response(plan_name: str, plan: dict, tags: dict, delete: bool = False) -> dict:
     """
     Formats plan details in check mode to match result expectations.
 
@@ -432,10 +428,7 @@ def plan_update_needed(existing_plan: dict, new_plan: dict) -> bool:
 
     # Check whether rules match
     existing_rules = json.dumps(
-        [
-            {key: val for key, val in rule.items() if key != "rule_id"}
-            for rule in existing_plan["backup_plan"]["rules"]
-        ],
+        [{key: val for key, val in rule.items() if key != "rule_id"} for rule in existing_plan["backup_plan"]["rules"]],
         sort_keys=True,
     )
     new_rules = json.dumps(new_plan["rules"], sort_keys=True)
@@ -447,9 +440,7 @@ def plan_update_needed(existing_plan: dict, new_plan: dict) -> bool:
         existing_plan["backup_plan"].get("advanced_backup_settings", []),
         sort_keys=True,
     )
-    new_advanced_backup_settings = json.dumps(
-        new_plan.get("advanced_backup_settings", []), sort_keys=True
-    )
+    new_advanced_backup_settings = json.dumps(new_plan.get("advanced_backup_settings", []), sort_keys=True)
     if existing_advanced_backup_settings != new_advanced_backup_settings:
         update_needed = True
 
@@ -499,9 +490,7 @@ def tag_backup_plan(
 
     new_tags = new_tags or {}
     current_tags = current_tags or {}
-    tags_to_add, tags_to_remove = compare_aws_tags(
-        current_tags, new_tags, purge_tags=module.params["purge_tags"]
-    )
+    tags_to_add, tags_to_remove = compare_aws_tags(current_tags, new_tags, purge_tags=module.params["purge_tags"])
 
     if not tags_to_add and not tags_to_remove:
         return False
@@ -552,10 +541,7 @@ def main():
     plan_name = module.params["backup_plan_name"]
     plan = {
         "backup_plan_name": module.params["backup_plan_name"],
-        "rules": [
-            {k: v for k, v in rule.items() if v is not None}
-            for rule in module.params["rules"] or []
-        ],
+        "rules": [{k: v for k, v in rule.items() if v is not None} for rule in module.params["rules"] or []],
         "advanced_backup_settings": [
             {k: v for k, v in setting.items() if v is not None}
             for setting in module.params["advanced_backup_settings"] or []
@@ -576,9 +562,7 @@ def main():
             if module.check_mode:  # Use supplied params as result data in check mode
                 backup_plan = format_check_mode_response(plan_name, plan, tags)
             else:
-                client_params = format_client_params(
-                    module, plan, tags=tags, operation="create"
-                )
+                client_params = format_client_params(module, plan, tags=tags, operation="create")
                 response = create_backup_plan(module, client, client_params)
                 backup_plan = get_plan_details(module, client, plan_name)[0]
             result["exists"] = True
@@ -616,9 +600,7 @@ def main():
             module.debug(msg=f"Backup plan {plan_name} not found.")
         else:  # Plan exists, delete it
             if module.check_mode:
-                response = format_check_mode_response(
-                    plan_name, existing_plan, tags, True
-                )
+                response = format_check_mode_response(plan_name, existing_plan, tags, True)
             else:
                 response = delete_backup_plan(module, client, existing_plan_id)
             result["changed"] = True

--- a/plugins/modules/backup_plan.py
+++ b/plugins/modules/backup_plan.py
@@ -15,6 +15,7 @@ description:
   - For more information see the AWS documentation for Backup plans U(https://docs.aws.amazon.com/aws-backup/latest/devguide/about-backup-plans.html).
 author:
   - Kristof Imre Szabo (@krisek)
+  - Alina Buzachis (@alinabuzachis)
 options:
   backup_plan_name:
     description:

--- a/plugins/modules/backup_plan.py
+++ b/plugins/modules/backup_plan.py
@@ -164,8 +164,7 @@ def main():
     if state == "present":
         if exist:  # state is present and backup plan exists => got to update
             # we need to get rules to manage the plan
-            full_plan = client.get_backup_plan(
-                BackupPlanId=response["BackupPlanId"])
+            full_plan = client.get_backup_plan(BackupPlanId=response["BackupPlanId"])
 
             update_needed = False
             configured_rules = [
@@ -190,13 +189,17 @@ def main():
                 if advanced_backup_settings:
                     backup_plan_data["AdvancedBackupSettings"] = advanced_backup_settings
                 update_response = client.update_backup_plan(
-                    aws_retry=True, BackupPlanId=response.get("BackupPlanId"), BackupPlan=backup_plan_data)
+                    aws_retry=True, BackupPlanId=response.get("BackupPlanId"), BackupPlan=backup_plan_data
+                )
                 changed = True
-            if ensure_tags(client, module, response["BackupPlanArn"],
-                           purge_tags=module.params.get("purge_tags"),
-                           tags=module.params.get("tags"),
-                           resource_type="BackupPlan",
-                           ):
+            if ensure_tags(
+                client,
+                module,
+                response["BackupPlanArn"],
+                purge_tags=module.params.get("purge_tags"),
+                tags=module.params.get("tags"),
+                resource_type="BackupPlan",
+            ):
                 changed = True
         else:  # state is present but backup plan doesnt exist => got to create
             backup_plan_data = {"BackupPlanName": backup_plan_name}
@@ -204,8 +207,7 @@ def main():
                 backup_plan_data["Rules"] = rules
             if advanced_backup_settings:
                 backup_plan_data["AdvancedBackupSettings"] = advanced_backup_settings
-            response = client.create_backup_plan(
-                aws_retry=True, BackupPlan=backup_plan_data)
+            response = client.create_backup_plan(aws_retry=True, BackupPlan=backup_plan_data)
             ensure_tags(
                 client,
                 module,
@@ -220,20 +222,19 @@ def main():
         if exist:
             try:
                 response_delete = client.delete_backup_plan(aws_retry=True, BackupPlanId=response.get("BackupPlanId"))
-                if (response_delete["ResponseMetadata"]["HTTPStatusCode"] == 200):
+                if response_delete["ResponseMetadata"]["HTTPStatusCode"] == 200:
                     changed = True
             except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
                 module.fail_json_aws(e, msg="Failed to delete plan")
 
     formatted_results = camel_dict_to_snake_dict(response)
     # Turn the resource tags from boto3 into an ansible friendly tag dictionary
-    formatted_results["tags"] = boto3_tag_list_to_ansible_dict(
-        formatted_results.get("tags", []))
+    formatted_results["tags"] = boto3_tag_list_to_ansible_dict(formatted_results.get("tags", []))
     module.exit_json(
         changed=changed,
         backup_plan=formatted_results,
         backup_plan_name=response.get("BackupPlanName"),
-        backup_plan_id=response.get("BackupPlanId")
+        backup_plan_id=response.get("BackupPlanId"),
     )
 
 

--- a/plugins/modules/backup_plan.py
+++ b/plugins/modules/backup_plan.py
@@ -4,22 +4,17 @@
 # Copyright: Contributors to the Ansible project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import json
-from ansible.module_utils.resource_tags import ensure_tags
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import camel_dict_to_snake_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 
 DOCUMENTATION = r"""
+---
 module: backup_plan
-short_description: create, delete and modify AWS Backup plans
 version_added: 6.0.0
+short_description: create, delete and modify AWS Backup plans
 description:
-  - Manages AWS Backup plans.
-  - For more information see the AWS documentation for backup plans U(https://docs.aws.amazon.com/aws-backup/latest/devguide/about-backup-plans.html).
+  - Manage AWS Backup plans.
+  - For more information see the AWS documentation for Backup plans U(https://docs.aws.amazon.com/aws-backup/latest/devguide/about-backup-plans.html).
+author:
+  - Kristof Imre Szabo (@krisek)
 options:
   backup_plan_name:
     description:
@@ -43,34 +38,30 @@ options:
     default: present
     choices: ['present', 'absent']
     type: str
-notes: []
-author:
-  - Kristof Imre Szabo (@krisek)
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules
   - amazon.aws.boto3
   - amazon.aws.tags
 """
-EXAMPLES = """
+
+EXAMPLES = r"""
 - name: create backup plan
-  backup_plan:
+  amazon.aws.backup_plan:
+    state: present
     backup_plan_name: elastic
     rules:
-    - RuleName: every_morning
-      TargetBackupVaultName: elastic
-      ScheduleExpression: "cron(0 5 ? * * *)"
-      StartWindowMinutes: 120
-      CompletionWindowMinutes: 10080
-      Lifecycle:
-        DeleteAfterDays: 7
-      EnableContinuousBackup: true
-  register: elastic_plan
-- name: show results
-  ansible.builtin.debug:
-    var: elastic_plan
+      - RuleName: every_morning
+        TargetBackupVaultName: elastic
+        ScheduleExpression: "cron(0 5 ? * * *)"
+        StartWindowMinutes: 120
+        CompletionWindowMinutes: 10080
+        Lifecycle:
+          DeleteAfterDays: 7
+        EnableContinuousBackup: true
+
 """
-RETURN = """
+RETURN = r"""
 backup_plan_name:
   description: backup plan name
   returned: always
@@ -121,121 +112,211 @@ backup_plan:
       returned: always
       type: str
 """
+
+import json
+from typing import Optional
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
+
 try:
-    import botocore
+    from botocore.exceptions import ClientError, BotoCoreError
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 
+def create_backup_plan(module: AnsibleAWSModule, client, params: dict):
+    """
+    Creates a Backup Plan
+
+    module : AnsibleAWSModule object
+    client : boto3 backup client connection object
+    params : The parameters to create a backup plan
+    """
+    params = {k: v for k, v in params.items() if v is not None}
+    try:
+        response = client.create_backup_plan(**params)
+    except (
+        BotoCoreError,
+        ClientError,
+    ) as err:
+        module.fail_json_aws(err, msg="Failed to create Backup Plan")
+    return response
+
+
+def get_plan_details(module, client, backup_plan_name: str):
+    try:
+        plan = paginated_list(client, filter_by=backup_plan_name)[0]
+    except (BotoCoreError, ClientError) as err:
+        module.debug("Unable to get backup plan details {0}".format(err))
+        plan = None
+    except IndexError:
+        plan = None
+    return plan
+
+
+def paginated_list(
+    client, filter_by: Optional[str] = None, **pagination_params
+) -> list[dict]:
+    results = []
+    paginator = client.get_paginator("list_backup_plans")
+    page_iterator = paginator.paginate(**pagination_params)
+    if filter_by:
+        filtered_iterator = page_iterator.search(
+            f"BackupPlansList[?BackupPlanName=='{filter_by}']"
+        )
+        results.extend(list(filtered_iterator))
+    else:
+        results.extend([item["BackupPlansList"] for item in page_iterator])
+    return results
+
+
+def plan_update_needed(client, backup_plan_id: str, backup_plan_data: dict) -> bool:
+    update_needed = False
+
+    # we need to get current rules to manage the plan
+    full_plan = client.get_backup_plan(BackupPlanId=backup_plan_id)
+
+    configured_rules = json.dumps(
+        [
+            {key: val for key, val in rule.items() if key != "RuleId"}
+            for rule in full_plan.get("BackupPlan", {}).get("Rules", [])
+        ],
+        sort_keys=True,
+    )
+    supplied_rules = json.dumps(backup_plan_data["BackupPlan"]["Rules"], sort_keys=True)
+
+    if configured_rules != supplied_rules:
+        # rules to be updated
+        update_needed = True
+
+    configured_advanced_backup_settings = json.dumps(
+        full_plan.get("BackupPlan", {}).get("AdvancedBackupSettings", None),
+        sort_keys=True,
+    )
+    supplied_advanced_backup_settings = json.dumps(
+        backup_plan_data["BackupPlan"]["AdvancedBackupSettings"], sort_keys=True
+    )
+    if configured_advanced_backup_settings != supplied_advanced_backup_settings:
+        # advanced settings to be updated
+        update_needed = True
+    return update_needed
+
+
+def update_backup_plan(
+    module: AnsibleAWSModule, client, backup_plan_id: str, backup_plan_data: dict
+):
+    try:
+        response = client.update_backup_plan(
+            BackupPlanId=backup_plan_id,
+            BackupPlan=backup_plan_data["BackupPlan"],
+        )
+    except (
+        BotoCoreError,
+        ClientError,
+    ) as err:
+        module.fail_json_aws(err, msg="Failed to create Backup Plan")
+    return response
+
+
+def delete_backup_plan(module: AnsibleAWSModule, client, backup_plan_id: str):
+    """
+    Delete a Backup Plan
+
+    module : AnsibleAWSModule object
+    client : boto3 client connection object
+    backup_plan_id : Backup Plan ID
+    """
+    try:
+        client.delete_backup_plan(BackupPlanId=backup_plan_id)
+    except (BotoCoreError, ClientError) as err:
+        module.fail_json_aws(err, msg="Failed to delete the Backup Plan")
+
+
 def main():
     argument_spec = dict(
-        backup_plan_name=dict(type="str", required=True),
-        rules=dict(type="list", required=False),
-        advanced_backup_settings=dict(type="list", required=False),
+        state=dict(default="present", choices=["present", "absent"]),
+        backup_plan_name=dict(required=True, type="str"),
+        rules=dict(type="list"),
+        advanced_backup_settings=dict(default=[], type="list"),
+        creator_request_id=dict(type="str"),
         tags=dict(required=False, type="dict", aliases=["resource_tags"]),
         purge_tags=dict(default=True, type="bool"),
-        state=dict(default="present", choices=["present", "absent"]),
     )
+
     required_if = [
         ("state", "present", ["backup_plan_name", "rules"]),
         ("state", "absent", ["backup_plan_name"]),
     ]
+
     module = AnsibleAWSModule(argument_spec=argument_spec, required_if=required_if)
+
+    # collect parameters
     state = module.params.get("state")
-    backup_plan_name = module.params.get("backup_plan_name")
-    rules = module.params.get("rules")
-    advanced_backup_settings = module.params.get("advanced_backup_settings")
-    try:
-        client = module.client("backup", retry_decorator=AWSRetry.jittered_backoff())
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to connect to AWS")
-    changed = False
-    # try to check if backup_plan is there
-    paginator = client.get_paginator("list_backup_plans")
-    backup_plans = []
-    for page in paginator.paginate():
-        backup_plans.extend(page["BackupPlansList"])
-    exist = False
-    response = {}
-    for backup_plan in backup_plans:
-        if backup_plan["BackupPlanName"] == backup_plan_name:
-            exist = True
-            response = backup_plan
+    backup_plan_name = module.params["backup_plan_name"]
+    purge_tags = module.params["purge_tags"]
+    client = module.client("backup")
+    results = {"changed": False, "exists": False}
+
+    # TODO: support check mode?
+
+    current_plan = get_plan_details(module, client, backup_plan_name)
+
     if state == "present":
-        if exist:  # state is present and backup plan exists => got to update
-            # we need to get rules to manage the plan
-            full_plan = client.get_backup_plan(BackupPlanId=response["BackupPlanId"])
+        new_plan_data = {
+            "BackupPlan": {
+                "BackupPlanName": backup_plan_name,
+                "Rules": module.params["rules"],
+                "AdvancedBackupSettings": module.params.get("advanced_backup_settings"),
+            },
+            "BackupPlanTags": module.params.get("tags"),
+            "CreatorRequestId": module.params.get("creator_request_id"),
+        }
 
-            update_needed = False
-            configured_rules = [
-                {key: val for key, val in rule.items() if key != "RuleId"}
-                for rule in full_plan.get("BackupPlan", {}).get("Rules", [])
-            ]
+        if current_plan is None:  # Plan does not exist, create it
+            create_backup_plan(module, client, new_plan_data)
+            # TODO: add tags
+            # ensure_tags(
+            #     client,
+            #     module,
+            #     response["BackupPlanArn"],
+            #     purge_tags=module.params.get("purge_tags"),
+            #     tags=module.params.get("tags"),
+            #     resource_type="BackupPlan",
+            # )
+            results["exists"] = True
 
-            if json.dumps(configured_rules, sort_keys=True) != json.dumps(rules, sort_keys=True):
-                # rules to be updated
-                update_needed = True
-            advanced_backup_settings_from_aws = json.dumps(
-                full_plan.get("BackupPlan", {}).get("AdvancedBackupSettings", None), sort_keys=True
-            )
-            advanced_backup_settings_from_param = json.dumps(advanced_backup_settings, sort_keys=True)
-            if advanced_backup_settings_from_aws != advanced_backup_settings_from_param:
-                # advanced settings to be updated
-                update_needed = True
-            if update_needed:
-                backup_plan_data = {"BackupPlanName": backup_plan_name}
-                if rules:
-                    backup_plan_data["Rules"] = rules
-                if advanced_backup_settings:
-                    backup_plan_data["AdvancedBackupSettings"] = advanced_backup_settings
-                update_response = client.update_backup_plan(
-                    aws_retry=True, BackupPlanId=response.get("BackupPlanId"), BackupPlan=backup_plan_data
-                )
-                changed = True
-            if ensure_tags(
-                client,
-                module,
-                response["BackupPlanArn"],
-                purge_tags=module.params.get("purge_tags"),
-                tags=module.params.get("tags"),
-                resource_type="BackupPlan",
-            ):
-                changed = True
-        else:  # state is present but backup plan doesnt exist => got to create
-            backup_plan_data = {"BackupPlanName": backup_plan_name}
-            if rules:
-                backup_plan_data["Rules"] = rules
-            if advanced_backup_settings:
-                backup_plan_data["AdvancedBackupSettings"] = advanced_backup_settings
-            response = client.create_backup_plan(aws_retry=True, BackupPlan=backup_plan_data)
-            response["BackupPlanName"] = backup_plan_name
-            ensure_tags(
-                client,
-                module,
-                response["BackupPlanArn"],
-                purge_tags=module.params.get("purge_tags"),
-                tags=module.params.get("tags"),
-                resource_type="BackupPlan",
-            )
-            changed = True
+        else:  # Plan exists, update if needed
+            results["exists"] = True
+            current_plan_id = current_plan["BackupPlanId"]
+            if plan_update_needed(client, current_plan_id, new_plan_data):
+                update_backup_plan(module, client, current_plan_id, new_plan_data)
+            if purge_tags:
+                pass
+                # TODO: Update plan tags
+                # ensure_tags(
+                #     client,
+                #     module,
+                #     response["BackupPlanArn"],
+                #     purge_tags=module.params.get("purge_tags"),
+                #     tags=module.params.get("tags"),
+                #     resource_type="BackupPlan",
+                # )
+        results["changed"] = True
+        new_plan = get_plan_details(module, client, backup_plan_name)
+        results["backup_plan"] = camel_dict_to_snake_dict(new_plan)
+
     elif state == "absent":
-        if exist:
-            try:
-                response_delete = client.delete_backup_plan(aws_retry=True, BackupPlanId=response.get("BackupPlanId"))
-                if response_delete["ResponseMetadata"]["HTTPStatusCode"] == 200:
-                    changed = True
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                module.fail_json_aws(e, msg="Failed to delete plan")
+        if current_plan is None:  # Plan does not exist, can't delete it
+            module.fail_json(
+                msg=f"Backup plan {backup_plan_name} not found.",
+                # TODO: existing_backup_plans="list existing backup plan names",
+            )
+        else:  # Plan exists, delete it
+            delete_backup_plan(module, client, current_plan["BackupPlanId"])
+            results["changed"] = True
+            results["exists"] = False
 
-    formatted_results = camel_dict_to_snake_dict(response)
-    # Turn the resource tags from boto3 into an ansible friendly tag dictionary
-    formatted_results["tags"] = boto3_tag_list_to_ansible_dict(formatted_results.get("tags", []))
-    module.exit_json(
-        changed=changed,
-        backup_plan=formatted_results,
-        backup_plan_name=response.get("BackupPlanName"),
-        backup_plan_id=response.get("BackupPlanId"),
-    )
+    module.exit_json(**results)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/backup_plan.py
+++ b/plugins/modules/backup_plan.py
@@ -219,7 +219,6 @@ def main():
             )
             changed = True
     elif state == "absent":
-
         if exist:
             try:
                 response_delete = client.delete_backup_plan(aws_retry=True, BackupPlanId=response.get("BackupPlanId"))

--- a/plugins/modules/backup_plan_info.py
+++ b/plugins/modules/backup_plan_info.py
@@ -74,9 +74,10 @@ backup_plans:
             description: Version id of the backup plan
             type: str
         backup_plan:
-            elements: dict
             returned: always
             description: Detailed information about the backup plan.
+            type: list
+            elements: dict
             contains:
                 backup_plan_name:
                     description: Name of the backup plan.

--- a/plugins/modules/backup_plan_info.py
+++ b/plugins/modules/backup_plan_info.py
@@ -1,0 +1,179 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+
+DOCUMENTATION = r"""
+---
+module: backup_plan_info
+version_added: 6.0.0
+short_description: Describe AWS Backup Plans
+description:
+  - Lists info about Backup Plan configuration.
+author:
+  - Gomathi Selvi Srinivasan (@GomathiselviS)
+  - Kristof Imre Szabo (@krisek)
+options:
+  backup_plan_names:
+    type: list
+    elements: str
+    default: []
+    description:
+      - Specifies a list of plan names.
+      - If an empty list is specified, information for the backup plans in the current region is returned.
+extends_documentation_fragment:
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
+  - amazon.aws.boto3
+"""
+
+EXAMPLES = r"""
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+# Gather information about all backup plans
+- amazon.aws.backup_plan_info
+# Gather information about a particular backup plan
+- amazon.aws.backup_plan_info:
+    backup plan_names:
+      - elastic
+"""
+
+RETURN = r"""
+backup_plans:
+    description: List of backup plan objects. Each element consists of a dict with all the information related to that backup plan.
+    type: list
+    elements: dict
+    returned: always
+    contains:
+        backup_plan_arn:
+            description: ARN of the backup plan.
+            type: str
+            sample: arn:aws:backup:eu-central-1:111122223333:backup-plan:1111f877-1ecf-4d79-9718-a861cd09df3b
+        backup_plan_id:
+            description: Id of the backup plan.
+            type: str
+            sample: 1111f877-1ecf-4d79-9718-a861cd09df3b
+        backup_plan_name:
+            description: Name of the backup plan.
+            type: str
+            sample: elastic
+        creation_date:
+            description: Creation date of the backup plan.
+            type: str
+            sample: '2023-01-24T10:08:03.193000+01:00'
+        last_execution_date:
+            description: Last execution date of the backup plan.
+            type: str
+            sample: '2023-03-24T06:30:08.250000+01:00'
+        tags:
+            description: Tags of the backup plan
+            type: str
+        version_id:
+            description: Version id of the backup plan
+            type: str
+        backup_plan:
+            elements: dict
+            returned: always
+            description: Detailed information about the backup plan.
+            contains:
+                backup_plan_name:
+                    description: Name of the backup plan.
+                    type: str
+                    sample: elastic
+                advanced_backup_settings:
+                    description: Advanced backup settings of the backup plan
+                    type: list
+                    elements: dict
+                    contains:
+                        resource_type:
+                            description: Resource type of the advanced setting
+                            type: str
+                        backup_options:
+                            description: Options of the advanced setting
+                            type: dict
+                rules:
+                    description:
+                    - An array of BackupRule objects, each of which specifies a scheduled task that is used to back up a selection of resources.
+                    type: list
+"""
+
+try:
+    import botocore
+except ImportError:
+    pass  # Handled by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.backup import get_backup_resource_tags
+
+
+def get_backup_plans(connection, module, backup_plan_name_list):
+    all_backup_plans = []
+    try:
+        result = connection.get_paginator("list_backup_plans")
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to get the backup plans.")
+    for page in result.paginate():
+        for backup_plan in page["BackupPlansList"]:
+            if backup_plan["BackupPlanName"] in backup_plan_name_list or len(backup_plan_name_list) == 0:
+                all_backup_plans.append(backup_plan["BackupPlanId"])
+    return all_backup_plans
+
+
+def get_backup_plan_detail(connection, module):
+    output = []
+    result = {}
+    backup_plan_name_list = module.params.get("backup_plan_names")
+    backup_plan_id_list = get_backup_plans(connection, module, backup_plan_name_list)
+
+    for backup_plan_id in backup_plan_id_list:
+        try:
+            output.append(connection.get_backup_plan(BackupPlanId=backup_plan_id, aws_retry=True))
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Failed to describe vault {0}".format(backup_plan_id))
+
+    # Turn the boto3 result in to ansible_friendly_snaked_names
+    snaked_backup_plan = []
+
+    for backup_plan in output:
+        try:
+            module.params["resource"] = backup_plan.get("BackupPlanArn", None)
+            tag_dict = get_backup_resource_tags(module, connection)
+            backup_plan.update({"tags": tag_dict})
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.warn("Failed to get the backup plan tags - {0}".format(e))
+        snaked_backup_plan.append(camel_dict_to_snake_dict(backup_plan))
+
+    # Turn the boto3 result in to ansible friendly tag dictionary
+    for v in snaked_backup_plan:
+        if "tags_list" in v:
+            v["tags"] = boto3_tag_list_to_ansible_dict(v["tags_list"], "key", "value")
+            del v["tags_list"]
+        if "response_metadata" in v:
+            del v["response_metadata"]
+        v["backup_plan_name"] = v["backup_plan"]["backup_plan_name"]
+    result["backup_plans"] = snaked_backup_plan
+    return result
+
+
+def main():
+    argument_spec = dict(
+        backup_plan_names=dict(type="list", elements="str", default=[]),
+    )
+
+    module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)
+
+    try:
+        connection = module.client("backup", retry_decorator=AWSRetry.jittered_backoff())
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to connect to AWS")
+    result = get_backup_plan_detail(connection, module)
+    module.exit_json(**result)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/backup_plan_info.py
+++ b/plugins/modules/backup_plan_info.py
@@ -20,10 +20,9 @@ options:
   backup_plan_names:
     type: list
     elements: str
-    default: []
+    required: true
     description:
       - Specifies a list of plan names.
-      - If an empty list is specified, information for the backup plans in the current region is returned.
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules
@@ -123,7 +122,7 @@ def get_backup_plan_detail(client, module):
 
 def main():
     argument_spec = dict(
-        backup_plan_names=dict(type="list", elements="str", default=[]),
+        backup_plan_names=dict(type="list", elements="str", required=True),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)

--- a/plugins/modules/backup_plan_info.py
+++ b/plugins/modules/backup_plan_info.py
@@ -15,6 +15,7 @@ description:
 author:
   - Gomathi Selvi Srinivasan (@GomathiselviS)
   - Kristof Imre Szabo (@krisek)
+  - Alina Buzachis (@alinabuzachis)
 options:
   backup_plan_names:
     type: list

--- a/tests/integration/targets/backup_plan/aliases
+++ b/tests/integration/targets/backup_plan/aliases
@@ -1,0 +1,3 @@
+cloud/aws
+backup_plan
+backup_vault

--- a/tests/integration/targets/backup_plan/defaults/main.yml
+++ b/tests/integration/targets/backup_plan/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+# defaults file for test_backup_plan
+backup_vault_name: '{{ tiny_prefix }}-backup-vault'
+backup_plan_name: '{{ tiny_prefix }}-backup-plan'

--- a/tests/integration/targets/backup_plan/tasks/main.yml
+++ b/tests/integration/targets/backup_plan/tasks/main.yml
@@ -30,9 +30,15 @@
     - name: Verify results
       ansible.builtin.assert:
         that:
-          - backup_plan_create_result exists is true
-          - backup_plan_create_result changed is true
-          - backup_plan_create_result.plan.backup_plan_name == backup_plan_name
+          - backup_plan_create_result.exists
+          - backup_plan_create_result.changed
+          - backup_plan_create_result.backup_plan.backup_plan_name == backup_plan_name
+
+    - name: Get info on AWS Backup plan
+      amazon.aws.backup_plan_info:
+        backup_plan_names:
+          - "{{ backup_plan_name }}"
+      register: backup_plan_info_result
 
   always:
     - name: Delete AWS Backup plan created during this test

--- a/tests/integration/targets/backup_plan/tasks/main.yml
+++ b/tests/integration/targets/backup_plan/tasks/main.yml
@@ -6,39 +6,177 @@
       security_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - name: Create an AWS Backup vault for the plan to target
+    - name: Create a backup vault for the plan to target
       amazon.aws.backup_vault:
         backup_vault_name: "{{ backup_vault_name }}"
+      register: backup_vault_create_result
 
-    - name: Create an AWS Backup plan
+    - name: Create a backup plan in check mode
       amazon.aws.backup_plan:
         backup_plan_name: "{{ backup_plan_name }}"
         rules:
-          - RuleName: daily
-            TargetBackupVaultName: "{{ backup_vault_name }}"
-            ScheduleExpression: "cron(0 5 ? * * *)"
-            StartWindowMinutes: 60
-            CompletionWindowMinutes: 1440
+          - rule_name: daily
+            target_backup_vault_name: "{{ backup_vault_name }}"
         tags:
-          environment: test
-      register: backup_plan_create_result
+          Environment: Test
+      check_mode: true
+      register: check_mode_create_result
 
-    - name: Print result
-      ansible.builtin.debug:
-        msg: "{{ backup_plan_create_result }}"
-
-    - name: Verify results
+    - name: Verify backup plan create in check mode result
       ansible.builtin.assert:
         that:
-          - backup_plan_create_result.exists
-          - backup_plan_create_result.changed
-          - backup_plan_create_result.backup_plan.backup_plan_name == backup_plan_name
+          - check_mode_create_result.exists is true
+          - check_mode_create_result.changed is true
+          - check_mode_create_result.backup_plan_name == backup_plan_name
 
-    - name: Get info on AWS Backup plan
+    - name: Get backup plan info
       amazon.aws.backup_plan_info:
         backup_plan_names:
           - "{{ backup_plan_name }}"
-      register: backup_plan_info_result
+      register: backup_plan_info
+
+    - name: Verify backup plan was not actually created in check mode
+      ansible.builtin.assert:
+        that:
+          - backup_plan_info.backup_plans | length == 0
+
+    - name: Create a backup plan
+      amazon.aws.backup_plan:
+        backup_plan_name: "{{ backup_plan_name }}"
+        rules:
+          - rule_name: daily
+            target_backup_vault_name: "{{ backup_vault_name }}"
+        tags:
+          Environment: Test
+      register: backup_plan_create_result
+
+    - name: Verify backup plan create result
+      ansible.builtin.assert:
+        that:
+          - backup_plan_create_result.exists is true
+          - backup_plan_create_result.changed is true
+          - backup_plan_create_result.backup_plan_name == backup_plan_name
+
+    - name: Get backup plan info
+      amazon.aws.backup_plan_info:
+        backup_plan_names:
+          - "{{ backup_plan_name }}"
+      register: backup_plan_info
+
+    - name: Recreate the same AWS Backup plan - idempotency check
+      amazon.aws.backup_plan:
+        backup_plan_name: "{{ backup_plan_name }}"
+        rules:
+          - rule_name: daily
+            target_backup_vault_name: "{{ backup_vault_name }}"
+        tags:
+          Environment: Test
+      register: backup_plan_idempotency_result
+
+    - name: Verify backup plan idempotency check result
+      ansible.builtin.assert:
+        that:
+          - backup_plan_idempotency_result.exists is true
+          - backup_plan_idempotency_result.changed is false
+          - backup_plan_idempotency_result.backup_plan_id == backup_plan_info.backup_plans[0].backup_plan_id
+          - backup_plan_idempotency_result.version_id == backup_plan_info.backup_plans[0].version_id
+          - backup_plan_idempotency_result.creation_date == backup_plan_info.backup_plans[0].creation_date
+
+    - name: Update backup plan in check mode
+      amazon.aws.backup_plan:
+        backup_plan_name: "{{ backup_plan_name }}"
+        rules:
+          - rule_name: hourly
+            target_backup_vault_name: "{{ backup_vault_name }}"
+            schedule_expression: "cron(0 * ? * * *)"
+        tags:
+          Environment: Dev
+      check_mode: true
+      register: check_mode_update_result
+
+    - name: Verify backup plan update in check mode result
+      ansible.builtin.assert:
+        that:
+          - check_mode_update_result.exists is true
+          - check_mode_update_result.changed is true
+          - check_mode_update_result.backup_plan.rules != backup_plan_info.backup_plans[0].backup_plan.rules
+          - check_mode_update_result.backup_plan.tags is defined
+
+    - name: Update Backup plan
+      amazon.aws.backup_plan:
+        backup_plan_name: "{{ backup_plan_name }}"
+        rules:
+          - rule_name: hourly
+            target_backup_vault_name: "{{ backup_vault_name }}"
+            schedule_expression: "cron(0 * ? * * *)"
+            start_window_minutes: 60
+            completion_window_minutes: 150
+            lifecycle:
+              move_to_cold_storage_after_days: 30
+              delete_after_days: 120
+            recovery_point_tags:
+              type: hourly_backup
+            copy_actions:
+              - destination_backup_vault_arn: "{{ backup_vault_create_result.vault.backup_vault_arn }}"
+                lifecycle:
+                  move_to_cold_storage_after_days: 90
+                  delete_after_days: 300
+        tags:
+          status: archive
+      register: backup_plan_update_result
+
+    - name: Verify backup plan update result
+      ansible.builtin.assert:
+        that:
+          - backup_plan_update_result.exists is true
+          - backup_plan_update_result.changed is true
+          - backup_plan_update_result.backup_plan_id == backup_plan_info.backup_plans[0].backup_plan_id
+          - backup_plan_update_result.backup_plan_arn == backup_plan_info.backup_plans[0].backup_plan_arn
+          - backup_plan_update_result.creation_date != backup_plan_info.backup_plans[0].creation_date
+          - backup_plan_update_result.version_id != backup_plan_info.backup_plans[0].version_id
+          - backup_plan_update_result.backup_plan.rules != backup_plan_info.backup_plans[0].backup_plan.rules
+          - backup_plan_update_result.tags != backup_plan_info.backup_plans[0].tags
+
+    - name: Delete backup plan in check mode
+      amazon.aws.backup_plan:
+        backup_plan_name: "{{ backup_plan_name }}"
+        state: absent
+      check_mode: true
+      register: check_mode_delete_result
+
+    - name: Verify backup plan delete in check mode result
+      ansible.builtin.assert:
+        that:
+          - check_mode_delete_result.exists is false
+          - check_mode_delete_result.changed is true
+          - check_mode_delete_result.backup_plan_name == backup_plan_info.backup_plans[0].backup_plan_name
+          - check_mode_delete_result.deletion_date is defined
+
+    - name: Get backup plan info
+      amazon.aws.backup_plan_info:
+        backup_plan_names:
+          - "{{ backup_plan_name }}"
+      register: backup_plan_info
+
+    - name: Verify backup plan was not actually deleted in check mode
+      ansible.builtin.assert:
+        that:
+          - backup_plan_info.backup_plans | length > 0
+
+    - name: Delete backup plan
+      amazon.aws.backup_plan:
+        backup_plan_name: "{{ backup_plan_name }}"
+        state: absent
+      register: backup_plan_delete_result
+
+    - name: Verify backup plan delete result
+      ansible.builtin.assert:
+        that:
+          - backup_plan_delete_result.exists is false
+          - backup_plan_delete_result.changed is true
+          - backup_plan_delete_result.backup_plan_id == backup_plan_info.backup_plans[0].backup_plan_id
+          - backup_plan_delete_result.backup_plan_arn == backup_plan_info.backup_plans[0].backup_plan_arn
+          - backup_plan_delete_result.deletion_date is defined
 
   always:
     - name: Delete AWS Backup plan created during this test

--- a/tests/integration/targets/backup_plan/tasks/main.yml
+++ b/tests/integration/targets/backup_plan/tasks/main.yml
@@ -1,0 +1,48 @@
+---
+- module_defaults:
+    group/aws:
+      aws_access_key: "{{ aws_access_key }}"
+      aws_secret_key: "{{ aws_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+    - name: Create an AWS Backup vault for the plan to target
+      amazon.aws.backup_vault:
+        backup_vault_name: "{{ backup_vault_name }}"
+
+    - name: Create an AWS Backup plan
+      amazon.aws.backup_plan:
+        backup_plan_name: "{{ backup_plan_name }}"
+        rules:
+          - RuleName: daily
+            TargetBackupVaultName: "{{ backup_vault_name }}"
+            ScheduleExpression: "cron(0 5 ? * * *)"
+            StartWindowMinutes: 60
+            CompletionWindowMinutes: 1440
+        tags:
+          environment: test
+      register: backup_plan_create_result
+
+    - name: Print result
+      ansible.builtin.debug:
+        msg: "{{ backup_plan_create_result }}"
+
+    - name: Verify results
+      ansible.builtin.assert:
+        that:
+          - backup_plan_create_result exists is true
+          - backup_plan_create_result changed is true
+          - backup_plan_create_result.plan.backup_plan_name == backup_plan_name
+
+  always:
+    - name: Delete AWS Backup plan created during this test
+      amazon.aws.backup_plan:
+        backup_plan_name: "{{ backup_plan_name }}"
+        state: absent
+      ignore_errors: true
+
+    - name: Delete AWS Backup vault created during this test
+      amazon.aws.backup_vault:
+        backup_vault_name: "{{ backup_vault_name }}"
+        state: absent
+      ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
These three modules add capability to manage all configurations related to backups on AWS.

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
backup_vault
backup_plan
backup_selection

##### ADDITIONAL INFORMATION

We've been using these three modules for 6 months now in our AWS estate, I thought it might be useful for others.

I know that this is not the repo for public contribution, but as there is already work being done on this area here, I think it still make sense to have a look on the code, I tried to be as comprehensive as possible.

No worries if it doesn't make into the main branch, feel free to cherry pick parts of it.