### PR TITLE
s3_bucket: fix VersionId==null when s3 object not versioned

### DIFF
--- a/changelogs/fragments/1538-s3-null.yml
+++ b/changelogs/fragments/1538-s3-null.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- s3_bucket - fixes issue when deleting a bucket with unversioned objects (https://github.com/ansible-collections/amazon.aws/issues/1533).

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -1163,7 +1163,7 @@ def destroy_bucket(s3_client, module):
                     # unversioned objects are deleted using `DeleteObject`
                     # rather than `DeleteObjectVersion`, improving backwards
                     # compatibility with older IAM policies.
-                    if not fk.get("VersionId"):
+                    if not fk.get("VersionId") or fk.get("VersionId")=="null":
                         fk.pop("VersionId")
 
                 if formatted_keys:

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -1163,7 +1163,7 @@ def destroy_bucket(s3_client, module):
                     # unversioned objects are deleted using `DeleteObject`
                     # rather than `DeleteObjectVersion`, improving backwards
                     # compatibility with older IAM policies.
-                    if not fk.get("VersionId") or fk.get("VersionId")=="null":
+                    if not fk.get("VersionId") or fk.get("VersionId") == "null":
                         fk.pop("VersionId")
 
                 if formatted_keys:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Boto3 1.26.129 (possibly earlier) returns "VersionId": "null" from s3_client.list_object_versions() when s3 objects are not versioned.  Previously, "VersionId" was None when an s3 object was not versioned.  This change broke s3_bucket.destroy_bucket() because the the VersionId was no longer popped (line 1166) when the s3 object was not versioned, and the subsequent attempts to delete the s3 object failed as the "VersionId" was absolutely not "null".  Adding in `or fk.get("VersionId")=="null" will catch this new value for non-versioned s3 objects while allowing backwards compatibility with previous versions that return None for "VersionId".

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1533 s3_bucket.destroy_bucket fails to delete unversioned items

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
s3_bucket.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
1.  Ensure that there is an s3 bucket with objects in it
2.
  - name: Remove buckets
    s3_bucket:
    name: "my_bucket_with_objects_with_no_versioning"
    state: absent
    force: yes

