### PR TITLE
s3_object - allow recursive copy of all objects in S3 bucket

### DIFF
--- a/changelogs/fragments/20230612-s3_object-support-copy-objects-recursively.yml
+++ b/changelogs/fragments/20230612-s3_object-support-copy-objects-recursively.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- s3_object - Allow recursive copy of objects in S3 bucket (https://github.com/ansible-collections/amazon.aws/issues/1379).

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -237,7 +237,7 @@ options:
       prefix:
         description:
         - Copy all the keys that begin with the specified prefix.
-        - Ignored if I(copy_src.object) is not set.
+        - Ignored if I(copy_src.object) is supplied.
         default: ""
         type: str
         version_added: 6.2.0
@@ -582,16 +582,13 @@ def paginated_versioned_list_with_fallback(s3, **pagination_params):
             yield [{"Key": key}]
 
 
-def list_keys(s3, bucket, prefix, marker=None, max_keys=None):
+def list_keys(s3, bucket, prefix=None, marker=None, max_keys=None):
     pagination_params = {
         "Bucket": bucket,
+        "Prefix": prefix,
+        "StartAfter": marker,
+        "MaxKeys": max_keys,
     }
-    if prefix:
-        pagination_params["Prefix"] = prefix
-    if marker:
-        pagination_params["StartAfter"] = marker
-    if max_keys:
-        pagination_params["MaxKeys"] = max_keys
     pagination_params = {k: v for k, v in pagination_params.items() if v}
 
     try:

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -1516,7 +1516,7 @@ def main():
             options=dict(
                 bucket=dict(required=True),
                 object=dict(),
-                prefix=dict(),
+                prefix=dict(default=""),
                 version_id=dict(),
             ),
         ),

--- a/tests/integration/targets/s3_object/tasks/copy_recursively.yml
+++ b/tests/integration/targets/s3_object/tasks/copy_recursively.yml
@@ -100,7 +100,7 @@
         mode: list
       register: _objects
 
-    - name: Ensure objects with prefix 'file' were copied into bucket
+    - name: Ensure all objects were copied into bucket
       assert:
         that:
           - _copy_all is changed
@@ -121,7 +121,7 @@
         mode: list
       register: _objects
 
-    - name: Ensure objects with prefix 'file' were copied into bucket
+    - name: Ensure number of copied objects remains the same.
       assert:
         that:
           - _copy_all_idempotency is not changed

--- a/tests/integration/targets/s3_object/tasks/copy_recursively.yml
+++ b/tests/integration/targets/s3_object/tasks/copy_recursively.yml
@@ -1,0 +1,152 @@
+- name: Test copy recursively object from one bucket to another one.
+  block:
+    - name: Create S3 bucket
+      s3_bucket:
+        name: "{{ item }}"
+        state: present
+      with_items:
+        - "{{ bucket_src }}"
+        - "{{ bucket_dst }}"
+
+    - name: Create object into bucket
+      s3_object:
+        bucket: "{{ bucket_src }}"
+        mode: put
+        content: "{{ item.content }}"
+        object: "{{ item.object }}"
+      with_items: "{{ s3_objects }}"
+
+    - name: Copy all objects from source bucket into destination bucket
+      s3_object:
+        bucket: "{{ bucket_dst }}"
+        mode: copy
+        copy_src:
+          bucket: "{{ bucket_src }}"
+      check_mode: true
+
+    - name: list objects from bucket
+      s3_object:
+        bucket: "{{ bucket_dst }}"
+        mode: list
+      register: _objects
+
+    - name: Ensure no object were found into bucket
+      assert:
+        that:
+          - _objects.s3_keys | length == 0
+
+    # Test: Copy all objects using prefix
+    - name: copy object using prefix
+      s3_object:
+        bucket: "{{ bucket_dst }}"
+        mode: copy
+        copy_src:
+          bucket: "{{ bucket_src }}"
+          prefix: "file"
+      register: _copy_with_prefix
+
+    - name: list objects from bucket
+      s3_object:
+        bucket: "{{ bucket_dst }}"
+        mode: list
+      register: _objects
+
+    - name: Ensure objects with prefix 'file' were copied into bucket
+      assert:
+        that:
+          - _copy_with_prefix is changed
+          - _objects.s3_keys | length == 3
+          - '"file1.txt" in _objects.s3_keys'
+          - '"file2.txt" in _objects.s3_keys'
+          - '"file3.txt" in _objects.s3_keys'
+
+    # Test: Copy all objects using prefix (idempotency)
+    - name: copy object using prefix (idempotency)
+      s3_object:
+        bucket: "{{ bucket_dst }}"
+        mode: copy
+        copy_src:
+          bucket: "{{ bucket_src }}"
+          prefix: "file"
+      register: _copy_with_prefix_idempotency
+
+    - name: list objects from bucket
+      s3_object:
+        bucket: "{{ bucket_dst }}"
+        mode: list
+      register: _objects
+
+    - name: Ensure objects with prefix 'file' were copied into bucket
+      assert:
+        that:
+          - _copy_with_prefix_idempotency is not changed
+          - _objects.s3_keys | length == 3
+          - '"file1.txt" in _objects.s3_keys'
+          - '"file2.txt" in _objects.s3_keys'
+          - '"file3.txt" in _objects.s3_keys'
+
+    # Test: Copy all objects from source bucket
+    - name: copy all objects from source bucket
+      s3_object:
+        bucket: "{{ bucket_dst }}"
+        mode: copy
+        copy_src:
+          bucket: "{{ bucket_src }}"
+      register: _copy_all
+
+    - name: list objects from bucket
+      s3_object:
+        bucket: "{{ bucket_dst }}"
+        mode: list
+      register: _objects
+
+    - name: Ensure objects with prefix 'file' were copied into bucket
+      assert:
+        that:
+          - _copy_all is changed
+          - _objects.s3_keys | length == 5
+
+    # Test: Copy all objects from source bucket (idempotency)
+    - name: copy all objects from source bucket (idempotency)
+      s3_object:
+        bucket: "{{ bucket_dst }}"
+        mode: copy
+        copy_src:
+          bucket: "{{ bucket_src }}"
+      register: _copy_all_idempotency
+
+    - name: list objects from bucket
+      s3_object:
+        bucket: "{{ bucket_dst }}"
+        mode: list
+      register: _objects
+
+    - name: Ensure objects with prefix 'file' were copied into bucket
+      assert:
+        that:
+          - _copy_all_idempotency is not changed
+          - _objects.s3_keys | length == 5
+  
+  vars:
+    bucket_src: "{{ bucket_name }}-recursive-src"
+    bucket_dst: "{{ bucket_name }}-recursive-dst"
+    s3_objects:
+      - object: file1.txt
+        content: |
+          some content for file1.txt
+      - object: file2.txt
+        content: |
+          some content for file2.txt
+      - object: file3.txt
+        content: |
+          some content for file3.txt
+      - object: testfile.py
+        content: "This is a sample text file"
+      - object: another.txt
+        content: "another file to create into bucket"
+
+  always:
+    - include_tasks: delete_bucket.yml
+      with_items:
+        - "{{ bucket_src }}"
+        - "{{ bucket_dst }}"

--- a/tests/integration/targets/s3_object/tasks/main.yml
+++ b/tests/integration/targets/s3_object/tasks/main.yml
@@ -1039,6 +1039,8 @@
             - "'tags' in result"
             - (result.tags | length) == 0
 
+      - include_tasks: copy_recursively.yml
+
   always:
 
     - name: delete temporary files

--- a/tests/unit/plugins/modules/test_s3_object.py
+++ b/tests/unit/plugins/modules/test_s3_object.py
@@ -17,26 +17,22 @@ utils = "ansible_collections.amazon.aws.plugins.module_utils.ec2"
 
 @patch(module_name + ".paginated_list")
 def test_list_keys_success(m_paginated_list):
-    module = MagicMock()
     s3 = MagicMock()
 
     m_paginated_list.return_value = ["delete.txt"]
 
-    s3_object.list_keys(module, s3, "a987e6b6026ab04e4717", "", "", 1000)
-
-    assert m_paginated_list.call_count == 1
-    module.exit_json.assert_called_with(msg="LIST operation complete", s3_keys=["delete.txt"])
+    assert ["delete.txt"] == s3_object.list_keys(s3, "a987e6b6026ab04e4717", "", "", 1000)
+    m_paginated_list.assert_called_once()
 
 
 @patch(module_name + ".paginated_list")
 def test_list_keys_failure(m_paginated_list):
-    module = MagicMock()
     s3 = MagicMock()
 
     m_paginated_list.side_effect = botocore.exceptions.BotoCoreError
 
     with pytest.raises(s3_object.S3ObjectFailure):
-        s3_object.list_keys(module, s3, "a987e6b6026ab04e4717", "", "", 1000)
+        s3_object.list_keys(s3, "a987e6b6026ab04e4717", "", "", 1000)
 
 
 @patch(module_name + ".delete_key")


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support to copy recursively all objects from one bucket to another one, user can set `prefix` to limit the object to copy.
closes #1379 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`s3_object`