### PR TITLE
rds_cluster - use include_tasks rather than include in the integration tests and several sanity fixes

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -60,5 +60,9 @@ jobs:
             {
               "ansible-version": "devel",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
             }
           ]

--- a/.github/workflows/units.yml
+++ b/.github/workflows/units.yml
@@ -59,6 +59,10 @@ jobs:
             {
               "ansible-version": "devel",
               "python-version": "3.8"
+            },
+            {
+              "ansible-version": "devel",
+              "python-version": "3.9"
             }
           ]
       collection_pre_install: ''

--- a/changelogs/fragments/20230726-rds_cluster-fix_integration_tests.yml
+++ b/changelogs/fragments/20230726-rds_cluster-fix_integration_tests.yml
@@ -1,0 +1,2 @@
+trivial:
+  - "Use ``include_tasks`` rather than ``include`` since it was removed from ansible-core."

--- a/changelogs/fragments/20230726-rds_cluster-fix_integration_tests.yml
+++ b/changelogs/fragments/20230726-rds_cluster-fix_integration_tests.yml
@@ -1,2 +1,4 @@
 trivial:
   - "Use ``include_tasks`` rather than ``include`` since it was removed from ansible-core."
+  - "cloudwatch_metric_alarm - fix ``dimensions`` argument mismatch. Argument ``dimensions`` in argument_spec defines default as (None) but documentation defines default as ({})."
+  - "cloudwatch_metric_alarm - fix ``metrics`` argument mismatch.Argument ``metrics`` in argument_spec defines default as ([]) but documentation defines default as (None)."

--- a/plugins/modules/cloudwatch_metric_alarm.py
+++ b/plugins/modules/cloudwatch_metric_alarm.py
@@ -54,6 +54,7 @@ options:
           - An array of MetricDataQuery structures that enable
             you to create an alarm based on the result of a metric math expression.
         type: list
+        default: []
         required: false
         default: []
         version_added: "5.5.0"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
rds_cluster - use include_tasks rather than include in the integration tests. include feature has been removed from Ansible-core.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rds_cluster

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
