### PR TITLE
Fix ec2_instance 'state' processing when exact_count is used

### DIFF
--- a/changelogs/fragments/1659-ec2_instance-ensure-state-exact_count.yml
+++ b/changelogs/fragments/1659-ec2_instance-ensure-state-exact_count.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- ec2_instance - fix state processing when exact_count is used (https://github.com/ansible-collections/amazon.aws/pull/1659).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -2390,9 +2390,9 @@ def enforce_count(
 
     current_count = len(existing_matches)
     if current_count == exact_count:
-        if desired_module_state != 'present':
+        if desired_module_state != "present":
             results = ensure_instance_state(desired_module_state)
-            if results['changed']:
+            if results["changed"]:
                 return results
         return dict(
             changed=False,

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -2384,14 +2384,18 @@ def handle_existing(
 
 
 def enforce_count(
-    client, module: AnsibleAWSModule, existing_matches: List[Dict[str, Any]], desired_module_state: str
+    client,
+    module: AnsibleAWSModule,
+    existing_matches: List[Dict[str, Any]],
+    desired_module_state: str,
+    filters: Optional[Dict[str, Any]],
 ) -> Dict[str, Any]:
     exact_count = module.params.get("exact_count")
 
     current_count = len(existing_matches)
     if current_count == exact_count:
         if desired_module_state != "present":
-            results = ensure_instance_state(desired_module_state)
+            results = ensure_instance_state(client, module, desired_module_state, filters)
             if results["changed"]:
                 return results
         return dict(
@@ -2827,7 +2831,7 @@ def main():
                     changed=False,
                 )
         elif module.params.get("exact_count"):
-            result = enforce_count(client, module, existing_matches, desired_module_state=state)
+            result = enforce_count(client, module, existing_matches, desired_module_state=state, filters=filters)
         elif existing_matches and not module.params.get("count"):
             for match in existing_matches:
                 warn_if_public_ip_assignment_changed(module, match)

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -2390,11 +2390,15 @@ def enforce_count(
 
     current_count = len(existing_matches)
     if current_count == exact_count:
+        if desired_module_state != 'present':
+            results = ensure_instance_state(desired_module_state)
+            if results['changed']:
+                return results
         return dict(
             changed=False,
             instances=[pretty_instance(i) for i in existing_matches],
             instance_ids=[i["InstanceId"] for i in existing_matches],
-            msg=f"{exact_count} instances already running, nothing to do.",
+            msg=f"{exact_count} instances already {desired_module_state}, nothing to do.",
         )
 
     if current_count < exact_count:

--- a/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
@@ -277,6 +277,57 @@
           - '"terminated_ids" not in terminate_multiple_instances'
           - '"ec2:TerminateInstances" not in terminate_multiple_instances.resource_actions'
 
+    - name: Trigger restart of instances with exact_count (check_mode)
+      amazon.aws.ec2_instance:
+        state: restarted
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 3
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+      register: restart_multiple_instances
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - restart_multiple_instances is not failed
+          - restart_multiple_instances.changed
+          - '"instances" in restart_multiple_instances'
+          - restart_multiple_instances.instances | length == 3
+          - '"reboot_success" in restart_multiple_instances'
+          - '"reboot_failed" in restart_multiple_instances'
+          - '"ec2:StopInstances" not in restart_multiple_instances.resource_actions'
+          - '"ec2:StartInstances" not in restart_multiple_instances.resource_actions'
+
+
+    - name: Trigger restart of instances with exact_count
+      amazon.aws.ec2_instance:
+        state: restarted
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 3
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: restart_multiple_instances
+
+    - ansible.builtin.assert:
+        that:
+          - restart_multiple_instances is not failed
+          - restart_multiple_instances.changed
+          - '"instances" in restart_multiple_instances'
+          - restart_multiple_instances.instances | length == 3
+          - '"reboot_success" in restart_multiple_instances'
+          - restart_multiple_instances.reboot_success | length == 3
+          - '"reboot_failed" in restart_multiple_instances'
+          - restart_multiple_instances.reboot_failed | length == 0
+          - '"ec2:StopInstances" in restart_multiple_instances.resource_actions'
+          - '"ec2:StartInstances" in restart_multiple_instances.resource_actions'
+
     - name: Enforce instance count to 6 - Launch 3 more instances (check_mode)
       amazon.aws.ec2_instance:
         instance_type: "{{ ec2_instance_type }}"


### PR DESCRIPTION
##### SUMMARY
Fixes (ie adds) 'state' processing for ec2_instance when 'exact_count' is used rather than 'instance_ids'

Note this only has effect when the exact_count is the same as the number of already existing, matching instances.
In other words, it (still) has no effect when instances are either added or terminated as a result of exact_count. This is probably OK, as those other cases already have set target states (ie running or terminated respectively).
But for the cases of managing the state of an existing group of instances, this adds that ability.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_instance

##### ADDITIONAL INFORMATION
Currently, given an ec2_instance call where exact_count == existing instance count, any specification of 'state' has no effect.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
