### PR TITLE
s3_object: fix value typo from last to latest

### DIFF
--- a/changelogs/fragments/1847-s3_object-fix-false-deprecation-warning.yml
+++ b/changelogs/fragments/1847-s3_object-fix-false-deprecation-warning.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - s3_object - Fix typo that caused false deprecation warning when setting `overwrite=latest` (https://github.com/ansible-collections/amazon.aws/pull/1847).

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -1535,11 +1535,11 @@ def main():
         if "amazonaws.com" not in endpoint_url:
             module.fail_json(msg="dualstack only applies to AWS S3")
 
-    if module.params.get("overwrite") not in ("always", "never", "different", "last"):
+    if module.params.get("overwrite") not in ("always", "never", "different", "latest"):
         module.deprecate(
             (
                 "Support for passing values of 'overwrite' other than 'always', 'never', "
-                "'different' or 'last', has been deprecated."
+                "'different' or 'latest', has been deprecated."
             ),
             date="2024-12-01",
             collection_name="amazon.aws",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1777 
Fixing value for `overwrite` to not produce `deprecation warning` on setting `overwirte=latest`.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
s3_object

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
