### PR TITLE
s3_object - fix NoSuchTagSet error when S3 endpoint doesn't support tags

### DIFF
--- a/changelogs/fragments/1607-NoSuchTagSet.yml
+++ b/changelogs/fragments/1607-NoSuchTagSet.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- s3_object - fixed ``NoSuchTagSet`` error when S3 endpoint doesn't support tags (https://github.com/ansible-collections/amazon.aws/issues/1607).

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -900,7 +900,7 @@ def get_current_object_tags_dict(module, s3, bucket, obj, version=None):
     except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
         module.warn("GetObjectTagging is not implemented by your storage provider.")
         return {}
-    except is_boto3_error_code(("NoSuchTagSet", "NoSuchTagSetError")):
+    except is_boto3_error_code(["NoSuchTagSet", "NoSuchTagSetError"]):
         return {}
     return boto3_tag_list_to_ansible_dict(current_tags)
 


### PR DESCRIPTION
##### SUMMARY

is_boto3_error_code only supports being passed a string or *list*.  In the refactor of s3_object it was passed a tuple, so the errors weren't being cleanly caught.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

s3_object

##### ADDITIONAL INFORMATION

fixes: #1607