### PR TITLE
[manual backport stable-5] ec2_vpc_nat_gateway - changes to no allocate eip address when connectivity_type=private (#1632)

### DIFF
--- a/changelogs/fragments/1632-changes-to-no-allocate-eip-when-connectivity_type=private.yml
+++ b/changelogs/fragments/1632-changes-to-no-allocate-eip-when-connectivity_type=private.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- ec2_vpc_nat_gateway - fixes to nat gateway so that when the user creates a private NAT gateway, an Elastic IP address should not be allocated. The module had inncorrectly always allocate elastic IP address when creating private nat gateway (https://github.com/ansible-collections/amazon.aws/pull/1632).

--- a/plugins/modules/ec2_vpc_nat_gateway.py
+++ b/plugins/modules/ec2_vpc_nat_gateway.py
@@ -746,12 +746,11 @@ def pre_create(client, module, subnet_id, tags, purge_tags, allocation_id=None, 
             )
             return changed, msg, results
         else:
-            changed, msg, allocation_id = (
-                allocate_eip_address(client, module)
-            )
+            if connectivity_type == "public":
+                changed, msg, allocation_id = allocate_eip_address(client, module)
 
-            if not changed:
-                return changed, msg, dict()
+                if not changed:
+                    return changed, msg, dict()
 
     elif eip_address or allocation_id:
         if eip_address and not allocation_id:

--- a/tests/integration/targets/ec2_vpc_nat_gateway/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_nat_gateway/tasks/main.yml
@@ -919,6 +919,7 @@
       - create_ngw.changed
       - create_ngw.connectivity_type == 'private'
       - '"create_time" in create_ngw'
+      - '"allocation_id" not in create_ngw.nat_gateway_addresses[0]'
 
   - name: 'set facts: NAT gateway ID'
     set_fact:


### PR DESCRIPTION
[manual backport stable-5] ec2_vpc_nat_gateway - changes to no allocate eip address when connectivity_type=private (#1632)

ec2_vpc_nat_gateway - changes to no allocate eip address when connectivity_type=private

SUMMARY

Fixes #1618

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

plugins/modules/ec2_vpc_nat_gateway.py
ADDITIONAL INFORMATION

Reviewed-by: Alina Buzachis
(cherry picked from commit afe9ccb52fa0611607c5a8f19f9454cba86980b3)