### PR TITLE
Gather information about all trails in a specific region

### DIFF
--- a/plugins/modules/cloudtrail_info.py
+++ b/plugins/modules/cloudtrail_info.py
@@ -36,6 +36,11 @@ EXAMPLES = r"""
 # Gather information about all trails
 - amazon.aws.cloudtrail_info:
 
+# Gather information about all trails in a specific region
+  amazon.aws.cloudtrail_info:
+    region: "us-east-1"
+
+
 # Gather information about a particular trail
 - amazon.aws.cloudtrail_info:
     trail_names:


### PR DESCRIPTION
##### SUMMARY

region parameter is used to specify the AWS region for which you want to gather information about trails. 

##### ISSUE TYPE
- Docs Pull Request
