### PR TITLE
[manual backport stable-5] ec2_metadata_facts: Add support to query instance tags in metadata (#1186)

### DIFF
--- a/changelogs/fragments/1186-ec2_metadata_facts-query-instance-metadata-tags.yml
+++ b/changelogs/fragments/1186-ec2_metadata_facts-query-instance-metadata-tags.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_metadata_facts - added support to query instance tags in metadata (https://github.com/ansible-collections/amazon.aws/pull/1186).

--- a/tests/integration/targets/ec2_metadata_facts/meta/main.yml
+++ b/tests/integration/targets/ec2_metadata_facts/meta/main.yml
@@ -1,3 +1,7 @@
 dependencies:
-- setup_ec2_facts
-- setup_sshkey
+  - setup_ec2_facts
+  - setup_sshkey
+  #required for run_instances with MetadataOptions.InstanceMetadataTags
+  - role: setup_botocore_pip
+    vars:
+      botocore_version: '1.23.30'

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -132,7 +132,6 @@
       tags:
         snake_case_key: a_snake_case_value
         camelCaseKey: aCamelCaseValue
-      wait: True
     register: ec2_instance
     vars:
       ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
@@ -153,8 +152,15 @@
       network:
         assign_public_ip: true
         delete_on_termination: true
+      metadata_options:
+          instance_metadata_tags: enabled
+      tags:
+        snake_case_key: a_snake_case_value
+        camelCaseKey: aCamelCaseValue
       wait: True
     register: ec2_instance_py2
+    vars:
+      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
   - set_fact:
       ec2_instance_id: "{{ ec2_instance.instances[0].instance_id }}"

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -32,6 +32,11 @@
   - include_role:
       name: '../setup_ec2_facts'
 
+  - include_role:
+      name: '../setup_botocore_pip'
+    vars:
+      botocore_version: '1.23.30'
+
   - set_fact:
       availability_zone: '{{ ec2_availability_zone_names[0] }}'
 
@@ -122,8 +127,15 @@
       network:
         assign_public_ip: true
         delete_on_termination: true
+      metadata_options:
+          instance_metadata_tags: enabled
+      tags:
+        snake_case_key: a_snake_case_value
+        camelCaseKey: aCamelCaseValue
       wait: True
     register: ec2_instance
+    vars:
+      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
   - set_fact:
       ec2_ami_id_py2: "{{ lookup('aws_ssm', '/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2', **connection_args) }}"

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
@@ -14,3 +14,5 @@
         - ansible_ec2_placement_availability_zone == availability_zone
         - ansible_ec2_security_groups == "{{ resource_prefix }}-sg"
         - ansible_ec2_user_data == "None"
+        - ansible_ec2_instance_tags_keys is defined
+        - ansible_ec2_instance_tags_keys | length == 3


### PR DESCRIPTION

ec2_metadata_facts: Add support to query instance tags in metadata

SUMMARY

Fixes #684
Added support to be able to query instance tags using ec2_metadata_facts. This PR adds a field in returned ansible_facts named  ansible_ec2_instance_tags_keys. Sample
"ansible_ec2_instance_tags_keys": [
        "Name",
        "snake_case_key"
],


ISSUE TYPE


Feature Pull Request

COMPONENT NAME

ec2_metadata_facts
ADDITIONAL INFORMATION



Support to enable instance metadata tags already exists in amazon.aws.ec2_instance

Reviewed-by: Mike Graves <mgraves@redhat.com>
Reviewed-by: Mandar Kulkarni <mandar242@gmail.com>
Reviewed-by: Gonéri Le Bouder <goneri@lebouder.net>
Reviewed-by: Alina Buzachis <None>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
