### PR TITLE
Add example for deleting an existing VPC

### DIFF
--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -113,7 +113,7 @@ EXAMPLES = r"""
 
 - name: Delete an existing VPC
   amazon.aws.ec2_vpc_net:
-    vpc_id: 0123456789abcdef0
+    vpc_id: vpc-0123456789abcdef0
     state: absent
 """
 

--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -110,6 +110,11 @@ EXAMPLES = r"""
     ipv6_cidr: True
     region: us-east-1
     tenancy: dedicated
+
+- name: Delete an existing VPC
+  amazon.aws.ec2_vpc_net:
+    vpc_id: vpc-01234-abcdef
+    state: absent
 """
 
 RETURN = r"""

--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -113,7 +113,7 @@ EXAMPLES = r"""
 
 - name: Delete an existing VPC
   amazon.aws.ec2_vpc_net:
-    vpc_id: vpc-01234-abcdef
+    vpc_id: 0123456789abcdef0
     state: absent
 """
 


### PR DESCRIPTION

##### SUMMARY
Delete an existing VPC by setting the state to "absent" and specify the vpc_id.


##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME
  amazon.aws.ec2_vpc_net:  state:

