### PR TITLE
cloudwatch_metric_alarm: fix idempotency for alarm without dimensions

### DIFF
--- a/changelogs/fragments/20240216-cloudwatch-metric-alarm-idempotency.yml
+++ b/changelogs/fragments/20240216-cloudwatch-metric-alarm-idempotency.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - cloudwatch_metric_alarm - Fix idempotency when creating cloudwatch metric alarm without dimensions (https://github.com/ansible-collections/amazon.aws/pull/1865).

--- a/plugins/modules/cloudwatch_metric_alarm.py
+++ b/plugins/modules/cloudwatch_metric_alarm.py
@@ -467,6 +467,10 @@ def create_metric_alarm(connection, module, params):
         if "TreatMissingData" not in alarm.keys():
             alarm["TreatMissingData"] = "missing"
 
+        # Prevent alarm without dimensions to always return changed
+        if not alarm["Dimensions"]:
+            alarm.pop("Dimensions", None)
+
         # Exclude certain props from change detection
         for key in [
             "ActionsEnabled",

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
@@ -509,43 +509,43 @@
           - ec2_instance_metric_mutually_exclusive.failed
           - '"parameters are mutually exclusive" in ec2_instance_metric_mutually_exclusive.msg'
 
-  - name: create alarm without dimensions
-    cloudwatch_metric_alarm:
-      state: present
-      name: '{{ alarm_full_name }}'
-      metric: CPUUtilization
-      namespace: AWS/EC2
-      treat_missing_data: missing
-      statistic: Average
-      comparison: LessThanOrEqualToThreshold
-      threshold: 5.0
-      period: 300
-      evaluation_periods: 3
-      unit: Percent
-      description: This will alarm when an instance's cpu usage average is lower than
-        5% for 15 minutes
+    - name: create alarm without dimensions
+      cloudwatch_metric_alarm:
+        state: present
+        name: '{{ alarm_full_name }}'
+        metric: CPUUtilization
+        namespace: AWS/EC2
+        treat_missing_data: missing
+        statistic: Average
+        comparison: LessThanOrEqualToThreshold
+        threshold: 5.0
+        period: 300
+        evaluation_periods: 3
+        unit: Percent
+        description: This will alarm when an instance's cpu usage average is lower than
+          5% for 15 minutes
 
-  - name: create alarm without dimensions (idempotent)
-    cloudwatch_metric_alarm:
-      state: present
-      name: '{{ alarm_full_name }}'
-      metric: CPUUtilization
-      namespace: AWS/EC2
-      treat_missing_data: missing
-      statistic: Average
-      comparison: LessThanOrEqualToThreshold
-      threshold: 5.0
-      period: 300
-      evaluation_periods: 3
-      unit: Percent
-      description: This will alarm when an instance's cpu usage average is lower than
-        5% for 15 minutes
-    register: ec2_instance_metric_alarm_no_dimensions_idempotent
+    - name: create alarm without dimensions (idempotent)
+      cloudwatch_metric_alarm:
+        state: present
+        name: '{{ alarm_full_name }}'
+        metric: CPUUtilization
+        namespace: AWS/EC2
+        treat_missing_data: missing
+        statistic: Average
+        comparison: LessThanOrEqualToThreshold
+        threshold: 5.0
+        period: 300
+        evaluation_periods: 3
+        unit: Percent
+        description: This will alarm when an instance's cpu usage average is lower than
+          5% for 15 minutes
+      register: ec2_instance_metric_alarm_no_dimensions_idempotent
 
-  - name: "Verify alarm without dimensions does not register as changed after update"
-    assert:
-      that:
-        - not ec2_instance_metric_alarm_no_dimensions_idempotent.changed
+    - name: "Verify alarm without dimensions does not register as changed after update"
+      assert:
+        that:
+          - not ec2_instance_metric_alarm_no_dimensions_idempotent.changed
 
   always:
     - name: try to delete the alarm

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
@@ -524,6 +524,19 @@
         unit: Percent
         description: This will alarm when an instance's cpu usage average is lower than
           5% for 15 minutes
+      register: ec2_instance_metric_alarm_no_dimensions
+
+    - name: get info on alarm without dimensions
+      amazon.aws.cloudwatch_metric_alarm_info:
+        alarm_names:
+          - "{{ alarm_full_name }}"
+      register: alarm_info_metrics_alarm_no_dimensions
+
+    - name: verify that an alarm was created without dimensions
+      ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_alarm_no_dimensions.changed
+          - alarm_info_metrics_alarm_no_dimensions.metric_alarms[0].dimensions | length == 0
 
     - name: create alarm without dimensions (idempotent)
       cloudwatch_metric_alarm:

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
@@ -509,6 +509,44 @@
           - ec2_instance_metric_mutually_exclusive.failed
           - '"parameters are mutually exclusive" in ec2_instance_metric_mutually_exclusive.msg'
 
+  - name: create alarm without dimensions
+    cloudwatch_metric_alarm:
+      state: present
+      name: '{{ alarm_full_name }}'
+      metric: CPUUtilization
+      namespace: AWS/EC2
+      treat_missing_data: missing
+      statistic: Average
+      comparison: LessThanOrEqualToThreshold
+      threshold: 5.0
+      period: 300
+      evaluation_periods: 3
+      unit: Percent
+      description: This will alarm when an instance's cpu usage average is lower than
+        5% for 15 minutes
+
+  - name: create alarm without dimensions (idempotent)
+    cloudwatch_metric_alarm:
+      state: present
+      name: '{{ alarm_full_name }}'
+      metric: CPUUtilization
+      namespace: AWS/EC2
+      treat_missing_data: missing
+      statistic: Average
+      comparison: LessThanOrEqualToThreshold
+      threshold: 5.0
+      period: 300
+      evaluation_periods: 3
+      unit: Percent
+      description: This will alarm when an instance's cpu usage average is lower than
+        5% for 15 minutes
+    register: ec2_instance_metric_alarm_no_dimensions_idempotent
+
+  - name: "Verify alarm without dimensions does not register as changed after update"
+    assert:
+      that:
+        - not ec2_instance_metric_alarm_no_dimensions_idempotent.changed
+
   always:
     - name: try to delete the alarm
       amazon.aws.cloudwatch_metric_alarm:


### PR DESCRIPTION
##### SUMMARY
A metric alarm in Cloudwatch can optionally have Dimensions. When a metric alarm in Cloudwatch does not have any dimensions, it returns: "Dimensions": [] when queried via boto3.

When configuring a metric alarm without Dimensions in Cloudwatch using the cloudwatch_metric_alarm plugin, Dimensions must be absent from the parameters.

Because "Dimensions": [] does not match Dimensions: None, the result is always Changed. 

This Pull Request fixes this by setting Dimensions from the returned alarm parameters to None when the field is empty.

Fixes #1750

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
cloudwatch_metric_alarm

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
