### PR TITLE
(test flake) ec2_vpc_dhcp_option - wait for deletion to complete

### DIFF
--- a/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml
@@ -388,20 +388,13 @@
       dhcp_options_ids: ["{{ original_dhcp_options_id }}"]
     register: dhcp_options
     ignore_errors: yes
+    retries: 5
+    until: dhcp_options is failed
+    delay: 5
 
   - assert:
       that:
         - dhcp_options.failed
-        - '"does not exist" in dhcp_options.error.message'
-
-  - name: verify the original set was deleted
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ original_dhcp_options_id }}"]
-    register: dhcp_options
-    ignore_errors: yes
-
-  - assert:
-      that:
         - '"does not exist" in dhcp_options.error.message'
 
   - set_fact:


### PR DESCRIPTION
##### SUMMARY

When replacing a DHCP Option Set we support automatically deleting the old option set.  As usual with AWS this isn't guaranteed to be instantaneous.

Long term it would be better to add a waiter, however the current tests being flaky has knock-on effects for unrelated changes (including releases)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_vpc_dhcp_option

##### ADDITIONAL INFORMATION

See for example: https://3d501427efede331c985-f49494dc6c135cc7f150f68fb57cd0c3.ssl.cf2.rackcdn.com/1829/a5289bee768839bf9bcb738523e28fd78ab68a5d/check/integration-amazon.aws-21/ae2a719/job-output.txt

The test cleanup includes listing all option sets (none left) and demonstrates that without further intervention the option set was gone.