### PR TITLE
ec2_key - fix security vulnerability

### DIFF
--- a/changelogs/fragments/ec2_key-fix-security-vulnerability.yml
+++ b/changelogs/fragments/ec2_key-fix-security-vulnerability.yml
@@ -1,3 +1,3 @@
 ---
-breaking_changes:
+minor_changes:
   - ec2_key - add support for new parameter ``file_name`` to save private key in when new key is created by AWS. When this option is provided the generated private key will be removed from the module return (https://github.com/ansible-collections/amazon.aws/pull/1704).

--- a/changelogs/fragments/ec2_key-fix-security-vulnerability.yml
+++ b/changelogs/fragments/ec2_key-fix-security-vulnerability.yml
@@ -1,3 +1,3 @@
 ---
 breaking_changes:
-  - ec2_key: module return ``private_key`` does not contains the private key anymore but rather the path to a file containing it, new module parameter ``path`` has been introduced to define this path. (https://github.com/ansible-collections/amazon.aws/pull/1704).
+  - ec2_key - module return ``private_key`` does not contains the private key anymore but rather the path to a file containing it, new module parameter ``path`` has been introduced to define this path. (https://github.com/ansible-collections/amazon.aws/pull/1704).

--- a/changelogs/fragments/ec2_key-fix-security-vulnerability.yml
+++ b/changelogs/fragments/ec2_key-fix-security-vulnerability.yml
@@ -1,3 +1,3 @@
 ---
 breaking_changes:
-  - ec2_key - module return ``private_key`` does not contains the private key anymore but rather the path to a file containing it, new module parameter ``path`` has been introduced to define this path. (https://github.com/ansible-collections/amazon.aws/pull/1704).
+  - ec2_key - add support for new parameter ``file_name`` to save private key in when new key is created by AWS. When this option is provided the generated private key will be removed from the module return (https://github.com/ansible-collections/amazon.aws/pull/1704).

--- a/changelogs/fragments/ec2_key-fix-security-vulnerability.yml
+++ b/changelogs/fragments/ec2_key-fix-security-vulnerability.yml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - ec2_key: module return ``private_key`` does not contains the private key anymore but rather the path to a file containing it, new module parameter ``path`` has been introduced to define this path. (https://github.com/ansible-collections/amazon.aws/pull/1704).

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -38,6 +38,7 @@ action_groups:
   - ec2_instance
   - ec2_instance_info
   - ec2_key
+  - ec2_key_info
   - ec2_security_group
   - ec2_security_group_info
   - ec2_snapshot

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -38,7 +38,6 @@ action_groups:
   - ec2_instance
   - ec2_instance_info
   - ec2_key
-  - ec2_key_info
   - ec2_security_group
   - ec2_security_group_info
   - ec2_snapshot

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -54,7 +54,7 @@ options:
       - The file is written out on the 'host' side rather than the 'controller' side.
       - Ignored when I(state=absent) or I(key_material) is provided.
     type: path
-    version_added: 7.0.0
+    version_added: 6.4.0
 notes:
   - Support for I(tags) and I(purge_tags) was added in release 2.1.0.
   - For security reasons, this module should be used with B(no_log=true) and (register) functionalities
@@ -162,6 +162,7 @@ key:
 """
 
 import uuid
+import os
 
 try:
     import botocore
@@ -271,8 +272,9 @@ def _write_private_key(key_data, file_name):
     from the ouput. This ensures we don't expose the key data in logs or task output.
     """
     try:
-        with open(file_name, "w") as f:
-            f.write(key_data["private_key"])
+        file = os.open(file_name, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+        os.write(file, key_data["private_key"].encode("utf-8"))
+        os.close(file)
     except (IOError, OSError) as e:
         raise Ec2KeyFailure(e, "Could not save private key to specified path. Private key is irretrievable.")
 

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -58,7 +58,7 @@ options:
 notes:
   - Support for I(tags) and I(purge_tags) was added in release 2.1.0.
   - For security reasons, this module should be used with B(no_log=true) and (register) functionalities
-    when creating new key pair without providing key_material.
+    when creating new key pair without providing I(key_material).
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules
@@ -148,7 +148,7 @@ key:
       sample: '{"my_key": "my value"}'
     private_key:
       description: private key of a newly created keypair
-      returned: when a new keypair is created by AWS (key_material is not provided) and I(file_name) is not provided.
+      returned: when a new keypair is created by AWS (I(key_material) is not provided) and I(file_name) is not provided.
       type: str
       sample: '-----BEGIN RSA PRIVATE KEY-----
         MIIEowIBAAKC...

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -47,10 +47,12 @@ options:
       - rsa
       - ed25519
     version_added: 3.1.0
-  path:
+  file_name:
     description:
-      - Name of the file containing the generated private key.
-      - Required when I(state=present) and I(key_material) is not provided.
+      - Name of the file where the generated private key will be saved.
+      - When provided, the I(key.private_key) attribute will be removed from the return value.
+      - The file is written out on the 'host' side rather than the 'controller' side.
+      - Ignored when I(state=absent) or I(key_material) is provided.
     type: path
     version_added: 7.0.0
 notes:
@@ -82,19 +84,17 @@ EXAMPLES = r"""
   amazon.aws.ec2_key:
     name: my_keypair
     key_material: 'ssh-rsa AAAAxyz...== me@example.com'
-    path: /tmp/aws_ssh_rsa
 
 - name: create key pair using key_material obtained using 'file' lookup plugin
   amazon.aws.ec2_key:
     name: my_keypair
     key_material: "{{ lookup('file', '/path/to/public_key/id_rsa.pub') }}"
-    path: /tmp/aws_ssh_rsa
 
-- name: Create ED25519 key pair
+- name: Create ED25519 key pair and save private key into a file
   amazon.aws.ec2_key:
     name: my_keypair
     key_type: ed25519
-    path: /tmp/aws_ssh_rsa
+    file_name: /tmp/aws_ssh_rsa
 
 # try creating a key pair with the name of an already existing keypair
 # but don't overwrite it even if the key is different (force=false)
@@ -104,16 +104,10 @@ EXAMPLES = r"""
     key_material: 'ssh-rsa AAAAxyz...== me@example.com'
     force: false
 
-- name: remove key pair on AWS by name
+- name: remove key pair from AWS by name
   amazon.aws.ec2_key:
     name: my_keypair
     state: absent
-
-- name: remove key pair on AWS and local filesystem
-  amazon.aws.ec2_key:
-    name: my_keypair
-    state: absent
-    path: /tmp/aws_ssh_rsa
 """
 
 RETURN = r"""
@@ -153,10 +147,12 @@ key:
       type: dict
       sample: '{"my_key": "my value"}'
     private_key:
-      description: Path to the generated SSH private key file.
-      returned: when state is present
+      description: private key of a newly created keypair
+      returned: when a new keypair is created by AWS (key_material is not provided) and I(file_name) is not provided.
       type: str
-      sample: /tmp/id_ssh_rsa
+      sample: '-----BEGIN RSA PRIVATE KEY-----
+        MIIEowIBAAKC...
+        -----END RSA PRIVATE KEY-----'
     type:
       description: type of a newly created keypair
       returned: when a new keypair is created by AWS
@@ -166,7 +162,6 @@ key:
 """
 
 import uuid
-import os
 
 try:
     import botocore
@@ -203,7 +198,7 @@ def _import_key_pair(ec2_client, name, key_material, tag_spec=None):
     return key
 
 
-def extract_key_data(key, key_type=None, path=None):
+def extract_key_data(key, key_type=None, file_name=None):
     data = {
         "name": key["KeyName"],
         "fingerprint": key["KeyFingerprint"],
@@ -215,13 +210,13 @@ def extract_key_data(key, key_type=None, path=None):
         "type": key.get("KeyType") or key_type,
     }
 
-    # Write the private key to disk and replace the value with the file path
-    if data["private_key"] is not None:
-        data = _write_private_key(data, path)
+    # Write the private key to disk and remove it from the return value
+    if file_name and data["private_key"] is not None:
+        data = _write_private_key(data, file_name)
     return scrub_none_parameters(data)
 
 
-def get_key_fingerprint(check_mode, ec2_client, key_material, path):
+def get_key_fingerprint(check_mode, ec2_client, key_material):
     """
     EC2's fingerprints are non-trivial to generate, so push this key
     to a temporary name and make ec2 calculate the fingerprint for us.
@@ -234,7 +229,7 @@ def get_key_fingerprint(check_mode, ec2_client, key_material, path):
         random_name = "ansible-" + str(uuid.uuid4())
         name_in_use = find_key_pair(ec2_client, random_name)
     temp_key = _import_key_pair(ec2_client, random_name, key_material)
-    delete_key_pair(check_mode, ec2_client, random_name, path, finish_task=False)
+    delete_key_pair(check_mode, ec2_client, random_name, finish_task=False)
     return temp_key["KeyFingerprint"]
 
 
@@ -270,23 +265,22 @@ def _create_key_pair(ec2_client, name, tag_spec, key_type):
     return key
 
 
-def _write_private_key(key_data, path):
+def _write_private_key(key_data, file_name):
     """
-    Write the private key data to the specified file, and replace private key
-    data with the path to the file. This ensures we don't expose the key data
-    in logs or task output.
+    Write the private key data to the specified file, and remove 'private_key'
+    from the ouput. This ensures we don't expose the key data in logs or task output.
     """
     try:
-        with open(path, "w") as f:
+        with open(file_name, "w") as f:
             f.write(key_data["private_key"])
     except (IOError, OSError) as e:
         raise Ec2KeyFailure(e, "Could not save private key to specified path. Private key is irretrievable.")
 
-    key_data["private_key"] = path
+    del key_data["private_key"]
     return key_data
 
 
-def create_new_key_pair(ec2_client, name, key_material, key_type, tags, path, check_mode):
+def create_new_key_pair(ec2_client, name, key_material, key_type, tags, file_name, check_mode):
     """
     key does not exist, we create new key
     """
@@ -298,34 +292,34 @@ def create_new_key_pair(ec2_client, name, key_material, key_type, tags, path, ch
         key = _import_key_pair(ec2_client, name, key_material, tag_spec)
     else:
         key = _create_key_pair(ec2_client, name, tag_spec, key_type)
-    key_data = extract_key_data(key, key_type, path)
+    key_data = extract_key_data(key, key_type, file_name)
 
     result = {"changed": True, "key": key_data, "msg": "key pair created"}
     return result
 
 
-def update_key_pair_by_key_material(check_mode, ec2_client, name, key, key_material, tag_spec, path):
+def update_key_pair_by_key_material(check_mode, ec2_client, name, key, key_material, tag_spec):
     if check_mode:
         return {"changed": True, "key": None, "msg": "key pair updated"}
-    new_fingerprint = get_key_fingerprint(check_mode, ec2_client, key_material, path)
+    new_fingerprint = get_key_fingerprint(check_mode, ec2_client, key_material)
     changed = False
     msg = "key pair already exists"
     if key["KeyFingerprint"] != new_fingerprint:
-        delete_key_pair(check_mode, ec2_client, name, path, finish_task=False)
+        delete_key_pair(check_mode, ec2_client, name, finish_task=False)
         key = _import_key_pair(ec2_client, name, key_material, tag_spec)
         msg = "key pair updated"
         changed = True
-    key_data = extract_key_data(key, path=path)
+    key_data = extract_key_data(key)
     return {"changed": changed, "key": key_data, "msg": msg}
 
 
-def update_key_pair_by_key_type(check_mode, ec2_client, name, key_type, tag_spec, path):
+def update_key_pair_by_key_type(check_mode, ec2_client, name, key_type, tag_spec, file_name):
     if check_mode:
         return {"changed": True, "key": None, "msg": "key pair updated"}
     else:
-        delete_key_pair(check_mode, ec2_client, name, path, finish_task=False)
+        delete_key_pair(check_mode, ec2_client, name, finish_task=False)
         key = _create_key_pair(ec2_client, name, tag_spec, key_type)
-        key_data = extract_key_data(key, key_type, path)
+        key_data = extract_key_data(key, key_type, file_name)
         return {"changed": True, "key": key_data, "msg": "key pair updated"}
 
 
@@ -336,7 +330,7 @@ def _delete_key_pair(ec2_client, key_name):
         raise Ec2KeyFailure(err, "error deleting key")
 
 
-def delete_key_pair(check_mode, ec2_client, name, path, finish_task=True):
+def delete_key_pair(check_mode, ec2_client, name, finish_task=True):
     key = find_key_pair(ec2_client, name)
 
     if key and check_mode:
@@ -350,16 +344,6 @@ def delete_key_pair(check_mode, ec2_client, name, path, finish_task=True):
             return
         result = {"changed": True, "key": None, "msg": "key deleted"}
 
-    # If keypair path on disk was provided, remove the files if they exist
-    if not check_mode and path is not None:
-        try:
-            if os.path.exists(path):
-                os.remove(path)
-            else:
-                result["msg"] = "key deleted from AWS but not found on filesystem at {0}".format(path)
-        except (IOError, OSError) as e:
-            raise Ec2KeyFailure(e, "Unable to delete local private key")
-
     return result
 
 
@@ -371,16 +355,16 @@ def handle_existing_key_pair_update(module, ec2_client, name, key):
     purge_tags = module.params.get("purge_tags")
     tag_spec = boto3_tag_specifications(tags, ["key-pair"])
     check_mode = module.check_mode
-    path = module.params.get("path")
+    file_name = module.params.get("file_name")
     if key_material and force:
-        result = update_key_pair_by_key_material(check_mode, ec2_client, name, key, key_material, tag_spec, path)
+        result = update_key_pair_by_key_material(check_mode, ec2_client, name, key, key_material, tag_spec)
     elif key_type and key_type != key["KeyType"]:
-        result = update_key_pair_by_key_type(check_mode, ec2_client, name, key_type, tag_spec, path)
+        result = update_key_pair_by_key_type(check_mode, ec2_client, name, key_type, tag_spec, file_name)
     else:
         changed = False
         changed |= ensure_ec2_tags(ec2_client, module, key["KeyPairId"], tags=tags, purge_tags=purge_tags)
         key = find_key_pair(ec2_client, name)
-        key_data = extract_key_data(key, path=path)
+        key_data = extract_key_data(key, file_name=file_name)
         result = {"changed": changed, "key": key_data, "msg": "key pair already exists"}
     return result
 
@@ -394,7 +378,7 @@ def main():
         tags=dict(type="dict", aliases=["resource_tags"]),
         purge_tags=dict(type="bool", default=True),
         key_type=dict(type="str", choices=["rsa", "ed25519"]),
-        path=dict(type="path", required=False),
+        file_name=dict(type="path", required=False),
     )
 
     module = AnsibleAWSModule(
@@ -410,23 +394,23 @@ def main():
     key_material = module.params.get("key_material")
     key_type = module.params.get("key_type")
     tags = module.params.get("tags")
-    path = module.params.get("path")
+    file_name = module.params.get("file_name")
 
     result = {}
 
     try:
         if state == "absent":
-            result = delete_key_pair(module.check_mode, ec2_client, name, path)
+            result = delete_key_pair(module.check_mode, ec2_client, name)
 
         elif state == "present":
-            if key_material is None and path is None:
-                module.fail_json("required one of 'path', 'key_material' when state is present.")
             # check if key already exists
             key = find_key_pair(ec2_client, name)
             if key:
                 result = handle_existing_key_pair_update(module, ec2_client, name, key)
             else:
-                result = create_new_key_pair(ec2_client, name, key_material, key_type, tags, path, module.check_mode)
+                result = create_new_key_pair(
+                    ec2_client, name, key_material, key_type, tags, file_name, module.check_mode
+                )
 
     except Ec2KeyFailure as e:
         if e.original_e:

--- a/tests/integration/targets/ec2_key/defaults/main.yml
+++ b/tests/integration/targets/ec2_key/defaults/main.yml
@@ -1,3 +1,4 @@
 ---
 # defaults file for test_ec2_key
 ec2_key_name: '{{resource_prefix}}'
+ec2_key_name_rsa: '{{resource_prefix}}-rsa'

--- a/tests/integration/targets/ec2_key/tasks/main.yml
+++ b/tests/integration/targets/ec2_key/tasks/main.yml
@@ -74,12 +74,13 @@
         that:
            - result is changed
 
-    - name: assert that key pair was not created
-      ec2_key_info:
-        names:
-          - '{{ ec2_key_name }}'
-      register: aws_keypair
-      failed_when: aws_keypair.keypairs | length > 0
+    # Uncomment after adding ec2_key_info module
+    # - name: assert that key pair was not created
+    #  ec2_key_info:
+    #    names:
+    #      - '{{ ec2_key_name }}'
+    #  register: aws_keypair
+    #  failed_when: aws_keypair.keypairs | length > 0
 
     - name: test creating a new key pair
       ec2_key:
@@ -110,12 +111,13 @@
           - '"spaced key" in result.key.tags'
           - result.key.tags['spaced key'] == 'Spaced value'
 
-    - name: assert that key pair was created
-      ec2_key_info:
-        names:
-          - '{{ ec2_key_name }}'
-      register: aws_keypair
-      failed_when: aws_keypair.keypairs | length == 0
+    # Uncomment after adding ec2_key_info module
+    # - name: assert that key pair was created
+    #  ec2_key_info:
+    #    names:
+    #      - '{{ ec2_key_name }}'
+    #  register: aws_keypair
+    #  failed_when: aws_keypair.keypairs | length == 0
 
     - name: Gather info about the key pair
       ec2_key_info:
@@ -195,12 +197,13 @@
         that:
            - result is changed
 
-    - name: assert that key pair was not created
-      ec2_key_info:
-        names:
-          - '{{ ec2_key_name_rsa }}'
-      register: aws_keypair
-      failed_when: aws_keypair.keypairs | length > 0
+    # Uncomment after adding ec2_key_info module
+    # - name: assert that key pair was not created
+    #  ec2_key_info:
+    #    names:
+    #      - '{{ ec2_key_name_rsa }}'
+    #  register: aws_keypair
+    #  failed_when: aws_keypair.keypairs | length > 0
 
     - name: assert that private key was not saved
       ansible.builtin.stat:
@@ -238,12 +241,14 @@
           - '"spaced key" in result.key.tags'
           - result.key.tags['spaced key'] == 'Spaced value'
 
-    - name: assert that key pair was created
-      ec2_key_info:
-        names:
-          - '{{ ec2_key_name_rsa }}'
-      register: aws_keypair
-      failed_when: aws_keypair.keypairs | length == 0
+
+    # Uncomment after adding ec2_key_info module
+    # - name: assert that key pair was created
+    #  ec2_key_info:
+    #    names:
+    #      - '{{ ec2_key_name_rsa }}'
+    #  register: aws_keypair
+    #  failed_when: aws_keypair.keypairs | length == 0
 
     - name: assert that private key was saved into file
       ansible.builtin.stat:
@@ -492,12 +497,13 @@
         that:
            - result is changed
 
-    - name: assert using check_mode did not removed key pair
-      ec2_key_info:
-        names:
-          - '{{ ec2_key_name }}'
-      register: keys
-      failed_when: keys.keypairs | length == 0
+    # Uncomment after adding ec2_key_info module
+    # - name: assert using check_mode did not removed key pair
+    #  ec2_key_info:
+    #    names:
+    #      - '{{ ec2_key_name }}'
+    #  register: keys
+    #  failed_when: keys.keypairs | length == 0
 
     - name: test removing an existent key
       ec2_key:
@@ -512,12 +518,13 @@
            - '"key" in result'
            - result.key == None
 
-    - name: assert that key pair was removed
-      ec2_key_info:
-        names:
-          - '{{ ec2_key_name }}'
-      register: keys
-      failed_when: keys.keypairs | length > 0
+    # Uncomment after adding ec2_key_info module
+    # - name: assert that key pair was removed
+    #  ec2_key_info:
+    #    names:
+    #      - '{{ ec2_key_name }}'
+    #  register: keys
+    #  failed_when: keys.keypairs | length > 0
 
     # ============================================================
     - name: test state=present with key_material

--- a/tests/integration/targets/ec2_key/tasks/main.yml
+++ b/tests/integration/targets/ec2_key/tasks/main.yml
@@ -74,13 +74,12 @@
         that:
            - result is changed
 
-    # Uncomment after adding ec2_key_info module
-    # - name: assert that key pair was not created
-    #  ec2_key_info:
-    #    names:
-    #      - '{{ ec2_key_name }}'
-    #  register: aws_keypair
-    #  failed_when: aws_keypair.keypairs | length > 0
+    - name: assert that key pair was not created
+      ec2_key_info:
+        names:
+          - '{{ ec2_key_name }}'
+      register: aws_keypair
+      failed_when: aws_keypair.keypairs | length > 0
 
     - name: test creating a new key pair
       ec2_key:
@@ -111,13 +110,12 @@
           - '"spaced key" in result.key.tags'
           - result.key.tags['spaced key'] == 'Spaced value'
 
-    # Uncomment after adding ec2_key_info module
-    # - name: assert that key pair was created
-    #  ec2_key_info:
-    #    names:
-    #      - '{{ ec2_key_name }}'
-    #  register: aws_keypair
-    #  failed_when: aws_keypair.keypairs | length == 0
+    - name: assert that key pair was created
+      ec2_key_info:
+        names:
+          - '{{ ec2_key_name }}'
+      register: aws_keypair
+      failed_when: aws_keypair.keypairs | length == 0
 
     - name: Gather info about the key pair
       ec2_key_info:
@@ -197,13 +195,12 @@
         that:
            - result is changed
 
-    # Uncomment after adding ec2_key_info module
-    # - name: assert that key pair was not created
-    #  ec2_key_info:
-    #    names:
-    #      - '{{ ec2_key_name_rsa }}'
-    #  register: aws_keypair
-    #  failed_when: aws_keypair.keypairs | length > 0
+    - name: assert that key pair was not created
+      ec2_key_info:
+        names:
+          - '{{ ec2_key_name_rsa }}'
+      register: aws_keypair
+      failed_when: aws_keypair.keypairs | length > 0
 
     - name: assert that private key was not saved
       ansible.builtin.stat:
@@ -242,13 +239,12 @@
           - result.key.tags['spaced key'] == 'Spaced value'
 
 
-    # Uncomment after adding ec2_key_info module
-    # - name: assert that key pair was created
-    #  ec2_key_info:
-    #    names:
-    #      - '{{ ec2_key_name_rsa }}'
-    #  register: aws_keypair
-    #  failed_when: aws_keypair.keypairs | length == 0
+    - name: assert that key pair was created
+      ec2_key_info:
+        names:
+          - '{{ ec2_key_name_rsa }}'
+      register: aws_keypair
+      failed_when: aws_keypair.keypairs | length == 0
 
     - name: assert that private key was saved into file
       ansible.builtin.stat:
@@ -497,13 +493,12 @@
         that:
            - result is changed
 
-    # Uncomment after adding ec2_key_info module
-    # - name: assert using check_mode did not removed key pair
-    #  ec2_key_info:
-    #    names:
-    #      - '{{ ec2_key_name }}'
-    #  register: keys
-    #  failed_when: keys.keypairs | length == 0
+    - name: assert using check_mode did not removed key pair
+      ec2_key_info:
+        names:
+          - '{{ ec2_key_name }}'
+      register: keys
+      failed_when: keys.keypairs | length == 0
 
     - name: test removing an existent key
       ec2_key:
@@ -518,13 +513,12 @@
            - '"key" in result'
            - result.key == None
 
-    # Uncomment after adding ec2_key_info module
-    # - name: assert that key pair was removed
-    #  ec2_key_info:
-    #    names:
-    #      - '{{ ec2_key_name }}'
-    #  register: keys
-    #  failed_when: keys.keypairs | length > 0
+    - name: assert that key pair was removed
+      ec2_key_info:
+        names:
+          - '{{ ec2_key_name }}'
+      register: keys
+      failed_when: keys.keypairs | length > 0
 
     # ============================================================
     - name: test state=present with key_material

--- a/tests/integration/targets/ec2_key/tasks/main.yml
+++ b/tests/integration/targets/ec2_key/tasks/main.yml
@@ -51,6 +51,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
+        path: "/tmp/my_key"
         tags:
           snake_case: 'a_snake_case_value'
           CamelCase: 'CamelCaseValue'
@@ -67,6 +68,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
+        path: "/tmp/my_key"
         tags:
           snake_case: 'a_snake_case_value'
           CamelCase: 'CamelCaseValue'
@@ -91,6 +93,7 @@
           - result.key.tags['CamelCase'] == 'CamelCaseValue'
           - '"spaced key" in result.key.tags'
           - result.key.tags['spaced key'] == 'Spaced value'
+          - result.key.private_key == '/tmp/my_key'
 
     - name: Gather info about the key pair
       ec2_key_info:
@@ -116,6 +119,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
+        path: "/tmp/my_key"
         tags:
           snake_case: 'a_snake_case_value'
           CamelCase: 'CamelCaseValue'
@@ -132,6 +136,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
+        path: "/tmp/my_key"
         tags:
           snake_case: 'a_snake_case_value'
           CamelCase: 'CamelCaseValue'
@@ -143,6 +148,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
+        path: "/tmp/my_key"
         tags:
           newKey: 'Another value'
         purge_tags: false
@@ -158,6 +164,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
+        path: "/tmp/my_key"
         tags:
           newKey: 'Another value'
         purge_tags: false
@@ -207,6 +214,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
+        path: "/tmp/my_key"
         tags:
           newKey: 'Another value'
         purge_tags: false
@@ -222,6 +230,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
+        path: "/tmp/my_key"
         tags:
           newKey: 'Another value'
         purge_tags: false
@@ -253,6 +262,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
+        path: "/tmp/my_key"
         tags:
           newKey: 'Another value'
         purge_tags: true
@@ -268,6 +278,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
+        path: "/tmp/my_key"
         tags:
           newKey: 'Another value'
         purge_tags: true
@@ -295,6 +306,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
+        path: "/tmp/my_key"
         tags:
           newKey: 'Another value'
         purge_tags: true
@@ -310,6 +322,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
+        path: "/tmp/my_key"
         tags:
           newKey: 'Another value'
         purge_tags: true
@@ -338,6 +351,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: absent
+        path: "/tmp/my_key"
       register: result
       check_mode: true
 
@@ -350,6 +364,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: absent
+        path: "/tmp/my_key"
       register: result
 
     - name: assert removing an existent key
@@ -365,6 +380,7 @@
         name: '{{ ec2_key_name }}'
         key_material: '{{ key_material }}'
         state: present
+        path: "/tmp/my_key"
       register: result
 
     - name: assert state=present with key_material
@@ -401,6 +417,7 @@
         name: '{{ ec2_key_name }}'
         key_material: '{{ key_material }}'
         state: present
+        path: "/tmp/my_key"
       register: result
 
     - name: assert state=present with key_material
@@ -424,6 +441,7 @@
         name: '{{ ec2_key_name }}'
         key_material: '{{ another_key_material }}'
         force: no
+        path: "/tmp/my_key"
       register: result
 
     - name: assert force=no with another_key_material (expect changed=false)
@@ -438,6 +456,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         key_material: '{{ another_key_material }}'
+        path: "/tmp/my_key"
       register: result
 
     - name: assert updating a key pair using another_key_material (expect changed=True)
@@ -451,6 +470,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: absent
+        path: "/tmp/my_key"
       register: result
 
     - name: assert state=absent with key_material (expect changed=true)
@@ -465,6 +485,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         key_type: ed25519
+        path: "/tmp/my_key"
       register: result
 
     - name: assert that task succeed
@@ -472,11 +493,13 @@
         that:
           - 'result.changed'
           - 'result.key.type == "ed25519"'
+          - 'result.key.private_key == "/tmp/my_key"'
 
     - name: Update key pair type from ED25519 to RSA
       ec2_key:
         name: '{{ ec2_key_name }}'
         key_type: rsa
+        path: "/tmp/my_key"
       register: result
 
     - name: assert that task succeed
@@ -484,6 +507,7 @@
         that:
           - 'result.changed'
           - 'result.key.type == "rsa"'
+          - 'result.key.private_key == "/tmp/my_key"'
 
   always:
 
@@ -492,3 +516,4 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: absent
+        path: "/tmp/my_key"

--- a/tests/integration/targets/ec2_key/tasks/main.yml
+++ b/tests/integration/targets/ec2_key/tasks/main.yml
@@ -9,6 +9,10 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
   block:
+    - name: Create temporary file to store key data in
+      tempfile:
+        suffix: .pem
+      register: _private_key_file
 
     # ============================================================
     - name: test with no parameters
@@ -51,7 +55,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
         tags:
           snake_case: 'a_snake_case_value'
           CamelCase: 'CamelCaseValue'
@@ -68,7 +72,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
         tags:
           snake_case: 'a_snake_case_value'
           CamelCase: 'CamelCaseValue'
@@ -93,7 +97,13 @@
           - result.key.tags['CamelCase'] == 'CamelCaseValue'
           - '"spaced key" in result.key.tags'
           - result.key.tags['spaced key'] == 'Spaced value'
-          - result.key.private_key == '/tmp/my_key'
+          - result.key.private_key == _private_key_file.path
+
+    - name: assert private data were saved into file
+      stat:
+        path: '{{ _private_key_file.path }}'
+      register: testfile
+      failed_when: (not testfile.stat.exists) or (testfile.stat.size == 0)
 
     - name: Gather info about the key pair
       ec2_key_info:
@@ -119,7 +129,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
         tags:
           snake_case: 'a_snake_case_value'
           CamelCase: 'CamelCaseValue'
@@ -136,7 +146,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
         tags:
           snake_case: 'a_snake_case_value'
           CamelCase: 'CamelCaseValue'
@@ -148,7 +158,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: false
@@ -164,7 +174,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: false
@@ -214,7 +224,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: false
@@ -230,7 +240,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: false
@@ -262,7 +272,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: true
@@ -278,7 +288,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: true
@@ -306,7 +316,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: true
@@ -322,7 +332,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: true
@@ -351,7 +361,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: absent
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
       register: result
       check_mode: true
 
@@ -360,11 +370,24 @@
         that:
            - result is changed
 
+    - name: assert using check_mode did not removed key pair
+      ec2_key_info:
+        names:
+          - '{{ ec2_key_name }}'
+      register: keys
+      failed_when: keys.keypairs | length == 0
+
+    - name: assert that private key file was not deleted
+      stat:
+        path: "{{ _private_key_file.path }}"
+      register: testfile
+      failed_when: not testfile.stat.exists
+
     - name: test removing an existent key
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: absent
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
       register: result
 
     - name: assert removing an existent key
@@ -374,13 +397,26 @@
            - '"key" in result'
            - result.key == None
 
+    - name: assert that key pair was removed
+      ec2_key_info:
+        names:
+          - '{{ ec2_key_name }}'
+      register: keys
+      failed_when: keys.keypairs | length > 0
+
+    - name: assert that private key file was deleted
+      stat:
+        path: "{{ _private_key_file.path }}"
+      register: testfile
+      failed_when: testfile.stat.exists
+
     # ============================================================
     - name: test state=present with key_material
       ec2_key:
         name: '{{ ec2_key_name }}'
         key_material: '{{ key_material }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
       register: result
 
     - name: assert state=present with key_material
@@ -417,7 +453,7 @@
         name: '{{ ec2_key_name }}'
         key_material: '{{ key_material }}'
         state: present
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
       register: result
 
     - name: assert state=present with key_material
@@ -441,7 +477,6 @@
         name: '{{ ec2_key_name }}'
         key_material: '{{ another_key_material }}'
         force: no
-        path: "/tmp/my_key"
       register: result
 
     - name: assert force=no with another_key_material (expect changed=false)
@@ -456,7 +491,6 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         key_material: '{{ another_key_material }}'
-        path: "/tmp/my_key"
       register: result
 
     - name: assert updating a key pair using another_key_material (expect changed=True)
@@ -470,7 +504,6 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: absent
-        path: "/tmp/my_key"
       register: result
 
     - name: assert state=absent with key_material (expect changed=true)
@@ -485,7 +518,7 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         key_type: ed25519
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
       register: result
 
     - name: assert that task succeed
@@ -493,13 +526,13 @@
         that:
           - 'result.changed'
           - 'result.key.type == "ed25519"'
-          - 'result.key.private_key == "/tmp/my_key"'
+          - 'result.key.private_key == _private_key_file.path'
 
     - name: Update key pair type from ED25519 to RSA
       ec2_key:
         name: '{{ ec2_key_name }}'
         key_type: rsa
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
       register: result
 
     - name: assert that task succeed
@@ -507,7 +540,7 @@
         that:
           - 'result.changed'
           - 'result.key.type == "rsa"'
-          - 'result.key.private_key == "/tmp/my_key"'
+          - 'result.key.private_key == _private_key_file.path'
 
   always:
 
@@ -516,4 +549,10 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: absent
-        path: "/tmp/my_key"
+        path: "{{ _private_key_file.path }}"
+
+    - name: Delete the temporary file
+      file:
+        path: '{{ _private_key_file.path }}'
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/ec2_key/tasks/main.yml
+++ b/tests/integration/targets/ec2_key/tasks/main.yml
@@ -9,10 +9,15 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
   block:
-    - name: Create temporary file to store key data in
+    - name: Create temporary directory
       tempfile:
-        suffix: .pem
-      register: _private_key_file
+        suffix: .private_key
+        state: directory
+      register: _tmpdir
+
+    - name: Define file name where to save private key
+      ansible.builtin.set_fact:
+        priv_key_file_name: "{{ _tmpdir.path }}/aws_ssh_rsa"
 
     # ============================================================
     - name: test with no parameters
@@ -51,11 +56,12 @@
           - 'not result.changed'
 
     # ============================================================
+    # Test: create new key by AWS (key_material not provided)
+    # ============================================================
     - name: test creating a new key pair (check_mode)
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "{{ _private_key_file.path }}"
         tags:
           snake_case: 'a_snake_case_value'
           CamelCase: 'CamelCaseValue'
@@ -68,11 +74,17 @@
         that:
            - result is changed
 
+    - name: assert that key pair was not created
+      ec2_key_info:
+        names:
+          - '{{ ec2_key_name }}'
+      register: aws_keypair
+      failed_when: aws_keypair.keypairs | length > 0
+
     - name: test creating a new key pair
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "{{ _private_key_file.path }}"
         tags:
           snake_case: 'a_snake_case_value'
           CamelCase: 'CamelCaseValue'
@@ -97,13 +109,13 @@
           - result.key.tags['CamelCase'] == 'CamelCaseValue'
           - '"spaced key" in result.key.tags'
           - result.key.tags['spaced key'] == 'Spaced value'
-          - result.key.private_key == _private_key_file.path
 
-    - name: assert private data were saved into file
-      stat:
-        path: '{{ _private_key_file.path }}'
-      register: testfile
-      failed_when: (not testfile.stat.exists) or (testfile.stat.size == 0)
+    - name: assert that key pair was created
+      ec2_key_info:
+        names:
+          - '{{ ec2_key_name }}'
+      register: aws_keypair
+      failed_when: aws_keypair.keypairs | length == 0
 
     - name: Gather info about the key pair
       ec2_key_info:
@@ -129,7 +141,6 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "{{ _private_key_file.path }}"
         tags:
           snake_case: 'a_snake_case_value'
           CamelCase: 'CamelCaseValue'
@@ -146,19 +157,138 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "{{ _private_key_file.path }}"
         tags:
           snake_case: 'a_snake_case_value'
           CamelCase: 'CamelCaseValue'
           "spaced key": 'Spaced value'
       register: result
 
+    - name: assert re-creating the same key
+      assert:
+        that:
+           - result is not changed
+
+    # ============================================================
+    # Test: create new key by AWS (key_material not provided)
+    # and save private_key into file name
+    # ============================================================
+    - name: Delete existing file name
+      ansible.builtin.file:
+        state: absent
+        path: "{{ priv_key_file_name }}"
+
+    - name: test creating a new key pair (check_mode)
+      ec2_key:
+        name: '{{ ec2_key_name_rsa }}'
+        state: present
+        file_name: "{{ priv_key_file_name }}"
+        tags:
+          snake_case: 'a_snake_case_value'
+          CamelCase: 'CamelCaseValue'
+          "spaced key": 'Spaced value'
+      register: result
+      check_mode: true
+      no_log: true
+
+    - name: assert creating a new key pair
+      assert:
+        that:
+           - result is changed
+
+    - name: assert that key pair was not created
+      ec2_key_info:
+        names:
+          - '{{ ec2_key_name_rsa }}'
+      register: aws_keypair
+      failed_when: aws_keypair.keypairs | length > 0
+
+    - name: assert that private key was not saved
+      ansible.builtin.stat:
+        path: "{{ priv_key_file_name }}"
+      register: result
+      failed_when: result.stat.exists
+
+    - name: test creating a new key pair
+      ec2_key:
+        name: '{{ ec2_key_name_rsa }}'
+        state: present
+        file_name: "{{ priv_key_file_name }}"
+        tags:
+          snake_case: 'a_snake_case_value'
+          CamelCase: 'CamelCaseValue'
+          "spaced key": 'Spaced value'
+      register: result
+
+    - name: assert creating a new key pair
+      assert:
+        that:
+          - result is changed
+          - '"key" in result'
+          - '"name" in result.key'
+          - '"fingerprint" in result.key'
+          - '"private_key" not in result.key'
+          - '"id" in result.key'
+          - '"tags" in result.key'
+          - result.key.name == ec2_key_name_rsa
+          - result.key.id.startswith('key-')
+          - '"snake_case" in result.key.tags'
+          - result.key.tags['snake_case'] == 'a_snake_case_value'
+          - '"CamelCase" in result.key.tags'
+          - result.key.tags['CamelCase'] == 'CamelCaseValue'
+          - '"spaced key" in result.key.tags'
+          - result.key.tags['spaced key'] == 'Spaced value'
+
+    - name: assert that key pair was created
+      ec2_key_info:
+        names:
+          - '{{ ec2_key_name_rsa }}'
+      register: aws_keypair
+      failed_when: aws_keypair.keypairs | length == 0
+
+    - name: assert that private key was saved into file
+      ansible.builtin.stat:
+        path: "{{ priv_key_file_name }}"
+      register: result
+      failed_when: (not result.stat.exists) or (result.stat.size == 0)
+
+    - name: 'test re-"creating" the same key (check_mode)'
+      ec2_key:
+        name: '{{ ec2_key_name_rsa }}'
+        state: present
+        file_name: "{{ priv_key_file_name }}"
+        tags:
+          snake_case: 'a_snake_case_value'
+          CamelCase: 'CamelCaseValue'
+          "spaced key": 'Spaced value'
+      register: result
+      check_mode: true
+
+    - name: assert re-creating the same key
+      assert:
+        that:
+           - result is not changed
+
+    - name: 'test re-"creating" the same key'
+      ec2_key:
+        name: '{{ ec2_key_name_rsa }}'
+        state: present
+        file_name: "{{ priv_key_file_name }}"
+        tags:
+          snake_case: 'a_snake_case_value'
+          CamelCase: 'CamelCaseValue'
+          "spaced key": 'Spaced value'
+      register: result
+
+    - name: assert re-creating the same key
+      assert:
+        that:
+           - result is not changed
+
     # ============================================================
     - name: test updating tags without purge (check mode)
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: false
@@ -174,7 +304,6 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: false
@@ -224,7 +353,6 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: false
@@ -240,7 +368,6 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: false
@@ -272,7 +399,6 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: true
@@ -288,7 +414,6 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: true
@@ -316,7 +441,6 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: true
@@ -332,7 +456,6 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: present
-        path: "{{ _private_key_file.path }}"
         tags:
           newKey: 'Another value'
         purge_tags: true
@@ -361,7 +484,6 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: absent
-        path: "{{ _private_key_file.path }}"
       register: result
       check_mode: true
 
@@ -377,17 +499,10 @@
       register: keys
       failed_when: keys.keypairs | length == 0
 
-    - name: assert that private key file was not deleted
-      stat:
-        path: "{{ _private_key_file.path }}"
-      register: testfile
-      failed_when: not testfile.stat.exists
-
     - name: test removing an existent key
       ec2_key:
         name: '{{ ec2_key_name }}'
         state: absent
-        path: "{{ _private_key_file.path }}"
       register: result
 
     - name: assert removing an existent key
@@ -404,19 +519,12 @@
       register: keys
       failed_when: keys.keypairs | length > 0
 
-    - name: assert that private key file was deleted
-      stat:
-        path: "{{ _private_key_file.path }}"
-      register: testfile
-      failed_when: testfile.stat.exists
-
     # ============================================================
     - name: test state=present with key_material
       ec2_key:
         name: '{{ ec2_key_name }}'
         key_material: '{{ key_material }}'
         state: present
-        path: "{{ _private_key_file.path }}"
       register: result
 
     - name: assert state=present with key_material
@@ -453,7 +561,6 @@
         name: '{{ ec2_key_name }}'
         key_material: '{{ key_material }}'
         state: present
-        path: "{{ _private_key_file.path }}"
       register: result
 
     - name: assert state=present with key_material
@@ -518,7 +625,6 @@
       ec2_key:
         name: '{{ ec2_key_name }}'
         key_type: ed25519
-        path: "{{ _private_key_file.path }}"
       register: result
 
     - name: assert that task succeed
@@ -526,13 +632,11 @@
         that:
           - 'result.changed'
           - 'result.key.type == "ed25519"'
-          - 'result.key.private_key == _private_key_file.path'
 
     - name: Update key pair type from ED25519 to RSA
       ec2_key:
         name: '{{ ec2_key_name }}'
         key_type: rsa
-        path: "{{ _private_key_file.path }}"
       register: result
 
     - name: assert that task succeed
@@ -540,19 +644,20 @@
         that:
           - 'result.changed'
           - 'result.key.type == "rsa"'
-          - 'result.key.private_key == _private_key_file.path'
 
   always:
 
     # ============================================================
     - name: Always delete the key we might create
       ec2_key:
-        name: '{{ ec2_key_name }}'
+        name: '{{ item }}'
         state: absent
-        path: "{{ _private_key_file.path }}"
+      with_items:
+        - '{{ ec2_key_name }}'
+        - '{{ ec2_key_name_rsa }}'
 
-    - name: Delete the temporary file
+    - name: Delete the temporary directory
       file:
-        path: '{{ _private_key_file.path }}'
+        path: '{{ _tmpdir.path }}'
         state: absent
       ignore_errors: true

--- a/tests/unit/plugins/modules/test_ec2_key.py
+++ b/tests/unit/plugins/modules/test_ec2_key.py
@@ -7,7 +7,6 @@ import pytest
 from unittest.mock import MagicMock
 from unittest.mock import patch
 from unittest.mock import ANY
-from unittest.mock import mock_open
 
 import botocore
 import copy


### PR DESCRIPTION
Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1816
##### SUMMARY

"When creating a new keypair the ec2_key module prints out the private key directly to the standard output. This makes it unusable in any kind of public workflow.
The only reasonable implementation to address this will be to write the private key to a file.  This is what other modules (such as community.crypto.openssh_keypair) that work with ssh keys do.
This fix consists in : 
- update module return `private_key` to store path to a file containing private key instead of private key directly
- add new module paramter ``path`` to define the path where the private key will be stored when creating a new key pair.


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
``ec2_key``

Co-authored-by: @jillr 