### PR TITLE
Use FQCN for integration tests

### DIFF
--- a/changelogs/fragments/20231204-integration-fqcn.yml
+++ b/changelogs/fragments/20231204-integration-fqcn.yml
@@ -1,0 +1,2 @@
+trivial:
+  - use FQCN for integration test targets.

--- a/tests/integration/targets/aws_az_info/tasks/main.yml
+++ b/tests/integration/targets/aws_az_info/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
 
   block:
   - name: 'List available AZs in current Region'

--- a/tests/integration/targets/aws_caller_info/tasks/main.yaml
+++ b/tests/integration/targets/aws_caller_info/tasks/main.yaml
@@ -4,6 +4,8 @@
         access_key: "{{ aws_access_key }}"
         secret_key: "{{ aws_secret_key }}"
         session_token: "{{ security_token | default(omit) }}"
+  collections:
+    - amazon.aws
   block:
   - name: retrieve caller facts
     aws_caller_info:

--- a/tests/integration/targets/aws_region_info/tasks/main.yml
+++ b/tests/integration/targets/aws_region_info/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
   block:
   - name: List available Regions
     aws_region_info:

--- a/tests/integration/targets/backup_plan/tasks/main.yml
+++ b/tests/integration/targets/backup_plan/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
     - name: Create a backup vault for the plan to target
       amazon.aws.backup_vault:

--- a/tests/integration/targets/backup_selection/tasks/main.yml
+++ b/tests/integration/targets/backup_selection/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
 
   block:
 

--- a/tests/integration/targets/backup_tag/tasks/main.yml
+++ b/tests/integration/targets/backup_tag/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
 
     - name: Create an AWS Backup Vault so we have something to tag

--- a/tests/integration/targets/backup_vault/tasks/main.yml
+++ b/tests/integration/targets/backup_vault/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
     - name: create a key
       kms_key:

--- a/tests/integration/targets/cloudformation/tasks/main.yml
+++ b/tests/integration/targets/cloudformation/tasks/main.yml
@@ -6,6 +6,8 @@
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
 
+  collections:
+    - amazon.aws
   block:
 
     # ==== Env setup ==========================================================

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
   block:
   - set_fact:
       alarm_full_name: '{{ alarm_prefix }}-{{ resource_prefix }}-cpu-low'

--- a/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
 
   block:
     - name: Create SNS topic

--- a/tests/integration/targets/cloudwatchlogs/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchlogs/tasks/main.yml
@@ -6,6 +6,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
 
   block:
 

--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -7,6 +7,8 @@
       region: '{{ aws_region }}'
     amazon.aws.ec2_eip:
       in_vpc: true
+  collections:
+    - amazon.aws
 
   block:
   - name: Get the current caller identity facts

--- a/tests/integration/targets/ec2_instance_block_devices/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_block_devices/tasks/main.yml
@@ -6,6 +6,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
     - name: New instance with an extra block device
       amazon.aws.ec2_instance:

--- a/tests/integration/targets/ec2_instance_checkmode_tests/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_checkmode_tests/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: "Make basic instance"
     ec2_instance:

--- a/tests/integration/targets/ec2_instance_cpu_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_cpu_options/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: "create t3.nano instance with cpu_options"
     ec2_instance:

--- a/tests/integration/targets/ec2_instance_default_vpc_tests/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_default_vpc_tests/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: "Make instance in a default subnet of the VPC"
     ec2_instance:

--- a/tests/integration/targets/ec2_instance_ebs_optimized/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_ebs_optimized/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: "Make EBS optimized instance in the testing subnet of the test VPC"
     ec2_instance:

--- a/tests/integration/targets/ec2_instance_external_resource_attach/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_external_resource_attach/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   # Make custom ENIs and attach via the `network` parameter
   - ec2_eni:

--- a/tests/integration/targets/ec2_instance_hibernation_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_hibernation_options/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
     - name: Create instance with hibernation option (check mode)
       ec2_instance:

--- a/tests/integration/targets/ec2_instance_iam_instance_role/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_iam_instance_role/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: "Create IAM role for test"
     iam_role:

--- a/tests/integration/targets/ec2_instance_info/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_info/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: "Make instance in the testing subnet created in the test VPC"
     ec2_instance:

--- a/tests/integration/targets/ec2_instance_instance_minimal/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_minimal/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: "Create a new instance (check_mode)"
     ec2_instance:

--- a/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
 ################################################################
 

--- a/tests/integration/targets/ec2_instance_instance_no_wait/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_no_wait/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: "New instance and don't wait for it to complete"
     ec2_instance:

--- a/tests/integration/targets/ec2_instance_license_specifications/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_license_specifications/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: "New instance with license specifications"
     ec2_instance:

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: "create t3.nano instance with metadata_options"
     ec2_instance:

--- a/tests/integration/targets/ec2_instance_placement_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_placement_options/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: New placement group
     community.aws.ec2_placement_group:

--- a/tests/integration/targets/ec2_instance_security_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_security_group/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: "New instance with 2 security groups"
     ec2_instance:

--- a/tests/integration/targets/ec2_instance_state_config_updates/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_state_config_updates/tasks/main.yml
@@ -10,6 +10,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
     - name: Make instance with sg and termination protection enabled
       amazon.aws.ec2_instance:

--- a/tests/integration/targets/ec2_instance_tags_and_vpc_settings/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_tags_and_vpc_settings/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: "Make instance in the testing subnet created in the test VPC"
     ec2_instance:

--- a/tests/integration/targets/ec2_instance_termination_protection/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_termination_protection/tasks/main.yml
@@ -4,6 +4,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
     - name: Create instance with termination protection (check mode)
       ec2_instance:

--- a/tests/integration/targets/ec2_instance_uptime/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_uptime/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
   - name: "create t3.nano instance"
     ec2_instance:

--- a/tests/integration/targets/ec2_key/tasks/main.yml
+++ b/tests/integration/targets/ec2_key/tasks/main.yml
@@ -8,6 +8,8 @@
       access_key: '{{ aws_access_key }}'
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
+  collections:
+    - amazon.aws
   block:
     - name: Create temporary directory
       tempfile:

--- a/tests/integration/targets/ec2_security_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/main.yml
@@ -16,6 +16,8 @@
         secret_key: "{{ aws_secret_key }}"
         session_token: "{{ security_token | default(omit)}}"
         region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
     - name: determine if there is a default VPC
       set_fact:

--- a/tests/integration/targets/ec2_tag/tasks/main.yml
+++ b/tests/integration/targets/ec2_tag/tasks/main.yml
@@ -6,6 +6,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
     - name: Create an EC2 volume so we have something to tag
       ec2_vol:

--- a/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml
@@ -12,6 +12,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default('') }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
 
   block:
 

--- a/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
   block:
   # ============================================================
   # BEGIN PRE-TEST SETUP

--- a/tests/integration/targets/ec2_vpc_igw/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_igw/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
   block:
   # ============================================================
   - name: Fetch IGWs in check_mode

--- a/tests/integration/targets/ec2_vpc_nat_gateway/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_nat_gateway/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
   block:
   # ============================================================
   - name: Create a VPC

--- a/tests/integration/targets/ec2_vpc_net/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_net/tasks/main.yml
@@ -6,6 +6,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   vars:
     first_tags:
       'Key with Spaces': Value with spaces

--- a/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
   block:
 
   - name: create VPC

--- a/tests/integration/targets/ec2_vpc_subnet/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_subnet/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
     # ============================================================
     - name: create a VPC

--- a/tests/integration/targets/elb_application_lb/tasks/main.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
   block:
   - name: Create a test VPC
     ec2_vpc_net:

--- a/tests/integration/targets/iam_policy/tasks/main.yml
+++ b/tests/integration/targets/iam_policy/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
   block:
     # ============================================================
   - name: Create user for tests

--- a/tests/integration/targets/iam_user/tasks/main.yml
+++ b/tests/integration/targets/iam_user/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
   block:
   - name: ensure improper usage of parameters fails gracefully
     iam_user_info:

--- a/tests/integration/targets/rds_cluster_create/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_create/tasks/main.yaml
@@ -4,6 +4,8 @@
       access_key: '{{ aws_access_key }}'
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
+  collections:
+    - amazon.aws
   block:
   - name: Ensure the resource doesn't exist
     rds_cluster:

--- a/tests/integration/targets/rds_cluster_create_sgs/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_create_sgs/tasks/main.yaml
@@ -4,6 +4,8 @@
       access_key: '{{ aws_access_key }}'
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
+  collections:
+    - amazon.aws
   block:
   - name: Ensure the resource doesn't exist
     rds_cluster:

--- a/tests/integration/targets/rds_cluster_modify/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_modify/tasks/main.yaml
@@ -4,6 +4,8 @@
       access_key: '{{ aws_access_key }}'
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
+  collections:
+    - amazon.aws
   block:
 
   # Disabled: Below tests require use of more than 1 region, not supported by CI at the moment

--- a/tests/integration/targets/rds_cluster_promote/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_promote/tasks/main.yaml
@@ -4,6 +4,8 @@
       access_key: '{{ aws_access_key }}'
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
+  collections:
+    - amazon.aws
   block:
   - name: Ensure the resource doesn't exist
     rds_cluster:

--- a/tests/integration/targets/rds_cluster_restore/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_restore/tasks/main.yaml
@@ -4,6 +4,8 @@
       access_key: '{{ aws_access_key }}'
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
+  collections:
+    - amazon.aws
   block:
   - name: Ensure the resource doesn't exist
     rds_cluster:

--- a/tests/integration/targets/rds_cluster_states/tasks/main.yml
+++ b/tests/integration/targets/rds_cluster_states/tasks/main.yml
@@ -4,6 +4,8 @@
       access_key: '{{ aws_access_key }}'
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
+  collections:
+    - amazon.aws
   block:
     # ------------------------------------------------------------------------------------------
     # Create DB cluster

--- a/tests/integration/targets/rds_cluster_tag/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_tag/tasks/main.yaml
@@ -4,6 +4,8 @@
       access_key: '{{ aws_access_key }}'
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
+  collections:
+    - amazon.aws
   block:
   - name: Ensure the resource doesn't exist
     rds_cluster:

--- a/tests/integration/targets/rds_option_group/tasks/main.yml
+++ b/tests/integration/targets/rds_option_group/tasks/main.yml
@@ -5,6 +5,8 @@
       access_key: '{{ aws_access_key }}'
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
+  collections:
+    - amazon.aws
 
 
   block:

--- a/tests/integration/targets/rds_param_group/tasks/main.yml
+++ b/tests/integration/targets/rds_param_group/tasks/main.yml
@@ -18,6 +18,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
   block:
 
     # ============================================================

--- a/tests/integration/targets/rds_subnet_group/tasks/main.yml
+++ b/tests/integration/targets/rds_subnet_group/tasks/main.yml
@@ -11,6 +11,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
   block:
 
   # ============================================================

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -16,6 +16,8 @@
     amazon.aws.route53:
       # Route53 is explicitly a global service
       region:
+  collections:
+    - amazon.aws
   block:
   - name: create VPC
     ec2_vpc_net:

--- a/tests/integration/targets/route53_health_check/tasks/main.yml
+++ b/tests/integration/targets/route53_health_check/tasks/main.yml
@@ -21,6 +21,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
   block:
   # Route53 can only test against routable IPs.  Request an EIP so some poor
   # soul doesn't get randomly hit by our testing.

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/main.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/main.yml
@@ -12,6 +12,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
     - debug:
         msg: "{{ inventory_hostname }} start: {{ lookup('pipe','date') }}"

--- a/tests/integration/targets/s3_bucket_info/tasks/main.yml
+++ b/tests/integration/targets/s3_bucket_info/tasks/main.yml
@@ -5,6 +5,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
   block:
   - name: Create a simple s3_bucket
     s3_bucket:

--- a/tests/integration/targets/s3_object/tasks/main.yml
+++ b/tests/integration/targets/s3_object/tasks/main.yml
@@ -6,6 +6,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
 
   block:
     # https://github.com/ansible/ansible/issues/77257

--- a/tests/integration/targets/setup_ec2_facts/tasks/main.yml
+++ b/tests/integration/targets/setup_ec2_facts/tasks/main.yml
@@ -14,6 +14,8 @@
       secret_key: '{{ aws_secret_key }}'
       session_token: '{{ security_token | default(omit) }}'
       region: '{{ aws_region }}'
+  collections:
+    - amazon.aws
 
   run_once: True
   block:

--- a/tests/integration/targets/setup_ec2_instance_env/tasks/main.yml
+++ b/tests/integration/targets/setup_ec2_instance_env/tasks/main.yml
@@ -6,6 +6,8 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
+  collections:
+    - amazon.aws
   block:
     - name: Create VPC for use in testing
       ec2_vpc_net:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The lack of FQCN for several of the integration test targets is creating issues in downstream testing. This PR adds the collections keyword to the targets that are using amazon.aws modules without a FQCN.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
