### PR TITLE
Add flake8 and black to tox.ini

### DIFF
--- a/changelogs/fragments/add_linters_to_tox.yml
+++ b/changelogs/fragments/add_linters_to_tox.yml
@@ -1,0 +1,2 @@
+trivial:
+- "Add black and flake8 to linters env in tox.ini."

--- a/plugins/modules/autoscaling_group.py
+++ b/plugins/modules/autoscaling_group.py
@@ -1219,7 +1219,7 @@ def create_autoscaling_group(connection):
             else:
                 ag["LaunchTemplate"] = launch_object["LaunchTemplate"]
         else:
-            module.fail_json_aws(e, msg="Missing LaunchConfigurationName or LaunchTemplate")
+            module.fail_json_aws(msg="Missing LaunchConfigurationName or LaunchTemplate")
 
         try:
             create_asg(connection, **ag)

--- a/plugins/modules/autoscaling_group.py
+++ b/plugins/modules/autoscaling_group.py
@@ -1219,7 +1219,7 @@ def create_autoscaling_group(connection):
             else:
                 ag["LaunchTemplate"] = launch_object["LaunchTemplate"]
         else:
-            module.fail_json_aws(msg="Missing LaunchConfigurationName or LaunchTemplate")
+            module.fail_json(msg="Missing LaunchConfigurationName or LaunchTemplate")
 
         try:
             create_asg(connection, **ag)

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -272,7 +272,7 @@ def associate_ip_and_device(
                 msg = f"Couldn't associate Elastic IP address with network interface '{device_id}'"
                 module.fail_json_aws(e, msg=msg)
         if not res:
-            module.fail_json_aws(msg="Association failed.")
+            module.fail_json(msg="Association failed.")
 
     return {"changed": True}
 

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -272,7 +272,7 @@ def associate_ip_and_device(
                 msg = f"Couldn't associate Elastic IP address with network interface '{device_id}'"
                 module.fail_json_aws(e, msg=msg)
         if not res:
-            module.fail_json_aws(e, msg="Association failed.")
+            module.fail_json_aws(msg="Association failed.")
 
     return {"changed": True}
 

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1433,7 +1433,7 @@ def main():
         preferred_backup_window=dict(aliases=["backup_window"]),
         preferred_maintenance_window=dict(aliases=["maintenance_window"]),
         processor_features=dict(type="dict"),
-        promotion_tier=dict(type='int'),
+        promotion_tier=dict(type="int"),
         publicly_accessible=dict(type="bool"),
         restore_time=dict(),
         s3_bucket_name=dict(),

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist = clean,ansible{2.12,2.13}-py{38,39,310}-{with_constraints,without_constraints}
+envlist = clean,ansible{2.12,2.13}-py{38,39,310}-{with_constraints,without_constraints},linters
 
 [testenv]
 description = Run the test-suite and generate a HTML coverage report
@@ -27,3 +27,26 @@ deps =
   flake8>=3.3.0,<5.0.0'
   flake8-html
 commands = -flake8 --select C90 --max-complexity 10 --format=html --htmldir={posargs:complexity} plugins
+
+[testenv:black]
+deps =
+  black >=23.0, <24.0
+commands =
+  black {toxinidir}/plugins {toxinidir}/tests
+
+[testenv:linters]
+deps =
+  {[testenv:black]deps}
+  flake8
+commands =
+  black -v --check {toxinidir}/plugins {toxinidir}/tests
+  flake8 {posargs} {toxinidir}/plugins {toxinidir}/tests
+
+[flake8]
+# E123, E125 skipped as they are invalid PEP-8.
+show-source = True
+ignore = E123,E125,E203,E402,E501,E741,F401,F811,F841,W503
+max-line-length = 160
+builtins = _
+
+


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Added linters env to tox.ini.  As suggested [here](https://github.com/ansible-collections/amazon.aws/pull/1499#discussion_r1183509977) we need not backport this update.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
