### PR TITLE
s3_object - deprecate leading slash in object keys

### DIFF
--- a/changelogs/fragments/1548-s3_object-leading-slash-deprecate.yml
+++ b/changelogs/fragments/1548-s3_object-leading-slash-deprecate.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+- s3_object - support for passing object keys with a leading ``/`` has been deprecated and will be removed in a release after 2025-12-01 (https://github.com/ansible-collections/amazon.aws/pull/1549).

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -94,8 +94,8 @@ options:
       - Object key names should not include the leading C(/), see
         U(https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-keys.html) for more
         information.
-#      - Support for passing the leading C(/) has been deprecated and will be removed
-#        in a release after 2025-12-01.
+      - Support for passing the leading C(/) has been deprecated and will be removed
+        in a release after 2025-12-01.
     type: str
   sig_v4:
     description:
@@ -1379,11 +1379,11 @@ def populate_params(module):
         if obj.startswith("/"):
             obj = obj[1:]
             variable_dict["object"] = obj
-            #  module.deprecate(
-            #      "Support for passing object key names with a leading '/' has been deprecated.",
-            #      date="2025-12-01",
-            #      collection_name="amazon.aws",
-            #  )
+            module.deprecate(
+                "Support for passing object key names with a leading '/' has been deprecated.",
+                date="2025-12-01",
+                collection_name="amazon.aws",
+            )
 
     variable_dict["validate"] = not variable_dict["ignore_nonexistent_bucket"]
     variable_dict["acl_disabled"] = False


### PR DESCRIPTION
##### SUMMARY

Deprecate support for removing leading `/` from object names

AWS APIs don't expect it to be there, pruning it may cause pain in future

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

s3_object

##### ADDITIONAL INFORMATION

Deprecation was split from #1549