### PR TITLE
ec2_vpc_nat_gateway - changes to no allocate eip address when connectivity_type=private

### DIFF
--- a/changelogs/fragments/1632-changes-to-no-allocate-eip-when-connectivity_type=private.yml
+++ b/changelogs/fragments/1632-changes-to-no-allocate-eip-when-connectivity_type=private.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_vpc_nat_gateway - fixes to nat gateway so that when the user creates a private NAT gateway, an Elastic IP address should not be allocated. The module had inncorrectly always allocate elastic IP address when creating private nat gateway (https://github.com/ansible-collections/amazon.aws/pull/1632).

--- a/plugins/modules/ec2_vpc_nat_gateway.py
+++ b/plugins/modules/ec2_vpc_nat_gateway.py
@@ -736,10 +736,11 @@ def pre_create(
             msg = f"NAT Gateway {existing_gateways[0]['nat_gateway_id']} already exists in subnet_id {subnet_id}"
             return changed, msg, results
         else:
-            changed, msg, allocation_id = allocate_eip_address(client, module)
+            if connectivity_type == "public":
+                changed, msg, allocation_id = allocate_eip_address(client, module)
 
-            if not changed:
-                return changed, msg, dict()
+                if not changed:
+                    return changed, msg, dict()
 
     elif eip_address or allocation_id:
         if eip_address and not allocation_id:

--- a/tests/integration/targets/ec2_vpc_nat_gateway/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_nat_gateway/tasks/main.yml
@@ -919,6 +919,7 @@
       - create_ngw.changed
       - create_ngw.connectivity_type == 'private'
       - '"create_time" in create_ngw'
+      - '"allocation_id" not in create_ngw.nat_gateway_addresses[0]'
 
   - name: 'set facts: NAT gateway ID'
     set_fact:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1618 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
plugins/modules/ec2_vpc_nat_gateway.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
