### PR TITLE
Default filters to empty dictionary

### DIFF
--- a/changelogs/fragments/ec2_vpc_route_table_info-filter-fix.yml
+++ b/changelogs/fragments/ec2_vpc_route_table_info-filter-fix.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_vpc_route_table_info - default filters to empty dictionary (https://github.com/ansible-collections/amazon.aws/issues/1668).

--- a/plugins/modules/ec2_vpc_route_table_info.py
+++ b/plugins/modules/ec2_vpc_route_table_info.py
@@ -20,6 +20,7 @@ options:
       - A dict of filters to apply. Each dict item consists of a filter key and a filter value.
         See U(https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeRouteTables.html) for possible filters.
     type: dict
+    default: {}
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules
@@ -260,7 +261,7 @@ def list_ec2_vpc_route_tables(connection, module):
 
 def main():
     argument_spec = dict(
-        filters=dict(default=None, type="dict"),
+        filters=dict(default={}, type="dict"),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Changes the default for the filters option from `None` to an empty dictionary.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes: #1668

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vpc_route_table_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This matches what other *info modules (e.g. [`ec2_vpc_endpoint_info`](https://github.com/ansible-collections/amazon.aws/blob/82162752ed79c810e16e0801a14b2126e3b6506b/plugins/modules/ec2_vpc_endpoint_info.py#L217) or [`ec2_vpc_subnet_info`](https://github.com/ansible-collections/amazon.aws/blob/82162752ed79c810e16e0801a14b2126e3b6506b/plugins/modules/ec2_vpc_subnet_info.py#L209)) do for the filters option default.

<!--- Paste verbatim command output below, e.g. before and after your change -->
