### PR TITLE
Use TagSpecifications parameter when creating EC2 resources

### DIFF
--- a/changelogs/fragments/1843-ec2_eip.yml
+++ b/changelogs/fragments/1843-ec2_eip.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_eip - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/issues/1843)

--- a/changelogs/fragments/1843-ec2_vpc_igw.yml
+++ b/changelogs/fragments/1843-ec2_vpc_igw.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_vpc_igw - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/issues/1843)

--- a/changelogs/fragments/1843-ec2_vpc_route_table.yml
+++ b/changelogs/fragments/1843-ec2_vpc_route_table.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_vpc_route_table - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/issues/1843)

--- a/changelogs/fragments/1843-ec2_vpc_subnet.yml
+++ b/changelogs/fragments/1843-ec2_vpc_subnet.yml
@@ -1,2 +1,4 @@
 minor_changes:
 - ec2_vpc_subnet - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/issues/1843)
+- ec2_vpc_subnet - the default value for ``tags`` has been changed from ``{}`` to ``None``, to remove tags from a subnet an empty map must
+  be explicitly passed to the module (https://github.com/ansible-collections/amazon.aws/pull/1876).

--- a/changelogs/fragments/1843-ec2_vpc_subnet.yml
+++ b/changelogs/fragments/1843-ec2_vpc_subnet.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- ec2_vpc_subnet - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/issues/1843)

--- a/plugins/module_utils/tagging.py
+++ b/plugins/module_utils/tagging.py
@@ -71,6 +71,12 @@ def boto3_tag_list_to_ansible_dict(tags_list, tag_name_key_name=None, tag_value_
 
 def ansible_dict_to_boto3_tag_list(tags_dict, tag_name_key_name="Key", tag_value_key_name="Value"):
     """Convert a flat dict of key:value pairs representing AWS resource tags to a boto3 list of dicts
+
+    Note: booleans are converted to their Capitalized text form ("True" and "False"), this is
+    different to ansible_dict_to_boto3_filter_list because historically we've used "to_text()" and
+    AWS stores tags as strings, whereas for things which are actually booleans in AWS are returned
+    as lowercase strings in filters.
+
     Args:
         tags_dict (dict): Dict representing AWS resource tags.
         tag_name_key_name (str): Value to use as the key for all tag keys (useful because boto3 doesn't always use "Key")
@@ -108,6 +114,11 @@ def _tag_name_to_filter_key(tag_name):
 def ansible_dict_to_tag_filter_dict(tags_dict):
     """Prepends "tag:" to all of the keys (not the values) in a dict
     This is useful when you're then going to build a filter including the tags.
+
+    Note: booleans are converted to their Capitalized text form ("True" and "False"), this is
+    different to ansible_dict_to_boto3_filter_list because historically we've used "to_text()" and
+    AWS stores tags as strings, whereas for things which are actually booleans in AWS are returned
+    as lowercase strings in filters.
 
     Args:
         tags_dict (dict): Dict representing AWS resource tags.

--- a/plugins/module_utils/tagging.py
+++ b/plugins/module_utils/tagging.py
@@ -101,6 +101,29 @@ def ansible_dict_to_boto3_tag_list(tags_dict, tag_name_key_name="Key", tag_value
     return tags_list
 
 
+def _tag_name_to_filter_key(tag_name):
+    return f"tag:{tag_name}"
+
+
+def ansible_dict_to_tag_filter_dict(tags_dict):
+    """Prepends "tag:" to all of the keys (not the values) in a dict
+    This is useful when you're then going to build a filter including the tags.
+
+    Args:
+        tags_dict (dict): Dict representing AWS resource tags.
+
+    Basic Usage:
+        >>> filters = ansible_dict_to_boto3_filter_list(ansible_dict_to_tag_filter_dict(tags))
+
+    Returns:
+        Dict: A dictionary suitable for passing to ansible_dict_to_boto3_filter_list which can
+        also be combined with other common filter parameters.
+    """
+    if not tags_dict:
+        return {}
+    return {_tag_name_to_filter_key(k): to_native(v) for k, v in tags_dict.items()}
+
+
 def boto3_tag_specifications(tags_dict, types=None):
     """Converts a list of resource types and a flat dictionary of key:value pairs representing AWS
     resource tags to a TagSpecification object.

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -225,6 +225,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ensure_ec2_tags
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_specifications
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
 
 
@@ -342,7 +343,16 @@ def address_is_associated_with_device(ec2, module, address, device_id, is_instan
     return False
 
 
-def allocate_address(ec2, module, domain, reuse_existing_ip_allowed, check_mode, tag_dict=None, public_ipv4_pool=None):
+def allocate_address(
+    ec2,
+    module,
+    domain,
+    reuse_existing_ip_allowed,
+    check_mode,
+    tags,
+    search_tags=None,
+    public_ipv4_pool=None,
+):
     """Allocate a new elastic IP address (when needed) and return it"""
     if not domain:
         domain = "standard"
@@ -351,8 +361,8 @@ def allocate_address(ec2, module, domain, reuse_existing_ip_allowed, check_mode,
         filters = []
         filters.append({"Name": "domain", "Values": [domain]})
 
-        if tag_dict is not None:
-            filters += ansible_dict_to_boto3_filter_list(tag_dict)
+        if search_tags is not None:
+            filters += ansible_dict_to_boto3_filter_list(search_tags)
 
         try:
             all_addresses = ec2.describe_addresses(Filters=filters, aws_retry=True)
@@ -369,12 +379,26 @@ def allocate_address(ec2, module, domain, reuse_existing_ip_allowed, check_mode,
             return unassociated_addresses[0], False
 
     if public_ipv4_pool:
-        return allocate_address_from_pool(ec2, module, domain, check_mode, public_ipv4_pool), True
+        return (
+            allocate_address_from_pool(
+                ec2,
+                module,
+                domain,
+                check_mode,
+                public_ipv4_pool,
+                tags,
+            ),
+            True,
+        )
+
+    params = {"Domain": domain}
+    if tags is not None:
+        params["TagSpecifications"] = boto3_tag_specifications(tags, types="elastic-ip")
 
     try:
         if check_mode:
             return None, True
-        result = ec2.allocate_address(Domain=domain, aws_retry=True), True
+        result = ec2.allocate_address(aws_retry=True, **params), True
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
         module.fail_json_aws(e, msg="Couldn't allocate Elastic IP address")
     return result
@@ -434,6 +458,7 @@ def ensure_present(
     reuse_existing_ip_allowed,
     allow_reassociation,
     check_mode,
+    tags,
     is_instance=True,
 ):
     changed = False
@@ -443,7 +468,14 @@ def ensure_present(
         if check_mode:
             return {"changed": True}
 
-        address, changed = allocate_address(ec2, module, domain, reuse_existing_ip_allowed, check_mode)
+        address, changed = allocate_address(
+            ec2,
+            module,
+            domain,
+            reuse_existing_ip_allowed,
+            check_mode,
+            tags,
+        )
 
     if device_id:
         # Allocate an IP for instance since no public_ip was provided
@@ -485,7 +517,14 @@ def ensure_absent(ec2, module, address, device_id, check_mode, is_instance=True)
         return release_address(ec2, module, address, check_mode)
 
 
-def allocate_address_from_pool(ec2, module, domain, check_mode, public_ipv4_pool):
+def allocate_address_from_pool(
+    ec2,
+    module,
+    domain,
+    check_mode,
+    public_ipv4_pool,
+    tags,
+):
     # type: (EC2Connection, AnsibleAWSModule, str, bool, str) -> Address
     """Overrides botocore's allocate_address function to support BYOIP"""
     if check_mode:
@@ -498,6 +537,9 @@ def allocate_address_from_pool(ec2, module, domain, check_mode, public_ipv4_pool
 
     if public_ipv4_pool is not None:
         params["PublicIpv4Pool"] = public_ipv4_pool
+
+    if tags is not None:
+        params["TagSpecifications"] = boto3_tag_specifications(tags, types="elastic-ip")
 
     try:
         result = ec2.allocate_address(aws_retry=True, **params)
@@ -583,7 +625,7 @@ def main():
         module.fail_json(msg=str(e))
 
     # Tags for *searching* for an EIP.
-    tag_dict = generate_tag_dict(module, tag_name, tag_value)
+    search_tags = generate_tag_dict(module, tag_name, tag_value)
 
     try:
         if device_id:
@@ -603,6 +645,7 @@ def main():
                     reuse_existing_ip_allowed,
                     allow_reassociation,
                     module.check_mode,
+                    tags,
                     is_instance=is_instance,
                 )
                 if "allocation_id" not in result:
@@ -617,7 +660,14 @@ def main():
                     }
                 else:
                     address, changed = allocate_address(
-                        ec2, module, domain, reuse_existing_ip_allowed, module.check_mode, tag_dict, public_ipv4_pool
+                        ec2,
+                        module,
+                        domain,
+                        reuse_existing_ip_allowed,
+                        module.check_mode,
+                        tags,
+                        search_tags,
+                        public_ipv4_pool,
                     )
                     if address:
                         result = {

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -392,7 +392,7 @@ def allocate_address(
         )
 
     params = {"Domain": domain}
-    if tags is not None:
+    if tags:
         params["TagSpecifications"] = boto3_tag_specifications(tags, types="elastic-ip")
 
     try:
@@ -538,7 +538,7 @@ def allocate_address_from_pool(
     if public_ipv4_pool is not None:
         params["PublicIpv4Pool"] = public_ipv4_pool
 
-    if tags is not None:
+    if tags:
         params["TagSpecifications"] = boto3_tag_specifications(tags, types="elastic-ip")
 
     try:

--- a/plugins/modules/ec2_vpc_igw.py
+++ b/plugins/modules/ec2_vpc_igw.py
@@ -148,6 +148,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ensure_ec2_t
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_specifications
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.waiters import get_waiter
 
@@ -311,7 +312,10 @@ class AnsibleEc2Igw:
                 self.get_matching_vpc(vpc_id)
 
             try:
-                response = self._connection.create_internet_gateway(aws_retry=True)
+                create_params = {}
+                if tags is not None:
+                    create_params["TagSpecifications"] = boto3_tag_specifications(tags, types="internet-gateway")
+                response = self._connection.create_internet_gateway(aws_retry=True, **create_params)
 
                 # Ensure the gateway exists before trying to attach it or add tags
                 waiter = get_waiter(self._connection, "internet_gateway_exists")

--- a/plugins/modules/ec2_vpc_igw.py
+++ b/plugins/modules/ec2_vpc_igw.py
@@ -313,7 +313,7 @@ class AnsibleEc2Igw:
 
             try:
                 create_params = {}
-                if tags is not None:
+                if tags:
                     create_params["TagSpecifications"] = boto3_tag_specifications(tags, types="internet-gateway")
                 response = self._connection.create_internet_gateway(aws_retry=True, **create_params)
 

--- a/plugins/modules/ec2_vpc_subnet.py
+++ b/plugins/modules/ec2_vpc_subnet.py
@@ -216,6 +216,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.arn import is_outpost_a
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import ensure_ec2_tags
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_tag_filter_dict
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_specifications
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
@@ -318,7 +319,7 @@ def ensure_tags(conn, module, subnet, tags, purge_tags, start_time):
 
     if module.params["wait"] and not module.check_mode:
         # Wait for tags to be updated
-        filters = [{"Name": f"tag:{k}", "Values": [v]} for k, v in tags.items()]
+        filters = ansible_dict_to_boto3_filter_list(ansible_dict_to_tag_filter_dict(tags))
         handle_waiter(conn, module, "subnet_exists", {"SubnetIds": [subnet["id"]], "Filters": filters}, start_time)
 
     return changed

--- a/plugins/modules/ec2_vpc_subnet.py
+++ b/plugins/modules/ec2_vpc_subnet.py
@@ -72,8 +72,6 @@ options:
       - Ignored unless I(wait=True).
     default: 300
     type: int
-  tags:
-    default: {}
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules
@@ -212,7 +210,6 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.arn import is_outpost_arn
@@ -280,7 +277,7 @@ def create_subnet(conn, module, vpc_id, cidr, tags, ipv6_cidr=None, outpost_arn=
     if az:
         params["AvailabilityZone"] = az
 
-    if tags is not None:
+    if tags:
         params["TagSpecifications"] = boto3_tag_specifications(tags, types="subnet")
 
     if outpost_arn:
@@ -315,6 +312,9 @@ def ensure_tags(conn, module, subnet, tags, purge_tags, start_time):
         tags=tags,
         retry_codes=["InvalidSubnetID.NotFound"],
     )
+
+    if not changed:
+        return changed
 
     if module.params["wait"] and not module.check_mode:
         # Wait for tags to be updated
@@ -483,10 +483,8 @@ def ensure_subnet_present(conn, module):
         )
         changed = True
 
-    if module.params["tags"] != subnet["tags"]:
-        stringified_tags_dict = dict((to_text(k), to_text(v)) for k, v in module.params["tags"].items())
-        if ensure_tags(conn, module, subnet, stringified_tags_dict, module.params["purge_tags"], start_time):
-            changed = True
+    if ensure_tags(conn, module, subnet, module.params["tags"], module.params["purge_tags"], start_time):
+        changed = True
 
     subnet = get_matching_subnet(conn, module, module.params["vpc_id"], module.params["cidr"])
     if not module.check_mode and module.params["wait"]:
@@ -554,7 +552,7 @@ def main():
         ipv6_cidr=dict(default="", required=False),
         outpost_arn=dict(default="", type="str", required=False),
         state=dict(default="present", choices=["present", "absent"]),
-        tags=dict(default={}, required=False, type="dict", aliases=["resource_tags"]),
+        tags=dict(required=False, type="dict", aliases=["resource_tags"]),
         vpc_id=dict(required=True),
         map_public=dict(default=False, required=False, type="bool"),
         assign_instances_ipv6=dict(default=False, required=False, type="bool"),

--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -143,6 +143,8 @@
   - assert:
       that:
       - eip is changed
+      - "'ec2:CreateTags' not in eip.resource_actions"
+      - "'ec2:DeleteTags' not in eip.resource_actions"
       - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
       - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
       - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length

--- a/tests/integration/targets/ec2_vpc_igw/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_igw/tasks/main.yml
@@ -48,7 +48,7 @@
       tags:
         Description: Created by ansible-test
     register: vpc_2_result
-  
+
   # ============================================================
   - name: Search for internet gateway by VPC - no matches
     ec2_vpc_igw_info:
@@ -91,6 +91,8 @@
   - name: Assert creation happened (expected changed=true)
     assert:
       that:
+      - "'ec2:CreateTags' not in vpc_igw_create.resource_actions"
+      - "'ec2:DeleteTags' not in vpc_igw_create.resource_actions"
       - vpc_igw_create is changed
       - vpc_igw_create.gateway_id.startswith("igw-")
       - vpc_igw_create.vpc_id == vpc_result.vpc.id

--- a/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -151,6 +151,8 @@
     assert:
       that:
       - create_public_table.changed
+      - "'ec2:CreateTags' not in create_public_table.resource_actions"
+      - "'ec2:DeleteTags' not in create_public_table.resource_actions"
       - create_public_table.route_table.id.startswith('rtb-')
       - "'Public' in create_public_table.route_table.tags"
       - create_public_table.route_table.tags['Public'] == 'true'

--- a/tests/integration/targets/ec2_vpc_subnet/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_subnet/tasks/main.yml
@@ -68,6 +68,8 @@
       assert:
         that:
            - 'vpc_subnet_create'
+           - "'ec2:CreateTags' not in vpc_subnet_create.resource_actions"
+           - "'ec2:DeleteTags' not in vpc_subnet_create.resource_actions"
            - 'vpc_subnet_create.subnet.id.startswith("subnet-")'
            - '"Name" in vpc_subnet_create.subnet.tags and vpc_subnet_create.subnet.tags["Name"] == ec2_vpc_subnet_name'
            - '"Description" in vpc_subnet_create.subnet.tags and vpc_subnet_create.subnet.tags["Description"] == ec2_vpc_subnet_description'

--- a/tests/unit/module_utils/test_tagging.py
+++ b/tests/unit/module_utils/test_tagging.py
@@ -6,6 +6,7 @@
 import pytest
 
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_tag_filter_dict
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_specifications
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import compare_aws_tags
@@ -35,6 +36,13 @@ class TestTagging:
             "UpperCamel": "upperCamelValue",
             "Normal case": "Normal Value",
             "lower case": "lower case value",
+        }
+
+        self.tag_filter_dict = {
+            "tag:lowerCamel": "lowerCamelValue",
+            "tag:UpperCamel": "upperCamelValue",
+            "tag:Normal case": "Normal Value",
+            "tag:lower case": "lower case value",
         }
 
         self.tag_minimal_boto3_list = [
@@ -243,3 +251,15 @@ class TestTagging:
         sorted_tag_spec = sorted(tag_specification, key=lambda i: (i["ResourceType"]))
         sorted_expected = sorted(expected_specification, key=lambda i: (i["ResourceType"]))
         assert sorted_tag_spec == sorted_expected
+
+    def test_ansible_dict_to_tag_filter_dict_empty(self):
+        assert ansible_dict_to_tag_filter_dict(None) == {}
+        assert ansible_dict_to_tag_filter_dict({}) == {}
+
+    def test_ansible_dict_to_tag_filter_dict_example(self):
+        assert ansible_dict_to_tag_filter_dict(self.tag_example_dict) == self.tag_filter_dict
+
+    def test_ansible_dict_to_tag_filter_dict_boolean(self):
+        dict_with_bool = {"boolean": True}
+        filter_dict_with_bool = {"tag:boolean": "True"}
+        assert ansible_dict_to_tag_filter_dict(dict_with_bool) == filter_dict_with_bool

--- a/tests/unit/module_utils/test_tagging.py
+++ b/tests/unit/module_utils/test_tagging.py
@@ -60,6 +60,14 @@ class TestTagging:
         assert ansible_dict_to_boto3_tag_list({}) == []
         assert ansible_dict_to_boto3_tag_list(None) == []
 
+    def test_ansible_dict_to_boto3_tag_list_boolean(self):
+        dict_with_bool = dict(boolean=True)
+        list_with_bool = [{"Key": "boolean", "Value": "True"}]
+        assert ansible_dict_to_boto3_tag_list(dict_with_bool) == list_with_bool
+        dict_with_bool = dict(boolean=False)
+        list_with_bool = [{"Key": "boolean", "Value": "False"}]
+        assert ansible_dict_to_boto3_tag_list(dict_with_bool) == list_with_bool
+
     # ========================================================
     #   tagging.boto3_tag_list_to_ansible_dict
     # ========================================================
@@ -138,6 +146,20 @@ class TestTagging:
         assert [] == keys_to_unset
         keys_to_set, keys_to_unset = compare_aws_tags(self.tag_example_dict, new_dict, purge_tags=True)
         assert new_keys == keys_to_set
+        assert [] == keys_to_unset
+
+    def test_compare_aws_tags_boolean(self):
+        dict_with_bool = dict(boolean=True)
+        dict_with_text_bool = dict(boolean="True")
+        # AWS always returns tag values as strings, so we only test this way around
+        keys_to_set, keys_to_unset = compare_aws_tags(dict_with_text_bool, dict_with_bool)
+        assert {} == keys_to_set
+        assert [] == keys_to_unset
+        keys_to_set, keys_to_unset = compare_aws_tags(dict_with_text_bool, dict_with_bool, purge_tags=False)
+        assert {} == keys_to_set
+        assert [] == keys_to_unset
+        keys_to_set, keys_to_unset = compare_aws_tags(dict_with_text_bool, dict_with_bool, purge_tags=True)
+        assert {} == keys_to_set
         assert [] == keys_to_unset
 
     def test_compare_aws_tags_complex_update(self):


### PR DESCRIPTION
##### SUMMARY

For the last couple of years Amazon's supported tagging EC2 resources as part of the creation actions.  Switch the last amazon.aws EC2 modules over to using TagSpecifications during creation to support folks using Tagging requirements as part of their IAM/SCP policies

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

ec2_vpc_route_table
ec2_vpc_igw
ec2_vpc_subnet
ec2_eip

##### ADDITIONAL INFORMATION

fixes: #1843