### PR TITLE
[manual backport stable-5] Lambda execute stack trace should be not formatted with extra space 

### DIFF
--- a/changelogs/fragments/1615-no_formatted_with_extra_space.yml
+++ b/changelogs/fragments/1615-no_formatted_with_extra_space.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- Fixes to the stack trace output, where it does not contain spaces between each character. The module had incorrectly always outputted extra spaces between each character. (https://github.com/ansible-collections/amazon.aws/pull/1615)

--- a/plugins/modules/lambda_execute.py
+++ b/plugins/modules/lambda_execute.py
@@ -252,17 +252,16 @@ def main():
                 [results['output'].get('stackTrace'), results['output'].get('errorMessage')]):
             # AWS sends back stack traces and error messages when a function failed
             # in a RequestResponse (synchronous) context.
-            template = ("Function executed, but there was an error in the Lambda function. "
-                        "Message: {errmsg}, Type: {type}, Stack Trace: {trace}")
+            template = (
+                "Function executed, but there was an error in the Lambda function. "
+                "Message: {errmsg}, Type: {type}, Stack Trace: {trace}"
+            )
+
             error_data = {
                 # format the stacktrace sent back as an array into a multiline string
-                'trace': '\n'.join(
-                    [' '.join([
-                        str(x) for x in line  # cast line numbers to strings
-                    ]) for line in results.get('output', {}).get('stackTrace', [])]
-                ),
-                'errmsg': results['output'].get('errorMessage'),
-                'type': results['output'].get('errorType')
+                "trace": "\n".join(results.get("output", {}).get("stackTrace", [])),
+                "errmsg": results["output"].get("errorMessage"),
+                "type": results["output"].get("errorType"),
             }
             module.fail_json(msg=template.format(**error_data), result=results)
 


### PR DESCRIPTION
…#1615)

Lambda execute stack trace should be not formatted with extra space

SUMMARY

Fixes #1497
ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

plugins/modules/lambda_execute.py
ADDITIONAL INFORMATION

Reviewed-by: Jill R
Reviewed-by: Bikouo Aubin
Reviewed-by: Alina Buzachis
Reviewed-by: Mike Graves <mgraves@redhat.com>
(cherry picked from commit 271523ea97f73f0e4c5a027eac4f4fc72f4b7093)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
