### PR TITLE
[manual backport stable-5] Fix: ec2_instance idempotency issue when attaching ENI to isntance (#1576)

### DIFF
--- a/changelogs/fragments/ec2_instance-eni-attach-idempotency.yml
+++ b/changelogs/fragments/ec2_instance-eni-attach-idempotency.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ec2_instance - fix check_mode issue when adding network interfaces (https://github.com/ansible-collections/amazon.aws/issues/1403).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1502,16 +1502,19 @@ def change_network_attachments(instance, params):
         # network.interfaces can create the need to attach new interfaces
         old_ids = [inty['NetworkInterfaceId'] for inty in instance['NetworkInterfaces']]
         to_attach = set(new_ids) - set(old_ids)
-        for eni_id in to_attach:
-            try:
-                client.attach_network_interface(
-                    aws_retry=True,
-                    DeviceIndex=new_ids.index(eni_id),
-                    InstanceId=instance['InstanceId'],
-                    NetworkInterfaceId=eni_id,
-                )
-            except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
-                module.fail_json_aws(e, msg="Could not attach interface {0} to instance {1}".format(eni_id, instance['InstanceId']))
+        if not module.check_mode:
+            for eni_id in to_attach:
+                try:
+                    client.attach_network_interface(
+                        aws_retry=True,
+                        DeviceIndex=new_ids.index(eni_id),
+                        InstanceId=instance["InstanceId"],
+                        NetworkInterfaceId=eni_id,
+                    )
+                except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
+                    module.fail_json_aws(
+                        e, msg=f"Could not attach interface {eni_id} to instance {instance['InstanceId']}"
+                    )
         return bool(len(to_attach))
     return False
 

--- a/tests/integration/targets/ec2_instance_external_resource_attach/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_external_resource_attach/tasks/main.yml
@@ -60,6 +60,39 @@
         - 'in_test_vpc_instance.instances.0.key_name == "{{ resource_prefix }}_test_key"'
         - '(in_test_vpc_instance.instances.0.network_interfaces | length) == 1'
 
+  - name: "Add a second interface (check_mode=true)"
+    ec2_instance:
+      state: present
+      name: "{{ resource_prefix }}-test-eni-vpc"
+      network:
+        interfaces:
+          - id: "{{ eni_a.interface.id }}"
+          - id: "{{ eni_b.interface.id }}"
+      image_id: "{{ ec2_ami_id }}"
+      tags:
+        TestId: "{{ ec2_instance_tag_TestId }}"
+      instance_type: "{{ ec2_instance_type }}"
+      wait: false
+    register: add_interface_check_mode
+    check_mode: true
+
+  - name: Validate task reported changed
+    assert:
+      that:
+        - add_interface_check_mode is changed
+
+  - name: "Gather {{ resource_prefix }}-test-eni-vpc info"
+    ec2_instance_info:
+      filters:
+        "tag:Name": '{{ resource_prefix }}-test-eni-vpc'
+    register: in_test_vpc_instance
+
+  - name: Validate that only 1 ENI is attached to instance as we run using check_mode=true
+    assert:
+      that:
+        - 'in_test_vpc_instance.instances.0.key_name == "{{ resource_prefix }}_test_key"'
+        - '(in_test_vpc_instance.instances.0.network_interfaces | length) == 1'
+
   - name: "Add a second interface"
     ec2_instance:
       state: present
@@ -75,8 +108,24 @@
       wait: false
     register: add_interface
     until: add_interface is not failed
-    ignore_errors: yes
+    ignore_errors: true
     retries: 10
+
+  - name: Validate that the instance has now 2 interfaces attached
+    block:
+      - name: "Gather {{ resource_prefix }}-test-eni-vpc info"
+        ec2_instance_info:
+          filters:
+            "tag:Name": '{{ resource_prefix }}-test-eni-vpc'
+        register: in_test_vpc_instance
+
+      - name: Validate that only 1 ENI is attached to instance as we run using check_mode=true
+        assert:
+          that:
+            - 'in_test_vpc_instance.instances.0.key_name == "{{ resource_prefix }}_test_key"'
+            - '(in_test_vpc_instance.instances.0.network_interfaces | length) == 2'
+
+    when: add_interface is successful
 
   - name: "Make instance in the testing subnet created in the test VPC(check mode)"
     ec2_instance:


### PR DESCRIPTION
ec2_instance - fix idempotency issue when attaching ENI to isntance

SUMMARY

closes #1403

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

ec2_instance

Reviewed-by: Alina Buzachis
(cherry picked from commit b7533c55cbfb63f136d04d3543d7ffb90d0ba7ca)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
