### PR TITLE
[DNM] Bump release to dev1 to force full CI run

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,6 +1,6 @@
 namespace: amazon
 name: aws
-version: 7.0.0-dev0
+version: 7.0.0-dev1
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 AMAZON_AWS_COLLECTION_NAME = "amazon.aws"
-AMAZON_AWS_COLLECTION_VERSION = "7.0.0-dev0"
+AMAZON_AWS_COLLECTION_VERSION = "7.0.0-dev1"
 
 
 _collection_info_context = {


### PR DESCRIPTION
##### SUMMARY

We've seen various failures because of breaking changes in the latest Ansible milestone, force a full CI run to make sure we have actually flushed them *all* out


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

common.py

##### ADDITIONAL INFORMATION
