### PR TITLE
[manual backport stable-5] ec2_ami: Add support for params BootMode, TpmSupport, UefiData (#1037)

### DIFF
--- a/changelogs/fragments/1037-ec2_ami-add-support-for-boot_mode-tpm_support-uefi_data.yml
+++ b/changelogs/fragments/1037-ec2_ami-add-support-for-boot_mode-tpm_support-uefi_data.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ec2_ami - add support for BootMode, TpmSupport, UefiData params (https://github.com/ansible-collections/amazon.aws/pull/1037).

--- a/tests/integration/targets/ec2_ami/meta/main.yml
+++ b/tests/integration/targets/ec2_ami/meta/main.yml
@@ -1,2 +1,5 @@
 dependencies:
   - setup_ec2_facts
+  - role: setup_botocore_pip
+    vars:
+      botocore_version: '1.26.0'

--- a/tests/integration/targets/ec2_ami/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami/tasks/main.yml
@@ -10,6 +10,12 @@
     - amazon.aws
   block:
 
+    # AWS CLI is needed until there's a module to get instance uefi data
+    - name: Install AWS CLI
+      pip:
+        name: awscli==1.25.83
+        state: present
+
     # ============================================================
 
     # SETUP: vpc, ec2 key pair, subnet, security group, ec2 instance, snapshot
@@ -73,6 +79,21 @@
         device_name: '{{ ec2_ami_root_disk }}'
         state: present
       register: setup_snapshot
+
+    # note: the current CI supported instance types (t2, t3, m1) do not support uefi boot mode + tpm_support
+    # disabling the task as aws documentation states that support for t3 will be coming soon
+    # - name: get instance UEFI data
+    #   command: aws ec2 get-instance-uefi-data --instance-id {{ ec2_instance_id }} --region {{ aws_region }}
+    #   environment:
+    #     AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+    #     AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+    #     AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+    #     AWS_DEFAULT_REGION: "{{ aws_region }}"
+    #   register: instance_uefi_data_output
+
+    # - name: Convert it to an object
+    #   set_fact:
+    #     instance_uefi_data: "{{ instance_uefi_data_output.stdout | from_json }}"
 
     # ============================================================
 
@@ -629,6 +650,52 @@
           - not result.changed
           - not result.failed
 
+    # ============================================================
+
+    - name: create an image from the snapshot with boot_mode and tpm_support
+      ec2_ami:
+        name: '{{ ec2_ami_name }}_ami-boot-tpm'
+        description: '{{ ec2_ami_description }}'
+        state: present
+        boot_mode: uefi
+        tpm_support: v2.0
+        launch_permissions:
+          user_ids: []
+        tags:
+          Name: '{{ ec2_ami_name }}_ami-boot-tpm'
+        root_device_name: '{{ ec2_ami_root_disk }}'
+        device_mapping:
+          - device_name: '{{ ec2_ami_root_disk }}'
+            volume_type: gp2
+            size: 8
+            delete_on_termination: true
+            snapshot_id: '{{ setup_snapshot.snapshot_id }}'
+      register: result
+      ignore_errors: true
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+
+    - name: set image id fact for deletion later
+      set_fact:
+        ec2_ami_image_id_boot_tpm: "{{ result.image_id }}"
+        ec2_ami_snapshot_boot_tpm: "{{ result.block_device_mapping[ec2_ami_root_disk].snapshot_id }}"
+
+    - name: gather facts about the image created
+      ec2_ami_info:
+        image_ids: '{{ ec2_ami_image_id_boot_tpm }}'
+      register: ami_facts_result_boot_tpm
+      ignore_errors: true
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+
+    - name: assert that new ami has been created with desired options
+      assert:
+        that:
+          - "result.changed"
+          - "result.image_id.startswith('ami-')"
+          - ami_facts_result_boot_tpm.images[0].image_id | length != 0
+          - ami_facts_result_boot_tpm.images[0].boot_mode == 'uefi'
+          - ami_facts_result_boot_tpm.images[0].tpm_support == 'v2.0'
 
     # ============================================================
 
@@ -640,6 +707,13 @@
     - name: Announce teardown start
       debug:
         msg: "***** TESTING COMPLETE. COMMENCE TEARDOWN *****"
+
+    - name: delete ami
+      ec2_ami:
+        state: absent
+        image_id: "{{ ec2_ami_image_id_boot_tpm }}"
+        wait: yes
+      ignore_errors: yes
 
     - name: delete ami
       ec2_ami:

--- a/tests/unit/plugins/modules/test_ec2_ami.py
+++ b/tests/unit/plugins/modules/test_ec2_ami.py
@@ -1,0 +1,44 @@
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock, Mock, patch, call
+
+import pytest
+
+from ansible_collections.amazon.aws.plugins.modules import ec2_ami
+
+module_name = "ansible_collections.amazon.aws.plugins.modules.ec2_ami"
+
+
+@patch(module_name + ".get_image_by_id")
+def test_create_image_uefi_data(m_get_image_by_id):
+    module = MagicMock()
+    connection = MagicMock()
+
+    m_get_image_by_id.return_value = {
+        "ImageId": "ami-0c7a795306730b288",
+        "BootMode": "uefi",
+        "TpmSupport": "v2.0",
+    }
+
+    module.params = {
+        "name": "my-image",
+        "boot_mode": "uefi",
+        "tpm_support": "v2.0",
+        "uefi_data": "QU1aTlVFRkk9xcN0AAAAAHj5a7fZ9+3aT2gcVRgA8Ek3NipiPST0pCiCIlTJtj20FzENCcQa",
+    }
+
+    ec2_ami.create_image(module, connection)
+    assert connection.register_image.call_count == 1
+    connection.register_image.assert_has_calls(
+        [
+            call(
+                aws_retry=True,
+                Description=None,
+                Name="my-image",
+                BootMode="uefi",
+                TpmSupport="v2.0",
+                UefiData="QU1aTlVFRkk9xcN0AAAAAHj5a7fZ9+3aT2gcVRgA8Ek3NipiPST0pCiCIlTJtj20FzENCcQa"
+            )
+        ]
+    )


### PR DESCRIPTION
ec2_ami: Add support for params BootMode, TpmSupport, UefiData

SUMMARY
Depends-On: #1066

Added support for params BootMode, TpmSupport, UefiData in ec2_ami.

Fixes #944
ISSUE TYPE


Feature Pull Request

COMPONENT NAME

ec2_ami
ADDITIONAL INFORMATION



Example playbook
- name: abc hosts: localhost gather_facts: false tasks: - name: AMI Creation with boot_mode and tpm_support amazon.aws.ec2_ami: name: ami-create-test_legacy-bios state: present architecture: x86_64 virtualization_type: hvm root_device_name: /dev/sda1 device_mapping: - device_name: /dev/sda1 snapshot_id: snap-xxxxxxxxx wait: yes region: us-east-2 boot_mode: legacy-bios tpm_support: v2.0 tags: name: ami-create-test

Reviewed-by: Gonéri Le Bouder <goneri@lebouder.net>
Reviewed-by: Mandar Kulkarni <mandar242@gmail.com>
Reviewed-by: Mike Graves <mgraves@redhat.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
