### PR TITLE
Use engine: 'aurora-mysql' rather than engine: 'aurora' in rds_cluster_snapshot integration tests

### DIFF
--- a/changelogs/fragments/20230503-rds_cluster-engine-rds_cluster_snapshot.yml
+++ b/changelogs/fragments/20230503-rds_cluster-engine-rds_cluster_snapshot.yml
@@ -1,0 +1,2 @@
+trivial:
+  - "Use engine: 'aurora-mysql' rather tan engine: 'aurora' in rds_cluster_snapshot tests."

--- a/tests/integration/targets/rds_cluster_snapshot/defaults/main.yml
+++ b/tests/integration/targets/rds_cluster_snapshot/defaults/main.yml
@@ -6,7 +6,7 @@ _resource_prefix: 'ansible-test-{{ tiny_prefix }}'
 cluster_id: '{{ _resource_prefix }}-rds-cluster'
 username: 'testrdsusername'
 password: "{{ lookup('password', 'dev/null length=12 chars=ascii_letters,digits') }}"
-engine: 'aurora'
+engine: 'aurora-mysql'
 port: 3306
 
 # Create snapshot


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Rds cluster snapshot integration tests fix
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
