### PR TITLE
route53: add wait_id return value in case of changes

### DIFF
--- a/changelogs/fragments/1683-route53-wait_id.yml
+++ b/changelogs/fragments/1683-route53-wait_id.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "route53 - add a ``wait_id`` return value when a change is done (https://github.com/ansible-collections/amazon.aws/pull/1683)."

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -249,7 +249,7 @@ wait_id:
     - The wait ID for the applied change. Can be used to wait for the change to propagate later on when I(wait=false).
   type: str
   returned: when changed
-  version_added: 5.6.0
+  version_added: 6.3.0
 """
 
 EXAMPLES = r"""

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -105,6 +105,8 @@
       that:
       - qdn is not failed
       - qdn is changed
+      - "'wait_id' in qdn"
+      - qdn.wait_id is string
 
   - name: Get A record using "get" method of route53 module
     route53:
@@ -191,6 +193,7 @@
       that:
       - non_qdn is not failed
       - non_qdn is not changed
+      - "'wait_id' not in non_qdn"
 
   - name: Create A record using zone ID
     route53:
@@ -705,6 +708,8 @@
       - create_geo_continent_check_mode is changed
       - create_geo_continent_check_mode is not failed
       - '"route53:ChangeResourceRecordSets" not in create_geo_continent_check_mode.resource_actions'
+      - '"wait_id" in create_geo_continent_check_mode'
+      - create_geo_continent_check_mode.wait_id is none
 
   - name: Create a record with geo_location - continent_code
     route53:


### PR DESCRIPTION
##### SUMMARY
This allows to wait for changes later on when `wait=false` is provided to the module.

Will be needed for a new route53_wait module I'll create a PR for soon in community.aws :)

(I'm not sure whether another 5.x.0 feature release is planned; in case it is not I'll update `version_added` and the `backport-5` label needs to be removed.)

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
route53
