### PR TITLE
1594_ec2_instance_key_name_is_not_an_error

### DIFF
--- a/changelogs/fragments/1594_ec2_instance_key_name_is_not_an_error.yml
+++ b/changelogs/fragments/1594_ec2_instance_key_name_is_not_an_error.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - if key_name is empty, assume it is absent

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1260,7 +1260,7 @@ def build_top_level_options(params):
             msg="You must include an image_id or image.id parameter to create an instance, or use a launch_template."
         )
 
-    if params.get("key_name") is not None:
+    if params.get("key_name") not in (None, ""):
         spec["KeyName"] = params.get("key_name")
 
     spec.update(build_userdata(params))


### PR DESCRIPTION
##### SUMMARY
ec2_instance / do not raise an error if key_name is a empty string

Closes #1594 

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_instance

##### ADDITIONAL INFORMATION