### PR TITLE
[manual backport stable-5] Fix misspelling in ec2_instance docs (#1689)

### DIFF
--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -360,7 +360,7 @@ options:
         version_added: 4.0.0
         type: str
         description:
-          - Wether the instance metadata endpoint is available via IPv6 (C(enabled)) or not (C(disabled)).
+          - Whether the instance metadata endpoint is available via IPv6 (C(enabled)) or not (C(disabled)).
           - Requires botocore >= 1.21.29
         choices: [enabled, disabled]
         default: 'disabled'
@@ -368,7 +368,7 @@ options:
         version_added: 4.0.0
         type: str
         description:
-          - Wether the instance tags are availble (C(enabled)) via metadata endpoint or not (C(disabled)).
+          - Whether the instance tags are availble (C(enabled)) via metadata endpoint or not (C(disabled)).
           - Requires botocore >= 1.23.30
         choices: [enabled, disabled]
         default: 'disabled'


### PR DESCRIPTION
Fix misspelling in ec2_instance docs

SUMMARY

Fixes a misspelling in the docs, "Wether" -> "Whether"

ISSUE TYPE

Docs Pull Request

COMPONENT NAME

ec2_instance

Reviewed-by: Mark Chappell
Reviewed-by: Alina Buzachis
(cherry picked from commit f0ab7b882071402ca75793a5a4f29f392d7a5d54)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
