### PR TITLE
rds_cluster: add support for ServerlessV2ScalingConfiguration

### DIFF
--- a/changelogs/fragments/1839-rds_cluster-add-support-for-serverless_v2_scaling_configuration.yml
+++ b/changelogs/fragments/1839-rds_cluster-add-support-for-serverless_v2_scaling_configuration.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+- rds_cluster - Add support for ServerlessV2ScalingConfiguration to create and modify cluster operations (https://github.com/ansible-collections/amazon.aws/pull/1839).

--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -716,6 +716,7 @@ serverless_v2_scaling_configuration:
       "max_capacity": 4.5,
       "min_capacity": 2.5
   }
+  version_added: 7.2.0
 status:
   description: The status of the DB cluster.
   returned: always

--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -708,6 +708,14 @@ reader_endpoint:
   returned: always
   type: str
   sample: rds-cluster-demo.cluster-ro-cvlrtwiennww.us-east-1.rds.amazonaws.com
+serverless_v2_scaling_configuration:
+  description: The scaling configuration for an Aurora Serverless v2 DB cluster.
+  returned: when configured
+  type: dict
+  sample: {
+      "max_capacity": 4.5,
+      "min_capacity": 2.5
+  }
 status:
   description: The status of the DB cluster.
   returned: always

--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -1256,7 +1256,7 @@ def main():
             options=dict(
                 min_capacity=dict(type="float"),
                 max_capacity=dict(type="float"),
-                ),
+            ),
         ),
         skip_final_snapshot=dict(type="bool", default=False),
         snapshot_identifier=dict(),

--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -350,6 +350,23 @@ options:
           - The prefix for all of the file names that contain the data used to create the Amazon Aurora DB cluster.
           - If you do not specify a SourceS3Prefix value, then the Amazon Aurora DB cluster is created by using all of the files in the Amazon S3 bucket.
         type: str
+    serverless_v2_scaling_configuration:
+        description:
+          - Contains the scaling configuration of an Aurora Serverless v2 DB cluster.
+        type: dict
+        suboptions:
+          min_capacity:
+            description:
+              - The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster.
+              - ACU values can be specified in in half-step increments, such as 8, 8.5, 9, and so on.
+              - The smallest possible value is 0.5.
+            type: float
+          max_capacity:
+            description:
+              - The maximum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster.
+              - ACU values can be specified in in half-step increments, such as 40, 40.5, 41, and so on.
+              - The largest possible value is 128.
+            type: float
     skip_final_snapshot:
         description:
           - Whether a final DB cluster snapshot is created before the DB cluster is deleted.
@@ -821,6 +838,7 @@ def get_create_options(params_dict):
         "StorageType",
         "Iops",
         "EngineMode",
+        "ServerlessV2ScalingConfiguration",
     ]
 
     return dict((k, v) for k, v in params_dict.items() if k in options and v is not None)
@@ -855,6 +873,7 @@ def get_modify_options(params_dict, force_update_password):
         "StorageType",
         "Iops",
         "EngineMode",
+        "ServerlessV2ScalingConfiguration",
     ]
     modify_options = dict((k, v) for k, v in params_dict.items() if k in options and v is not None)
     if not force_update_password:
@@ -1232,6 +1251,13 @@ def main():
         s3_bucket_name=dict(),
         s3_ingestion_role_arn=dict(),
         s3_prefix=dict(),
+        serverless_v2_scaling_configuration=dict(
+            type="dict",
+            options=dict(
+                min_capacity=dict(type="float"),
+                max_capacity=dict(type="float"),
+                ),
+        ),
         skip_final_snapshot=dict(type="bool", default=False),
         snapshot_identifier=dict(),
         source_db_cluster_identifier=dict(),

--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -358,15 +358,16 @@ options:
           min_capacity:
             description:
               - The minimum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster.
-              - ACU values can be specified in in half-step increments, such as 8, 8.5, 9, and so on.
-              - The smallest possible value is 0.5.
+              - ACU values can be specified in in half-step increments, such as C(8), C(8.5), C(9), and so on.
+              - The smallest possible value is C(0.5).
             type: float
           max_capacity:
             description:
               - The maximum number of Aurora capacity units (ACUs) for a DB instance in an Aurora Serverless v2 cluster.
-              - ACU values can be specified in in half-step increments, such as 40, 40.5, 41, and so on.
-              - The largest possible value is 128.
+              - ACU values can be specified in in half-step increments, such as C(40), C(40.5), C(41), and so on.
+              - The largest possible value is C(128).
             type: float
+        version_added: 7.1.0
     skip_final_snapshot:
         description:
           - Whether a final DB cluster snapshot is created before the DB cluster is deleted.

--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -367,7 +367,7 @@ options:
               - ACU values can be specified in in half-step increments, such as C(40), C(40.5), C(41), and so on.
               - The largest possible value is C(128).
             type: float
-        version_added: 7.1.0
+        version_added: 7.2.0
     skip_final_snapshot:
         description:
           - Whether a final DB cluster snapshot is created before the DB cluster is deleted.

--- a/tests/integration/targets/rds_cluster_modify/defaults/main.yml
+++ b/tests/integration/targets/rds_cluster_modify/defaults/main.yml
@@ -18,6 +18,9 @@ test_engine: aurora-mysql
 test_engine_version: 8.0
 test_instance_class: db.r5.large
 
+min_capacity: 2.5
+max_capacity: 4.5
+
 # Global cluster parameters ================================
 test_global_cluster_name: ansible-test-global-{{ tiny_prefix }}
 

--- a/tests/integration/targets/rds_cluster_modify/tasks/create_update_cluster_serverless_v2_scaling_configuration.yaml
+++ b/tests/integration/targets/rds_cluster_modify/tasks/create_update_cluster_serverless_v2_scaling_configuration.yaml
@@ -1,0 +1,118 @@
+---
+- name: Run tests for testing serverless v2 scaling configuration
+  block:
+    - name: Create a cluster (check_mode)
+      amazon.aws.rds_cluster:
+        db_cluster_identifier: "{{ cluster_id }}"
+        region: "{{ aws_region }}"
+        engine: "{{ test_engine }}"
+        engine_version: "{{ test_engine_version }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        serverless_v2_scaling_configuration:
+          min_capacity: "{{ min_capacity }}"
+          max_capacity: "{{ max_capacity }}"
+      check_mode: true
+      register: create_result_check_mode
+
+    - name: Get RDS cluster info
+      amazon.aws.rds_cluster_info:
+        db_cluster_identifier: "{{ cluster_id }}"
+        region: "{{ aws_region }}"
+      register: result
+
+    - assert:
+        that:
+          - create_result_check_mode is changed
+          - create_result_check_mode is not failed
+          - result.clusters | length == 0
+
+    - name: Create a cluster
+      amazon.aws.rds_cluster:
+        db_cluster_identifier: "{{ cluster_id }}"
+        region: "{{ aws_region }}"
+        engine: "{{ test_engine }}"
+        engine_version: "{{ test_engine_version }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        serverless_v2_scaling_configuration:
+          min_capacity: "{{ min_capacity }}"
+          max_capacity: "{{ max_capacity }}"
+      register: create_result
+
+    - name: Get RDS cluster info
+      amazon.aws.rds_cluster_info:
+        db_cluster_identifier: "{{ cluster_id }}"
+        region: "{{ aws_region }}"
+      register: result
+
+    - assert:
+        that:
+          - create_result is changed
+          - create_result is not failed
+          - result.clusters[0].serverless_v2_scaling_configuration is defined
+          - result.clusters[0].serverless_v2_scaling_configuration.min_capacity == 2.5
+          - result.clusters[0].serverless_v2_scaling_configuration.max_capacity == 4.5
+
+    - name: Modify cluster - update serverless v2 scaling configuration (check_mode)
+      amazon.aws.rds_cluster:
+        db_cluster_identifier: "{{ cluster_id }}"
+        region: "{{ aws_region }}"
+        engine: "{{ test_engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        serverless_v2_scaling_configuration:
+          min_capacity: 2
+          max_capacity: 5
+      check_mode: true
+      register: modify_result_check_mode
+
+    - name: Get RDS cluster info
+      amazon.aws.rds_cluster_info:
+        db_cluster_identifier: "{{ cluster_id }}"
+        region: "{{ aws_region }}"
+      register: result
+
+    - assert:
+        that:
+          - modify_result_check_mode is changed
+          - modify_result_check_mode is not failed
+          - result.clusters[0].serverless_v2_scaling_configuration is defined
+          - result.clusters[0].serverless_v2_scaling_configuration.min_capacity != 2
+          - result.clusters[0].serverless_v2_scaling_configuration.max_capacity != 5
+
+    - name: Modify cluster - update serverless v2 scaling configuration
+      amazon.aws.rds_cluster:
+        db_cluster_identifier: "{{ cluster_id }}"
+        region: "{{ aws_region }}"
+        engine: "{{ test_engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        serverless_v2_scaling_configuration:
+          min_capacity: 2
+          max_capacity: 5
+      register: modify_result
+
+    - name: Get RDS cluster info
+      amazon.aws.rds_cluster_info:
+        db_cluster_identifier: "{{ cluster_id }}"
+        region: "{{ aws_region }}"
+      register: result
+
+    - assert:
+        that:
+          - modify_result is changed
+          - modify_result is not failed
+          - result.clusters[0].serverless_v2_scaling_configuration is defined
+          - result.clusters[0].serverless_v2_scaling_configuration.min_capacity == 2
+          - result.clusters[0].serverless_v2_scaling_configuration.max_capacity == 5
+
+  always:
+
+    - name: Delete DB cluster created in this test
+      amazon.aws.rds_cluster:
+        cluster_id: "{{ cluster_id }}"
+        region: "{{ aws_region }}"
+        skip_final_snapshot: true
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/rds_cluster_modify/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_modify/tasks/main.yaml
@@ -15,7 +15,7 @@
       import_tasks: create_update_cluster_serverless_v2_scaling_configuration.yaml
 
     - name: Ensure the resource doesn't exist
-      rds_cluster:
+      amazon.aws.rds_cluster:
         id: "{{ cluster_id }}"
         state: absent
         engine: "{{ engine}}"

--- a/tests/integration/targets/rds_cluster_modify/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_modify/tasks/main.yaml
@@ -11,13 +11,16 @@
   # - name: Run tests for testing remove cluster from global db
   #   import_tasks: remove_from_global_db.yaml
 
+    - name: Run tests for testing serverless v2 scaling configuration
+      import_tasks: create_update_cluster_serverless_v2_scaling_configuration.yaml
+
     - name: Ensure the resource doesn't exist
-      amazon.aws.rds_cluster:
-        id: "{{ cluster_id }}"
+      rds_cluster:
+        id: '{{ cluster_id }}'
         state: absent
-        engine: "{{ engine}}"
-        username: "{{ username }}"
-        password: "{{ password }}"
+        engine: '{{ engine}}'
+        username: '{{ username }}'
+        password: '{{ password }}'
         skip_final_snapshot: true
       register: _result_delete_db_cluster
 

--- a/tests/integration/targets/rds_cluster_modify/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_modify/tasks/main.yaml
@@ -16,11 +16,11 @@
 
     - name: Ensure the resource doesn't exist
       rds_cluster:
-        id: '{{ cluster_id }}'
+        id: "{{ cluster_id }}"
         state: absent
-        engine: '{{ engine}}'
-        username: '{{ username }}'
-        password: '{{ password }}'
+        engine: "{{ engine}}"
+        username: "{{ username }}"
+        password: "{{ password }}"
         skip_final_snapshot: true
       register: _result_delete_db_cluster
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1476 

Add support for ServerlessV2ScalingConfiguration in create_db_cluster and modify_db_cluster

https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_ServerlessV2ScalingConfiguration.html
https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html


<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rds_cluster
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
