### PR TITLE
Ensure ec2_instance tests filter correctly

### DIFF
--- a/changelogs/fragments/1505-ec2_instance_test_fixes.yml
+++ b/changelogs/fragments/1505-ec2_instance_test_fixes.yml
@@ -1,0 +1,2 @@
+trivial:
+  - ec2_instance - Add filter statement to integration tests to prevent test collisions (https://github.com/ansible-collections/amazon.aws/pull/1505)

--- a/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
@@ -16,6 +16,8 @@
       state: present
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
+      filters:
+        "tag:TestId": "{{ ec2_instance_tag_TestId }}"
     register: create_multiple_instances
     check_mode: true
 
@@ -35,6 +37,8 @@
       state: present
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
+      filters:
+       "tag:TestId": "{{ ec2_instance_tag_TestId }}"
       wait: true
     register: create_multiple_instances
 


### PR DESCRIPTION
##### SUMMARY
Multiple instances test picks up instances from other tests when run concurrently. Use tag filters to prevent this.

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml

##### ADDITIONAL INFORMATION
in the example here: https://39d585ceb0884fd58f3d-34626b4834f21056500b5be2783f089d.ssl.cf5.rackcdn.com/1500/eb91ab4ac10d4af904d629a7296502aff59d9d06/check/integration-amazon.aws-1/86d0d4c/job-output.txt
the `Create multiple instance (check_mode)` task erroneously picks up instances from the ec2_instance_instance_minimal test target.