### PR TITLE
Add pause to allow permissions to propagate

### DIFF
--- a/tests/integration/targets/lambda_policy/tasks/main.yml
+++ b/tests/integration/targets/lambda_policy/tasks/main.yml
@@ -110,6 +110,9 @@
       action: lambda:InvokeFunction
       principal: apigateway.amazonaws.com
       source_arn: arn:aws:execute-api:{{ aws_region }}:{{ aws_caller_info.account }}:*/*
+  - name: Wait for permissions to propagate
+    ansible.builtin.pause:
+      seconds: 5
   - name: check API works with execute permissions
     uri:
       url: https://{{create_result.api_id}}.execute-api.{{aws_region}}.amazonaws.com/lambdabased/mini/Mr_Ansible_Tester


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Downstream testing has been having problems with the `lambda_policy` test target, due to a lag in the permissions being applied. This adds a brief pause to allow for their propagation.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
