### PR TITLE
[manual backport stable-5] kms_key: Add multi region support to create_key (#1290)

### DIFF
--- a/changelogs/fragments/1290-create_multi_region_key.yml
+++ b/changelogs/fragments/1290-create_multi_region_key.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- kms_key - Add multi_region option to create_key (https://github.com/ansible-collections/amazon.aws/pull/1290).

--- a/tests/integration/targets/kms_key/inventory
+++ b/tests/integration/targets/kms_key/inventory
@@ -4,6 +4,8 @@ states
 grants
 modify
 tagging
+# CI's AWS account doesnot support multi region
+# multi_region
 
 [all:vars]
 ansible_connection=local

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_multi_region.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_multi_region.yml
@@ -1,0 +1,100 @@
+- block:
+    # ============================================================
+    #   PREPARATION
+    #
+    # Get some information about who we are before starting our tests
+    # we'll need this as soon as we start working on the policies
+  - name: get ARN of calling user
+    aws_caller_info:
+    register: aws_caller_info
+  - name: See whether key exists and its current state
+    kms_key_info:
+      alias: '{{ kms_key_alias }}'
+  - name: create a multi region key - check mode
+    kms_key:
+      alias: '{{ kms_key_alias }}-check'
+      tags:
+        Hello: World
+      state: present
+      multi_region: True
+      enabled: yes
+    register: key_check
+    check_mode: yes
+  - name: find facts about the check mode key
+    kms_key_info:
+      alias: '{{ kms_key_alias }}-check'
+    register: check_key
+  - name: ensure that check mode worked as expected
+    assert:
+      that:
+      - check_key.kms_keys | length == 0
+      - key_check is changed
+
+  - name: create a multi region key
+    kms_key:
+      alias: '{{ kms_key_alias }}'
+      tags:
+        Hello: World
+      state: present
+      enabled: yes
+      multi_region: True
+      enable_key_rotation: no
+    register: key
+  - name: assert that state is enabled
+    assert:
+      that:
+      - key is changed
+      - '"key_id" in key'
+      - key.key_id | length >= 36
+      - not key.key_id.startswith("arn:aws")
+      - '"key_arn" in key'
+      - key.key_arn.endswith(key.key_id)
+      - key.key_arn.startswith("arn:aws")
+      - key.key_state == "Enabled"
+      - key.enabled == True
+      - key.tags | length == 1
+      - key.tags['Hello'] == 'World'
+      - key.enable_key_rotation == false
+      - key.key_usage == 'ENCRYPT_DECRYPT'
+      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+      - key.grants | length == 0
+      - key.key_policies | length == 1
+      - key.key_policies[0].Id == 'key-default-1'
+      - key.description == ''
+      - key.multi_region == True
+
+  - name: Sleep to wait for updates to propagate
+    wait_for:
+      timeout: 45
+  
+  - name: create a key (expect failure)
+    kms_key:
+      alias: '{{ kms_key_alias }}'
+      tags:
+        Hello: World
+      state: present
+      enabled: yes
+      multi_region: True
+    register: result
+    ignore_errors: True
+  
+  - assert:
+      that:
+      - result is failed
+      - result.msg != "MODULE FAILURE"
+      - result.changed == False
+      - '"You cannot change the multi-region property on an existing key." in result.msg'
+      
+  always:
+    # ============================================================
+    #   CLEAN-UP
+  - name: finish off by deleting keys
+    kms_key:
+      state: absent
+      alias: '{{ item }}'
+      pending_window: 7
+    ignore_errors: true
+    loop:
+    - '{{ kms_key_alias }}'
+    - '{{ kms_key_alias }}-diff-spec-usage'
+    - '{{ kms_key_alias }}-check'

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_states.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_states.yml
@@ -59,6 +59,7 @@
       - key.key_policies | length == 1
       - key.key_policies[0].Id == 'key-default-1'
       - key.description == ''
+      - key.multi_region == False
 
   - name: Sleep to wait for updates to propagate
     wait_for:
@@ -105,6 +106,7 @@
       - key.key_policies | length == 1
       - key.key_policies[0].Id == 'key-default-1'
       - key.description == ''
+      - key.multi_region == False
 
     # ------------------------------------------------------------------------------------------
 

--- a/tests/unit/plugins/modules/test_kms_key.py
+++ b/tests/unit/plugins/modules/test_kms_key.py
@@ -1,0 +1,82 @@
+#
+# (c) 2022 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+
+from unittest.mock import MagicMock, call, patch
+from ansible_collections.amazon.aws.plugins.modules import kms_key
+
+
+module_name = "ansible_collections.amazon.aws.plugins.modules.kms_key"
+key_details = {
+    "KeyMetadata": {
+        "aliases": ["mykey"],
+        "Arn": "arn:aws:kms:us-east-1:12345678:key/mrk-12345678",
+        "customer_master_key_spec": "SYMMETRIC_DEFAULT",
+        "description": "",
+        "enable_key_rotation": False,
+        "enabled": True,
+        "encryption_algorithms": ["SYMMETRIC_DEFAULT"],
+        "grants": [],
+        "key_arn": "arn:aws:kms:us-east-1:12345678:key/mrk-12345678",
+        "key_id": "mrk-12345678",
+        "key_manager": "CUSTOMER",
+        "key_policies": [
+            {
+                "Id": "key-default-1",
+                "Statement": [
+                    {
+                        "Action": "kms:*",
+                        "Effect": "Allow",
+                        "Principal": {"AWS": "arn:aws:iam::12345678:root"},
+                        "Resource": "*",
+                        "Sid": "Enable IAM User Permissions",
+                    }
+                ],
+                "Version": "2012-10-17",
+            }
+        ],
+        "key_spec": "SYMMETRIC_DEFAULT",
+        "key_state": "Enabled",
+        "key_usage": "ENCRYPT_DECRYPT",
+        "multi_region": True,
+        "multi_region_configuration": {
+            "multi_region_key_type": "PRIM   ARY",
+            "primary_key": {
+                "arn": "arn:aws:kms:us-east-1:12345678:key/mrk-12345678",
+                "region": "us-east-1",
+            },
+            "replica_keys": [],
+        },
+        "origin": "AWS_KMS",
+        "tags": {"Hello": "World2"},
+    }
+}
+
+
+@patch(module_name + ".get_kms_metadata_with_backoff")
+def test_fetch_key_metadata(m_get_kms_metadata_with_backoff):
+
+    module = MagicMock()
+    kms_client = MagicMock()
+
+    m_get_kms_metadata_with_backoff.return_value = key_details
+    kms_key.fetch_key_metadata(kms_client, module, "mrk-12345678", "mykey")
+    assert m_get_kms_metadata_with_backoff.call_count == 1
+
+
+def test_validate_params():
+
+    module = MagicMock()
+    module.params = {
+        "state": "present",
+        "multi_region": True
+    }
+
+    result = kms_key.validate_params(module, key_details["KeyMetadata"])
+    module.fail_json.assert_called_with(
+        msg="You cannot change the multi-region property on an existing key."
+    )


### PR DESCRIPTION
kms_key: Add multi region support to create_key

Signed-off-by: GomathiselviS gomathiselvi@gmail.com SUMMARY


Fixes #1281
ISSUE TYPE


Feature Pull Request

COMPONENT NAME

ADDITIONAL INFORMATION

Reviewed-by: Gonéri Le Bouder <goneri@lebouder.net>
Reviewed-by: Jill R <None>
Reviewed-by: Mark Chappell <None>
Reviewed-by: Alina Buzachis <None>
Reviewed-by: GomathiselviS <None>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
