### PR TITLE
Get information about public RDS snapshots

### DIFF
--- a/plugins/modules/rds_snapshot_info.py
+++ b/plugins/modules/rds_snapshot_info.py
@@ -63,6 +63,11 @@ EXAMPLES = r"""
     db_snapshot_identifier: snapshot_name
   register: new_database_info
 
+- name: Get information about public RDS snapshots
+  amazon.aws.rds_snapshot_info:
+    snapshot_type: public
+  register: public_snapshots
+
 - name: Get all RDS snapshots for an RDS instance
   amazon.aws.rds_snapshot_info:
     db_instance_identifier: helloworld-rds-master


### PR DESCRIPTION
##### SUMMARY
- Get Information About Public Snapshots using 
- amazon.aws.rds_snapshot_info: snapshot_type: public

##### ISSUE TYPE
- Docs Pull Request
