### PR TITLE
[Manual backport to stable-6] ec2_snapshot, ec2_snapshot_info: Add support to modify snapshot share permissions (#1464)

### DIFF
--- a/changelogs/fragments/1464-ec2_snapshot-ec2_snapshot_info-support-modifying-create-volume-permissions.yml
+++ b/changelogs/fragments/1464-ec2_snapshot-ec2_snapshot_info-support-modifying-create-volume-permissions.yml
@@ -1,0 +1,3 @@
+minor_changes:
+- ec2_snapshot - Add support for modifying createVolumePermission (https://github.com/ansible-collections/amazon.aws/pull/1464).
+- ec2_snapshot_info - Add createVolumePermission to output result (https://github.com/ansible-collections/amazon.aws/pull/1464).

--- a/plugins/modules/ec2_snapshot.py
+++ b/plugins/modules/ec2_snapshot.py
@@ -70,6 +70,39 @@ options:
     required: false
     default: 0
     type: int
+  modify_create_vol_permission:
+    description:
+      - If set to C(true), ec2 snapshot's createVolumePermissions can be modified.
+    required: false
+    type: bool
+    version_added: 6.1.0
+  purge_create_vol_permission:
+    description:
+      - Whether unspecified group names or user IDs should be removed from the snapshot createVolumePermission.
+      - Must set I(modify_create_vol_permission) to C(True) for when I(purge_create_vol_permission) is set to C(True).
+    required: False
+    type: bool
+    default: False
+    version_added: 6.1.0
+  group_names:
+    description:
+      - The group to be added or removed. The possible value is C(all).
+      - Mutually exclusive with I(user_ids).
+    required: false
+    type: list
+    elements: str
+    choices: ["all"]
+    version_added: 6.1.0
+  user_ids:
+    description:
+      - The account user IDs to be added or removed.
+      - If createVolumePermission on snapshot is currently set to Public i.e. I(group_names=all),
+        providing I(user_ids) will not make createVolumePermission Private unless I(create_volume_permission) is set to C(true).
+      - Mutually exclusive with I(group_names).
+    required: false
+    type: list
+    elements: str
+    version_added: 6.1.0
 author: "Will Thames (@willthames)"
 extends_documentation_fragment:
   - amazon.aws.common.modules
@@ -106,6 +139,44 @@ EXAMPLES = r"""
 - amazon.aws.ec2_snapshot:
     volume_id: vol-abcdef12
     last_snapshot_min_age: 60
+
+- name: Reset snapshot createVolumePermission (change permission to "Private")
+  amazon.aws.ec2_snapshot:
+    snapshot_id: snap-06a6f641234567890
+    modify_create_vol_permission: true
+    purge_create_vol_permission: true
+
+- name: Modify snapshot createVolmePermission to add user IDs (specify purge_create_vol_permission=true to change permssion to "Private")
+  amazon.aws.ec2_snapshot:
+    snapshot_id: snap-06a6f641234567890
+    modify_create_vol_permission: true
+    user_ids:
+      - '123456789012'
+      - '098765432109'
+
+- name: Modify snapshot createVolmePermission - remove all except specified user_ids
+  amazon.aws.ec2_snapshot:
+    snapshot_id: snap-06a6f641234567890
+    modify_create_vol_permission: true
+    purge_create_vol_permission: true
+    user_ids:
+      - '123456789012'
+
+- name: Replace (purge existing) snapshot createVolmePermission annd add user IDs
+  amazon.aws.ec2_snapshot:
+    snapshot_id: snap-06a6f641234567890
+    modify_create_vol_permission: true
+    purge_create_vol_permission: true
+    user_ids:
+      - '111111111111'
+
+- name: Modify snapshot createVolmePermission - make createVolumePermission "Public"
+  amazon.aws.ec2_snapshot:
+    snapshot_id: snap-06a6f641234567890
+    modify_create_vol_permission: true
+    purge_create_vol_permission: true
+    group_names:
+      - all
 """
 
 RETURN = r"""
@@ -332,6 +403,109 @@ def delete_snapshot(module, ec2, snapshot_id):
     module.exit_json(changed=True)
 
 
+def _describe_snapshot_attribute(module, ec2, snapshot_id):
+    try:
+        response = ec2.describe_snapshot_attribute(Attribute="createVolumePermission", SnapshotId=snapshot_id)
+    except (
+        botocore.exceptions.BotoCoreError,
+        botocore.exceptions.ClientError,
+    ) as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Failed to describe snapshot attribute createVolumePermission")
+
+    return response["CreateVolumePermissions"]
+
+
+def build_modify_createVolumePermission_params(module):
+    snapshot_id = module.params.get("snapshot_id")
+    user_ids = module.params.get("user_ids")
+    group_names = module.params.get("group_names")
+
+    if not user_ids and not group_names:
+        module.fail_json(msg="Please provide either Group IDs or User IDs to modify permissions")
+
+    params = {
+        "Attribute": "createVolumePermission",
+        "OperationType": "add",
+        "SnapshotId": snapshot_id,
+        "GroupNames": group_names,
+        "UserIds": user_ids,
+    }
+
+    # remove empty value params
+    params = {k: v for k, v in params.items() if v}
+
+    return params
+
+
+def check_user_or_group_update_needed(module, ec2):
+    existing_create_vol_permission = _describe_snapshot_attribute(module, ec2, module.params.get("snapshot_id"))
+    purge_permission = module.params.get("purge_create_vol_permission")
+    supplied_group_names = module.params.get("group_names")
+    supplied_user_ids = module.params.get("user_ids")
+
+    # if createVolumePermission is already "Public", adding "user_ids" is not needed
+    if any(item.get("Group") == "all" for item in existing_create_vol_permission) and not purge_permission:
+        return False
+
+    if supplied_group_names:
+        existing_group_names = {item.get("Group") for item in existing_create_vol_permission or []}
+        if set(supplied_group_names) == set(existing_group_names):
+            return False
+        else:
+            return True
+
+    if supplied_user_ids:
+        existing_user_ids = {item.get("UserId") for item in existing_create_vol_permission or []}
+        if set(supplied_user_ids) == set(existing_user_ids):
+            return False
+        else:
+            return True
+
+    if purge_permission and existing_create_vol_permission == []:
+        return False
+
+    return True
+
+
+def _modify_snapshot_createVolumePermission(module, ec2, snapshot_id, purge_create_vol_permission):
+    update_needed = check_user_or_group_update_needed(module, ec2)
+
+    if not update_needed:
+        module.exit_json(changed=False, msg="Supplied CreateVolumePermission already applied, update not needed")
+
+    if purge_create_vol_permission is True:
+        _reset_snapshpot_attribute(module, ec2, snapshot_id)
+        if not module.params.get("user_ids") and not module.params.get("group_names"):
+            module.exit_json(changed=True, msg="Reset createVolumePermission successfully")
+
+    params = build_modify_createVolumePermission_params(module)
+
+    if module.check_mode:
+        module.exit_json(changed=True, msg="Would have modified CreateVolumePermission")
+
+    try:
+        ec2.modify_snapshot_attribute(**params)
+    except (
+        botocore.exceptions.BotoCoreError,
+        botocore.exceptions.ClientError,
+    ) as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Failed to modify createVolumePermission")
+
+    module.exit_json(changed=True, msg="Successfully modified CreateVolumePermission")
+
+
+def _reset_snapshpot_attribute(module, ec2, snapshot_id):
+    if module.check_mode:
+        module.exit_json(changed=True, msg="Would have reset CreateVolumePermission")
+    try:
+        response = ec2.reset_snapshot_attribute(Attribute="createVolumePermission", SnapshotId=snapshot_id)
+    except (
+        botocore.exceptions.BotoCoreError,
+        botocore.exceptions.ClientError,
+    ) as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Failed to reset createVolumePermission")
+
+
 def create_snapshot_ansible_module():
     argument_spec = dict(
         volume_id=dict(),
@@ -344,12 +518,18 @@ def create_snapshot_ansible_module():
         last_snapshot_min_age=dict(type="int", default=0),
         snapshot_tags=dict(type="dict", default=dict()),
         state=dict(choices=["absent", "present"], default="present"),
+        modify_create_vol_permission=dict(type="bool"),
+        purge_create_vol_permission=dict(type="bool", default=False),
+        user_ids=dict(type="list", elements="str"),
+        group_names=dict(type="list", elements="str", choices=["all"]),
     )
     mutually_exclusive = [
         ("instance_id", "snapshot_id", "volume_id"),
+        ("group_names", "user_ids"),
     ]
     required_if = [
         ("state", "absent", ("snapshot_id",)),
+        ("purge_create_vol_permission", True, ("modify_create_vol_permission",)),
     ]
     required_one_of = [
         ("instance_id", "snapshot_id", "volume_id"),
@@ -383,6 +563,8 @@ def main():
     last_snapshot_min_age = module.params.get("last_snapshot_min_age")
     snapshot_tags = module.params.get("snapshot_tags")
     state = module.params.get("state")
+    modify_create_vol_permission = module.params.get("modify_create_vol_permission")
+    purge_create_vol_permission = module.params.get("purge_create_vol_permission")
 
     ec2 = module.client("ec2", retry_decorator=AWSRetry.jittered_backoff(retries=10))
 
@@ -392,7 +574,9 @@ def main():
             ec2=ec2,
             snapshot_id=snapshot_id,
         )
-    else:
+    elif modify_create_vol_permission is True:
+        _modify_snapshot_createVolumePermission(module, ec2, snapshot_id, purge_create_vol_permission)
+    elif state == "present":
         create_snapshot(
             module=module,
             description=description,

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -194,6 +194,13 @@ snapshots:
             type: str
             returned: always
             sample: "arn:aws:kms:ap-southeast-2:123456789012:key/74c9742a-a1b2-45cb-b3fe-abcdef123456"
+        create_volume_permissions:
+            description:
+              - The users and groups that have the permissions for creating volumes from the snapshot.
+              - The module will return empty list if the create volume permissions on snapshot are 'private'.
+            type: list
+            elements: dict
+            sample: [{"group": "all"}]
 next_token_id:
     description:
     - Contains the value returned from a previous paginated request where C(max_results) was used and the results exceeded the value of that parameter.
@@ -203,7 +210,7 @@ next_token_id:
 """
 
 try:
-    from botocore.exceptions import ClientError
+    from botocore.exceptions import BotoCoreError, ClientError
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
@@ -232,7 +239,7 @@ def build_request_args(snapshot_ids, owner_ids, restorable_by_user_ids, filters,
 
 
 def get_snapshots(connection, module, request_args):
-    snapshot_ids = request_args.get("snapshot_ids")
+    snapshot_ids = request_args.get("SnapshotIds")
     try:
         snapshots = connection.describe_snapshots(aws_retry=True, **request_args)
     except is_boto3_error_code("InvalidSnapshot.NotFound") as e:
@@ -243,6 +250,15 @@ def get_snapshots(connection, module, request_args):
     return snapshots
 
 
+def _describe_snapshot_attribute(module, ec2, snapshot_id):
+    try:
+        response = ec2.describe_snapshot_attribute(Attribute="createVolumePermission", SnapshotId=snapshot_id)
+    except (BotoCoreError, ClientError) as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Failed to describe snapshot attribute createVolumePermission")
+
+    return response["CreateVolumePermissions"]
+
+
 def list_ec2_snapshots(connection, module, request_args):
     try:
         snapshots = get_snapshots(connection, module, request_args)
@@ -250,6 +266,13 @@ def list_ec2_snapshots(connection, module, request_args):
         module.fail_json_aws(e, msg="Failed to describe snapshots")
 
     result = {}
+
+    # Add createVolumePermission info to snapshots result
+    for snapshot in snapshots["Snapshots"]:
+        snapshot_id = snapshot.get("SnapshotId")
+        create_vol_permission = _describe_snapshot_attribute(module, connection, snapshot_id)
+        snapshot["CreateVolumePermissions"] = create_vol_permission
+
     # Turn the boto3 result in to ansible_friendly_snaked_names
     snaked_snapshots = []
     for snapshot in snapshots["Snapshots"]:

--- a/tests/integration/targets/ec2_snapshot/tasks/main.yml
+++ b/tests/integration/targets/ec2_snapshot/tasks/main.yml
@@ -26,6 +26,9 @@
       aws_az_info:
       register: azs
 
+    - name: Run tasks for testing snapshot createVolumePermissions modifications
+      import_tasks: test_modify_create_volume_permissions.yml
+
     # Create a new volume in detached mode without tags
     - name: Create a detached volume without tags
       ec2_vol:

--- a/tests/integration/targets/ec2_snapshot/tasks/test_modify_create_volume_permissions.yml
+++ b/tests/integration/targets/ec2_snapshot/tasks/test_modify_create_volume_permissions.yml
@@ -1,0 +1,454 @@
+---
+# Setup for this task =================================
+- name: Tests relating to createVolumePermission
+  block:
+    - name: Create a volume
+      ec2_vol:
+        volume_size: 1
+        zone: '{{ azs.availability_zones[0].zone_name }}'
+      register: create_vol_result
+
+    - set_fact:
+        volume_id: "{{ create_vol_result.volume_id }}"
+
+    - name: Take snapshot of volume
+      ec2_snapshot:
+        volume_id: '{{ volume_id }}'
+        snapshot_tags:
+          Name: 'mandkulk-test-modify-test-snap'
+      register: create_snapshot_result
+
+    - set_fact:
+        snapshot_id: "{{ create_snapshot_result.snapshot_id }}"
+
+
+  # Run Tests ============================================
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+
+    - name: assert that createVolumePermission are "Private"
+      assert:
+        that:
+          - info_result.snapshots[0].create_volume_permissions | length == 0
+
+  # Update Permissions to add user_ids --------------------------------------------------------
+    - name: Modify snapshot createVolmePermission - ADD new user_ids - check_mode
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        user_ids:
+          - '111111111111'
+          - '222222222222'
+        wait: true
+      register: update_permission_result
+      check_mode: true
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+
+    - assert:
+        that:
+          - update_permission_result is changed
+          - update_permission_result is not failed
+          - info_result.snapshots[0].create_volume_permissions | length == 0
+
+    - name: Modify snapshot createVolmePermission - ADD new user_ids
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        user_ids:
+          - '111111111111'
+          - '222222222222'
+        wait: true
+      register: update_permission_result
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is changed
+          - update_permission_result is not failed
+          - permissions_list | length == 2
+          - '"111111111111" in permissions_list'
+          - '"222222222222" in permissions_list'
+
+    - name: Modify snapshot createVolmePermission - ADD new user_ids - idempotent
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        user_ids:
+          - '111111111111'
+          - '222222222222'
+        wait: true
+      register: update_permission_result
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is not changed
+          - update_permission_result is not failed
+          - permissions_list | length == 2
+
+    - name: Modify snapshot createVolmePermission - ADD new user_ids - idempotent - check_mode
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        user_ids:
+          - '111111111111'
+          - '222222222222'
+        wait: true
+      register: update_permission_result
+      check_mode: true
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is not changed
+          - update_permission_result is not failed
+          - permissions_list | length == 2
+
+  # Update Permissions to remove user_id --------------------------------------------------------
+    - name: Modify snapshot createVolmePermission - remove user_id - check_mode
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        purge_create_vol_permission: true
+        user_ids:
+          - '111111111111'
+        wait: true
+      register: update_permission_result
+      check_mode: true
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+
+    - assert:
+        that:
+          - update_permission_result is changed
+          - update_permission_result is not failed
+          - info_result.snapshots[0].create_volume_permissions | length == 2
+
+    - name: Modify snapshot createVolmePermission - remove user_id
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        purge_create_vol_permission: true
+        user_ids:
+          - '222222222222'
+        wait: true
+      register: update_permission_result
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is changed
+          - update_permission_result is not failed
+          - permissions_list | length == 1
+          - '"111111111111" not in permissions_list'
+          - '"222222222222" in permissions_list'
+
+    - name: Modify snapshot createVolmePermission - remove user_id - idempotent
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        purge_create_vol_permission: true
+        user_ids:
+          - '222222222222'
+        wait: true
+      register: update_permission_result
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is not changed
+          - update_permission_result is not failed
+          - permissions_list | length == 1
+
+    - name: Modify snapshot createVolmePermission - remove user_id - idempotent - check_mode
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        purge_create_vol_permission: true
+        user_ids:
+          - '222222222222'
+        wait: true
+      register: update_permission_result
+      check_mode: true
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is not changed
+          - update_permission_result is not failed
+          - permissions_list | length == 1
+
+  # Update Permissions to Public --------------------------------------------------------
+    - name: Modify snapshot createVolmePermission - add group_names 'all' - check_mode
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        purge_create_vol_permission: true
+        group_names:
+          - 'all'
+        wait: true
+      register: update_permission_result
+      check_mode: true
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is changed
+          - update_permission_result is not failed
+          - info_result.snapshots[0].create_volume_permissions | length == 1
+          - '"222222222222" in permissions_list'
+
+    - name: Modify snapshot createVolmePermission - add group_names 'all'
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        purge_create_vol_permission: true
+        group_names:
+          - 'all'
+        wait: true
+      register: update_permission_result
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='group') | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is changed
+          - update_permission_result is not failed
+          - permissions_list | length == 1
+          - '"222222222222" not in permissions_list'
+          - '"all" in permissions_list'
+
+    - name: Modify snapshot createVolmePermission - add group_names 'all' - idempotent
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        purge_create_vol_permission: true
+        group_names:
+          - 'all'
+        wait: true
+      register: update_permission_result
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='group') | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is not changed
+          - update_permission_result is not failed
+          - permissions_list | length == 1
+          - '"222222222222" not in permissions_list'
+          - '"all" in permissions_list'
+
+    - name: Modify snapshot createVolmePermission - add group_names 'all' - idempotent - check_mode
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        purge_create_vol_permission: true
+        group_names:
+          - 'all'
+        wait: true
+      register: update_permission_result
+      check_mode: true
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='group') | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is not changed
+          - update_permission_result is not failed
+          - permissions_list | length == 1
+          - '"222222222222" not in permissions_list'
+          - '"all" in permissions_list'
+
+  # Reset Permissions to Private --------------------------------------------------------
+    - name: Modify snapshot createVolmePermission - RESET to 'private' - check_mode
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        purge_create_vol_permission: true
+        wait: true
+      register: update_permission_result
+      check_mode: true
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='group') | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is changed
+          - update_permission_result is not failed
+          - permissions_list | length == 1
+          - '"222222222222" not in permissions_list'
+          - '"all" in permissions_list'
+
+    - name: Modify snapshot createVolmePermission - RESET to 'private'
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        purge_create_vol_permission: true
+        wait: true
+      register: update_permission_result
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is changed
+          - update_permission_result is not failed
+          - permissions_list | length == 0
+          - '"222222222222" not in permissions_list'
+          - '"all" not in permissions_list'
+
+    - name: Modify snapshot createVolmePermission - RESET to 'private' - idempotent
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        purge_create_vol_permission: true
+        wait: true
+      register: update_permission_result
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is not changed
+          - update_permission_result is not failed
+          - permissions_list | length == 0
+          - '"222222222222" not in permissions_list'
+          - '"all" not in permissions_list'
+
+    - name: Modify snapshot createVolmePermission - RESET to 'private' - idempotent - check_mode
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        modify_create_vol_permission: true
+        purge_create_vol_permission: true
+        wait: true
+      register: update_permission_result
+      check_mode: true
+
+    - name: Get current createVolumePermission
+      ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ snapshot_id }}"
+      register: info_result
+    - set_fact:
+        permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | list }}"
+
+    - assert:
+        that:
+          - update_permission_result is not changed
+          - update_permission_result is not failed
+          - permissions_list | length == 0
+          - '"222222222222" not in permissions_list'
+          - '"all" not in permissions_list'
+
+# Teardown for this task ===============================
+  always:
+
+  - name: Delete snapshot
+    ec2_snapshot:
+      snapshot_id: "{{ snapshot_id }}"
+      state: absent
+    ignore_errors: true
+
+  - name: Delete volume
+    ec2_vol:
+      id: "{{ volume_id }}"
+      state: absent
+    ignore_errors: true


### PR DESCRIPTION
[Manual backport to stable-6] ec2_snapshot, ec2_snapshot_info: Add support to modify snapshot share permissions (#1464)

SUMMARY


Add support for modifying and resetting snapshot share permissions (createVolumePermissions) of a ec2 snapshot to amazon.aws.ec2_snapshot. Add ec2 snapshot's snapshot share permissions (createVolumePermissions) to return value of amazon.aws.ec2_snapshot_info.


ISSUE TYPE


Feature Pull Request

COMPONENT NAME

amazon.aws.ec2_snapshot
amazon.aws.ec2_snapshot_info
ADDITIONAL INFORMATION


API references

describe_snapshot_attribute
modify_snapshot_attribute
reset_snapshot_attribute

Reviewed-by: Mark Chappell
Reviewed-by: Alina Buzachis
Reviewed-by: Mike Graves <mgraves@redhat.com>
Reviewed-by: Mandar Kulkarni <mandar242@gmail.com>

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
