### PR TITLE
Gather information about all backup selections in a specific region

### DIFF
--- a/plugins/modules/backup_selection_info.py
+++ b/plugins/modules/backup_selection_info.py
@@ -43,6 +43,11 @@ EXAMPLES = r"""
   amazon.aws.backup_selection_info:
     backup_plan_name: "{{ backup_plan_name }}"
 
+- name: Gather information about all backup selections in a specific region
+  amazon.aws.backup_selection_info:
+    backup_plan_name: "{{ backup_plan_name }}"
+    region: "us-west-2"  
+
 - name: Gather information about a particular backup selection
   amazon.aws.backup_selection_info:
     backup_plan_name: "{{ backup_plan_name }}"


### PR DESCRIPTION
##### SUMMARY
Use region flag within amazon.aws.backup_selection_info module to Gather information about all backup selections in a specific region


##### ISSUE TYPE
- Docs Pull Request
