### PR TITLE
Fixes #1607 - Catch botocore exception when getting bucket tags

### DIFF
--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -920,6 +920,8 @@ def get_current_object_tags_dict(module, s3, bucket, obj, version=None):
         return {}
     except is_boto3_error_code(("NoSuchTagSet", "NoSuchTagSetError")):
         return {}
+    except botocore.exceptions.ClientError:
+        return {}
     return boto3_tag_list_to_ansible_dict(current_tags)
 
 


### PR DESCRIPTION
##### SUMMARY
Fixes #1607 - Catch botocore exception when getting bucket tags

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
s3_object

##### ADDITIONAL INFORMATION
I tried the exact scenario mentioned in the bug and confirmed that I got this error 
```
botocore.exceptions.ClientError: An error occurred (NoSuchTagSet) when calling the GetObjectTagging operation: The TagSet does not exist
```
After catching that exception, it is no longer an issue.

Before
```
priya@priya-ThinkPad-E570:~/Downloads$ ansible localhost -m amazon.aws.s3_object -a "mode=put endpoint_url=https://s3.wasabisys.com bucket=testansiblepriya src=/tmp/test object=foo " -vvv
ansible [core 2.15.2]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/priya/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  ansible collection location = /home/priya/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.11.2 (main, May 30 2023, 17:45:26) [GCC 12.2.0] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True
Using /etc/ansible/ansible.cfg as config file
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Parsed /etc/ansible/hosts inventory source with ini plugin
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: priya
<127.0.0.1> EXEC /bin/sh -c 'echo ~priya && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/priya/.ansible/tmp `"&& mkdir "` echo /home/priya/.ansible/tmp/ansible-tmp-1690467831.7416854-108958-271332352600 `" && echo ansible-tmp-1690467831.7416854-108958-271332352600="` echo /home/priya/.ansible/tmp/ansible-tmp-1690467831.7416854-108958-271332352600 `" ) && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'test -e /tmp/test && sleep 0'
Using module file /home/priya/.ansible/collections/ansible_collections/amazon/aws/plugins/modules/s3_object.py
<127.0.0.1> PUT /home/priya/.ansible/tmp/ansible-local-108954x7nlja_5/tmpn5q9fert TO /home/priya/.ansible/tmp/ansible-tmp-1690467831.7416854-108958-271332352600/AnsiballZ_s3_object.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/priya/.ansible/tmp/ansible-tmp-1690467831.7416854-108958-271332352600/ /home/priya/.ansible/tmp/ansible-tmp-1690467831.7416854-108958-271332352600/AnsiballZ_s3_object.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3 /home/priya/.ansible/tmp/ansible-tmp-1690467831.7416854-108958-271332352600/AnsiballZ_s3_object.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/priya/.ansible/tmp/ansible-tmp-1690467831.7416854-108958-271332352600/ > /dev/null 2>&1 && sleep 0'
The full traceback is:
Traceback (most recent call last):
  File "/tmp/ansible_amazon.aws.s3_object_payload_r45sqn3r/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/modules/s3_object.py", line 1026, in ensure_tags
  File "/tmp/ansible_amazon.aws.s3_object_payload_r45sqn3r/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/modules/s3_object.py", line 974, in get_current_object_tags_dict
  File "/tmp/ansible_amazon.aws.s3_object_payload_r45sqn3r/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/retries.py", line 105, in deciding_wrapper
    return retrying_wrapper(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/tmp/ansible_amazon.aws.s3_object_payload_r45sqn3r/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/cloud.py", line 119, in _retry_wrapper
    return _retry_func(
           ^^^^^^^^^^^^
  File "/tmp/ansible_amazon.aws.s3_object_payload_r45sqn3r/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/module_utils/cloud.py", line 68, in _retry_func
    return func()
           ^^^^^^
  File "/home/priya/.local/lib/python3.11/site-packages/botocore/client.py", line 534, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/priya/.local/lib/python3.11/site-packages/botocore/client.py", line 976, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (NoSuchTagSet) when calling the GetObjectTagging operation: The TagSet does not exist

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/tmp/ansible_amazon.aws.s3_object_payload_r45sqn3r/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/modules/s3_object.py", line 1540, in main
  File "/tmp/ansible_amazon.aws.s3_object_payload_r45sqn3r/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/modules/s3_object.py", line 1202, in s3_object_do_put
  File "/tmp/ansible_amazon.aws.s3_object_payload_r45sqn3r/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/modules/s3_object.py", line 771, in upload_s3file
  File "/tmp/ansible_amazon.aws.s3_object_payload_r45sqn3r/ansible_amazon.aws.s3_object_payload.zip/ansible_collections/amazon/aws/plugins/modules/s3_object.py", line 1032, in ensure_tags
S3ObjectFailure: Failed to get object tags.
localhost | FAILED! => {
    "boto3_version": "1.28.12",
    "botocore_version": "1.31.12",
    "changed": false,
    "error": {
        "code": "NoSuchTagSet",
        "message": "The TagSet does not exist"
    },
    "invocation": {
        "module_args": {
            "access_key": "K901WKC3B3GTTAOVLPL4",
            "aws_ca_bundle": null,
            "aws_config": null,
            "bucket": "testansiblepriya",
            "ceph": false,
            "content": null,
            "content_base64": null,
            "copy_src": null,
            "debug_botocore_endpoint_logs": false,
            "dest": null,
            "dualstack": false,
            "encrypt": true,
            "encryption_kms_key_id": null,
            "encryption_mode": "AES256",
            "endpoint_url": "https://s3.wasabisys.com",
            "expiry": 600,
            "headers": null,
            "ignore_nonexistent_bucket": false,
            "marker": "",
            "max_keys": 1000,
            "metadata": null,
            "mode": "put",
            "object": "foo",
            "overwrite": "different",
            "permission": [
                "private"
            ],
            "prefix": "",
            "profile": null,
            "purge_tags": true,
            "region": null,
            "retries": 0,
            "secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "session_token": null,
            "sig_v4": true,
            "src": "/tmp/test",
            "tags": null,
            "validate_bucket_name": true,
            "validate_certs": true,
            "version": null
        }
    },
    "msg": "Failed to get object tags.: An error occurred (NoSuchTagSet) when calling the GetObjectTagging operation: The TagSet does not exist",
    "response_metadata": {
        "host_id": "2+rXVgY3/uIyShj6ju3SCumk5IjqL16SmrBxZx3WA7BjGdnhYo99I99HPNZnRoIIcPbTDOwk8218",
        "http_headers": {
            "content-type": "application/xml",
            "date": "Thu, 27 Jul 2023 14:23:54 GMT",
            "server": "WasabiS3/7.15.2121-2023-07-18-0ee420c377 (head02)",
            "transfer-encoding": "chunked",
            "x-amz-id-2": "2+rXVgY3/uIyShj6ju3SCumk5IjqL16SmrBxZx3WA7BjGdnhYo99I99HPNZnRoIIcPbTDOwk8218",
            "x-amz-request-id": "E98E0F9CD66E192A:A"
        },
        "http_status_code": 404,
        "request_id": "E98E0F9CD66E192A:A",
        "retry_attempts": 0
    }
}

```
After
```
priya@priya-ThinkPad-E570:~/Downloads$ ansible localhost -m amazon.aws.s3_object -a "mode=put endpoint_url=https://s3.wasabisys.com bucket=testansiblepriya src=/tmp/test object=foo " -vvv
ansible [core 2.15.2]
  config file = /etc/ansible/ansible.cfg
  configured module search path = ['/home/priya/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/lib/python3/dist-packages/ansible
  ansible collection location = /home/priya/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/bin/ansible
  python version = 3.11.2 (main, May 30 2023, 17:45:26) [GCC 12.2.0] (/usr/bin/python3)
  jinja version = 3.1.2
  libyaml = True
Using /etc/ansible/ansible.cfg as config file
host_list declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
script declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
auto declined parsing /etc/ansible/hosts as it did not pass its verify_file() method
Parsed /etc/ansible/hosts inventory source with ini plugin
Skipping callback 'default', as we already have a stdout callback.
Skipping callback 'minimal', as we already have a stdout callback.
Skipping callback 'oneline', as we already have a stdout callback.
<127.0.0.1> ESTABLISH LOCAL CONNECTION FOR USER: priya
<127.0.0.1> EXEC /bin/sh -c 'echo ~priya && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '( umask 77 && mkdir -p "` echo /home/priya/.ansible/tmp `"&& mkdir "` echo /home/priya/.ansible/tmp/ansible-tmp-1690468828.4470508-110135-128599619663359 `" && echo ansible-tmp-1690468828.4470508-110135-128599619663359="` echo /home/priya/.ansible/tmp/ansible-tmp-1690468828.4470508-110135-128599619663359 `" ) && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'test -e /tmp/test && sleep 0'
Using module file /home/priya/.ansible/collections/ansible_collections/amazon/aws/plugins/modules/s3_object.py
<127.0.0.1> PUT /home/priya/.ansible/tmp/ansible-local-1101312q3qir97/tmp_xas_k1j TO /home/priya/.ansible/tmp/ansible-tmp-1690468828.4470508-110135-128599619663359/AnsiballZ_s3_object.py
<127.0.0.1> EXEC /bin/sh -c 'chmod u+x /home/priya/.ansible/tmp/ansible-tmp-1690468828.4470508-110135-128599619663359/ /home/priya/.ansible/tmp/ansible-tmp-1690468828.4470508-110135-128599619663359/AnsiballZ_s3_object.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c '/usr/bin/python3 /home/priya/.ansible/tmp/ansible-tmp-1690468828.4470508-110135-128599619663359/AnsiballZ_s3_object.py && sleep 0'
<127.0.0.1> EXEC /bin/sh -c 'rm -f -r /home/priya/.ansible/tmp/ansible-tmp-1690468828.4470508-110135-128599619663359/ > /dev/null 2>&1 && sleep 0'
localhost | SUCCESS => {
    "changed": false,
    "expiry": 600,
    "invocation": {
        "module_args": {
            "access_key": "K901WKC3B3GTTAOVLPL4",
            "aws_ca_bundle": null,
            "aws_config": null,
            "bucket": "testansiblepriya",
            "ceph": false,
            "content": null,
            "content_base64": null,
            "copy_src": null,
            "debug_botocore_endpoint_logs": false,
            "dest": null,
            "dualstack": false,
            "encrypt": true,
            "encryption_kms_key_id": null,
            "encryption_mode": "AES256",
            "endpoint_url": "https://s3.wasabisys.com",
            "expiry": 600,
            "headers": null,
            "ignore_nonexistent_bucket": false,
            "marker": "",
            "max_keys": 1000,
            "metadata": null,
            "mode": "put",
            "object": "foo",
            "overwrite": "different",
            "permission": [
                "private"
            ],
            "prefix": "",
            "profile": null,
            "purge_tags": true,
            "region": null,
            "retries": 0,
            "secret_key": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "session_token": null,
            "sig_v4": true,
            "src": "/tmp/test",
            "tags": null,
            "validate_bucket_name": true,
            "validate_certs": true,
            "version": null
        }
    },
    "msg": "Download url:",
    "tags": {},
    "url": "https://s3.wasabisys.com/testansiblepriya/foo?AWSAccessKeyId=K901WKC3B3GTTAOVLPL4&Signature=DrVdyMXAUryUAmK1AWrFgJdL7xk%3D&Expires=1690469431"
}

```