### PR TITLE
ec2_vpc_endpoint - test flake

### DIFF
--- a/changelogs/fragments/endpoint.yml
+++ b/changelogs/fragments/endpoint.yml
@@ -1,0 +1,2 @@
+trivial:
+- ec2_vpc_endpoint - don't assume an endpoint we might not have created has no routes attached.

--- a/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
@@ -147,7 +147,6 @@
       - '"creation_timestamp" in first_endpoint'
       - '"policy_document" in first_endpoint'
       - '"route_table_ids" in first_endpoint'
-      - first_endpoint.route_table_ids | length == 0
       - '"service_name" in first_endpoint'
       - '"state" in first_endpoint'
       - '"vpc_endpoint_id" in first_endpoint'


### PR DESCRIPTION
##### SUMMARY

Test was assuming that an endpoint we might not have created had no routes attached.  This makes the test flaky when things are run in parallel.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_vpc_endpoint

##### ADDITIONAL INFORMATION

Routes (existence or not) are tested in later tests where we know which endpoint we're looking at.