### PR TITLE
cloudwatchevent_rule: Fix json input handling for input_template

### DIFF
--- a/changelogs/fragments/1883-cloudwatchevent_rule-fix-json-input-handling-for-input_template.yml
+++ b/changelogs/fragments/1883-cloudwatchevent_rule-fix-json-input-handling-for-input_template.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - cloudwatchevent_rule - Fix to avoid adding quotes to JSON input for provided input_template (https://github.com/ansible-collections/amazon.aws/pull/1883).

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -212,11 +212,6 @@ def _validate_json(s):
         return False
 
 
-def _snakify(dict):
-    """Converts camel case to snake case"""
-    return camel_dict_to_snake_dict(dict)
-
-
 class CloudWatchEventRule:
     def __init__(
         self, module, name, client, schedule_expression=None, event_pattern=None, description=None, role_arn=None
@@ -241,7 +236,7 @@ class CloudWatchEventRule:
             botocore.exceptions.ClientError,
         ) as e:  # pylint: disable=duplicate-except
             self.module.fail_json_aws(e, msg=f"Could not describe rule {self.name}")
-        return _snakify(rule_info)
+        return camel_dict_to_snake_dict(rule_info)
 
     def put(self, enabled=True):
         """Creates or updates the rule in AWS"""
@@ -304,7 +299,7 @@ class CloudWatchEventRule:
             botocore.exceptions.ClientError,
         ) as e:  # pylint: disable=duplicate-except
             self.module.fail_json_aws(e, msg=f"Could not find target for rule {self.name}")
-        return _snakify(targets)["targets"]
+        return camel_dict_to_snake_dict(targets)["targets"]
 
     def put_targets(self, targets):
         """Creates or updates the provided targets on the rule in AWS"""
@@ -461,7 +456,7 @@ class CloudWatchEventRuleManager:
         self.targets = temp
         # remote_targets is snakified output of client.list_targets_by_rule()
         # therefore snakified version of t should be compared to avoid wrong result of below conditional
-        return [t for t in self.targets if _snakify(t) not in remote_targets]
+        return [t for t in self.targets if camel_dict_to_snake_dict(t) not in remote_targets]
 
     def _remote_target_ids_to_remove(self):
         """Returns a list of targets that need to be removed remotely"""

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -203,6 +203,7 @@ def _format_json(json_string):
     except json.decoder.JSONDecodeError:
         return str(json.dumps(json_string))
 
+
 def _validate_json(s):
     try:
         json.loads(s)
@@ -210,9 +211,11 @@ def _validate_json(s):
     except json.JSONDecodeError:
         return False
 
+
 def _snakify(dict):
     """Converts camel case to snake case"""
     return camel_dict_to_snake_dict(dict)
+
 
 class CloudWatchEventRule:
     def __init__(
@@ -351,8 +354,6 @@ class CloudWatchEventRule:
                     target_request["InputTransformer"]["InputPathsMap"] = target["input_transformer"]["input_paths_map"]
             targets_request.append(target_request)
         return targets_request
-
-
 
 
 class CloudWatchEventRuleManager:

--- a/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
@@ -7,6 +7,10 @@
       region: "{{ aws_region }}"
 
   block:
+
+    - name: Run tests for testing json input_template
+      ansible.builtin.import_tasks: test_json_input_template.yml
+
     - name: Create SNS topic
       community.aws.sns_topic:
         name: TestSNSTopic

--- a/tests/integration/targets/cloudwatchevent_rule/tasks/test_json_input_template.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/tasks/test_json_input_template.yml
@@ -38,10 +38,10 @@
         that:
           - event_rule_input_transformer_output.changed
 
-    # - name: Assert that event rule is created with a valid json value for input_template
-    #   ansible.builtin.assert:
-    #     that:
-    #       - event_rule_input_transformer_output.targets[0].input_transformer.input_template == ''
+    - name: Assert that event rule is created with a valid json value for input_template
+      ansible.builtin.assert:
+        that:
+          - event_rule_input_transformer_output.targets[0].input_transformer.input_template | from_json
 
     - name: Create cloudwatch event rule with input transformer (idempotent)
       amazon.aws.cloudwatchevent_rule:

--- a/tests/integration/targets/cloudwatchevent_rule/tasks/test_json_input_template.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/tasks/test_json_input_template.yml
@@ -38,7 +38,7 @@
         that:
           - event_rule_input_transformer_output.changed
 
-    # - name: Assert that event rule is created with a valid json value for input_transformer
+    # - name: Assert that event rule is created with a valid json value for input_template
     #   ansible.builtin.assert:
     #     that:
     #       - event_rule_input_transformer_output.targets[0].input_transformer.input_template == ''

--- a/tests/integration/targets/cloudwatchevent_rule/tasks/test_json_input_template.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/tasks/test_json_input_template.yml
@@ -1,0 +1,76 @@
+---
+- name: Run tests for json input_template
+  block:
+
+    - name: Create SNS topic
+      community.aws.sns_topic:
+        name: TestSNSTopic-Json
+        state: present
+        display_name: Test SNS Topic
+      register: sns_topic_output
+
+    - name: Define JSON input_template
+      ansible.builtin.set_fact:
+        json_input_template: |
+          {
+            "instance" : "<instance>",
+            "state": "<state>"
+          }
+
+    - name: Create cloudwatch event rule with input transformer
+      amazon.aws.cloudwatchevent_rule:
+        name: "{{ input_transformer_event_name }}-Json"
+        description: Event rule with input transformer configuration
+        state: present
+        event_pattern: '{"source":["aws.ec2"],"detail-type":["EC2 Instance State-change Notification"],"detail":{"state":["pending"]}}'
+        targets:
+          - id: "{{ sns_topic_output.sns_topic.name }}"
+            arn: "{{ sns_topic_output.sns_topic.topic_arn }}"
+            input_transformer:
+              input_paths_map:
+                instance: $.detail.instance-id
+                state: $.detail.state
+              input_template: "{{ json_input_template }}"
+      register: event_rule_input_transformer_output
+
+    - name: Assert that input transformer event rule was created
+      ansible.builtin.assert:
+        that:
+          - event_rule_input_transformer_output.changed
+
+    # - name: Assert that event rule is created with a valid json value for input_transformer
+    #   ansible.builtin.assert:
+    #     that:
+    #       - event_rule_input_transformer_output.targets[0].input_transformer.input_template == ''
+
+    - name: Create cloudwatch event rule with input transformer (idempotent)
+      amazon.aws.cloudwatchevent_rule:
+        name: "{{ input_transformer_event_name }}-Json"
+        description: Event rule with input transformer configuration
+        state: present
+        event_pattern: '{"source":["aws.ec2"],"detail-type":["EC2 Instance State-change Notification"],"detail":{"state":["pending"]}}'
+        targets:
+          - id: "{{ sns_topic_output.sns_topic.name }}"
+            arn: "{{ sns_topic_output.sns_topic.topic_arn }}"
+            input_transformer:
+              input_paths_map:
+                instance: $.detail.instance-id
+                state: $.detail.state
+              input_template: "{{ json_input_template }}"
+      register: event_rule_input_transformer_output
+
+  always:
+    - name: Assert that no changes were made to the rule
+      ansible.builtin.assert:
+        that:
+          - event_rule_input_transformer_output is not changed
+
+    - name: Delete input transformer CloudWatch event rules
+      amazon.aws.cloudwatchevent_rule:
+        name: "{{ input_transformer_event_name }}-Json"
+        state: absent
+
+    - name: Delete SNS topic
+      community.aws.sns_topic:
+        name: TestSNSTopic-Json
+        state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1842 

This PR
- Moves `_snakify()` out of `class CloudWatchEventRule` https://github.com/ansible-collections/amazon.aws/pull/1883/files#diff-3a2f223edc4e34ea28b9859827a830844d92a8cd97f1300a2d16b1703a083bc8R213-R215

- Fixes conditional in function `_targets_to_put()` to avoid wrong results due to `_snakify()` https://github.com/ansible-collections/amazon.aws/pull/1883/files#diff-3a2f223edc4e34ea28b9859827a830844d92a8cd97f1300a2d16b1703a083bc8R461-R463

- Updates code to add quotes `"` to `input_template` only when the given input is not JSON to avoid quotes being added to provided JSON input https://github.com/ansible-collections/amazon.aws/pull/1883/files#diff-3a2f223edc4e34ea28b9859827a830844d92a8cd97f1300a2d16b1703a083bc8R452-R458

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudwatchevent_rule
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
