### PR TITLE
Fix typo in device return sample

### DIFF
--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -208,7 +208,7 @@ device:
     description: device name of attached volume
     returned: when success
     type: str
-    sample: "/def/sdf"
+    sample: "/dev/sdf"
 volume_id:
     description: the id of volume
     returned: when success


### PR DESCRIPTION
I think the sample should start "/dev" not "/def".

##### SUMMARY
Quick typo fix

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
ec2_vol

##### ADDITIONAL INFORMATION
Just a typo

<!--- Paste verbatim command output below, e.g. before and after your change -->
```n/a
```
