### PR TITLE
[manual backport stable-6] autoscaling_group_info - Fix ValidationError when describing ASGs tha…

### DIFF
--- a/changelogs/fragments/1593-autoscaling_group_info-20-target-groups-per-call.yml
+++ b/changelogs/fragments/1593-autoscaling_group_info-20-target-groups-per-call.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - autoscaling_group_info - fix ValidationError when describing an autoscaling group that has more than 20 target groups attached to it by breaking the request into chunks (https://github.com/ansible-collections/amazon.aws/pull/1593).
+  - autoscaling_group - fix ValidationError when describing an autoscaling group that has more than 20 target groups attached to it by breaking the request into chunks (https://github.com/ansible-collections/amazon.aws/pull/1593).

--- a/plugins/modules/autoscaling_group.py
+++ b/plugins/modules/autoscaling_group.py
@@ -901,12 +901,18 @@ def get_properties(autoscaling_group):
     if properties["target_group_arns"]:
         elbv2_connection = module.client("elbv2")
         tg_paginator = elbv2_connection.get_paginator("describe_target_groups")
-        tg_result = tg_paginator.paginate(TargetGroupArns=properties["target_group_arns"]).build_full_result()
-        target_groups = tg_result["TargetGroups"]
+        # Limit of 20 similar to https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html
+        tg_chunk_size = 20
+        properties["target_group_names"] = []
+        tg_chunks = [
+            properties["target_group_arns"][i: i + tg_chunk_size]
+            for i in range(0, len(properties["target_group_arns"]), tg_chunk_size)
+        ]
+        for chunk in tg_chunks:
+            tg_result = tg_paginator.paginate(TargetGroupArns=chunk).build_full_result()
+            properties["target_group_names"].extend([tg["TargetGroupName"] for tg in tg_result["TargetGroups"]])
     else:
-        target_groups = []
-
-    properties["target_group_names"] = [tg["TargetGroupName"] for tg in target_groups]
+        properties["target_group_names"] = []
 
     return properties
 

--- a/plugins/modules/autoscaling_group_info.py
+++ b/plugins/modules/autoscaling_group_info.py
@@ -414,8 +414,18 @@ def find_asgs(conn, module, name=None, tags=None):
                 if elbv2:
                     try:
                         tg_paginator = elbv2.get_paginator("describe_target_groups")
-                        tg_result = tg_paginator.paginate(TargetGroupArns=asg["target_group_arns"]).build_full_result()
-                        asg["target_group_names"] = [tg["TargetGroupName"] for tg in tg_result["TargetGroups"]]
+                        # Limit of 20 similar to https://docs.aws.amazon.com/elasticloadbalancing/latest/APIReference/API_DescribeLoadBalancers.html
+                        tg_chunk_size = 20
+                        asg["target_group_names"] = []
+                        tg_chunks = [
+                            asg["target_group_arns"][i: i + tg_chunk_size]
+                            for i in range(0, len(asg["target_group_arns"]), tg_chunk_size)
+                        ]
+                        for chunk in tg_chunks:
+                            tg_result = tg_paginator.paginate(TargetGroupArns=chunk).build_full_result()
+                            asg["target_group_names"].extend(
+                                [tg["TargetGroupName"] for tg in tg_result["TargetGroups"]]
+                            )
                     except is_boto3_error_code("TargetGroupNotFound"):
                         asg["target_group_names"] = []
                     except (

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/create_update_delete.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/create_update_delete.yml
@@ -474,8 +474,8 @@
 
     # Target group names have max length of 32 characters
   - set_fact:
-      tg1_name: "{{ (resource_prefix + '-tg1' ) | regex_search('(.{1,32})$') }}"
-      tg2_name: "{{ (resource_prefix + '-tg2' ) | regex_search('(.{1,32})$') }}"
+      tg1_name: "ansible-test-{{tiny_prefix}}-asg-t1"
+      tg2_name: "ansible-test-{{tiny_prefix}}-asg-t2"
   - name: create target group 1
     elb_target_group:
       name: '{{ tg1_name }}'


### PR DESCRIPTION
…t have more than 20 Load Balancer Target Groups attached (#1593)

autoscaling_group_info - Fix ValidationError when describing ASGs that have more than 20 Load Balancer Target Groups attached

SUMMARY

When retrieving autoscaling group info from an ASG that has more than 20 load balancer target groups attached to it the AWS API returns a ValidationError via Ansible:
    "error": {
        "code": "ValidationError",
        "message": "You cannot describe more than '20' target groups at a time",
        "type": "Sender"
    },

This commit (if length of target_group_arns is greater than 20) breaks the target_group_arns list into chunks and builds the target_group_names list incrementally to avoid exceeding the AWS limit of 20.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

autoscaling_group_info
ADDITIONAL INFORMATION

Before
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: botocore.exceptions.ClientError: An error occurred (ValidationError) when calling the DescribeTargetGroups operation: You cannot describe more than '20' target groups at a time failed: [us-west-1] (item=['redacted', 'redacted']) => {
    "ansible_loop_var": "item",
    "boto3_version": "1.26.136",
    "botocore_version": "1.29.146",
    "changed": false,
    "error": {
        "code": "ValidationError",
        "message": "You cannot describe more than '20' target groups at a time",
        "type": "Sender"
    },
    "item": [
        "01",
        "proxy"
    ],
    "response_metadata": {
        "http_headers": {
            "connection": "close",
            "content-length": "321",
            "content-type": "text/xml",
            "date": "Fri, 02 Jun 2023 21:45:34 GMT",
            "x-amzn-requestid": "32205cd9-0c1c-4c8b-bf6f-0536d1251f72"
        },
        "http_status_code": 400,
        "request_id": "32205cd9-0c1c-4c8b-bf6f-0536d1251f72",
        "retry_attempts": 0
    }
}

MSG:

Failed to describe Target Groups: An error occurred (ValidationError) when calling the DescribeTargetGroups operation: You cannot describe more than '20' target groups at a time

These are the sections of output below
https://docs.ansible.com/ansible/latest/collections/amazon/aws/autoscaling_group_info_module.html#return-target_group_arns https://docs.ansible.com/ansible/latest/collections/amazon/aws/autoscaling_group_info_module.html#return-target_group_names After this commit, the module is able to retrieve and return target group names vs ValidationError above. ...
            "target_group_arns": [
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs0-001-pd01/54a21ec73d9567de",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs1-001-pd01/9c3c288759270055",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs10-001-pd01/1a8f765efa2b21f3",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs11-001-pd01/be79ff24e7c9dfc8",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs12-001-pd01/b0efa4c98c3707ea",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs13-001-pd01/5ba3bd3e820189e5",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs14-001-pd01/9eb427e64e64cb34",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs15-001-pd01/cd57f2fc112ef1be",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs16-001-pd01/7c96ab6cf57065d9",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs17-001-pd01/b2f2cb1f8c56fccd",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs18-001-pd01/48d5b7e958256383",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs19-001-pd01/c31c2835b325053e",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs2-001-pd01/088e22de058a5682",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs20-001-pd01/06bc6d5594c400d8",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs21-001-pd01/d2e19039fb58901a",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs22-001-pd01/3e542166d868cd51",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs23-001-pd01/915a38152472f256",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs24-001-pd01/0d490d00340a3b0c",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs25-001-pd01/4da43adf85c2c74f",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs26-001-pd01/dd6eed2cf2b3b40a",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs27-001-pd01/b6a70661615b58e5",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs28-001-pd01/9f90bb0063a399d3",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs29-001-pd01/a5de186522047a38",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs3-001-pd01/1abe1864526da4f4",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs30-001-pd01/acdd881d550190b0",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs31-001-pd01/e2b2d9f7496a1e42",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs32-001-pd01/c67d2beab9937b36",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs33-001-pd01/1a6e069d76d35129",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs34-001-pd01/7e7a041ba28d9ba1",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs35-001-pd01/7e9c6316c8bfbdcc",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs36-001-pd01/a63ef453fb2a9ffc",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs37-001-pd01/6d2b70df56a6e6b8",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs38-001-pd01/c29789ed0c5f185a",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs39-001-pd01/b2ee2dd578012057",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs4-001-pd01/6bac5695356d7a31",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs40-001-pd01/7b7a1b4110b676a0",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs41-001-pd01/69f80d314ea3998c",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs42-001-pd01/f3b542db69b6364e",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs43-001-pd01/e2af6db68a4f90c1",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs44-001-pd01/d8e30df7de550115",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs45-001-pd01/28030e72b5771b95",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs46-001-pd01/4c6558b79bea34e9",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs47-001-pd01/8de7ffe13bb7fdd8",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs48-001-pd01/02d57221242667e8",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs49-001-pd01/5847cbf10c46b9aa",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs5-001-pd01/82828f534fc4f0ba",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs6-001-pd01/c6258cfe31de8ff8",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs7-001-pd01/e665c3b1fceb2717",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs8-001-pd01/5309914c19f919cc",
                "arn:aws:elasticloadbalancing:us-west-1:redacted:targetgroup/tgcs9-001-pd01/bf33d7ca75fe4c37"
            ],
            "target_group_names": [
                "tgcs0-001-pd01",
                "tgcs1-001-pd01",
                "tgcs10-001-pd01",
                "tgcs11-001-pd01",
                "tgcs12-001-pd01",
                "tgcs13-001-pd01",
                "tgcs14-001-pd01",
                "tgcs15-001-pd01",
                "tgcs16-001-pd01",
                "tgcs17-001-pd01",
                "tgcs18-001-pd01",
                "tgcs19-001-pd01",
                "tgcs2-001-pd01",
                "tgcs20-001-pd01",
                "tgcs21-001-pd01",
                "tgcs22-001-pd01",
                "tgcs23-001-pd01",
                "tgcs24-001-pd01",
                "tgcs25-001-pd01",
                "tgcs26-001-pd01",
                "tgcs27-001-pd01",
                "tgcs28-001-pd01",
                "tgcs29-001-pd01",
                "tgcs3-001-pd01",
                "tgcs30-001-pd01",
                "tgcs31-001-pd01",
                "tgcs32-001-pd01",
                "tgcs33-001-pd01",
                "tgcs34-001-pd01",
                "tgcs35-001-pd01",
                "tgcs36-001-pd01",
                "tgcs37-001-pd01",
                "tgcs38-001-pd01",
                "tgcs39-001-pd01",
                "tgcs4-001-pd01",
                "tgcs40-001-pd01",
                "tgcs41-001-pd01",
                "tgcs42-001-pd01",
                "tgcs43-001-pd01",
                "tgcs44-001-pd01",
                "tgcs45-001-pd01",
                "tgcs46-001-pd01",
                "tgcs47-001-pd01",
                "tgcs48-001-pd01",
                "tgcs49-001-pd01",
                "tgcs5-001-pd01",
                "tgcs6-001-pd01",
                "tgcs7-001-pd01",
                "tgcs8-001-pd01",
                "tgcs9-001-pd01"
            ],
...

Reviewed-by: Mark Chappell
Reviewed-by: Bryan J. Hong
Reviewed-by: Alina Buzachis
(cherry picked from commit 3d045fda5df9dd6d867c05c29982a6186d616b5a)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
