### PR TITLE
[backport][stable-6] Mass update of docs and tests (credentials/session tokens) 

### DIFF
--- a/changelogs/fragments/1714-parameters.yml
+++ b/changelogs/fragments/1714-parameters.yml
@@ -1,0 +1,2 @@
+trivial:
+- update docs and integration tests to use the canonical parameter names for the credentials parameters.

--- a/changelogs/fragments/ec2_region.yml
+++ b/changelogs/fragments/ec2_region.yml
@@ -1,0 +1,2 @@
+trivial:
+- tweak integration tests to use aws_region rather than ec2_region.

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -157,9 +157,9 @@ regions:
 # Example using filters, ignoring permission errors, and specifying the hostname precedence
 plugin: amazon.aws.aws_ec2
 # The values for profile, access key, secret key and token can be hardcoded like:
-boto_profile: aws_profile
+profile: aws_profile
 # or you could use Jinja as:
-# boto_profile: "{{ lookup('env', 'AWS_PROFILE') | default('aws_profile', true) }}"
+# profile: "{{ lookup('env', 'AWS_PROFILE') | default('aws_profile', true) }}"
 # Populate inventory with instances in these regions
 regions:
   - us-east-1
@@ -243,7 +243,7 @@ exclude_filters:
 
 # Example using groups to assign the running hosts to a group based on vpc_id
 plugin: amazon.aws.aws_ec2
-boto_profile: aws_profile
+profile: aws_profile
 # Populate inventory with instances in these regions
 regions:
   - us-east-2

--- a/plugins/lookup/secretsmanager_secret.py
+++ b/plugins/lookup/secretsmanager_secret.py
@@ -105,8 +105,8 @@ EXAMPLES = r"""
    # If an object is of the form `{"key1":{"key2":{"key3":1}}}` the query would return the value `1`.
  - name: lookup secretsmanager secret in a specific region using specified region and aws profile using nested feature
    debug: >
-    msg="{{ lookup('amazon.aws.aws_secret', 'secrets.environments.production.password', region=region, aws_profile=aws_profile,
-    aws_access_key=aws_access_key, aws_secret_key=aws_secret_key, nested=true) }}"
+    msg="{{ lookup('amazon.aws.aws_secret', 'secrets.environments.production.password', region=region, profile=aws_profile,
+    access_key=aws_access_key, secret_key=aws_secret_key, nested=true) }}"
    # The secret can be queried using the following syntax: `aws_secret_object_name.key1.key2.key3`.
    # If an object is of the form `{"key1":{"key2":{"key3":1}}}` the query would return the value `1`.
    # Region is the AWS region where the AWS secret is stored.

--- a/plugins/lookup/ssm_parameter.py
+++ b/plugins/lookup/ssm_parameter.py
@@ -85,13 +85,13 @@ EXAMPLES = r"""
   debug: msg="{{ lookup('amazon.aws.aws_ssm', 'Hello', decrypt=False ) }}"
 
 - name: lookup ssm parameter store using a specified aws profile
-  debug: msg="{{ lookup('amazon.aws.aws_ssm', 'Hello', aws_profile='myprofile' ) }}"
+  debug: msg="{{ lookup('amazon.aws.aws_ssm', 'Hello', profile='myprofile' ) }}"
 
 - name: lookup ssm parameter store using explicit aws credentials
-  debug: msg="{{ lookup('amazon.aws.aws_ssm', 'Hello', aws_access_key=my_aws_access_key, aws_secret_key=my_aws_secret_key, aws_security_token=my_security_token ) }}" # noqa: E501
+  debug: msg="{{ lookup('amazon.aws.aws_ssm', 'Hello', access_key=my_aws_access_key, secret_key=my_aws_secret_key, session_token=my_session_token ) }}" # noqa: E501
 
 - name: lookup ssm parameter store with all options
-  debug: msg="{{ lookup('amazon.aws.aws_ssm', 'Hello', decrypt=false, region='us-east-2', aws_profile='myprofile') }}"
+  debug: msg="{{ lookup('amazon.aws.aws_ssm', 'Hello', decrypt=false, region='us-east-2', profile='myprofile') }}"
 
 - name: lookup ssm parameter and fail if missing
   debug: msg="{{ lookup('amazon.aws.aws_ssm', 'missing-parameter') }}"

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -285,13 +285,13 @@ notes:
 """
 
 EXAMPLES = r"""
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+
 - name: example using security group rule descriptions
   amazon.aws.ec2_security_group:
     name: "{{ name }}"
     description: sg with rule descriptions
     vpc_id: vpc-xxxxxxxx
-    profile: "{{ aws_profile }}"
-    region: us-east-1
     rules:
       - proto: tcp
         ports:
@@ -304,8 +304,6 @@ EXAMPLES = r"""
     name: "{{ name }}"
     description: sg for ICMP
     vpc_id: vpc-xxxxxxxx
-    profile: "{{ aws_profile }}"
-    region: us-east-1
     rules:
       - proto: icmp
         icmp_type: 3
@@ -317,9 +315,6 @@ EXAMPLES = r"""
     name: example
     description: an example EC2 group
     vpc_id: 12345
-    region: eu-west-1
-    aws_secret_key: SECRET
-    aws_access_key: ACCESS
     rules:
       - proto: tcp
         from_port: 80
@@ -377,7 +372,6 @@ EXAMPLES = r"""
     name: example2
     description: an example2 EC2 group
     vpc_id: 12345
-    region: eu-west-1
     rules:
       # 'ports' rule keyword was introduced in version 2.4. It accepts a single
       # port value or a list of values including ranges (from_port-to_port).
@@ -414,7 +408,6 @@ EXAMPLES = r"""
 
 - name: "Delete group by its id"
   amazon.aws.ec2_security_group:
-    region: eu-west-1
     group_id: sg-33b4ee5b
     state: absent
 """

--- a/tests/integration/targets/autoscaling_group/main.yml
+++ b/tests/integration/targets/autoscaling_group/main.yml
@@ -9,9 +9,9 @@
   tasks:
   - module_defaults:
       group/aws:
-        aws_access_key: '{{ aws_access_key }}'
-        aws_secret_key: '{{ aws_secret_key }}'
-        security_token: '{{ security_token | default(omit) }}'
+        access_key: '{{ aws_access_key }}'
+        secret_key: '{{ aws_secret_key }}'
+        session_token: '{{ security_token | default(omit) }}'
         region: '{{ aws_region }}'
     block:
     - include_role:

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/create_update_delete.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/create_update_delete.yml
@@ -7,9 +7,9 @@
 
   - name: test without specifying required module options
     autoscaling_group:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
     ignore_errors: true
     register: result
   - name: assert name is a required module option

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/main.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/main.yml
@@ -5,9 +5,9 @@
 - name: Wrap up all tests and setup AWS credentials
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
       aws_config:
         retries:

--- a/tests/integration/targets/aws_az_info/tasks/main.yml
+++ b/tests/integration/targets/aws_az_info/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key | default(omit) }}'
-      aws_secret_key: '{{ aws_secret_key | default(omit) }}'
-      security_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
+      region: '{{ aws_region }}'
 
   block:
   - name: 'List available AZs in current Region'

--- a/tests/integration/targets/aws_caller_info/tasks/main.yaml
+++ b/tests/integration/targets/aws_caller_info/tasks/main.yaml
@@ -1,9 +1,9 @@
 - module_defaults:
     group/aws:
         region: "{{ aws_region }}"
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token | default(omit) }}"
+        access_key: "{{ aws_access_key }}"
+        secret_key: "{{ aws_secret_key }}"
+        session_token: "{{ security_token | default(omit) }}"
   block:
   - name: retrieve caller facts
     aws_caller_info:

--- a/tests/integration/targets/backup_plan/tasks/main.yml
+++ b/tests/integration/targets/backup_plan/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - name: Create a backup vault for the plan to target

--- a/tests/integration/targets/backup_selection/tasks/main.yml
+++ b/tests/integration/targets/backup_selection/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
 
   block:

--- a/tests/integration/targets/backup_tag/tasks/main.yml
+++ b/tests/integration/targets/backup_tag/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
 

--- a/tests/integration/targets/backup_vault/tasks/main.yml
+++ b/tests/integration/targets/backup_vault/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - name: create a key

--- a/tests/integration/targets/callback_aws_resource_actions/main.yml
+++ b/tests/integration/targets/callback_aws_resource_actions/main.yml
@@ -4,9 +4,9 @@
   - amazon.aws
   module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   tasks:
   - ec2_instance_info:

--- a/tests/integration/targets/cloudformation/tasks/main.yml
+++ b/tests/integration/targets/cloudformation/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key | default(omit) }}'
-      aws_secret_key: '{{ aws_secret_key | default(omit) }}'
-      security_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
+      region: '{{ aws_region }}'
 
   block:
 

--- a/tests/integration/targets/cloudtrail/tasks/main.yml
+++ b/tests/integration/targets/cloudtrail/tasks/main.yml
@@ -1347,9 +1347,9 @@
       state: present
       name: '{{ cloudtrail_name }}'
       kms_key_id: 'alias/{{ kms_alias }}'
-      aws_access_key: "{{ noKms_assumed_role.sts_creds.access_key }}"
-      aws_secret_key: "{{ noKms_assumed_role.sts_creds.secret_key }}"
-      security_token: "{{ noKms_assumed_role.sts_creds.session_token }}"
+      access_key: "{{ noKms_assumed_role.sts_creds.access_key }}"
+      secret_key: "{{ noKms_assumed_role.sts_creds.secret_key }}"
+      session_token: "{{ noKms_assumed_role.sts_creds.session_token }}"
     check_mode: yes
     register: output
   - assert:

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: run cloudwatch_metric_alarm tests
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   - set_fact:

--- a/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
 
   block:

--- a/tests/integration/targets/cloudwatchlogs/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchlogs/tasks/main.yml
@@ -2,9 +2,9 @@
 
 - module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
 
   block:

--- a/tests/integration/targets/ec2_ami/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami/tasks/main.yml
@@ -3,9 +3,9 @@
 - module_defaults:
     group/aws:
       aws_region: '{{ aws_region }}'
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
   collections:
     - amazon.aws
   block:

--- a/tests/integration/targets/ec2_ami_instance/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami_instance/tasks/main.yml
@@ -3,9 +3,9 @@
 - module_defaults:
     group/aws:
       aws_region: '{{ aws_region }}'
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
   collections:
     - amazon.aws
   block:

--- a/tests/integration/targets/ec2_ami_snapshot/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami_snapshot/tasks/main.yml
@@ -3,9 +3,9 @@
 - module_defaults:
     group/aws:
       aws_region: '{{ aws_region }}'
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
   collections:
     - amazon.aws
   block:

--- a/tests/integration/targets/ec2_ami_tpm/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami_tpm/tasks/main.yml
@@ -3,9 +3,9 @@
 - module_defaults:
     group/aws:
       aws_region: '{{ aws_region }}'
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
   collections:
     - amazon.aws
   block:

--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: Integration testing for ec2_eip
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
     amazon.aws.ec2_eip:
       in_vpc: true

--- a/tests/integration/targets/ec2_eni/tasks/main.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/main.yaml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
 
   collections:

--- a/tests/integration/targets/ec2_instance_block_devices/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_block_devices/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "New instance with an extra block device"

--- a/tests/integration/targets/ec2_instance_checkmode_tests/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_checkmode_tests/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "Make basic instance"

--- a/tests/integration/targets/ec2_instance_cpu_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_cpu_options/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "create t3.nano instance with cpu_options"

--- a/tests/integration/targets/ec2_instance_default_vpc_tests/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_default_vpc_tests/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "Make instance in a default subnet of the VPC"

--- a/tests/integration/targets/ec2_instance_ebs_optimized/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_ebs_optimized/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "Make EBS optimized instance in the testing subnet of the test VPC"

--- a/tests/integration/targets/ec2_instance_external_resource_attach/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_external_resource_attach/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   # Make custom ENIs and attach via the `network` parameter

--- a/tests/integration/targets/ec2_instance_hibernation_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_hibernation_options/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - name: Create instance with hibernation option (check mode)

--- a/tests/integration/targets/ec2_instance_iam_instance_role/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_iam_instance_role/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "Create IAM role for test"

--- a/tests/integration/targets/ec2_instance_instance_minimal/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_minimal/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "Create a new instance (check_mode)"

--- a/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
@@ -369,7 +369,7 @@
 
   - name: Gather information about any running instance with Name ending with "-test-enf_cnt"
     ec2_instance_info:
-      region: "{{ ec2_region }}"
+      region: "{{ aws_region }}"
       filters:
         "tag:Name": "*-test-enf_cnt"
         instance-state-name: [ "running"]

--- a/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
 ################################################################

--- a/tests/integration/targets/ec2_instance_instance_no_wait/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_no_wait/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "New instance and don't wait for it to complete"

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: test with boto3 version that supports instance_metadata_tags
   module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "create t3.nano instance with metadata_options"

--- a/tests/integration/targets/ec2_instance_security_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_security_group/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "New instance with 2 security groups"

--- a/tests/integration/targets/ec2_instance_state_config_updates/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_state_config_updates/tasks/main.yml
@@ -4,9 +4,9 @@
 # https://github.com/ansible-collections/community.aws/issues/16
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "Make instance with sg and termination protection enabled"

--- a/tests/integration/targets/ec2_instance_tags_and_vpc_settings/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_tags_and_vpc_settings/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "Make instance in the testing subnet created in the test VPC"

--- a/tests/integration/targets/ec2_instance_termination_protection/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_termination_protection/tasks/main.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - name: Create instance with termination protection (check mode)

--- a/tests/integration/targets/ec2_instance_uptime/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_uptime/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "create t3.nano instance"

--- a/tests/integration/targets/ec2_instance_uptime/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_uptime/tasks/main.yml
@@ -10,7 +10,7 @@
     ec2_instance:
       state: 'running'
       name: "{{ resource_prefix }}-test-uptime"
-      region: "{{ ec2_region }}"
+      region: "{{ aws_region }}"
       image_id: "{{ ec2_ami_id }}"
       tags:
         TestId: "{{ ec2_instance_tag_TestId }}"
@@ -32,7 +32,7 @@
 
   - name: "check using uptime 100 hours - should find nothing"
     ec2_instance_info:
-      region: "{{ ec2_region }}"
+      region: "{{ aws_region }}"
       uptime: 6000
       filters:
         instance-state-name: [ "running"]
@@ -51,7 +51,7 @@
 
   - name: "check using uptime 1 minute"
     ec2_instance_info:
-      region: "{{ ec2_region }}"
+      region: "{{ aws_region }}"
       uptime: 1
       filters:
         instance-state-name: [ "running"]

--- a/tests/integration/targets/ec2_key/tasks/main.yml
+++ b/tests/integration/targets/ec2_key/tasks/main.yml
@@ -5,9 +5,9 @@
 - module_defaults:
     group/aws:
       region: '{{ aws_region }}'
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
   block:
     - name: Create temporary directory
       tempfile:

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
 
   hosts: localhost
@@ -23,9 +23,9 @@
       # As lookup plugins don't have access to module_defaults
       connection_args:
         region: "{{ aws_region }}"
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        aws_session_token: "{{ security_token | default(omit) }}"
+        access_key: "{{ aws_access_key }}"
+        secret_key: "{{ aws_secret_key }}"
+        session_token: "{{ security_token | default(omit) }}"
 
   - include_role:
       name: '../setup_sshkey'

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/teardown.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/teardown.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
 
   hosts: localhost

--- a/tests/integration/targets/ec2_security_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/main.yml
@@ -3,18 +3,18 @@
     # lookup plugins don't have access to module_defaults
     connection_args:
         region: "{{ aws_region }}"
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        aws_security_token: "{{ security_token | default(omit) }}"
+        access_key: "{{ aws_access_key }}"
+        secret_key: "{{ aws_secret_key }}"
+        session_token: "{{ security_token | default(omit) }}"
   no_log: True
 
 # ============================================================
 - name: Run all tests
   module_defaults:
       group/aws:
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        security_token: "{{ security_token | default(omit)}}"
+        access_key: "{{ aws_access_key }}"
+        secret_key: "{{ aws_secret_key }}"
+        session_token: "{{ security_token | default(omit)}}"
         region: "{{ aws_region }}"
   block:
     - name: determine if there is a default VPC

--- a/tests/integration/targets/ec2_snapshot/tasks/main.yml
+++ b/tests/integration/targets/ec2_snapshot/tasks/main.yml
@@ -12,9 +12,9 @@
 - name: Integration testing for ec2_snapshot
   module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
 
   collections:

--- a/tests/integration/targets/ec2_spot_instance/tasks/main.yaml
+++ b/tests/integration/targets/ec2_spot_instance/tasks/main.yaml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
 
   collections:

--- a/tests/integration/targets/ec2_tag/tasks/main.yml
+++ b/tests/integration/targets/ec2_tag/tasks/main.yml
@@ -2,9 +2,9 @@
 # tasks file for test_ec2_tag
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - name: Create an EC2 volume so we have something to tag

--- a/tests/integration/targets/ec2_vol/tasks/main.yml
+++ b/tests/integration/targets/ec2_vol/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key | default(omit) }}'
-      aws_secret_key: '{{ aws_secret_key | default(omit) }}'
-      security_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
+      region: '{{ aws_region }}'
 
   collections:
     - amazon.aws

--- a/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml
@@ -8,9 +8,9 @@
 # ============================================================
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default('') }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default('') }}"
       region: "{{ aws_region }}"
 
   block:

--- a/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: ec2_vpc_endpoint tests
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   # ============================================================

--- a/tests/integration/targets/ec2_vpc_endpoint_service_info/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint_service_info/tasks/main.yml
@@ -2,9 +2,9 @@
 - name: Verify ec2_vpc_endpoint_service_info
   module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   collections:
     - amazon.aws

--- a/tests/integration/targets/ec2_vpc_igw/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_igw/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: ec2_vpc_igw tests
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   # ============================================================

--- a/tests/integration/targets/ec2_vpc_nat_gateway/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_nat_gateway/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: ec2_vpc_nat_gateway tests
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   # ============================================================

--- a/tests/integration/targets/ec2_vpc_net/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_net/tasks/main.yml
@@ -2,9 +2,9 @@
 - name: Setup AWS Environment
   module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   vars:
     first_tags:

--- a/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: ec2_vpc_route_table integration tests
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
 

--- a/tests/integration/targets/ec2_vpc_subnet/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_subnet/tasks/main.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     # ============================================================

--- a/tests/integration/targets/elb_application_lb/tasks/main.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: elb_application_lb integration tests
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   - name: Create a test VPC

--- a/tests/integration/targets/elb_classic_lb/tasks/main.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/main.yml
@@ -16,9 +16,9 @@
 - module_defaults:
     group/aws:
       region: "{{ aws_region }}"
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   collections:
     - amazon.aws
     - community.aws

--- a/tests/integration/targets/iam_instance_profile/tasks/main.yml
+++ b/tests/integration/targets/iam_instance_profile/tasks/main.yml
@@ -5,9 +5,9 @@
 - name: "Setup AWS connection info"
   module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   collections:
     - amazon.aws

--- a/tests/integration/targets/iam_policy/tasks/main.yml
+++ b/tests/integration/targets/iam_policy/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: Run integration tests for IAM (inline) Policy management
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
     # ============================================================

--- a/tests/integration/targets/iam_user/tasks/main.yml
+++ b/tests/integration/targets/iam_user/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: set up aws connection info
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   - name: ensure improper usage of parameters fails gracefully

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/manage_ec2_instances.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/manage_ec2_instances.yml
@@ -12,9 +12,9 @@
 
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
 
   tasks:

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/populate_cache.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/populate_cache.yml
@@ -7,9 +7,9 @@
 
     - module_defaults:
         group/aws:
-          aws_access_key: '{{ aws_access_key }}'
-          aws_secret_key: '{{ aws_secret_key }}'
-          security_token: '{{ security_token | default(omit) }}'
+          access_key: '{{ aws_access_key }}'
+          secret_key: '{{ aws_secret_key }}'
+          session_token: '{{ security_token | default(omit) }}'
           region: '{{ aws_region }}'
       block:
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_inventory_ssm.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_inventory_ssm.yml
@@ -10,9 +10,9 @@
 
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
 
   vars:

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_concatenation.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_concatenation.yml
@@ -7,9 +7,9 @@
 
     - module_defaults:
         group/aws:
-          aws_access_key: '{{ aws_access_key }}'
-          aws_secret_key: '{{ aws_secret_key }}'
-          security_token: '{{ security_token | default(omit) }}'
+          access_key: '{{ aws_access_key }}'
+          secret_key: '{{ aws_secret_key }}'
+          session_token: '{{ security_token | default(omit) }}'
           region: '{{ aws_region }}'
       block:
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml
@@ -7,9 +7,9 @@
 
     - module_defaults:
         group/aws:
-          aws_access_key: '{{ aws_access_key }}'
-          aws_secret_key: '{{ aws_secret_key }}'
-          security_token: '{{ security_token | default(omit) }}'
+          access_key: '{{ aws_access_key }}'
+          secret_key: '{{ aws_secret_key }}'
+          session_token: '{{ security_token | default(omit) }}'
           region: '{{ aws_region }}'
       block:
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags.yml
@@ -7,9 +7,9 @@
 
     - module_defaults:
         group/aws:
-          aws_access_key: '{{ aws_access_key }}'
-          aws_secret_key: '{{ aws_secret_key }}'
-          security_token: '{{ security_token | default(omit) }}'
+          access_key: '{{ aws_access_key }}'
+          secret_key: '{{ aws_secret_key }}'
+          session_token: '{{ security_token | default(omit) }}'
           region: '{{ aws_region }}'
       block:
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags_classic.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags_classic.yml
@@ -7,9 +7,9 @@
 
     - module_defaults:
         group/aws:
-          aws_access_key: '{{ aws_access_key }}'
-          aws_secret_key: '{{ aws_secret_key }}'
-          security_token: '{{ security_token | default(omit) }}'
+          access_key: '{{ aws_access_key }}'
+          secret_key: '{{ aws_secret_key }}'
+          session_token: '{{ security_token | default(omit) }}'
           region: '{{ aws_region }}'
       block:
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostvars_prefix_suffix.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostvars_prefix_suffix.yml
@@ -7,9 +7,9 @@
 
     - module_defaults:
         group/aws:
-          aws_access_key: '{{ aws_access_key }}'
-          aws_secret_key: '{{ aws_secret_key }}'
-          security_token: '{{ security_token | default(omit) }}'
+          access_key: '{{ aws_access_key }}'
+          secret_key: '{{ aws_secret_key }}'
+          session_token: '{{ security_token | default(omit) }}'
           region: '{{ aws_region }}'
       block:
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_include_or_exclude_filters.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_include_or_exclude_filters.yml
@@ -7,9 +7,9 @@
 
     - module_defaults:
         group/aws:
-          aws_access_key: '{{ aws_access_key }}'
-          aws_secret_key: '{{ aws_secret_key }}'
-          security_token: '{{ security_token | default(omit) }}'
+          access_key: '{{ aws_access_key }}'
+          secret_key: '{{ aws_secret_key }}'
+          session_token: '{{ security_token | default(omit) }}'
           region: '{{ aws_region }}'
       block:
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_literal_string.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_literal_string.yml
@@ -7,9 +7,9 @@
 
     - module_defaults:
         group/aws:
-          aws_access_key: '{{ aws_access_key }}'
-          aws_secret_key: '{{ aws_secret_key }}'
-          security_token: '{{ security_token | default(omit) }}'
+          access_key: '{{ aws_access_key }}'
+          secret_key: '{{ aws_secret_key }}'
+          session_token: '{{ security_token | default(omit) }}'
           region: '{{ aws_region }}'
       block:
 

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_use_contrib_script_keys.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_use_contrib_script_keys.yml
@@ -7,9 +7,9 @@
 
     - module_defaults:
         group/aws:
-          aws_access_key: '{{ aws_access_key }}'
-          aws_secret_key: '{{ aws_secret_key }}'
-          security_token: '{{ security_token | default(omit) }}'
+          access_key: '{{ aws_access_key }}'
+          secret_key: '{{ aws_secret_key }}'
+          session_token: '{{ security_token | default(omit) }}'
           region: '{{ aws_region }}'
       block:
 

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory.yml.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_ec2
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
 - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_cache.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_cache.yml.j2
@@ -2,10 +2,10 @@ plugin: amazon.aws.aws_ec2
 cache: True
 cache_plugin: jsonfile
 cache_connection: aws_ec2_cache_dir
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
 - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_concatenation.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_concatenation.yml.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_ec2
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
 - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_constructed.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_constructed.yml.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_ec2
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
 - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_hostnames_using_tags.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_hostnames_using_tags.yml.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_ec2
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
 - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_hostnames_using_tags_classic.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_hostnames_using_tags_classic.yml.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_ec2
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
 - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_hostvars_prefix_suffix.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_hostvars_prefix_suffix.yml.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_ec2
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
 - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_include_or_exclude_filters.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_include_or_exclude_filters.yml.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_ec2
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
 - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_literal_string.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_literal_string.yml.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_ec2
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
 - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_ssm.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_ssm.yml.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_ec2
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
 - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_template.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_template.yml.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_ec2
-aws_access_key_id: '{{ '{{ lookup("env", "MY_ACCESS_KEY") }}' }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ '{{ lookup("env", "MY_ACCESS_KEY") }}' }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
 - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_use_contrib_script_keys.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_use_contrib_script_keys.yml.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_ec2
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
 - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_rds/playbooks/populate_cache.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/populate_cache.yml
@@ -14,9 +14,9 @@
 
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
 
   tasks:

--- a/tests/integration/targets/inventory_aws_rds/playbooks/setup_instance.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/setup_instance.yml
@@ -14,9 +14,9 @@
 
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
 
   tasks:

--- a/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_with_hostvars_prefix_suffix.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_with_hostvars_prefix_suffix.yml
@@ -14,9 +14,9 @@
 
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
 
   tasks:

--- a/tests/integration/targets/inventory_aws_rds/playbooks/test_populating_inventory_with_constructed.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/test_populating_inventory_with_constructed.yml
@@ -14,9 +14,9 @@
 
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
 
   tasks:

--- a/tests/integration/targets/inventory_aws_rds/templates/inventory.j2
+++ b/tests/integration/targets/inventory_aws_rds/templates/inventory.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_rds
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
   - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_rds/templates/inventory_with_cache.j2
+++ b/tests/integration/targets/inventory_aws_rds/templates/inventory_with_cache.j2
@@ -2,10 +2,10 @@ plugin: amazon.aws.aws_rds
 cache: True
 cache_plugin: jsonfile
 cache_connection: '{{ aws_inventory_cache_dir }}'
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
   - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_rds/templates/inventory_with_constructed.j2
+++ b/tests/integration/targets/inventory_aws_rds/templates/inventory_with_constructed.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_rds
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
   - '{{ aws_region }}'

--- a/tests/integration/targets/inventory_aws_rds/templates/inventory_with_hostvars_prefix_suffix.j2
+++ b/tests/integration/targets/inventory_aws_rds/templates/inventory_with_hostvars_prefix_suffix.j2
@@ -1,8 +1,8 @@
 plugin: amazon.aws.aws_rds
-aws_access_key_id: '{{ aws_access_key }}'
-aws_secret_access_key: '{{ aws_secret_key }}'
+access_key: '{{ aws_access_key }}'
+secret_key: '{{ aws_secret_key }}'
 {% if security_token | default(false) %}
-aws_security_token: '{{ security_token }}'
+session_token: '{{ security_token }}'
 {% endif %}
 regions:
   - '{{ aws_region }}'

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/main.yml
@@ -3,9 +3,9 @@
   - community.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   - include_tasks: ./test_{{ inventory_hostname }}.yml

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: set connection information for AWS modules and run tests
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   collections:
   - community.general

--- a/tests/integration/targets/lambda_alias/tasks/main.yml
+++ b/tests/integration/targets/lambda_alias/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: set connection information for AWS modules and run tests
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   collections:
     - community.general

--- a/tests/integration/targets/lambda_event/tasks/main.yml
+++ b/tests/integration/targets/lambda_event/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: set connection information for AWS modules and run tests
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   collections:
   - community.general

--- a/tests/integration/targets/lambda_layer/tasks/main.yml
+++ b/tests/integration/targets/lambda_layer/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key | default(omit) }}'
-      aws_secret_key: '{{ aws_secret_key | default(omit) }}'
-      security_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
+      region: '{{ aws_region }}'
 
   collections:
     - amazon.aws

--- a/tests/integration/targets/lambda_policy/tasks/main.yml
+++ b/tests/integration/targets/lambda_policy/tasks/main.yml
@@ -1,9 +1,9 @@
 - name: Integration testing for lambda_policy
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   collections:
     - community.general

--- a/tests/integration/targets/lookup_aws_account_attribute/tasks/main.yaml
+++ b/tests/integration/targets/lookup_aws_account_attribute/tasks/main.yaml
@@ -2,17 +2,17 @@
     # As a lookup plugin we don't have access to module_defaults
     connection_args:
         region: "{{ aws_region }}"
-        aws_access_key: "{{ aws_access_key }}"
-        aws_secret_key: "{{ aws_secret_key }}"
-        aws_security_token: "{{ security_token | default(omit) }}"
+        access_key: "{{ aws_access_key }}"
+        secret_key: "{{ aws_secret_key }}"
+        session_token: "{{ security_token | default(omit) }}"
   no_log: True
 
 - module_defaults:
     group/aws:
       region: "{{ aws_region }}"
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   block:
   - name: 'Check for EC2 Classic support (has-ec2-classic)'
     set_fact:

--- a/tests/integration/targets/lookup_secretsmanager_secret/tasks/main.yaml
+++ b/tests/integration/targets/lookup_secretsmanager_secret/tasks/main.yaml
@@ -2,17 +2,17 @@
     # As a lookup plugin we don't have access to module_defaults
     connection_args:
       region: "{{ aws_region }}"
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      aws_security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   no_log: True
 
 - module_defaults:
     group/aws:
       region: "{{ aws_region }}"
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   collections:
     - amazon.aws
     - community.aws

--- a/tests/integration/targets/lookup_ssm_parameter/tasks/main.yml
+++ b/tests/integration/targets/lookup_ssm_parameter/tasks/main.yml
@@ -3,9 +3,9 @@
     # As a lookup plugin we don't have access to module_defaults
     connection_args:
       region: "{{ aws_region }}"
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      aws_security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   no_log: True
 
 - name: 'aws_ssm lookup plugin integration tests'
@@ -14,9 +14,9 @@
   - community.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   vars:
     skip: 'skip'

--- a/tests/integration/targets/module_utils_waiter/roles/get_waiter/tasks/main.yml
+++ b/tests/integration/targets/module_utils_waiter/roles/get_waiter/tasks/main.yml
@@ -4,7 +4,7 @@
       region: '{{ aws_region }}'
       access_key: '{{ aws_access_key }}'
       secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      session_token: '{{ security_token | default(omit) }}'
   block:
   - name: 'Attempt to get a waiter (no retry decorator)'
     example_module:

--- a/tests/integration/targets/rds_cluster_create/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_create/tasks/main.yaml
@@ -1,9 +1,9 @@
 - module_defaults:
     group/aws:
       region: '{{ aws_region }}'
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
   block:
   - name: Ensure the resource doesn't exist
     rds_cluster:

--- a/tests/integration/targets/rds_cluster_create_sgs/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_create_sgs/tasks/main.yaml
@@ -1,9 +1,9 @@
 - module_defaults:
     group/aws:
       region: '{{ aws_region }}'
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
   block:
   - name: Ensure the resource doesn't exist
     rds_cluster:

--- a/tests/integration/targets/rds_cluster_modify/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_modify/tasks/main.yaml
@@ -1,9 +1,9 @@
 - module_defaults:
     group/aws:
       region: '{{ aws_region }}'
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
   block:
   - name: Ensure the resource doesn't exist
     rds_cluster:

--- a/tests/integration/targets/rds_cluster_multi_az/tasks/main.yml
+++ b/tests/integration/targets/rds_cluster_multi_az/tasks/main.yml
@@ -2,9 +2,9 @@
 - module_defaults:
     group/aws:
       region: "{{ aws_region }}"
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   collections:
     - amazon.aws
 

--- a/tests/integration/targets/rds_cluster_promote/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_promote/tasks/main.yaml
@@ -1,9 +1,9 @@
 - module_defaults:
     group/aws:
       region: '{{ aws_region }}'
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
   block:
   - name: Ensure the resource doesn't exist
     rds_cluster:

--- a/tests/integration/targets/rds_cluster_restore/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_restore/tasks/main.yaml
@@ -1,9 +1,9 @@
 - module_defaults:
     group/aws:
       region: '{{ aws_region }}'
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
   block:
   - name: Ensure the resource doesn't exist
     rds_cluster:

--- a/tests/integration/targets/rds_cluster_snapshot/tasks/main.yml
+++ b/tests/integration/targets/rds_cluster_snapshot/tasks/main.yml
@@ -2,9 +2,9 @@
 - module_defaults:
     group/aws:
       region: "{{ aws_region }}"
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   collections:
     - amazon.aws
   block:

--- a/tests/integration/targets/rds_cluster_states/tasks/main.yml
+++ b/tests/integration/targets/rds_cluster_states/tasks/main.yml
@@ -1,9 +1,9 @@
 - module_defaults:
     group/aws:
       region: '{{ aws_region }}'
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
   block:
     # ------------------------------------------------------------------------------------------
     # Create DB cluster

--- a/tests/integration/targets/rds_cluster_tag/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_tag/tasks/main.yaml
@@ -1,9 +1,9 @@
 - module_defaults:
     group/aws:
       region: '{{ aws_region }}'
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
   block:
   - name: Ensure the resource doesn't exist
     rds_cluster:

--- a/tests/integration/targets/rds_instance_aurora/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_aurora/tasks/main.yml
@@ -3,9 +3,9 @@
   - community.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
 

--- a/tests/integration/targets/rds_instance_complex/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_complex/tasks/main.yml
@@ -3,9 +3,9 @@
   - community.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   #TODO: test availability_zone and multi_az

--- a/tests/integration/targets/rds_instance_modify/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_modify/tasks/main.yml
@@ -3,9 +3,9 @@
   - community.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   - name: Ensure the resource doesn't exist

--- a/tests/integration/targets/rds_instance_processor/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_processor/tasks/main.yml
@@ -3,9 +3,9 @@
   - community.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
 

--- a/tests/integration/targets/rds_instance_replica/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_replica/tasks/main.yml
@@ -3,9 +3,9 @@
   - community.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
 

--- a/tests/integration/targets/rds_instance_restore/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_restore/tasks/main.yml
@@ -3,9 +3,9 @@
   - community.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
      # TODO: snapshot, s3

--- a/tests/integration/targets/rds_instance_sgroups/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_sgroups/tasks/main.yml
@@ -3,9 +3,9 @@
   - community.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
 

--- a/tests/integration/targets/rds_instance_snapshot/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_snapshot/tasks/main.yml
@@ -2,9 +2,9 @@
 - module_defaults:
     group/aws:
       region: "{{ aws_region }}"
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   collections:
     - community.aws
     - amazon.aws

--- a/tests/integration/targets/rds_instance_snapshot_mgmt/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_snapshot_mgmt/tasks/main.yml
@@ -3,9 +3,9 @@
   - community.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   - name: Ensure the resource doesn't exist

--- a/tests/integration/targets/rds_instance_states/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_states/tasks/main.yml
@@ -3,9 +3,9 @@
   - community.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   - name: Ensure the resource doesn't exist

--- a/tests/integration/targets/rds_instance_tagging/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_tagging/tasks/main.yml
@@ -3,9 +3,9 @@
   - community.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   - name: Test tagging db with storage type gp3

--- a/tests/integration/targets/rds_instance_upgrade/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_upgrade/tasks/main.yml
@@ -3,9 +3,9 @@
   - community.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   - name: Ensure the resource doesn't exist

--- a/tests/integration/targets/rds_option_group/tasks/main.yml
+++ b/tests/integration/targets/rds_option_group/tasks/main.yml
@@ -2,9 +2,9 @@
   module_defaults:
     group/aws:
       region: '{{ aws_region }}'
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
 
 
   block:

--- a/tests/integration/targets/rds_param_group/tasks/main.yml
+++ b/tests/integration/targets/rds_param_group/tasks/main.yml
@@ -14,10 +14,10 @@
 - name: rds_option_group tests
   module_defaults:
     group/aws:
-      ec2_access_key: '{{ aws_access_key }}'
-      ec2_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
-      region: '{{ ec2_region }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
+      region: '{{ aws_region }}'
   block:
 
     # ============================================================

--- a/tests/integration/targets/rds_subnet_group/tasks/main.yml
+++ b/tests/integration/targets/rds_subnet_group/tasks/main.yml
@@ -7,9 +7,9 @@
 
 - module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
 

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -9,9 +9,9 @@
 - name: Test basics (new zone, A and AAAA records)
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
     amazon.aws.route53:
       # Route53 is explicitly a global service

--- a/tests/integration/targets/route53_health_check/tasks/main.yml
+++ b/tests/integration/targets/route53_health_check/tasks/main.yml
@@ -17,9 +17,9 @@
 #
 - module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
   # Route53 can only test against routable IPs.  Request an EIP so some poor

--- a/tests/integration/targets/route53_zone/tasks/main.yml
+++ b/tests/integration/targets/route53_zone/tasks/main.yml
@@ -4,9 +4,9 @@
     - amazon.aws
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
   block:
 

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/acl.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/acl.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - set_fact:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_bucket_key.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_bucket_key.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - name: Set facts for encryption_bucket_key test

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_kms.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_kms.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - set_fact:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_sse.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_sse.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - set_fact:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/main.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/main.yml
@@ -8,9 +8,9 @@
 - name: "Wrap up all tests and setup AWS credentials"
   module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - debug:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/object_lock.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/object_lock.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - set_fact:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - set_fact:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/public_access.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/public_access.yml
@@ -1,9 +1,9 @@
 ---
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
     - set_fact:

--- a/tests/integration/targets/s3_object/tasks/main.yml
+++ b/tests/integration/targets/s3_object/tasks/main.yml
@@ -2,9 +2,9 @@
 # Integration tests for s3_object
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
 
   block:

--- a/tests/integration/targets/setup_ec2_facts/tasks/main.yml
+++ b/tests/integration/targets/setup_ec2_facts/tasks/main.yml
@@ -10,9 +10,9 @@
 #
 - module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit) }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
 
   run_once: True

--- a/tests/integration/targets/setup_ec2_instance_env/tasks/cleanup.yml
+++ b/tests/integration/targets/setup_ec2_instance_env/tasks/cleanup.yml
@@ -1,8 +1,8 @@
 - module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: Set termination protection to false (so we can terminate instance) (cleanup)

--- a/tests/integration/targets/setup_ec2_instance_env/tasks/main.yml
+++ b/tests/integration/targets/setup_ec2_instance_env/tasks/main.yml
@@ -1,9 +1,9 @@
 - run_once: '{{ setup_run_once | default("no") | bool }}'
   module_defaults:
     group/aws:
-      aws_access_key: "{{ aws_access_key }}"
-      aws_secret_key: "{{ aws_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
   - name: "Create VPC for use in testing"

--- a/tests/integration/targets/setup_ec2_vpc/tasks/cleanup.yml
+++ b/tests/integration/targets/setup_ec2_vpc/tasks/cleanup.yml
@@ -2,9 +2,9 @@
 - name: Run all tests
   module_defaults:
     group/aws:
-      aws_access_key: '{{ aws_access_key }}'
-      aws_secret_key: '{{ aws_secret_key }}'
-      security_token: '{{ security_token | default(omit)}}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit)}}'
       region: '{{ aws_region }}'
   block:
 


### PR DESCRIPTION
##### SUMMARY

Manual backport of #1714 and #1721

We had a cleanup of credentials/session parameters which included a batch of deprecations and renames.
Ensure that all of our tests and docs are using the 'canonical' names

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/inventory/aws_ec2.py
plugins/lookup/secretsmanager_secret.py
plugins/lookup/ssm_parameter.py
plugins/modules/ec2_security_group.py
tests/integration

##### ADDITIONAL INFORMATION