### PR TITLE
[manual backport stable-5] Don't consider prop 'StateTransitionedTimestamp' in change detection (#1440)

### DIFF
--- a/changelogs/fragments/1440-cloudwatch_metric_alarm-fix-change-detection.yml
+++ b/changelogs/fragments/1440-cloudwatch_metric_alarm-fix-change-detection.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- cloudwatch_metric_alarm - Don't consider ``StateTransitionedTimestamp`` in change detection. (https://github.com/ansible-collections/amazon.aws/pull/1440).

--- a/plugins/modules/cloudwatch_metric_alarm.py
+++ b/plugins/modules/cloudwatch_metric_alarm.py
@@ -238,9 +238,11 @@ def create_metric_alarm(connection, module, params):
         if 'TreatMissingData' not in alarm.keys():
             alarm['TreatMissingData'] = 'missing'
 
+        # Exclude certain props from change detection
         for key in ['ActionsEnabled', 'StateValue', 'StateReason',
                     'StateReasonData', 'StateUpdatedTimestamp',
-                    'AlarmArn', 'AlarmConfigurationUpdatedTimestamp']:
+                    'StateTransitionedTimestamp',
+                    'AlarmArn', 'AlarmConfigurationUpdatedTimestamp', 'Metrics']:
             alarm.pop(key, None)
         if alarm != params:
             changed = True


### PR DESCRIPTION
SUMMARY

Remove property 'StateTransitionedTimestamp' from the list of props when determining if an alarm has changed and needs to be create/updated.

Fixes #1439
ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
cloudwatch-metric-alarm
ADDITIONAL INFORMATION
See issue #1439 for additional details.

Reviewed-by: Mark Chappell
Reviewed-by: Alina Buzachis

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
