### PR TITLE
Update document to use no_log and register when creating a new keypair

### DIFF
--- a/changelogs/fragments/doc_update_for_keypair_nolog.yml
+++ b/changelogs/fragments/doc_update_for_keypair_nolog.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+- Update the document to use no_log and register when creating a new keypair.

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -49,6 +49,8 @@ options:
     version_added: 3.1.0
 notes:
   - Support for I(tags) and I(purge_tags) was added in release 2.1.0.
+  - For security reasons, this module should be used with B(no_log=true) and (register) functionalities
+    when creating new key pair without providing key_material.
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules
@@ -64,8 +66,11 @@ EXAMPLES = r"""
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 
 - name: create a new EC2 key pair, returns generated private key
+  # use no_log to avoid private key being displayed into output
   amazon.aws.ec2_key:
     name: my_keypair
+  no_log: true
+  register: aws_ec2_key_pair
 
 - name: create key pair using provided key_material
   amazon.aws.ec2_key:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
"When creating a new keypair the ec2_key module prints out the private key directly to the standard output. This makes it unusable in any kind of public workflow."

To fix this security vulnerability no_log and register should be used while using this module to create a keypair.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
