### PR TITLE
module_utils/backup - explicitly pass resource to get_backup_tags

### DIFF
--- a/changelogs/fragments/backup_resource.yml
+++ b/changelogs/fragments/backup_resource.yml
@@ -1,0 +1,2 @@
+trivial:
+- backup - explicitly pass ``resource`` rather than reading indirectly from module.params.

--- a/plugins/module_utils/backup.py
+++ b/plugins/module_utils/backup.py
@@ -13,8 +13,7 @@ from typing import Union
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 
-def get_backup_resource_tags(module, backup_client):
-    resource = module.params.get("resource")
+def get_backup_resource_tags(module, backup_client, resource):
     try:
         response = backup_client.list_tags(ResourceArn=resource)
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
@@ -66,8 +65,8 @@ def get_plan_details(module, client, backup_plan_name: str):
     snaked_backup_plan = []
 
     try:
-        module.params["resource"] = result.get("BackupPlanArn", None)
-        # tag_dict = get_backup_resource_tags(module, client)
+        resource = result.get("BackupPlanArn", None)
+        # tag_dict = get_backup_resource_tags(module, client, resource)
         # result.update({"tags": tag_dict})
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Failed to get the backup plan tags")

--- a/plugins/modules/backup_tag.py
+++ b/plugins/modules/backup_tag.py
@@ -124,7 +124,7 @@ def manage_tags(module, backup_client):
     state = module.params.get("state")
     purge_tags = module.params.get("purge_tags")
 
-    current_tags = get_backup_resource_tags(module, backup_client)
+    current_tags = get_backup_resource_tags(module, backup_client, resource)
     tags_to_add, tags_to_remove = compare_aws_tags(current_tags, tags, purge_tags=purge_tags)
 
     remove_tags = {}
@@ -157,7 +157,7 @@ def manage_tags(module, backup_client):
             except (BotoCoreError, ClientError) as set_tag_error:
                 module.fail_json_aws(set_tag_error, msg=f"Failed to set tags {tags_to_add} on resource {resource}")
 
-    result["tags"] = get_backup_resource_tags(module, backup_client)
+    result["tags"] = get_backup_resource_tags(module, backup_client, resource)
     return result
 
 

--- a/plugins/modules/backup_tag_info.py
+++ b/plugins/modules/backup_tag_info.py
@@ -57,7 +57,7 @@ def main():
     )
     backup_client = module.client("backup")
 
-    current_tags = get_backup_resource_tags(module, backup_client)
+    current_tags = get_backup_resource_tags(module, backup_client, module.params["resource"])
 
     module.exit_json(changed=False, tags=current_tags)
 

--- a/plugins/modules/backup_vault.py
+++ b/plugins/modules/backup_vault.py
@@ -187,8 +187,8 @@ def get_vault_facts(module, client, vault_name):
     # Now check to see if our vault exists and get status and tags
     if resp:
         if resp.get("BackupVaultArn"):
-            module.params["resource"] = resp.get("BackupVaultArn")
-            resp["tags"] = get_backup_resource_tags(module, client)
+            resource = resp.get("BackupVaultArn")
+            resp["tags"] = get_backup_resource_tags(module, client, resource)
 
         # Check for non-existent values and populate with None
         optional_vals = set(
@@ -302,7 +302,7 @@ def main():
             module,
             client,
             tags=tags,
-            vault_arn=module.params["resource"],
+            vault_arn=vault["BackupVaultArn"],
             curr_tags=vault["tags"],
             purge_tags=purge_tags,
         )

--- a/plugins/modules/backup_vault_info.py
+++ b/plugins/modules/backup_vault_info.py
@@ -139,8 +139,8 @@ def get_backup_vault_detail(connection, module):
     snaked_backup_vault = []
     for backup_vault in output:
         try:
-            module.params["resource"] = backup_vault.get("BackupVaultArn", None)
-            tag_dict = get_backup_resource_tags(module, connection)
+            resource = backup_vault.get("BackupVaultArn", None)
+            tag_dict = get_backup_resource_tags(module, connection, resource)
             backup_vault.update({"tags": tag_dict})
         except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
             module.warn(f"Failed to get the backup vault tags - {e}")


### PR DESCRIPTION
##### SUMMARY

We've currently got some nasty hacks being used that rewrite module.params.  Explicitly pass the resource ID in, it's better when we're working on 

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

module_utils/backup

##### ADDITIONAL INFORMATION
