### PR TITLE
Support for multiple assume roles to get collective inventory

### DIFF
--- a/plugins/doc_fragments/assume_role.py
+++ b/plugins/doc_fragments/assume_role.py
@@ -22,4 +22,10 @@ options:
       - The ARN of the IAM role to assume to perform the lookup.
       - You should still provide AWS credentials with enough privilege to perform the AssumeRole action.
     aliases: ["iam_role_arn"]
+  assume_role_arns:
+    description:
+      - List of ARNs which can be assumed to get collective inventory result.
+      - This conflicts with `assume_role_arn`.
+      - You should still provide AWS credentials with enough privilege to perform the AssumeRole action.
+    aliases: ["iam_role_arns"]
 """


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This change is to implement a ability to get a collective inventory. 

**Motivation came from our setup**, we have a centralized management account from which things can be managed in underlying accounts and we been struggling to attain a central inventory from all accounts in one go, which lead to implement this and we strongly believe this can be useful to community and others can take advantage of it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
New option included to the plugin, `assume_role_arns: []`

This can be taken advantage of if ansible controller is running from a central location and have ability to assume multiple roles in different accounts, this will result in a collective inventory from all the locations

example:
```
assume_role_arns:
  - arn:aws:iam::<account-id-1>:role/<role-name>
  - arn:aws:iam::<account-id-2>:role/<role-name>
  - arn:aws:iam::<account-id-3>:role/<role-name>
```

This will give out the inventory from all the 3 accounts, assuming the controller its running from have access to assume these roles.

**NOTE: this will still expect a base credential setup, that is, either AWS Keys or EC2 instance profile(when running from an EC2)**

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This new option conflicts with an existing option, `assume_role_arn`, we can use **either one but not both**

To test this here is an example file I used, 

```
plugin: aws_ec2
assume_role_arns:
  - arn:aws:iam::<acc-id-1>:role/<role-name>
  - arn:aws:iam::<acc-id-2>:role/<role-name>
regions:
  - us-west-2
  - eu-central-1
  - ap-southeast-2

keyed_groups:
  - key: tags.Name
    separator: ""

hostnames:
  - 'private-ip-address'
```
and when running `ansible-inventory -i <file-name>--graph -vvv ` gives me inventory from both accounts across 3 regions, and i used a base credential which has assuming access to these 2 roles used.

**Exception:**
It fails with conflict error when used both `assume_role_arn` and `assume_role_arns` like this in a file
```
plugin: aws_ec2
assume_role_arn: arn:aws:iam::<acc-id-x>:role/<role-name>
assume_role_arns:
  - arn:aws:iam::<acc-id-1>:role/<role-name>
  - arn:aws:iam::<acc-id-2>:role/<role-name>
regions:
  - us-west-2
  - eu-central-1
  - ap-southeast-2

keyed_groups:
  - key: tags.Name
    separator: ""

hostnames:
  - 'private-ip-address'
```
error: `Conflict here, cannot have not
assume_role_arn and assume_role_arns used together`

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
