### PR TITLE
[backport stable-5] rds_cluster - Add AllocatedStorage, DBClusterInstanceClass, StorageType, Iops, and EngineMode

### DIFF
--- a/changelogs/fragments/20230713-rds_cluster-fix_params_passage.yml
+++ b/changelogs/fragments/20230713-rds_cluster-fix_params_passage.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - rds_cluster - Add ``AllocatedStorage``, ``DBClusterInstanceClass``, ``StorageType``, ``Iops``, and ``EngineMode`` to the list of parameters that can be passed when creating or modifying a Multi-AZ RDS cluster (https://github.com/ansible-collections/amazon.aws/pull/1657).

--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -773,6 +773,11 @@ def get_create_options(params_dict):
         "DomainIAMRoleName",
         "EnableGlobalWriteForwarding",
         "GlobalClusterIdentifier",
+        "AllocatedStorage",
+        "DBClusterInstanceClass",
+        "StorageType",
+        "Iops",
+        "EngineMode",
     ]
 
     return dict((k, v) for k, v in params_dict.items() if k in options and v is not None)
@@ -780,12 +785,33 @@ def get_create_options(params_dict):
 
 def get_modify_options(params_dict, force_update_password):
     options = [
-        'ApplyImmediately', 'BacktrackWindow', 'BackupRetentionPeriod', 'PreferredBackupWindow',
-        'DBClusterIdentifier', 'DBClusterParameterGroupName', 'EnableIAMDatabaseAuthentication',
-        'EngineVersion', 'PreferredMaintenanceWindow', 'MasterUserPassword', 'NewDBClusterIdentifier',
-        'OptionGroupName', 'Port', 'VpcSecurityGroupIds', 'EnableIAMDatabaseAuthentication',
-        'CloudwatchLogsExportConfiguration', 'DeletionProtection', 'EnableHttpEndpoint',
-        'CopyTagsToSnapshot', 'EnableGlobalWriteForwarding', 'Domain', 'DomainIAMRoleName',
+        "ApplyImmediately",
+        "BacktrackWindow",
+        "BackupRetentionPeriod",
+        "PreferredBackupWindow",
+        "DBClusterIdentifier",
+        "DBClusterParameterGroupName",
+        "EnableIAMDatabaseAuthentication",
+        "EngineVersion",
+        "PreferredMaintenanceWindow",
+        "MasterUserPassword",
+        "NewDBClusterIdentifier",
+        "OptionGroupName",
+        "Port",
+        "VpcSecurityGroupIds",
+        "EnableIAMDatabaseAuthentication",
+        "CloudwatchLogsExportConfiguration",
+        "DeletionProtection",
+        "EnableHttpEndpoint",
+        "CopyTagsToSnapshot",
+        "EnableGlobalWriteForwarding",
+        "Domain",
+        "DomainIAMRoleName",
+        "AllocatedStorage",
+        "DBClusterInstanceClass",
+        "StorageType",
+        "Iops",
+        "EngineMode",
     ]
     modify_options = dict((k, v) for k, v in params_dict.items() if k in options and v is not None)
     if not force_update_password:
@@ -955,8 +981,9 @@ def ensure_present(cluster, parameters, method_name, method_options_name):
     changed = False
 
     if not cluster:
-        if parameters.get('Tags') is not None:
-            parameters['Tags'] = ansible_dict_to_boto3_tag_list(parameters['Tags'])
+        if parameters.get("Tags") is not None:
+            parameters["Tags"] = ansible_dict_to_boto3_tag_list(parameters["Tags"])
+
         call_method(client, module, method_name, eval(method_options_name)(parameters))
         changed = True
     else:
@@ -1116,7 +1143,6 @@ def main():
         module.fail_json(msg='skip_final_snapshot is False but all of the following are missing: final_snapshot_identifier')
 
     parameters = arg_spec_to_rds_params(dict((k, module.params[k]) for k in module.params if k in parameter_options))
-
     changed = False
     method_name, method_options_name = get_rds_method_attribute_name(cluster)
 


### PR DESCRIPTION
Add AllocatedStorage, DBClusterInstanceClass, StorageType, Iops, and EngineMode to the list of parameters that can be passed when creating or modifying a Multi-AZ RDS cluster. (#1657)

rds_cluster - enable creation or modification of AllocatedStorage, DBClusterInstanceClass, StorageType, Iops, and EngineMode

SUMMARY

Add AllocatedStorage, DBClusterInstanceClass, StorageType, Iops and EngineMode to the list of parameters that can be passed when creating or modifying a Multi-AZ RDS cluster.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

rds_cluster

Reviewed-by: Taeho Park
Reviewed-by: Mike Graves <mgraves@redhat.com>
(cherry picked from commit 70aafdd9ab53fede7d948c89382125e98aa1bc11)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
