### PR TITLE
Replace pycrypto test dependency

### DIFF
--- a/changelogs/fragments/1448-replace-pycrypto.yml
+++ b/changelogs/fragments/1448-replace-pycrypto.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - replace pycrypto test dependency with cryptography (https://github.com/ansible-collections/amazon.aws/pull/1448).

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -14,4 +14,4 @@ netaddr
 # Sometimes needed where we don't have features we need in modules
 awscli
 # Used for comparing SSH Public keys to the Amazon fingerprints
-pycrypto
+cryptography

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -8,4 +8,4 @@ virtualenv
 # Sometimes needed where we don't have features we need in modules
 awscli
 # Used for comparing SSH Public keys to the Amazon fingerprints
-pycrypto
+cryptography


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The dependency on pycrypto was replaced with cryptography almost a year ago in https://github.com/ansible-collections/amazon.aws/pull/799, but the test dependencies never got updated. Presumably, this worked because Ansible depends on cryptography already.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
