### PR TITLE
[manual backport stable-5] new modules: lambda_layer and lambda_layer_info (#1095)

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -70,6 +70,8 @@ action_groups:
   - lambda_event
   - lambda_execute
   - lambda_info
+  - lambda_layer
+  - lambda_layer_info
   - lambda_policy
   - rds_cluster
   - rds_cluster_info

--- a/plugins/modules/lambda_layer.py
+++ b/plugins/modules/lambda_layer.py
@@ -1,0 +1,368 @@
+#!/usr/bin/python
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: lambda_layer
+version_added: 5.1.0
+short_description: Creates an AWS Lambda layer or deletes an AWS Lambda layer version
+description:
+  - This module allows the management of AWS Lambda functions aliases via the Ansible
+  - Creates an Lambda layer from a ZIP archive.
+    Each time you call this module with the same layer name, a new version is created.
+  - Deletes a version of an Lambda layer.
+
+author: "Aubin Bikouo (@abikouo)"
+options:
+  state:
+    description:
+    - Determines if an Lambda layer should be created, or deleted. When set to C(present), an Lambda layer version will be
+      created. If set to C(absent), an existing Lambda layer version will be deleted.
+    type: str
+    default: present
+    choices: [ absent, present ]
+  name:
+    description:
+    - The name or Amazon Resource Name (ARN) of the Lambda layer.
+    type: str
+    required: true
+    aliases:
+    - layer_name
+  description:
+    description:
+    - The description of the version.
+    - Ignored when I(state=absent).
+    - Mutually exclusive with I(version).
+    type: str
+  content:
+    description:
+    - The function layer archive.
+    - Required when I(state=present).
+    - Ignored when I(state=absent).
+    - Mutually exclusive with I(version).
+    type: dict
+    suboptions:
+      s3_bucket:
+        description:
+        - The Amazon S3 bucket of the layer archive.
+        type: str
+      s3_key:
+        description:
+        - The Amazon S3 key of the layer archive.
+        type: str
+      s3_object_version:
+        description:
+        - For versioned objects, the version of the layer archive object to use.
+        type: str
+      zip_file:
+        description:
+        - Path to the base64-encoded file of the layer archive.
+        type: path
+  compatible_runtimes:
+    description:
+    - A list of compatible function runtimes.
+    - Ignored when I(state=absent).
+    - Mutually exclusive with I(version).
+    type: list
+    elements: str
+  license_info:
+    description:
+    - The layer's software license. It can be any of an SPDX license identifier,
+      the URL of a license hosted on the internet or the full text of the license.
+    - Ignored when I(state=absent).
+    - Mutually exclusive with I(version).
+    type: str
+  compatible_architectures:
+    description:
+    - A list of compatible instruction set architectures. For example, x86_64.
+    - Mutually exclusive with I(version).
+    type: list
+    elements: str
+  version:
+    description:
+    - The version number of the layer to delete.
+    - Set to C(-1) to delete all versions for the specified layer name.
+    - Required when I(state=absent).
+    - Ignored when I(state=present).
+    - Mutually exclusive with I(description), I(content), I(compatible_runtimes),
+      I(license_info), I(compatible_architectures).
+    type: int
+extends_documentation_fragment:
+- amazon.aws.aws
+- amazon.aws.ec2
+- amazon.aws.boto3
+
+'''
+
+EXAMPLES = '''
+---
+# Create a new Python library layer version from a zip archive located into a S3 bucket
+- name: Create a new python library layer
+  amazon.aws.lambda_layer:
+    state: present
+    name: sample-layer
+    description: 'My Python layer'
+    content:
+      s3_bucket: 'lambda-layers-us-west-2-123456789012'
+      s3_key: 'python_layer.zip'
+    compatible_runtimes:
+      - python3.6
+      - python3.7
+    license_info: MIT
+    compatible_architectures:
+      - x86_64
+
+# Create a layer version from a zip in the local filesystem
+- name: Create a new layer from a zip in the local filesystem
+  amazon.aws.lambda_layer:
+    state: present
+    name: sample-layer
+    description: 'My Python layer'
+    content:
+      zip_file: 'python_layer.zip'
+    compatible_runtimes:
+      - python3.6
+      - python3.7
+    license_info: MIT
+    compatible_architectures:
+      - x86_64
+
+# Delete a layer version
+- name: Delete a layer version
+  amazon.aws.lambda_layer:
+    state: absent
+    name: sample-layer
+    version: 2
+
+# Delete all versions of test-layer
+- name: Delete all versions
+  amazon.aws.lambda_layer:
+    state: absent
+    name: test-layer
+    version: -1
+'''
+
+RETURN = '''
+layer_version:
+  description: info about the layer version that was created or deleted.
+  returned: always
+  type: list
+  elements: dict
+  contains:
+    content:
+        description: Details about the layer version.
+        returned: I(state=present)
+        type: complex
+        contains:
+          location:
+            description: A link to the layer archive in Amazon S3 that is valid for 10 minutes.
+            returned: I(state=present)
+            type: str
+            sample: "https://awslambda-us-east-1-layers.s3.us-east-1.amazonaws.com/snapshots/123456789012/pylayer-9da91deffd3b4941b8baeeae5daeffe4"
+          code_sha256:
+            description: The SHA-256 hash of the layer archive.
+            returned: I(state=present)
+            type: str
+            sample: "VLluleJZ3HTwDrdYolSMrS+8iPwEkcoXXaegjXf+dmc="
+          code_size:
+            description: The size of the layer archive in bytes.
+            returned: I(state=present)
+            type: int
+            sample: 9473675
+          signing_profile_version_arn:
+            description: The Amazon Resource Name (ARN) for a signing profile version.
+            returned: When a signing profile is defined
+            type: str
+          signing_job_arn:
+            description: The Amazon Resource Name (ARN) of a signing job.
+            returned: When a signing profile is defined
+            type: str
+    layer_arn:
+        description: The ARN of the layer.
+        returned: if the layer version exists or has been created
+        type: str
+        sample: "arn:aws:lambda:eu-west-2:123456789012:layer:pylayer"
+    layer_version_arn:
+        description: The ARN of the layer version.
+        returned: if the layer version exists or has been created
+        type: str
+        sample: "arn:aws:lambda:eu-west-2:123456789012:layer:pylayer:2"
+    description:
+        description: The description of the version.
+        returned: I(state=present)
+        type: str
+    created_date:
+        description: The date that the layer version was created, in ISO-8601 format (YYYY-MM-DDThh:mm:ss.sTZD).
+        returned: if the layer version exists or has been created
+        type: str
+        sample: "2022-09-28T14:27:35.866+0000"
+    version:
+        description: The version number.
+        returned: if the layer version exists or has been created
+        type: int
+        sample: 1
+    compatible_runtimes:
+        description: A list of compatible runtimes.
+        returned: if it was defined for the layer version.
+        type: list
+        sample: ["python3.7"]
+    license_info:
+        description: The layer's software license.
+        returned: if it was defined for the layer version.
+        type: str
+        sample: "GPL-3.0-only"
+    compatible_architectures:
+        description: A list of compatible instruction set architectures.
+        returned: if it was defined for the layer version.
+        type: list
+'''
+
+try:
+    import botocore
+except ImportError:
+    pass  # Handled by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+
+
+@AWSRetry.jittered_backoff()
+def _list_layer_versions(client, **params):
+    paginator = client.get_paginator('list_layer_versions')
+    return paginator.paginate(**params).build_full_result()
+
+
+class LambdaLayerFailure(Exception):
+    def __init__(self, exc, msg):
+        self.exc = exc
+        self.msg = msg
+        super().__init__(self)
+
+
+def list_layer_versions(lambda_client, name):
+
+    try:
+        layer_versions = _list_layer_versions(lambda_client, LayerName=name)['LayerVersions']
+        return [camel_dict_to_snake_dict(layer) for layer in layer_versions]
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        raise LambdaLayerFailure(e, "Unable to list layer versions for name {0}".format(name))
+
+
+def create_layer_version(lambda_client, params, check_mode=False):
+    if check_mode:
+        return {"msg": "Create operation skipped - running in check mode", "changed": True}
+
+    opt = {"LayerName": params.get("name"), "Content": {}}
+    keys = [
+        ('description', 'Description'),
+        ('compatible_runtimes', 'CompatibleRuntimes'),
+        ('license_info', 'LicenseInfo'),
+        ('compatible_architectures', 'CompatibleArchitectures'),
+    ]
+    for k, d in keys:
+        if params.get(k) is not None:
+            opt[d] = params.get(k)
+
+    # Read zip file if any
+    zip_file = params["content"].get("zip_file")
+    if zip_file is not None:
+        with open(zip_file, "rb") as zf:
+            opt["Content"]["ZipFile"] = zf.read()
+    else:
+        opt["Content"]["S3Bucket"] = params["content"].get("s3_bucket")
+        opt["Content"]["S3Key"] = params["content"].get("s3_key")
+        if params["content"].get("s3_object_version") is not None:
+            opt["Content"]["S3ObjectVersion"] = params["content"].get("s3_object_version")
+
+    try:
+        layer_version = lambda_client.publish_layer_version(**opt)
+        layer_version.pop("ResponseMetadata", None)
+        return {"changed": True, "layer_versions": [camel_dict_to_snake_dict(layer_version)]}
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+        raise LambdaLayerFailure(e, "Failed to publish a new layer version (check that you have required permissions).")
+
+
+def delete_layer_version(lambda_client, params, check_mode=False):
+    name = params.get("name")
+    version = params.get("version")
+    layer_versions = list_layer_versions(lambda_client, name)
+    deleted_versions = []
+    changed = False
+    for layer in layer_versions:
+        if version == -1 or layer["version"] == version:
+            deleted_versions.append(layer)
+            changed = True
+            if not check_mode:
+                try:
+                    lambda_client.delete_layer_version(LayerName=name, VersionNumber=layer["version"])
+                except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+                    LambdaLayerFailure(e, "Failed to delete layer version LayerName={0}, VersionNumber={1}.".format(name, version))
+    return {"changed": changed, "layer_versions": deleted_versions}
+
+
+def execute_module(module, lambda_client):
+
+    try:
+
+        state = module.params.get("state")
+        f_operation = create_layer_version
+        if state == "absent":
+            f_operation = delete_layer_version
+
+        module.exit_json(**f_operation(lambda_client, module.params, module.check_mode))
+    except LambdaLayerFailure as e:
+        module.fail_json_aws(e.exc, msg=e.msg)
+
+
+def main():
+    argument_spec = dict(
+        state=dict(type="str", choices=["present", "absent"], default="present"),
+        name=dict(type="str", required=True, aliases=["layer_name"]),
+        description=dict(type="str"),
+        content=dict(
+            type="dict",
+            options=dict(
+                s3_bucket=dict(type="str"),
+                s3_key=dict(type="str", no_log=False),
+                s3_object_version=dict(type="str"),
+                zip_file=dict(type="path"),
+            ),
+            required_together=[['s3_bucket', 's3_key']],
+            required_one_of=[['s3_bucket', 'zip_file']],
+            mutually_exclusive=[['s3_bucket', 'zip_file']],
+        ),
+        compatible_runtimes=dict(type="list", elements="str"),
+        license_info=dict(type="str"),
+        compatible_architectures=dict(type="list", elements="str"),
+        version=dict(type="int"),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        required_if=[
+            ("state", "present", ["content"]),
+            ("state", "absent", ["version"]),
+        ],
+        mutually_exclusive=[
+            ['version', 'description'],
+            ['version', 'content'],
+            ['version', 'compatible_runtimes'],
+            ['version', 'license_info'],
+            ['version', 'compatible_architectures'],
+        ],
+        supports_check_mode=True,
+    )
+
+    lambda_client = module.client('lambda')
+    execute_module(module, lambda_client)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/lambda_layer_info.py
+++ b/plugins/modules/lambda_layer_info.py
@@ -1,0 +1,221 @@
+#!/usr/bin/python
+# Copyright: Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import absolute_import, division, print_function
+__metaclass__ = type
+
+
+DOCUMENTATION = '''
+---
+module: lambda_layer_info
+version_added: 5.1.0
+short_description: List lambda layer or lambda layer versions
+description:
+  - This module is used to list the versions of an Lambda layer or all available lambda layers.
+  - The lambda layer versions that have been deleted aren't listed.
+
+author: "Aubin Bikouo (@abikouo)"
+options:
+  name:
+    description:
+    - The name or Amazon Resource Name (ARN) of the Lambda layer.
+    type: str
+    aliases:
+    - layer_name
+  compatible_runtime:
+    description:
+    - A runtime identifier.
+    - Specify this option without I(name) to list only latest layers versions of layers that indicate
+      that they're compatible with that runtime.
+    - Specify this option with I(name) to list only layer versions that indicate that
+      they're compatible with that runtime.
+    type: str
+  compatible_architecture:
+    description:
+    - A compatible instruction set architectures.
+    - Specify this option without I(name) to include only to list only latest layers versions of layers that
+      are compatible with that instruction set architecture.
+    - Specify this option with I(name) to include only layer versions that are compatible with that architecture.
+    type: str
+extends_documentation_fragment:
+- amazon.aws.aws
+- amazon.aws.ec2
+- amazon.aws.boto3
+
+'''
+
+EXAMPLES = '''
+---
+# Display information about the versions for the layer named blank-java-lib
+- name: Retrieve layer versions
+  amazon.aws.lambda_layer_info:
+    name: blank-java-lib
+
+# Display information about the versions for the layer named blank-java-lib compatible with architecture x86_64
+- name: Retrieve layer versions
+  amazon.aws.lambda_layer_info:
+    name: blank-java-lib
+    compatible_architecture: x86_64
+
+# list latest versions of available layers
+- name: list latest versions for all layers
+  amazon.aws.lambda_layer_info:
+
+# list latest versions of available layers compatible with runtime python3.7
+- name: list latest versions for all layers
+  amazon.aws.lambda_layer_info:
+    compatible_runtime: python3.7
+'''
+
+RETURN = '''
+layers_versions:
+  description:
+  - The layers versions that exists.
+  returned: success
+  type: list
+  elements: dict
+  contains:
+    layer_arn:
+        description: The ARN of the layer.
+        returned: when C(name) is provided
+        type: str
+        sample: "arn:aws:lambda:eu-west-2:123456789012:layer:pylayer"
+    layer_version_arn:
+        description: The ARN of the layer version.
+        returned: if the layer version exists or has been created
+        type: str
+        sample: "arn:aws:lambda:eu-west-2:123456789012:layer:pylayer:2"
+    description:
+        description: The description of the version.
+        returned: I(state=present)
+        type: str
+    created_date:
+        description: The date that the layer version was created, in ISO-8601 format (YYYY-MM-DDThh:mm:ss.sTZD).
+        returned: if the layer version exists or has been created
+        type: str
+        sample: "2022-09-28T14:27:35.866+0000"
+    version:
+        description: The version number.
+        returned: if the layer version exists or has been created
+        type: int
+        sample: 1
+    compatible_runtimes:
+        description: A list of compatible runtimes.
+        returned: if it was defined for the layer version.
+        type: list
+        sample: ["python3.7"]
+    license_info:
+        description: The layer's software license.
+        returned: if it was defined for the layer version.
+        type: str
+        sample: "GPL-3.0-only"
+    compatible_architectures:
+        description: A list of compatible instruction set architectures.
+        returned: if it was defined for the layer version.
+        type: list
+'''
+
+try:
+    import botocore
+except ImportError:
+    pass  # Handled by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AWSRetry
+
+
+@AWSRetry.jittered_backoff()
+def _list_layer_versions(client, **params):
+    paginator = client.get_paginator('list_layer_versions')
+    return paginator.paginate(**params).build_full_result()
+
+
+@AWSRetry.jittered_backoff()
+def _list_layers(client, **params):
+    paginator = client.get_paginator('list_layers')
+    return paginator.paginate(**params).build_full_result()
+
+
+class LambdaLayerInfoFailure(Exception):
+    def __init__(self, exc, msg):
+        self.exc = exc
+        self.msg = msg
+        super().__init__(self)
+
+
+def list_layer_versions(lambda_client, name, compatible_runtime=None, compatible_architecture=None):
+
+    params = {"LayerName": name}
+    if compatible_runtime:
+        params["CompatibleRuntime"] = compatible_runtime
+    if compatible_architecture:
+        params["CompatibleArchitecture"] = compatible_architecture
+    try:
+        layer_versions = _list_layer_versions(lambda_client, **params)['LayerVersions']
+        return [camel_dict_to_snake_dict(layer) for layer in layer_versions]
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        raise LambdaLayerInfoFailure(exc=e, msg="Unable to list layer versions for name {0}".format(name))
+
+
+def list_layers(lambda_client, compatible_runtime=None, compatible_architecture=None):
+
+    params = {}
+    if compatible_runtime:
+        params["CompatibleRuntime"] = compatible_runtime
+    if compatible_architecture:
+        params["CompatibleArchitecture"] = compatible_architecture
+    try:
+        layers = _list_layers(lambda_client, **params)['Layers']
+        layer_versions = []
+        for item in layers:
+            layer = {key: value for key, value in item.items() if key != "LatestMatchingVersion"}
+            layer.update(item.get("LatestMatchingVersion"))
+            layer_versions.append(camel_dict_to_snake_dict(layer))
+        return layer_versions
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        raise LambdaLayerInfoFailure(exc=e, msg="Unable to list layers {0}".format(params))
+
+
+def execute_module(module, lambda_client):
+
+    params = {}
+    f_operation = list_layers
+    name = module.params.get("name")
+    if name is not None:
+        f_operation = list_layer_versions
+        params["name"] = name
+    compatible_runtime = module.params.get("compatible_runtime")
+    if compatible_runtime is not None:
+        params["compatible_runtime"] = compatible_runtime
+    compatible_architecture = module.params.get("compatible_architecture")
+    if compatible_architecture is not None:
+        params["compatible_architecture"] = compatible_architecture
+
+    try:
+        result = f_operation(lambda_client, **params)
+        module.exit_json(changed=False, layers_versions=result)
+    except LambdaLayerInfoFailure as e:
+        module.fail_json_aws(exception=e.exc, msg=e.msg)
+
+
+def main():
+    argument_spec = dict(
+        name=dict(type="str", aliases=["layer_name"]),
+        compatible_runtime=dict(type="str"),
+        compatible_architecture=dict(type="str"),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    lambda_client = module.client('lambda')
+    execute_module(module, lambda_client)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/integration/targets/lambda_layer/aliases
+++ b/tests/integration/targets/lambda_layer/aliases
@@ -1,0 +1,2 @@
+cloud/aws
+lambda_layer_info

--- a/tests/integration/targets/lambda_layer/defaults/main.yml
+++ b/tests/integration/targets/lambda_layer/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+lambda_hander_content: |
+  # Copyright: Ansible Project
+  # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+  import logging
+  from datetime import datetime
+  logger = logging.getLogger()
+  logger.setLevel(logging.INFO)
+  def lambda_handler(event, context):
+      logger.info('Ansible amazon.aws collection lambda handler executed at {0}'.format(datetime.now().strftime("%y%m%d-%H%M%S")))

--- a/tests/integration/targets/lambda_layer/tasks/main.yml
+++ b/tests/integration/targets/lambda_layer/tasks/main.yml
@@ -45,7 +45,7 @@
         bucket: "{{ s3_bucket_name }}"
         mode: put
         object: "{{ s3_bucket_object }}"
-        permission: public-read
+        # permission: public-read  # Commented on because botocore.exceptions.ClientError: An error occurred (AccessControlListNotSupported) when calling the PutObject operation: The bucket does not allow ACLs
         src: "{{ zip_file_path }}"
 
     - name: Create lambda layer (check_mode=true)
@@ -98,7 +98,7 @@
     - name: Retrieve all layers with latest version
       lambda_layer_info:
       register: layers
-    
+
     - name: Ensure layer created above was found
       assert:
         that:

--- a/tests/integration/targets/lambda_layer/tasks/main.yml
+++ b/tests/integration/targets/lambda_layer/tasks/main.yml
@@ -1,0 +1,248 @@
+---
+- module_defaults:
+    group/aws:
+      aws_access_key: '{{ aws_access_key | default(omit) }}'
+      aws_secret_key: '{{ aws_secret_key | default(omit) }}'
+      security_token: '{{ security_token | default(omit) }}'
+      region: '{{ aws_region | default(omit) }}'
+
+  collections:
+    - amazon.aws
+
+  vars:
+    s3_bucket_name: "{{ resource_prefix }}-bucket"
+    s3_bucket_object: "{{ resource_prefix }}-obj-1"
+    layer_name: "{{ resource_prefix }}-layer"
+
+  block:
+    - name: Create temporary directory
+      tempfile:
+        state: directory
+        suffix: .lambda_handler
+      register: _dir
+
+    - copy:
+        content: "{{ lambda_hander_content }}"
+        dest: "{{ _dir.path }}/lambda_handler.py"
+        remote_src: true
+
+    - set_fact:
+        zip_file_path: "{{ _dir.path }}/lambda_handler.zip"
+
+    - name: Create lambda handler archive
+      archive:
+        path: "{{ _dir.path }}/lambda_handler.py"
+        dest: "{{ zip_file_path }}"
+        format: zip
+
+    - name: Create S3 bucket for testing
+      s3_bucket:
+        name: "{{ s3_bucket_name }}"
+        state: present
+
+    - name: add object into bucket
+      s3_object:
+        bucket: "{{ s3_bucket_name }}"
+        mode: put
+        object: "{{ s3_bucket_object }}"
+        permission: public-read
+        src: "{{ zip_file_path }}"
+
+    - name: Create lambda layer (check_mode=true)
+      lambda_layer:
+        name: "{{ layer_name }}"
+        description: '{{ resource_prefix }} lambda layer first version'
+        content:
+          zip_file: "{{ zip_file_path }}"
+        compatible_runtimes:
+          - python3.7
+        license_info: GPL-3.0-only
+      register: create_check_mode
+      check_mode: true
+
+    - name: Retrieve all layers versions
+      lambda_layer_info:
+        name: "{{ layer_name }}"
+      register: layers
+
+    - name: Ensure lambda layer was not created
+      assert:
+        that:
+          - create_check_mode is changed
+          - create_check_mode.msg == "Create operation skipped - running in check mode"
+          - layers.layers_versions | length == 0
+
+    - name: Create lambda layer (first version)
+      lambda_layer:
+        name: "{{ layer_name }}"
+        description: '{{ resource_prefix }} lambda layer first version'
+        content:
+          zip_file: "{{ zip_file_path }}"
+        compatible_runtimes:
+          - python3.7
+        license_info: GPL-3.0-only
+      register: first_version
+
+    - name: Create another lambda layer version
+      lambda_layer:
+        name: "{{ layer_name }}"
+        description: '{{ resource_prefix }} lambda layer second version'
+        content:
+          s3_bucket: "{{ s3_bucket_name }}"
+          s3_key: "{{ s3_bucket_object }}"
+        compatible_runtimes:
+          - python3.7
+        license_info: GPL-3.0-only
+      register: last_version
+
+    - name: Retrieve all layers with latest version
+      lambda_layer_info:
+      register: layers
+    
+    - name: Ensure layer created above was found
+      assert:
+        that:
+          - '"layers_versions" in layers'
+          - first_version.layer_versions | length == 1
+          - last_version.layer_versions | length == 1
+          - last_version.layer_versions.0.layer_arn in layers_arns
+          - last_version.layer_versions.0.layer_version_arn in layers_version_arns
+          - first_version.layer_versions.0.layer_version_arn not in layers_version_arns
+      vars:
+        layers_arns: '{{ layers.layers_versions | map(attribute="layer_arn") | list }}'
+        layers_version_arns: '{{ layers.layers_versions | map(attribute="layer_version_arn") | list }}'
+
+    - name: Retrieve all layers versions
+      lambda_layer_info:
+        name: "{{ layer_name }}"
+      register: layers
+
+    - name: Ensure layer created above was found
+      assert:
+        that:
+          - '"layers_versions" in layers'
+          - layers.layers_versions | length == 2
+          - first_version.layer_versions | length == 1
+          - last_version.layer_versions | length == 1
+          - last_version.layer_versions.0.layer_version_arn in layers_version_arns
+          - first_version.layer_versions.0.layer_version_arn in layers_version_arns
+      vars:
+        layers_version_arns: '{{ layers.layers_versions | map(attribute="layer_version_arn") | list }}'
+
+    - name: Delete latest layer version
+      lambda_layer:
+        name: "{{ layer_name }}"
+        version: "{{ last_version.layer_versions.0.version }}"
+        state: absent
+      check_mode: true
+      register: delete_check_mode
+
+    - name: Retrieve all layers versions
+      lambda_layer_info:
+        name: "{{ layer_name }}"
+      register: layers
+
+    - name: Ensure no layer version was deleted
+      assert:
+        that:
+          - delete_check_mode is changed
+          - delete_check_mode.layer_versions | length == 1
+          - layers.layers_versions | length == 2
+          - last_version.layer_versions.0.layer_version_arn in layers_version_arns
+          - first_version.layer_versions.0.layer_version_arn in layers_version_arns
+      vars:
+        layers_version_arns: '{{ layers.layers_versions | map(attribute="layer_version_arn") | list }}'
+
+    - name: Delete latest layer version
+      lambda_layer:
+        name: "{{ layer_name }}"
+        version: "{{ last_version.layer_versions.0.version }}"
+        state: absent
+      register: delete_layer
+
+    - name: Retrieve all layers versions
+      lambda_layer_info:
+        name: "{{ layer_name }}"
+      register: layers
+
+    - name: Ensure latest layer version was deleted
+      assert:
+        that:
+          - delete_layer is changed
+          - delete_layer.layer_versions | length == 1
+          - layers.layers_versions | length == 1
+          - last_version.layer_versions.0.layer_version_arn not in layers_version_arns
+          - first_version.layer_versions.0.layer_version_arn in layers_version_arns
+      vars:
+        layers_version_arns: '{{ layers.layers_versions | map(attribute="layer_version_arn") | list }}'
+
+    - name: Delete again the latest layer version (idempotency)
+      lambda_layer:
+        name: "{{ layer_name }}"
+        version: "{{ last_version.layer_versions.0.version }}"
+        state: absent
+      register: delete_idempotent
+
+    - name: Ensure nothing changed
+      assert:
+        that:
+          - delete_idempotent is not changed
+
+    - name: Create multiple lambda layer versions
+      lambda_layer:
+        name: "{{ layer_name }}"
+        description: '{{ resource_prefix }} lambda layer version compatible with python3.{{ item }}'
+        content:
+          s3_bucket: "{{ s3_bucket_name }}"
+          s3_key: "{{ s3_bucket_object }}"
+        compatible_runtimes:
+          - "python3.{{ item }}"
+        license_info: GPL-3.0-only
+      with_items: ["9", "10"]
+
+    - name: Delete all layer versions
+      lambda_layer:
+        name: "{{ layer_name }}"
+        version: -1
+        state: absent
+      register: delete_layer
+
+    - name: Retrieve all layers versions
+      lambda_layer_info:
+        name: "{{ layer_name }}"
+      register: layers
+
+    - name: Ensure layer does not exist anymore
+      assert:
+        that:
+          - delete_layer is changed
+          - delete_layer.layer_versions | length > 1
+          - layers.layers_versions | length == 0
+
+  always:
+    - name: Delete lambda layer if not deleted during testing
+      lambda_layer:
+        name: "{{ layer_name }}"
+        version: -1
+        state: absent
+      ignore_errors: true
+
+    - name: Delete temporary directory
+      file:
+        state: absent
+        path: "{{ _dir.path }}"
+      ignore_errors: true
+
+    - name: Remove object from bucket
+      s3_object:
+        bucket: "{{ s3_bucket_name }}"
+        mode: delobj
+        object: "{{ s3_bucket_object }}"
+      ignore_errors: true
+
+    - name: Delete S3 bucket
+      s3_bucket:
+        name: "{{ s3_bucket_name }}"
+        force: true
+        state: absent
+      ignore_errors: true

--- a/tests/unit/plugins/modules/test_lambda_layer.py
+++ b/tests/unit/plugins/modules/test_lambda_layer.py
@@ -1,0 +1,493 @@
+#
+# (c) 2022 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+
+from unittest.mock import MagicMock, call, patch
+from ansible_collections.amazon.aws.plugins.modules import lambda_layer
+
+
+def raise_lambdalayer_exception(e=None, m=None):
+    e = e or "lambda layer exc"
+    m = m or "unit testing"
+    return lambda_layer.LambdaLayerFailure(exc=e, msg=m)
+
+
+mod_list_layer = 'ansible_collections.amazon.aws.plugins.modules.lambda_layer.list_layer_versions'
+mod_create_layer = 'ansible_collections.amazon.aws.plugins.modules.lambda_layer.create_layer_version'
+mod_delete_layer = 'ansible_collections.amazon.aws.plugins.modules.lambda_layer.delete_layer_version'
+
+
+@pytest.mark.parametrize(
+    "params,api_result,calls,ansible_result",
+    [
+        (
+            {
+                "name": "testlayer",
+                "version": 4
+            },
+            [],
+            [],
+            {"changed": False, "layer_versions": []}
+        ),
+        (
+            {
+                "name": "testlayer",
+                "version": 4
+            },
+            [
+                {
+                    'compatible_runtimes': ["python3.7"],
+                    'created_date': "2022-09-29T10:31:35.977+0000",
+                    'layer_version_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:2",
+                    "license_info": "MIT",
+                    'version': 2,
+                    'compatible_architectures': [
+                        'arm64'
+                    ]
+                },
+                {
+                    "created_date": "2022-09-29T10:31:26.341+0000",
+                    "description": "lambda layer first version",
+                    "layer_version_arn": "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:1",
+                    "version": 1
+                }
+            ],
+            [],
+            {"changed": False, "layer_versions": []}
+        ),
+        (
+            {
+                "name": "testlayer",
+                "version": 2
+            },
+            [
+                {
+                    'compatible_runtimes': ["python3.7"],
+                    'created_date': "2022-09-29T10:31:35.977+0000",
+                    'layer_version_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:2",
+                    "license_info": "MIT",
+                    'version': 2,
+                    'compatible_architectures': [
+                        'arm64'
+                    ]
+                },
+                {
+                    "created_date": "2022-09-29T10:31:26.341+0000",
+                    "description": "lambda layer first version",
+                    "layer_version_arn": "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:1",
+                    "version": 1
+                }
+            ],
+            [
+                call(LayerName='testlayer', VersionNumber=2)
+            ],
+            {
+                "changed": True,
+                "layer_versions": [
+                    {
+                        'compatible_runtimes': ["python3.7"],
+                        'created_date': "2022-09-29T10:31:35.977+0000",
+                        'layer_version_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:2",
+                        "license_info": "MIT",
+                        'version': 2,
+                        'compatible_architectures': [
+                            'arm64'
+                        ]
+                    }
+                ]
+            }
+        ),
+        (
+            {
+                "name": "testlayer",
+                "version": -1
+            },
+            [
+                {
+                    'compatible_runtimes': ["python3.7"],
+                    'created_date': "2022-09-29T10:31:35.977+0000",
+                    'layer_version_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:2",
+                    "license_info": "MIT",
+                    'version': 2,
+                    'compatible_architectures': [
+                        'arm64'
+                    ]
+                },
+                {
+                    "created_date": "2022-09-29T10:31:26.341+0000",
+                    "description": "lambda layer first version",
+                    "layer_version_arn": "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:1",
+                    "version": 1
+                }
+            ],
+            [
+                call(LayerName='testlayer', VersionNumber=2),
+                call(LayerName='testlayer', VersionNumber=1)
+            ],
+            {
+                "changed": True,
+                "layer_versions": [
+                    {
+                        'compatible_runtimes': ["python3.7"],
+                        'created_date': "2022-09-29T10:31:35.977+0000",
+                        'layer_version_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:2",
+                        "license_info": "MIT",
+                        'version': 2,
+                        'compatible_architectures': [
+                            'arm64'
+                        ]
+                    },
+                    {
+                        "created_date": "2022-09-29T10:31:26.341+0000",
+                        "description": "lambda layer first version",
+                        "layer_version_arn": "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:1",
+                        "version": 1
+                    }
+                ]
+            }
+        )
+    ]
+)
+@patch(mod_list_layer)
+def test_delete_layer(m_list_layer, params, api_result, calls, ansible_result):
+
+    lambda_client = MagicMock()
+    lambda_client.delete_layer_version.return_value = None
+
+    m_list_layer.return_value = api_result
+    result = lambda_layer.delete_layer_version(lambda_client, params)
+    assert result == ansible_result
+
+    m_list_layer.assert_called_once_with(
+        lambda_client, params.get("name")
+    )
+
+    if not calls:
+        lambda_client.delete_layer_version.assert_not_called()
+    else:
+        lambda_client.delete_layer_version.assert_has_calls(calls, any_order=True)
+
+
+@patch(mod_list_layer)
+def test_delete_layer_check_mode(m_list_layer):
+
+    lambda_client = MagicMock()
+    lambda_client.delete_layer_version.return_value = None
+
+    m_list_layer.return_value = [
+        {
+            'compatible_runtimes': ["python3.7"],
+            'created_date': "2022-09-29T10:31:35.977+0000",
+            'layer_version_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:2",
+            "license_info": "MIT",
+            'version': 2,
+            'compatible_architectures': [
+                'arm64'
+            ]
+        },
+        {
+            "created_date": "2022-09-29T10:31:26.341+0000",
+            "description": "lambda layer first version",
+            "layer_version_arn": "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:1",
+            "version": 1
+        }
+    ]
+    params = {"name": "testlayer", "version": -1}
+    result = lambda_layer.delete_layer_version(lambda_client, params, check_mode=True)
+    ansible_result = {
+        "changed": True,
+        "layer_versions": [
+            {
+                'compatible_runtimes': ["python3.7"],
+                'created_date': "2022-09-29T10:31:35.977+0000",
+                'layer_version_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:2",
+                "license_info": "MIT",
+                'version': 2,
+                'compatible_architectures': [
+                    'arm64'
+                ]
+            },
+            {
+                "created_date": "2022-09-29T10:31:26.341+0000",
+                "description": "lambda layer first version",
+                "layer_version_arn": "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:1",
+                "version": 1
+            }
+        ]
+    }
+    assert result == ansible_result
+
+    m_list_layer.assert_called_once_with(
+        lambda_client, params.get("name")
+    )
+    lambda_client.delete_layer_version.assert_not_called()
+
+
+@patch(mod_list_layer)
+def test_delete_layer_failure(m_list_layer):
+
+    lambda_client = MagicMock()
+    lambda_client.delete_layer_version.side_effect = raise_lambdalayer_exception()
+
+    m_list_layer.return_value = [
+        {
+            "created_date": "2022-09-29T10:31:26.341+0000",
+            "description": "lambda layer first version",
+            "layer_version_arn": "arn:aws:lambda:eu-west-2:123456789012:layer:testlayer:1",
+            "version": 1
+        }
+    ]
+    params = {"name": "testlayer", "version": 1}
+    with pytest.raises(lambda_layer.LambdaLayerFailure):
+        lambda_layer.delete_layer_version(lambda_client, params)
+
+
+@pytest.mark.parametrize(
+    "b_s3content",
+    [
+        (True),
+        (False)
+    ]
+)
+@patch(mod_list_layer)
+def test_create_layer(m_list_layer, b_s3content, tmp_path):
+    params = {
+        "name": "testlayer",
+        "description": "ansible units testing sample layer",
+        "content": {},
+        "license_info": "MIT"
+    }
+
+    lambda_client = MagicMock()
+
+    lambda_client.publish_layer_version.return_value = {
+        'CompatibleRuntimes': [
+            'python3.6',
+            'python3.7',
+        ],
+        'Content': {
+            'CodeSha256': 'tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=',
+            'CodeSize': 169,
+            'Location': 'https://awslambda-us-west-2-layers.s3.us-west-2.amazonaws.com/snapshots/123456789012/my-layer-4aaa2fbb',
+        },
+        'CreatedDate': '2018-11-14T23:03:52.894+0000',
+        'Description': "ansible units testing sample layer",
+        'LayerArn': 'arn:aws:lambda:us-west-2:123456789012:layer:my-layer',
+        'LayerVersionArn': 'arn:aws:lambda:us-west-2:123456789012:layer:testlayer:1',
+        'LicenseInfo': 'MIT',
+        'Version': 1,
+        'ResponseMetadata': {
+            'http_header': 'true',
+        },
+    }
+
+    expected = {
+        "changed": True,
+        "layer_versions": [
+            {
+                'compatible_runtimes': ['python3.6', 'python3.7'],
+                'content': {
+                    'code_sha256': 'tv9jJO+rPbXUUXuRKi7CwHzKtLDkDRJLB3cC3Z/ouXo=',
+                    'code_size': 169,
+                    'location': 'https://awslambda-us-west-2-layers.s3.us-west-2.amazonaws.com/snapshots/123456789012/my-layer-4aaa2fbb'
+                },
+                'created_date': '2018-11-14T23:03:52.894+0000',
+                'description': 'ansible units testing sample layer',
+                'layer_arn': 'arn:aws:lambda:us-west-2:123456789012:layer:my-layer',
+                'layer_version_arn': 'arn:aws:lambda:us-west-2:123456789012:layer:testlayer:1',
+                'license_info': 'MIT',
+                'version': 1
+            }
+        ]
+    }
+
+    if b_s3content:
+        params["content"] = {
+            "s3_bucket": "mybucket",
+            "s3_key": "mybucket-key",
+            "s3_object_version": "v1"
+        }
+        content_arg = {
+            "S3Bucket": "mybucket",
+            "S3Key": "mybucket-key",
+            "S3ObjectVersion": "v1"
+        }
+    else:
+        binary_data = b"simple lambda layer content"
+        test_dir = tmp_path / "lambda_layer"
+        test_dir.mkdir()
+        zipfile = test_dir / "lambda.zip"
+        zipfile.write_bytes(binary_data)
+
+        params["content"] = {"zip_file": str(zipfile)}
+        content_arg = {
+            "ZipFile": binary_data,
+        }
+
+    result = lambda_layer.create_layer_version(lambda_client, params)
+
+    assert result == expected
+
+    lambda_client.publish_layer_version.assert_called_with(
+        LayerName="testlayer",
+        Description="ansible units testing sample layer",
+        LicenseInfo="MIT",
+        Content=content_arg,
+    )
+
+    m_list_layer.assert_not_called()
+
+
+@patch(mod_list_layer)
+def test_create_layer_check_mode(m_list_layer):
+    params = {
+        "name": "testlayer",
+        "description": "ansible units testing sample layer",
+        "content": {
+            "s3_bucket": "mybucket",
+            "s3_key": "mybucket-key",
+            "s3_object_version": "v1"
+        },
+        "license_info": "MIT"
+    }
+
+    lambda_client = MagicMock()
+
+    result = lambda_layer.create_layer_version(lambda_client, params, check_mode=True)
+    assert result == {"msg": "Create operation skipped - running in check mode", "changed": True}
+
+    m_list_layer.assert_not_called()
+    lambda_client.publish_layer_version.assert_not_called()
+
+
+def test_create_layer_failure():
+    params = {
+        "name": "testlayer",
+        "description": "ansible units testing sample layer",
+        "content": {
+            "s3_bucket": "mybucket",
+            "s3_key": "mybucket-key",
+            "s3_object_version": "v1"
+        },
+        "compatible_runtimes": [
+            "nodejs",
+            "python3.9"
+        ],
+        "compatible_architectures": [
+            'x86_64',
+            'arm64'
+        ]
+    }
+    lambda_client = MagicMock()
+    lambda_client.publish_layer_version.side_effect = raise_lambdalayer_exception()
+
+    with pytest.raises(lambda_layer.LambdaLayerFailure):
+        lambda_layer.create_layer_version(lambda_client, params)
+
+
+def test_create_layer_using_unexisting_file():
+    params = {
+        "name": "testlayer",
+        "description": "ansible units testing sample layer",
+        "content": {
+            "zip_file": "this_file_does_not_exist",
+        },
+        "compatible_runtimes": [
+            "nodejs",
+            "python3.9"
+        ],
+        "compatible_architectures": [
+            'x86_64',
+            'arm64'
+        ]
+    }
+
+    lambda_client = MagicMock()
+
+    lambda_client.publish_layer_version.return_value = {}
+    with pytest.raises(FileNotFoundError):
+        lambda_layer.create_layer_version(lambda_client, params)
+
+    lambda_client.publish_layer_version.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "params,failure",
+    [
+        (
+            {"name": "test-layer"},
+            False
+        ),
+        (
+            {"name": "test-layer", "state": "absent"},
+            False
+        ),
+        (
+            {"name": "test-layer"},
+            True
+        ),
+        (
+            {"name": "test-layer", "state": "absent"},
+            True
+        ),
+    ]
+)
+@patch(mod_create_layer)
+@patch(mod_delete_layer)
+def test_execute_module(m_delete_layer, m_create_layer, params, failure):
+
+    module = MagicMock()
+    module.params = params
+    module.check_mode = False
+    module.exit_json.side_effect = SystemExit(1)
+    module.fail_json_aws.side_effect = SystemExit(2)
+
+    lambda_client = MagicMock()
+
+    state = params.get("state", "present")
+    result = {"changed": True, "layers_versions": {}}
+
+    if not failure:
+        if state == "present":
+            m_create_layer.return_value = result
+            with pytest.raises(SystemExit):
+                lambda_layer.execute_module(module, lambda_client)
+
+            module.exit_json.assert_called_with(**result)
+            module.fail_json_aws.assert_not_called()
+            m_create_layer.assert_called_with(
+                lambda_client, params, module.check_mode
+            )
+            m_delete_layer.assert_not_called()
+
+        elif state == "absent":
+            m_delete_layer.return_value = result
+            with pytest.raises(SystemExit):
+                lambda_layer.execute_module(module, lambda_client)
+
+            module.exit_json.assert_called_with(**result)
+            module.fail_json_aws.assert_not_called()
+            m_delete_layer.assert_called_with(
+                lambda_client, params, module.check_mode
+            )
+            m_create_layer.assert_not_called()
+    else:
+        exc = "lambdalayer_execute_module_exception"
+        msg = "this_exception_is_used_for_unit_testing"
+        m_create_layer.side_effect = raise_lambdalayer_exception(exc, msg)
+        m_delete_layer.side_effect = raise_lambdalayer_exception(exc, msg)
+
+        with pytest.raises(SystemExit):
+            lambda_layer.execute_module(module, lambda_client)
+
+        module.exit_json.assert_not_called()
+        module.fail_json_aws.assert_called_with(
+            exc, msg=msg
+        )

--- a/tests/unit/plugins/modules/test_lambda_layer_info.py
+++ b/tests/unit/plugins/modules/test_lambda_layer_info.py
@@ -1,0 +1,358 @@
+#
+# (c) 2022 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+import pytest
+from botocore.exceptions import BotoCoreError
+
+from unittest.mock import MagicMock, call, patch
+from ansible_collections.amazon.aws.plugins.modules import lambda_layer_info
+
+
+mod__list_layer_versions = 'ansible_collections.amazon.aws.plugins.modules.lambda_layer_info._list_layer_versions'
+mod__list_layers = 'ansible_collections.amazon.aws.plugins.modules.lambda_layer_info._list_layers'
+mod_list_layer_versions = 'ansible_collections.amazon.aws.plugins.modules.lambda_layer_info.list_layer_versions'
+mod_list_layers = 'ansible_collections.amazon.aws.plugins.modules.lambda_layer_info.list_layers'
+
+
+list_layers_paginate_result = {
+    'NextMarker': '002',
+    'Layers': [
+        {
+            'LayerName': "test-layer-01",
+            'LayerArn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-01",
+            'LatestMatchingVersion': {
+                'LayerVersionArn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-01:1",
+                'Version': 1,
+                'Description': "lambda layer created for unit tests",
+                'CreatedDate': "2022-09-29T10:31:26.341+0000",
+                'CompatibleRuntimes': [
+                    'nodejs',
+                    'nodejs4.3',
+                    'nodejs6.10'
+                ],
+                'LicenseInfo': 'MIT',
+                'CompatibleArchitectures': [
+                    'arm64'
+                ]
+            }
+        },
+        {
+            'LayerName': "test-layer-02",
+            'LayerArn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-02",
+            'LatestMatchingVersion': {
+                'LayerVersionArn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-02:1",
+                'Version': 1,
+                'CreatedDate': "2022-09-29T10:31:26.341+0000",
+                'CompatibleArchitectures': [
+                    'arm64'
+                ]
+            }
+        },
+    ],
+    'ResponseMetadata': {
+        'http': 'true',
+    },
+}
+
+list_layers_result = [
+    {
+        'layer_name': "test-layer-01",
+        'layer_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-01",
+        'layer_version_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-01:1",
+        'version': 1,
+        'description': "lambda layer created for unit tests",
+        'created_date': "2022-09-29T10:31:26.341+0000",
+        'compatible_runtimes': [
+            'nodejs',
+            'nodejs4.3',
+            'nodejs6.10'
+        ],
+        'license_info': 'MIT',
+        'compatible_architectures': [
+            'arm64'
+        ]
+    },
+    {
+        'layer_name': "test-layer-02",
+        'layer_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-02",
+        'layer_version_arn': "arn:aws:lambda:eu-west-2:123456789012:layer:test-layer-02:1",
+        'version': 1,
+        'created_date': "2022-09-29T10:31:26.341+0000",
+        'compatible_architectures': [
+            'arm64'
+        ]
+    }
+]
+
+
+list_layers_versions_paginate_result = {
+    'LayerVersions': [
+        {
+            'CompatibleRuntimes': ["python3.7"],
+            'CreatedDate': "2022-09-29T10:31:35.977+0000",
+            'LayerVersionArn': "arn:aws:lambda:eu-west-2:123456789012:layer:layer-01:2",
+            "LicenseInfo": "MIT",
+            'Version': 2,
+            'CompatibleArchitectures': [
+                'arm64'
+            ]
+        },
+        {
+            "CompatibleRuntimes": ["python3.7"],
+            "CreatedDate": "2022-09-29T10:31:26.341+0000",
+            "Description": "lambda layer first version",
+            "LayerVersionArn": "arn:aws:lambda:eu-west-2:123456789012:layer:layer-01:1",
+            "LicenseInfo": "GPL-3.0-only",
+            "Version": 1
+        }
+    ],
+    'ResponseMetadata': {
+        'http': 'true',
+    },
+    'NextMarker': '001',
+}
+
+
+list_layers_versions_result = [
+    {
+        "compatible_runtimes": ["python3.7"],
+        "created_date": "2022-09-29T10:31:35.977+0000",
+        "layer_version_arn": "arn:aws:lambda:eu-west-2:123456789012:layer:layer-01:2",
+        "license_info": "MIT",
+        "version": 2,
+        'compatible_architectures': [
+            'arm64'
+        ]
+    },
+    {
+        "compatible_runtimes": ["python3.7"],
+        "created_date": "2022-09-29T10:31:26.341+0000",
+        "description": "lambda layer first version",
+        "layer_version_arn": "arn:aws:lambda:eu-west-2:123456789012:layer:layer-01:1",
+        "license_info": "GPL-3.0-only",
+        "version": 1
+    }
+]
+
+
+@pytest.mark.parametrize(
+    "params,call_args",
+    [
+        (
+            {
+                "compatible_runtime": "nodejs",
+                "compatible_architecture": "arm64"
+            },
+            {
+                "CompatibleRuntime": "nodejs",
+                "CompatibleArchitecture": "arm64"
+            }
+        ),
+        (
+            {
+                "compatible_runtime": "nodejs",
+            },
+            {
+                "CompatibleRuntime": "nodejs",
+            }
+        ),
+        (
+            {
+                "compatible_architecture": "arm64"
+            },
+            {
+                "CompatibleArchitecture": "arm64"
+            }
+        ),
+        (
+            {}, {}
+        )
+    ]
+)
+@patch(mod__list_layers)
+def test_list_layers_with_latest_version(m__list_layers, params, call_args):
+
+    lambda_client = MagicMock()
+
+    m__list_layers.return_value = list_layers_paginate_result
+    layers = lambda_layer_info.list_layers(lambda_client, **params)
+
+    m__list_layers.assert_has_calls(
+        [
+            call(lambda_client, **call_args)
+        ]
+    )
+    assert layers == list_layers_result
+
+
+@pytest.mark.parametrize(
+    "params,call_args",
+    [
+        (
+            {
+                "name": "layer-01",
+                "compatible_runtime": "nodejs",
+                "compatible_architecture": "arm64"
+            },
+            {
+                "LayerName": "layer-01",
+                "CompatibleRuntime": "nodejs",
+                "CompatibleArchitecture": "arm64"
+            }
+        ),
+        (
+            {
+                "name": "layer-01",
+                "compatible_runtime": "nodejs",
+            },
+            {
+                "LayerName": "layer-01",
+                "CompatibleRuntime": "nodejs",
+            }
+        ),
+        (
+            {
+                "name": "layer-01",
+                "compatible_architecture": "arm64"
+            },
+            {
+                "LayerName": "layer-01",
+                "CompatibleArchitecture": "arm64"
+            }
+        ),
+        (
+            {"name": "layer-01"}, {"LayerName": "layer-01"}
+        )
+    ]
+)
+@patch(mod__list_layer_versions)
+def test_list_layer_versions(m__list_layer_versions, params, call_args):
+
+    lambda_client = MagicMock()
+
+    m__list_layer_versions.return_value = list_layers_versions_paginate_result
+    layers = lambda_layer_info.list_layer_versions(lambda_client, **params)
+
+    m__list_layer_versions.assert_has_calls(
+        [
+            call(lambda_client, **call_args)
+        ]
+    )
+    assert layers == list_layers_versions_result
+
+
+def raise_botocore_exception():
+    return BotoCoreError(error="failed", operation="list_layers")
+
+
+@pytest.mark.parametrize(
+    "params",
+    [
+        (
+            {
+                "name": "test-layer",
+                "compatible_runtime": "nodejs",
+                "compatible_architecture": "arm64"
+            }
+        ),
+        (
+            {
+                "compatible_runtime": "nodejs",
+                "compatible_architecture": "arm64"
+            }
+        )
+    ]
+)
+@patch(mod__list_layers)
+@patch(mod__list_layer_versions)
+def test_list_layers_with_failure(m__list_layer_versions, m__list_layers, params):
+
+    lambda_client = MagicMock()
+
+    if "name" in params:
+        m__list_layer_versions.side_effect = raise_botocore_exception()
+        test_function = lambda_layer_info.list_layer_versions
+    else:
+        m__list_layers.side_effect = raise_botocore_exception()
+        test_function = lambda_layer_info.list_layers
+
+    with pytest.raises(lambda_layer_info.LambdaLayerInfoFailure):
+        test_function(lambda_client, **params)
+
+
+def raise_layer_info_exception(exc, msg):
+    return lambda_layer_info.LambdaLayerInfoFailure(exc=exc, msg=msg)
+
+
+@pytest.mark.parametrize(
+    "params,failure",
+    [
+        (
+            {
+                "name": "test-layer",
+                "compatible_runtime": "nodejs",
+                "compatible_architecture": "arm64"
+            },
+            False
+        ),
+        (
+            {
+                "compatible_runtime": "nodejs",
+                "compatible_architecture": "arm64"
+            },
+            False
+        ),
+        (
+            {
+                "name": "test-layer",
+                "compatible_runtime": "nodejs",
+                "compatible_architecture": "arm64"
+            },
+            True
+        )
+    ]
+)
+@patch(mod_list_layers)
+@patch(mod_list_layer_versions)
+def test_execute_module(m_list_layer_versions, m_list_layers, params, failure):
+
+    lambda_client = MagicMock()
+
+    module = MagicMock()
+    module.params = params
+    module.exit_json.side_effect = SystemExit(1)
+    module.fail_json_aws.side_effect = SystemExit(2)
+
+    method_called, method_not_called = m_list_layers, m_list_layer_versions
+    if "name" in params:
+        method_not_called, method_called = m_list_layers, m_list_layer_versions
+
+    if failure:
+        exc = "lambda_layer_exception"
+        msg = "this exception has been generated for unit tests"
+
+        method_called.side_effect = raise_layer_info_exception(exc, msg)
+
+        with pytest.raises(SystemExit):
+            lambda_layer_info.execute_module(module, lambda_client)
+
+        module.fail_json_aws.assert_called_with(exception=exc, msg=msg)
+
+    else:
+        result = {"A": "valueA", "B": "valueB"}
+        method_called.return_value = result
+
+        with pytest.raises(SystemExit):
+            lambda_layer_info.execute_module(module, lambda_client)
+
+        module.exit_json.assert_called_with(
+            changed=False, layers_versions=result
+        )
+        method_called.assert_called_with(lambda_client, **params)
+        method_not_called.list_layers.assert_not_called()


### PR DESCRIPTION
new modules: lambda_layer and lambda_layer_info

SUMMARY

The module lambda_layer allows user to publish or delete lambda layer version, while lambda_layer_info is used to list lambda layers or all versions of a specific lambda layer

ISSUE TYPE


New Module Pull Request

COMPONENT NAME

lambda_layer
lambda_layer_info
ADDITIONAL INFORMATION





Closes: #1116

Reviewed-by: Mark Chappell <None>
Reviewed-by: Bikouo Aubin <None>
Reviewed-by: Jill R <None>
Reviewed-by: Alina Buzachis <None>
Reviewed-by: Gonéri Le Bouder <goneri@lebouder.net>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
