### PR TITLE
Add a workflow (+actions) to automatically generate the GitHub Release when a valid tag is pushed

### DIFF
--- a/.github/actions/ansible_release_log/action.yml
+++ b/.github/actions/ansible_release_log/action.yml
@@ -1,0 +1,55 @@
+name: "Ansible GitHub Release Logs"
+author: "Mark Chappell (tremble)"
+branding:
+  icon: "git-branch"
+  color: "gray-dark"
+description: "Generate Changelog entries for a GitHub release"
+
+inputs:
+  release:
+    description: "The release version to publish"
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+
+    - name: Prepare release environment
+      run: |
+        pip install rst-to-myst[sphinx]
+        pip install antsibull-changelog
+      shell: bash
+
+    - name: Checkout current ref
+      uses: actions/checkout@master
+      with:
+        ref: ${{ github.ref }}
+
+    - name: Generate release log (RST)
+      run: |
+        antsibull-changelog generate -vvv --output changelog-release.rst --only-latest "${INPUT_RELEASE}"
+      shell: bash
+      env:
+        INPUT_RELEASE: ${{ inputs.release }}
+
+    - name: Upload RST release log
+      uses: actions/upload-artifact@v3
+      with:
+        name: changelog-rst
+        path: changelog-release.rst
+
+    - name: Convert release log (MD)
+      run: |
+        rst2myst convert changelog-release.rst
+        sed -i 's/^#/###/' changelog-release.md
+      shell: bash
+
+    - name: Upload MD release log
+      uses: actions/upload-artifact@v3
+      with:
+        name: changelog-md
+        path: changelog-release.md

--- a/.github/actions/ansible_release_tag/action.yml
+++ b/.github/actions/ansible_release_tag/action.yml
@@ -1,0 +1,41 @@
+name: "Ansible GitHub Release"
+author: "Mark Chappell (tremble)"
+branding:
+  icon: "git-branch"
+  color: "gray-dark"
+description: "Publish GitHub releases from an action"
+
+inputs:
+  release:
+    description: "The release version to publish"
+    required: true
+
+  collection-name:
+    description: "The name of the collection"
+    required: true
+
+
+runs:
+  using: composite
+  steps:
+
+    - name: Checkout current ref
+      uses: actions/checkout@master
+      with:
+        ref: ${{ github.ref }}
+
+    - name: Download MD release log
+      uses: actions/download-artifact@v3
+      with:
+        name: changelog-md
+
+    - name: Create Release
+      run: |
+        ls
+        cat changelog-release.md
+        gh release create "${RELEASE}" --verify-tag  -t "${COLLECTION_NAME} ${RELEASE}" -F changelog-release.md
+      shell: bash
+      env:
+        COLLECTION_NAME: ${{ inputs.collection-name }}
+        RELEASE: ${{ inputs.release }}
+        GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,32 @@
+name: Generate GitHub Release
+concurrency:
+  group: release-${{ github.head_ref }}
+  cancel-in-progress: true
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  generate-release-log:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Release Log
+        uses: ansible-collections/amazon.aws/.github/actions/ansible_release_log@main
+        with:
+          release: ${{ github.ref_name }}
+
+  perform-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs:
+      - generate-release-log
+    steps:
+      - name: Generate Release
+        uses: ansible-collections/amazon.aws/.github/actions/ansible_release_tag@main
+        with:
+          release: ${{ github.ref_name }}
+          collection-name: amazon.aws


### PR DESCRIPTION
Depends-on: https://github.com/ansible-community/antsibull-changelog/pull/131/ 
(And a release of antsibull-changelog once it's merged)

##### SUMMARY

Automatically generate the GitHub release when we push a valid tag.  (Because we keep forgetting)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

.github/

##### ADDITIONAL INFORMATION
