### PR TITLE
[stable-5] lookup plugins - raise correct error

### DIFF
--- a/changelogs/fragments/1528-lookup-error.yml
+++ b/changelogs/fragments/1528-lookup-error.yml
@@ -1,0 +1,5 @@
+bugfixes:
+- aws_account_attribute - raise correct ``AnsibleLookupError`` rather than ``AnsibleError`` (https://github.com/ansible-collections/amazon.aws/issues/1528).
+- aws_secret -  raise correct ``AnsibleLookupError`` rather than ``AnsibleError`` (https://github.com/ansible-collections/amazon.aws/issues/1528).
+- aws_service_ip_ranges raise correct ``AnsibleLookupError`` rather than ``AnsibleError`` (https://github.com/ansible-collections/amazon.aws/issues/1528).
+- aws_ssm - raise correct ``AnsibleLookupError`` rather than ``AnsibleError`` (https://github.com/ansible-collections/amazon.aws/issues/1528).

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -45,7 +45,7 @@ _raw:
 
 import json
 
-from ansible.errors import AnsibleError
+from ansible.errors import AnsibleLookupError
 from ansible.module_utils.six.moves.urllib.error import HTTPError
 from ansible.module_utils.six.moves.urllib.error import URLError
 from ansible.module_utils._text import to_native
@@ -70,15 +70,15 @@ class LookupModule(LookupBase):
         except getattr(json.decoder, 'JSONDecodeError', ValueError) as e:
             # on Python 3+, json.decoder.JSONDecodeError is raised for bad
             # JSON. On 2.x it's a ValueError
-            raise AnsibleError("Could not decode AWS IP ranges: %s" % to_native(e))
+            raise AnsibleLookupError("Could not decode AWS IP ranges: %s" % to_native(e))
         except HTTPError as e:
-            raise AnsibleError("Received HTTP error while pulling IP ranges: %s" % to_native(e))
+            raise AnsibleLookupError("Received HTTP error while pulling IP ranges: %s" % to_native(e))
         except SSLValidationError as e:
-            raise AnsibleError("Error validating the server's certificate for: %s" % to_native(e))
+            raise AnsibleLookupError("Error validating the server's certificate for: %s" % to_native(e))
         except URLError as e:
-            raise AnsibleError("Failed look up IP range service: %s" % to_native(e))
+            raise AnsibleLookupError("Failed look up IP range service: %s" % to_native(e))
         except ConnectionError as e:
-            raise AnsibleError("Error connecting to IP range service: %s" % to_native(e))
+            raise AnsibleLookupError("Error connecting to IP range service: %s" % to_native(e))
 
         if 'region' in kwargs:
             region = kwargs['region']


### PR DESCRIPTION
##### SUMMARY

Lookup plugins are currently raising "AnsibleError" this is in turn leading to a surprising error.  Our tests didn't catch this because we expected an error (just a clean error) and our error message was still in there.

fixes: #1528 

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

aws_ssm

##### ADDITIONAL INFORMATION
```
TASK [lookup_aws_ssm : lookup a missing key (error)] ***************************
task path: /root/ansible_collections/amazon/aws/tests/output/.tmp/integration/lookup_aws_ssm-uhhi4kie-ÅÑŚÌβŁÈ/tests/integration/targets/lookup_aws_ssm/tasks/main.yml:43
AWS_ssm name lookup term: ['/ansible-test-32065799-mchappel/Simple']
exception during Jinja2 execution: Traceback (most recent call last):
  File "/root/ansible_collections/amazon/aws/plugins/lookup/aws_ssm.py", line 272, in get_parameter_value
    response = client.get_parameter(**ssm_dict)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/botocore/client.py", line 386, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/dist-packages/botocore/client.py", line 705, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.errorfactory.ParameterNotFound: An error occurred (ParameterNotFound) when calling the GetParameter operation: 

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/root/ansible/lib/ansible/template/__init__.py", line 831, in _lookup
    ran = instance.run(loop_terms, variables=self._available_variables, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/ansible_collections/amazon/aws/plugins/lookup/aws_ssm.py", line 241, in run
    ret.append(self.get_parameter_value(client, ssm_dict, term, on_missing.lower(), on_denied.lower()))
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/ansible_collections/amazon/aws/plugins/lookup/aws_ssm.py", line 276, in get_parameter_value
    raise AnsibleError("Failed to find SSM parameter %s (ResourceNotFound)" % term)
ansible.errors.AnsibleError: Failed to find SSM parameter /ansible-test-32065799-mchappel/Simple (ResourceNotFound)
fatal: [testhost]: FAILED! => {
    "msg": "An unhandled exception occurred while running the lookup plugin 'amazon.aws.aws_ssm'. Error was a <class 'ansible.errors.AnsibleError'>, original message: Failed to find SSM parameter /ansible-test-32065799-mchappel/Simple (ResourceNotFound). Failed to find SSM parameter /ansible-test-32065799-mchappel/Simple (ResourceNotFound)"
}
...ignoring
```

Direct to stable-5 as the issue was fixed during the refactor work  in main.