### PR TITLE
Pick up app_callback -> set_password rather than app_callback -> set_passwd

### DIFF
--- a/changelogs/fragments/20230424-ec2_instance-app_callback.yml
+++ b/changelogs/fragments/20230424-ec2_instance-app_callback.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_instance - Pick up ``app_callback -> set_password`` rather than ``app_callback -> set_passwd`` (https://github.com/ansible-collections/amazon.aws/issues/1449).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1240,7 +1240,7 @@ def build_userdata(params):
             job_template_id=params.get("aap_callback").get("job_template_id"),
             host_config_key=params.get("aap_callback").get("host_config_key"),
             windows=params.get("aap_callback").get("windows"),
-            passwd=params.get("aap_callback").get("set_passwd"),
+            passwd=params.get("aap_callback").get("set_password"),
         )
         return {"UserData": userdata}
     return {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes: https://github.com/ansible-collections/amazon.aws/issues/1449
Pick up app_callback -> set_password rather than app_callback -> set_passwd

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
