### PR TITLE
add wait_for_modify_volume_complete option

### DIFF
--- a/changelogs/fragments/1558-ec2_vol-add-wait-for-modify-volume-complete.yml
+++ b/changelogs/fragments/1558-ec2_vol-add-wait-for-modify-volume-complete.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_vol - added ``wait`` and ``wait_timeout`` options (https://github.com/ansible-collections/amazon.aws/pull/1558).

--- a/changelogs/fragments/1558-ec2_vol-add-wait-for-modifyvolume-complete.yml
+++ b/changelogs/fragments/1558-ec2_vol-add-wait-for-modifyvolume-complete.yml
@@ -1,2 +1,0 @@
-minor_changes:
-- ec2_vol - added ``wait_for_modify_volume_complete`` option (https://github.com/ansible-collections/amazon.aws/pull/1558).

--- a/changelogs/fragments/1558-ec2_vol-add-wait-for-modifyvolume-complete.yml
+++ b/changelogs/fragments/1558-ec2_vol-add-wait-for-modifyvolume-complete.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_vol - added ``wait_for_modify_volume_complete`` option (https://github.com/ansible-collections/amazon.aws/pull/1558).

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -108,6 +108,7 @@ options:
     description:
       - Wait for volume modification to complete
     type: bool
+    default: false
     version_added: 6.3.0
 author:
   - "Lester Wade (@lwade)"

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -455,9 +455,7 @@ def update_volume(module, ec2_conn, volume):
                     mod_state = mod_response.get("VolumesModifications")[0].get("ModificationState")
 
                     if mod_state == "failed":
-                        module.fail_json(
-                            msg=f"Volume {volume['volume_id']} modification has failed."
-                        )
+                        module.fail_json(msg=f"Volume {volume['volume_id']} modification has failed.")
 
                     # this can take a long time, depending on how much bigger the requested volume size is
                     if _attempt > _max_attempts:
@@ -741,7 +739,7 @@ def main():
         outpost_arn=dict(type="str"),
         purge_tags=dict(type="bool", default=True),
         multi_attach=dict(type="bool"),
-        wait_for_modify_volume_complete=dict(default=False, type="bool")
+        wait_for_modify_volume_complete=dict(default=False, type="bool"),
     )
 
     module = AnsibleAWSModule(
@@ -768,7 +766,6 @@ def main():
     multi_attach = module.params.get("multi_attach")
     modify_volume = module.params.get("modify_volume")
     wait_for_modify_volume_complete = module.params.get("wait_for_modify_volume_complete")
-
 
     # Ensure we have the zone or can get the zone
     if instance is None and zone is None and state == "present":


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vol

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
I ran into the following issue when trying to modify an unattached volume: 

```paste below
boto3_version: 1.26.122
  botocore_version: 1.29.122
  error:
    code: OperationNotPermitted
    message: 'Cannot attach volume vol-02f06b9e2f1e6d1e0 when it is in modification state: MODIFYING'
  msg: 'Error while attaching EBS volume: An error occurred (OperationNotPermitted) when calling the AttachVolume operation: Cannot attach volume vol-02f06b9e2f1e6d1e0 when it is in modification state: MODIFYING'
```
There seems to be no waiter, but if we poll `describe_volumes_modifications` we can wait until `ModificationState` is `complete`.