### PR TITLE
Update ec2_vpc_net.py to allow setting `ipv6_cidr: false` in task.

### DIFF
--- a/plugins/modules/ec2_vpc_net.py
+++ b/plugins/modules/ec2_vpc_net.py
@@ -384,7 +384,7 @@ def wait_for_vpc_ipv6_state(module, connection, vpc_id, ipv6_assoc_state):
     If ipv6_assoc_state is False, wait for VPC to be dissociated from all Amazon-provided IPv6 CIDR blocks.
     """
 
-    if ipv6_assoc_state is None:
+    if not ipv6_assoc_state:
         return
     if module.check_mode:
         return


### PR DESCRIPTION
Module will fail if `ipv6_cidr: false` is set in task.  This change fixes that bug.

##### SUMMARY
Module will fail if `ipv6_cidr: false` is set in task.  This change fixes that bug.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_net

##### ADDITIONAL INFORMATION
If the option `ipv6_cidr: false` (which is the default), is used with this module,
the module fails with the following error:

`fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to wait for IPv6 CIDR association"}`

One can comment that line out, but that does not solve the problem of having a set of VMs to create,
some of which will need IPV6 and some of which will not.

Before:
```
fatal: [localhost]: FAILED! => {"changed": false, "msg": "Failed to wait for IPv6 CIDR association"}
```

After:
```
changed: [localhost]
```
