### PR TITLE
elb_application_lb_info - ensure queries for additional ALB data have retries enabled

### DIFF
--- a/changelogs/fragments/1767-elb_application_lb_info-Throttling.yml
+++ b/changelogs/fragments/1767-elb_application_lb_info-Throttling.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- elb_application_lb_info - ensure all API queries use the retry decorator (https://github.com/ansible-collections/amazon.aws/issues/1767).

--- a/changelogs/fragments/1767-elb_application_lb_info-Throttling.yml
+++ b/changelogs/fragments/1767-elb_application_lb_info-Throttling.yml
@@ -1,2 +1,4 @@
 bugfixes:
 - elb_application_lb_info - ensure all API queries use the retry decorator (https://github.com/ansible-collections/amazon.aws/issues/1767).
+minor_changes:
+- elb_application_lb_info - drop redundant ``describe_load_balancers`` call fetching ``ip_address_type`` (https://github.com/ansible-collections/amazon.aws/pull/1768).

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -279,15 +279,6 @@ def get_load_balancer_tags(connection, module, load_balancer_arn):
         module.fail_json_aws(e, msg="Failed to describe load balancer tags")
 
 
-def get_load_balancer_ipaddresstype(connection, module, load_balancer_arn):
-    try:
-        return connection.describe_load_balancers(aws_retry=True, LoadBalancerArns=[load_balancer_arn])["LoadBalancers"][0][
-            "IpAddressType"
-        ]
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to describe load balancer ip address type")
-
-
 def list_load_balancers(connection, module):
     load_balancer_arns = module.params.get("load_balancer_arns")
     names = module.params.get("names")
@@ -317,11 +308,6 @@ def list_load_balancers(connection, module):
         # For each listener, get listener rules
         for listener in load_balancer["listeners"]:
             listener["rules"] = get_listener_rules(connection, module, listener["ListenerArn"])
-
-        # Get ALB ip address type
-        load_balancer["IpAddressType"] = get_load_balancer_ipaddresstype(
-            connection, module, load_balancer["LoadBalancerArn"]
-        )
 
     # Turn the boto3 result in to ansible_friendly_snaked_names
     snaked_load_balancers = [

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -232,23 +232,31 @@ def get_paginator(connection, **kwargs):
 
 def get_alb_listeners(connection, module, alb_arn):
     try:
-        return connection.describe_listeners(LoadBalancerArn=alb_arn)["Listeners"]
+        return connection.describe_listeners(
+            aws_retry=True,
+            LoadBalancerArn=alb_arn,
+        )["Listeners"]
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to describe alb listeners")
 
 
 def get_listener_rules(connection, module, listener_arn):
     try:
-        return connection.describe_rules(ListenerArn=listener_arn)["Rules"]
+        return connection.describe_rules(
+            aws_retry=True,
+            ListenerArn=listener_arn,
+        )["Rules"]
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to describe listener rules")
 
 
 def get_load_balancer_attributes(connection, module, load_balancer_arn):
     try:
-        load_balancer_attributes = boto3_tag_list_to_ansible_dict(
-            connection.describe_load_balancer_attributes(LoadBalancerArn=load_balancer_arn)["Attributes"]
-        )
+        attributes = connection.describe_load_balancer_attributes(
+            aws_retry=True,
+            LoadBalancerArn=load_balancer_arn,
+        )["Attributes"]
+        load_balancer_attributes = boto3_tag_list_to_ansible_dict(attributes)
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to describe load balancer attributes")
 
@@ -262,16 +270,18 @@ def get_load_balancer_attributes(connection, module, load_balancer_arn):
 
 def get_load_balancer_tags(connection, module, load_balancer_arn):
     try:
-        return boto3_tag_list_to_ansible_dict(
-            connection.describe_tags(ResourceArns=[load_balancer_arn])["TagDescriptions"][0]["Tags"]
-        )
+        tag_descriptions = connection.describe_tags(
+            aws_retry=True,
+            ResourceArns=[load_balancer_arn],
+        )["TagDescriptions"]
+        return boto3_tag_list_to_ansible_dict(tag_descriptions[0]["Tags"])
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to describe load balancer tags")
 
 
 def get_load_balancer_ipaddresstype(connection, module, load_balancer_arn):
     try:
-        return connection.describe_load_balancers(LoadBalancerArns=[load_balancer_arn])["LoadBalancers"][0][
+        return connection.describe_load_balancers(aws_retry=True, LoadBalancerArns=[load_balancer_arn])["LoadBalancers"][0][
             "IpAddressType"
         ]
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:


### PR DESCRIPTION
##### SUMMARY

As per #1767 the queries to pull extra info about ALBs are hitting rate limits when there's a lot of ALBs.  Unfortunately the initial list operation has limited server-side filtering capabilities (and we don't have consistent client side filtering implemented at this time).

Ensure that all of the extra queries have retries with jittered backoff enabled.

Additionally, drops a redundant describe_load_balancers call to retrieve the ip_address_type information.  (added by https://github.com/ansible-collections/community.aws/pull/499)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

elb_application_lb_info

##### ADDITIONAL INFORMATION

I don't consider this a full fix for #1767 so I'm not using the "fixes".