### PR TITLE
ACMServiceManager.list_certificates_with_backoff: explicit key type filter added

### DIFF
--- a/changelogs/fragments/1567-list-certificate-all-key-types.yml
+++ b/changelogs/fragments/1567-list-certificate-all-key-types.yml
@@ -1,2 +1,2 @@
 bugfixes:
-- acm - fixes list_certificates returning only RSA_2048 certificates
+- module_utils.acm - fixes list_certificates returning only RSA_2048 certificates (https://github.com/ansible-collections/amazon.aws/issues/1567).

--- a/changelogs/fragments/1567-list-certificate-all-key-types.yml
+++ b/changelogs/fragments/1567-list-certificate-all-key-types.yml
@@ -1,3 +1,2 @@
 bugfixes:
 - acm - fixes list_certificates returning only RSA_2048 certificates
-

--- a/changelogs/fragments/1567-list-certificate-all-key-types.yml
+++ b/changelogs/fragments/1567-list-certificate-all-key-types.yml
@@ -1,0 +1,3 @@
+bugfixes:
+- acm - fixes list_certificates returning only RSA_2048 certificates
+

--- a/plugins/module_utils/acm.py
+++ b/plugins/module_utils/acm.py
@@ -63,7 +63,15 @@ class ACMServiceManager:
     @AWSRetry.jittered_backoff(delay=5, catch_extra_error_codes=["RequestInProgressException"])
     def list_certificates_with_backoff(self, statuses=None):
         paginator = self.client.get_paginator("list_certificates")
-        kwargs = dict()
+        # `list_certificates` requires explicit key type filter, or it returns only RSA_2048 certificates
+        kwargs = {
+            "Includes": {
+                "keyTypes": [
+                    "RSA_1024", "RSA_2048", "RSA_3072", "RSA_4096",
+                    "EC_prime256v1", "EC_secp384r1", "EC_secp521r1",
+                ],
+            },
+        }
         if statuses:
             kwargs["CertificateStatuses"] = statuses
         return paginator.paginate(**kwargs).build_full_result()["CertificateSummaryList"]

--- a/plugins/module_utils/acm.py
+++ b/plugins/module_utils/acm.py
@@ -67,8 +67,13 @@ class ACMServiceManager:
         kwargs = {
             "Includes": {
                 "keyTypes": [
-                    "RSA_1024", "RSA_2048", "RSA_3072", "RSA_4096",
-                    "EC_prime256v1", "EC_secp384r1", "EC_secp521r1",
+                    "RSA_1024",
+                    "RSA_2048",
+                    "RSA_3072",
+                    "RSA_4096",
+                    "EC_prime256v1",
+                    "EC_secp384r1",
+                    "EC_secp521r1",
                 ],
             },
         }


### PR DESCRIPTION
##### SUMMARY

Fixes #1567

[ACM.Client.list_certificates](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/acm/client/list_certificates.html#ACM.Client.list_certificates) requires explicit certificate type filter in order to return the non-RSA_2048 certificates too, and this is needed to ensure the idempotency of importing such certificates.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
acm

