### PR TITLE
elb_application_lb_info - Add parameters to skip fetching some data

### DIFF
--- a/changelogs/fragments/1776-elb_application_lb_info-fetch-subsets.yml
+++ b/changelogs/fragments/1776-elb_application_lb_info-fetch-subsets.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - "elb_application_lb_info - add new parameters ``include_attributes``, ``include_listeners`` and  ``include_listener_rules`` to optionally speed up module by fetching less information (https://github.com/ansible-collections/amazon.aws/pull/1776)."

--- a/changelogs/fragments/1776-elb_application_lb_info-fetch-subsets.yml
+++ b/changelogs/fragments/1776-elb_application_lb_info-fetch-subsets.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "elb_application_lb_info - add new parameters ``include_attributes``, ``include_listeners`` and  ``include_listener_rules`` to optionally speed up module by fetching less information (https://github.com/ansible-collections/amazon.aws/pull/1776)."

--- a/changelogs/fragments/1778-elb_application_lb_info-fetch-subsets.yml
+++ b/changelogs/fragments/1778-elb_application_lb_info-fetch-subsets.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - "elb_application_lb_info - add new parameters ``include_attributes``, ``include_listeners`` and  ``include_listener_rules`` to optionally speed up module by fetching less information (https://github.com/ansible-collections/amazon.aws/pull/1778)."

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -33,12 +33,14 @@ options:
     required: false
     type: bool
     default: true
+    version_added: 7.0.0
   include_listeners:
     description:
       - Whether or not to include load balancer listeners in the response.
     required: false
     type: bool
     default: true
+    version_added: 7.0.0
   include_listener_rules:
     description:
       - Whether or not to include load balancer listener rules in the response.
@@ -46,6 +48,7 @@ options:
     required: false
     type: bool
     default: true
+    version_added: 7.0.0
 
 extends_documentation_fragment:
   - amazon.aws.common.modules

--- a/tests/integration/targets/elb_application_lb/tasks/main.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/main.yml
@@ -1413,7 +1413,7 @@
       - alb_info.load_balancers | selectattr('routing_http_xff_client_port_enabled', 'defined') | length > 0
       - alb_info.load_balancers | selectattr('waf_fail_open_enabled', 'defined') | length > 0
       - alb_info.load_balancers | selectattr('listeners', 'defined') | length > 0
-      - alb_info.load_balancers | map(attribute='listeners') | selectattr('rules', 'defined') | length > 0
+      - alb_info.load_balancers | map(attribute='listeners') | flatten | selectattr('rules', 'defined') | length > 0
 
   - name: Get ALB application info excluding attributes
     elb_application_lb_info:
@@ -1459,7 +1459,7 @@
   - assert:
       that:
       - alb_info.load_balancers | selectattr('listeners', 'defined') | length > 0
-      - alb_info.load_balancers | map(attribute='listeners') | selectattr('rules', 'defined') | length == 0
+      - alb_info.load_balancers | map(attribute='listeners') | flatten | selectattr('rules', 'defined') | length == 0
 
   - name: Get ALB application minimal info
     elb_application_lb_info:

--- a/tests/integration/targets/elb_application_lb/tasks/main.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/main.yml
@@ -1395,6 +1395,94 @@
       that:
       - alb_info.load_balancers[0].security_groups[0] == sec_group2.group_id
 
+  - name: Get ALB application info without skipping anything
+    elb_application_lb_info:
+    register: alb_info
+  - assert:
+      that:
+      - alb_info.load_balancers | selectattr('access_logs_s3_bucket', 'defined') | length > 0
+      - alb_info.load_balancers | selectattr('access_logs_s3_enabled', 'defined') | length > 0
+      - alb_info.load_balancers | selectattr('access_logs_s3_prefix', 'defined') | length > 0
+      - alb_info.load_balancers | selectattr('deletion_protection_enabled', 'defined') | length > 0
+      - alb_info.load_balancers | selectattr('idle_timeout_timeout_seconds', 'defined') | length > 0
+      - alb_info.load_balancers | selectattr('load_balancing_cross_zone_enabled', 'defined') | length > 0
+      - alb_info.load_balancers | selectattr('routing_http2_enabled', 'defined') | length > 0
+      - alb_info.load_balancers | selectattr('routing_http_desync_mitigation_mode', 'defined') | length > 0
+      - alb_info.load_balancers | selectattr('routing_http_drop_invalid_header_fields_enabled', 'defined') | length > 0
+      - alb_info.load_balancers | selectattr('routing_http_x_amzn_tls_version_and_cipher_suite_enabled', 'defined') | length > 0
+      - alb_info.load_balancers | selectattr('routing_http_xff_client_port_enabled', 'defined') | length > 0
+      - alb_info.load_balancers | selectattr('waf_fail_open_enabled', 'defined') | length > 0
+      - alb_info.load_balancers | selectattr('listeners', 'defined') | length > 0
+      - alb_info.load_balancers | map(attribute='listeners') | selectattr('rules', 'defined') | length > 0
+
+  - name: Get ALB application info excluding attributes
+    elb_application_lb_info:
+      include_attributes: false
+    register: alb_info
+  - assert:
+      that:
+      - alb_info.load_balancers | selectattr('access_logs_s3_bucket', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('access_logs_s3_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('access_logs_s3_prefix', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('deletion_protection_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('idle_timeout_timeout_seconds', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('load_balancing_cross_zone_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('routing_http2_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('routing_http_desync_mitigation_mode', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('routing_http_drop_invalid_header_fields_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('routing_http_x_amzn_tls_version_and_cipher_suite_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('routing_http_xff_client_port_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('waf_fail_open_enabled', 'defined') | length == 0
+
+  - name: Get ALB application info without listeners, but with rules
+    elb_application_lb_info:
+      include_listeners: false
+    register: alb_info
+  - assert:
+      that:
+      - alb_info.load_balancers | selectattr('listeners', 'defined') | length > 0
+      - alb_info.load_balancers[0].listeners | length > 0
+
+  - name: Get ALB application info without listeners or rules
+    elb_application_lb_info:
+      include_listeners: false
+      include_listener_rules: false
+    register: alb_info
+  - assert:
+      that:
+      - alb_info.load_balancers | selectattr('listeners', 'defined') | length == 0
+
+  - name: Get ALB application info without listener rules
+    elb_application_lb_info:
+      include_listener_rules: false
+    register: alb_info
+  - assert:
+      that:
+      - alb_info.load_balancers | selectattr('listeners', 'defined') | length > 0
+      - alb_info.load_balancers | map(attribute='listeners') | selectattr('rules', 'defined') | length == 0
+
+  - name: Get ALB application minimal info
+    elb_application_lb_info:
+      include_attributes: false
+      include_listeners: false
+      include_listener_rules: false
+    register: alb_info
+  - assert:
+      that:
+      - alb_info.load_balancers | selectattr('access_logs_s3_bucket', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('access_logs_s3_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('access_logs_s3_prefix', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('deletion_protection_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('idle_timeout_timeout_seconds', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('load_balancing_cross_zone_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('routing_http2_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('routing_http_desync_mitigation_mode', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('routing_http_drop_invalid_header_fields_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('routing_http_x_amzn_tls_version_and_cipher_suite_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('routing_http_xff_client_port_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('waf_fail_open_enabled', 'defined') | length == 0
+      - alb_info.load_balancers | selectattr('listeners', 'defined') | length == 0
+
     # ------------------------------------------------------------------------------------------
 
   - name: Delete an ALB - check_mode


### PR DESCRIPTION
Add include_attributes, include_listeners and include_listener_rules.

##### SUMMARY

Related to #1767.

This PR adds parameters to the module which disable fetching certain data.
They all default to `true` for backwards compatibility. In my tests disabling all 3 speeds it up by around 10x when fetching a lot (100+) ALBs.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
elb_application_lb_info

##### ADDITIONAL INFORMATION

Please let me know if the coupling of `include_listeners` and `include_listener_rules` isn't desired. I can add checks to require `include_listeners` be true if `include_listener_rules` as an alternative (or something else?).
