### PR TITLE
[stable-5] [backport/1511] s3_bucket - Ensure public_access settings are configured before policies

### DIFF
--- a/changelogs/fragments/1511-s3_bucket-public_access.yml
+++ b/changelogs/fragments/1511-s3_bucket-public_access.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- s3_bucket - ensure ``public_access`` is configured before updating policies (https://github.com/ansible-collections/amazon.aws/pull/1511).

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/acl.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/acl.yml
@@ -12,6 +12,7 @@
     - name: 'Create a simple bucket'
       s3_bucket:
         name: '{{ local_bucket_name }}'
+        object_ownership: BucketOwnerPreferred
         public_access:
           block_public_acls: true
           block_public_policy: true

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/complex.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/complex.yml
@@ -9,6 +9,8 @@
         policy: "{{ lookup('template','policy.json') }}"
         requester_pays: yes
         versioning: yes
+        public_access:
+          block_public_acls: false
         tags:
           example: tag1
           another: tag2


### PR DESCRIPTION
Manual backport of #1511 

##### SUMMARY

At the end of April Amazon updated various S3 bucket defaults.  Buckets now have public_access blocked by default, and object_owner set to "BucketOwnerEnforced". https://aws.amazon.com/blogs/aws/heads-up-amazon-s3-security-changes-are-coming-in-april-of-2023/ This uncovered a race condition where we set the policy before setting the public_access configs

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

s3_bucket

##### ADDITIONAL INFORMATION
