### PR TITLE
Lambda execute stack trace should be not formatted with extra space

### DIFF
--- a/changelogs/fragments/1604-no_formatted_with_extra_space.yml
+++ b/changelogs/fragments/1604-no_formatted_with_extra_space.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Fixes to the stack trace output, where it does not contain spaces between each character. The module had incorrectly always outputted extra spaces between each character. (https://github.com/ansible-collections/amazon.aws/pull/1615)

--- a/changelogs/fragments/1604-no_formatted_with_extra_space.yml
+++ b/changelogs/fragments/1604-no_formatted_with_extra_space.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-- Fixes to the stack trace output, where it does not contain spaces between each character. The module had incorrectly always outputted extra spaces between each character. (https://github.com/ansible-collections/amazon.aws/pull/1615)

--- a/changelogs/fragments/1615-no_formatted_with_extra_space.yml
+++ b/changelogs/fragments/1615-no_formatted_with_extra_space.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Fixes to the stack trace output, where it does not contain spaces between each character. The module had incorrectly always outputted extra spaces between each character. (https://github.com/ansible-collections/amazon.aws/pull/1615)`

--- a/changelogs/fragments/1615-no_formatted_with_extra_space.yml
+++ b/changelogs/fragments/1615-no_formatted_with_extra_space.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
-- Fixes to the stack trace output, where it does not contain spaces between each character. The module had incorrectly always outputted extra spaces between each character. (https://github.com/ansible-collections/amazon.aws/pull/1615)`
+-  'lambda_execute - Fixes to the stack trace output, where it does not contain spaces between each character. The module had incorrectly always outputted extra spaces between each character. (https://github.com/ansible-collections/amazon.aws/pull/1615)'

--- a/changelogs/fragments/1615-no_formatted_with_extra_space.yml
+++ b/changelogs/fragments/1615-no_formatted_with_extra_space.yml
@@ -1,3 +1,3 @@
 ---
 bugfixes:
--  'lambda_execute - Fixes to the stack trace output, where it does not contain spaces between each character. The module had incorrectly always outputted extra spaces between each character. (https://github.com/ansible-collections/amazon.aws/pull/1615)'
+- Fixes to the stack trace output, where it does not contain spaces between each character. The module had incorrectly always outputted extra spaces between each character. (https://github.com/ansible-collections/amazon.aws/pull/1615)

--- a/plugins/modules/lambda_execute.py
+++ b/plugins/modules/lambda_execute.py
@@ -262,11 +262,12 @@ def main():
                 "Function executed, but there was an error in the Lambda function. "
                 "Message: {errmsg}, Type: {type}, Stack Trace: {trace}"
             )
+
             error_data = {
                 # format the stacktrace sent back as an array into a multiline string
                 "trace": "\n".join(
                     [
-                        line for line in results.get("output", {}).get("stackTrace", [])
+                        list(results.get("output", {}).get("stackTrace", []))
                     ]
                 ),
                 "errmsg": results["output"].get("errorMessage"),

--- a/plugins/modules/lambda_execute.py
+++ b/plugins/modules/lambda_execute.py
@@ -265,11 +265,7 @@ def main():
 
             error_data = {
                 # format the stacktrace sent back as an array into a multiline string
-                "trace": "\n".join(
-                    [
-                        list(results.get("output", {}).get("stackTrace", []))
-                    ]
-                ),
+                "trace": "\n".join(results.get("output", {}).get("stackTrace", [])),
                 "errmsg": results["output"].get("errorMessage"),
                 "type": results["output"].get("errorType"),
             }

--- a/plugins/modules/lambda_execute.py
+++ b/plugins/modules/lambda_execute.py
@@ -266,8 +266,7 @@ def main():
                 # format the stacktrace sent back as an array into a multiline string
                 "trace": "\n".join(
                     [
-                        " ".join([str(x) for x in line])  # cast line numbers to strings
-                        for line in results.get("output", {}).get("stackTrace", [])
+                        line for line in results.get("output", {}).get("stackTrace", [])
                     ]
                 ),
                 "errmsg": results["output"].get("errorMessage"),


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #1497 

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/lambda_execute.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
