### PR TITLE
feat: add mq inventory plugin; addresses #1571

### DIFF
--- a/plugins/inventory/aws_mq.py
+++ b/plugins/inventory/aws_mq.py
@@ -1,0 +1,282 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2023 Ansible Project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+name: aws_mq
+short_description: MQ broker inventory source
+description:
+  - Get brokers from Amazon Web Services MQ.
+  - Uses a YAML configuration file that ends with aws_mq.(yml|yaml).
+options:
+  regions:
+    description:
+      - A list of regions in which to describe MQ brokers. Available regions are listed here
+        U(https://aws.amazon.com/about-aws/global-infrastructure/regional-product-services/)
+    type: list
+    elements: str
+    default: []
+  strict_permissions:
+    description: By default if an AccessDenied exception is encountered this plugin will fail. You can set strict_permissions to
+      False in the inventory config file which will allow the restrictions to be gracefully skipped.
+    type: bool
+    default: True
+  statuses:
+    description:
+      - A list of desired states for brokers to be added to inventory. Set to ['all'] as a shorthand to find everything.
+        Possible value are listed here U(https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/broker-statuses.html)
+    type: list
+    elements: str
+    default:
+      - RUNNING
+      - CREATION_IN_PROGRESS
+  hostvars_prefix:
+    description:
+      - The prefix for host variables names coming from AWS.
+    type: str
+  hostvars_suffix:
+    description:
+      - The suffix for host variables names coming from AWS.
+    type: str
+notes:
+  - Ansible versions prior to 2.10 should use the fully qualified plugin name 'amazon.aws.aws_mq'.
+extends_documentation_fragment:
+  - inventory_cache
+  - constructed
+  - amazon.aws.boto3
+  - amazon.aws.common.plugins
+  - amazon.aws.region.plugins
+  - amazon.aws.assume_role.plugins
+author:
+  - Ali AlKhalidi (@doteast)
+"""
+
+EXAMPLES = r"""
+plugin: aws_mq
+regions:
+  - ca-central-1
+keyed_groups:
+  - key: engine_type
+    prefix: mq
+compose:
+  app: 'tags.Applications|split(",")'
+hostvars_prefix: aws_
+hostvars_suffix: _mq
+"""
+
+try:
+    import botocore
+except ImportError:
+    pass  # will be captured by imported HAS_BOTO3
+
+from ansible.errors import AnsibleError
+from ansible.module_utils._text import to_native
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AWSInventoryBase
+
+broker_attr = [
+    "MaintenanceWindowStartTime",
+    "AutoMinorVersionUpgrade",
+    "AuthenticationStrategy",
+    "PubliclyAccessible",
+    "EncryptionOptions",
+    "HostInstanceType",
+    "BrokerInstances",
+    "SecurityGroups",
+    "DeploymentMode",
+    "EngineVersion",
+    "StorageType",
+    "BrokerState",
+    "EngineType",
+    "SubnetIds",
+    "BrokerArn",
+    "BrokerId",
+    "Created",
+    "Logs",
+]
+
+inventory_group = "aws_mq"
+
+
+def _find_hosts_matching_statuses(hosts, statuses):
+    if not statuses:
+      statuses = ["RUNNING", "CREATION_IN_PROGRESS"]
+    if "all" in statuses:
+        return hosts
+    valid_hosts = []
+    for host in hosts:
+        if host.get("BrokerState") in statuses:
+            valid_hosts.append(host)
+    return valid_hosts
+
+def _get_mq_hostname(host):
+    if host.get("BrokerName"):
+        return host["BrokerName"]
+
+def _get_broker_host_tags(detail):
+    tags = []
+    if "Tags" in detail:
+        for key, value in detail["Tags"].items():
+            tags.append({"Key": key, "Value": value})
+    return tags
+
+def _add_details_to_hosts(connection, hosts, strict):
+    for host in hosts:
+        detail=None
+        resource_id = host["BrokerId"]
+        try:
+            detail = connection.describe_broker(BrokerId=resource_id)
+        except is_boto3_error_code("AccessDenied") as e:
+            if not strict:
+                pass
+            else:
+                raise AnsibleError(f"Failed to query MQ: {to_native(e)}")
+        except (
+            botocore.exceptions.BotoCoreError,
+            botocore.exceptions.ClientError,
+        ) as e:  # pylint: disable=duplicate-except
+            raise AnsibleError(f"Failed to query MQ: {to_native(e)}")
+
+        if detail:
+            # special handling of tags
+            host['Tags'] = _get_broker_host_tags(detail)
+
+            # collect rest of attributes
+            for attr in broker_attr:
+                if attr in detail:
+                    host[attr] = detail[attr]
+
+class InventoryModule(AWSInventoryBase):
+
+    NAME = "amazon.aws.aws_mq"
+    INVENTORY_FILE_SUFFIXES = ("aws_mq.yml", "aws_mq.yaml")
+
+    def __init__(self):
+        super(InventoryModule, self).__init__()
+
+    def _get_broker_hosts(self, connection, strict):
+
+        def _boto3_paginate_wrapper(func, *args, **kwargs):
+            results = []
+            try:
+                results = func(*args, **kwargs)
+                results = results["BrokerSummaries"]
+                _add_details_to_hosts(connection, results, strict)
+            except is_boto3_error_code("AccessDenied") as e:  # pylint: disable=duplicate-except
+                if not strict:
+                    results = []
+                else:
+                    raise AnsibleError(f"Failed to query MQ: {to_native(e)}")
+            except (
+                botocore.exceptions.ClientError,
+                botocore.exceptions.BotoCoreError,
+             ) as e:  # pylint: disable=duplicate-except
+                raise AnsibleError(f"Failed to query MQ: {to_native(e)}")
+            return results
+        return _boto3_paginate_wrapper
+
+    def _get_all_hosts(self, regions, strict, statuses):
+        """
+        :param regions: a list of regions in which to describe hosts
+        :param strict: a boolean determining whether to fail or ignore 403 error codes
+        :param statuses: a list of statuses that the returned hosts should match
+        :return A list of host dictionaries
+        """
+        all_instances = []
+
+        for connection, _region in self.all_clients("mq"):
+            paginator = connection.get_paginator("list_brokers")
+            all_instances.extend(
+                self._get_broker_hosts(connection, strict)
+                (paginator.paginate().build_full_result)
+            )
+        sorted_hosts = list(
+            sorted(all_instances, key=lambda x: x["BrokerName"])
+        )
+        return _find_hosts_matching_statuses(sorted_hosts, statuses)
+
+    def _populate_from_cache(self, cache_data):
+        hostvars = cache_data.pop("_meta", {}).get("hostvars", {})
+        for group in cache_data:
+            if group == "all":
+                continue
+            self.inventory.add_group(group)
+            hosts = cache_data[group].get("hosts", [])
+            for host in hosts:
+                self._populate_host_vars([host], hostvars.get(host, {}), group)
+            self.inventory.add_child("all", group)
+
+    def _populate(self, hosts):
+        group = inventory_group
+        self.inventory.add_group(group)
+        if hosts:
+            self._add_hosts(
+                hosts=hosts,
+                group=group
+            )
+            self.inventory.add_child("all", group)
+
+    def _format_inventory(self, hosts):
+        results = {"_meta": {"hostvars": {}}}
+        group = inventory_group
+        results[group] = {"hosts": []}
+        for host in hosts:
+            hostname = _get_mq_hostname(host)
+            results[group]["hosts"].append(hostname)
+            h = self.inventory.get_host(hostname)
+            results["_meta"]['hostvars'][h.name] = h.vars
+        return results
+
+    def _add_hosts(self, hosts, group):
+        """
+        :param hosts: a list of hosts to add to the group
+        :param group: name of the group the host list belongs to
+        """
+        for host in hosts:
+            hostname = _get_mq_hostname(host)
+            host = camel_dict_to_snake_dict(host, ignore_list=["Tags", "EngineType"])
+            host["tags"] = boto3_tag_list_to_ansible_dict(host.get("tags", []))
+            if host.get("engine_type"):
+              # align value with API spec of all upper
+              host["engine_type"] = host.get("engine_type", "").upper()
+
+            self.inventory.add_host(hostname, group=group)
+            new_vars = dict()
+            hostvars_prefix = self.get_option("hostvars_prefix")
+            hostvars_suffix = self.get_option("hostvars_suffix")
+            for hostvar, hostval in host.items():
+                if hostvars_prefix:
+                    hostvar = hostvars_prefix + hostvar
+                if hostvars_suffix:
+                    hostvar = hostvar + hostvars_suffix
+                new_vars[hostvar] = hostval
+                self.inventory.set_variable(hostname, hostvar, hostval)
+            host.update(new_vars)
+
+            strict = self.get_option("strict")
+            self._set_composite_vars(self.get_option("compose"), host, hostname, strict=strict)
+            self._add_host_to_composed_groups(self.get_option("groups"), host, hostname, strict=strict)
+            self._add_host_to_keyed_groups(self.get_option("keyed_groups"), host, hostname, strict=strict)
+
+    def parse(self, inventory, loader, path, cache=True):
+        super().parse(inventory, loader, path, cache=cache)
+
+        # get user specifications
+        regions = self.get_option("regions")
+        strict_permissions = self.get_option("strict_permissions")
+        statuses = self.get_option("statuses")
+
+        result_was_cached, results = self.get_cached_result(path, cache)
+        if result_was_cached:
+          self._populate_from_cache(results)
+          return
+
+        results = self._get_all_hosts(regions, strict_permissions, statuses)
+        self._populate(results)
+
+        formatted_inventory = self._format_inventory(results)
+        self.update_cached_result(path, cache, formatted_inventory)

--- a/tests/integration/targets/inventory_aws_mq/aliases
+++ b/tests/integration/targets/inventory_aws_mq/aliases
@@ -1,0 +1,2 @@
+time=10m
+cloud/aws

--- a/tests/integration/targets/inventory_aws_mq/meta/main.yml
+++ b/tests/integration/targets/inventory_aws_mq/meta/main.yml
@@ -1,0 +1,1 @@
+dependencies: []

--- a/tests/integration/targets/inventory_aws_mq/playbooks/create_inventory_config.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/create_inventory_config.yml
@@ -1,0 +1,16 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+
+  vars:
+    template_name: "../templates/{{ template | default('inventory.j2') }}"
+
+  vars_files:
+    - vars/main.yml
+
+  tasks:
+    - name: write inventory config file
+      copy:
+        dest: ../test.aws_mq.yml
+        content: "{{ lookup('template', template_name) }}"

--- a/tests/integration/targets/inventory_aws_mq/playbooks/empty_inventory_config.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/empty_inventory_config.yml
@@ -1,0 +1,9 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+  tasks:
+    - name: write inventory config file
+      copy:
+        dest: ../test.aws_mq.yml
+        content: ""

--- a/tests/integration/targets/inventory_aws_mq/playbooks/populate_cache.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/populate_cache.yml
@@ -1,0 +1,40 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+
+  environment: "{{ ansible_test.environment }}"
+
+  collections:
+    - amazon.aws
+    - community.aws
+
+  vars_files:
+    - vars/main.yml
+
+  # Toggle between the next two blocks, to run the tests with mq modules
+  # from community.aws >= 6.0.0 or command module
+  # module_defaults:
+  #   group/aws:
+  #     aws_access_key: '{{ aws_access_key }}'
+  #     aws_secret_key: '{{ aws_secret_key }}'
+  #     security_token: '{{ security_token | default(omit) }}'
+  #     region: '{{ aws_region }}'
+  environment:
+    AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
+    AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
+    AWS_DEFAULT_REGION: '{{ aws_region }}'
+
+  tasks:
+    - name: refresh inventory to populate cache
+      meta: refresh_inventory
+
+    - name: assert group was populated with inventory but is empty
+      assert:
+        that:
+          - "'aws_mq' in groups"
+          - "groups.aws_mq | length == 1"
+
+    - name: Delete MQ instance
+      include_tasks: tasks/mq_instance_delete_cmd.yml
+      # include_tasks: tasks/mq_instance_delete.yml

--- a/tests/integration/targets/inventory_aws_mq/playbooks/populate_cache.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/populate_cache.yml
@@ -3,7 +3,13 @@
   connection: local
   gather_facts: no
 
-  environment: "{{ ansible_test.environment }}"
+  vars:
+    env_vars:
+      AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
+      AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
+      AWS_DEFAULT_REGION: '{{ aws_region }}'
+
+  environment: "{{ ansible_test.environment | combine(env_vars) }}"
 
   collections:
     - amazon.aws
@@ -11,19 +17,6 @@
 
   vars_files:
     - vars/main.yml
-
-  # Toggle between the next two blocks, to run the tests with mq modules
-  # from community.aws >= 6.0.0 or command module
-  # module_defaults:
-  #   group/aws:
-  #     aws_access_key: '{{ aws_access_key }}'
-  #     aws_secret_key: '{{ aws_secret_key }}'
-  #     security_token: '{{ security_token | default(omit) }}'
-  #     region: '{{ aws_region }}'
-  environment:
-    AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
-    AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
-    AWS_DEFAULT_REGION: '{{ aws_region }}'
 
   tasks:
     - name: refresh inventory to populate cache

--- a/tests/integration/targets/inventory_aws_mq/playbooks/populate_cache.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/populate_cache.yml
@@ -8,6 +8,7 @@
       AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
       AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
       AWS_DEFAULT_REGION: '{{ aws_region }}'
+      AWS_SECURITY_TOKEN: '{{ security_token }}'
 
   environment: "{{ ansible_test.environment | combine(env_vars) }}"
 

--- a/tests/integration/targets/inventory_aws_mq/playbooks/setup_instance.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/setup_instance.yml
@@ -3,7 +3,14 @@
   connection: local
   gather_facts: no
 
-  environment: "{{ ansible_test.environment }}"
+  vars:
+    env_vars:
+      AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
+      AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
+      AWS_DEFAULT_REGION: '{{ aws_region }}'
+      AWS_SECURITY_TOKEN: '{{ security_token }}'
+
+  environment: "{{ ansible_test.environment | combine(env_vars) }}"
 
   collections:
     - amazon.aws
@@ -11,19 +18,6 @@
 
   vars_files:
     - vars/main.yml
-
-  # Toggle between the next two blocks, to run the tests with mq modules
-  # from community.aws >= 6.0.0 or command module
-  # module_defaults:
-  #   group/aws:
-  #     aws_access_key: '{{ aws_access_key }}'
-  #     aws_secret_key: '{{ aws_secret_key }}'
-  #     security_token: '{{ security_token | default(omit) }}'
-  #     region: '{{ aws_region }}'
-  environment:
-    AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
-    AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
-    AWS_DEFAULT_REGION: '{{ aws_region }}'
 
   tasks:
     # Toggle between the following blocks, to run the tests with mq modules

--- a/tests/integration/targets/inventory_aws_mq/playbooks/setup_instance.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/setup_instance.yml
@@ -1,0 +1,33 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+
+  environment: "{{ ansible_test.environment }}"
+
+  collections:
+    - amazon.aws
+    - community.aws
+
+  vars_files:
+    - vars/main.yml
+
+  # Toggle between the next two blocks, to run the tests with mq modules
+  # from community.aws >= 6.0.0 or command module
+  # module_defaults:
+  #   group/aws:
+  #     aws_access_key: '{{ aws_access_key }}'
+  #     aws_secret_key: '{{ aws_secret_key }}'
+  #     security_token: '{{ security_token | default(omit) }}'
+  #     region: '{{ aws_region }}'
+  environment:
+    AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
+    AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
+    AWS_DEFAULT_REGION: '{{ aws_region }}'
+
+  tasks:
+    # Toggle between the following blocks, to run the tests with mq modules
+    # from community.aws >= 6.0.0 or command module
+    # - include_tasks: 'tasks/get_aws_defaults.yml'
+    # - include_tasks: 'tasks/mq_instance_{{ operation }}.yml'
+    - include_tasks: 'tasks/mq_instance_{{ operation }}_cmd.yml'

--- a/tests/integration/targets/inventory_aws_mq/playbooks/tasks/find_broker.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/tasks/find_broker.yml
@@ -1,0 +1,13 @@
+---
+- name: List brokers
+  command: >
+    aws mq  list-brokers
+  register: list_result
+
+- name: Find broker by name, if exists
+  set_fact:
+    broker_exists: "{{ ( broker_name in broker_name_list ) | bool }}"
+    broker_id: "{{ (broker_entry | first)['BrokerId'] | default('', true) }}"
+  vars:
+    broker_name_list: "{{ list_result.stdout | from_json | json_query('BrokerSummaries') | map(attribute='BrokerName') }}"
+    broker_entry: "{{ list_result.stdout | from_json | json_query('BrokerSummaries') | selectattr('BrokerName', '==', broker_name) }}"

--- a/tests/integration/targets/inventory_aws_mq/playbooks/tasks/get_aws_defaults.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/tasks/get_aws_defaults.yml
@@ -1,0 +1,14 @@
+---
+- amazon.aws.ec2_vpc_net_info:
+    filters:
+      "is-default": true
+  register: default_vpc_info
+- set_fact:
+    default_vpc: "{{ default_vpc_info.vpcs | map(attribute='id') }}"
+
+- amazon.aws.ec2_security_group_info:
+    filters:
+      vpc-id: "{{ default_vpc }}"
+  register: default_security_group_info
+- set_fact:
+    default_security_groups: "{{ default_security_group_info.security_groups | map(attribute='group_id')  }}"

--- a/tests/integration/targets/inventory_aws_mq/playbooks/tasks/mq_instance_create.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/tasks/mq_instance_create.yml
@@ -1,0 +1,10 @@
+---
+- name: Create minimal MQ instance in default VPC and default subnet group
+  community.aws.mq_broker:
+    tags: "{{ resource_tags | default(omit) }}"
+    state: present
+    engine_type: "{{ engine }}"
+    broker_name: '{{ broker_name }}'
+    security_groups: "{{ default_security_groups }}"
+    host_instance_type: 'mq.t3.micro'
+  register: result

--- a/tests/integration/targets/inventory_aws_mq/playbooks/tasks/mq_instance_create_cmd.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/tasks/mq_instance_create_cmd.yml
@@ -1,0 +1,26 @@
+---
+- include_tasks: find_broker.yml
+- block:
+  - name: Get engine versions
+    command: >
+      aws mq  describe-broker-engine-types --engine {{ engine }}
+    register: describe_engine_result
+
+  - name: Select latest engine version
+    set_fact:
+      engine_version: "{{ describe_engine_result.stdout | from_json | json_query('BrokerEngineTypes[0].EngineVersions') | map(attribute='Name') | sort | max }}"
+
+  - name: Create minimal MQ instance in default VPC and default subnet group
+    command: >
+      aws mq create-broker
+        --broker-name {{ broker_name }}
+        --deployment-mode SINGLE_INSTANCE
+        --engine-type {{ engine }}
+        --engine-version {{ engine_version }}
+        {% if resource_tags is defined %}--tags '{{ resource_tags | to_json }}'{% endif %}
+        --host-instance-type mq.t3.micro
+        --users=ConsoleAccess=True,Groups=admin,Password=aODvFQAt4tt1W,Username=master
+        --auto-minor-version-upgrade
+        --no-publicly-accessible
+  when:
+    - not broker_exists

--- a/tests/integration/targets/inventory_aws_mq/playbooks/tasks/mq_instance_delete.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/tasks/mq_instance_delete.yml
@@ -1,0 +1,13 @@
+---
+- name: remove broker instance
+  community.aws.mq_broker:
+    state: absent
+    engine_type: "{{ engine }}"
+    broker_name: '{{ broker_name }}'
+  register: delete_result
+  failed_when:
+    - delete_result.get('failed',false)
+    - (delete_result.get('message','')).find('be deleted while in state [CREATION_IN_PROGRESS]') == -1
+  until: (delete_result.get('message','')).find('be deleted while in state [CREATION_IN_PROGRESS]') == -1
+  retries: 150
+  delay:   60

--- a/tests/integration/targets/inventory_aws_mq/playbooks/tasks/mq_instance_delete_cmd.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/tasks/mq_instance_delete_cmd.yml
@@ -1,0 +1,17 @@
+---
+- include_tasks: find_broker.yml
+- name: remove broker instance
+  command: >
+    aws mq delete-broker --broker-id {{ broker_id }}
+  register: delete_broker_result
+  failed_when:
+    - delete_broker_result.failed
+    - >
+      'be deleted while in state [CREATION_IN_PROGRESS]' not in delete_broker_result.stderr and 'Cannot find broker ID' not in delete_broker_result.stderr
+  until:
+    - >
+      'be deleted while in state [CREATION_IN_PROGRESS]' not in delete_broker_result.stderr or 'Cannot find broker ID' in delete_broker_result.stderr
+  retries: 160
+  delay: 60
+  when:
+    - broker_exists

--- a/tests/integration/targets/inventory_aws_mq/playbooks/test_invalid_aws_mq_inventory_config.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/test_invalid_aws_mq_inventory_config.yml
@@ -1,0 +1,9 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+  tasks:
+    - name: assert inventory was not populated by aws_mq inventory plugin
+      assert:
+        that:
+          - "'aws_mq' not in groups"

--- a/tests/integration/targets/inventory_aws_mq/playbooks/test_inventory_cache.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/test_inventory_cache.yml
@@ -1,0 +1,18 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+  tasks:
+    - name: assert cache was used to populate inventory
+      assert:
+        that:
+          - "'aws_mq' in groups"
+          - "groups.aws_mq | length == 1"
+
+    - meta: refresh_inventory
+
+    - name: assert refresh_inventory updated the cache
+      assert:
+        that:
+          - "'aws_mq' in groups"
+          - "not groups.aws_mq"

--- a/tests/integration/targets/inventory_aws_mq/playbooks/test_inventory_no_hosts.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/test_inventory_no_hosts.yml
@@ -1,0 +1,14 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+  environment: "{{ ansible_test.environment }}"
+  collections:
+    - amazon.aws
+    - community.aws
+  tasks:
+    - name: assert group was populated with inventory but is empty
+      assert:
+        that:
+          - "'aws_mq' in groups"
+          - "not groups.aws_mq"

--- a/tests/integration/targets/inventory_aws_mq/playbooks/test_inventory_no_hosts.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/test_inventory_no_hosts.yml
@@ -2,7 +2,15 @@
 - hosts: 127.0.0.1
   connection: local
   gather_facts: no
-  environment: "{{ ansible_test.environment }}"
+  vars:
+    env_vars:
+      AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
+      AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
+      AWS_DEFAULT_REGION: '{{ aws_region }}'
+      AWS_SECURITY_TOKEN: '{{ security_token }}'
+
+  environment: "{{ ansible_test.environment | combine(env_vars) }}"
+
   collections:
     - amazon.aws
     - community.aws

--- a/tests/integration/targets/inventory_aws_mq/playbooks/test_inventory_with_hostvars_prefix_suffix.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/test_inventory_with_hostvars_prefix_suffix.yml
@@ -1,0 +1,38 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+
+  environment: "{{ ansible_test.environment }}"
+
+  collections:
+    - amazon.aws
+    - community.aws
+
+  vars_files:
+    - vars/main.yml
+
+  module_defaults:
+    group/aws:
+      aws_access_key: '{{ aws_access_key }}'
+      aws_secret_key: '{{ aws_secret_key }}'
+      security_token: '{{ security_token | default(omit) }}'
+      region: '{{ aws_region }}'
+
+  tasks:
+
+    - name: assert the hostvars are defined with prefix and/or suffix
+      assert:
+        that:
+          - "hostvars[broker_name].{{ vars_prefix }}host_instance_type{{ vars_suffix }} == 'mq.t3.micro'"
+          - "hostvars[broker_name].{{ vars_prefix }}engine_type{{ vars_suffix }} == '{{ engine }}'"
+          - "hostvars[broker_name].{{ vars_prefix }}broker_state{{ vars_suffix }} in ('CREATION_IN_PROGRESS', 'RUNNING')"
+          - "'host_instance_type' not in hostvars[broker_name]"
+          - "'engine_type' not in hostvars[broker_name]"
+          - "'broker_state' not in hostvars[broker_name]"
+          - "'ansible_diff_mode' in hostvars[broker_name]"
+          - "'ansible_forks' in hostvars[broker_name]"
+          - "'ansible_version' in hostvars[broker_name]"
+      vars:
+        vars_prefix: "{{ inventory_prefix | default('') }}"
+        vars_suffix: "{{ inventory_suffix | default('') }}"

--- a/tests/integration/targets/inventory_aws_mq/playbooks/test_inventory_with_hostvars_prefix_suffix.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/test_inventory_with_hostvars_prefix_suffix.yml
@@ -3,7 +3,14 @@
   connection: local
   gather_facts: no
 
-  environment: "{{ ansible_test.environment }}"
+  vars:
+    env_vars:
+      AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
+      AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
+      AWS_DEFAULT_REGION: '{{ aws_region }}'
+      AWS_SECURITY_TOKEN: '{{ security_token }}'
+
+  environment: "{{ ansible_test.environment | combine(env_vars) }}"
 
   collections:
     - amazon.aws
@@ -11,13 +18,6 @@
 
   vars_files:
     - vars/main.yml
-
-  module_defaults:
-    group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
 
   tasks:
 

--- a/tests/integration/targets/inventory_aws_mq/playbooks/test_populating_inventory.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/test_populating_inventory.yml
@@ -1,0 +1,17 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+
+  environment: "{{ ansible_test.environment }}"
+
+  vars_files:
+    - vars/main.yml
+
+  tasks:
+    - name: assert aws_mq inventory group contains MQ instance created by previous playbook
+      assert:
+        that:
+          - "'aws_mq' in groups"
+          - "groups.aws_mq | length == 1"
+          - "groups.aws_mq.0 == '{{ broker_name }}'"

--- a/tests/integration/targets/inventory_aws_mq/playbooks/test_populating_inventory.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/test_populating_inventory.yml
@@ -3,7 +3,14 @@
   connection: local
   gather_facts: no
 
-  environment: "{{ ansible_test.environment }}"
+  vars:
+    env_vars:
+      AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
+      AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
+      AWS_DEFAULT_REGION: '{{ aws_region }}'
+      AWS_SECURITY_TOKEN: '{{ security_token }}'
+
+  environment: "{{ ansible_test.environment | combine(env_vars) }}"
 
   vars_files:
     - vars/main.yml

--- a/tests/integration/targets/inventory_aws_mq/playbooks/test_populating_inventory_with_constructed.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/test_populating_inventory_with_constructed.yml
@@ -1,0 +1,42 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+
+  environment: "{{ ansible_test.environment }}"
+
+  collections:
+    - amazon.aws
+    - community.aws
+
+  vars_files:
+    - vars/main.yml
+
+  # Toggle between the next two blocks, to run the tests with mq modules
+  # from community.aws >= 6.0.0 or command module
+  # module_defaults:
+  #   group/aws:
+  #     aws_access_key: '{{ aws_access_key }}'
+  #     aws_secret_key: '{{ aws_secret_key }}'
+  #     security_token: '{{ security_token | default(omit) }}'
+  #     region: '{{ aws_region }}'
+  environment:
+    AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
+    AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
+    AWS_DEFAULT_REGION: '{{ aws_region }}'
+
+  tasks:
+
+    - debug:
+        var: groups
+
+    - name: assert the keyed groups from constructed config were added to inventory
+      assert:
+        that:
+          # There are 6 groups: all, ungrouped, aws_mq, engine_type keyed group
+          - "groups | length == 4"
+          - '"all" in groups'
+          - '"ungrouped" in groups'
+          - '"aws_mq" in groups'
+          - '"tag_workload_type_other" in groups'
+          - '"mq_ACTIVEMQ" in groups'

--- a/tests/integration/targets/inventory_aws_mq/playbooks/test_populating_inventory_with_constructed.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/test_populating_inventory_with_constructed.yml
@@ -3,7 +3,14 @@
   connection: local
   gather_facts: no
 
-  environment: "{{ ansible_test.environment }}"
+  vars:
+    env_vars:
+      AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
+      AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
+      AWS_DEFAULT_REGION: '{{ aws_region }}'
+      AWS_SECURITY_TOKEN: '{{ security_token }}'
+
+  environment: "{{ ansible_test.environment | combine(env_vars) }}"
 
   collections:
     - amazon.aws
@@ -11,19 +18,6 @@
 
   vars_files:
     - vars/main.yml
-
-  # Toggle between the next two blocks, to run the tests with mq modules
-  # from community.aws >= 6.0.0 or command module
-  # module_defaults:
-  #   group/aws:
-  #     aws_access_key: '{{ aws_access_key }}'
-  #     aws_secret_key: '{{ aws_secret_key }}'
-  #     security_token: '{{ security_token | default(omit) }}'
-  #     region: '{{ aws_region }}'
-  environment:
-    AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
-    AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
-    AWS_DEFAULT_REGION: '{{ aws_region }}'
 
   tasks:
 
@@ -33,8 +27,8 @@
     - name: assert the keyed groups from constructed config were added to inventory
       assert:
         that:
-          # There are 6 groups: all, ungrouped, aws_mq, engine_type keyed group
-          - "groups | length == 4"
+          # There are 5 groups: all, ungrouped, aws_mq, tag and engine_type keyed group
+          - "groups | length == 5"
           - '"all" in groups'
           - '"ungrouped" in groups'
           - '"aws_mq" in groups'

--- a/tests/integration/targets/inventory_aws_mq/playbooks/vars/main.yml
+++ b/tests/integration/targets/inventory_aws_mq/playbooks/vars/main.yml
@@ -1,0 +1,6 @@
+---
+broker_name: "{{ resource_prefix }}-activemq"
+engine: "ACTIVEMQ"
+resource_tags:
+  workload_type: other
+aws_inventory_cache_dir: ""

--- a/tests/integration/targets/inventory_aws_mq/requirements.yml
+++ b/tests/integration/targets/inventory_aws_mq/requirements.yml
@@ -1,0 +1,6 @@
+---
+collections:
+- name: communit.aws
+  version: 6.0.0
+  source: git+https://github.com/ansible-collections/community.aws.git
+  type: git

--- a/tests/integration/targets/inventory_aws_mq/runme.sh
+++ b/tests/integration/targets/inventory_aws_mq/runme.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -eux
+
+function cleanup() {
+    ansible-playbook playbooks/setup_instance.yml -e "operation=delete" "$@"
+    exit 1
+}
+
+trap 'cleanup "${@}"'  ERR
+
+# Uncomment for testing with community.aws >= 6.0.0
+# ansible-galaxy collection install -n -r requirements.yml
+
+pip install jmespath
+ansible-galaxy collection install community.general
+# ensure test config is empty
+ansible-playbook playbooks/empty_inventory_config.yml "$@"
+
+export ANSIBLE_INVENTORY_ENABLED="amazon.aws.aws_mq"
+
+# test with default inventory file
+ansible-playbook playbooks/test_invalid_aws_mq_inventory_config.yml "$@"
+
+export ANSIBLE_INVENTORY=test.aws_mq.yml
+
+# test empty inventory config
+ansible-playbook playbooks/test_invalid_aws_mq_inventory_config.yml "$@"
+
+# delete existing resources
+ansible-playbook playbooks/setup_instance.yml -e "operation=delete" "$@"
+
+# generate inventory config and test using it
+ansible-playbook playbooks/create_inventory_config.yml "$@" &&
+
+# test inventory with no hosts
+ansible-playbook playbooks/test_inventory_no_hosts.yml "$@" &&
+
+# create MQ resources
+ansible-playbook playbooks/setup_instance.yml -e "operation=create" "$@" &&
+
+# test inventory populated with MQ instance
+ansible-playbook playbooks/test_populating_inventory.yml "$@" &&
+
+# generate inventory config with constructed features and test using it
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_constructed.j2'" "$@" &&
+ansible-playbook playbooks/test_populating_inventory_with_constructed.yml "$@" &&
+
+# generate inventory config with hostvars_prefix features and test using it
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_hostvars_prefix_suffix.j2'" -e "inventory_prefix='aws_mq_'" "$@" &&
+ansible-playbook playbooks/test_inventory_with_hostvars_prefix_suffix.yml -e "inventory_prefix='aws_mq_'" "$@" &&
+
+# generate inventory config with hostvars_suffix features and test using it
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_hostvars_prefix_suffix.j2'" -e "inventory_suffix='_aws_mq'" "$@" &&
+ansible-playbook playbooks/test_inventory_with_hostvars_prefix_suffix.yml -e "inventory_suffix='_aws_mq'" "$@" &&
+
+# generate inventory config with hostvars_prefix and hostvars_suffix features and test using it
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_hostvars_prefix_suffix.j2'" -e "inventory_prefix='aws_'" -e "inventory_suffix='_mq'" "$@" &&
+ansible-playbook playbooks/test_inventory_with_hostvars_prefix_suffix.yml -e "inventory_prefix='aws_'" -e "inventory_suffix='_mq'" "$@" &&
+
+# generate inventory config with statuses and test using it
+ansible-playbook playbooks/create_inventory_config.yml -e '{"inventory_statuses": true}' "$@" &&
+ansible-playbook playbooks/test_inventory_no_hosts.yml "$@" &&
+
+# generate inventory config with caching and test using it
+AWS_MQ_CACHE_DIR="aws_mq_cache_dir"
+rm -rf "${AWS_MQ_CACHE_DIR}"  &&
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_cache.j2'" -e "aws_inventory_cache_dir=$AWS_MQ_CACHE_DIR" "$@" &&
+ansible-playbook playbooks/populate_cache.yml "$@" &&
+ansible-playbook playbooks/test_inventory_cache.yml "$@" &&
+rm -rf "${AWS_MQ_CACHE_DIR}" &&
+
+# cleanup inventory config
+ansible-playbook playbooks/empty_inventory_config.yml "$@"
+
+ansible-playbook playbooks/setup_instance.yml -e "operation=delete" "$@"
+

--- a/tests/integration/targets/inventory_aws_mq/templates/inventory.j2
+++ b/tests/integration/targets/inventory_aws_mq/templates/inventory.j2
@@ -1,0 +1,12 @@
+plugin: amazon.aws.aws_mq
+aws_access_key_id: '{{ aws_access_key }}'
+aws_secret_access_key: '{{ aws_secret_key }}'
+{% if security_token | default(false) %}
+aws_security_token: '{{ security_token }}'
+{% endif %}
+regions:
+  - '{{ aws_region }}'
+{% if inventory_statuses | default(false) %}
+statuses:
+  - CREATION_FAILED
+{% endif %}

--- a/tests/integration/targets/inventory_aws_mq/templates/inventory_with_cache.j2
+++ b/tests/integration/targets/inventory_aws_mq/templates/inventory_with_cache.j2
@@ -1,0 +1,11 @@
+plugin: amazon.aws.aws_mq
+cache: True
+cache_plugin: jsonfile
+cache_connection: '{{ aws_inventory_cache_dir }}'
+aws_access_key_id: '{{ aws_access_key }}'
+aws_secret_access_key: '{{ aws_secret_key }}'
+{% if security_token | default(false) %}
+aws_security_token: '{{ security_token }}'
+{% endif %}
+regions:
+  - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_mq/templates/inventory_with_constructed.j2
+++ b/tests/integration/targets/inventory_aws_mq/templates/inventory_with_constructed.j2
@@ -1,0 +1,13 @@
+plugin: amazon.aws.aws_mq
+aws_access_key_id: '{{ aws_access_key }}'
+aws_secret_access_key: '{{ aws_secret_key }}'
+{% if security_token | default(false) %}
+aws_security_token: '{{ security_token }}'
+{% endif %}
+regions:
+  - '{{ aws_region }}'
+keyed_groups:
+  - key: tags
+    prefix: tag
+  - key: engine_type
+    prefix: mq

--- a/tests/integration/targets/inventory_aws_mq/templates/inventory_with_hostvars_prefix_suffix.j2
+++ b/tests/integration/targets/inventory_aws_mq/templates/inventory_with_hostvars_prefix_suffix.j2
@@ -1,0 +1,14 @@
+plugin: amazon.aws.aws_mq
+aws_access_key_id: '{{ aws_access_key }}'
+aws_secret_access_key: '{{ aws_secret_key }}'
+{% if security_token | default(false) %}
+aws_security_token: '{{ security_token }}'
+{% endif %}
+regions:
+  - '{{ aws_region }}'
+{% if inventory_prefix | default(false) %}
+hostvars_prefix: '{{ inventory_prefix }}'
+{% endif %}
+{% if inventory_suffix | default(false) %}
+hostvars_suffix: '{{ inventory_suffix }}'
+{% endif %}

--- a/tests/unit/plugins/inventory/test_aws_mq.py
+++ b/tests/unit/plugins/inventory/test_aws_mq.py
@@ -1,0 +1,635 @@
+# -*- coding: utf-8 -*-
+
+# Copyright 2023 Ali AlKhalidi <@doteast>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+
+import copy
+import pytest
+import random
+import string
+from unittest.mock import MagicMock
+from unittest.mock import call
+from unittest.mock import patch
+
+try:
+    import botocore
+except ImportError:
+    # Handled by HAS_BOTO3
+    pass
+
+from ansible.errors import AnsibleError
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.inventory.aws_mq import (
+    InventoryModule,
+    _find_hosts_matching_statuses,
+    _get_mq_hostname,
+    _get_broker_host_tags,
+    _add_details_to_hosts
+)
+
+if not HAS_BOTO3:
+    pytestmark = pytest.mark.skip("test_aws_mq.py requires the python modules 'boto3' and 'botocore'")
+
+
+def make_clienterror_exception(code="AccessDenied"):
+    return botocore.exceptions.ClientError(
+        {
+            "Error": {"Code": code, "Message": "User is not authorized to perform: xxx on resource: user yyyy"},
+            "ResponseMetadata": {"RequestId": "01234567-89ab-cdef-0123-456789abcdef"},
+        },
+        "getXXX",
+    )
+
+
+@pytest.fixture()
+def inventory():
+    inventory = InventoryModule()
+    inventory.inventory = MagicMock()
+    inventory.inventory.set_variable = MagicMock()
+
+    inventory.all_clients = MagicMock()
+    inventory.get_option = MagicMock()
+
+    inventory._populate_host_vars = MagicMock()
+    inventory._set_composite_vars = MagicMock()
+    inventory._add_host_to_composed_groups = MagicMock()
+    inventory._add_host_to_keyed_groups = MagicMock()
+
+    inventory.get_cache_key = MagicMock()
+
+    inventory._cache = {}
+
+    return inventory
+
+
+@pytest.fixture()
+def connection():
+    conn = MagicMock()
+    return conn
+
+
+@pytest.mark.parametrize(
+    "suffix,result",
+    [
+        ("aws_mq.yml", True),
+        ("aws_mq.yaml", True),
+        ("aws_MQ.yml", False),
+        ("AWS_mq.yaml", False),
+    ],
+)
+def test_inventory_verify_file_suffix(inventory, suffix, result, tmp_path):
+    test_dir = tmp_path / "test_aws_mq"
+    test_dir.mkdir()
+    inventory_file = "inventory" + suffix
+    inventory_file = test_dir / inventory_file
+    inventory_file.write_text("my inventory")
+    assert result == inventory.verify_file(str(inventory_file))
+
+
+def test_inventory_verify_file_with_missing_file(inventory):
+    inventory_file = "this_file_does_not_exist_aws_mq.yml"
+    assert not inventory.verify_file(inventory_file)
+
+
+def generate_random_string(with_digits=True, with_punctuation=True, length=16):
+    data = string.ascii_letters
+    if with_digits:
+        data += string.digits
+    if with_punctuation:
+        data += string.punctuation
+    return "".join([random.choice(data) for i in range(length)])
+
+
+@pytest.mark.parametrize(
+    "hosts,statuses,expected",
+    [
+        (
+            [
+                {"host": "host1", "BrokerState": "DELETION_IN_PROGRESS"},
+                {"host": "host2", "BrokerState": "RUNNING"},
+                {"host": "host3", "BrokerState": "REBOOT_IN_PROGRESS"},
+                {"host": "host4", "BrokerState": "CRITICAL_ACTION_REQUIRED"},
+                {"host": "host5", "BrokerState": "CREATION_FAILED"},
+                {"host": "host6", "BrokerState": "CREATION_IN_PROGRESS"},
+            ],
+            ["RUNNING"],
+            [{"host": "host2", "BrokerState": "RUNNING"}],
+        ),
+        (
+            [
+                {"host": "host1", "BrokerState": "DELETION_IN_PROGRESS"},
+                {"host": "host2", "BrokerState": "RUNNING"},
+                {"host": "host3", "BrokerState": "REBOOT_IN_PROGRESS"},
+                {"host": "host4", "BrokerState": "CRITICAL_ACTION_REQUIRED"},
+                {"host": "host5", "BrokerState": "CREATION_FAILED"},
+                {"host": "host6", "BrokerState": "CREATION_IN_PROGRESS"},
+            ],
+            ["all"],
+            [
+                {"host": "host1", "BrokerState": "DELETION_IN_PROGRESS"},
+                {"host": "host2", "BrokerState": "RUNNING"},
+                {"host": "host3", "BrokerState": "REBOOT_IN_PROGRESS"},
+                {"host": "host4", "BrokerState": "CRITICAL_ACTION_REQUIRED"},
+                {"host": "host5", "BrokerState": "CREATION_FAILED"},
+                {"host": "host6", "BrokerState": "CREATION_IN_PROGRESS"},
+            ],
+        ),
+        (
+            [
+                {"host": "host1", "BrokerState": "DELETION_IN_PROGRESS"},
+                {"host": "host2", "BrokerState": "RUNNING"},
+                {"host": "host3", "BrokerState": "CREATION_FAILED"},
+                {"host": "host4", "BrokerState": "CRITICAL_ACTION_REQUIRED"},
+                {"host": "host5", "BrokerState": "RUNNING"},
+                {"host": "host6", "BrokerState": "CREATION_IN_PROGRESS"},
+            ],
+            ["RUNNING"],
+            [
+                {"host": "host2", "BrokerState": "RUNNING"},
+                {"host": "host5", "BrokerState": "RUNNING"},
+            ],
+        ),
+    ],
+)
+def test_find_hosts_matching_statuses(hosts, statuses, expected):
+    assert expected == _find_hosts_matching_statuses(hosts, statuses)
+
+
+@pytest.mark.parametrize("hosts", ["", "host1", "host2,host3", "host2,host3,host1"])
+@patch("ansible_collections.amazon.aws.plugins.inventory.aws_mq._get_mq_hostname")
+def test_inventory_format_inventory(m_get_mq_hostname, inventory, hosts):
+    hosts_vars = {
+        "host1": {"var10": "value10"},
+        "host2": {"var20": "value20", "var21": "value21"},
+        "host3": {"var30": "value30", "var31": "value31", "var32": "value32"},
+    }
+
+    m_get_mq_hostname.side_effect = lambda h: h["name"]
+
+    class _inventory_host(object):
+        def __init__(self, name, host_vars):
+            self.name = name
+            self.vars = host_vars
+
+    inventory.inventory = MagicMock()
+    inventory.inventory.get_host.side_effect = lambda x: _inventory_host(name=x, host_vars=hosts_vars.get(x))
+
+    hosts = [{"name": x} for x in hosts.split(",") if x]
+    expected = {
+        "_meta": {"hostvars": {x["name"]: hosts_vars.get(x["name"]) for x in hosts}},
+        "aws_mq": {"hosts": [x["name"] for x in hosts]},
+    }
+
+    assert expected == inventory._format_inventory(hosts)
+    if hosts == []:
+        m_get_mq_hostname.assert_not_called()
+
+
+@pytest.mark.parametrize("length", range(0, 10, 2))
+def test_inventory_populate(inventory, length):
+    group = "aws_mq"
+    hosts = [f"host_{int(i)}" for i in range(length)]
+
+    inventory._add_hosts = MagicMock()
+    inventory._populate(hosts=hosts)
+
+    inventory.inventory.add_group.assert_called_with("aws_mq")
+
+    if len(hosts) == 0:
+        inventory.inventory._add_hosts.assert_not_called()
+        inventory.inventory.add_child.assert_not_called()
+    else:
+        inventory._add_hosts.assert_called_with(hosts=hosts, group=group)
+        inventory.inventory.add_child.assert_called_with("all", group)
+
+def test_inventory_populate_from_cache(inventory):
+    cache_data = {
+        "_meta": {
+            "hostvars": {
+                "broker_A": {"var10": "value10"},
+                "broker_B": {"var2": "value2"},
+                "broker_C": {"var3": ["value30", "value31", "value32"]},
+            }
+        },
+        "all": {"hosts": ["broker_A", "broker_D", "broker_B", "broker_C"]},
+        "aws_broker_group_A": {"hosts": ["broker_A", "broker_D"]},
+        "aws_broker_group_B": {"hosts": ["broker_B"]},
+        "aws_broker_group_C": {"hosts": ["broker_C"]},
+    }
+
+    inventory._populate_from_cache(cache_data)
+    inventory.inventory.add_group.assert_has_calls(
+        [
+            call("aws_broker_group_A"),
+            call("aws_broker_group_B"),
+            call("aws_broker_group_C"),
+        ],
+        any_order=True,
+    )
+    inventory.inventory.add_child.assert_has_calls(
+        [
+            call("all", "aws_broker_group_A"),
+            call("all", "aws_broker_group_B"),
+            call("all", "aws_broker_group_C"),
+        ],
+        any_order=True,
+    )
+
+    inventory._populate_host_vars.assert_has_calls(
+        [
+            call(["broker_A"], {"var10": "value10"}, "aws_broker_group_A"),
+            call(["broker_D"], {}, "aws_broker_group_A"),
+            call(["broker_B"], {"var2": "value2"}, "aws_broker_group_B"),
+            call(["broker_C"], {"var3": ["value30", "value31", "value32"]}, "aws_broker_group_C"),
+        ],
+        any_order=True,
+    )
+
+
+@pytest.mark.parametrize("detail", [{}, {"Tags": {"tag1": "value1", "tag2": "value2", "Tag3": "Value2"}}])
+def test_get_broker_host_tags(detail):
+    expected_tags = [
+        {"Key": "tag1", "Value": "value1"},
+        {"Key": "tag2", "Value": "value2"},
+        {"Key": "Tag3", "Value": "Value2"}
+    ]
+
+    tags = _get_broker_host_tags(detail)
+
+    if not detail:
+        assert tags == []
+    else:
+        assert tags == expected_tags
+
+
+@pytest.mark.parametrize("strict", [True, False])
+def test_add_details_to_hosts_with_no_hosts(connection, strict):
+    hosts = []
+
+    _add_details_to_hosts(connection, hosts, strict)
+    connection.describe_broker.assert_not_called()
+
+
+def test_add_details_to_hosts_with_failure_not_strict(connection):
+    hosts = [{"BrokerId": "1"}]
+
+    connection.describe_broker.side_effect = make_clienterror_exception()
+
+    _add_details_to_hosts(connection, hosts, strict=False)
+
+    assert hosts == [{"BrokerId": "1"}]
+
+
+def test_add_details_to_hosts_with_failure_strict(connection):
+    hosts = [{"BrokerId": "1"}]
+
+    connection.describe_broker.side_effect = make_clienterror_exception()
+
+    with pytest.raises(AnsibleError):
+        _add_details_to_hosts(connection, hosts, strict=True)
+
+
+def test_add_details_to_hosts_with_hosts(connection):
+    hosts = [
+        {"BrokerId": "1"},
+        {"BrokerId": "2"}
+    ]
+    broker_hosts_tags = {
+        "1": {"Tags": {"tag10": "value10", "tag11": "value11"}},
+        "2": {"Tags": {"tag20": "value20", "tag21": "value21", "tag22": "value22"}}
+    }
+    connection.describe_broker.side_effect = lambda **kwargs: broker_hosts_tags.get(kwargs.get("BrokerId"))
+
+    _add_details_to_hosts(connection, hosts, strict=False)
+
+    assert hosts == [
+        {"BrokerId": "1", "Tags":
+            [
+                {"Key": "tag10", "Value": "value10"},
+                {"Key": "tag11", "Value": "value11"},
+            ]},
+        {"BrokerId": "2", "Tags":
+            [
+                {"Key": "tag20", "Value": "value20"},
+                {"Key": "tag21", "Value": "value21"},
+                {"Key": "tag22", "Value": "value22"}
+            ]},
+    ]
+
+
+ADD_DETAILS_TO_HOSTS = "ansible_collections.amazon.aws.plugins.inventory.aws_mq._add_details_to_hosts"
+
+
+@patch(ADD_DETAILS_TO_HOSTS)
+def test_get_broker_hosts(m_add_details_to_hosts, inventory, connection):
+    broker = {
+        "BrokerArn": "arn:xxx:xxxx",
+        "BrokerId": "resource_id",
+        "BrokerName": "brk1",
+        "BrokerState": "RUNNING",
+        "EngineType": "RABBITMQ",
+        "DeploymentMode": "CLUSTER_MULTI_AZ"
+    }
+
+    conn_paginator = MagicMock()
+    paginate = MagicMock()
+
+    connection.get_paginator.return_value = conn_paginator
+    conn_paginator.paginate.return_value = paginate
+
+    paginate.build_full_result.side_effect = lambda **kwargs: {"BrokerSummaries": [broker]}
+
+    connection.describe_broker.return_value = {}
+    connection.list_brokers.return_value = {"BrokerSummaries": [broker]}
+
+    strict = False
+
+    result = inventory._get_broker_hosts(connection=connection, strict=strict)(paginate.build_full_result)
+
+    assert result == [broker]
+
+    m_add_details_to_hosts.assert_called_with(connection, result, strict)
+
+
+@pytest.mark.parametrize("strict", [True, False])
+@patch(ADD_DETAILS_TO_HOSTS)
+def test_get_broker_hosts_with_access_denied(m_add_details_to_hosts, inventory, connection, strict):
+    conn_paginator = MagicMock()
+    paginate = MagicMock()
+
+    connection.get_paginator.return_value = conn_paginator
+    conn_paginator.paginate.return_value = paginate
+
+    paginate.build_full_result.side_effect = make_clienterror_exception()
+
+    if strict:
+        with pytest.raises(AnsibleError):
+            inventory._get_broker_hosts(connection=connection, strict=strict)(paginate.build_full_result)
+    else:
+        assert inventory._get_broker_hosts(connection=connection, strict=strict)(paginate.build_full_result) == []
+
+    m_add_details_to_hosts.assert_not_called()
+
+
+@patch(ADD_DETAILS_TO_HOSTS)
+def test_get_broker_hosts_with_client_error(m_add_details_to_hosts, inventory, connection):
+    conn_paginator = MagicMock()
+    paginate = MagicMock()
+
+    connection.get_paginator.return_value = conn_paginator
+    conn_paginator.paginate.return_value = paginate
+
+    paginate.build_full_result.side_effect = make_clienterror_exception(code="Unknown")
+
+    with pytest.raises(AnsibleError):
+        inventory._get_broker_hosts(connection=connection, strict=False)(paginate.build_full_result)
+
+    m_add_details_to_hosts.assert_not_called()
+
+
+FIND_HOSTS_MATCHING_STATUSES = (
+    "ansible_collections.amazon.aws.plugins.inventory.aws_mq._find_hosts_matching_statuses"
+)
+
+
+@pytest.mark.parametrize("regions", range(1, 5))
+@patch(FIND_HOSTS_MATCHING_STATUSES)
+def test_inventory_get_all_hosts(m_find_hosts, inventory, regions):
+    params = {
+        "regions": [f"us-east-{int(i)}" for i in range(regions)],
+        "strict": random.choice((True, False)),
+        "statuses": [random.choice(
+            [
+                "RUNNING",
+                "CREATION_IN_PROGRESS",
+                "REBOOT_IN_PROGRESS",
+                "DELETION_IN_PROGRESS",
+                "CRITICAL_ACTION_REQUIRED"
+            ]) for i in range(3)],
+    }
+
+    connections = [MagicMock() for i in range(regions)]
+
+    inventory.all_clients.return_value = [(connections[i], f"us-east-{int(i)}") for i in range(regions)]
+
+    ids = list(reversed(range(regions)))
+    broker_hosts = [{"BrokerName": f"broker_00{int(i)}"} for i in ids]
+
+    inventory._get_broker_hosts = MagicMock()
+    inventory._get_broker_hosts._boto3_paginate_wrapper = MagicMock()
+    inventory._get_broker_hosts._boto3_paginate_wrapper.side_effect = [[i] for i in broker_hosts]
+    inventory._get_broker_hosts.return_value = inventory._get_broker_hosts._boto3_paginate_wrapper
+
+    result = list(sorted(broker_hosts, key=lambda x: x["BrokerName"]))
+
+    m_find_hosts.return_value = result
+
+    assert result == inventory._get_all_hosts(**params)
+    inventory.all_clients.assert_called_with("mq")
+    inventory._get_broker_hosts.assert_has_calls(
+        [call(connections[i], params["strict"]) for i in range(regions)],
+        any_order=True
+    )
+
+    m_find_hosts.assert_called_with(result, params["statuses"])
+
+
+@pytest.mark.parametrize("hostvars_prefix", [True])
+@pytest.mark.parametrize("hostvars_suffix", [True])
+@patch("ansible_collections.amazon.aws.plugins.inventory.aws_mq._get_mq_hostname")
+def test_inventory_add_hosts(m_get_mq_hostname, inventory, hostvars_prefix, hostvars_suffix):
+    _options = {
+      "strict": random.choice((False, True)),
+      "compose": random.choice((False, True)),
+      "keyed_groups": "keyed_group_test_inventory_add_hosts",
+      "groups": ["all", "test_inventory_add_hosts"],
+    }
+
+    if hostvars_prefix:
+        _options["hostvars_prefix"] = f"prefix_{generate_random_string(length=8, with_punctuation=False)}"
+    if hostvars_suffix:
+        _options["hostvars_suffix"] = f"suffix_{generate_random_string(length=8, with_punctuation=False)}"
+
+    def _get_option_side_effect(x):
+        return _options.get(x)
+
+    inventory.get_option.side_effect = _get_option_side_effect
+
+    m_get_mq_hostname.side_effect = lambda h: h["BrokerName"]
+
+    hosts = [
+        {
+            "BrokerName": "broker_i_001",
+            "Tags": [{"Key": "Name", "Value": "broker_001"}, {"Key": "RunningEngine", "Value": "ActiveMQ"}],
+            "availability_zone": "us-east-1a",
+        },
+        {
+            "BrokerName": "broker_i_002",
+            "Tags": [{"Key": "ClusterName", "Value": "test_cluster"}, {"Key": "RunningOS", "Value": "CoreOS"}],
+        },
+        {
+            "BrokerName": "test_cluster",
+            "Tags": [{"Key": "CluserVersionOrigin", "Value": "2.0"}, {"Key": "Provider", "Value": "RedHat"}],
+        },
+        {
+            "BrokerName": "another_cluster",
+            "Tags": [{"Key": "TestingPurpose", "Value": "Ansible"}],
+            "availability_zones": ["us-west-1a", "us-east-1b"],
+        },
+    ]
+
+    group = f"test_add_hosts_group_{generate_random_string(length=10, with_punctuation=False)}"
+    inventory._add_hosts(hosts, group)
+
+    m_get_mq_hostname.assert_has_calls([call(h) for h in hosts], any_order=True)
+
+    hosts_names = ["broker_i_001", "broker_i_002", "test_cluster", "another_cluster"]
+    inventory.inventory.add_host.assert_has_calls([call(name, group=group) for name in hosts_names], any_order=True)
+
+    camel_hosts = [
+        {
+            "broker_name": "broker_i_001",
+            "tags": {"Name": "broker_001", "RunningEngine": "ActiveMQ"},
+            "availability_zone": "us-east-1a",
+        },
+        {"broker_name": "broker_i_002", "tags": {"ClusterName": "test_cluster", "RunningOS": "CoreOS"}},
+        {"broker_name": "test_cluster", "tags": {"CluserVersionOrigin": "2.0", "Provider": "RedHat"}},
+        {
+            "broker_name": "another_cluster",
+            "tags": {"TestingPurpose": "Ansible"},
+            "availability_zones": ["us-west-1a", "us-east-1b"],
+        },
+    ]
+
+    set_variable_calls = []
+    for i in range(len(camel_hosts)):
+        for var, value in camel_hosts[i].items():
+            if hostvars_prefix:
+                var = _options["hostvars_prefix"] + var
+            if hostvars_suffix:
+                var += _options["hostvars_suffix"]
+            set_variable_calls.append(call(hosts_names[i], var, value))
+
+    inventory.get_option.assert_has_calls([call("hostvars_prefix"), call("hostvars_suffix")])
+    inventory.inventory.set_variable.assert_has_calls(set_variable_calls)
+
+    if hostvars_prefix or hostvars_suffix:
+        tmp = []
+        for host in camel_hosts:
+            new_host = copy.deepcopy(host)
+            for key in host:
+                new_key = key
+                if hostvars_prefix:
+                    new_key = _options["hostvars_prefix"] + new_key
+                if hostvars_suffix:
+                    new_key += _options["hostvars_suffix"]
+                new_host[new_key] = host[key]
+            tmp.append(new_host)
+        camel_hosts = tmp
+
+    inventory._set_composite_vars.assert_has_calls(
+        [
+            call(_options["compose"], camel_hosts[i], hosts_names[i], strict=_options["strict"])
+            for i in range(len(camel_hosts))
+        ],
+        any_order=True,
+    )
+    inventory._add_host_to_composed_groups.assert_has_calls(
+        [
+            call(_options["groups"], camel_hosts[i], hosts_names[i], strict=_options["strict"])
+            for i in range(len(camel_hosts))
+        ],
+        any_order=True,
+    )
+    inventory._add_host_to_keyed_groups.assert_has_calls(
+        [
+            call(_options["keyed_groups"], camel_hosts[i], hosts_names[i], strict=_options["strict"])
+            for i in range(len(camel_hosts))
+        ],
+        any_order=True,
+    )
+
+
+BASE_INVENTORY_PARSE = "ansible_collections.amazon.aws.plugins.inventory.aws_mq.AWSInventoryBase.parse"
+
+
+@pytest.mark.parametrize("user_cache_directive", [True, False])
+@pytest.mark.parametrize("cache", [True, False])
+@pytest.mark.parametrize("cache_hit", [True, False])
+@patch(BASE_INVENTORY_PARSE)
+def test_inventory_parse(
+    m_parse, inventory, user_cache_directive, cache, cache_hit
+):
+    inventory_data = MagicMock()
+    loader = MagicMock()
+    path = generate_random_string(with_punctuation=False, with_digits=False)
+
+    options = {}
+    options["regions"] = [f"us-east-{d}" for d in range(random.randint(1, 5))]
+    options["strict_permissions"] = random.choice((True, False))
+    options["statuses"] = generate_random_string(with_punctuation=False)
+
+    options["cache"] = user_cache_directive
+
+    def get_option_side_effect(v):
+        return options.get(v)
+
+    inventory.get_option.side_effect = get_option_side_effect
+
+    cache_key = path + generate_random_string()
+    inventory.get_cache_key.return_value = cache_key
+
+    cache_key_value = generate_random_string()
+    if cache_hit:
+        inventory._cache[cache_key] = cache_key_value
+
+    inventory._populate = MagicMock()
+    inventory._populate_from_cache = MagicMock()
+    inventory._get_all_hosts = MagicMock()
+    all_hosts = [
+        {"host": f"host_{int(random.randint(1, 1000))}"},
+        {"host": f"host_{int(random.randint(1, 1000))}"},
+        {"host": f"host_{int(random.randint(1, 1000))}"},
+        {"host": f"host_{int(random.randint(1, 1000))}"},
+    ]
+    inventory._get_all_hosts.return_value = all_hosts
+
+    format_cache_key_value = f"format_inventory_{all_hosts}"
+    inventory._format_inventory = MagicMock()
+    inventory._format_inventory.return_value = format_cache_key_value
+
+    inventory.parse(inventory_data, loader, path, cache)
+
+    m_parse.assert_called_with(inventory_data, loader, path, cache=cache)
+
+    if not cache or not user_cache_directive or (cache and user_cache_directive and not cache_hit):
+        inventory._get_all_hosts.assert_called_with(
+            options["regions"],
+            options["strict_permissions"],
+            options["statuses"],
+        )
+        inventory._populate.assert_called_with(all_hosts)
+        inventory._format_inventory.assert_called_with(all_hosts)
+    else:
+        inventory._get_all_hosts.assert_not_called()
+
+    if cache and user_cache_directive and cache_hit:
+        inventory._populate_from_cache.assert_called_with(cache_key_value)
+
+    if cache and user_cache_directive and not cache_hit or (not cache and user_cache_directive):
+        # validate that cache was populated
+        assert inventory._cache[cache_key] == format_cache_key_value


### PR DESCRIPTION
##### SUMMARY
MQ broker inventory source

##### ISSUE TYPE
- New Module Pull Request

##### COMPONENT NAME
aws_mq

##### ADDITIONAL INFORMATION
EXAMPLE USAGE:
```
plugin: aws_mq
regions:
  - ca-central-1
keyed_groups:
  - key: engine_type
    prefix: mq
compose:
  app: 'tags.Applications|split(",")'
hostvars_prefix: aws_
hostvars_suffix: _mq
```
