### PR TITLE
[PR #1696/fe7057be backport][stable-5] Add a workflow (+actions) to automatically generate the GitHub Release when a valid tag is pushed

### DIFF
--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -1,0 +1,35 @@
+name: Generate GitHub Release (manual trigger)
+concurrency:
+  group: release-${{ github.head_ref }}
+  cancel-in-progress: true
+on:
+  workflow_dispatch:
+    inputs:
+      release:
+        required: true
+        description: 'Release to generate'
+        type: string
+
+jobs:
+  generate-release-log:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Release Log
+        uses: ansible-collections/amazon.aws/.github/actions/ansible_release_log@main
+        with:
+          release: ${{ inputs.release }}
+
+  perform-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs:
+      - generate-release-log
+    steps:
+      - name: Generate Release
+        uses: ansible-collections/amazon.aws/.github/actions/ansible_release_tag@main
+        with:
+          release: ${{ inputs.release }}
+          collection-name: amazon.aws

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,0 +1,32 @@
+name: Generate GitHub Release
+concurrency:
+  group: release-${{ github.head_ref }}
+  cancel-in-progress: true
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  generate-release-log:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Generate Release Log
+        uses: ansible-collections/amazon.aws/.github/actions/ansible_release_log@main
+        with:
+          release: ${{ github.ref_name }}
+
+  perform-release:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    needs:
+      - generate-release-log
+    steps:
+      - name: Generate Release
+        uses: ansible-collections/amazon.aws/.github/actions/ansible_release_tag@main
+        with:
+          release: ${{ github.ref_name }}
+          collection-name: amazon.aws


### PR DESCRIPTION
This is a backport of PR #1696 as merged into main (fe7057b).

##### SUMMARY

Automatically generate the GitHub release when we push a valid tag.  (Because we keep forgetting)

##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

.github/

##### ADDITIONAL INFORMATION

Reviewed-by: Mark Chappell