### PR TITLE
lambda_info: remove unnecessary snake_casing of env_vars when querying lambda config

### DIFF
--- a/changelogs/fragments/1457-lambda_info-fix-env-var-in-output.yml
+++ b/changelogs/fragments/1457-lambda_info-fix-env-var-in-output.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- lambda_info - Do not convert environment variables to snake_case when querying lambda config. (https://github.com/ansible-collections/amazon.aws/pull/1457).

--- a/plugins/modules/lambda_info.py
+++ b/plugins/modules/lambda_info.py
@@ -395,7 +395,14 @@ def config_details(client, module, function_name):
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Trying to get {0} configuration".format(function_name))
 
-    return camel_dict_to_snake_dict(lambda_info)
+    if 'Environment' in lambda_info and 'Variables' in lambda_info['Environment']:
+        env_vars = lambda_info['Environment']['Variables']
+        snaked_lambda_info = camel_dict_to_snake_dict(lambda_info)
+        snaked_lambda_info['environment']['variables'] = env_vars
+    else:
+        snaked_lambda_info = camel_dict_to_snake_dict(lambda_info)
+
+    return snaked_lambda_info
 
 
 def mapping_details(client, module, function_name):

--- a/plugins/modules/lambda_info.py
+++ b/plugins/modules/lambda_info.py
@@ -395,10 +395,10 @@ def config_details(client, module, function_name):
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Trying to get {0} configuration".format(function_name))
 
-    if 'Environment' in lambda_info and 'Variables' in lambda_info['Environment']:
-        env_vars = lambda_info['Environment']['Variables']
+    if "Environment" in lambda_info and "Variables" in lambda_info["Environment"]:
+        env_vars = lambda_info["Environment"]["Variables"]
         snaked_lambda_info = camel_dict_to_snake_dict(lambda_info)
-        snaked_lambda_info['environment']['variables'] = env_vars
+        snaked_lambda_info["environment"]["variables"] = env_vars
     else:
         snaked_lambda_info = camel_dict_to_snake_dict(lambda_info)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR modifies code to avoid converting environment variables to snake_case when querying `config`.
Fixes #1412 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lambda_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
