### PR TITLE
iam_group - add support for setting the path

### DIFF
--- a/changelogs/fragments/20231130-iam_group.yml
+++ b/changelogs/fragments/20231130-iam_group.yml
@@ -1,0 +1,4 @@
+minor_changes:
+- iam_group - add support for setting group path (https://github.com/ansible-collections/amazon.aws/pull/1892).
+- iam_group - adds attached_policies return value (https://github.com/ansible-collections/amazon.aws/pull/1892).
+- iam_group - code refactored to avoid single long function (https://github.com/ansible-collections/amazon.aws/pull/1892).

--- a/plugins/module_utils/iam.py
+++ b/plugins/module_utils/iam.py
@@ -98,7 +98,7 @@ def convert_managed_policy_names_to_arns(client, policy_names):
     try:
         return [allpolicies[policy] for policy in policy_names if policy is not None]
     except KeyError as e:
-        raise AnsibleIAMError(message="Failed to find policy by name:" +str(e))
+        raise AnsibleIAMError(message="Failed to find policy by name:" + str(e))
 
 
 def get_aws_account_id(module):

--- a/plugins/modules/iam_group.py
+++ b/plugins/modules/iam_group.py
@@ -19,7 +19,8 @@ options:
   name:
     description:
       - The name of the group.
-      - Note: group names are unique within an account.  Paths (I(path)) do B(not) affect
+      - >-
+        Note: group names are unique within an account.  Paths (I(path)) do B(not) affect
         the uniqueness requirements of I(name).  For example it is not permitted to have both
         C(/Path1/MyGroup) and C(/Path2/MyGroup) in the same account.
     required: true
@@ -31,6 +32,7 @@ options:
         U(https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_identifiers.html).
     aliases: ['prefix', 'path_prefix']
     version_added: 7.1.0
+    type: str
   managed_policies:
     description:
       - A list of managed policy ARNs or friendly names to attach to the role.
@@ -178,7 +180,7 @@ iam_group:
         attached_policies:
             version_added: 7.1.0
             description:
-                list containing basic information about managed policies attached to the group.
+                - list containing basic information about managed policies attached to the group.
             returned: success
             type: complex
             contains:
@@ -248,8 +250,6 @@ def ensure_managed_policies(connection, module, group_info, managed_policies, pu
     if managed_policies:
         managed_policies = convert_friendly_names_to_arns(connection, module, managed_policies)
 
-    if "GroupName" not in group_info["Group"]:
-        module.fail_json(msg="GroupName missing", group=group)
     group_name = group_info["Group"]["GroupName"]
 
     current_attached_policies_desc = get_attached_policy_list(connection, module, group_name)

--- a/tests/integration/targets/iam_group/defaults/main.yml
+++ b/tests/integration/targets/iam_group/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 test_user:  '{{ resource_prefix }}-user'
 test_group: '{{ resource_prefix }}-group'
+test_path: '/{{ resource_prefix }}-prefix/'
+
+safe_managed_policy: AWSDenyAll
+custom_policy_name: '{{ resource_prefix }}-denyall'

--- a/tests/integration/targets/iam_group/files/deny-all.json
+++ b/tests/integration/targets/iam_group/files/deny-all.json
@@ -1,0 +1,12 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Action": [
+                "*"
+            ],
+            "Effect": "Deny",
+            "Resource": "*"
+        }
+    ]
+}

--- a/tests/integration/targets/iam_group/tasks/deletion.yml
+++ b/tests/integration/targets/iam_group/tasks/deletion.yml
@@ -1,0 +1,42 @@
+---
+- name: remove group (check_mode)
+  iam_group:
+    name: '{{ test_group }}'
+    state: absent
+  register: iam_group
+  check_mode: true
+
+- assert:
+    that:
+      - iam_group is changed
+
+- name: remove group
+  iam_group:
+    name: '{{ test_group }}'
+    state: absent
+  register: iam_group
+
+- assert:
+    that:
+      - iam_group is changed
+
+- name: re-remove group (check_mode)
+  iam_group:
+    name: '{{ test_group }}'
+    state: absent
+  register: iam_group
+  check_mode: true
+
+- assert:
+    that:
+      - iam_group is not changed
+
+- name: re-remove group
+  iam_group:
+    name: '{{ test_group }}'
+    state: absent
+  register: iam_group
+
+- assert:
+    that:
+      - iam_group is not changed

--- a/tests/integration/targets/iam_group/tasks/main.yml
+++ b/tests/integration/targets/iam_group/tasks/main.yml
@@ -14,6 +14,18 @@
       name: '{{ test_user }}'
       state: present
 
+  - name: Create Safe IAM Managed Policy
+    iam_managed_policy:
+      state: present
+      policy_name: '{{ custom_policy_name }}'
+      policy_description: A safe (deny-all) managed policy
+      policy: "{{ lookup('file', 'deny-all.json') }}"
+    register: create_managed_policy
+
+  - assert:
+      that:
+      - create_managed_policy is succeeded
+
   - name: ensure group exists
     iam_group:
       name: '{{ test_group }}'
@@ -24,102 +36,28 @@
 
   - assert:
       that:
-        - iam_group.iam_group.users
+        - "'users' in iam_group.iam_group"
+        - "'group' in iam_group.iam_group"
+        - "'attached_policies' in iam_group.iam_group"
         - iam_group is changed
+        - iam_group.iam_group.group.group_name == test_group
+        - iam_group.iam_group.group.path == "/"
 
-  - name: add non existent user to group
-    iam_group:
-      name: '{{ test_group }}'
-      users:
-        - '{{ test_user }}'
-        - NonExistentUser
-      state: present
-    ignore_errors: yes
-    register: iam_group
-
-  - name: assert that adding non existent user to group fails with helpful message
-    assert:
-      that:
-        - iam_group is failed
-        - iam_group.msg.startswith("Couldn't add user NonExistentUser to group {{ test_group }}")
-
-  - name: remove a user
-    iam_group:
-      name: '{{ test_group }}'
-      purge_users: True
-      users: []
-      state: present
-    register: iam_group
-
-  - assert:
-      that:
-        - iam_group is changed
-        - not iam_group.iam_group.users
-
-  - name: re-remove a user (no change)
-    iam_group:
-      name: '{{ test_group }}'
-      purge_users: True
-      users: []
-      state: present
-    register: iam_group
-
-  - assert:
-      that:
-        - iam_group is not changed
-        - not iam_group.iam_group.users
-
-  - name: Add the user again
-    iam_group:
-      name: '{{ test_group }}'
-      users:
-        - '{{ test_user }}'
-      state: present
-    register: iam_group
-
-  - assert:
-      that:
-        - iam_group is changed
-        - iam_group.iam_group.users
-
-  - name: Re-add the user
-    iam_group:
-      name: '{{ test_group }}'
-      users:
-        - '{{ test_user }}'
-      state: present
-    register: iam_group
-
-  - assert:
-      that:
-        - iam_group is not changed
-        - iam_group.iam_group.users
-
-  - name: remove group
-    iam_group:
-      name: '{{ test_group }}'
-      state: absent
-    register: iam_group
-
-  - assert:
-      that:
-        - iam_group is changed
-
-  - name: re-remove group
-    iam_group:
-      name: '{{ test_group }}'
-      state: absent
-    register: iam_group
-
-  - assert:
-      that:
-        - iam_group is not changed
+  - include_tasks: users.yml
+  - include_tasks: path.yml
+  - include_tasks: policy_update.yml
+  - include_tasks: deletion.yml
 
   always:
   - name: remove group
     iam_group:
       name: '{{ test_group }}'
       state: absent
+
+  - name: Remove Safe IAM Managed Policy
+    iam_managed_policy:
+      state: absent
+      policy_name: '{{ custom_policy_name }}'
 
   - name: remove ansible user
     iam_user:

--- a/tests/integration/targets/iam_group/tasks/path.yml
+++ b/tests/integration/targets/iam_group/tasks/path.yml
@@ -1,0 +1,58 @@
+---
+# Path management
+
+- name: Set path (check_mode)
+  iam_group:
+    name: '{{ test_group }}'
+    path: '{{ test_path }}'
+    state: present
+  register: iam_group
+  check_mode: true
+
+- assert:
+    that:
+      - iam_group is changed
+
+- name: Set path
+  iam_group:
+    name: '{{ test_group }}'
+    path: '{{ test_path }}'
+    state: present
+  register: iam_group
+
+- assert:
+    that:
+      - iam_group is changed
+      - "'users' in iam_group.iam_group"
+      - "'group' in iam_group.iam_group"
+      - iam_group.iam_group.group.group_name == test_group
+      - iam_group.iam_group.group.path == test_path
+
+- name: Retry set path (check_mode)
+  iam_group:
+    name: '{{ test_group }}'
+    path: '{{ test_path }}'
+    state: present
+  register: iam_group
+  check_mode: true
+
+- assert:
+    that:
+      - iam_group is not changed
+
+- name: Retry set path
+  iam_group:
+    name: '{{ test_group }}'
+    path: '{{ test_path }}'
+    state: present
+  register: iam_group
+
+- assert:
+    that:
+      - iam_group is not changed
+      - "'users' in iam_group.iam_group"
+      - "'group' in iam_group.iam_group"
+      - iam_group.iam_group.group.group_name == test_group
+      - iam_group.iam_group.group.path == test_path
+
+# /end Path management

--- a/tests/integration/targets/iam_group/tasks/policy_update.yml
+++ b/tests/integration/targets/iam_group/tasks/policy_update.yml
@@ -1,0 +1,183 @@
+- name: Add Managed Policy (CHECK MODE)
+  iam_group:
+    name: '{{ test_group }}'
+    state: present
+    purge_policies: no
+    managed_policy:
+      - '{{ safe_managed_policy }}'
+  check_mode: yes
+  register: iam_group
+- assert:
+    that:
+      - iam_group is changed
+
+- name: Add Managed Policy
+  iam_group:
+    name: '{{ test_group }}'
+    state: present
+    purge_policies: no
+    managed_policy:
+      - '{{ safe_managed_policy }}'
+  register: iam_group
+- assert:
+    that:
+      - iam_group is changed
+      - iam_group.iam_group.group.group_name == test_group
+      - iam_group.iam_group.attached_policies | length == 1
+      - iam_group.iam_group.attached_policies[0].policy_name == safe_managed_policy
+
+- name: Add Managed Policy (no change) - check mode
+  iam_group:
+    name: '{{ test_group }}'
+    state: present
+    purge_policies: no
+    managed_policy:
+      - '{{ safe_managed_policy }}'
+  register: iam_group
+  check_mode: yes
+- assert:
+    that:
+      - iam_group is not changed
+
+- name: Add Managed Policy (no change)
+  iam_group:
+    name: '{{ test_group }}'
+    state: present
+    purge_policies: no
+    managed_policy:
+      - '{{ safe_managed_policy }}'
+  register: iam_group
+- assert:
+    that:
+      - iam_group is not changed
+      - iam_group.iam_group.group.group_name == test_group
+      - iam_group.iam_group.attached_policies | length == 1
+      - iam_group.iam_group.attached_policies[0].policy_name == safe_managed_policy
+
+# ------------------------------------------------------------------------------------------
+
+- name: Update Managed Policy without purge (CHECK MODE)
+  iam_group:
+    name: '{{ test_group }}'
+    state: present
+    purge_policies: no
+    managed_policy:
+      - '{{ custom_policy_name }}'
+  check_mode: yes
+  register: iam_group
+- assert:
+    that:
+      - iam_group is changed
+
+- name: Update Managed Policy without purge
+  iam_group:
+    name: '{{ test_group }}'
+    state: present
+    purge_policies: no
+    managed_policy:
+      - '{{ custom_policy_name }}'
+  register: iam_group
+- assert:
+    that:
+      - iam_group is changed
+      - iam_group.iam_group.group.group_name == test_group
+      - iam_group.iam_group.attached_policies | length == 2
+      - custom_policy_name in attached_policy_names
+      - safe_managed_policy in attached_policy_names
+  vars:
+    attached_policy_names: "{{ iam_group.iam_group.attached_policies | map(attribute='policy_name') }}"
+
+- name: Update Managed Policy without purge (no change) - check mode
+  iam_group:
+    name: '{{ test_group }}'
+    state: present
+    purge_policies: no
+    managed_policy:
+      - '{{ custom_policy_name }}'
+  register: iam_group
+  check_mode: yes
+- assert:
+    that:
+      - iam_group is not changed
+
+- name: Update Managed Policy without purge (no change)
+  iam_group:
+    name: '{{ test_group }}'
+    state: present
+    purge_policies: no
+    managed_policy:
+      - '{{ custom_policy_name }}'
+  register: iam_group
+- assert:
+    that:
+      - iam_group is not changed
+      - iam_group.iam_group.group.group_name == test_group
+      - iam_group.iam_group.attached_policies | length == 2
+      - custom_policy_name in attached_policy_names
+      - safe_managed_policy in attached_policy_names
+  vars:
+    attached_policy_names: "{{ iam_group.iam_group.attached_policies | map(attribute='policy_name') }}"
+
+# ------------------------------------------------------------------------------------------
+
+- name: Update Managed Policy with purge (CHECK MODE)
+  iam_group:
+    name: '{{ test_group }}'
+    state: present
+    managed_policy:
+      - '{{ custom_policy_name }}'
+    purge_policies: yes
+  check_mode: yes
+  register: iam_group
+- assert:
+    that:
+      - iam_group is changed
+
+- name: Update Managed Policy with purge
+  iam_group:
+    name: '{{ test_group }}'
+    state: present
+    managed_policy:
+      - '{{ custom_policy_name }}'
+    purge_policies: yes
+  register: iam_group
+- assert:
+    that:
+      - iam_group is changed
+      - iam_group.iam_group.group.group_name == test_group
+      - iam_group.iam_group.attached_policies | length == 1
+      - custom_policy_name in attached_policy_names
+      - safe_managed_policy not in attached_policy_names
+  vars:
+    attached_policy_names: "{{ iam_group.iam_group.attached_policies | map(attribute='policy_name') }}"
+
+- name: Update Managed Policy with purge (no change) - check mode
+  iam_group:
+    name: '{{ test_group }}'
+    state: present
+    managed_policy:
+      - '{{ custom_policy_name }}'
+    purge_policies: yes
+  register: iam_group
+  check_mode: yes
+- assert:
+    that:
+      - iam_group is not changed
+
+- name: Update Managed Policy with purge (no change)
+  iam_group:
+    name: '{{ test_group }}'
+    state: present
+    managed_policy:
+      - '{{ custom_policy_name }}'
+    purge_policies: yes
+  register: iam_group
+- assert:
+    that:
+      - iam_group is not changed
+      - iam_group.iam_group.group.group_name == test_group
+      - iam_group.iam_group.attached_policies | length == 1
+      - custom_policy_name in attached_policy_names
+      - safe_managed_policy not in attached_policy_names
+  vars:
+    attached_policy_names: "{{ iam_group.iam_group.attached_policies | map(attribute='policy_name') }}"

--- a/tests/integration/targets/iam_group/tasks/users.yml
+++ b/tests/integration/targets/iam_group/tasks/users.yml
@@ -1,0 +1,74 @@
+---
+- name: add non existent user to group
+  iam_group:
+    name: '{{ test_group }}'
+    users:
+      - '{{ test_user }}'
+      - NonExistentUser
+    state: present
+  ignore_errors: yes
+  register: iam_group
+
+- name: assert that adding non existent user to group fails with helpful message
+  assert:
+    that:
+      - iam_group is failed
+      - iam_group.msg.startswith("Couldn't add user NonExistentUser to group {{ test_group }}")
+
+- name: remove a user
+  iam_group:
+    name: '{{ test_group }}'
+    purge_users: True
+    users: []
+    state: present
+  register: iam_group
+
+- assert:
+    that:
+      - iam_group is changed
+      - '"users" in iam_group.iam_group'
+      - iam_group.iam_group.users | length == 0
+
+- name: re-remove a user (no change)
+  iam_group:
+    name: '{{ test_group }}'
+    purge_users: True
+    users: []
+    state: present
+  register: iam_group
+
+- assert:
+    that:
+      - iam_group is not changed
+      - '"users" in iam_group.iam_group'
+      - iam_group.iam_group.users | length == 0
+
+- name: Add the user again
+  iam_group:
+    name: '{{ test_group }}'
+    users:
+      - '{{ test_user }}'
+    state: present
+  register: iam_group
+
+- assert:
+    that:
+      - iam_group is changed
+      - '"users" in iam_group.iam_group'
+      - iam_group.iam_group.users | length == 1
+      - iam_group.iam_group.users[0].user_name == test_user
+
+- name: Re-add the user
+  iam_group:
+    name: '{{ test_group }}'
+    users:
+      - '{{ test_user }}'
+    state: present
+  register: iam_group
+
+- assert:
+    that:
+      - iam_group is not changed
+      - '"users" in iam_group.iam_group'
+      - iam_group.iam_group.users | length == 1
+      - iam_group.iam_group.users[0].user_name == test_user


### PR DESCRIPTION
##### SUMMARY

Adds support for the 'path' option on IAM Groups.
Adds attached_policies return value.

Also refactors ``create_or_update_group`` because it was getting large and unwieldy.
Splits up test file, and adds tests for policy management

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

iam_group

##### ADDITIONAL INFORMATION

