### PR TITLE
Bulk migration to Python 3.6 f-strings (2)

### DIFF
--- a/changelogs/fragments/fstring-2.yml
+++ b/changelogs/fragments/fstring-2.yml
@@ -1,0 +1,5 @@
+# 1483 includes a fragment and links to 1513
+trivial:
+- bulk migration of ``%`` and ``.format()`` to fstrings (https://github.com/ansible-collections/amazon.aws/pull/1513).
+minor_changes:
+- rds_param_group - drop Python2 import fallbacks (https://github.com/ansible-collections/amazon.aws/pull/1513).

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -141,12 +141,12 @@ def describe_resource_with_tags(func):
         except is_boto3_error_code("AccessDenied") as e:  # pylint: disable=duplicate-except
             if not strict:
                 return []
-            raise AnsibleError("Failed to query RDS: {0}".format(to_native(e)))
+            raise AnsibleError(f"Failed to query RDS: {to_native(e)}")
         except (
             botocore.exceptions.BotoCoreError,
             botocore.exceptions.ClientError,
         ) as e:  # pylint: disable=duplicate-except
-            raise AnsibleError("Failed to query RDS: {0}".format(to_native(e)))
+            raise AnsibleError(f"Failed to query RDS: {to_native(e)}")
 
         return results
 

--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -1182,7 +1182,7 @@ def main():
                 and module.params.get("db_cluster_instance_class")
             ):
                 module.fail_json(
-                    f"When engine={module.params['engine']} allocated_storage, iops and db_cluster_instance_class msut be specified"
+                    f"When engine={module.params['engine']} allocated_storage, iops and db_cluster_instance_class must be specified"
                 )
             else:
                 # Fall to default value

--- a/plugins/modules/rds_cluster_snapshot.py
+++ b/plugins/modules/rds_cluster_snapshot.py
@@ -246,7 +246,7 @@ def get_snapshot(snapshot_id):
         botocore.exceptions.BotoCoreError,
         botocore.exceptions.ClientError,
     ) as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg="Couldn't get snapshot {0}".format(snapshot_id))
+        module.fail_json_aws(e, msg=f"Couldn't get snapshot {snapshot_id}")
     return snapshot
 
 
@@ -256,11 +256,8 @@ def get_parameters(parameters, method_name):
 
     required_options = get_boto3_client_method_parameters(client, method_name, required=True)
     if any(parameters.get(k) is None for k in required_options):
-        module.fail_json(
-            msg="To {0} requires the parameters: {1}".format(
-                get_rds_method_attribute(method_name, module).operation_description, required_options
-            )
-        )
+        attribute_description = get_rds_method_attribute(method_name, module).operation_description
+        module.fail_json(msg=f"To {attribute_description} requires the parameters: {required_options}")
     options = get_boto3_client_method_parameters(client, method_name)
     parameters = dict((k, v) for k, v in parameters.items() if k in options and v is not None)
 

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -987,11 +987,8 @@ def get_parameters(client, module, parameters, method_name):
 
     required_options = get_boto3_client_method_parameters(client, method_name, required=True)
     if any(parameters.get(k) is None for k in required_options):
-        module.fail_json(
-            msg="To {0} requires the parameters: {1}".format(
-                get_rds_method_attribute(method_name, module).operation_description, required_options
-            )
-        )
+        description = get_rds_method_attribute(method_name, module).operation_description
+        module.fail_json(msg=f"To {description} requires the parameters: {required_options}")
     options = get_boto3_client_method_parameters(client, method_name)
     parameters = dict((k, v) for k, v in parameters.items() if k in options and v is not None)
 
@@ -1086,7 +1083,10 @@ def get_options_with_changing_values(client, module, parameters):
 
                 if new_storage_throughput < 500 and GP3_THROUGHPUT:
                     module.fail_json(
-                        msg="Storage Throughput must be at least 500 when the allocated storage is larger than or equal to 400 GB."
+                        msg=(
+                            "Storage Throughput must be at least 500 when the allocated storage is larger than or equal"
+                            " to 400 GB."
+                        )
                     )
 
                 if current_iops != new_iops:
@@ -1245,10 +1245,10 @@ def validate_options(client, module, instance):
         modified_instance = {}
 
     if modified_id and instance and modified_instance:
-        module.fail_json(msg="A new instance ID {0} was provided but it already exists".format(modified_id))
+        module.fail_json(msg=f"A new instance ID {modified_id} was provided but it already exists")
     if modified_id and not instance and modified_instance:
         module.fail_json(
-            msg="A new instance ID {0} was provided but the instance to be renamed does not exist".format(modified_id)
+            msg=f"A new instance ID {modified_id} was provided but the instance to be renamed does not exist"
         )
     if state in ("absent", "terminated") and instance and not skip_final_snapshot and snapshot_id is None:
         module.fail_json(
@@ -1257,12 +1257,13 @@ def validate_options(client, module, instance):
     if engine is not None and not (engine.startswith("mysql") or engine.startswith("oracle")) and tde_options:
         module.fail_json(msg="TDE is available for MySQL and Oracle DB instances")
     if read_replica is True and not instance and creation_source not in [None, "instance"]:
-        module.fail_json(
-            msg="Cannot create a read replica from {0}. You must use a source DB instance".format(creation_source)
-        )
+        module.fail_json(msg=f"Cannot create a read replica from {creation_source}. You must use a source DB instance")
     if read_replica is True and not instance and not source_instance:
         module.fail_json(
-            msg="read_replica is true and the instance does not exist yet but all of the following are missing: source_db_instance_identifier"
+            msg=(
+                "read_replica is true and the instance does not exist yet but all of the following are missing:"
+                " source_db_instance_identifier"
+            )
         )
 
 
@@ -1321,9 +1322,7 @@ def ensure_iam_roles(client, module, instance_id):
     engine = instance.get("engine")
     if engine not in valid_engines_iam_roles:
         module.fail_json(
-            msg="DB engine {0} is not valid for adding IAM roles. Valid engines are {1}".format(
-                engine, valid_engines_iam_roles
-            )
+            msg=f"DB engine {engine} is not valid for adding IAM roles. Valid engines are {valid_engines_iam_roles}"
         )
 
     changed = False
@@ -1509,7 +1508,8 @@ def main():
     # see: amazon.aws.module_util.rds.handle_errors.
     if module.params.get("allow_major_version_upgrade") and module.check_mode:
         module.warn(
-            "allow_major_version_upgrade is not returned when describing db instances, so changed will always be `True` on check mode runs."
+            "allow_major_version_upgrade is not returned when describing db instances, so changed will always be `True`"
+            " on check mode runs."
         )
 
     client = module.client("rds")

--- a/plugins/modules/rds_instance_info.py
+++ b/plugins/modules/rds_instance_info.py
@@ -387,7 +387,7 @@ def get_instance_tags(conn, arn):
     try:
         return boto3_tag_list_to_ansible_dict(conn.list_tags_for_resource(ResourceName=arn, aws_retry=True)["TagList"])
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        raise RdsInstanceInfoFailure(e, "Couldn't get tags for instance %s" % arn)
+        raise RdsInstanceInfoFailure(e, f"Couldn't get tags for instance {arn}")
 
 
 def instance_info(conn, instance_name, filters):

--- a/plugins/modules/rds_instance_snapshot.py
+++ b/plugins/modules/rds_instance_snapshot.py
@@ -257,7 +257,7 @@ def get_snapshot(snapshot_id):
         botocore.exceptions.BotoCoreError,
         botocore.exceptions.ClientError,
     ) as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg="Couldn't get snapshot {0}".format(snapshot_id))
+        module.fail_json_aws(e, msg=f"Couldn't get snapshot {snapshot_id}")
     return snapshot
 
 
@@ -267,11 +267,8 @@ def get_parameters(parameters, method_name):
 
     required_options = get_boto3_client_method_parameters(client, method_name, required=True)
     if any(parameters.get(k) is None for k in required_options):
-        module.fail_json(
-            msg="To {0} requires the parameters: {1}".format(
-                get_rds_method_attribute(method_name, module).operation_description, required_options
-            )
-        )
+        method_description = get_rds_method_attribute(method_name, module).operation_description
+        module.fail_json(msg=f"To {method_description} requires the parameters: {*required_options,}")
     options = get_boto3_client_method_parameters(client, method_name)
     parameters = dict((k, v) for k, v in parameters.items() if k in options and v is not None)
 

--- a/plugins/modules/rds_param_group.py
+++ b/plugins/modules/rds_param_group.py
@@ -105,6 +105,8 @@ tags:
     returned: when state is present
 """
 
+from itertools import zip_longest
+
 try:
     import botocore
 except ImportError:
@@ -182,8 +184,7 @@ def update_parameters(module, connection):
     for param_key, param_value in desired.items():
         if param_key not in lookup:
             errors.append(
-                "Parameter %s is not an available parameter for the %s engine"
-                % (param_key, module.params.get("engine"))
+                f"Parameter {param_key} is not an available parameter for the {module.params.get('engine')} engine"
             )
         else:
             converted_value = convert_parameter(lookup[param_key], param_value)
@@ -194,14 +195,10 @@ def update_parameters(module, connection):
                         dict(ParameterValue=converted_value, ParameterName=param_key, ApplyMethod=apply_method)
                     )
                 else:
-                    errors.append("Parameter %s is not modifiable" % param_key)
+                    errors.append(f"Parameter {param_key} is not modifiable")
 
     # modify_db_parameters takes at most 20 parameters
     if modify_list and not module.check_mode:
-        try:
-            from itertools import izip_longest as zip_longest  # python 2
-        except ImportError:
-            from itertools import zip_longest  # python 3
         for modify_slice in zip_longest(*[iter(modify_list)] * 20, fillvalue=None):
             non_empty_slice = [item for item in modify_slice if item]
             try:

--- a/plugins/modules/rds_snapshot_info.py
+++ b/plugins/modules/rds_snapshot_info.py
@@ -303,8 +303,8 @@ except ImportError:
 def common_snapshot_info(module, conn, method, prefix, params):
     paginator = conn.get_paginator(method)
     try:
-        results = paginator.paginate(**params).build_full_result()["%ss" % prefix]
-    except is_boto3_error_code("%sNotFound" % prefix):
+        results = paginator.paginate(**params).build_full_result()[f"{prefix}s"]
+    except is_boto3_error_code(f"{prefix}NotFound"):
         results = []
     except (
         botocore.exceptions.ClientError,
@@ -316,10 +316,11 @@ def common_snapshot_info(module, conn, method, prefix, params):
         try:
             if snapshot["SnapshotType"] != "shared":
                 snapshot["Tags"] = boto3_tag_list_to_ansible_dict(
-                    conn.list_tags_for_resource(ResourceName=snapshot["%sArn" % prefix], aws_retry=True)["TagList"]
+                    conn.list_tags_for_resource(ResourceName=snapshot[f"{prefix}Arn"], aws_retry=True)["TagList"]
                 )
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, "Couldn't get tags for snapshot %s" % snapshot["%sIdentifier" % prefix])
+            snapshot_name = snapshot[f"{prefix}Identifier"]
+            module.fail_json_aws(e, f"Couldn't get tags for snapshot {snapshot_name}")
 
     return [camel_dict_to_snake_dict(snapshot, ignore_list=["Tags"]) for snapshot in results]
 


### PR DESCRIPTION
##### SUMMARY

We've dropped support for Python <3.6, bulk migrate to fstrings and perform some general string cleanup

A combination of
* `black --preview`
* `flynt`
* some manual cleanup

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/
tests/unit/

##### ADDITIONAL INFORMATION

This PR is specifically targetting the RDS related modules.
There's still more to come...