### PR TITLE
inventory aws_ec2 - Add az id as hostvar

### DIFF
--- a/changelogs/fragments/1550-az-id-as-hostvar.yml
+++ b/changelogs/fragments/1550-az-id-as-hostvar.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-- inventory aws ec2 - add AZ id to hostvars ()
+- inventory aws ec2 - add AZ id to hostvars (https://github.com/ansible-collections/amazon.aws/pull/1651)

--- a/changelogs/fragments/1550-az-id-as-hostvar.yml
+++ b/changelogs/fragments/1550-az-id-as-hostvar.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- inventory aws ec2 - add AZ id to hostvars ()

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_az_id.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_az_id.yml
@@ -1,0 +1,43 @@
+---
+- hosts: 127.0.0.1
+  connection: local
+  gather_facts: no
+  environment: "{{ ansible_test.environment }}"
+  tasks:
+
+    - module_defaults:
+        group/aws:
+          aws_access_key: '{{ aws_access_key }}'
+          aws_secret_key: '{{ aws_secret_key }}'
+          security_token: '{{ security_token | default(omit) }}'
+          region: '{{ aws_region }}'
+      block:
+
+        # Create VPC, subnet, security group, and find image_id to create instance
+        - include_tasks: tasks/setup.yml
+
+        # Create new host, refresh inventory
+        - name: create a new host
+          ec2_instance:
+            image_id: '{{ image_id }}'
+            name: '{{ resource_prefix }}'
+            tags:
+              OtherTag: value
+            instance_type: t2.micro
+            security_groups: '{{ sg_id }}'
+            vpc_subnet_id: '{{ subnet_id }}'
+            wait: false
+
+        - meta: refresh_inventory
+
+        - name: Get AZ information from AWS
+          aws_az_info:
+            filters:
+              zone-name: "{{ hostvars[resource_prefix]['placement']['availability_zone'] }}"
+          register: az_info
+
+        - name: Run tests
+          assert:
+            that:
+              - hostvars[resource_prefix]['placement']['availability_zone_id'] is defined # Ensure AZ id is set
+              - hostvars[resource_prefix]['placement']['availability_zone_id'] == az_info['availability_zones'][0]['zone_id'] # Ensure AZ id is equale to the one from AWS API call

--- a/tests/integration/targets/inventory_aws_ec2/runme.sh
+++ b/tests/integration/targets/inventory_aws_ec2/runme.sh
@@ -78,6 +78,10 @@ ansible-playbook playbooks/test_inventory_cache.yml "$@"
 ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_ssm.yml.j2'" "$@"
 ansible-playbook playbooks/test_inventory_ssm.yml "$@"
 
+# generate inventory config with az id information
+ansible-playbook playbooks/create_inventory_config.yml -e "template='inventory_with_az_id.yml.j2'" "$@"
+ansible-playbook playbooks/test_az_id.yml "$@"
+
 # remove inventory cache
 rm -r aws_ec2_cache_dir/
 

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_az_id.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_az_id.yml.j2
@@ -1,0 +1,13 @@
+plugin: amazon.aws.aws_ec2
+aws_access_key_id: '{{ aws_access_key }}'
+aws_secret_access_key: '{{ aws_secret_key }}'
+{% if security_token | default(false) %}
+aws_security_token: '{{ security_token }}'
+{% endif %}
+regions:
+- '{{ aws_region }}'
+filters:
+  tag:Name:
+  - '{{ resource_prefix }}'
+hostnames:
+- tag:Name


### PR DESCRIPTION
##### SUMMARY
Add AZ id as a hostvar under `placement` block.

Fixes https://github.com/ansible-collections/amazon.aws/issues/1550

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/inventory/aws_ec2.py

##### ADDITIONAL INFORMATION

```
BEFORE:
"placement": {
    "availability_zone": "eu-central-1c",
    "group_name": "",
    "region": "eu-central-1",
    "tenancy": "default"
},

AFTER:
"placement": {
    "availability_zone": "eu-central-1c",
    "availability_zone_id": "euc1-az1",
    "group_name": "",
    "region": "eu-central-1",
    "tenancy": "default"
},
```
