### PR TITLE
[WIP] ec2_instance: ability to change the instance type

### DIFF
--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1563,6 +1563,7 @@ def diff_instance_and_params(instance, params, skip=None):
     param_mappings = [
         ParamMapper("ebs_optimized", "EbsOptimized", "ebsOptimized", value_wrapper),
         ParamMapper("termination_protection", "DisableApiTermination", "disableApiTermination", value_wrapper),
+        ParamMapper('instance_type', 'InstanceType', 'instanceType', value_wrapper)
         # user data is an immutable property
         # ParamMapper('user_data', 'UserData', 'userData', value_wrapper),
     ]


### PR DESCRIPTION
##### SUMMARY

Currently the `ec2_instance` module ignores changes on `instance_type` parameter.  
Furthermore, changes on `instance_type` are only possible when the `state` is `stopped`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request


##### COMPONENT NAME
ec2_instance

##### ADDITIONAL INFORMATION

```yml
---
- hosts: localhost
  tasks:
  - name: new instance
    amazon.aws.ec2_instance:
      name: ansible-one1
      key_name: popnuc
      vpc_subnet_id: subnet-943ad4d8
      instance_type: t4g.nano
      security_group: default
      image_id: "{{ lookup('aws_ssm', '/aws/service/canonical/ubuntu/server-minimal/22.04/stable/current/arm64/hvm/ebs-gp2/ami-id') }}"
      wait: true
    register: bla

  - name: stopp instance
    amazon.aws.ec2_instance:
      name: ansible-one1
      key_name: popnuc
      instance_ids: "{{ bla.instance_ids }}"
      state: stopped
      wait: true

  - name: start different size
    amazon.aws.ec2_instance:
      name: ansible-one1
      key_name: popnuc
      instance_ids: "{{ bla.instance_ids }}"
      state: started
      instance_type: t4g.micro
      wait: true
```
