### PR TITLE
[backport] [stable-5] Flag RSA example in unit test to be ignored by GitLeaks (#1518)

### DIFF
--- a/tests/unit/plugins/modules/test_ec2_key.py
+++ b/tests/unit/plugins/modules/test_ec2_key.py
@@ -220,10 +220,14 @@ def test__create_key_pair():
     expected_params = {'KeyName': name}
 
     ec2_client.create_key_pair.return_value = {
-        'KeyFingerprint': 'd7:ff:a6:63:18:64:9c:57:a1:ee:ca:a4:ad:c2:81:62',
-        'KeyMaterial': '-----BEGIN RSA PRIVATE KEY-----\nMIIEXm7/Bi9wba2m0Qtclu\nCXQw2paSIZb\n-----END RSA PRIVATE KEY-----',
-        'KeyName': 'my_keypair',
-        'KeyPairId': 'key-012345678905a208d'
+        "KeyFingerprint": "d7:ff:a6:63:18:64:9c:57:a1:ee:ca:a4:ad:c2:81:62",
+        "KeyMaterial": (
+            "-----BEGIN RSA PRIVATE KEY-----\n"  # gitleaks:allow
+            "MIIEXm7/Bi9wba2m0Qtclu\nCXQw2paSIZb\n"
+            "-----END RSA PRIVATE KEY-----"
+        ),
+        "KeyName": "my_keypair",
+        "KeyPairId": "key-012345678905a208d",
     }
 
     result = ec2_key._create_key_pair(ec2_client, name, tag_spec, key_type)


### PR DESCRIPTION
##### SUMMARY

The example in the unit test keeps triggering GitLeaks, flag to be ignored by GitLeaks (it's a fake)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_key

##### ADDITIONAL INFORMATION

Reviewed-by: Jill R
Reviewed-by: Alina Buzachis
