### PR TITLE
Copy 2.16 ignore file to 2.17 (route53 'get' mode)

### DIFF
--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,0 +1,1 @@
+plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this


### PR DESCRIPTION
##### SUMMARY

2.16 has branched, devel is now 2.17 and needs its own ignore file.

##### ISSUE TYPE

- Tests Pull Request

##### COMPONENT NAME

tests/sanity/ignore-2.17.txt

##### ADDITIONAL INFORMATION
