### PR TITLE
[manual backport stable-5] Fix typo in rds_instance docs for master_user_password (#1617)

### DIFF
--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -252,7 +252,7 @@ options:
     master_user_password:
         description:
           - An 8-41 character password for the master database user. The password can contain any printable ASCII character
-            except "/", """, or "@". To modify the password use I(force_update_password). Use I(apply immediately) to change
+            except C(/), C("), or C(@). To modify the password use I(force_update_password). Use I(apply_immediately) to change
             the password immediately, otherwise it is updated during the next maintenance window.
         aliases:
           - password


### PR DESCRIPTION
Fix typo in rds_instance docs for master_user_password

SUMMARY

Fix typo in rds_instance docs for master_user_password attribute

ISSUE TYPE

Docs Pull Request

COMPONENT NAME

rds_instance
ADDITIONAL INFORMATION

Reviewed-by: Mark Chappell
Reviewed-by: Alina Buzachis
(cherry picked from commit a04109d26f733bbd04cf6d9d5ea8c22196cde217)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
