### PR TITLE
Fix misspelling in ec2_instance docs

### DIFF
--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -360,14 +360,14 @@ options:
         version_added: 4.0.0
         type: str
         description:
-          - Wether the instance metadata endpoint is available via IPv6 (C(enabled)) or not (C(disabled)).
+          - Whether the instance metadata endpoint is available via IPv6 (C(enabled)) or not (C(disabled)).
         choices: [enabled, disabled]
         default: 'disabled'
       instance_metadata_tags:
         version_added: 4.0.0
         type: str
         description:
-          - Wether the instance tags are availble (C(enabled)) via metadata endpoint or not (C(disabled)).
+          - Whether the instance tags are availble (C(enabled)) via metadata endpoint or not (C(disabled)).
         choices: [enabled, disabled]
         default: 'disabled'
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes a misspelling in the docs, "Wether" -> "Whether"

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance
