### PR TITLE
[WIP]Add integration tests target time to aliases files

### DIFF
--- a/changelogs/fragments/20231205-integration-aliases-time.yml
+++ b/changelogs/fragments/20231205-integration-aliases-time.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- Add time to integration targets aliases files.

--- a/changelogs/fragments/20231205-integration-aliases-time.yml
+++ b/changelogs/fragments/20231205-integration-aliases-time.yml
@@ -1,2 +1,2 @@
-minor_changes:
+trivial:
 - Add time to integration targets aliases files.

--- a/tests/integration/targets/autoscaling_group/aliases
+++ b/tests/integration/targets/autoscaling_group/aliases
@@ -1,4 +1,4 @@
-time=10m
+time=30m
 cloud/aws
 
 autoscaling_group_info

--- a/tests/integration/targets/autoscaling_group/aliases
+++ b/tests/integration/targets/autoscaling_group/aliases
@@ -1,4 +1,4 @@
-time=30m
+time=10m
 cloud/aws
 
 autoscaling_group_info

--- a/tests/integration/targets/cloudformation/aliases
+++ b/tests/integration/targets/cloudformation/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 cloudformation_info
+time=10m

--- a/tests/integration/targets/ec2_ami_instance/aliases
+++ b/tests/integration/targets/ec2_ami_instance/aliases
@@ -1,4 +1,4 @@
-time=30m
+time=20m
 cloud/aws
 ec2_ami
 ec2_ami_info

--- a/tests/integration/targets/ec2_ami_snapshot/aliases
+++ b/tests/integration/targets/ec2_ami_snapshot/aliases
@@ -1,4 +1,4 @@
-time=10m
+time=5m
 cloud/aws
 
 ec2_ami

--- a/tests/integration/targets/ec2_ami_tpm/aliases
+++ b/tests/integration/targets/ec2_ami_tpm/aliases
@@ -1,4 +1,4 @@
-time=10m
+time=5m
 
 cloud/aws
 ec2_ami

--- a/tests/integration/targets/ec2_spot_instance/aliases
+++ b/tests/integration/targets/ec2_spot_instance/aliases
@@ -1,2 +1,3 @@
 cloud/aws
 ec2_spot_instance_info
+time=7m

--- a/tests/integration/targets/ec2_vpc_dhcp_option/aliases
+++ b/tests/integration/targets/ec2_vpc_dhcp_option/aliases
@@ -1,1 +1,2 @@
 cloud/aws
+time=5m

--- a/tests/integration/targets/ec2_vpc_net/aliases
+++ b/tests/integration/targets/ec2_vpc_net/aliases
@@ -1,2 +1,3 @@
 ec2_vpc_net_info
 cloud/aws
+time=2m

--- a/tests/integration/targets/lambda_policy/aliases
+++ b/tests/integration/targets/lambda_policy/aliases
@@ -1,1 +1,2 @@
 cloud/aws
+time=2m

--- a/tests/integration/targets/rds_instance_aurora/aliases
+++ b/tests/integration/targets/rds_instance_aurora/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-time=30m
+time=17m
 rds_instance

--- a/tests/integration/targets/rds_instance_complex/aliases
+++ b/tests/integration/targets/rds_instance_complex/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-time=15m
+time=10m
 rds_instance

--- a/tests/integration/targets/rds_instance_snapshot_mgmt/aliases
+++ b/tests/integration/targets/rds_instance_snapshot_mgmt/aliases
@@ -1,4 +1,4 @@
 cloud/aws
 rds_instance_info
-time=30m
+time=45m
 rds_instance

--- a/tests/integration/targets/rds_instance_states/aliases
+++ b/tests/integration/targets/rds_instance_states/aliases
@@ -1,4 +1,4 @@
 cloud/aws
 rds_instance_info
-time=30m
+time=35m
 rds_instance

--- a/tests/integration/targets/rds_instance_tagging/aliases
+++ b/tests/integration/targets/rds_instance_tagging/aliases
@@ -1,3 +1,3 @@
 cloud/aws
-time=15m
+time=20m
 rds_instance

--- a/tests/integration/targets/route53/aliases
+++ b/tests/integration/targets/route53/aliases
@@ -2,3 +2,4 @@ cloud/aws
 
 route53_info
 module_utils_route53
+time=2m

--- a/tests/integration/targets/sts_assume_role/aliases
+++ b/tests/integration/targets/sts_assume_role/aliases
@@ -1,1 +1,2 @@
 cloud/aws
+time=2m


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The lack time on several of the integration test targets aliases files is creating issues in downstream testing.
This PR adds test time duration to several aliases files, by that we improve the test splitter work
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
