### PR TITLE
ec2_metadata_facts - Skip tests against 2.7 hosts when running Ansible-core >= 2.17

### DIFF
--- a/tests/integration/targets/ec2_metadata_facts/templates/inventory.j2
+++ b/tests/integration/targets/ec2_metadata_facts/templates/inventory.j2
@@ -6,7 +6,9 @@
 
 [testhost:children]
 testhost_py3
+{% if ansible_version.full is version_compare('2.17', '<') %}
 testhost_py2
+{% endif %}
 
 [testhost:vars]
 ansible_ssh_private_key_file="{{ sshkey }}"


### PR DESCRIPTION
##### SUMMARY

ansible-core 2.17 will drop support for Python 2.7.  While in general we require Python > 3.7, we've had an exception for ec2_metadata_facts since it doesn't actually need botocore and it's used outside of the AWS ecosystem.

Unfortunately it's no longer possible to test against 2.7 targets using the devel branch, so we'll have to skip those tests in CI (can still be run locally if folks are using ansible-core <2.17

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

ec2_metadata_facts

##### ADDITIONAL INFORMATION
