### PR TITLE
Corrected the bug in examples for iam_instance_profile

### DIFF
--- a/plugins/modules/iam_instance_profile.py
+++ b/plugins/modules/iam_instance_profile.py
@@ -48,16 +48,16 @@ extends_documentation_fragment:
 
 EXAMPLES = r"""
 - name: Find all existing IAM instance profiles
-  amazon.aws.iam_instance_profile_info:
+  amazon.aws.iam_instance_profile:
   register: result
 
 - name: Describe a single instance profile
-  amazon.aws.iam_instance_profile_info:
+  amazon.aws.iam_instance_profile:
     name: MyIAMProfile
   register: result
 
 - name: Find all IAM instance profiles starting with /some/path/
-  amazon.aws.iam_instance_profile_info:
+  amazon.aws.iam_instance_profile:
     prefile: /some/path/
   register: result
 """


### PR DESCRIPTION
##### SUMMARY
In this pull request, I have corrected the bug because of which it was pointing to iam_instance_profile_info examples instead of itself. It Fixes #1811 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
NA

##### ADDITIONAL INFORMATION
I just corrected the file path in the file.

Could you please check once? Will be happy to learn and contribute more. 