### PR TITLE
aws_az_info - add example of filtering by state

### DIFF
--- a/plugins/modules/aws_az_info.py
+++ b/plugins/modules/aws_az_info.py
@@ -39,6 +39,12 @@ EXAMPLES = r"""
   amazon.aws.aws_az_info:
     filters:
       zone-name: eu-west-1a
+
+- name: Gather information in a availability zones based on their state, such as "available"
+  amazon.aws.aws_az_info:
+    region: us-east-1
+    filters:
+      state: available
 """
 
 RETURN = r"""


### PR DESCRIPTION


##### SUMMARY
You can filter availability zones based on their state, such as "available," "unavailable," or "modifying."

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
  amazon.aws.aws_az_info:

