### PR TITLE
ec2_metadata_facts - Handle decompression when EC2 instance user-data is compressed

### DIFF
--- a/changelogs/fragments/20230526-ec2_mertadata_facts-handle_compressed_user_data.yml
+++ b/changelogs/fragments/20230526-ec2_mertadata_facts-handle_compressed_user_data.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-  - ec2_metadata_facts - Handle decompression when EC2 instance user-data is gzip compressed. The fetch_url method from ansible.module_utils.urls does not decompress the user-data unless the header explicitly contains ``Content-Encoding: gzip`` (https://github.com/ansible-collections/amazon.aws/pull/1575).
+  - 'ec2_metadata_facts - Handle decompression when EC2 instance user-data is gzip compressed. The fetch_url method from ansible.module_utils.urls does not decompress the user-data unless the header explicitly contains ``Content-Encoding: gzip`` (https://github.com/ansible-collections/amazon.aws/pull/1575).'

--- a/changelogs/fragments/20230526-ec2_mertadata_facts-handle_compressed_user_data.yml
+++ b/changelogs/fragments/20230526-ec2_mertadata_facts-handle_compressed_user_data.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_metadata_facts - Handle decompression when EC2 instance user-data is gzip compressed. The fetch_url method from ansible.module_utils.urls does not decompress the user-data unless the header explicitly contains 'Content-Encoding' = 'gzip' (https://github.com/ansible-collections/amazon.aws/pull/1575).

--- a/changelogs/fragments/20230526-ec2_mertadata_facts-handle_compressed_user_data.yml
+++ b/changelogs/fragments/20230526-ec2_mertadata_facts-handle_compressed_user_data.yml
@@ -1,2 +1,3 @@
+---
 bugfixes:
-  - ec2_metadata_facts - Handle decompression when EC2 instance user-data is gzip compressed. The fetch_url method from ansible.module_utils.urls does not decompress the user-data unless the header explicitly contains 'Content-Encoding' = 'gzip' (https://github.com/ansible-collections/amazon.aws/pull/1575).
+  - ec2_metadata_facts - Handle decompression when EC2 instance user-data is gzip compressed. The fetch_url method from ansible.module_utils.urls does not decompress the user-data unless the header explicitly contains ``Content-Encoding: gzip`` (https://github.com/ansible-collections/amazon.aws/pull/1575).

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -485,6 +485,14 @@ class Ec2Metadata:
         self._token = None
         self._prefix = "ansible_ec2_%s"
 
+    def _decode(self, data):
+        try:
+            return data.decode("utf-8")
+        except UnicodeDecodeError:
+            # Decoding as UTF-8 failed, return data without raising an error
+            self.module.warn("Decoding user-data as UTF-8 failed, return data as is ignoring any error")
+            return data.decode("utf-8", errors="ignore")
+
     def decode_user_data(self, data):
         is_compressed = False
 
@@ -492,21 +500,17 @@ class Ec2Metadata:
         if data.startswith(b"\x78\x9c") or data.startswith(b"\x1f\x8b"):
             is_compressed = True
 
-        try:
-            if is_compressed:
-                # Data is compressed, attempt decompression and decode using UTF-8
-                decoded_data = zlib.decompress(data, zlib.MAX_WBITS | 32).decode("utf-8")
-            else:
-                # Data is not compressed, decode using UTF-8
-                decoded_data = data.decode("utf-8")
-            return decoded_data
-        except zlib.error:
-            # Unable to decompress, return original data
-            return data.decode("utf-8")
-        except UnicodeDecodeError:
-            # Decoding as UTF-8 failed, return data without raising an error
-            self.module.warn("Decoding user-data as UTF-8 failed, return data as is ignoring any error")
-            return data.decode("utf-8", errors="ignore")
+        if is_compressed:
+            # Data is compressed, attempt decompression and decode using UTF-8
+            try:
+                decompressed = zlib.decompress(data, zlib.MAX_WBITS | 32)
+                return self._decode(decompressed)
+            except zlib.error:
+                # Unable to decompress, return original data
+                return self._decode(data)
+        else:
+            # Data is not compressed, decode using UTF-8
+            return self._decode(data)
 
     def _fetch(self, url):
         encoded_url = quote(url, safe="%/:=&?~#+!$,;'@()*[]")

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -507,6 +507,9 @@ class Ec2Metadata:
                 return self._decode(decompressed)
             except zlib.error:
                 # Unable to decompress, return original data
+                self.module.warn(
+                    "Unable to decompress user-data using zlib, attempt to decode original user-data as UTF-8"
+                )
                 return self._decode(data)
         else:
             # Data is not compressed, decode using UTF-8

--- a/tests/unit/plugins/modules/test_ec2_metadata_facts.py
+++ b/tests/unit/plugins/modules/test_ec2_metadata_facts.py
@@ -1,7 +1,6 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import base64
 import gzip
 import io
 import pytest
@@ -78,30 +77,7 @@ packages: ['httpie']
 --MIMEBOUNDARY--
 """
 
-    return_value = gzip.compress(bytes(base64.b64encode(user_data)))
-    m_fetch_url.return_value = (io.BytesIO(return_value), {"status": 200})
-
-    assert ec2_instance._fetch("http://169.254.169.254/latest/user-data") == user_data.decode("utf-8")
-
-
-@patch(module_name + ".fetch_url")
-def test__fetch_user_data_base64_encoded(m_fetch_url, ec2_instance):
-    user_data = b"""Content-Type: multipart/mixed; boundary="MIMEBOUNDARY"
-MIME-Version: 1.0
-
---MIMEBOUNDARY
-Content-Transfer-Encoding: 7bit
-Content-Type: text/cloud-config
-Mime-Version: 1.0
-
-packages: ['httpie']
-
---MIMEBOUNDARY--
-"""
-
-    return_value = bytes(base64.b64encode(user_data))
-    m_fetch_url.return_value = (io.BytesIO(return_value), {"status": 200})
-
+    m_fetch_url.return_value = (io.BytesIO(gzip.compress(user_data)), {"status": 200})
     assert ec2_instance._fetch("http://169.254.169.254/latest/user-data") == user_data.decode("utf-8")
 
 
@@ -121,5 +97,4 @@ packages: ['httpie']
 """
 
     m_fetch_url.return_value = (io.BytesIO(user_data), {"status": 200})
-
     assert ec2_instance._fetch("http://169.254.169.254/latest/user-data") == user_data.decode("utf-8")

--- a/tests/unit/plugins/modules/test_ec2_metadata_facts.py
+++ b/tests/unit/plugins/modules/test_ec2_metadata_facts.py
@@ -1,6 +1,8 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+import base64
+import gzip
 import io
 import pytest
 from unittest.mock import MagicMock
@@ -59,3 +61,65 @@ def test_fetch_recusive(m_fetch_url, ec2_instance):
     ]
     ec2_instance.fetch("http://169.254.169.254/latest/meta-data/")
     assert ec2_instance._data == {"http://169.254.169.254/latest/meta-data/whatever/my-key": "my-value"}
+
+
+@patch(module_name + ".fetch_url")
+def test__fetch_user_data_compressed(m_fetch_url, ec2_instance):
+    user_data = b"""Content-Type: multipart/mixed; boundary="MIMEBOUNDARY"
+MIME-Version: 1.0
+
+--MIMEBOUNDARY
+Content-Transfer-Encoding: 7bit
+Content-Type: text/cloud-config
+Mime-Version: 1.0
+
+packages: ['httpie']
+
+--MIMEBOUNDARY--
+"""
+
+    return_value = gzip.compress(bytes(base64.b64encode(user_data)))
+    m_fetch_url.return_value = (io.BytesIO(return_value), {"status": 200})
+
+    assert ec2_instance._fetch("http://169.254.169.254/latest/user-data") == user_data.decode("utf-8")
+
+
+@patch(module_name + ".fetch_url")
+def test__fetch_user_data_base64_encoded(m_fetch_url, ec2_instance):
+    user_data = b"""Content-Type: multipart/mixed; boundary="MIMEBOUNDARY"
+MIME-Version: 1.0
+
+--MIMEBOUNDARY
+Content-Transfer-Encoding: 7bit
+Content-Type: text/cloud-config
+Mime-Version: 1.0
+
+packages: ['httpie']
+
+--MIMEBOUNDARY--
+"""
+
+    return_value = bytes(base64.b64encode(user_data))
+    m_fetch_url.return_value = (io.BytesIO(return_value), {"status": 200})
+
+    assert ec2_instance._fetch("http://169.254.169.254/latest/user-data") == user_data.decode("utf-8")
+
+
+@patch(module_name + ".fetch_url")
+def test__fetch_user_data_plain(m_fetch_url, ec2_instance):
+    user_data = b"""Content-Type: multipart/mixed; boundary="MIMEBOUNDARY"
+MIME-Version: 1.0
+
+--MIMEBOUNDARY
+Content-Transfer-Encoding: 7bit
+Content-Type: text/cloud-config
+Mime-Version: 1.0
+
+packages: ['httpie']
+
+--MIMEBOUNDARY--
+"""
+
+    m_fetch_url.return_value = (io.BytesIO(user_data), {"status": 200})
+
+    assert ec2_instance._fetch("http://169.254.169.254/latest/user-data") == user_data.decode("utf-8")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Handle decompression when user-data is compressed. The fetch_url method from ansible.module_utils.urls does not decompress the user-data because the header is missing (The API does not set 'Content-Encoding' = 'gzip').

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_metadata_facts

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
