### PR TITLE
aws_ec2 inventory - migration to Python 3.6 f-strings

### DIFF
--- a/changelogs/fragments/fstring-ec2_inv.yml
+++ b/changelogs/fragments/fstring-ec2_inv.yml
@@ -1,0 +1,3 @@
+# 1483 includes a fragment and links to 1513
+trivial:
+- bulk migration of ``%`` and ``.format()`` to fstrings (https://github.com/ansible-collections/amazon.aws/pull/1526).

--- a/changelogs/fragments/fstring-ec2_inv.yml
+++ b/changelogs/fragments/fstring-ec2_inv.yml
@@ -1,3 +1,5 @@
 # 1483 includes a fragment and links to 1513
 trivial:
 - bulk migration of ``%`` and ``.format()`` to fstrings (https://github.com/ansible-collections/amazon.aws/pull/1526).
+minor_changes:
+- ec2_vpc_subnet - retry fetching subnet details after creation if the first attempt fails (https://github.com/ansible-collections/amazon.aws/pull/1526).

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -416,7 +416,7 @@ def _prepare_host_vars(
 
     if use_contrib_script_compatible_ec2_tag_keys:
         for k, v in host_vars["tags"].items():
-            host_vars["ec2_tag_%s" % k] = v
+            host_vars[f"ec2_tag_{k}"] = v
 
     if hostvars_prefix or hostvars_suffix:
         for hostvar, hostval in host_vars.copy().items():

--- a/plugins/modules/ec2_vpc_subnet.py
+++ b/plugins/modules/ec2_vpc_subnet.py
@@ -481,6 +481,11 @@ def ensure_subnet_present(conn, module):
 
     subnet = get_matching_subnet(conn, module, module.params["vpc_id"], module.params["cidr"])
     if not module.check_mode and module.params["wait"]:
+        for _rewait in range(0, 5):
+            if subnet:
+                break
+            time.sleep(2)
+            subnet = get_matching_subnet(conn, module, module.params["vpc_id"], module.params["cidr"])
         # GET calls are not monotonic for map_public_ip_on_launch and assign_ipv6_address_on_creation
         # so we only wait for those if necessary just before returning the subnet
         subnet = ensure_final_subnet(conn, module, subnet, start_time)

--- a/tests/integration/targets/inventory_aws_ec2/tasks/setup.yml
+++ b/tests/integration/targets/inventory_aws_ec2/tasks/setup.yml
@@ -7,7 +7,7 @@
       owner-id: '125523088429'
       virtualization-type: hvm
       root-device-type: ebs
-      name: 'Fedora-Cloud-Base-34-1.2.x86_64*'
+      name: 'Fedora-Cloud-Base-37-1.2.x86_64*'
   register: fedora_images
 
 - name: Set image id, vpc cidr and subnet cidr


### PR DESCRIPTION
##### SUMMARY

We've dropped support for Python <3.6, bulk migrate to fstrings and perform some general string cleanup

A combination of
* `black --preview`
* `flynt`
* some manual cleanup

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/inventory/aws_ec2.py

##### ADDITIONAL INFORMATION
