### PR TITLE
Tag security groups on create

### DIFF
--- a/changelogs/fragments/1843-ec2_security_group-tags.yml
+++ b/changelogs/fragments/1843-ec2_security_group-tags.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_security_group - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/pull/1844)

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -1060,7 +1060,7 @@ def _create_security_group_with_wait(client, name, description, vpc_id, tags):
     if vpc_id:
         params["VpcId"] = vpc_id
     if tags:
-        params['TagSpecifications'] = boto3_tag_specifications(tags, ['security-group'])
+        params["TagSpecifications"] = boto3_tag_specifications(tags, ["security-group"])
 
     created_group = client.create_security_group(aws_retry=True, **params)
     get_waiter(
@@ -1078,7 +1078,7 @@ def create_security_group(client, module, name, description, vpc_id, tags):
         if vpc_id:
             params["VpcId"] = vpc_id
         if tags:
-            params['TagSpecifications'] = boto3_tag_specifications(tags, ['security-group'])
+            params["TagSpecifications"] = boto3_tag_specifications(tags, ["security-group"])
         try:
             group = client.create_security_group(aws_retry=True, **params)
         except (BotoCoreError, ClientError) as e:

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -1056,7 +1056,7 @@ def update_rule_descriptions(
 
 
 def _create_security_group_with_wait(client, name, description, vpc_id, tags):
-    params = dict(GroupName=name, Description=description, Tags=tags)
+    params = dict(GroupName=name, Description=description)
     if vpc_id:
         params["VpcId"] = vpc_id
     if tags:

--- a/tests/integration/targets/ec2_security_group/tasks/group_info.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/group_info.yml
@@ -18,6 +18,15 @@
           test: '{{ resource_prefix }}_ec2_group_info_module'
       register: group_info_test_setup
 
+    - name: Ensure tags were added without the additional CreateTags/RemoveTags calls
+      assert:
+        that:
+          - group_info_test_setup.tags | length == 1
+          - "'test' in group_info_test_setup.tags"
+          - group_info_test_setup.tags.test == "{{ resource_prefix }}_ec2_group_info_module"
+          - "'ec2:CreateTags' not in group_info_test_setup.resource_actions"
+          - "'ec2:DeleteTags' not in group_info_test_setup.resource_actions"
+
     - name: Create another group for testing group info retrieval below
       ec2_security_group:
         name: '{{ ec2_group_name }}-info-2'


### PR DESCRIPTION
##### SUMMARY
Apply tags to security groups on create
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`ec2_security_group`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
This fixes the issues mentioned in #1843 for security groups bu combining the resource creation and tagging into one command. This does not (at the moment) fix the same issue for other modules.
<!--- Paste verbatim command output below, e.g. before and after your change -->
![image](https://github.com/ansible-collections/amazon.aws/assets/26094248/909ef80a-def8-45e9-b9a5-2e12368eb5aa)