### PR TITLE
Remove unrelated snapshot comment from rds_instance state docs

### DIFF
--- a/changelogs/fragments/1578-rds-instance-docs.yml
+++ b/changelogs/fragments/1578-rds-instance-docs.yml
@@ -1,0 +1,2 @@
+trivial:
+  - "Remove incorrect mention of RDS snapshots in RDS instance state parameter, and reformat the remaining parameter explanation."

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -24,11 +24,11 @@ options:
   # General module options
     state:
         description:
-          - Whether the snapshot should exist or not. I(rebooted) is not idempotent and will leave the DB instance in a running state
+          - Desired state of the RDS Instance.
+          - I(state=rebooted) is not idempotent and will leave the DB instance in a running state
             and start it prior to rebooting if it was stopped. I(present) will leave the DB instance in the current running/stopped state,
             (running if creating the DB instance).
-          - I(state=running) and I(state=started) are synonyms, as are I(state=rebooted) and I(state=restarted). Note - rebooting the instance
-            is not idempotent.
+          - I(state=running) and I(state=started) are synonyms, as are I(state=rebooted) and I(state=restarted).
         choices: ['present', 'absent', 'terminated', 'running', 'started', 'stopped', 'rebooted', 'restarted']
         default: 'present'
         type: str


### PR DESCRIPTION
##### SUMMARY

The `state` field for `rds_instance` mentions snapshots. But that's irrelevant. Probably an error when copy-pasting to create the module.

Fixes #1574

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
rds_instance
