### PR TITLE
aws_ec2 inventory : Modify accepted type for hostnames argument in the module doc

### DIFF
--- a/changelogs/fragments/ec2-inventory-hostnames-doc.yml
+++ b/changelogs/fragments/ec2-inventory-hostnames-doc.yml
@@ -1,0 +1,2 @@
+trivial:
+  - "Module documetation fix for hostnames argument. It can be list of str and dict."

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -580,7 +580,6 @@ class InventoryModule(AWSInventoryBase):
         :param hostnames: a list of hostname destination variables
         :return all the candidats matching the expectation
         """
-
         if not hostnames:
             hostnames = ["dns-name", "private-dns-name"]
 

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -775,7 +775,7 @@ class InventoryModule(AWSInventoryBase):
         use_ssm_inventory = self.get_option("use_ssm_inventory")
 
         if not all(isinstance(element, (dict, str)) for element in hostnames):
-            self.fail_aws("hostnames should be a list of dict and str.")
+            self.fail_aws("Hostnames should be a list of dict and str.")
 
         if self.get_option("include_extra_api_calls"):
             self.display.deprecate(

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -580,6 +580,7 @@ class InventoryModule(AWSInventoryBase):
         :param hostnames: a list of hostname destination variables
         :return all the candidats matching the expectation
         """
+
         if not hostnames:
             hostnames = ["dns-name", "private-dns-name"]
 
@@ -773,6 +774,9 @@ class InventoryModule(AWSInventoryBase):
         hostvars_suffix = self.get_option("hostvars_suffix")
         use_contrib_script_compatible_ec2_tag_keys = self.get_option("use_contrib_script_compatible_ec2_tag_keys")
         use_ssm_inventory = self.get_option("use_ssm_inventory")
+
+        if hostnames and not all(isinstance(element, dict | str) for element in hostnames):
+            self.fail_aws("hostnames should be a list of dict and str.")
 
         if self.get_option("include_extra_api_calls"):
             self.display.deprecate(

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -32,16 +32,17 @@ options:
   hostnames:
     description:
       - A list in order of precedence for hostname variables.
+      - The elements of the list can be a dict with the keys mentioned below or a string.
+      - Can be one of the options specified in U(http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options).
+      - If value provided does not exist in the above options, it will be used as a literal string.
+      - To use tags as hostnames use the syntax tag:Name=Value to use the hostname Name_Value, or tag:Name to use the value of the Name tag.
     type: list
-    elements: dict
+    elements: raw
     default: []
     suboptions:
       name:
         description:
           - Name of the host.
-          - Can be one of the options specified in U(http://docs.aws.amazon.com/cli/latest/reference/ec2/describe-instances.html#options).
-          - To use tags as hostnames use the syntax tag:Name=Value to use the hostname Name_Value, or tag:Name to use the value of the Name tag.
-          - If value provided does not exist in the above options, it will be used as a literal string.
         type: str
         required: True
       prefix:

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -774,7 +774,7 @@ class InventoryModule(AWSInventoryBase):
         use_contrib_script_compatible_ec2_tag_keys = self.get_option("use_contrib_script_compatible_ec2_tag_keys")
         use_ssm_inventory = self.get_option("use_ssm_inventory")
 
-        if hostnames and not all(isinstance(element, dict | str) for element in hostnames):
+        if not all(isinstance(element, (dict, str)) for element in hostnames):
             self.fail_aws("hostnames should be a list of dict and str.")
 
         if self.get_option("include_extra_api_calls"):


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Fixes #1460 

The argument `hostnames` is of type list, whose elements can be string and dict.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
