### PR TITLE
s3_object - fix regression related to leading / in object key names

### DIFF
--- a/changelogs/fragments/1548-s3_object-leading-slash.yml
+++ b/changelogs/fragments/1548-s3_object-leading-slash.yml
@@ -1,0 +1,4 @@
+bugfixes:
+- s3_object - fixes regression related to objects with a leading ``/`` (https://github.com/ansible-collections/amazon.aws/issues/1548).
+deprecated_features:
+- s3_object - support for passing object keys with a leading ``/`` has been deprecated and will be removed in a release after 2025-12-01 (https://github.com/ansible-collections/amazon.aws/pull/1549).

--- a/changelogs/fragments/1548-s3_object-leading-slash.yml
+++ b/changelogs/fragments/1548-s3_object-leading-slash.yml
@@ -1,4 +1,4 @@
 bugfixes:
 - s3_object - fixes regression related to objects with a leading ``/`` (https://github.com/ansible-collections/amazon.aws/issues/1548).
-deprecated_features:
-- s3_object - support for passing object keys with a leading ``/`` has been deprecated and will be removed in a release after 2025-12-01 (https://github.com/ansible-collections/amazon.aws/pull/1549).
+# deprecated_features:
+# - s3_object - support for passing object keys with a leading ``/`` has been deprecated and will be removed in a release after 2025-12-01 (https://github.com/ansible-collections/amazon.aws/pull/1549).

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -93,8 +93,9 @@ options:
       - Can be used to create "virtual directories", see examples.
       - Object key names should not include the leading C(/), see
         U(https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html) for more
-        information.  Support for passing the leading C(/) has been deprecated and will be removed
-        in a release after 2025-12-01.
+        information.
+#      - Support for passing the leading C(/) has been deprecated and will be removed
+#        in a release after 2025-12-01.
     type: str
   sig_v4:
     description:
@@ -1378,11 +1379,11 @@ def populate_params(module):
         if obj.startswith("/"):
             obj = obj[1:]
             variable_dict["object"] = obj
-            module.deprecate(
-                "Support for passing object key names with a leading '/' has been deprecated.",
-                date="2025-12-01",
-                collection_name="amazon.aws",
-            )
+            #  module.deprecate(
+            #      "Support for passing object key names with a leading '/' has been deprecated.",
+            #      date="2025-12-01",
+            #      collection_name="amazon.aws",
+            #  )
 
     variable_dict["validate"] = not variable_dict["ignore_nonexistent_bucket"]
     variable_dict["acl_disabled"] = False

--- a/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
+++ b/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
@@ -98,7 +98,7 @@
           - permission_result is changed
           - upload_file_result is not failed
           - '"PutObjectAcl operation : The bucket does not allow ACLs." in permission_result.warnings'
-          - '"Virtual directory /test_directory/ created" in permission_result.msg'
+          - '"Virtual directory test_directory/ created" in permission_result.msg'
 
   always:
 

--- a/tests/integration/targets/s3_object/tasks/delete_bucket.yml
+++ b/tests/integration/targets/s3_object/tasks/delete_bucket.yml
@@ -1,9 +1,8 @@
 - name: delete bucket at the end of Integration tests
   block:
     - name: list bucket object
-      s3_object:
-        bucket: "{{ item }}"
-        mode: list
+      s3_object_info:
+        bucket_name: "{{ item }}"
       register: objects
       ignore_errors: true
 

--- a/tests/integration/targets/s3_object/tasks/main.yml
+++ b/tests/integration/targets/s3_object/tasks/main.yml
@@ -645,13 +645,14 @@
             that:
               - result is not changed
 
+    # Public objects aren't allowed by default
     - name: fail to upload the file to the bucket with an ACL
       s3_object:
         bucket: "{{ bucket_name_acl }}"
         mode: put
         src: "{{ remote_tmp_dir }}/upload.txt"
         object: file-with-permissions.txt
-        permission: private
+        permission: public-read
         ignore_nonexistent_bucket: True
       register: upload_private
       ignore_errors: True

--- a/tests/integration/targets/s3_object/tasks/main.yml
+++ b/tests/integration/targets/s3_object/tasks/main.yml
@@ -649,7 +649,7 @@
       s3_object:
         bucket: "{{ bucket_name_acl }}"
         mode: put
-        src: "{{ tmpdir.path }}/upload.txt"
+        src: "{{ remote_tmp_dir }}/upload.txt"
         object: file-with-permissions.txt
         permission: private
         ignore_nonexistent_bucket: True

--- a/tests/integration/targets/s3_object/tasks/main.yml
+++ b/tests/integration/targets/s3_object/tasks/main.yml
@@ -269,6 +269,27 @@
         that:
           - upload_file.stat.checksum == download_file.stat.checksum
 
+    - name: test get object (absolute path)
+      s3_object:
+        bucket: "{{ bucket_name }}"
+        mode: get
+        dest: "{{ remote_tmp_dir }}/download-2.txt"
+        object: /delete.txt
+      retries: 3
+      delay: 3
+      register: result
+      until: "result.msg == 'GET operation complete'"
+
+    - name: stat the file so we can compare the checksums
+      stat:
+        path: "{{ remote_tmp_dir }}/download-2.txt"
+        get_checksum: yes
+      register: download_file
+
+    - assert:
+        that:
+          - upload_file.stat.checksum == download_file.stat.checksum
+
     - name: test get with overwrite=different and identical files
       s3_object:
         bucket: "{{ bucket_name }}"

--- a/tests/unit/plugins/modules/test_s3_object.py
+++ b/tests/unit/plugins/modules/test_s3_object.py
@@ -95,7 +95,7 @@ def test_s3_object_do_list_success(m_paginated_list, m_list_keys):
 
 
 @patch(utils + ".get_aws_connection_info")
-def test_populate_facts(m_get_aws_connection_info):
+def test_populate_params(m_get_aws_connection_info):
     module = MagicMock()
     m_get_aws_connection_info.return_value = (
         "us-east-1",
@@ -143,10 +143,18 @@ def test_populate_facts(m_get_aws_connection_info):
         "validate_certs": True,
         "version": None,
     }
-    result = s3_object.populate_facts(module)
+    result = s3_object.populate_params(module)
     for k, v in module.params.items():
         assert result[k] == v
 
+    module.params.update({"object": "example.txt", "mode": "get"})
+    result = s3_object.populate_params(module)
+    assert result["object"] == "example.txt"
+
+    module.params.update({"object": "/example.txt", "mode": "get"})
+    result = s3_object.populate_params(module)
+    assert result["object"] == "example.txt"
+
     module.params.update({"object": "example.txt", "mode": "delete"})
-    result = s3_object.populate_facts(module)
-    module.fail_json.assert_called_with(msg="Parameter obj cannot be used with mode=delete")
+    result = s3_object.populate_params(module)
+    module.fail_json.assert_called_with(msg="Parameter object cannot be used with mode=delete")


### PR DESCRIPTION
##### SUMMARY

fixes #1548 

S3 object key names should *not* include a leading `/` (https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html).  However, for historical reasons we've supported them (we just pruned them out) this pruning was dropped in 6.0.0 without warning.

For the sake of simplifying things and moving closer to the actual AWS resources, deprecate pruning out the leading `/`.  (Arbitrarily modifying inputs and resource names tends to lead to strange edge cases)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

s3_object

##### ADDITIONAL INFORMATION

Regression of https://github.com/ansible/ansible/issues/30576 / https://github.com/ansible/ansible/pull/30579