### PR TITLE
Set the back-off delay to 5 minutes before re-deployment

### DIFF
--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -181,6 +181,14 @@ EXAMPLES = r"""
     tags:
       Stack: "ansible-cloudformation"
 
+- name: Re-try the launch of CloudFormation Stack after 5 minutes of failure
+  amazon.aws.cloudformation:
+      stack_name: "my-cloudformation-stack"
+      state: "present"
+      region: "us-east-1"
+      template: "files/cloudformation-template.yaml"
+      backoff_delay: 300  
+        
 # Basic role example
 - name: create a stack, specify role that cloudformation assumes
   amazon.aws.cloudformation:

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -187,8 +187,8 @@ EXAMPLES = r"""
       state: "present"
       region: "us-east-1"
       template: "files/cloudformation-template.yaml"
-      backoff_delay: 300  
-        
+      backoff_delay: 300
+
 # Basic role example
 - name: create a stack, specify role that cloudformation assumes
   amazon.aws.cloudformation:


### PR DESCRIPTION
##### SUMMARY
backoff_delay parameter is set to 5 minutes before attempting the next retry. This can be useful to avoid immediate repeated API requests in case of throttling.



##### ISSUE TYPE
- Docs Pull Request
