### PR TITLE
s3_object - remove docs for create/delete bucket.

### DIFF
--- a/changelogs/fragments/1799-s3_object-bucket.yml
+++ b/changelogs/fragments/1799-s3_object-bucket.yml
@@ -1,0 +1,2 @@
+trivial:
+- s3_object - Remove examples for creating/deleting buckets - support removed in 6.0.0.

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -338,24 +338,6 @@ EXAMPLES = r"""
     marker: /my/desired/0023.txt
     max_keys: 472
 
-- name: Create an empty bucket
-  amazon.aws.s3_object:
-    bucket: mybucket
-    mode: create
-    permission: public-read
-
-- name: Create a bucket with key as directory, in the EU region
-  amazon.aws.s3_object:
-    bucket: mybucket
-    object: /my/directory/path
-    mode: create
-    region: eu-west-1
-
-- name: Delete a bucket and all contents
-  amazon.aws.s3_object:
-    bucket: mybucket
-    mode: delete
-
 - name: GET an object but don't download if the file checksums match. New in 2.0
   amazon.aws.s3_object:
     bucket: mybucket


### PR DESCRIPTION
##### SUMMARY

We dropped support for creating/deleting buckets through s3_object.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

s3_object

##### ADDITIONAL INFORMATION
