### PR TITLE
Fix missing FQCNs in integration test

### DIFF
--- a/.github/BOTMETA.yml
+++ b/.github/BOTMETA.yml
@@ -1,3 +1,4 @@
+---
 automerge: false
 files:
   maintainers: $team_aws

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -3,159 +3,158 @@ name: Bug report
 description: Create a report to help us improve
 
 body:
-- type: markdown
-  attributes:
-    value: |
-      ⚠
-      Verify first that your issue is not [already reported on GitHub][issue search].
-      Where possible also test if the latest release and main branch are affected too.
-      *Complete **all** sections as described, this form is processed automatically.*
+  - type: markdown
+    attributes:
+      value: |
+        ⚠
+        Verify first that your issue is not [already reported on GitHub][issue search].
+        Where possible also test if the latest release and main branch are affected too.
+        *Complete **all** sections as described, this form is processed automatically.*
 
-      [issue search]: https://github.com/ansible-collections/amazon.aws/search?q=is%3Aissue&type=issues
+        [issue search]: https://github.com/ansible-collections/amazon.aws/search?q=is%3Aissue&type=issues
 
-- type: textarea
-  attributes:
-    label: Summary
-    description: |
-      Explain the problem briefly below.
-    placeholder: >-
-      When I try to do X with the collection from the main branch on GitHub, Y
-      breaks in a way Z under the env E. Here are all the details I know
-      about this problem...
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        Explain the problem briefly below.
+      placeholder: >-
+        When I try to do X with the collection from the main branch on GitHub, Y
+        breaks in a way Z under the env E. Here are all the details I know
+        about this problem...
+    validations:
+      required: true
 
-- type: dropdown
-  attributes:
-    label: Issue Type
-    # FIXME: Once GitHub allows defining the default choice, update this
-    options:
-    - Bug Report
-  validations:
-    required: true
+  - type: dropdown
+    attributes:
+      label: Issue Type
+      # FIXME: Once GitHub allows defining the default choice, update this
+      options:
+        - Bug Report
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
+  - type: textarea
+    attributes:
     # For smaller collections we could use a multi-select and hardcode the list
     # May generate this list via GitHub action and walking files under https://github.com/ansible-collections/community.general/tree/main/plugins
     # Select from list, filter as you type (`mysql` would only show the 3 mysql components)
     # OR freeform - doesn't seem to be supported in adaptivecards
-    label: Component Name
-    description: >-
-      Write the short name of the module or plugin below,
-      *use your best guess if unsure*.
-    placeholder: ec2_instance, ec2_security_group
-  validations:
-    required: true
-
-- type: textarea
-  attributes:
-    label: Ansible Version
-    description: >-
-      Paste verbatim output from `ansible --version` between
-      tripple backticks.
-    value: |
-      ```console (paste below)
-      $ ansible --version
-
-      ```
-  validations:
-    required: true
-
-- type: textarea
-  attributes:
-    label: Collection Versions
-    description: >-
-      Paste verbatim output from `ansible-galaxy collection list` between
-      tripple backticks.
-    value: |
-      ```console (paste below)
-      $ ansible-galaxy collection list
-      ```
-  validations:
-    required: true
-
-- type: textarea
-  attributes:
-    label: AWS SDK versions
-    description: >-
-      The AWS modules depend heavily on the Amazon AWS SDKs which are regularly updated.
-      Paste verbatim output from `pip show boto boto3 botocore` between quotes
-    value: |
-      ```console (paste below)
-      $ pip show boto boto3 botocore
-      ```
-  validations:
-    required: true
-
-- type: textarea
-  attributes:
-    label: Configuration
-    description: >-
-      If this issue has an example piece of YAML that can help to reproduce this problem, please provide it.
-      This can be a piece of YAML from, e.g., an automation, script, scene or configuration.
-
-      Paste verbatim output from `ansible-config dump --only-changed` between quotes
-    value: |
-      ```console (paste below)
-      $ ansible-config dump --only-changed
-
-      ```
-
-- type: textarea
-  attributes:
-    label: OS / Environment
-    description: >-
-      Provide all relevant information below, e.g. target OS versions,
-      network device firmware, etc.
-    placeholder: RHEL 8, CentOS Stream etc.
-  validations:
-    required: false
-
-- type: textarea
-  attributes:
-    label: Steps to Reproduce
-    description: |
-      Describe exactly how to reproduce the problem, using a minimal test-case. It would *really* help us understand your problem if you could also paste any playbooks, configs and commands you used.
-
-      **HINT:** You can paste https://gist.github.com links for larger files.
-    value: |
-      <!--- Paste example playbooks or commands between quotes below -->
-      ```yaml (paste below)
-
-      ```
-  validations:
-    required: true
-
-- type: textarea
-  attributes:
-    label: Expected Results
-    description: >-
-      Describe what you expected to happen when running the steps above.
-    placeholder: >-
-      I expected X to happen because I assumed Y.
-      that it did not.
-  validations:
-    required: true
-
-- type: textarea
-  attributes:
-    label: Actual Results
-    description: |
-      Describe what actually happened. If possible run with extra verbosity (`-vvvv`).
-
-      Paste verbatim command output between quotes.
-    value: |
-      ```console (paste below)
-
-      ```
-
-- type: checkboxes
-  attributes:
-    label: Code of Conduct
-    description: |
-      Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
-    options:
-    - label: I agree to follow the Ansible Code of Conduct
+      label: Component Name
+      description: >-
+        Write the short name of the module or plugin below,
+        *use your best guess if unsure*.
+      placeholder: ec2_instance, ec2_security_group
+    validations:
       required: true
-...
+
+  - type: textarea
+    attributes:
+      label: Ansible Version
+      description: >-
+        Paste verbatim output from `ansible --version` between
+        tripple backticks.
+      value: |
+        ```console (paste below)
+        $ ansible --version
+
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Collection Versions
+      description: >-
+        Paste verbatim output from `ansible-galaxy collection list` between
+        tripple backticks.
+      value: |
+        ```console (paste below)
+        $ ansible-galaxy collection list
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: AWS SDK versions
+      description: >-
+        The AWS modules depend heavily on the Amazon AWS SDKs which are regularly updated.
+        Paste verbatim output from `pip show boto boto3 botocore` between quotes
+      value: |
+        ```console (paste below)
+        $ pip show boto boto3 botocore
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Configuration
+      description: >-
+        If this issue has an example piece of YAML that can help to reproduce this problem, please provide it.
+        This can be a piece of YAML from, e.g., an automation, script, scene or configuration.
+
+        Paste verbatim output from `ansible-config dump --only-changed` between quotes
+      value: |
+        ```console (paste below)
+        $ ansible-config dump --only-changed
+
+        ```
+
+  - type: textarea
+    attributes:
+      label: OS / Environment
+      description: >-
+        Provide all relevant information below, e.g. target OS versions,
+        network device firmware, etc.
+      placeholder: RHEL 8, CentOS Stream etc.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Steps to Reproduce
+      description: |
+        Describe exactly how to reproduce the problem, using a minimal test-case. It would *really* help us understand your problem if you could also paste any playbooks, configs and commands you used.
+
+        **HINT:** You can paste https://gist.github.com links for larger files.
+      value: |
+        <!--- Paste example playbooks or commands between quotes below -->
+        ```yaml (paste below)
+
+        ```
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected Results
+      description: >-
+        Describe what you expected to happen when running the steps above.
+      placeholder: >-
+        I expected X to happen because I assumed Y.
+        that it did not.
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual Results
+      description: |
+        Describe what actually happened. If possible run with extra verbosity (`-vvvv`).
+
+        Paste verbatim command output between quotes.
+      value: |
+        ```console (paste below)
+
+        ```
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: |
+        Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
+      options:
+        - label: I agree to follow the Ansible Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/ci_report.yml
+++ b/.github/ISSUE_TEMPLATE/ci_report.yml
@@ -3,74 +3,73 @@ name: CI Bug Report
 description: Create a report to help us improve our CI
 
 body:
-- type: markdown
-  attributes:
-    value: |
-      ⚠
-      Verify first that your issue is not [already reported on GitHub][issue search].
-      *Complete **all** sections as described, this form is processed automatically.*
+  - type: markdown
+    attributes:
+      value: |
+        ⚠
+        Verify first that your issue is not [already reported on GitHub][issue search].
+        *Complete **all** sections as described, this form is processed automatically.*
 
-      [issue search]: https://github.com/ansible-collections/amazon.aws/search?q=is%3Aissue&type=issues
+        [issue search]: https://github.com/ansible-collections/amazon.aws/search?q=is%3Aissue&type=issues
 
-- type: textarea
-  attributes:
-    label: Summary
-    description: |
-      Describe the new issue briefly below.
-    placeholder: >-
-      I opened a Pull Request and CI failed to run.  I believe this is due to a problem with the CI rather than my code.
-  validations:
-    required: true
-
-- type: dropdown
-  attributes:
-    label: Issue Type
-    # FIXME: Once GitHub allows defining the default choice, update this
-    options:
-    - CI Bug Report
-  validations:
-    required: true
-
-- type: textarea
-  attributes:
-    label: CI Jobs
-    description: >-
-      Please provide a link to the failed CI tests.
-    placeholder: https://dashboard.zuul.ansible.com/t/ansible/buildset/be956faa49d84e43bc860d0cd3dc8503
-  validations:
-    required: false
-
-- type: textarea
-  attributes:
-    label: Pull Request
-    description: >-
-      Please provide a link to the Pull Request where the tests are failing
-    placeholder: https://github.com/ansible-collections/amazon.aws/runs/3040421733
-  validations:
-    required: false
-
-- type: textarea
-  attributes:
-    label: Additional Information
-    description: |
-      Please provide as much information as possible to help us understand the issue being reported.
-      Where possible, please include the specific errors that you're seeing.
-
-      **HINT:** You can paste https://gist.github.com links for larger files.
-    value: |
-      <!--- Paste example playbooks or commands between quotes below -->
-      ```yaml (paste below)
-
-      ```
-  validations:
-    required: false
-
-- type: checkboxes
-  attributes:
-    label: Code of Conduct
-    description: |
-      Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
-    options:
-    - label: I agree to follow the Ansible Code of Conduct
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        Describe the new issue briefly below.
+      placeholder: >-
+        I opened a Pull Request and CI failed to run.  I believe this is due to a problem with the CI rather than my code.
+    validations:
       required: true
-...
+
+  - type: dropdown
+    attributes:
+      label: Issue Type
+      # FIXME: Once GitHub allows defining the default choice, update this
+      options:
+        - CI Bug Report
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: CI Jobs
+      description: >-
+        Please provide a link to the failed CI tests.
+      placeholder: https://dashboard.zuul.ansible.com/t/ansible/buildset/be956faa49d84e43bc860d0cd3dc8503
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Pull Request
+      description: >-
+        Please provide a link to the Pull Request where the tests are failing
+      placeholder: https://github.com/ansible-collections/amazon.aws/runs/3040421733
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: |
+        Please provide as much information as possible to help us understand the issue being reported.
+        Where possible, please include the specific errors that you're seeing.
+
+        **HINT:** You can paste https://gist.github.com links for larger files.
+      value: |
+        <!--- Paste example playbooks or commands between quotes below -->
+        ```yaml (paste below)
+
+        ```
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: |
+        Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
+      options:
+        - label: I agree to follow the Ansible Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,27 +1,27 @@
 ---
 # Ref: https://help.github.com/en/github/building-a-strong-community/configuring-issue-templates-for-your-repository#configuring-the-template-chooser
-blank_issues_enabled: false  # default: true
+blank_issues_enabled: false # default: true
 contact_links:
-- name: Security bug report
-  url: https://docs.ansible.com/ansible-core/devel/community/reporting_bugs_and_features.html?utm_medium=github&utm_source=issue_template_chooser_ansible_collections
-  about: |
-    Please learn how to report security vulnerabilities here.
+  - name: Security bug report
+    url: https://docs.ansible.com/ansible-core/devel/community/reporting_bugs_and_features.html?utm_medium=github&utm_source=issue_template_chooser_ansible_collections
+    about: |
+      Please learn how to report security vulnerabilities here.
 
-    For all security related bugs, email security@ansible.com
-    instead of using this issue tracker and you will receive
-    a prompt response.
+      For all security related bugs, email security@ansible.com
+      instead of using this issue tracker and you will receive
+      a prompt response.
 
-    For more information, see
-    https://docs.ansible.com/ansible/latest/community/reporting_bugs_and_features.html
-- name: Ansible Code of Conduct
-  url: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_template_chooser_ansible_collections
-  about: Be nice to other members of the community.
-- name: Talks to the community
-  url: https://docs.ansible.com/ansible/latest/community/communication.html?utm_medium=github&utm_source=issue_template_chooser#mailing-list-information
-  about: Please ask and answer usage questions here
-- name: Working groups
-  url: https://github.com/ansible/community/wiki
-  about: Interested in improving a specific area? Become a part of a working group!
-- name: For Enterprise
-  url: https://www.ansible.com/products/engine?utm_medium=github&utm_source=issue_template_chooser_ansible_collections
-  about: Red Hat offers support for the Ansible Automation Platform
+      For more information, see
+      https://docs.ansible.com/ansible/latest/community/reporting_bugs_and_features.html
+  - name: Ansible Code of Conduct
+    url: https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_template_chooser_ansible_collections
+    about: Be nice to other members of the community.
+  - name: Talks to the community
+    url: https://docs.ansible.com/ansible/latest/community/communication.html?utm_medium=github&utm_source=issue_template_chooser#mailing-list-information
+    about: Please ask and answer usage questions here
+  - name: Working groups
+    url: https://github.com/ansible/community/wiki
+    about: Interested in improving a specific area? Become a part of a working group!
+  - name: For Enterprise
+    url: https://www.ansible.com/products/engine?utm_medium=github&utm_source=issue_template_chooser_ansible_collections
+    about: Red Hat offers support for the Ansible Automation Platform

--- a/.github/ISSUE_TEMPLATE/documentation_report.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_report.yml
@@ -4,127 +4,126 @@ description: Ask us about docs
 # NOTE: issue body is enabled to allow screenshots
 
 body:
-- type: markdown
-  attributes:
-    value: |
-      ⚠
-      Verify first that your issue is not [already reported on GitHub][issue search].
-      Where possible also test if the latest release and main branch are affected too.
-      *Complete **all** sections as described, this form is processed automatically.*
+  - type: markdown
+    attributes:
+      value: |
+        ⚠
+        Verify first that your issue is not [already reported on GitHub][issue search].
+        Where possible also test if the latest release and main branch are affected too.
+        *Complete **all** sections as described, this form is processed automatically.*
 
-      [issue search]: https://github.com/ansible-collections/amazon.aws/search?q=is%3Aissue&type=issues
+        [issue search]: https://github.com/ansible-collections/amazon.aws/search?q=is%3Aissue&type=issues
 
-- type: textarea
-  attributes:
-    label: Summary
-    description: |
-      Explain the problem briefly below, add suggestions to wording or structure.
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        Explain the problem briefly below, add suggestions to wording or structure.
 
-      **HINT:** Did you know the documentation has an `Edit on GitHub` link on every page?
-    placeholder: >-
-      I was reading the Collection documentation of version X and I'm having
-      problems understanding Y. It would be very helpful if that got
-      rephrased as Z.
-  validations:
-    required: true
+        **HINT:** Did you know the documentation has an `Edit on GitHub` link on every page?
+      placeholder: >-
+        I was reading the Collection documentation of version X and I'm having
+        problems understanding Y. It would be very helpful if that got
+        rephrased as Z.
+    validations:
+      required: true
 
-- type: dropdown
-  attributes:
-    label: Issue Type
-    # FIXME: Once GitHub allows defining the default choice, update this
-    options:
-    - Documentation Report
-  validations:
-    required: true
+  - type: dropdown
+    attributes:
+      label: Issue Type
+      # FIXME: Once GitHub allows defining the default choice, update this
+      options:
+        - Documentation Report
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
+  - type: textarea
+    attributes:
     # For smaller collections we could use a multi-select and hardcode the list
     # May generate this list via GitHub action and walking files under https://github.com/ansible-collections/community.general/tree/main/plugins
     # Select from list, filter as you type (`mysql` would only show the 3 mysql components)
     # OR freeform - doesn't seem to be supported in adaptivecards
-    label: Component Name
-    description: >-
-      Write the short name of the rst file, module, plugin or task below,
-      *use your best guess if unsure*.
-    placeholder: ec2_instance, ec2_security_group
-  validations:
-    required: true
-
-- type: textarea
-  attributes:
-    label: Ansible Version
-    description: >-
-      Paste verbatim output from `ansible --version` between
-      tripple backticks.
-    value: |
-      ```console (paste below)
-      $ ansible --version
-
-      ```
-  validations:
-    required: false
-
-- type: textarea
-  attributes:
-    label: Collection Versions
-    description: >-
-      Paste verbatim output from `ansible-galaxy collection list` between
-      tripple backticks.
-    value: |
-      ```console (paste below)
-      $ ansible-galaxy collection list
-      ```
-  validations:
-    required: false
-
-- type: textarea
-  attributes:
-    label: Configuration
-    description: >-
-      If this issue has an example piece of YAML that can help to reproduce this problem, please provide it.
-      This can be a piece of YAML from, e.g., an automation, script, scene or configuration.
-
-      Paste verbatim output from `ansible-config dump --only-changed` between quotes
-    value: |
-      ```console (paste below)
-      $ ansible-config dump --only-changed
-
-      ```
-  validations:
-    required: false
-
-- type: textarea
-  attributes:
-    label: OS / Environment
-    description: >-
-      Provide all relevant information below, e.g. OS version,
-      browser, etc.
-    placeholder: RHEL 8, Firefox etc.
-  validations:
-    required: false
-
-- type: textarea
-  attributes:
-    label: Additional Information
-    description: |
-      Describe how this improves the documentation, e.g. before/after situation or screenshots.
-
-      **Tip:** It's not possible to upload the screenshot via this field directly but you can use the last textarea in this form to attach them.
-
-      **HINT:** You can paste https://gist.github.com links for larger files.
-    placeholder: >-
-      When the improvement is applied, it makes it more straightforward
-      to understand X.
-  validations:
-    required: false
-
-- type: checkboxes
-  attributes:
-    label: Code of Conduct
-    description: |
-      Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
-    options:
-    - label: I agree to follow the Ansible Code of Conduct
+      label: Component Name
+      description: >-
+        Write the short name of the rst file, module, plugin or task below,
+        *use your best guess if unsure*.
+      placeholder: ec2_instance, ec2_security_group
+    validations:
       required: true
-...
+
+  - type: textarea
+    attributes:
+      label: Ansible Version
+      description: >-
+        Paste verbatim output from `ansible --version` between
+        tripple backticks.
+      value: |
+        ```console (paste below)
+        $ ansible --version
+
+        ```
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Collection Versions
+      description: >-
+        Paste verbatim output from `ansible-galaxy collection list` between
+        tripple backticks.
+      value: |
+        ```console (paste below)
+        $ ansible-galaxy collection list
+        ```
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Configuration
+      description: >-
+        If this issue has an example piece of YAML that can help to reproduce this problem, please provide it.
+        This can be a piece of YAML from, e.g., an automation, script, scene or configuration.
+
+        Paste verbatim output from `ansible-config dump --only-changed` between quotes
+      value: |
+        ```console (paste below)
+        $ ansible-config dump --only-changed
+
+        ```
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: OS / Environment
+      description: >-
+        Provide all relevant information below, e.g. OS version,
+        browser, etc.
+      placeholder: RHEL 8, Firefox etc.
+    validations:
+      required: false
+
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: |
+        Describe how this improves the documentation, e.g. before/after situation or screenshots.
+
+        **Tip:** It's not possible to upload the screenshot via this field directly but you can use the last textarea in this form to attach them.
+
+        **HINT:** You can paste https://gist.github.com links for larger files.
+      placeholder: >-
+        When the improvement is applied, it makes it more straightforward
+        to understand X.
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: |
+        Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
+      options:
+        - label: I agree to follow the Ansible Code of Conduct
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,72 +3,71 @@ name: Feature request
 description: Suggest an idea for this project
 
 body:
-- type: markdown
-  attributes:
-    value: |
-      ⚠
-      Verify first that your issue is not [already reported on GitHub][issue search].
-      Where possible also test if the latest release and main branch are affected too.
-      *Complete **all** sections as described, this form is processed automatically.*
+  - type: markdown
+    attributes:
+      value: |
+        ⚠
+        Verify first that your issue is not [already reported on GitHub][issue search].
+        Where possible also test if the latest release and main branch are affected too.
+        *Complete **all** sections as described, this form is processed automatically.*
 
-      [issue search]: https://github.com/ansible-collections/amazon.aws/search?q=is%3Aissue&type=issues
+        [issue search]: https://github.com/ansible-collections/amazon.aws/search?q=is%3Aissue&type=issues
 
-- type: textarea
-  attributes:
-    label: Summary
-    description: |
-      Describe the new feature/improvement briefly below.
-    placeholder: >-
-      I am trying to do X with the collection from the main branch on GitHub and
-      I think that implementing a feature Y would be very helpful for me and
-      every other user of amazon.aws because of Z.
-  validations:
-    required: true
+  - type: textarea
+    attributes:
+      label: Summary
+      description: |
+        Describe the new feature/improvement briefly below.
+      placeholder: >-
+        I am trying to do X with the collection from the main branch on GitHub and
+        I think that implementing a feature Y would be very helpful for me and
+        every other user of amazon.aws because of Z.
+    validations:
+      required: true
 
-- type: dropdown
-  attributes:
-    label: Issue Type
-    # FIXME: Once GitHub allows defining the default choice, update this
-    options:
-    - Feature Idea
-  validations:
-    required: true
+  - type: dropdown
+    attributes:
+      label: Issue Type
+      # FIXME: Once GitHub allows defining the default choice, update this
+      options:
+        - Feature Idea
+    validations:
+      required: true
 
-- type: textarea
-  attributes:
+  - type: textarea
+    attributes:
     # For smaller collections we could use a multi-select and hardcode the list
     # May generate this list via GitHub action and walking files under https://github.com/ansible-collections/community.general/tree/main/plugins
     # Select from list, filter as you type (`mysql` would only show the 3 mysql components)
     # OR freeform - doesn't seem to be supported in adaptivecards
-    label: Component Name
-    description: >-
-      Write the short name of the module or plugin below,
-      *use your best guess if unsure*.
-    placeholder: ec2_instance, ec2_security_group
-  validations:
-    required: true
-
-- type: textarea
-  attributes:
-    label: Additional Information
-    description: |
-      Describe how the feature would be used, why it is needed and what it would solve.
-
-      **HINT:** You can paste https://gist.github.com links for larger files.
-    value: |
-      <!--- Paste example playbooks or commands between quotes below -->
-      ```yaml (paste below)
-
-      ```
-  validations:
-    required: false
-
-- type: checkboxes
-  attributes:
-    label: Code of Conduct
-    description: |
-      Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
-    options:
-    - label: I agree to follow the Ansible Code of Conduct
+      label: Component Name
+      description: >-
+        Write the short name of the module or plugin below,
+        *use your best guess if unsure*.
+      placeholder: ec2_instance, ec2_security_group
+    validations:
       required: true
-...
+
+  - type: textarea
+    attributes:
+      label: Additional Information
+      description: |
+        Describe how the feature would be used, why it is needed and what it would solve.
+
+        **HINT:** You can paste https://gist.github.com links for larger files.
+      value: |
+        <!--- Paste example playbooks or commands between quotes below -->
+        ```yaml (paste below)
+
+        ```
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: Code of Conduct
+      description: |
+        Read the [Ansible Code of Conduct](https://docs.ansible.com/ansible/latest/community/code_of_conduct.html?utm_medium=github&utm_source=issue_form--ansible-collections) first.
+      options:
+        - label: I agree to follow the Ansible Code of Conduct
+          required: true

--- a/.github/actions/ansible_release_log/action.yml
+++ b/.github/actions/ansible_release_log/action.yml
@@ -1,13 +1,14 @@
-name: "Ansible GitHub Release Logs"
-author: "Mark Chappell (tremble)"
+---
+name: Ansible GitHub Release Logs
+author: Mark Chappell (tremble)
 branding:
-  icon: "git-branch"
-  color: "gray-dark"
-description: "Generate Changelog entries for a GitHub release"
+  icon: git-branch
+  color: gray-dark
+description: Generate Changelog entries for a GitHub release
 
 inputs:
   release:
-    description: "The release version to publish"
+    description: The release version to publish
     required: true
 
 runs:

--- a/.github/actions/ansible_release_tag/action.yml
+++ b/.github/actions/ansible_release_tag/action.yml
@@ -1,24 +1,23 @@
-name: "Ansible GitHub Release"
-author: "Mark Chappell (tremble)"
+---
+name: Ansible GitHub Release
+author: Mark Chappell (tremble)
 branding:
-  icon: "git-branch"
-  color: "gray-dark"
-description: "Publish GitHub releases from an action"
+  icon: git-branch
+  color: gray-dark
+description: Publish GitHub releases from an action
 
 inputs:
   release:
-    description: "The release version to publish"
+    description: The release version to publish
     required: true
 
   collection-name:
-    description: "The name of the collection"
+    description: The name of the collection
     required: true
-
 
 runs:
   using: composite
   steps:
-
     - name: Checkout current ref
       uses: actions/checkout@master
       with:

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,5 +1,6 @@
+---
 # DO NOT MODIFY
 
 # Settings: https://probot.github.io/apps/settings/
 # Pull settings from https://github.com/ansible-collections/.github/blob/master/.github/settings.yml
-_extends: ".github"
+_extends: .github

--- a/.github/workflows/all_green_check.yml
+++ b/.github/workflows/all_green_check.yml
@@ -5,7 +5,7 @@ concurrency:
   group: ${{ github.head_ref }}
   cancel-in-progress: true
 
-on:  # yamllint disable-line rule:truthy
+on: # yamllint disable-line rule:truthy
   pull_request:
     types:
       - opened
@@ -13,17 +13,17 @@ on:  # yamllint disable-line rule:truthy
       - synchronize
     branches:
       - main
-      - 'stable-*'
+      - stable-*
     tags:
-      - '*'
+      - "*"
 
 jobs:
   linters:
-    uses: ./.github/workflows/linters.yml  # use the callable linters job to run tests
+    uses: ./.github/workflows/linters.yml # use the callable linters job to run tests
   sanity:
-    uses: ./.github/workflows/sanity.yml  # use the callable sanity job to run tests
+    uses: ./.github/workflows/sanity.yml # use the callable sanity job to run tests
   units:
-    uses: ./.github/workflows/units.yml  # use the callable units job to run tests
+    uses: ./.github/workflows/units.yml # use the callable units job to run tests
   all_green:
     if: ${{ always() }}
     needs:

--- a/.github/workflows/ansible-bot.yml
+++ b/.github/workflows/ansible-bot.yml
@@ -1,3 +1,4 @@
+---
 name: ansible bot
 on:
   issues:

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -16,7 +16,7 @@ on:
       - main
       - stable-*
     tags:
-      - '*'
+      - "*"
 jobs:
   changelog:
     uses: ansible-network/github_actions/.github/workflows/changelog.yml@main

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -1,3 +1,4 @@
+---
 name: Collection Docs
 concurrency:
   group: docs-${{ github.head_ref }}
@@ -5,7 +6,6 @@ concurrency:
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, closed]
-
 env:
   GHP_BASE_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}
 
@@ -45,7 +45,7 @@ jobs:
       - name: PR comment
         uses: ansible-community/github-docs-build/actions/ansible-docs-build-comment@main
         with:
-          body-includes: '## Docs Build'
+          body-includes: "## Docs Build"
           reactions: heart
           action: ${{ needs.build-docs.outputs.changed != 'true' && 'remove' || '' }}
           on-closed-action: remove

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -1,3 +1,4 @@
+---
 name: Collection Docs
 concurrency:
   group: docs-push-${{ github.sha }}
@@ -8,9 +9,9 @@ on:
       - main
       - stable-*
     tags:
-      - '*'
+      - "*"
   schedule:
-    - cron: '0 12 * * *'
+    - cron: "0 12 * * *"
 
 jobs:
   build-docs:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,11 +1,11 @@
 ---
 name: changelog and linters
 
-on: [workflow_call]  # allow this workflow to be called from other workflows
+on: [workflow_call] # allow this workflow to be called from other workflows
 
 jobs:
   linters:
     uses: ansible-network/github_actions/.github/workflows/tox.yml@main
     with:
       envname: ""
-      labelname: "lint"
+      labelname: lint

--- a/.github/workflows/release-manual.yml
+++ b/.github/workflows/release-manual.yml
@@ -1,3 +1,4 @@
+---
 name: Generate GitHub Release (manual trigger)
 concurrency:
   group: release-${{ github.head_ref }}
@@ -7,7 +8,7 @@ on:
     inputs:
       release:
         required: true
-        description: 'Release to generate'
+        description: Release to generate
         type: string
 
 jobs:

--- a/.github/workflows/release-tag.yml
+++ b/.github/workflows/release-tag.yml
@@ -1,3 +1,4 @@
+---
 name: Generate GitHub Release
 concurrency:
   group: release-${{ github.head_ref }}
@@ -5,7 +6,7 @@ concurrency:
 on:
   push:
     tags:
-      - '*'
+      - "*"
 
 jobs:
   generate-release-log:

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -1,7 +1,7 @@
 ---
 name: sanity tests
 
-on: [workflow_call]  # allow this workflow to be called from other workflows
+on: [workflow_call] # allow this workflow to be called from other workflows
 
 jobs:
   sanity:

--- a/.github/workflows/units.yml
+++ b/.github/workflows/units.yml
@@ -1,7 +1,7 @@
 ---
 name: unit tests
 
-on: [workflow_call]  # allow this workflow to be called from other workflows
+on: [workflow_call] # allow this workflow to be called from other workflows
 
 jobs:
   unit-source:

--- a/.github/workflows/update-variables.yml
+++ b/.github/workflows/update-variables.yml
@@ -2,16 +2,15 @@
 name: update collection variables
 
 concurrency:
-  group: '${{ github.workflow }} @ ${{ github.sha }}'
+  group: ${{ github.workflow }} @ ${{ github.sha }}
   cancel-in-progress: true
 
 on:
   push:
     branches:
       - main
-      - 'stable-*'
+      - stable-*
   pull_request_target:
-
 jobs:
   update-variables:
     uses: ansible-network/github_actions/.github/workflows/update_aws_variables.yml@main

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -1,2580 +1,1958 @@
-ancestor: null
+---
+ancestor:
 releases:
   1.1.0:
     changes:
       breaking_changes:
-      - aws_s3 - can now delete versioned buckets even when they are not empty - set
-        mode to delete to delete a versioned bucket and everything in it.
+        - aws_s3 - can now delete versioned buckets even when they are not empty - set mode to delete to delete a versioned bucket and everything in it.
       bugfixes:
-      - aws_ec2 - fix idempotency when managing tags
-      - aws_ec2 - fix idempotency when metrics are enable
-      - aws_s3 - Delete objects and delete markers so versioned buckets can be removed.
-      - aws_s3 - Try to wait for the bucket to exist before setting the access control
-        list.
-      - cloudformation_info - Fix a KeyError returning information about the stack(s).
-      - ec2_asg - Ensure ``wait`` is honored during replace operations
-      - ec2_launch_template - Update output to include latest_version and default_version,
-        matching the documentation
-      - ec2_transit_gateway - Use AWSRetry before ClientError is handled when describing
-        transit gateways
-      - ec2_transit_gateway - fixed issue where auto_attach set to yes was not being
-        honored (https://github.com/ansible/ansible/issues/61907)
-      - ec2_vol - fix filtering bug
-      - s3_bucket - Accept XNotImplemented response to support NetApp StorageGRID.
+        - aws_ec2 - fix idempotency when managing tags
+        - aws_ec2 - fix idempotency when metrics are enable
+        - aws_s3 - Delete objects and delete markers so versioned buckets can be removed.
+        - aws_s3 - Try to wait for the bucket to exist before setting the access control list.
+        - cloudformation_info - Fix a KeyError returning information about the stack(s).
+        - ec2_asg - Ensure ``wait`` is honored during replace operations
+        - ec2_launch_template - Update output to include latest_version and default_version, matching the documentation
+        - ec2_transit_gateway - Use AWSRetry before ClientError is handled when describing transit gateways
+        - ec2_transit_gateway - fixed issue where auto_attach set to yes was not being honored (https://github.com/ansible/ansible/issues/61907)
+        - ec2_vol - fix filtering bug
+        - s3_bucket - Accept XNotImplemented response to support NetApp StorageGRID.
       deprecated_features:
-      - cloudformation - The ``template_format`` option had no effect since Ansible
-        2.3 and will be removed after 2022-06-01
-      - cloudformation - the ``template_format`` option has been deprecated and will
-        be removed in a later release. It has been ignored by the module since Ansible
-        2.3.
-      - data_pipeline - The ``version`` option had no effect and will be removed in
-        after 2022-06-01
-      - ec2 - in a later release, the ``group`` and ``group_id`` options will become
-        mutually exclusive.  Currently ``group_id`` is ignored if you pass both.
-      - ec2_ami - The ``no_device`` alias ``NoDevice`` has been deprecated  and will
-        be removed after 2022-06-01
-      - ec2_ami - The ``virtual_name`` alias ``VirtualName`` has been deprecated and
-        will be removed after 2022-06-01
-      - ec2_eip - The ``wait_timeout`` option had no effect and will be removed after
-        2022-06-01
-      - ec2_key - The ``wait_timeout`` option had no effect and will be removed after
-        2022-06-01
-      - ec2_key - The ``wait`` option had no effect and will be removed after 2022-06-01
-      - ec2_key - the ``wait_timeout`` option has been deprecated and will be removed
-        in a later release. It has had no effect since Ansible 2.5.
-      - ec2_key - the ``wait`` option has been deprecated and will be removed in a
-        later release. It has had no effect since Ansible 2.5.
-      - ec2_lc - The ``associate_public_ip_address`` option had no effect and will
-        be removed after 2022-06-01
-      - ec2_tag - deprecate the ``list`` option in favor of ec2_tag_info
-      - ec2_tag - support for ``list`` as a state has been deprecated and will be
-        removed in a later release.  The ``ec2_tag_info`` can be used to fetch the
-        tags on an EC2 resource.
+        - cloudformation - The ``template_format`` option had no effect since Ansible 2.3 and will be removed after 2022-06-01
+        - cloudformation - the ``template_format`` option has been deprecated and will be removed in a later release. It has been ignored by the module since Ansible
+          2.3.
+        - data_pipeline - The ``version`` option had no effect and will be removed in after 2022-06-01
+        - ec2 - in a later release, the ``group`` and ``group_id`` options will become mutually exclusive.  Currently ``group_id`` is ignored if you pass both.
+        - ec2_ami - The ``no_device`` alias ``NoDevice`` has been deprecated  and will be removed after 2022-06-01
+        - ec2_ami - The ``virtual_name`` alias ``VirtualName`` has been deprecated and will be removed after 2022-06-01
+        - ec2_eip - The ``wait_timeout`` option had no effect and will be removed after 2022-06-01
+        - ec2_key - The ``wait_timeout`` option had no effect and will be removed after 2022-06-01
+        - ec2_key - The ``wait`` option had no effect and will be removed after 2022-06-01
+        - ec2_key - the ``wait_timeout`` option has been deprecated and will be removed in a later release. It has had no effect since Ansible 2.5.
+        - ec2_key - the ``wait`` option has been deprecated and will be removed in a later release. It has had no effect since Ansible 2.5.
+        - ec2_lc - The ``associate_public_ip_address`` option had no effect and will be removed after 2022-06-01
+        - ec2_tag - deprecate the ``list`` option in favor of ec2_tag_info
+        - ec2_tag - support for ``list`` as a state has been deprecated and will be removed in a later release.  The ``ec2_tag_info`` can be used to fetch the tags
+          on an EC2 resource.
       major_changes:
-      - ec2 module_utils - The ``AWSRetry`` decorator no longer catches ``NotFound``
-        exceptions by default.  ``NotFound`` exceptions need to be explicitly added
-        using ``catch_extra_error_codes``.  Some AWS modules may see an increase in
-        transient failures due to AWS''s eventual consistency model.
+        - ec2 module_utils - The ``AWSRetry`` decorator no longer catches ``NotFound`` exceptions by default.  ``NotFound`` exceptions need to be explicitly added
+          using ``catch_extra_error_codes``.  Some AWS modules may see an increase in transient failures due to AWS''s eventual consistency model.
       minor_changes:
-      - Add ``aws_security_token``, ``aws_endpoint_url`` and ``endpoint_url`` aliases
-        to improve AWS module parameter naming consistency.
-      - Add support for ``aws_ca_bundle`` to boto3 based AWS modules
-      - Add support for configuring boto3 profiles using ``AWS_PROFILE`` and ``AWS_DEFAULT_PROFILE``
-      - Added check_mode support to aws_az_info
-      - Added check_mode support to ec2_eni_info
-      - Added check_mode support to ec2_snapshot_info
-      - ansible_dict_to_boto3_filter_list - convert integers and bools to strings
-        before using them in filters.
-      - aws_direct_connect_virtual_interface - add direct_connect_gateway_id parameter.
-        This field is only applicable in private VIF cases (public=False) and is mutually
-        exclusive to virtual_gateway_id.
-      - cloudformation - Return change_set_id in the cloudformation output if a change
-        set was created.
-      - ec2 - deprecate allowing both group and group_id - currently we ignore group_id
-        if both are passed.
-      - ec2_ami_info - allow integer and bool values for filtering images (https://github.com/ansible/ansible/issues/43570).
-      - ec2_asg - Add support for Max Instance Lifetime
-      - ec2_asg - Add the ability to use mixed_instance_policy in launch template
-        driven autoscaling groups
-      - ec2_asg - Migrated to AnsibleAWSModule
-      - ec2_placement_group - make ``name`` a required field.
-      - ec2_vol_info - Code cleanup and use of the AWSRetry decorator to improve stability
-      - ec2_vpc_net - Enable IPv6 CIDR assignment
+        - Add ``aws_security_token``, ``aws_endpoint_url`` and ``endpoint_url`` aliases to improve AWS module parameter naming consistency.
+        - Add support for ``aws_ca_bundle`` to boto3 based AWS modules
+        - Add support for configuring boto3 profiles using ``AWS_PROFILE`` and ``AWS_DEFAULT_PROFILE``
+        - Added check_mode support to aws_az_info
+        - Added check_mode support to ec2_eni_info
+        - Added check_mode support to ec2_snapshot_info
+        - ansible_dict_to_boto3_filter_list - convert integers and bools to strings before using them in filters.
+        - aws_direct_connect_virtual_interface - add direct_connect_gateway_id parameter. This field is only applicable in private VIF cases (public=False) and is
+          mutually exclusive to virtual_gateway_id.
+        - cloudformation - Return change_set_id in the cloudformation output if a change set was created.
+        - ec2 - deprecate allowing both group and group_id - currently we ignore group_id if both are passed.
+        - ec2_ami_info - allow integer and bool values for filtering images (https://github.com/ansible/ansible/issues/43570).
+        - ec2_asg - Add support for Max Instance Lifetime
+        - ec2_asg - Add the ability to use mixed_instance_policy in launch template driven autoscaling groups
+        - ec2_asg - Migrated to AnsibleAWSModule
+        - ec2_placement_group - make ``name`` a required field.
+        - ec2_vol_info - Code cleanup and use of the AWSRetry decorator to improve stability
+        - ec2_vpc_net - Enable IPv6 CIDR assignment
     fragments:
-    - 107_info_check_mode.yml
-    - 108-ec2_vol-deprecate-list.yml
-    - 27800-ec2_vpc_net-ipv6-support.yml
-    - 28-ec2_ami_info_int_bool_filter.yml
-    - 52_direct_connect_gateway_id.yml
-    - 54435_aws_s3_fix_removing_versioned_buckets.yaml
-    - 61279-ec2_launch_template-output.yml
-    - 61284-ec2_asg-idempotency.yml
-    - 61735-wait-for-s3-bucket-to-exist-before-modifying.yaml
-    - 61933-ec2_transit_gateway-honor-auto_attach-setting.yaml
-    - 62290-fix-cloudformation_info-KeyError.yaml
-    - 63752-cloudformation-return-changeset-id.yaml
-    - 64230-deprecate-unused.yml
-    - 64368-deprecate-unused.yml
-    - 65555-amazon-sanity-required.yml
-    - 65960-ec2_vol-filtering-bugfix.yml
-    - 66840-ec2_tag-deprecate-list.yaml
-    - 66863-ec2_asg-max_instance_lifetime-and-honor-wait-on-replace.yaml
-    - 66966-ec2-group-and-group_id.yml
-    - 66979-ec2_vol_info-ansibleawsmodule.yaml
-    - 67045-ec2_asg_mixed_instance_policy.yml
-    - 67247-fix-ec2_transit_gateway-retries.yaml
-    - 67462-s3_bucket-accept-storagegrid-response.yaml
-    - 93-deprecate-accidental.yml
-    - 99-awsmodule.yml
-    - porting-guide.yml
-    release_date: '2020-08-13'
+      - 107_info_check_mode.yml
+      - 108-ec2_vol-deprecate-list.yml
+      - 27800-ec2_vpc_net-ipv6-support.yml
+      - 28-ec2_ami_info_int_bool_filter.yml
+      - 52_direct_connect_gateway_id.yml
+      - 54435_aws_s3_fix_removing_versioned_buckets.yaml
+      - 61279-ec2_launch_template-output.yml
+      - 61284-ec2_asg-idempotency.yml
+      - 61735-wait-for-s3-bucket-to-exist-before-modifying.yaml
+      - 61933-ec2_transit_gateway-honor-auto_attach-setting.yaml
+      - 62290-fix-cloudformation_info-KeyError.yaml
+      - 63752-cloudformation-return-changeset-id.yaml
+      - 64230-deprecate-unused.yml
+      - 64368-deprecate-unused.yml
+      - 65555-amazon-sanity-required.yml
+      - 65960-ec2_vol-filtering-bugfix.yml
+      - 66840-ec2_tag-deprecate-list.yaml
+      - 66863-ec2_asg-max_instance_lifetime-and-honor-wait-on-replace.yaml
+      - 66966-ec2-group-and-group_id.yml
+      - 66979-ec2_vol_info-ansibleawsmodule.yaml
+      - 67045-ec2_asg_mixed_instance_policy.yml
+      - 67247-fix-ec2_transit_gateway-retries.yaml
+      - 67462-s3_bucket-accept-storagegrid-response.yaml
+      - 93-deprecate-accidental.yml
+      - 99-awsmodule.yml
+      - porting-guide.yml
+    release_date: "2020-08-13"
   1.2.0:
     changes:
       bugfixes:
-      - ec2 module_utils - Ensure boto3 verify parameter isn't overridden by setting
-        a profile (https://github.com/ansible-collections/amazon.aws/issues/129)
-      - 's3_bucket - Ceph compatibility: treat error code NoSuchTagSetError used by
-        Ceph synonymously to NoSuchTagSet used by AWS'
+        - ec2 module_utils - Ensure boto3 verify parameter isn't overridden by setting a profile (https://github.com/ansible-collections/amazon.aws/issues/129)
+        - "s3_bucket - Ceph compatibility: treat error code NoSuchTagSetError used by Ceph synonymously to NoSuchTagSet used by AWS"
       deprecated_features:
-      - All AWS Modules - ``aws_access_key``, ``aws_secret_key`` and ``security_token``
-        will be made mutually exclusive with ``profile`` after 2022-06-01.
+        - All AWS Modules - ``aws_access_key``, ``aws_secret_key`` and ``security_token`` will be made mutually exclusive with ``profile`` after 2022-06-01.
       minor_changes:
-      - ec2 module_utils - Update ``ec2_connect`` (boto2) behaviour so that ``ec2_url``
-        overrides ``region``.
-      - module_utils.core - Support passing arbitrary extra keys to fail_json_aws,
-        matching capabilities of fail_json.
+        - ec2 module_utils - Update ``ec2_connect`` (boto2) behaviour so that ``ec2_url`` overrides ``region``.
+        - module_utils.core - Support passing arbitrary extra keys to fail_json_aws, matching capabilities of fail_json.
     fragments:
-    - 121-ec2_url-resolution-order.yaml
-    - 129-verify_overridden.yml
-    - 140-fail_json_aws_keys.yml
-    - 151-deprecate-profile-credential-combination.yml
-    - 71484-ceph-tag-set-compat.yaml
-    release_date: '2020-08-28'
+      - 121-ec2_url-resolution-order.yaml
+      - 129-verify_overridden.yml
+      - 140-fail_json_aws_keys.yml
+      - 151-deprecate-profile-credential-combination.yml
+      - 71484-ceph-tag-set-compat.yaml
+    release_date: "2020-08-28"
   1.2.1:
     changes:
       minor_changes:
-      - ec2_eni - Add support for tagging.
-      - ec2_eni - Port ec2_eni module to boto3 and add an integration test suite.
-      - ec2_eni_info - Add retries on transient AWS failures.
-      - ec2_eni_info - Add support for providing an ENI ID.
+        - ec2_eni - Add support for tagging.
+        - ec2_eni - Port ec2_eni module to boto3 and add an integration test suite.
+        - ec2_eni_info - Add retries on transient AWS failures.
+        - ec2_eni_info - Add support for providing an ENI ID.
     fragments:
-    - 141-ec2_eni-boto3.yml
-    release_date: '2020-10-07'
+      - 141-ec2_eni-boto3.yml
+    release_date: "2020-10-07"
   1.3.0:
     changes:
       bugfixes:
-      - ec2 - Code fix so module can create ec2 instances with ``ec2_volume_iops``
-        option (https://github.com/ansible-collections/amazon.aws/pull/177).
-      - ec2 - ignore terminated instances and instances that are shutting down when
-        starting and stopping (https://github.com/ansible-collections/amazon.aws/issues/146).
-      - ec2_group - Fixes error handling during tagging failures (https://github.com/ansible-collections/amazon.aws/issues/210).
-      - ec2_group_info - Code fix so module works with Python 3.8 (make dict immutable
-        in loop) (https://github.com/ansible-collections/amazon.aws/pull/181)
+        - ec2 - Code fix so module can create ec2 instances with ``ec2_volume_iops`` option (https://github.com/ansible-collections/amazon.aws/pull/177).
+        - ec2 - ignore terminated instances and instances that are shutting down when starting and stopping (https://github.com/ansible-collections/amazon.aws/issues/146).
+        - ec2_group - Fixes error handling during tagging failures (https://github.com/ansible-collections/amazon.aws/issues/210).
+        - ec2_group_info - Code fix so module works with Python 3.8 (make dict immutable in loop) (https://github.com/ansible-collections/amazon.aws/pull/181)
       minor_changes:
-      - aws_caller_info - add AWSRetry decorator to automatically retry on common
-        temporary failures (https://github.com/ansible-collections/amazon.aws/pull/208)
-      - aws_s3 - Add support for uploading templated content (https://github.com/ansible-collections/amazon.aws/pull/20).
-      - aws_secret - add ``on_missing`` and ``on_denied`` option (https://github.com/ansible-collections/amazon.aws/pull/122).
-      - ec2_ami - Add retries for ratelimiting related errors (https://github.com/ansible-collections/amazon.aws/pull/195).
-      - ec2_ami - fixed and streamlined ``max_attempts`` logic when waiting for AMI
-        creation to finish (https://github.com/ansible-collections/amazon.aws/pull/194).
-      - ec2_ami - increased default ``wait_timeout`` to 1200 seconds (https://github.com/ansible-collections/amazon.aws/pull/194).
-      - ec2_ami_info - Add retries for ratelimiting related errors (https://github.com/ansible-collections/amazon.aws/pull/195).
-      - ec2_eni - Improve reliability of the module by adding waiters and performing
-        lookups by ENI ID rather than repeated searches (https://github.com/ansible-collections/amazon.aws/pull/180).
-      - ec2_eni_info - Improve reliability of the module by adding waiters and performing
-        lookups by ENI ID rather than repeated searches (https://github.com/ansible-collections/amazon.aws/pull/180).
-      - ec2_group - add AWSRetry decorator to automatically retry on common temporary
-        failures (https://github.com/ansible-collections/amazon.aws/pull/207)
-      - ec2_group_info - add AWSRetry decorator to automatically retry on common temporary
-        failures (https://github.com/ansible-collections/amazon.aws/pull/207)
-      - ec2_snapshot_info - add AWSRetry decorator to automatically retry on common
-        temporary failures (https://github.com/ansible-collections/amazon.aws/pull/208)
-      - ec2_vol - Add automatic retries on AWS rate limit errors (https://github.com/ansible-collections/amazon.aws/pull/199).
-      - ec2_vol - ported ec2_vol to use boto3 (https://github.com/ansible-collections/amazon.aws/pull/53).
-      - ec2_vpc_dhcp_option_info - add AWSRetry decorator to automatically retry on
-        common temporary failures (https://github.com/ansible-collections/amazon.aws/pull/208)
-      - module_utils/core - add helper function ``scrub_none_parameters`` to remove
-        params set to ``None`` (https://github.com/ansible-collections/community.aws/issues/251).
-      - module_utils/waiters - Add retries to our waiters for the same failure codes
-        that we retry with AWSRetry (https://github.com/ansible-collections/amazon.aws/pull/185)
-      - s3_bucket - Add support for managing the ``public_access`` settings (https://github.com/ansible-collections/amazon.aws/pull/171).
+        - aws_caller_info - add AWSRetry decorator to automatically retry on common temporary failures (https://github.com/ansible-collections/amazon.aws/pull/208)
+        - aws_s3 - Add support for uploading templated content (https://github.com/ansible-collections/amazon.aws/pull/20).
+        - aws_secret - add ``on_missing`` and ``on_denied`` option (https://github.com/ansible-collections/amazon.aws/pull/122).
+        - ec2_ami - Add retries for ratelimiting related errors (https://github.com/ansible-collections/amazon.aws/pull/195).
+        - ec2_ami - fixed and streamlined ``max_attempts`` logic when waiting for AMI creation to finish (https://github.com/ansible-collections/amazon.aws/pull/194).
+        - ec2_ami - increased default ``wait_timeout`` to 1200 seconds (https://github.com/ansible-collections/amazon.aws/pull/194).
+        - ec2_ami_info - Add retries for ratelimiting related errors (https://github.com/ansible-collections/amazon.aws/pull/195).
+        - ec2_eni - Improve reliability of the module by adding waiters and performing lookups by ENI ID rather than repeated searches (https://github.com/ansible-collections/amazon.aws/pull/180).
+        - ec2_eni_info - Improve reliability of the module by adding waiters and performing lookups by ENI ID rather than repeated searches (https://github.com/ansible-collections/amazon.aws/pull/180).
+        - ec2_group - add AWSRetry decorator to automatically retry on common temporary failures (https://github.com/ansible-collections/amazon.aws/pull/207)
+        - ec2_group_info - add AWSRetry decorator to automatically retry on common temporary failures (https://github.com/ansible-collections/amazon.aws/pull/207)
+        - ec2_snapshot_info - add AWSRetry decorator to automatically retry on common temporary failures (https://github.com/ansible-collections/amazon.aws/pull/208)
+        - ec2_vol - Add automatic retries on AWS rate limit errors (https://github.com/ansible-collections/amazon.aws/pull/199).
+        - ec2_vol - ported ec2_vol to use boto3 (https://github.com/ansible-collections/amazon.aws/pull/53).
+        - ec2_vpc_dhcp_option_info - add AWSRetry decorator to automatically retry on common temporary failures (https://github.com/ansible-collections/amazon.aws/pull/208)
+        - module_utils/core - add helper function ``scrub_none_parameters`` to remove params set to ``None`` (https://github.com/ansible-collections/community.aws/issues/251).
+        - module_utils/waiters - Add retries to our waiters for the same failure codes that we retry with AWSRetry (https://github.com/ansible-collections/amazon.aws/pull/185)
+        - s3_bucket - Add support for managing the ``public_access`` settings (https://github.com/ansible-collections/amazon.aws/pull/171).
     fragments:
-    - 122-aws_secret-add-on_missing-and-on_denied-option.yml
-    - 171-s3_bucket-public_access.yml
-    - 177-fix-ec2-volume-creation-issue-with-iops.yaml
-    - 180-ec2_eni-stabilisation.yml
-    - 181-ec2-group-info-python-fix.yaml
-    - 184-scrub-none-params.yaml
-    - 185-waiter-retry-failures.yml
-    - 194-ec2-ami-max-attempts.yaml
-    - 195-ec2_ami-retries.yml
-    - 197-ignore-terminated-instances.yaml
-    - 199-ec2_vol-retries.yml
-    - 20-aws_s3-content.yml
-    - 207-ec2_group-retries.yml
-    - 208-info-retries.yaml
-    - 211-fix-error-handling-during-tagging-failure.yaml
-    - 53-ec2_vol-boto3-port.yml
-    release_date: '2020-12-10'
+      - 122-aws_secret-add-on_missing-and-on_denied-option.yml
+      - 171-s3_bucket-public_access.yml
+      - 177-fix-ec2-volume-creation-issue-with-iops.yaml
+      - 180-ec2_eni-stabilisation.yml
+      - 181-ec2-group-info-python-fix.yaml
+      - 184-scrub-none-params.yaml
+      - 185-waiter-retry-failures.yml
+      - 194-ec2-ami-max-attempts.yaml
+      - 195-ec2_ami-retries.yml
+      - 197-ignore-terminated-instances.yaml
+      - 199-ec2_vol-retries.yml
+      - 20-aws_s3-content.yml
+      - 207-ec2_group-retries.yml
+      - 208-info-retries.yaml
+      - 211-fix-error-handling-during-tagging-failure.yaml
+      - 53-ec2_vol-boto3-port.yml
+    release_date: "2020-12-10"
   1.4.0:
     changes:
       bugfixes:
-      - ec2_vol - a creation or update now returns a structure with an up to date
-        list of tags (https://github.com/ansible-collections/amazon.aws/pull/241).
+        - ec2_vol - a creation or update now returns a structure with an up to date list of tags (https://github.com/ansible-collections/amazon.aws/pull/241).
       minor_changes:
-      - aws_ec2 - Add hostname options concatenation
-      - aws_ec2 inventory plugin - avoid a superfluous import of ``ansible.utils.display.Display``
-        (https://github.com/ansible-collections/amazon.aws/pull/226).
-      - aws_ec2 module - Replace inverse aws instance-state-name filters !terminated,
-        !shutting-down in favor of postive filters pending, running, stopping, stopped.
-        Issue 235. (https://github.com/ansible-collections/amazon.aws/pull/237)
-      - aws_secret - add ``bypath`` functionality (https://github.com/ansible-collections/amazon.aws/pull/192).
-      - ec2_key - add AWSRetry decorator to automatically retry on common temporary
-        failures (https://github.com/ansible-collections/amazon.aws/pull/213).
-      - ec2_vol - Add support for gp3 volumes and support for modifying existing volumes
-        (https://github.com/ansible-collections/amazon.aws/issues/55).
-      - module_utils/elbv2 - add logic to compare_rules to suit Values list nested
-        within dicts unique to each field type. Fixes issue (https://github.com/ansible-collections/amazon.aws/issues/187)
-      - various AWS plugins and module_utils - Cleanup unused imports (https://github.com/ansible-collections/amazon.aws/pull/217).
+        - aws_ec2 - Add hostname options concatenation
+        - aws_ec2 inventory plugin - avoid a superfluous import of ``ansible.utils.display.Display`` (https://github.com/ansible-collections/amazon.aws/pull/226).
+        - aws_ec2 module - Replace inverse aws instance-state-name filters !terminated, !shutting-down in favor of postive filters pending, running, stopping, stopped.
+          Issue 235. (https://github.com/ansible-collections/amazon.aws/pull/237)
+        - aws_secret - add ``bypath`` functionality (https://github.com/ansible-collections/amazon.aws/pull/192).
+        - ec2_key - add AWSRetry decorator to automatically retry on common temporary failures (https://github.com/ansible-collections/amazon.aws/pull/213).
+        - ec2_vol - Add support for gp3 volumes and support for modifying existing volumes (https://github.com/ansible-collections/amazon.aws/issues/55).
+        - module_utils/elbv2 - add logic to compare_rules to suit Values list nested within dicts unique to each field type. Fixes issue (https://github.com/ansible-collections/amazon.aws/issues/187)
+        - various AWS plugins and module_utils - Cleanup unused imports (https://github.com/ansible-collections/amazon.aws/pull/217).
     fragments:
-    - 188-httprequestmethodconfig-keyerror.yaml
-    - 192-aws_secret-bypath-option.yaml
-    - 213-ec2_key-retries.yml
-    - 215-gp3-and-change-support-for-ec2_vol.yaml
-    - 217-duplicate-imports.yml
-    - 226_avoid_extra_Display_import.yaml
-    - 237_replace_inverse_ec2_aws_filter.yaml
-    - 241_ec2_vol-returns-an-up-to-date-tag-dict-of-the-volume.yaml
-    - 25-aws_ec2-hostname-options-concatenation.yaml
-    release_date: '2021-02-05'
+      - 188-httprequestmethodconfig-keyerror.yaml
+      - 192-aws_secret-bypath-option.yaml
+      - 213-ec2_key-retries.yml
+      - 215-gp3-and-change-support-for-ec2_vol.yaml
+      - 217-duplicate-imports.yml
+      - 226_avoid_extra_Display_import.yaml
+      - 237_replace_inverse_ec2_aws_filter.yaml
+      - 241_ec2_vol-returns-an-up-to-date-tag-dict-of-the-volume.yaml
+      - 25-aws_ec2-hostname-options-concatenation.yaml
+    release_date: "2021-02-05"
   1.4.1:
     changes:
       minor_changes:
-      - module_utils - the ipaddress module utility has been vendored into this collection.  This
-        eliminates the collection dependency on ansible.netcommon (which had removed
-        the library in its 2.0 release).  The ipaddress library is provided for internal
-        use in this collection only. (https://github.com/ansible-collections/amazon.aws/issues/273)-
+        - module_utils - the ipaddress module utility has been vendored into this collection.  This eliminates the collection dependency on ansible.netcommon (which
+          had removed the library in its 2.0 release).  The ipaddress library is provided for internal use in this collection only. (https://github.com/ansible-collections/amazon.aws/issues/273)-
     fragments:
-    - 273-vendor-ipaddress-utility.yml
-    release_date: '2021-03-05'
+      - 273-vendor-ipaddress-utility.yml
+    release_date: "2021-03-05"
   1.5.0:
     changes:
       bugfixes:
-      - ec2_vol - create or update now preserves the existing tags, including Name
-        (https://github.com/ansible-collections/amazon.aws/issues/229)
-      - ec2_vol - fix exception when platform information isn't available (https://github.com/ansible-collections/amazon.aws/issues/305).
+        - ec2_vol - create or update now preserves the existing tags, including Name (https://github.com/ansible-collections/amazon.aws/issues/229)
+        - ec2_vol - fix exception when platform information isn't available (https://github.com/ansible-collections/amazon.aws/issues/305).
       minor_changes:
-      - AWS inventory plugins - use shared HAS_BOTO3 helper rather than copying code
-        (https://github.com/ansible-collections/amazon.aws/pull/288).
-      - AWS lookup plugins - use shared HAS_BOTO3 helper rather than copying code
-        (https://github.com/ansible-collections/amazon.aws/pull/288).
-      - aws_account_attribute - add retries on common AWS failures (https://github.com/ansible-collections/amazon.aws/pull/295).
-      - aws_ec2 inventory - expose a new configuration key ``use_contrib_script_compatible_ec2_tag_keys``
-        to reproduce a behavior of the old ``ec2.py`` inventory script. With this
-        option enabled, each tag is exposed using a ``ec2_tag_TAGNAME`` key (https://github.com/ansible-collections/amazon.aws/pull/331).
-      - aws_ec2 inventory - expose to new keys called ``include_filters`` and ``exclude_filters``
-        to give the user the ability to compose an inventory with multiple queries
-        (https://github.com/ansible-collections/amazon.aws/pull/328).
-      - aws_ec2 inventory plugin - Added support for using Jinja2 templates in the
-        authentication fields (https://github.com/ansible-collections/amazon.aws/pull/57).
-      - cloudformation - added support for StackPolicyDuringUpdateBody (https://github.com/ansible-collections/amazon.aws/pull/155).
-      - ec2_metadata_facts - add support for IMDSv2 (https://github.com/ansible-collections/amazon.aws/pull/43).
-      - ec2_snapshot_info - add the ``max_results`` along with ``next_token_id`` option
-        (https://github.com/ansible-collections/amazon.aws/pull/321).
-      - ec2_tag - use common code for tagging resources (https://github.com/ansible-collections/amazon.aws/pull/309).
-      - ec2_tag_info - use common code for tagging resources (https://github.com/ansible-collections/amazon.aws/pull/309).
-      - ec2_vol - add the ``purge_tags`` option (https://github.com/ansible-collections/amazon.aws/pull/242).
-      - ec2_vol - use common code for tagging resources (https://github.com/ansible-collections/amazon.aws/pull/309).
-      - ec2_vpc_net - use a custom waiter which can handle API rate limiting (https://github.com/ansible-collections/amazon.aws/pull/270).
-      - ec2_vpc_subnet - use AWSRetry decorator to more consistently handle API rate
-        limiting (https://github.com/ansible-collections/amazon.aws/pull/270).
-      - ec2_vpc_subnet - use common code for tagging resources (https://github.com/ansible-collections/amazon.aws/pull/309).
-      - module_utils.cloudfront_facts - linting cleanup (https://github.com/ansible-collections/amazon.aws/pull/291).
-      - module_utils.ec2 - linting cleanup (https://github.com/ansible-collections/amazon.aws/pull/291).
-      - module_utils/core - add a helper function ``normalize_boto3_result`` (https://github.com/ansible-collections/amazon.aws/pull/271).
-      - module_utils/core - add parameter ``descend_into_lists`` to ``scrub_none_parameters``
-        helper function (https://github.com/ansible-collections/amazon.aws/pull/262).
-      - module_utils/ec2 - added additional helper functions for tagging EC2 resources
-        (https://github.com/ansible-collections/amazon.aws/pull/309).
-      - sanity tests - add ignore.txt for 2.12 (https://github.com/ansible-collections/amazon.aws/pull/315).
+        - AWS inventory plugins - use shared HAS_BOTO3 helper rather than copying code (https://github.com/ansible-collections/amazon.aws/pull/288).
+        - AWS lookup plugins - use shared HAS_BOTO3 helper rather than copying code (https://github.com/ansible-collections/amazon.aws/pull/288).
+        - aws_account_attribute - add retries on common AWS failures (https://github.com/ansible-collections/amazon.aws/pull/295).
+        - aws_ec2 inventory - expose a new configuration key ``use_contrib_script_compatible_ec2_tag_keys`` to reproduce a behavior of the old ``ec2.py`` inventory
+          script. With this option enabled, each tag is exposed using a ``ec2_tag_TAGNAME`` key (https://github.com/ansible-collections/amazon.aws/pull/331).
+        - aws_ec2 inventory - expose to new keys called ``include_filters`` and ``exclude_filters`` to give the user the ability to compose an inventory with multiple
+          queries (https://github.com/ansible-collections/amazon.aws/pull/328).
+        - aws_ec2 inventory plugin - Added support for using Jinja2 templates in the authentication fields (https://github.com/ansible-collections/amazon.aws/pull/57).
+        - cloudformation - added support for StackPolicyDuringUpdateBody (https://github.com/ansible-collections/amazon.aws/pull/155).
+        - ec2_metadata_facts - add support for IMDSv2 (https://github.com/ansible-collections/amazon.aws/pull/43).
+        - ec2_snapshot_info - add the ``max_results`` along with ``next_token_id`` option (https://github.com/ansible-collections/amazon.aws/pull/321).
+        - ec2_tag - use common code for tagging resources (https://github.com/ansible-collections/amazon.aws/pull/309).
+        - ec2_tag_info - use common code for tagging resources (https://github.com/ansible-collections/amazon.aws/pull/309).
+        - ec2_vol - add the ``purge_tags`` option (https://github.com/ansible-collections/amazon.aws/pull/242).
+        - ec2_vol - use common code for tagging resources (https://github.com/ansible-collections/amazon.aws/pull/309).
+        - ec2_vpc_net - use a custom waiter which can handle API rate limiting (https://github.com/ansible-collections/amazon.aws/pull/270).
+        - ec2_vpc_subnet - use AWSRetry decorator to more consistently handle API rate limiting (https://github.com/ansible-collections/amazon.aws/pull/270).
+        - ec2_vpc_subnet - use common code for tagging resources (https://github.com/ansible-collections/amazon.aws/pull/309).
+        - module_utils.cloudfront_facts - linting cleanup (https://github.com/ansible-collections/amazon.aws/pull/291).
+        - module_utils.ec2 - linting cleanup (https://github.com/ansible-collections/amazon.aws/pull/291).
+        - module_utils/core - add a helper function ``normalize_boto3_result`` (https://github.com/ansible-collections/amazon.aws/pull/271).
+        - module_utils/core - add parameter ``descend_into_lists`` to ``scrub_none_parameters`` helper function (https://github.com/ansible-collections/amazon.aws/pull/262).
+        - module_utils/ec2 - added additional helper functions for tagging EC2 resources (https://github.com/ansible-collections/amazon.aws/pull/309).
+        - sanity tests - add ignore.txt for 2.12 (https://github.com/ansible-collections/amazon.aws/pull/315).
     fragments:
-    - 155-support-for-StackPolicyDuringUpdateBody.yaml
-    - 241_ec2_vol-add_purge_tags_parameter.yaml
-    - 242_ec2_vol-preset-the-name-tag-of-the-volume.yaml
-    - 261-scrub-params-descend-into-lists.yml
-    - 270-vpc-waiters.yaml
-    - 271-normalize_boto3_result.yml
-    - 288-has_boto3.yml
-    - 291-lint-cleanup.yml
-    - 295-aws_account_attribute-awsretry.yml
-    - 305-ec2_vol-no-platform.yml
-    - 309-ec2_tags.yml
-    - 321-ec2_snapshot_info-add_max_results_and_next_token_parameters.yaml
-    - 328_aws_ec2_inventory_includes_entries_matching.yaml
-    - 331_aws_ec2_inventory_use_contrib_script_compatible_ec2_tag_keys.yaml
-    - 43-ec2_metadata_facts-IMDSv2.yml
-    - 57-aws_ec2-support-for-templates.yml
-    - ignore_212.yml
-    release_date: '2021-04-27'
+      - 155-support-for-StackPolicyDuringUpdateBody.yaml
+      - 241_ec2_vol-add_purge_tags_parameter.yaml
+      - 242_ec2_vol-preset-the-name-tag-of-the-volume.yaml
+      - 261-scrub-params-descend-into-lists.yml
+      - 270-vpc-waiters.yaml
+      - 271-normalize_boto3_result.yml
+      - 288-has_boto3.yml
+      - 291-lint-cleanup.yml
+      - 295-aws_account_attribute-awsretry.yml
+      - 305-ec2_vol-no-platform.yml
+      - 309-ec2_tags.yml
+      - 321-ec2_snapshot_info-add_max_results_and_next_token_parameters.yaml
+      - 328_aws_ec2_inventory_includes_entries_matching.yaml
+      - 331_aws_ec2_inventory_use_contrib_script_compatible_ec2_tag_keys.yaml
+      - 43-ec2_metadata_facts-IMDSv2.yml
+      - 57-aws_ec2-support-for-templates.yml
+      - ignore_212.yml
+    release_date: "2021-04-27"
   1.5.1:
     changes:
       bugfixes:
-      - ec2_vol - Fixes ``changed`` status when ``modify_volume`` is used, but no
-        new  disk is being attached.  The module incorrectly reported that no change
-        had  occurred even when disks had been modified (iops, throughput, type, etc.).
-        (https://github.com/ansible-collections/amazon.aws/issues/482).
-      - ec2_vol - fix iops setting and enforce iops/throughput parameters usage (https://github.com/ansible-collections/amazon.aws/pull/334)
+        - ec2_vol - Fixes ``changed`` status when ``modify_volume`` is used, but no new  disk is being attached.  The module incorrectly reported that no change had  occurred
+          even when disks had been modified (iops, throughput, type, etc.). (https://github.com/ansible-collections/amazon.aws/issues/482).
+        - ec2_vol - fix iops setting and enforce iops/throughput parameters usage (https://github.com/ansible-collections/amazon.aws/pull/334)
       minor_changes:
-      - ec2_instance - remove unnecessary raise when exiting with a failure (https://github.com/ansible-collections/amazon.aws/pull/460).
+        - ec2_instance - remove unnecessary raise when exiting with a failure (https://github.com/ansible-collections/amazon.aws/pull/460).
     fragments:
-    - 334-ec2_vol-iops-and-throughput-issues.yaml
-    - 460-pylint.yml
-    - 486-ec2_vol_fixed_returned_changed_var.yml
-    release_date: '2021-09-09'
+      - 334-ec2_vol-iops-and-throughput-issues.yaml
+      - 460-pylint.yml
+      - 486-ec2_vol_fixed_returned_changed_var.yml
+    release_date: "2021-09-09"
   2.0.0:
     changes:
       breaking_changes:
-      - 'ec2_instance - instance wait for state behaviour has changed.  If plays require
-        the old behavior of waiting for the instance monitoring status to become ``OK``
-        when launching a new instance, the action will need to specify ``state: started``
-        (https://github.com/ansible-collections/amazon.aws/pull/481).'
-      - ec2_snapshot - support for waiting indefinitely has been dropped, new default
-        is 10 minutes (https://github.com/ansible-collections/amazon.aws/pull/356).
-      - ec2_vol_info - return ``attachment_set`` is now a list of attachments with
-        Multi-Attach support on disk. (https://github.com/ansible-collections/amazon.aws/pull/362).
-      - ec2_vpc_dhcp_option - The module has been refactored to use boto3. Keys and
-        value types returned by the module are now consistent, which is a change from
-        the previous behaviour. A ``purge_tags`` option has been added, which defaults
-        to ``True``.  (https://github.com/ansible-collections/amazon.aws/pull/252)
-      - ec2_vpc_dhcp_option_info - Now preserves case for tag keys in return value.
-        (https://github.com/ansible-collections/amazon.aws/pull/252)
-      - module_utils.core - The boto3 switch has been removed from the region parameter
-        (https://github.com/ansible-collections/amazon.aws/pull/287).
-      - module_utils/compat - vendored copy of ipaddress removed (https://github.com/ansible-collections/amazon.aws/pull/461).
-      - module_utils/core - updated the ``scrub_none_parameters`` function so that
-        ``descend_into_lists`` is set to ``True`` by default (https://github.com/ansible-collections/amazon.aws/pull/297).
+        - "ec2_instance - instance wait for state behaviour has changed.  If plays require the old behavior of waiting for the instance monitoring status to become
+          ``OK`` when launching a new instance, the action will need to specify ``state: started`` (https://github.com/ansible-collections/amazon.aws/pull/481)."
+        - ec2_snapshot - support for waiting indefinitely has been dropped, new default is 10 minutes (https://github.com/ansible-collections/amazon.aws/pull/356).
+        - ec2_vol_info - return ``attachment_set`` is now a list of attachments with Multi-Attach support on disk. (https://github.com/ansible-collections/amazon.aws/pull/362).
+        - ec2_vpc_dhcp_option - The module has been refactored to use boto3. Keys and value types returned by the module are now consistent, which is a change from
+          the previous behaviour. A ``purge_tags`` option has been added, which defaults to ``True``.  (https://github.com/ansible-collections/amazon.aws/pull/252)
+        - ec2_vpc_dhcp_option_info - Now preserves case for tag keys in return value. (https://github.com/ansible-collections/amazon.aws/pull/252)
+        - module_utils.core - The boto3 switch has been removed from the region parameter (https://github.com/ansible-collections/amazon.aws/pull/287).
+        - module_utils/compat - vendored copy of ipaddress removed (https://github.com/ansible-collections/amazon.aws/pull/461).
+        - module_utils/core - updated the ``scrub_none_parameters`` function so that ``descend_into_lists`` is set to ``True`` by default (https://github.com/ansible-collections/amazon.aws/pull/297).
       bugfixes:
-      - aws_s3 - Fix upload permission when an S3 bucket ACL policy requires a particular
-        canned ACL (https://github.com/ansible-collections/amazon.aws/pull/318)
-      - ec2_ami - Fix ami issue when creating an ami with no_device parameter (https://github.com/ansible-collections/amazon.aws/pull/386)
-      - ec2_instance - ``ec2_instance`` was waiting on EC2 instance monitoring status
-        to be ``OK`` when launching a new instance. This could cause a play to wait
-        multiple minutes for AWS's monitoring to complete status checks (https://github.com/ansible-collections/amazon.aws/pull/481).
-      - ec2_snapshot - Fix snapshot issue when capturing a snapshot of a volume without
-        tags (https://github.com/ansible-collections/amazon.aws/pull/383)
-      - ec2_vol - Fixes ``changed`` status when ``modify_volume`` is used, but no
-        new  disk is being attached.  The module incorrectly reported that no change
-        had  occurred even when disks had been modified (iops, throughput, type, etc.).
-        (https://github.com/ansible-collections/amazon.aws/issues/482).
-      - ec2_vol - fix iops setting and enforce iops/throughput parameters usage (https://github.com/ansible-collections/amazon.aws/pull/334)
-      - inventory - ``include_filters`` won't be ignored anymore if ``filters`` is
-        not set (https://github.com/ansible-collections/amazon.aws/issues/457).
-      - s3_bucket - Fix error handling when attempting to set a feature that is not
-        implemented (https://github.com/ansible-collections/amazon.aws/pull/391).
-      - s3_bucket - Gracefully handle ``NotImplemented`` exceptions when fetching
-        encryption settings (https://github.com/ansible-collections/amazon.aws/issues/390).
+        - aws_s3 - Fix upload permission when an S3 bucket ACL policy requires a particular canned ACL (https://github.com/ansible-collections/amazon.aws/pull/318)
+        - ec2_ami - Fix ami issue when creating an ami with no_device parameter (https://github.com/ansible-collections/amazon.aws/pull/386)
+        - ec2_instance - ``ec2_instance`` was waiting on EC2 instance monitoring status to be ``OK`` when launching a new instance. This could cause a play to wait
+          multiple minutes for AWS's monitoring to complete status checks (https://github.com/ansible-collections/amazon.aws/pull/481).
+        - ec2_snapshot - Fix snapshot issue when capturing a snapshot of a volume without tags (https://github.com/ansible-collections/amazon.aws/pull/383)
+        - ec2_vol - Fixes ``changed`` status when ``modify_volume`` is used, but no new  disk is being attached.  The module incorrectly reported that no change had  occurred
+          even when disks had been modified (iops, throughput, type, etc.). (https://github.com/ansible-collections/amazon.aws/issues/482).
+        - ec2_vol - fix iops setting and enforce iops/throughput parameters usage (https://github.com/ansible-collections/amazon.aws/pull/334)
+        - inventory - ``include_filters`` won't be ignored anymore if ``filters`` is not set (https://github.com/ansible-collections/amazon.aws/issues/457).
+        - s3_bucket - Fix error handling when attempting to set a feature that is not implemented (https://github.com/ansible-collections/amazon.aws/pull/391).
+        - s3_bucket - Gracefully handle ``NotImplemented`` exceptions when fetching encryption settings (https://github.com/ansible-collections/amazon.aws/issues/390).
       deprecated_features:
-      - ec2 - the boto based ``ec2`` module has been deprecated in favour of the boto3
-        based ``ec2_instance`` module. The ``ec2`` module will be removed in release
-        4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/424).
-      - ec2_vpc_dhcp_option - The ``new_config`` return key has been deprecated and
-        will be removed in a future release.  It will be replaced by ``dhcp_config``.  Both
-        values are returned in the interim. (https://github.com/ansible-collections/amazon.aws/pull/252)
+        - ec2 - the boto based ``ec2`` module has been deprecated in favour of the boto3 based ``ec2_instance`` module. The ``ec2`` module will be removed in release
+          4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/424).
+        - ec2_vpc_dhcp_option - The ``new_config`` return key has been deprecated and will be removed in a future release.  It will be replaced by ``dhcp_config``.  Both
+          values are returned in the interim. (https://github.com/ansible-collections/amazon.aws/pull/252)
       major_changes:
-      - amazon.aws collection - Due to the AWS SDKs announcing the end of support
-        for Python less than 3.6 (https://boto3.amazonaws.com/v1/documentation/api/1.17.64/guide/migrationpy3.html)
-        this collection now requires Python 3.6+ (https://github.com/ansible-collections/amazon.aws/pull/298).
-      - amazon.aws collection - The amazon.aws collection has dropped support for
-        ``botocore<1.18.0`` and ``boto3<1.15.0``. Most modules will continue to work
-        with older versions of the AWS SDK, however compatibility with older versions
-        of the SDK is not guaranteed and will not be tested. When using older versions
-        of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/502).
-      - ec2_instance - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.ec2_instance``.
-      - ec2_instance_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.ec2_instance_info``.
-      - ec2_vpc_endpoint - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.ec2_vpc_endpoint``.
-      - ec2_vpc_endpoint_facts - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.ec2_vpc_endpoint_info``.
-      - ec2_vpc_endpoint_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.ec2_vpc_endpoint_info``.
-      - ec2_vpc_endpoint_service_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.ec2_vpc_endpoint_service_info``.
-      - ec2_vpc_igw - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.ec2_vpc_igw``.
-      - ec2_vpc_igw_facts - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.ec2_vpc_igw_facts``.
-      - ec2_vpc_igw_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.ec2_vpc_igw_info``.
-      - ec2_vpc_nat_gateway - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.ec2_vpc_nat_gateway``.
-      - ec2_vpc_nat_gateway_facts - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.ec2_vpc_nat_gateway_info``.
-      - ec2_vpc_nat_gateway_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.ec2_vpc_nat_gateway_info``.
-      - ec2_vpc_route_table - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.ec2_vpc_route_table``.
-      - ec2_vpc_route_table_facts - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.ec2_vpc_route_table_facts``.
-      - ec2_vpc_route_table_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.ec2_vpc_route_table_info``.
+        - amazon.aws collection - Due to the AWS SDKs announcing the end of support for Python less than 3.6 (https://boto3.amazonaws.com/v1/documentation/api/1.17.64/guide/migrationpy3.html)
+          this collection now requires Python 3.6+ (https://github.com/ansible-collections/amazon.aws/pull/298).
+        - amazon.aws collection - The amazon.aws collection has dropped support for ``botocore<1.18.0`` and ``boto3<1.15.0``. Most modules will continue to work with
+          older versions of the AWS SDK, however compatibility with older versions of the SDK is not guaranteed and will not be tested. When using older versions
+          of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/502).
+        - ec2_instance - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.ec2_instance``.
+        - ec2_instance_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.ec2_instance_info``.
+        - ec2_vpc_endpoint - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.ec2_vpc_endpoint``.
+        - ec2_vpc_endpoint_facts - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this
+          module should be updated to use ``amazon.aws.ec2_vpc_endpoint_info``.
+        - ec2_vpc_endpoint_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this
+          module should be updated to use ``amazon.aws.ec2_vpc_endpoint_info``.
+        - ec2_vpc_endpoint_service_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name
+          for this module should be updated to use ``amazon.aws.ec2_vpc_endpoint_service_info``.
+        - ec2_vpc_igw - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.ec2_vpc_igw``.
+        - ec2_vpc_igw_facts - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.ec2_vpc_igw_facts``.
+        - ec2_vpc_igw_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.ec2_vpc_igw_info``.
+        - ec2_vpc_nat_gateway - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.ec2_vpc_nat_gateway``.
+        - ec2_vpc_nat_gateway_facts - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for
+          this module should be updated to use ``amazon.aws.ec2_vpc_nat_gateway_info``.
+        - ec2_vpc_nat_gateway_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this
+          module should be updated to use ``amazon.aws.ec2_vpc_nat_gateway_info``.
+        - ec2_vpc_route_table - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.ec2_vpc_route_table``.
+        - ec2_vpc_route_table_facts - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for
+          this module should be updated to use ``amazon.aws.ec2_vpc_route_table_facts``.
+        - ec2_vpc_route_table_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this
+          module should be updated to use ``amazon.aws.ec2_vpc_route_table_info``.
       minor_changes:
-      - aws_ec2 - use a generator rather than list comprehension (https://github.com/ansible-collections/amazon.aws/pull/465).
-      - aws_s3 - Tests for compatibility with older versions of the AWS SDKs have
-        been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - aws_s3 - Tests for compatibility with older versions of the AWS SDKs have
-        been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - aws_s3 - add ``tags`` and ``purge_tags`` features for an S3 object (https://github.com/ansible-collections/amazon.aws/pull/335)
-      - aws_s3 - new mode to copy existing on another bucket (https://github.com/ansible-collections/amazon.aws/pull/359).
-      - aws_secret - added support for gracefully handling deleted secrets (https://github.com/ansible-collections/amazon.aws/pull/455).
-      - aws_ssm - add ``on_missing`` and ``on_denied`` option (https://github.com/ansible-collections/amazon.aws/pull/370).
-      - cloudformation - Tests for compatibility with older versions of the AWS SDKs
-        have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - cloudformation - Tests for compatibility with older versions of the AWS SDKs
-        have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - ec2_ami - ensure tags are propagated to the snapshot(s) when creating an AMI
-        (https://github.com/ansible-collections/amazon.aws/pull/437).
-      - ec2_eni - fix idempotency when ``security_groups`` attribute is specified
-        (https://github.com/ansible-collections/amazon.aws/pull/337).
-      - ec2_eni - timeout increased when waiting for ENIs to finish detaching (https://github.com/ansible-collections/amazon.aws/pull/501).
-      - ec2_group - Tests for compatibility with older versions of the AWS SDKs have
-        been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - ec2_group - Tests for compatibility with older versions of the AWS SDKs have
-        been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - ec2_group - use a generator rather than list comprehension (https://github.com/ansible-collections/amazon.aws/pull/465).
-      - ec2_group - use system ipaddress module, available with Python >= 3.3, instead
-        of vendored copy (https://github.com/ansible-collections/amazon.aws/pull/461).
-      - ec2_instance - Tests for compatibility with older versions of the AWS SDKs
-        have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - ec2_instance - Tests for compatibility with older versions of the AWS SDKs
-        have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - ec2_instance - add ``throughput`` parameter for gp3 volume types (https://github.com/ansible-collections/amazon.aws/pull/433).
-      - ec2_instance - add support for controlling metadata options (https://github.com/ansible-collections/amazon.aws/pull/414).
-      - ec2_instance - remove unnecessary raise when exiting with a failure (https://github.com/ansible-collections/amazon.aws/pull/460).
-      - ec2_instance_info - Tests for compatibility with older versions of the AWS
-        SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - ec2_instance_info - Tests for compatibility with older versions of the AWS
-        SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - ec2_snapshot - migrated to use the boto3 python library (https://github.com/ansible-collections/amazon.aws/pull/356).
-      - ec2_spot_instance_info - Added a new module that describes the specified Spot
-        Instance requests (https://github.com/ansible-collections/amazon.aws/pull/487).
-      - ec2_vol - add parameter ``multi_attach`` to support Multi-Attach on volume
-        creation/update (https://github.com/ansible-collections/amazon.aws/pull/362).
-      - ec2_vol - relax the boto3/botocore requirements and only require botocore
-        1.19.27 for modifying the ``throughput`` parameter (https://github.com/ansible-collections/amazon.aws/pull/346).
-      - ec2_vpc_dhcp_option - Now also returns a boto3-style resource description
-        in the ``dhcp_options`` result key.  This includes any tags for the ``dhcp_options_id``
-        and has the same format as the current return value of ``ec2_vpc_dhcp_option_info``.
-        (https://github.com/ansible-collections/amazon.aws/pull/252)
-      - ec2_vpc_dhcp_option_info - Now also returns a user-friendly ``dhcp_config``
-        key that matches the historical ``new_config`` key from ec2_vpc_dhcp_option,
-        and alleviates the need to use ``items2dict(key_name='key', value_name='values')``
-        when parsing the output of the module. (https://github.com/ansible-collections/amazon.aws/pull/252)
-      - ec2_vpc_subnet - Tests for compatibility with older versions of the AWS SDKs
-        have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - ec2_vpc_subnet - Tests for compatibility with older versions of the AWS SDKs
-        have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - integration tests - remove dependency with collection ``community.general``
-        (https://github.com/ansible-collections/amazon.aws/pull/361).
-      - module_utils/waiter - add RDS cluster ``cluster_available`` waiter (https://github.com/ansible-collections/amazon.aws/pull/464).
-      - module_utils/waiter - add RDS cluster ``cluster_deleted`` waiter (https://github.com/ansible-collections/amazon.aws/pull/464).
-      - module_utils/waiter - add Route53 ``resource_record_sets_changed`` waiter
-        (https://github.com/ansible-collections/amazon.aws/pull/350).
-      - s3_bucket - Tests for compatibility with older versions of the AWS SDKs have
-        been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - s3_bucket - Tests for compatibility with older versions of the AWS SDKs have
-        been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
-      - s3_bucket - add new option ``object_ownership`` to configure object ownership
-        (https://github.com/ansible-collections/amazon.aws/pull/311)
-      - s3_bucket - updated to use HeadBucket instead of ListBucket when testing for
-        bucket existence (https://github.com/ansible-collections/amazon.aws/pull/357).
+        - aws_ec2 - use a generator rather than list comprehension (https://github.com/ansible-collections/amazon.aws/pull/465).
+        - aws_s3 - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - aws_s3 - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - aws_s3 - add ``tags`` and ``purge_tags`` features for an S3 object (https://github.com/ansible-collections/amazon.aws/pull/335)
+        - aws_s3 - new mode to copy existing on another bucket (https://github.com/ansible-collections/amazon.aws/pull/359).
+        - aws_secret - added support for gracefully handling deleted secrets (https://github.com/ansible-collections/amazon.aws/pull/455).
+        - aws_ssm - add ``on_missing`` and ``on_denied`` option (https://github.com/ansible-collections/amazon.aws/pull/370).
+        - cloudformation - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - cloudformation - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - ec2_ami - ensure tags are propagated to the snapshot(s) when creating an AMI (https://github.com/ansible-collections/amazon.aws/pull/437).
+        - ec2_eni - fix idempotency when ``security_groups`` attribute is specified (https://github.com/ansible-collections/amazon.aws/pull/337).
+        - ec2_eni - timeout increased when waiting for ENIs to finish detaching (https://github.com/ansible-collections/amazon.aws/pull/501).
+        - ec2_group - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - ec2_group - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - ec2_group - use a generator rather than list comprehension (https://github.com/ansible-collections/amazon.aws/pull/465).
+        - ec2_group - use system ipaddress module, available with Python >= 3.3, instead of vendored copy (https://github.com/ansible-collections/amazon.aws/pull/461).
+        - ec2_instance - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - ec2_instance - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - ec2_instance - add ``throughput`` parameter for gp3 volume types (https://github.com/ansible-collections/amazon.aws/pull/433).
+        - ec2_instance - add support for controlling metadata options (https://github.com/ansible-collections/amazon.aws/pull/414).
+        - ec2_instance - remove unnecessary raise when exiting with a failure (https://github.com/ansible-collections/amazon.aws/pull/460).
+        - ec2_instance_info - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - ec2_instance_info - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - ec2_snapshot - migrated to use the boto3 python library (https://github.com/ansible-collections/amazon.aws/pull/356).
+        - ec2_spot_instance_info - Added a new module that describes the specified Spot Instance requests (https://github.com/ansible-collections/amazon.aws/pull/487).
+        - ec2_vol - add parameter ``multi_attach`` to support Multi-Attach on volume creation/update (https://github.com/ansible-collections/amazon.aws/pull/362).
+        - ec2_vol - relax the boto3/botocore requirements and only require botocore 1.19.27 for modifying the ``throughput`` parameter (https://github.com/ansible-collections/amazon.aws/pull/346).
+        - ec2_vpc_dhcp_option - Now also returns a boto3-style resource description in the ``dhcp_options`` result key.  This includes any tags for the ``dhcp_options_id``
+          and has the same format as the current return value of ``ec2_vpc_dhcp_option_info``. (https://github.com/ansible-collections/amazon.aws/pull/252)
+        - ec2_vpc_dhcp_option_info - Now also returns a user-friendly ``dhcp_config`` key that matches the historical ``new_config`` key from ec2_vpc_dhcp_option,
+          and alleviates the need to use ``items2dict(key_name='key', value_name='values')`` when parsing the output of the module. (https://github.com/ansible-collections/amazon.aws/pull/252)
+        - ec2_vpc_subnet - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - ec2_vpc_subnet - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - integration tests - remove dependency with collection ``community.general`` (https://github.com/ansible-collections/amazon.aws/pull/361).
+        - module_utils/waiter - add RDS cluster ``cluster_available`` waiter (https://github.com/ansible-collections/amazon.aws/pull/464).
+        - module_utils/waiter - add RDS cluster ``cluster_deleted`` waiter (https://github.com/ansible-collections/amazon.aws/pull/464).
+        - module_utils/waiter - add Route53 ``resource_record_sets_changed`` waiter (https://github.com/ansible-collections/amazon.aws/pull/350).
+        - s3_bucket - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - s3_bucket - Tests for compatibility with older versions of the AWS SDKs have been removed (https://github.com/ansible-collections/amazon.aws/pull/442).
+        - s3_bucket - add new option ``object_ownership`` to configure object ownership (https://github.com/ansible-collections/amazon.aws/pull/311)
+        - s3_bucket - updated to use HeadBucket instead of ListBucket when testing for bucket existence (https://github.com/ansible-collections/amazon.aws/pull/357).
     fragments:
-    - 252_boto3_refactor_ec2_vpc_dhcp_option.yaml
-    - 290-lint-cleanup.yml
-    - 297-scrub_none_parameters-descend-default.yml
-    - 298-python3.6.yml
-    - 311-s3_bucket-allow-object-ownership-configuration.yaml
-    - 318-s3-upload-acl.yml
-    - 334-ec2_vol-iops-and-throughput-issues.yaml
-    - 335-aws_s3-tagging-object-feature.yaml
-    - 337-ec2_eni-fix-idempotency-security-groups.yml
-    - 346-ec2_vol-boto3-requirements.yml
-    - 350-route53-waiter.yml
-    - 356-ec2_snapshot-boto3-migration.yml
-    - 357-s3_bucket-use-head.yml
-    - 359-aws_s3-add-copy-mode.yml
-    - 361-drop-community.general-support-for-integration.tests.yml
-    - 362-ec2_vol-add-multi-attach-parameter.yml
-    - 370-aws_ssm-add-on_missing-and-on_denied-option.yml
-    - 383_ec2_snapshot_tags.yml
-    - 386_ec2_ami_no_device.yml
-    - 391-s3_bucket-enc_notimplemented.yml
-    - 414-ec2_instance-support-controlling-metadata-options.yml
-    - 424-deprecate-ec2.yml
-    - 433-ec2_instance-throughput.yml
-    - 437-ec2_ami-propagate-tags-to-snapshot.yml
-    - 442-boto3-minimums.yml
-    - 442-boto3-minimums.yml
-    - 455-lookup_aws_secret-deleted.yml
-    - 460-pylint.yml
-    - 461-ipaddress.yml
-    - 464-rds_cluster-waiter.yml
-    - 465-pylint.yml
-    - 481-ec2_instance-wait_sanity.yml
-    - 483-ec2_vol_fix_returned_changed_var.yml
-    - 487-ec2_spot_instance_info-add-new-module.yml
-    - 501-ec2_eni-timeout.yml
-    - include_filters_with_filter.yaml
-    - migrate_ec2_instance.yml
-    - migrate_ec2_vpc_endpoint.yml
-    - migrate_ec2_vpc_igw.yml
-    - migrate_ec2_vpc_nat_gateway.yml
-    - migrate_ec2_vpc_route_table.yml
+      - 252_boto3_refactor_ec2_vpc_dhcp_option.yaml
+      - 290-lint-cleanup.yml
+      - 297-scrub_none_parameters-descend-default.yml
+      - 298-python3.6.yml
+      - 311-s3_bucket-allow-object-ownership-configuration.yaml
+      - 318-s3-upload-acl.yml
+      - 334-ec2_vol-iops-and-throughput-issues.yaml
+      - 335-aws_s3-tagging-object-feature.yaml
+      - 337-ec2_eni-fix-idempotency-security-groups.yml
+      - 346-ec2_vol-boto3-requirements.yml
+      - 350-route53-waiter.yml
+      - 356-ec2_snapshot-boto3-migration.yml
+      - 357-s3_bucket-use-head.yml
+      - 359-aws_s3-add-copy-mode.yml
+      - 361-drop-community.general-support-for-integration.tests.yml
+      - 362-ec2_vol-add-multi-attach-parameter.yml
+      - 370-aws_ssm-add-on_missing-and-on_denied-option.yml
+      - 383_ec2_snapshot_tags.yml
+      - 386_ec2_ami_no_device.yml
+      - 391-s3_bucket-enc_notimplemented.yml
+      - 414-ec2_instance-support-controlling-metadata-options.yml
+      - 424-deprecate-ec2.yml
+      - 433-ec2_instance-throughput.yml
+      - 437-ec2_ami-propagate-tags-to-snapshot.yml
+      - 442-boto3-minimums.yml
+      - 442-boto3-minimums.yml
+      - 455-lookup_aws_secret-deleted.yml
+      - 460-pylint.yml
+      - 461-ipaddress.yml
+      - 464-rds_cluster-waiter.yml
+      - 465-pylint.yml
+      - 481-ec2_instance-wait_sanity.yml
+      - 483-ec2_vol_fix_returned_changed_var.yml
+      - 487-ec2_spot_instance_info-add-new-module.yml
+      - 501-ec2_eni-timeout.yml
+      - include_filters_with_filter.yaml
+      - migrate_ec2_instance.yml
+      - migrate_ec2_vpc_endpoint.yml
+      - migrate_ec2_vpc_igw.yml
+      - migrate_ec2_vpc_nat_gateway.yml
+      - migrate_ec2_vpc_route_table.yml
     modules:
-    - description: request, stop, reboot or cancel spot instance
-      name: ec2_spot_instance
-      namespace: ''
-    - description: Gather information about ec2 spot instance requests
-      name: ec2_spot_instance_info
-      namespace: ''
-    release_date: '2021-09-03'
+      - description: request, stop, reboot or cancel spot instance
+        name: ec2_spot_instance
+        namespace: ""
+      - description: Gather information about ec2 spot instance requests
+        name: ec2_spot_instance_info
+        namespace: ""
+    release_date: "2021-09-03"
   2.1.0:
     changes:
       bugfixes:
-      - AWS action group - added missing ``ec2_instance_facts`` entry (https://github.com/ansible-collections/amazon.aws/issues/557)
-      - ec2_ami - fix problem when creating an AMI from an instance with ephemeral
-        volumes (https://github.com/ansible-collections/amazon.aws/issues/511).
-      - ec2_instance - ensure that ec2_instance falls back to the tag(Name) parameter
-        when no filter and no name parameter is passed (https://github.com/ansible-collections/amazon.aws/issues/526).
-      - s3_bucket - update error handling to better support DigitalOcean Space (https://github.com/ansible-collections/amazon.aws/issues/508).
+        - AWS action group - added missing ``ec2_instance_facts`` entry (https://github.com/ansible-collections/amazon.aws/issues/557)
+        - ec2_ami - fix problem when creating an AMI from an instance with ephemeral volumes (https://github.com/ansible-collections/amazon.aws/issues/511).
+        - ec2_instance - ensure that ec2_instance falls back to the tag(Name) parameter when no filter and no name parameter is passed (https://github.com/ansible-collections/amazon.aws/issues/526).
+        - s3_bucket - update error handling to better support DigitalOcean Space (https://github.com/ansible-collections/amazon.aws/issues/508).
       deprecated_features:
-      - ec2_classic_lb - setting of the ``ec2_elb`` fact has been deprecated and will
-        be removed in release 4.0.0 of the collection. The module now returns ``elb``
-        which can be accessed using the register keyword (https://github.com/ansible-collections/amazon.aws/pull/552).
+        - ec2_classic_lb - setting of the ``ec2_elb`` fact has been deprecated and will be removed in release 4.0.0 of the collection. The module now returns ``elb``
+          which can be accessed using the register keyword (https://github.com/ansible-collections/amazon.aws/pull/552).
       minor_changes:
-      - aws_service_ip_ranges - add new option ``ipv6_prefixes`` to get only IPV6
-        addresses and prefixes for Amazon services (https://github.com/ansible-collections/amazon.aws/pull/430)
-      - cloudformation - fix detection when there are no changes. Sometimes when there
-        are no changes, the change set will have a status FAILED with StatusReason
-        No updates are to be performed (https://github.com/ansible-collections/amazon.aws/pull/507).
-      - ec2_ami - add check_mode support (https://github.com/ansible-collections/amazon.aws/pull/516).
-      - ec2_ami - use module_util helper for tagging AMIs (https://github.com/ansible-collections/amazon.aws/pull/520).
-      - ec2_ami - when creating an AMI from an instance pass the tagging options at
-        creation time (https://github.com/ansible-collections/amazon.aws/pull/551).
-      - ec2_elb_lb - module renamed to ``elb_classic_lb`` (https://github.com/ansible-collections/amazon.aws/pull/377).
-      - ec2_eni - add check mode support (https://github.com/ansible-collections/amazon.aws/pull/534).
-      - ec2_eni - use module_util helper for tagging ENIs (https://github.com/ansible-collections/amazon.aws/pull/522).
-      - ec2_instance - use module_util helpers for tagging (https://github.com/ansible-collections/amazon.aws/pull/527).
-      - ec2_key - add support for tagging key pairs (https://github.com/ansible-collections/amazon.aws/pull/548).
-      - ec2_snapshot - add check_mode support (https://github.com/ansible-collections/amazon.aws/pull/512).
-      - ec2_vol - add check_mode support (https://github.com/ansible-collections/amazon.aws/pull/509).
-      - ec2_vpc_dhcp_option - use module_util helpers for tagging (https://github.com/ansible-collections/amazon.aws/pull/531).
-      - ec2_vpc_endpoint - added ``vpc_endpoint_security_groups`` parameter to support
-        defining the security group attached to an interface endpoint (https://github.com/ansible-collections/amazon.aws/pull/544).
-      - ec2_vpc_endpoint - added ``vpc_endpoint_subnets`` parameter to support defining
-        the subnet attached to an interface or gateway endpoint (https://github.com/ansible-collections/amazon.aws/pull/544).
-      - ec2_vpc_endpoint - use module_util helper for tagging (https://github.com/ansible-collections/amazon.aws/pull/525).
-      - ec2_vpc_endpoint - use module_util helpers for tagging (https://github.com/ansible-collections/amazon.aws/pull/531).
-      - ec2_vpc_igw - use module_util helper for tagging (https://github.com/ansible-collections/amazon.aws/pull/523).
-      - ec2_vpc_igw - use module_util helpers for tagging (https://github.com/ansible-collections/amazon.aws/pull/531).
-      - ec2_vpc_nat_gateway - use module_util helper for tagging (https://github.com/ansible-collections/amazon.aws/pull/524).
-      - ec2_vpc_nat_gateway - use module_util helpers for tagging (https://github.com/ansible-collections/amazon.aws/pull/531).
-      - elb_classic_lb - added retries on common AWS temporary API failures (https://github.com/ansible-collections/amazon.aws/pull/377).
-      - elb_classic_lb - added support for check_mode (https://github.com/ansible-collections/amazon.aws/pull/377).
-      - elb_classic_lb - added support for wait during creation (https://github.com/ansible-collections/amazon.aws/pull/377).
-      - elb_classic_lb - added support for wait during instance addition and removal
-        (https://github.com/ansible-collections/amazon.aws/pull/377).
-      - elb_classic_lb - migrated to boto3 SDK (https://github.com/ansible-collections/amazon.aws/pull/377).
-      - elb_classic_lb - various error messages changed due to refactor (https://github.com/ansible-collections/amazon.aws/pull/377).
-      - module_utils.ec2 - moved generic tagging helpers into module_utils.tagging
-        (https://github.com/ansible-collections/amazon.aws/pull/527).
-      - module_utils.tagging - add new helper to generate TagSpecification lists (https://github.com/ansible-collections/amazon.aws/pull/527).
+        - aws_service_ip_ranges - add new option ``ipv6_prefixes`` to get only IPV6 addresses and prefixes for Amazon services (https://github.com/ansible-collections/amazon.aws/pull/430)
+        - cloudformation - fix detection when there are no changes. Sometimes when there are no changes, the change set will have a status FAILED with StatusReason
+          No updates are to be performed (https://github.com/ansible-collections/amazon.aws/pull/507).
+        - ec2_ami - add check_mode support (https://github.com/ansible-collections/amazon.aws/pull/516).
+        - ec2_ami - use module_util helper for tagging AMIs (https://github.com/ansible-collections/amazon.aws/pull/520).
+        - ec2_ami - when creating an AMI from an instance pass the tagging options at creation time (https://github.com/ansible-collections/amazon.aws/pull/551).
+        - ec2_elb_lb - module renamed to ``elb_classic_lb`` (https://github.com/ansible-collections/amazon.aws/pull/377).
+        - ec2_eni - add check mode support (https://github.com/ansible-collections/amazon.aws/pull/534).
+        - ec2_eni - use module_util helper for tagging ENIs (https://github.com/ansible-collections/amazon.aws/pull/522).
+        - ec2_instance - use module_util helpers for tagging (https://github.com/ansible-collections/amazon.aws/pull/527).
+        - ec2_key - add support for tagging key pairs (https://github.com/ansible-collections/amazon.aws/pull/548).
+        - ec2_snapshot - add check_mode support (https://github.com/ansible-collections/amazon.aws/pull/512).
+        - ec2_vol - add check_mode support (https://github.com/ansible-collections/amazon.aws/pull/509).
+        - ec2_vpc_dhcp_option - use module_util helpers for tagging (https://github.com/ansible-collections/amazon.aws/pull/531).
+        - ec2_vpc_endpoint - added ``vpc_endpoint_security_groups`` parameter to support defining the security group attached to an interface endpoint (https://github.com/ansible-collections/amazon.aws/pull/544).
+        - ec2_vpc_endpoint - added ``vpc_endpoint_subnets`` parameter to support defining the subnet attached to an interface or gateway endpoint (https://github.com/ansible-collections/amazon.aws/pull/544).
+        - ec2_vpc_endpoint - use module_util helper for tagging (https://github.com/ansible-collections/amazon.aws/pull/525).
+        - ec2_vpc_endpoint - use module_util helpers for tagging (https://github.com/ansible-collections/amazon.aws/pull/531).
+        - ec2_vpc_igw - use module_util helper for tagging (https://github.com/ansible-collections/amazon.aws/pull/523).
+        - ec2_vpc_igw - use module_util helpers for tagging (https://github.com/ansible-collections/amazon.aws/pull/531).
+        - ec2_vpc_nat_gateway - use module_util helper for tagging (https://github.com/ansible-collections/amazon.aws/pull/524).
+        - ec2_vpc_nat_gateway - use module_util helpers for tagging (https://github.com/ansible-collections/amazon.aws/pull/531).
+        - elb_classic_lb - added retries on common AWS temporary API failures (https://github.com/ansible-collections/amazon.aws/pull/377).
+        - elb_classic_lb - added support for check_mode (https://github.com/ansible-collections/amazon.aws/pull/377).
+        - elb_classic_lb - added support for wait during creation (https://github.com/ansible-collections/amazon.aws/pull/377).
+        - elb_classic_lb - added support for wait during instance addition and removal (https://github.com/ansible-collections/amazon.aws/pull/377).
+        - elb_classic_lb - migrated to boto3 SDK (https://github.com/ansible-collections/amazon.aws/pull/377).
+        - elb_classic_lb - various error messages changed due to refactor (https://github.com/ansible-collections/amazon.aws/pull/377).
+        - module_utils.ec2 - moved generic tagging helpers into module_utils.tagging (https://github.com/ansible-collections/amazon.aws/pull/527).
+        - module_utils.tagging - add new helper to generate TagSpecification lists (https://github.com/ansible-collections/amazon.aws/pull/527).
     fragments:
-    - 377-ec2_elb_lb-boto3.yml
-    - 430-add_support_for_ipv6_addresses.yml
-    - 507-fix_cloudformation_changeset_detection.yml
-    - 508-s3_bucket-digital_ocean.yml
-    - 509-ec2_vol_add_check_mode_support.yml
-    - 512-ec2_snapshot_add_check_mode_support.yml.yml
-    - 516-ec2_ami_add_check_mode_support.yml
-    - 520-ec2_ami-tagging.yml
-    - 522-ec2_eni-tagging.yml
-    - 523-ec2_vpc_igw-tagging.yml
-    - 524-ec2_vpc_nat_gateway-tagging.yml
-    - 525-ec2_vpc_endpoint-tagging.yml
-    - 526-ec2_instance_search_tags.yml
-    - 527-ec2_instance-tagging.yml
-    - 531-use_tags_handlers.yml
-    - 534-ec2_eni_add_check_mode_support.yml
-    - 544-vpc-endpoint-add-subnets-sg-option.yml
-    - 548-ec2_key-tagging.yml
-    - 551-ec2_ami-tag-on-create.yml
-    - 552-elb_classic_lb-fact.yml
-    - 557-action_group-missing-entry.yml
-    release_date: '2021-11-11'
+      - 377-ec2_elb_lb-boto3.yml
+      - 430-add_support_for_ipv6_addresses.yml
+      - 507-fix_cloudformation_changeset_detection.yml
+      - 508-s3_bucket-digital_ocean.yml
+      - 509-ec2_vol_add_check_mode_support.yml
+      - 512-ec2_snapshot_add_check_mode_support.yml.yml
+      - 516-ec2_ami_add_check_mode_support.yml
+      - 520-ec2_ami-tagging.yml
+      - 522-ec2_eni-tagging.yml
+      - 523-ec2_vpc_igw-tagging.yml
+      - 524-ec2_vpc_nat_gateway-tagging.yml
+      - 525-ec2_vpc_endpoint-tagging.yml
+      - 526-ec2_instance_search_tags.yml
+      - 527-ec2_instance-tagging.yml
+      - 531-use_tags_handlers.yml
+      - 534-ec2_eni_add_check_mode_support.yml
+      - 544-vpc-endpoint-add-subnets-sg-option.yml
+      - 548-ec2_key-tagging.yml
+      - 551-ec2_ami-tag-on-create.yml
+      - 552-elb_classic_lb-fact.yml
+      - 557-action_group-missing-entry.yml
+    release_date: "2021-11-11"
   2.2.0:
     changes:
       bugfixes:
-      - aws_ec2 inventory - use the iam_role_arn configuration parameter to assume
-        the role before trying to call DescribeRegions if the regions configuration
-        is not set and AWS credentials provided without enough privilege to perform
-        the DescribeRegions action. (https://github.com/ansible-collections/amazon.aws/issues/566).
-      - ec2_vol - Sets the Iops value in req_obj even if the iops value has not changed,
-        to allow modifying volume types that require passing an iops value to boto.
-        (https://github.com/ansible-collections/amazon.aws/pull/606)
-      - ec2_vol - changing a volume from a type that does not support IOPS (like ``standard``)
-        to a type that does (like ``gp3``) fails (https://github.com/ansible-collections/amazon.aws/issues/626).
-      - ec2_vpc_igw - fix 'NoneType' object is not subscriptable error (https://github.com/ansible-collections/amazon.aws/pull/691).
-      - ec2_vpc_igw - use paginator for describe internet gateways and add retry to
-        fix NoneType object is not subscriptable error (https://github.com/ansible-collections/amazon.aws/pull/695).
-      - elb_classic_lb - handle security_group_ids when providing security_group_names
-        and fix broken tasks in integration test (https://github.com/ansible-collections/amazon.aws/pull/592).
+        - aws_ec2 inventory - use the iam_role_arn configuration parameter to assume the role before trying to call DescribeRegions if the regions configuration is
+          not set and AWS credentials provided without enough privilege to perform the DescribeRegions action. (https://github.com/ansible-collections/amazon.aws/issues/566).
+        - ec2_vol - Sets the Iops value in req_obj even if the iops value has not changed, to allow modifying volume types that require passing an iops value to boto.
+          (https://github.com/ansible-collections/amazon.aws/pull/606)
+        - ec2_vol - changing a volume from a type that does not support IOPS (like ``standard``) to a type that does (like ``gp3``) fails (https://github.com/ansible-collections/amazon.aws/issues/626).
+        - ec2_vpc_igw - fix 'NoneType' object is not subscriptable error (https://github.com/ansible-collections/amazon.aws/pull/691).
+        - ec2_vpc_igw - use paginator for describe internet gateways and add retry to fix NoneType object is not subscriptable error (https://github.com/ansible-collections/amazon.aws/pull/695).
+        - elb_classic_lb - handle security_group_ids when providing security_group_names and fix broken tasks in integration test (https://github.com/ansible-collections/amazon.aws/pull/592).
       minor_changes:
-      - ec2_instance - add count parameter support (https://github.com/ansible-collections/amazon.aws/pull/539).
+        - ec2_instance - add count parameter support (https://github.com/ansible-collections/amazon.aws/pull/539).
     fragments:
-    - 539-ec2_instance_add_count_param.yml
-    - 592-elb_classic_lb-handle-sg-ids-fix-tests.yml
-    - 606-ec2_vol-set-iops-even-if-unchanged-for-boto-req.yml
-    - 619-inventory-aws_ec2-assume-arn-role-when-listing-regions.yml
-    - 626-ec2_vol-iops-when-source-does-not-have-iops.yml
-    - 691-ec2_vpc_igw-fix-null-igw-error.yml
-    - 695-ec2_vpc_igw-fix-nonetype-with-paginator.yml
-    release_date: '2022-03-22'
+      - 539-ec2_instance_add_count_param.yml
+      - 592-elb_classic_lb-handle-sg-ids-fix-tests.yml
+      - 606-ec2_vol-set-iops-even-if-unchanged-for-boto-req.yml
+      - 619-inventory-aws_ec2-assume-arn-role-when-listing-regions.yml
+      - 626-ec2_vol-iops-when-source-does-not-have-iops.yml
+      - 691-ec2_vpc_igw-fix-null-igw-error.yml
+      - 695-ec2_vpc_igw-fix-nonetype-with-paginator.yml
+    release_date: "2022-03-22"
   2.3.0:
     changes:
       bugfixes:
-      - aws_account_attribute lookup plugin - fix linting errors in documentation
-        data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - aws_ec2 inventory plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - aws_rds inventory plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - aws_resource_actions callback plugin - fix linting errors in documentation
-        data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - aws_secret lookup plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - aws_service_ip_ranges lookup plugin - fix linting errors in documentation
-        data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - aws_ssm lookup plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - ec2_instance - ec2_instance module broken in Python 3.8 - dict keys modified
-        during iteration (https://github.com/ansible-collections/amazon.aws/issues/709).
-      - module.utils.s3 - Update validate_bucket_name minimum length to 3 (https://github.com/ansible-collections/amazon.aws/pull/802).
+        - aws_account_attribute lookup plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - aws_ec2 inventory plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - aws_rds inventory plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - aws_resource_actions callback plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - aws_secret lookup plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - aws_service_ip_ranges lookup plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - aws_ssm lookup plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - ec2_instance - ec2_instance module broken in Python 3.8 - dict keys modified during iteration (https://github.com/ansible-collections/amazon.aws/issues/709).
+        - module.utils.s3 - Update validate_bucket_name minimum length to 3 (https://github.com/ansible-collections/amazon.aws/pull/802).
     fragments:
-    - 709-ec_2_instance-python-3-8-compatibility.yml
-    - 802-update-s3-module_util-validate_bucket_name-to-accept-3-character-bucket-name.yml
-    - validate-plugins.yml
-    release_date: '2022-05-25'
+      - 709-ec_2_instance-python-3-8-compatibility.yml
+      - 802-update-s3-module_util-validate_bucket_name-to-accept-3-character-bucket-name.yml
+      - validate-plugins.yml
+    release_date: "2022-05-25"
   3.0.0:
     changes:
       breaking_changes:
-      - aws_caller_facts - Remove deprecated ``aws_caller_facts`` alias.  Please use
-        ``aws_caller_info`` instead.
-      - cloudformation_facts - Remove deprecated ``cloudformation_facts`` alias.  Please
-        use ``cloudformation_info`` instead.
-      - ec2_ami_facts - Remove deprecated ``ec2_ami_facts`` alias.  Please use ``ec2_ami_info``
-        instead.
-      - ec2_eni_facts - Remove deprecated ``ec2_eni_facts`` alias.  Please use ``ec2_eni_info``
-        instead.
-      - ec2_group_facts - Remove deprecated ``ec2_group_facts`` alias.  Please use
-        ``ec2_group_info`` instead.
-      - ec2_instance_facts - Remove deprecated ``ec2_instance_facts`` alias.  Please
-        use ``ec2_instance_info`` instead.
-      - ec2_snapshot_facts - Remove deprecated ``ec2_snapshot_facts`` alias.  Please
-        use ``ec2_snapshot_info`` instead.
-      - ec2_vol_facts - Remove deprecated ``ec2_vol_facts`` alias.  Please use ``ec2_vol_info``
-        instead.
-      - ec2_vpc_dhcp_option_facts - Remove deprecated ``ec2_vpc_dhcp_option_facts``
-        alias.  Please use ``ec2_vpc_dhcp_option_info`` instead.
-      - ec2_vpc_endpoint_facts - Remove deprecated ``ec2_vpc_endpoint_facts`` alias.  Please
-        use ``ec2_vpc_endpoint_info`` instead.
-      - ec2_vpc_igw_facts - Remove deprecated ``ec2_vpc_igw_facts`` alias.  Please
-        use ``ec2_vpc_igw_info`` instead.
-      - ec2_vpc_nat_gateway_facts - Remove deprecated ``ec2_vpc_nat_gateway_facts``
-        alias.  Please use ``ec2_vpc_nat_gateway_info`` instead.
-      - ec2_vpc_net_facts - Remove deprecated ``ec2_vpc_net_facts`` alias.  Please
-        use ``ec2_vpc_net_info`` instead.
-      - ec2_vpc_route_table_facts - Remove deprecated ``ec2_vpc_route_table_facts``
-        alias.  Please use ``ec2_vpc_route_table_info`` instead.
-      - ec2_vpc_subnet_facts - Remove deprecated ``ec2_vpc_subnet_facts`` alias.  Please
-        use ``ec2_vpc_subnet_info`` instead.
+        - aws_caller_facts - Remove deprecated ``aws_caller_facts`` alias.  Please use ``aws_caller_info`` instead.
+        - cloudformation_facts - Remove deprecated ``cloudformation_facts`` alias.  Please use ``cloudformation_info`` instead.
+        - ec2_ami_facts - Remove deprecated ``ec2_ami_facts`` alias.  Please use ``ec2_ami_info`` instead.
+        - ec2_eni_facts - Remove deprecated ``ec2_eni_facts`` alias.  Please use ``ec2_eni_info`` instead.
+        - ec2_group_facts - Remove deprecated ``ec2_group_facts`` alias.  Please use ``ec2_group_info`` instead.
+        - ec2_instance_facts - Remove deprecated ``ec2_instance_facts`` alias.  Please use ``ec2_instance_info`` instead.
+        - ec2_snapshot_facts - Remove deprecated ``ec2_snapshot_facts`` alias.  Please use ``ec2_snapshot_info`` instead.
+        - ec2_vol_facts - Remove deprecated ``ec2_vol_facts`` alias.  Please use ``ec2_vol_info`` instead.
+        - ec2_vpc_dhcp_option_facts - Remove deprecated ``ec2_vpc_dhcp_option_facts`` alias.  Please use ``ec2_vpc_dhcp_option_info`` instead.
+        - ec2_vpc_endpoint_facts - Remove deprecated ``ec2_vpc_endpoint_facts`` alias.  Please use ``ec2_vpc_endpoint_info`` instead.
+        - ec2_vpc_igw_facts - Remove deprecated ``ec2_vpc_igw_facts`` alias.  Please use ``ec2_vpc_igw_info`` instead.
+        - ec2_vpc_nat_gateway_facts - Remove deprecated ``ec2_vpc_nat_gateway_facts`` alias.  Please use ``ec2_vpc_nat_gateway_info`` instead.
+        - ec2_vpc_net_facts - Remove deprecated ``ec2_vpc_net_facts`` alias.  Please use ``ec2_vpc_net_info`` instead.
+        - ec2_vpc_route_table_facts - Remove deprecated ``ec2_vpc_route_table_facts`` alias.  Please use ``ec2_vpc_route_table_info`` instead.
+        - ec2_vpc_subnet_facts - Remove deprecated ``ec2_vpc_subnet_facts`` alias.  Please use ``ec2_vpc_subnet_info`` instead.
       deprecated_features:
-      - module_utils - support for the original AWS SDK ``boto`` has been deprecated
-        in favour of the ``boto3``/``botocore`` SDK. All ``boto`` based modules have
-        either been deprecated or migrated to ``botocore``, and the remaining support
-        code in module_utils will be removed in release 4.0.0 of the amazon.aws collection.
-        Any modules outside of the amazon.aws and community.aws collections based
-        on the ``boto`` library will need to be migrated to the ``boto3``/``botocore``
-        libraries (https://github.com/ansible-collections/amazon.aws/pull/575).
+        - module_utils - support for the original AWS SDK ``boto`` has been deprecated in favour of the ``boto3``/``botocore`` SDK. All ``boto`` based modules have
+          either been deprecated or migrated to ``botocore``, and the remaining support code in module_utils will be removed in release 4.0.0 of the amazon.aws collection.
+          Any modules outside of the amazon.aws and community.aws collections based on the ``boto`` library will need to be migrated to the ``boto3``/``botocore``
+          libraries (https://github.com/ansible-collections/amazon.aws/pull/575).
       major_changes:
-      - amazon.aws collection - The amazon.aws collection has dropped support for
-        ``botocore<1.19.0`` and ``boto3<1.16.0``. Most modules will continue to work
-        with older versions of the AWS SDK, however compatibility with older versions
-        of the SDK is not guaranteed and will not be tested. When using older versions
-        of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/574).
+        - amazon.aws collection - The amazon.aws collection has dropped support for ``botocore<1.19.0`` and ``boto3<1.16.0``. Most modules will continue to work with
+          older versions of the AWS SDK, however compatibility with older versions of the SDK is not guaranteed and will not be tested. When using older versions
+          of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/574).
       minor_changes:
-      - ec2_instance - add count parameter support (https://github.com/ansible-collections/amazon.aws/pull/539).
+        - ec2_instance - add count parameter support (https://github.com/ansible-collections/amazon.aws/pull/539).
     fragments:
-    - 539-ec2_instance_add_count_param.yml
-    - 574-botocore-1-19-0.yml
-    - 575-deprecate-boto.yml
-    - remove_deprecated_facts.yml
-    release_date: '2021-12-06'
+      - 539-ec2_instance_add_count_param.yml
+      - 574-botocore-1-19-0.yml
+      - 575-deprecate-boto.yml
+      - remove_deprecated_facts.yml
+    release_date: "2021-12-06"
   3.1.0:
     changes:
       bugfixes:
-      - Various modules and plugins - use vendored version of ``distutils.version``
-        instead of the deprecated Python standard library ``distutils`` (https://github.com/ansible-collections/amazon.aws/pull/599).
-      - aws_acm - No longer raising ResourceNotFound exception while retrieving ACM
-        certificates.
-      - aws_s3 - fix exception raised when using module to copy from source to destination
-        and key is missing from source (https://github.com/ansible-collections/amazon.aws/issues/602).
-      - ec2_instance - Add a condition to handle default ```instance_type``` value
-        for fix breaking on instance creation with launch template (https://github.com/ansible-collections/amazon.aws/pull/587).
-      - ec2_key - add support for ED25519 key type (https://github.com/ansible-collections/amazon.aws/issues/572).
-      - ec2_vol - Sets the Iops value in req_obj even if the iops value has not changed,
-        to allow modifying volume types that require passing an iops value to boto.
-        (https://github.com/ansible-collections/amazon.aws/pull/606)
-      - elb_classic_lb - handle security_group_ids when providing security_group_names
-        and fix broken tasks in integration test (https://github.com/ansible-collections/amazon.aws/pull/592).
-      - s3_bucket - Enable the management of bucket-level ACLs (https://github.com/ansible-collections/amazon.aws/issues/573).
+        - Various modules and plugins - use vendored version of ``distutils.version`` instead of the deprecated Python standard library ``distutils`` (https://github.com/ansible-collections/amazon.aws/pull/599).
+        - aws_acm - No longer raising ResourceNotFound exception while retrieving ACM certificates.
+        - aws_s3 - fix exception raised when using module to copy from source to destination and key is missing from source (https://github.com/ansible-collections/amazon.aws/issues/602).
+        - ec2_instance - Add a condition to handle default ```instance_type``` value for fix breaking on instance creation with launch template (https://github.com/ansible-collections/amazon.aws/pull/587).
+        - ec2_key - add support for ED25519 key type (https://github.com/ansible-collections/amazon.aws/issues/572).
+        - ec2_vol - Sets the Iops value in req_obj even if the iops value has not changed, to allow modifying volume types that require passing an iops value to boto.
+          (https://github.com/ansible-collections/amazon.aws/pull/606)
+        - elb_classic_lb - handle security_group_ids when providing security_group_names and fix broken tasks in integration test (https://github.com/ansible-collections/amazon.aws/pull/592).
+        - s3_bucket - Enable the management of bucket-level ACLs (https://github.com/ansible-collections/amazon.aws/issues/573).
       deprecated_features:
-      - ec2_instance - The default value for ```instance_type``` has been deprecated,
-        in the future release you must set an instance_type or a launch_template (https://github.com/ansible-collections/amazon.aws/pull/587).
+        - ec2_instance - The default value for ```instance_type``` has been deprecated, in the future release you must set an instance_type or a launch_template (https://github.com/ansible-collections/amazon.aws/pull/587).
       minor_changes:
-      - add new parameters hostvars_prefix and hostvars_suffix for inventory plugins
-        aws_ec2 and aws_rds (https://github.com/ansible-collections/amazon.aws/issues/535).
-      - aws_s3 - Add ``validate_bucket_name`` option, to control bucket name validation
-        (https://github.com/ansible-collections/amazon.aws/pull/615).
-      - aws_s3 - add latest choice on ``overwrite`` parameter to get latest object
-        on S3 (https://github.com/ansible-collections/amazon.aws/pull/595).
-      - ec2_vol - add support for OutpostArn param (https://github.com/ansible-collections/amazon.aws/pull/597).
-      - ec2_vol - tag volume on creation (https://github.com/ansible-collections/amazon.aws/pull/603).
-      - ec2_vpc_route_table - add support for IPv6 in creating route tables (https://github.com/ansible-collections/amazon.aws/pull/601).
-      - s3_bucket - Add ``validate_bucket_name`` option, to control bucket name validation
-        (https://github.com/ansible-collections/amazon.aws/pull/615).
+        - add new parameters hostvars_prefix and hostvars_suffix for inventory plugins aws_ec2 and aws_rds (https://github.com/ansible-collections/amazon.aws/issues/535).
+        - aws_s3 - Add ``validate_bucket_name`` option, to control bucket name validation (https://github.com/ansible-collections/amazon.aws/pull/615).
+        - aws_s3 - add latest choice on ``overwrite`` parameter to get latest object on S3 (https://github.com/ansible-collections/amazon.aws/pull/595).
+        - ec2_vol - add support for OutpostArn param (https://github.com/ansible-collections/amazon.aws/pull/597).
+        - ec2_vol - tag volume on creation (https://github.com/ansible-collections/amazon.aws/pull/603).
+        - ec2_vpc_route_table - add support for IPv6 in creating route tables (https://github.com/ansible-collections/amazon.aws/pull/601).
+        - s3_bucket - Add ``validate_bucket_name`` option, to control bucket name validation (https://github.com/ansible-collections/amazon.aws/pull/615).
     fragments:
-    - 587-ec2_instance-default-instance-type-launch-template.yml
-    - 592-elb_classic_lb-handle-sg-ids-fix-tests.yml
-    - 593-aws_s3-fix-copy-when-missing-key.yml
-    - 595-aws_s3-add-latest-choice-on-overwrite-parameter.yml
-    - 597-ec2_vol-add-outpostarn-support.yml
-    - 601-ec2_vpc_route_table-ipv6-support.yml
-    - 603-ec2_vol-add-tags-on-creation.yml
-    - 606-ec2_vol-set-iops-even-if-unchanged-for-boto-req.yml
-    - 611-s3_bucket-add-support-for-acl.yml
-    - 614-ec2_key-add-support-for-ed25519-key-type.yml
-    - 615-s3-validate_bucket_name.yml
-    - 619-aws_ec2-aws_rds-add-support-for-hostvars_prefix-and-hostvars_suffix.yml
-    - 646-acm-resource-not-found.yml
-    - disutils.version.yml
-    release_date: '2022-02-10'
+      - 587-ec2_instance-default-instance-type-launch-template.yml
+      - 592-elb_classic_lb-handle-sg-ids-fix-tests.yml
+      - 593-aws_s3-fix-copy-when-missing-key.yml
+      - 595-aws_s3-add-latest-choice-on-overwrite-parameter.yml
+      - 597-ec2_vol-add-outpostarn-support.yml
+      - 601-ec2_vpc_route_table-ipv6-support.yml
+      - 603-ec2_vol-add-tags-on-creation.yml
+      - 606-ec2_vol-set-iops-even-if-unchanged-for-boto-req.yml
+      - 611-s3_bucket-add-support-for-acl.yml
+      - 614-ec2_key-add-support-for-ed25519-key-type.yml
+      - 615-s3-validate_bucket_name.yml
+      - 619-aws_ec2-aws_rds-add-support-for-hostvars_prefix-and-hostvars_suffix.yml
+      - 646-acm-resource-not-found.yml
+      - disutils.version.yml
+    release_date: "2022-02-10"
   3.1.1:
     changes:
       minor_changes:
-      - bump the release version of the amazon.aws collection from 3.1.0 to 3.1.1
-        because of a bug that occurred while uploading to Galaxy.
+        - bump the release version of the amazon.aws collection from 3.1.0 to 3.1.1 because of a bug that occurred while uploading to Galaxy.
     fragments:
-    - bump_release_version.yml
-    release_date: '2022-02-15'
+      - bump_release_version.yml
+    release_date: "2022-02-15"
   3.2.0:
     changes:
       bugfixes:
-      - aws_ec2 inventory - use the iam_role_arn configuration parameter to assume
-        the role before trying to call DescribeRegions if the regions configuration
-        is not set and AWS credentials provided without enough privilege to perform
-        the DescribeRegions action. (https://github.com/ansible-collections/amazon.aws/issues/566).
-      - ec2_vol - changing a volume from a type that does not support IOPS (like ``standard``)
-        to a type that does (like ``gp3``) fails (https://github.com/ansible-collections/amazon.aws/issues/626).
-      - ec2_vpc_igw - fix 'NoneType' object is not subscriptable error (https://github.com/ansible-collections/amazon.aws/pull/691).
-      - ec2_vpc_igw - use paginator for describe internet gateways and add retry to
-        fix NoneType object is not subscriptable error (https://github.com/ansible-collections/amazon.aws/pull/695).
-      - ec2_vpc_net - In check mode, ensure the module does not change the configuration.
-        Handle case when Amazon-provided ipv6 block is enabled, then disabled, then
-        enabled again. Do not disable IPv6 CIDR association (using Amazon pool) if
-        ipv6_cidr property is not present in the task. If the VPC already exists and
-        ipv6_cidr property, retain the current config (https://github.com/ansible-collections/amazon.aws/pull/631).
+        - aws_ec2 inventory - use the iam_role_arn configuration parameter to assume the role before trying to call DescribeRegions if the regions configuration is
+          not set and AWS credentials provided without enough privilege to perform the DescribeRegions action. (https://github.com/ansible-collections/amazon.aws/issues/566).
+        - ec2_vol - changing a volume from a type that does not support IOPS (like ``standard``) to a type that does (like ``gp3``) fails (https://github.com/ansible-collections/amazon.aws/issues/626).
+        - ec2_vpc_igw - fix 'NoneType' object is not subscriptable error (https://github.com/ansible-collections/amazon.aws/pull/691).
+        - ec2_vpc_igw - use paginator for describe internet gateways and add retry to fix NoneType object is not subscriptable error (https://github.com/ansible-collections/amazon.aws/pull/695).
+        - ec2_vpc_net - In check mode, ensure the module does not change the configuration. Handle case when Amazon-provided ipv6 block is enabled, then disabled,
+          then enabled again. Do not disable IPv6 CIDR association (using Amazon pool) if ipv6_cidr property is not present in the task. If the VPC already exists
+          and ipv6_cidr property, retain the current config (https://github.com/ansible-collections/amazon.aws/pull/631).
       minor_changes:
-      - aws_secret - add pagination for ``bypath`` functionality (https://github.com/ansible-collections/amazon.aws/pull/591).
-      - ec2_instance - Fix scope of deprecation warning to not show warning when ``state``
-        in ``absent`` (https://github.com/ansible-collections/amazon.aws/pull/719).
-      - ec2_vpc_route_table - support associating internet gateways (https://github.com/ansible-collections/amazon.aws/pull/690).
-      - module_utils.elbv2 - Add support for alb specific attributes and compare_elb_attributes
-        method to support check_mode in module_utils.elbv2 (https://github.com/ansible-collections/amazon.aws/pull/696).
-      - s3_bucket - Add support for enforced bucket owner object ownership (https://github.com/ansible-collections/amazon.aws/pull/694).
+        - aws_secret - add pagination for ``bypath`` functionality (https://github.com/ansible-collections/amazon.aws/pull/591).
+        - ec2_instance - Fix scope of deprecation warning to not show warning when ``state`` in ``absent`` (https://github.com/ansible-collections/amazon.aws/pull/719).
+        - ec2_vpc_route_table - support associating internet gateways (https://github.com/ansible-collections/amazon.aws/pull/690).
+        - module_utils.elbv2 - Add support for alb specific attributes and compare_elb_attributes method to support check_mode in module_utils.elbv2 (https://github.com/ansible-collections/amazon.aws/pull/696).
+        - s3_bucket - Add support for enforced bucket owner object ownership (https://github.com/ansible-collections/amazon.aws/pull/694).
     fragments:
-    - 591-aws_secrets-handle-pagination.yml
-    - 619-inventory-aws_ec2-assume-arn-role-when-listing-regions.yml
-    - 626-ec2_vol-iops-when-source-does-not-have-iops.yml
-    - 631-ec2_vpc_net-check_mode.yml
-    - 690-ec2_vpc_route_table-associate-igw.yml
-    - 691-ec2_vpc_igw-fix-null-igw-error.yml
-    - 694-s3_bucket-owner_enforcement.yml
-    - 695-ec2_vpc_igw-fix-nonetype-with-paginator.yml
-    - 696-elbv2-support-alb-attributes.yml
-    - 719-ec2_instance-fix-deprecation-warning-scope.yml
-    release_date: '2022-04-05'
+      - 591-aws_secrets-handle-pagination.yml
+      - 619-inventory-aws_ec2-assume-arn-role-when-listing-regions.yml
+      - 626-ec2_vol-iops-when-source-does-not-have-iops.yml
+      - 631-ec2_vpc_net-check_mode.yml
+      - 690-ec2_vpc_route_table-associate-igw.yml
+      - 691-ec2_vpc_igw-fix-null-igw-error.yml
+      - 694-s3_bucket-owner_enforcement.yml
+      - 695-ec2_vpc_igw-fix-nonetype-with-paginator.yml
+      - 696-elbv2-support-alb-attributes.yml
+      - 719-ec2_instance-fix-deprecation-warning-scope.yml
+    release_date: "2022-04-05"
   3.3.0:
     changes:
       bugfixes:
-      - Include ``PSF-license.txt`` file for ``plugins/module_utils/_version.py``.
-      - aws_account_attribute lookup plugin - fix linting errors in documentation
-        data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - aws_ec2 inventory plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - aws_rds inventory plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - aws_resource_actions callback plugin - fix linting errors in documentation
-        data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - aws_secret lookup plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - aws_service_ip_ranges lookup plugin - fix linting errors in documentation
-        data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - aws_ssm - Fix environment variables for client configuration (e.g., AWS_PROFILE,
-        AWS_ACCESS_KEY_ID) (https://github.com/ansible-collections/amazon.aws/pull/837).
-      - aws_ssm lookup plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
-      - ec2_instance - ec2_instance module broken in Python 3.8 - dict keys modified
-        during iteration (https://github.com/ansible-collections/amazon.aws/issues/709).
-      - module.utils.rds - Add waiter for promoting read replica to fix idempotency
-        issue (https://github.com/ansible-collections/amazon.aws/pull/714).
-      - module.utils.rds - Catch InvalidDBSecurityGroupStateFault when modifying a
-        db instance (https://github.com/ansible-collections/amazon.aws/pull/776).
-      - module.utils.s3 - Update validate_bucket_name minimum length to 3 (https://github.com/ansible-collections/amazon.aws/pull/802).
+        - Include ``PSF-license.txt`` file for ``plugins/module_utils/_version.py``.
+        - aws_account_attribute lookup plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - aws_ec2 inventory plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - aws_rds inventory plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - aws_resource_actions callback plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - aws_secret lookup plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - aws_service_ip_ranges lookup plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - aws_ssm - Fix environment variables for client configuration (e.g., AWS_PROFILE, AWS_ACCESS_KEY_ID) (https://github.com/ansible-collections/amazon.aws/pull/837).
+        - aws_ssm lookup plugin - fix linting errors in documentation data (https://github.com/ansible-collections/amazon.aws/pull/701).
+        - ec2_instance - ec2_instance module broken in Python 3.8 - dict keys modified during iteration (https://github.com/ansible-collections/amazon.aws/issues/709).
+        - module.utils.rds - Add waiter for promoting read replica to fix idempotency issue (https://github.com/ansible-collections/amazon.aws/pull/714).
+        - module.utils.rds - Catch InvalidDBSecurityGroupStateFault when modifying a db instance (https://github.com/ansible-collections/amazon.aws/pull/776).
+        - module.utils.s3 - Update validate_bucket_name minimum length to 3 (https://github.com/ansible-collections/amazon.aws/pull/802).
       minor_changes:
-      - aws_ec2 inventory - Allow for literal strings in hostname that don't match
-        filter parameters in ec2 describe-instances (https://github.com/ansible-collections/amazon.aws/pull/826).
-      - aws_ssm - Add support for ``endpoint`` parameter (https://github.com/ansible-collections/amazon.aws/pull/837).
-      - module.utils.rds - add retry_codes to get_rds_method_attribute return data
-        to use in call_method and add unit tests (https://github.com/ansible-collections/amazon.aws/pull/776).
-      - module.utils.rds - refactor to utilize get_rds_method_attribute return data
-        (https://github.com/ansible-collections/amazon.aws/pull/776).
-      - module_utils - add new aliases ``aws_session_token`` and ``session_token``
-        to the ``security_token`` parameter to be more in-line with the boto SDK (https://github.com/ansible-collections/amazon.aws/pull/631).
-      - module_utils.rds - Add support and unit tests for addition/removal of IAM
-        roles to/from a db instance in module_utils.rds with waiters (https://github.com/ansible-collections/amazon.aws/pull/714).
+        - aws_ec2 inventory - Allow for literal strings in hostname that don't match filter parameters in ec2 describe-instances (https://github.com/ansible-collections/amazon.aws/pull/826).
+        - aws_ssm - Add support for ``endpoint`` parameter (https://github.com/ansible-collections/amazon.aws/pull/837).
+        - module.utils.rds - add retry_codes to get_rds_method_attribute return data to use in call_method and add unit tests (https://github.com/ansible-collections/amazon.aws/pull/776).
+        - module.utils.rds - refactor to utilize get_rds_method_attribute return data (https://github.com/ansible-collections/amazon.aws/pull/776).
+        - module_utils - add new aliases ``aws_session_token`` and ``session_token`` to the ``security_token`` parameter to be more in-line with the boto SDK (https://github.com/ansible-collections/amazon.aws/pull/631).
+        - module_utils.rds - Add support and unit tests for addition/removal of IAM roles to/from a db instance in module_utils.rds with waiters (https://github.com/ansible-collections/amazon.aws/pull/714).
     fragments:
-    - 655-aws_ec2-aws_rds-add-support-for-hostvars_prefix-and-hostvars_suffix.yml
-    - 709-ec_2_instance-python-3-8-compatibility.yml
-    - 714-module_util_rds-support-iam-roles-add-waiters.yml
-    - 776-module_util_rds-add-extra-retry-codes-refactor.yml
-    - 802-update-s3-module_util-validate_bucket_name-to-accept-3-character-bucket-name.yml
-    - 826-inventory-aws_ec2-allow-literal-string-in-hostname.yml
-    - 837-aws_ssm-envars.yml
-    - psf-license.yml
-    - validate-plugins.yml
-    release_date: '2022-05-26'
+      - 655-aws_ec2-aws_rds-add-support-for-hostvars_prefix-and-hostvars_suffix.yml
+      - 709-ec_2_instance-python-3-8-compatibility.yml
+      - 714-module_util_rds-support-iam-roles-add-waiters.yml
+      - 776-module_util_rds-add-extra-retry-codes-refactor.yml
+      - 802-update-s3-module_util-validate_bucket_name-to-accept-3-character-bucket-name.yml
+      - 826-inventory-aws_ec2-allow-literal-string-in-hostname.yml
+      - 837-aws_ssm-envars.yml
+      - psf-license.yml
+      - validate-plugins.yml
+    release_date: "2022-05-26"
   3.3.1:
     changes:
       release_summary: Various minor documentation fixes.
-    release_date: '2022-06-22'
+    release_date: "2022-06-22"
   3.4.0:
     changes:
       bugfixes:
-      - elb_application_lb - fix ``KeyError`` when balancing across two Target Groups
-        (https://github.com/ansible-collections/community.aws/issues/1089).
-      - elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating
-        a new ELB in check mode with a health check (https://github.com/ansible-collections/amazon.aws/pull/915).
-      - elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating
-        a new ELB using security group names (https://github.com/ansible-collections/amazon.aws/issues/914).
+        - elb_application_lb - fix ``KeyError`` when balancing across two Target Groups (https://github.com/ansible-collections/community.aws/issues/1089).
+        - elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating a new ELB in check mode with a health check (https://github.com/ansible-collections/amazon.aws/pull/915).
+        - elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating a new ELB using security group names (https://github.com/ansible-collections/amazon.aws/issues/914).
       minor_changes:
-      - ec2_instance - expanded the use of the automatic retries on temporary failures
-        (https://github.com/ansible-collections/amazon.aws/issues/927).
+        - ec2_instance - expanded the use of the automatic retries on temporary failures (https://github.com/ansible-collections/amazon.aws/issues/927).
     fragments:
-    - 1089-elb_application_lb-ForwardConfig-KeyError.yml
-    - 914-elb_classic_lb-security_group_names.yml
-    - 927-ec2_instance-retries.yml
-    release_date: '2022-08-02'
+      - 1089-elb_application_lb-ForwardConfig-KeyError.yml
+      - 914-elb_classic_lb-security_group_names.yml
+      - 927-ec2_instance-retries.yml
+    release_date: "2022-08-02"
   3.5.0:
     changes:
       bugfixes:
-      - ec2_metadata_facts - fix ``'NoneType' object is not callable`` exception when
-        using Ansible 2.13+ (https://github.com/ansible-collections/amazon.aws/issues/942).
+        - ec2_metadata_facts - fix ``'NoneType' object is not callable`` exception when using Ansible 2.13+ (https://github.com/ansible-collections/amazon.aws/issues/942).
       minor_changes:
-      - ec2_security_group - set type as ``list`` for rules->group_name as it can
-        accept both ``str`` and ``list`` (https://github.com/ansible-collections/amazon.aws/pull/971).
-      release_summary: 'Following the release of amazon.aws 5.0.0, 3.5.0 is a bugfix
-        release and the final planned release for the 3.x series.
-
-        '
+        - ec2_security_group - set type as ``list`` for rules->group_name as it can accept both ``str`` and ``list`` (https://github.com/ansible-collections/amazon.aws/pull/971).
+      release_summary: "Following the release of amazon.aws 5.0.0, 3.5.0 is a bugfix release and the final planned release for the 3.x series.\n"
     fragments:
-    - 638-ec2_security_group_group_name_datatype.yml
-    - 943-ec2_metadata_facts-fix-NoneType-callable.yml
-    - RELEASE-3.5.0.yml
-    - unit-tests_test_rds_py37_only.yaml
-    release_date: '2022-10-06'
+      - 638-ec2_security_group_group_name_datatype.yml
+      - 943-ec2_metadata_facts-fix-NoneType-callable.yml
+      - RELEASE-3.5.0.yml
+      - unit-tests_test_rds_py37_only.yaml
+    release_date: "2022-10-06"
   3.5.1:
     changes:
       minor_changes:
-      - ec2_instance - refacter ``tower_callback`` code to handle parameter validation
-        as part of the argument specification (https://github.com/ansible-collections/amazon.aws/pull/1199).
-      - ec2_instance - the ``tower_callback`` parameter has been renamed to ``aap_callback``,
-        ``tower_callback`` remains as an alias.  This change should have no observable
-        effect for users outside the module documentation (https://github.com/ansible-collections/amazon.aws/pull/1199).
+        - ec2_instance - refacter ``tower_callback`` code to handle parameter validation as part of the argument specification (https://github.com/ansible-collections/amazon.aws/pull/1199).
+        - ec2_instance - the ``tower_callback`` parameter has been renamed to ``aap_callback``, ``tower_callback`` remains as an alias.  This change should have no
+          observable effect for users outside the module documentation (https://github.com/ansible-collections/amazon.aws/pull/1199).
       release_summary: 3.5.1 is a security bugfix release.
       security_fixes:
-      - ec2_instance - fixes leak of password into logs when using ``tower_callback.windows=True``
-        and ``tower_callback.set_password`` (https://github.com/ansible-collections/amazon.aws/pull/1199).
+        - ec2_instance - fixes leak of password into logs when using ``tower_callback.windows=True`` and ``tower_callback.set_password`` (https://github.com/ansible-collections/amazon.aws/pull/1199).
     fragments:
-    - 20221021-ec2_instance-tower_callback.yml
-    - 20221026-pytest-forked.yml
-    - release_summary.yml
-    release_date: '2023-01-09'
+      - 20221021-ec2_instance-tower_callback.yml
+      - 20221026-pytest-forked.yml
+      - release_summary.yml
+    release_date: "2023-01-09"
   4.0.0:
     changes:
       breaking_changes:
-      - Tags beginning with ``aws:`` will not be removed when purging tags, these
-        tags are reserved by Amazon and may not be updated or deleted (https://github.com/ansible-collections/amazon.aws/issues/817).
-      - amazon.aws collection - the ``profile`` parameter is now mutually exclusive
-        with the ``aws_access_key``, ``aws_secret_key`` and ``security_token`` parameters
-        (https://github.com/ansible-collections/amazon.aws/pull/834).
-      - aws_az_info - the module alias ``aws_az_facts`` was deprecated in Ansible
-        2.9 and has now been removed (https://github.com/ansible-collections/amazon.aws/pull/832).
-      - aws_s3 - the default value for ``ensure overwrite`` has been changed to ``different``
-        instead of ``always`` so that the module is idempotent by default (https://github.com/ansible-collections/amazon.aws/issues/811).
-      - aws_ssm - on_denied and on_missing now both default to error, for consistency
-        with both aws_secret and the base Lookup class (https://github.com/ansible-collections/amazon.aws/issues/617).
-      - ec2 - The ``ec2`` module has been removed in release 4.0.0 and replaced by
-        the ``ec2_instance`` module (https://github.com/ansible-collections/amazon.aws/pull/630).
-      - ec2_vpc_igw_info - The default value for ``convert_tags`` has been changed
-        to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/835).
-      - elb_classic_lb - the ``ec2_elb`` fact has been removed (https://github.com/ansible-collections/amazon.aws/pull/827).
-      - module_utils - Support for the original AWS SDK aka ``boto`` has been removed,
-        including all relevant helper functions. All modules should now use the ``boto3``/``botocore``
-        AWS SDK (https://github.com/ansible-collections/amazon.aws/pull/630)
+        - Tags beginning with ``aws:`` will not be removed when purging tags, these tags are reserved by Amazon and may not be updated or deleted (https://github.com/ansible-collections/amazon.aws/issues/817).
+        - amazon.aws collection - the ``profile`` parameter is now mutually exclusive with the ``aws_access_key``, ``aws_secret_key`` and ``security_token`` parameters
+          (https://github.com/ansible-collections/amazon.aws/pull/834).
+        - aws_az_info - the module alias ``aws_az_facts`` was deprecated in Ansible 2.9 and has now been removed (https://github.com/ansible-collections/amazon.aws/pull/832).
+        - aws_s3 - the default value for ``ensure overwrite`` has been changed to ``different`` instead of ``always`` so that the module is idempotent by default
+          (https://github.com/ansible-collections/amazon.aws/issues/811).
+        - aws_ssm - on_denied and on_missing now both default to error, for consistency with both aws_secret and the base Lookup class (https://github.com/ansible-collections/amazon.aws/issues/617).
+        - ec2 - The ``ec2`` module has been removed in release 4.0.0 and replaced by the ``ec2_instance`` module (https://github.com/ansible-collections/amazon.aws/pull/630).
+        - ec2_vpc_igw_info - The default value for ``convert_tags`` has been changed to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/835).
+        - elb_classic_lb - the ``ec2_elb`` fact has been removed (https://github.com/ansible-collections/amazon.aws/pull/827).
+        - module_utils - Support for the original AWS SDK aka ``boto`` has been removed, including all relevant helper functions. All modules should now use the ``boto3``/``botocore``
+          AWS SDK (https://github.com/ansible-collections/amazon.aws/pull/630)
       bugfixes:
-      - ec2_group - fix uncaught exception when running with ``--diff`` and ``--check``
-        to create a new security group (https://github.com/ansible-collections/amazon.aws/issues/440).
-      - ec2_instance - Add a condition to handle default ```instance_type``` value
-        for fix breaking on instance creation with launch template (https://github.com/ansible-collections/amazon.aws/pull/587).
-      - ec2_instance - raise an error when missing permission to stop instance when
-        ``state`` is set to ``rebooted``` (https://github.com/ansible-collections/amazon.aws/pull/671).
-      - ec2_vpc_igw - use gateway_id rather than filters to paginate if possible to
-        fix 'NoneType' object is not subscriptable error (https://github.com/ansible-collections/amazon.aws/pull/766).
-      - ec2_vpc_net - fix a bug where CIDR configuration would be updated in check
-        mode (https://github.com/ansible/ansible/issues/62678).
-      - ec2_vpc_net - fix a bug where the module would get stuck if DNS options were
-        updated in check mode (https://github.com/ansible/ansible/issues/62677).
-      - elb_classic_lb - modify the return value of _format_listeners method to resolve
-        a failure creating https listeners (https://github.com/ansible-collections/amazon.aws/pull/860).
+        - ec2_group - fix uncaught exception when running with ``--diff`` and ``--check`` to create a new security group (https://github.com/ansible-collections/amazon.aws/issues/440).
+        - ec2_instance - Add a condition to handle default ```instance_type``` value for fix breaking on instance creation with launch template (https://github.com/ansible-collections/amazon.aws/pull/587).
+        - ec2_instance - raise an error when missing permission to stop instance when ``state`` is set to ``rebooted``` (https://github.com/ansible-collections/amazon.aws/pull/671).
+        - ec2_vpc_igw - use gateway_id rather than filters to paginate if possible to fix 'NoneType' object is not subscriptable error (https://github.com/ansible-collections/amazon.aws/pull/766).
+        - ec2_vpc_net - fix a bug where CIDR configuration would be updated in check mode (https://github.com/ansible/ansible/issues/62678).
+        - ec2_vpc_net - fix a bug where the module would get stuck if DNS options were updated in check mode (https://github.com/ansible/ansible/issues/62677).
+        - elb_classic_lb - modify the return value of _format_listeners method to resolve a failure creating https listeners (https://github.com/ansible-collections/amazon.aws/pull/860).
       deprecated_features:
-      - aws_s3 - The ``S3_URL`` alias for the s3_url option has been deprecated and
-        will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
-      - ec2_ami - The ``DeviceName`` alias for the device_name option has been deprecated
-        and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
-      - ec2_ami - The ``NoDevice`` alias for the no_device option has been deprecated
-        and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
-      - ec2_ami - The ``VirtualName`` alias for the virtual_name option has been deprecated
-        and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
-      - ec2_ami - the current default value of ``False`` for ``purge_tags`` has been
-        deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
-      - ec2_instance - The default value for ```instance_type``` has been deprecated,
-        in the future release you must set an instance_type or a launch_template (https://github.com/ansible-collections/amazon.aws/pull/587).
-      - ec2_instance - the current default value of ``False`` for ``purge_tags`` has
-        been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/849).
-      - ec2_key - the current default value of ``False`` for ``purge_tags`` has been
-        deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
-      - ec2_vol - the current default value of ``False`` for ``purge_tags`` has been
-        deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
-      - ec2_vpc_dhcp_option_info - The ``DhcpOptionIds`` alias for the dhcp_option_ids
-        option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
-      - ec2_vpc_dhcp_option_info - The ``DryRun`` alias for the dry_run option has
-        been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
-      - ec2_vpc_endpoint - the current default value of ``False`` for ``purge_tags``
-        has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
-      - ec2_vpc_net - the current default value of ``False`` for ``purge_tags`` has
-        been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/848).
-      - ec2_vpc_route_table - the current default value of ``False`` for ``purge_tags``
-        has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
-      - s3_bucket - The ``S3_URL`` alias for the s3_url option has been deprecated
-        and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
-      - s3_object - Support for creation and deletion of S3 buckets has been deprecated.  Please
-        use the ``amazon.aws.s3_bucket`` module to create and delete buckets (https://github.com/ansible-collections/amazon.aws/pull/869).
+        - aws_s3 - The ``S3_URL`` alias for the s3_url option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
+        - ec2_ami - The ``DeviceName`` alias for the device_name option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
+        - ec2_ami - The ``NoDevice`` alias for the no_device option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
+        - ec2_ami - The ``VirtualName`` alias for the virtual_name option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
+        - ec2_ami - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
+        - ec2_instance - The default value for ```instance_type``` has been deprecated, in the future release you must set an instance_type or a launch_template (https://github.com/ansible-collections/amazon.aws/pull/587).
+        - ec2_instance - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/849).
+        - ec2_key - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
+        - ec2_vol - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
+        - ec2_vpc_dhcp_option_info - The ``DhcpOptionIds`` alias for the dhcp_option_ids option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
+        - ec2_vpc_dhcp_option_info - The ``DryRun`` alias for the dry_run option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
+        - ec2_vpc_endpoint - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
+        - ec2_vpc_net - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/848).
+        - ec2_vpc_route_table - the current default value of ``False`` for ``purge_tags`` has been deprecated and will be updated in release 5.0.0 to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/846).
+        - s3_bucket - The ``S3_URL`` alias for the s3_url option has been deprecated and will be removed in release 5.0.0 (https://github.com/ansible-collections/community.aws/pull/795).
+        - s3_object - Support for creation and deletion of S3 buckets has been deprecated.  Please use the ``amazon.aws.s3_bucket`` module to create and delete buckets
+          (https://github.com/ansible-collections/amazon.aws/pull/869).
       major_changes:
-      - amazon.aws collection - The amazon.aws collection has dropped support for
-        ``botocore<1.20.0`` and ``boto3<1.17.0``. Most modules will continue to work
-        with older versions of the AWS SDK, however compatibility with older versions
-        of the SDK is not guaranteed and will not be tested. When using older versions
-        of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/574).
+        - amazon.aws collection - The amazon.aws collection has dropped support for ``botocore<1.20.0`` and ``boto3<1.17.0``. Most modules will continue to work with
+          older versions of the AWS SDK, however compatibility with older versions of the SDK is not guaranteed and will not be tested. When using older versions
+          of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/574).
       minor_changes:
-      - aws_s3 - Add ``validate_bucket_name`` option, to control bucket name validation
-        (https://github.com/ansible-collections/amazon.aws/pull/615).
-      - aws_s3 - The ``aws_s3`` module has been renamed to ``s3_object`` (https://github.com/ansible-collections/amazon.aws/pull/869).
-      - aws_s3 - ``resource_tags`` has been added as an alias for the ``tags`` parameter
-        (https://github.com/ansible-collections/amazon.aws/pull/845).
-      - ec2_eni - Change parameter ``device_index`` data type to string when passing
-        to ``describe_network_inter`` api call (https://github.com/ansible-collections/amazon.aws/pull/877).
-      - ec2_eni - ``resource_tags`` has been added as an alias for the ``tags`` parameter
-        (https://github.com/ansible-collections/amazon.aws/pull/845).
-      - ec2_group - add ``egress_rules`` as an alias for ``rules_egress`` (https://github.com/ansible-collections/amazon.aws/pull/878).
-      - ec2_group - add ``purge_egress_rules`` as an alias for ``purge_rules_egress``
-        (https://github.com/ansible-collections/amazon.aws/pull/878).
-      - ec2_instance - Add missing ``metadata_options`` parameters (https://github.com/ansible-collections/amazon.aws/pull/715).
-      - ec2_key - ``resource_tags`` has been added as an alias for the ``tags`` parameter
-        (https://github.com/ansible-collections/amazon.aws/pull/845).
-      - ec2_vpc_net - add support for managing VPCs by ID (https://github.com/ansible-collections/amazon.aws/pull/848).
-      - ec2_vpc_subnet - add support for OutpostArn param (https://github.com/ansible-collections/amazon.aws/pull/598).
-      - elb_classic_lb - ``resource_tags`` has been added as an alias for the ``tags``
-        parameter (https://github.com/ansible-collections/amazon.aws/pull/845).
-      - s3_bucket - Add ``validate_bucket_name`` option, to control bucket name validation
-        (https://github.com/ansible-collections/amazon.aws/pull/615).
-      - s3_bucket - ``resource_tags`` has been added as an alias for the ``tags``
-        parameter (https://github.com/ansible-collections/amazon.aws/pull/845).
+        - aws_s3 - Add ``validate_bucket_name`` option, to control bucket name validation (https://github.com/ansible-collections/amazon.aws/pull/615).
+        - aws_s3 - The ``aws_s3`` module has been renamed to ``s3_object`` (https://github.com/ansible-collections/amazon.aws/pull/869).
+        - aws_s3 - ``resource_tags`` has been added as an alias for the ``tags`` parameter (https://github.com/ansible-collections/amazon.aws/pull/845).
+        - ec2_eni - Change parameter ``device_index`` data type to string when passing to ``describe_network_inter`` api call (https://github.com/ansible-collections/amazon.aws/pull/877).
+        - ec2_eni - ``resource_tags`` has been added as an alias for the ``tags`` parameter (https://github.com/ansible-collections/amazon.aws/pull/845).
+        - ec2_group - add ``egress_rules`` as an alias for ``rules_egress`` (https://github.com/ansible-collections/amazon.aws/pull/878).
+        - ec2_group - add ``purge_egress_rules`` as an alias for ``purge_rules_egress`` (https://github.com/ansible-collections/amazon.aws/pull/878).
+        - ec2_instance - Add missing ``metadata_options`` parameters (https://github.com/ansible-collections/amazon.aws/pull/715).
+        - ec2_key - ``resource_tags`` has been added as an alias for the ``tags`` parameter (https://github.com/ansible-collections/amazon.aws/pull/845).
+        - ec2_vpc_net - add support for managing VPCs by ID (https://github.com/ansible-collections/amazon.aws/pull/848).
+        - ec2_vpc_subnet - add support for OutpostArn param (https://github.com/ansible-collections/amazon.aws/pull/598).
+        - elb_classic_lb - ``resource_tags`` has been added as an alias for the ``tags`` parameter (https://github.com/ansible-collections/amazon.aws/pull/845).
+        - s3_bucket - Add ``validate_bucket_name`` option, to control bucket name validation (https://github.com/ansible-collections/amazon.aws/pull/615).
+        - s3_bucket - ``resource_tags`` has been added as an alias for the ``tags`` parameter (https://github.com/ansible-collections/amazon.aws/pull/845).
       removed_features:
-      - cloudformation - the ``template_format`` option has been removed. It has been
-        ignored by the module since Ansible 2.3 (https://github.com/ansible-collections/amazon.aws/pull/833).
-      - ec2_key - the ``wait_timeout`` option had no effect, was deprecated in release
-        1.0.0, and has now been removed (https://github.com/ansible-collections/amazon.aws/pull/830).
-      - ec2_key - the ``wait`` option had no effect, was deprecated in release 1.0.0,
-        and has now been removed (https://github.com/ansible-collections/amazon.aws/pull/830).
-      - ec2_tag - the previously deprecated state ``list`` has been removed.  To list
-        tags on an EC2 resource the ``ec2_tag_info`` module can be used (https://github.com/ansible-collections/amazon.aws/pull/829).
-      - ec2_vol - the previously deprecated state ``list`` has been removed.  To list
-        volumes the ``ec2_vol_info`` module can be used (https://github.com/ansible-collections/amazon.aws/pull/828).
-      - module_utils.batch - the class ``ansible_collections.amazon.aws.plugins.module_utils.batch.AWSConnection``
-        has been removed.  Please use ``AnsibleAWSModule.client()`` instead (https://github.com/ansible-collections/amazon.aws/pull/831).
+        - cloudformation - the ``template_format`` option has been removed. It has been ignored by the module since Ansible 2.3 (https://github.com/ansible-collections/amazon.aws/pull/833).
+        - ec2_key - the ``wait_timeout`` option had no effect, was deprecated in release 1.0.0, and has now been removed (https://github.com/ansible-collections/amazon.aws/pull/830).
+        - ec2_key - the ``wait`` option had no effect, was deprecated in release 1.0.0, and has now been removed (https://github.com/ansible-collections/amazon.aws/pull/830).
+        - ec2_tag - the previously deprecated state ``list`` has been removed.  To list tags on an EC2 resource the ``ec2_tag_info`` module can be used (https://github.com/ansible-collections/amazon.aws/pull/829).
+        - ec2_vol - the previously deprecated state ``list`` has been removed.  To list volumes the ``ec2_vol_info`` module can be used (https://github.com/ansible-collections/amazon.aws/pull/828).
+        - module_utils.batch - the class ``ansible_collections.amazon.aws.plugins.module_utils.batch.AWSConnection`` has been removed.  Please use ``AnsibleAWSModule.client()``
+          instead (https://github.com/ansible-collections/amazon.aws/pull/831).
     fragments:
-    - 108-ec2_vol-state-list-remove.yml
-    - 151-profile-mutually-exclusive.yml
-    - 318-ec2_vpc_igw_info-convert-tags.yml
-    - 552-elb_classic_lb-fact-remove.yml
-    - 57613-facts.yml
-    - 587-ec2_instance-default-instance-type-launch-template.yml
-    - 598-ec2_vpc_subnet-add-outpostarn-support.yml
-    - 615-s3-validate_bucket_name.yml
-    - 617-aws_ssm-on_missing-and-on-denied-now-default-to-error.yml
-    - 630-remove-boto.yml
-    - 64230-ec2_key-remove-unused.yml
-    - 64368-cloudformation.yml
-    - 66840-ec2_tag-remove-list.yml
-    - 67191-remove-AWSConnection.yml
-    - 715-ec2-instance-metadata-options.yml
-    - 756-ec2_instance-raise-an-error-when-missing-permission.yml
-    - 766-ec2_vpc_igw-use-InternetGatewayIds-not-filters.yml
-    - 795-deprecate-aliases.yml
-    - 811-aws_s3-ovewrite-default.yml
-    - 817-skip_purge_aws.yaml
-    - 845-tagging.yml
-    - 846-tagging-deprecate.yml
-    - 848-ec2_vpc_net-tagging-and-id.yml
-    - 849-ec2_instance-tagging-deprecate.yml
-    - 860-elb_classic_lb-create-https-listeners.yml
-    - 869-s3_object.yml
-    - 877-ec2_eni-device_index-data-change-type-to-str.yml
-    - 878-ec2_group.yml
-    - release-4--botocore.yml
-    release_date: '2022-06-22'
+      - 108-ec2_vol-state-list-remove.yml
+      - 151-profile-mutually-exclusive.yml
+      - 318-ec2_vpc_igw_info-convert-tags.yml
+      - 552-elb_classic_lb-fact-remove.yml
+      - 57613-facts.yml
+      - 587-ec2_instance-default-instance-type-launch-template.yml
+      - 598-ec2_vpc_subnet-add-outpostarn-support.yml
+      - 615-s3-validate_bucket_name.yml
+      - 617-aws_ssm-on_missing-and-on-denied-now-default-to-error.yml
+      - 630-remove-boto.yml
+      - 64230-ec2_key-remove-unused.yml
+      - 64368-cloudformation.yml
+      - 66840-ec2_tag-remove-list.yml
+      - 67191-remove-AWSConnection.yml
+      - 715-ec2-instance-metadata-options.yml
+      - 756-ec2_instance-raise-an-error-when-missing-permission.yml
+      - 766-ec2_vpc_igw-use-InternetGatewayIds-not-filters.yml
+      - 795-deprecate-aliases.yml
+      - 811-aws_s3-ovewrite-default.yml
+      - 817-skip_purge_aws.yaml
+      - 845-tagging.yml
+      - 846-tagging-deprecate.yml
+      - 848-ec2_vpc_net-tagging-and-id.yml
+      - 849-ec2_instance-tagging-deprecate.yml
+      - 860-elb_classic_lb-create-https-listeners.yml
+      - 869-s3_object.yml
+      - 877-ec2_eni-device_index-data-change-type-to-str.yml
+      - 878-ec2_group.yml
+      - release-4--botocore.yml
+    release_date: "2022-06-22"
   4.1.0:
     changes:
       bugfixes:
-      - aws_ec2 - ensure the correct number of hosts are returned when tags as hostnames
-        are used (https://github.com/ansible-collections/amazon.aws/pull/862).
-      - elb_application_lb - fix ``KeyError`` when balancing across two Target Groups
-        (https://github.com/ansible-collections/community.aws/issues/1089).
-      - elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating
-        a new ELB in check mode with a health check (https://github.com/ansible-collections/amazon.aws/pull/915).
-      - elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating
-        a new ELB using security group names (https://github.com/ansible-collections/amazon.aws/issues/914).
+        - aws_ec2 - ensure the correct number of hosts are returned when tags as hostnames are used (https://github.com/ansible-collections/amazon.aws/pull/862).
+        - elb_application_lb - fix ``KeyError`` when balancing across two Target Groups (https://github.com/ansible-collections/community.aws/issues/1089).
+        - elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating a new ELB in check mode with a health check (https://github.com/ansible-collections/amazon.aws/pull/915).
+        - elb_classic_lb - fix ``'NoneType' object has no attribute`` bug when creating a new ELB using security group names (https://github.com/ansible-collections/amazon.aws/issues/914).
       deprecated_features:
-      - amazon.aws collection - due to the AWS SDKs announcing the end of support
-        for Python less than 3.7 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
-        support for Python less than 3.7 by this collection has been deprecated and
-        will be removed in a release after 2023-05-31 (https://github.com/ansible-collections/amazon.aws/pull/935).
+        - amazon.aws collection - due to the AWS SDKs announcing the end of support for Python less than 3.7 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
+          support for Python less than 3.7 by this collection has been deprecated and will be removed in a release after 2023-05-31 (https://github.com/ansible-collections/amazon.aws/pull/935).
       minor_changes:
-      - ec2_instance - expanded the use of the automatic retries on temporary failures
-        (https://github.com/ansible-collections/amazon.aws/issues/927).
-      - s3_bucket - updated module to enable support for setting S3 Bucket Keys for
-        SSE-KMS (https://github.com/ansible-collections/amazon.aws/pull/882).
+        - ec2_instance - expanded the use of the automatic retries on temporary failures (https://github.com/ansible-collections/amazon.aws/issues/927).
+        - s3_bucket - updated module to enable support for setting S3 Bucket Keys for SSE-KMS (https://github.com/ansible-collections/amazon.aws/pull/882).
     fragments:
-    - 1089-elb_application_lb-ForwardConfig-KeyError.yml
-    - 862-aws_ec2-hostnames.yml
-    - 882-s3_bucket-bucket-keys.yml
-    - 914-elb_classic_lb-security_group_names.yml
-    - 927-ec2_instance-retries.yml
-    - python.yml
-    release_date: '2022-08-02'
+      - 1089-elb_application_lb-ForwardConfig-KeyError.yml
+      - 862-aws_ec2-hostnames.yml
+      - 882-s3_bucket-bucket-keys.yml
+      - 914-elb_classic_lb-security_group_names.yml
+      - 927-ec2_instance-retries.yml
+      - python.yml
+    release_date: "2022-08-02"
   4.2.0:
     changes:
       deprecated_features:
-      - module_utils.cloud - removal of the ``CloudRetry.backoff`` has been delayed
-        until release 6.0.0.  It is recommended to update custom modules to use ``jittered_backoff``
-        or ``exponential_backoff`` instead (https://github.com/ansible-collections/amazon.aws/pull/951).
+        - module_utils.cloud - removal of the ``CloudRetry.backoff`` has been delayed until release 6.0.0.  It is recommended to update custom modules to use ``jittered_backoff``
+          or ``exponential_backoff`` instead (https://github.com/ansible-collections/amazon.aws/pull/951).
       minor_changes:
-      - ec2_security_group - set type as ``list`` for rules->group_name as it can
-        accept both ``str`` and ``list`` (https://github.com/ansible-collections/amazon.aws/pull/971).
-      - various modules - linting fixups (https://github.com/ansible-collections/amazon.aws/pull/953).
+        - ec2_security_group - set type as ``list`` for rules->group_name as it can accept both ``str`` and ``list`` (https://github.com/ansible-collections/amazon.aws/pull/971).
+        - various modules - linting fixups (https://github.com/ansible-collections/amazon.aws/pull/953).
     fragments:
-    - 638-ec2_security_group_group_name_datatype.yml
-    - 951-cloudretry.yml
-    - 965-linting.yml
-    release_date: '2022-09-14'
+      - 638-ec2_security_group_group_name_datatype.yml
+      - 951-cloudretry.yml
+      - 965-linting.yml
+    release_date: "2022-09-14"
   4.3.0:
     changes:
       bugfixes:
-      - ec2_metadata_facts - fix ``'NoneType' object is not callable`` exception when
-        using Ansible 2.13+ (https://github.com/ansible-collections/amazon.aws/issues/942).
-      - 'module_utils/cloud - Fix ``ValueError: ansible_collections.amazon.aws.plugins.module_utils.core.__spec__
-        is None`` error on Ansible 2.9 (https://github.com/ansible-collections/amazon.aws/issues/1083).'
+        - ec2_metadata_facts - fix ``'NoneType' object is not callable`` exception when using Ansible 2.13+ (https://github.com/ansible-collections/amazon.aws/issues/942).
+        - "module_utils/cloud - Fix ``ValueError: ansible_collections.amazon.aws.plugins.module_utils.core.__spec__ is None`` error on Ansible 2.9 (https://github.com/ansible-collections/amazon.aws/issues/1083)."
       minor_changes:
-      - ec2_instance - expanded the use of the automatic retries to ``InsuffienctInstanceCapacity``
-        (https://github.com/ansible-collections/amazon.aws/issues/1038).
-      release_summary: 'The amazon.aws 4.3.0 release includes a number of minor bug
-        fixes and improvements.
-
-        Following the release of amazon.aws 5.0.0, backports to the 4.x series will
-        be limited to
-
-        security issues and bugfixes.
-
-        '
+        - ec2_instance - expanded the use of the automatic retries to ``InsuffienctInstanceCapacity`` (https://github.com/ansible-collections/amazon.aws/issues/1038).
+      release_summary: "The amazon.aws 4.3.0 release includes a number of minor bug fixes and improvements.\nFollowing the release of amazon.aws 5.0.0, backports
+        to the 4.x series will be limited to\nsecurity issues and bugfixes.\n"
     fragments:
-    - 1038-ec2-insufficient-capacity.yml
-    - 1083-__spec__-is-None.yml
-    - 943-ec2_metadata_facts-fix-NoneType-callable.yml
-    - RELEASE-4.3.0.yml
-    - tests-cloud.yml
-    - unit-tests_test_rds_py37_only.yaml
-    release_date: '2022-10-06'
+      - 1038-ec2-insufficient-capacity.yml
+      - 1083-__spec__-is-None.yml
+      - 943-ec2_metadata_facts-fix-NoneType-callable.yml
+      - RELEASE-4.3.0.yml
+      - tests-cloud.yml
+      - unit-tests_test_rds_py37_only.yaml
+    release_date: "2022-10-06"
   4.4.0:
     changes:
       minor_changes:
-      - ec2_instance - refacter ``tower_callback`` code to handle parameter validation
-        as part of the argument specification (https://github.com/ansible-collections/amazon.aws/pull/1199).
-      - ec2_instance - the ``tower_callback`` parameter has been renamed to ``aap_callback``,
-        ``tower_callback`` remains as an alias.  This change should have no observable
-        effect for users outside the module documentation (https://github.com/ansible-collections/amazon.aws/pull/1199).
-      release_summary: The amazon.aws 4.4.0 release includes a number of security
-        and minor bug fixes.
+        - ec2_instance - refacter ``tower_callback`` code to handle parameter validation as part of the argument specification (https://github.com/ansible-collections/amazon.aws/pull/1199).
+        - ec2_instance - the ``tower_callback`` parameter has been renamed to ``aap_callback``, ``tower_callback`` remains as an alias.  This change should have no
+          observable effect for users outside the module documentation (https://github.com/ansible-collections/amazon.aws/pull/1199).
+      release_summary: The amazon.aws 4.4.0 release includes a number of security and minor bug fixes.
       security_fixes:
-      - ec2_instance - fixes leak of password into logs when using ``tower_callback.windows=True``
-        and ``tower_callback.set_password`` (https://github.com/ansible-collections/amazon.aws/pull/1199).
+        - ec2_instance - fixes leak of password into logs when using ``tower_callback.windows=True`` and ``tower_callback.set_password`` (https://github.com/ansible-collections/amazon.aws/pull/1199).
     fragments:
-    - 1148-build_run_instance_spec.yml
-    - 1318-module_utils.yml
-    - 20221021-ec2_instance-tower_callback.yml
-    - 20221026-pytest-forked.yml
-    - 20230103-sanity-ec2_eni_info.yml
-    - 20230106-ec2_vol.yml
-    - release_summary.yml
-    release_date: '2023-01-09'
+      - 1148-build_run_instance_spec.yml
+      - 1318-module_utils.yml
+      - 20221021-ec2_instance-tower_callback.yml
+      - 20221026-pytest-forked.yml
+      - 20230103-sanity-ec2_eni_info.yml
+      - 20230106-ec2_vol.yml
+      - release_summary.yml
+    release_date: "2023-01-09"
   4.5.0:
     changes:
       bugfixes:
-      - ec2_vol - handle ec2_vol.tags when the associated instance already exists
-        (https://github.com/ansible-collections/amazon.aws/pull/1071).
+        - ec2_vol - handle ec2_vol.tags when the associated instance already exists (https://github.com/ansible-collections/amazon.aws/pull/1071).
       minor_changes:
-      - ec2_key - minor refactoring and improved unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1288).
-      release_summary: 'This release contains a minor bugfix for the ``ec2_vol`` module,
-        some minor work on the ``ec2_key`` module, and various documentation fixes.  This
-        is the last planned release of the 4.x series.
-
-        '
+        - ec2_key - minor refactoring and improved unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1288).
+      release_summary: "This release contains a minor bugfix for the ``ec2_vol`` module, some minor work on the ``ec2_key`` module, and various documentation fixes.\
+        \  This is the last planned release of the 4.x series.\n"
     fragments:
-    - 1071-ec2_vol_tags_idempotent.yaml
-    - 1357-subnet-example.yml
-    - 1395-s3-encryption.yml
-    - release-notes.yml
-    - unit-tests_test_ec2_key_only.yaml
-    release_date: '2023-05-05'
+      - 1071-ec2_vol_tags_idempotent.yaml
+      - 1357-subnet-example.yml
+      - 1395-s3-encryption.yml
+      - release-notes.yml
+      - unit-tests_test_ec2_key_only.yaml
+    release_date: "2023-05-05"
   5.0.0:
     changes:
       breaking_changes:
-      - amazon.aws collection - Support for ansible-core < 2.11 has been dropped (https://github.com/ansible-collections/amazon.aws/pull/1087).
-      - amazon.aws collection - The amazon.aws collection has dropped support for
-        ``botocore<1.21.0`` and ``boto3<1.18.0``. Most modules will continue to work
-        with older versions of the AWS SDK, however compatibility with older versions
-        of the SDK is not guaranteed and will not be tested. When using older versions
-        of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/934).
-      - doc_fragments - remove minimum collection requirements from doc_fragments/aws.py
-        and allow pulling those from doc_fragments/aws_boto3.py instead (https://github.com/ansible-collections/amazon.aws/pull/985).
-      - ec2_ami - the default value for ``purge_tags`` has been changed from ``False``
-        to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
-      - ec2_ami - the parameter aliases ``DeviceName``, ``VirtualName`` and ``NoDevice``
-        were previously deprecated and have been removed, please use ``device_name``,
-        ``virtual_name`` and ``no_device`` instead (https://github.com/ansible-collections/amazon.aws/pull/913).
-      - ec2_eni_info - the mutual exclusivity of the ``eni_id`` and ``filters`` parameters
-        is now enforced, previously ``filters`` would be ignored if ``eni_id`` was
-        set (https://github.com/ansible-collections/amazon.aws/pull/954).
-      - ec2_instance - the default value for ``purge_tags`` has been changed from
-        ``False`` to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
-      - ec2_key - the default value for ``purge_tags`` has been changed from ``False``
-        to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
-      - ec2_vol - the default value for ``purge_tags`` has been changed from ``False``
-        to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
-      - ec2_vpc_dhcp_option_info - the parameter aliases ``DhcpOptionIds`` and ``DryRun``
-        were previously deprecated and have been removed, please use ``dhcp_options_ids``
-        and ``no_device`` instead (https://github.com/ansible-collections/amazon.aws/pull/913).
-      - ec2_vpc_endpoint - the default value for ``purge_tags`` has been changed from
-        ``False`` to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
-      - ec2_vpc_net - the default value for ``purge_tags`` has been changed from ``False``
-        to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
-      - ec2_vpc_route_table - the default value for ``purge_tags`` has been changed
-        from ``False`` to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
-      - s3_bucket - the previously deprecated alias ``S3_URL`` for the ``s3_url``
-        parameter has been removed.  Playbooks shuold be updated to use ``s3_url``
-        (https://github.com/ansible-collections/amazon.aws/pull/908).
-      - s3_object - the previously deprecated alias ``S3_URL`` for the ``s3_url``
-        parameter has been removed.  Playbooks should be updated to use ``s3_url``
-        (https://github.com/ansible-collections/amazon.aws/pull/908).
+        - amazon.aws collection - Support for ansible-core < 2.11 has been dropped (https://github.com/ansible-collections/amazon.aws/pull/1087).
+        - amazon.aws collection - The amazon.aws collection has dropped support for ``botocore<1.21.0`` and ``boto3<1.18.0``. Most modules will continue to work with
+          older versions of the AWS SDK, however compatibility with older versions of the SDK is not guaranteed and will not be tested. When using older versions
+          of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/934).
+        - doc_fragments - remove minimum collection requirements from doc_fragments/aws.py and allow pulling those from doc_fragments/aws_boto3.py instead (https://github.com/ansible-collections/amazon.aws/pull/985).
+        - ec2_ami - the default value for ``purge_tags`` has been changed from ``False`` to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
+        - ec2_ami - the parameter aliases ``DeviceName``, ``VirtualName`` and ``NoDevice`` were previously deprecated and have been removed, please use ``device_name``,
+          ``virtual_name`` and ``no_device`` instead (https://github.com/ansible-collections/amazon.aws/pull/913).
+        - ec2_eni_info - the mutual exclusivity of the ``eni_id`` and ``filters`` parameters is now enforced, previously ``filters`` would be ignored if ``eni_id``
+          was set (https://github.com/ansible-collections/amazon.aws/pull/954).
+        - ec2_instance - the default value for ``purge_tags`` has been changed from ``False`` to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
+        - ec2_key - the default value for ``purge_tags`` has been changed from ``False`` to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
+        - ec2_vol - the default value for ``purge_tags`` has been changed from ``False`` to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
+        - ec2_vpc_dhcp_option_info - the parameter aliases ``DhcpOptionIds`` and ``DryRun`` were previously deprecated and have been removed, please use ``dhcp_options_ids``
+          and ``no_device`` instead (https://github.com/ansible-collections/amazon.aws/pull/913).
+        - ec2_vpc_endpoint - the default value for ``purge_tags`` has been changed from ``False`` to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
+        - ec2_vpc_net - the default value for ``purge_tags`` has been changed from ``False`` to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
+        - ec2_vpc_route_table - the default value for ``purge_tags`` has been changed from ``False`` to ``True`` (https://github.com/ansible-collections/amazon.aws/pull/916).
+        - s3_bucket - the previously deprecated alias ``S3_URL`` for the ``s3_url`` parameter has been removed.  Playbooks shuold be updated to use ``s3_url`` (https://github.com/ansible-collections/amazon.aws/pull/908).
+        - s3_object - the previously deprecated alias ``S3_URL`` for the ``s3_url`` parameter has been removed.  Playbooks should be updated to use ``s3_url`` (https://github.com/ansible-collections/amazon.aws/pull/908).
       bugfixes:
-      - aws_ec2 - address a regression introduced in 4.1.0 (https://github.com/ansible-collections/amazon.aws/pull/862)
-        that cause the presnse of duplicated hosts in the inventory.
-      - cloudtrail - Fix key error TagList to TagsList (https://github.com/ansible-collections/amazon.aws/issues/1088).
-      - ec2_instance - Only show the deprecation warning for the default value of
-        ``instance_type`` when ``count`` or ``exact_count`` are specified (https://github.com//issues/980).
-      - ec2_metadata_facts - fix ``'NoneType' object is not callable`` exception when
-        using Ansible 2.13+ (https://github.com/ansible-collections/amazon.aws/issues/942).
-      - module_utils/botocore - fix ``object has no attribute 'fail'`` error in error
-        handling (https://github.com/ansible-collections/amazon.aws/pull/1045).
-      - module_utils/elbv2 - fixes ``KeyError`` when using ``UseExistingClientSecret``
-        rather than ``ClientSecret`` (https://github.com/ansible-collections/amazon.aws/pull/940).
-      - module_utils/elbv2 - improvements to idempotency when comparing listeners
-        (https://github.com/ansible-collections/community.aws/issues/604).
-      - s3_object - also use ``ignore_nonexistent_bucket`` when listing a bucket (https://github.com/ansible-collections/amazon.aws/issues/966).
+        - aws_ec2 - address a regression introduced in 4.1.0 (https://github.com/ansible-collections/amazon.aws/pull/862) that cause the presnse of duplicated hosts
+          in the inventory.
+        - cloudtrail - Fix key error TagList to TagsList (https://github.com/ansible-collections/amazon.aws/issues/1088).
+        - ec2_instance - Only show the deprecation warning for the default value of ``instance_type`` when ``count`` or ``exact_count`` are specified (https://github.com//issues/980).
+        - ec2_metadata_facts - fix ``'NoneType' object is not callable`` exception when using Ansible 2.13+ (https://github.com/ansible-collections/amazon.aws/issues/942).
+        - module_utils/botocore - fix ``object has no attribute 'fail'`` error in error handling (https://github.com/ansible-collections/amazon.aws/pull/1045).
+        - module_utils/elbv2 - fixes ``KeyError`` when using ``UseExistingClientSecret`` rather than ``ClientSecret`` (https://github.com/ansible-collections/amazon.aws/pull/940).
+        - module_utils/elbv2 - improvements to idempotency when comparing listeners (https://github.com/ansible-collections/community.aws/issues/604).
+        - s3_object - also use ``ignore_nonexistent_bucket`` when listing a bucket (https://github.com/ansible-collections/amazon.aws/issues/966).
       deprecated_features:
-      - amazon.aws collection - due to the AWS SDKs announcing the end of support
-        for Python less than 3.7 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
-        support for Python less than 3.7 by this collection has been deprecated and
-        will be removed in a release after 2023-05-31 (https://github.com/ansible-collections/amazon.aws/pull/935).
-      - inventory/aws_ec2 - the ``include_extra_api_calls`` is now deprecated, its
-        value is silently ignored (https://github.com/ansible-collections/amazon.aws/pull/1097).
+        - amazon.aws collection - due to the AWS SDKs announcing the end of support for Python less than 3.7 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
+          support for Python less than 3.7 by this collection has been deprecated and will be removed in a release after 2023-05-31 (https://github.com/ansible-collections/amazon.aws/pull/935).
+        - inventory/aws_ec2 - the ``include_extra_api_calls`` is now deprecated, its value is silently ignored (https://github.com/ansible-collections/amazon.aws/pull/1097).
       major_changes:
-      - autoscaling_group - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.autoscaling_group``.
-      - autoscaling_group_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.autoscaling_group_info``.
-      - cloudtrail - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.cloudtrail``.
-      - cloudwatch_metric_alarm - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.cloudwatch_metric_alarm``.
-      - cloudwatchevent_rule - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.cloudwatchevent_rule``.
-      - cloudwatchlogs_log_group - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.cloudwatchlogs_log_group``.
-      - cloudwatchlogs_log_group_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.cloudwatchlogs_log_group_info``.
-      - cloudwatchlogs_log_group_metric_filter - The module has been migrated from
-        the ``community.aws`` collection. Playbooks using the Fully Qualified Collection
-        Name for this module should be updated to use ``amazon.aws.cloudwatchlogs_log_group_metric_filter``.
-      - ec2_eip - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.ec2_eip``.
-      - ec2_eip_info - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.ec2_eip_info``.
-      - elb_application_lb - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.elb_application_lb``.
-      - elb_application_lb_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.elb_application_lb_info``.
-      - execute_lambda - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.execute_lambda``.
-      - iam_policy - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.iam_policy``.
-      - iam_policy_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.iam_policy_info``.
-      - iam_user - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.iam_user``.
-      - iam_user_info - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.iam_user_info``.
-      - kms_key - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.kms_key``.
-      - kms_key_info - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.kms_key_info``.
-      - lambda - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.lambda``.
-      - lambda_alias - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.lambda_alias``.
-      - lambda_event - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.lambda_event``.
-      - lambda_execute - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.lambda_execute``.
-      - lambda_info - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.lambda_info``.
-      - lambda_policy - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.lambda_policy``.
-      - rds_cluster - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.rds_cluster``.
-      - rds_cluster_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.rds_cluster_info``.
-      - rds_cluster_snapshot - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.rds_cluster_snapshot``.
-      - rds_instance - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.rds_instance``.
-      - rds_instance_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.rds_instance_info``.
-      - rds_instance_snapshot - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.rds_instance_snapshot``.
-      - rds_option_group - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.rds_option_group``.
-      - rds_option_group_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.rds_option_group_info``.
-      - rds_param_group - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.rds_param_group``.
-      - rds_snapshot_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.rds_snapshot_info``.
-      - rds_subnet_group - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.rds_subnet_group``.
-      - route53 - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.route53``.
-      - route53_health_check - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.route53_health_check``.
-      - route53_info - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.route53_info``.
-      - route53_zone - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.route53_zone``.
+        - autoscaling_group - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.autoscaling_group``.
+        - autoscaling_group_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this
+          module should be updated to use ``amazon.aws.autoscaling_group_info``.
+        - cloudtrail - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.cloudtrail``.
+        - cloudwatch_metric_alarm - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this
+          module should be updated to use ``amazon.aws.cloudwatch_metric_alarm``.
+        - cloudwatchevent_rule - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this
+          module should be updated to use ``amazon.aws.cloudwatchevent_rule``.
+        - cloudwatchlogs_log_group - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this
+          module should be updated to use ``amazon.aws.cloudwatchlogs_log_group``.
+        - cloudwatchlogs_log_group_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name
+          for this module should be updated to use ``amazon.aws.cloudwatchlogs_log_group_info``.
+        - cloudwatchlogs_log_group_metric_filter - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection
+          Name for this module should be updated to use ``amazon.aws.cloudwatchlogs_log_group_metric_filter``.
+        - ec2_eip - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.ec2_eip``.
+        - ec2_eip_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.ec2_eip_info``.
+        - elb_application_lb - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.elb_application_lb``.
+        - elb_application_lb_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this
+          module should be updated to use ``amazon.aws.elb_application_lb_info``.
+        - execute_lambda - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.execute_lambda``.
+        - iam_policy - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.iam_policy``.
+        - iam_policy_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.iam_policy_info``.
+        - iam_user - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.iam_user``.
+        - iam_user_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.iam_user_info``.
+        - kms_key - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.kms_key``.
+        - kms_key_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.kms_key_info``.
+        - lambda - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.lambda``.
+        - lambda_alias - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.lambda_alias``.
+        - lambda_event - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.lambda_event``.
+        - lambda_execute - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.lambda_execute``.
+        - lambda_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.lambda_info``.
+        - lambda_policy - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.lambda_policy``.
+        - rds_cluster - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.rds_cluster``.
+        - rds_cluster_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.rds_cluster_info``.
+        - rds_cluster_snapshot - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this
+          module should be updated to use ``amazon.aws.rds_cluster_snapshot``.
+        - rds_instance - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.rds_instance``.
+        - rds_instance_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.rds_instance_info``.
+        - rds_instance_snapshot - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this
+          module should be updated to use ``amazon.aws.rds_instance_snapshot``.
+        - rds_option_group - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.rds_option_group``.
+        - rds_option_group_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this
+          module should be updated to use ``amazon.aws.rds_option_group_info``.
+        - rds_param_group - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.rds_param_group``.
+        - rds_snapshot_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.rds_snapshot_info``.
+        - rds_subnet_group - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.rds_subnet_group``.
+        - route53 - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.route53``.
+        - route53_health_check - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this
+          module should be updated to use ``amazon.aws.route53_health_check``.
+        - route53_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.route53_info``.
+        - route53_zone - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.route53_zone``.
       minor_changes:
-      - Ability to record and replay the API interaction of a module for testing purpose.
-        Show case the feature with an example (https://github.com/ansible-collections/amazon.aws/pull/998).
-      - Remove the empty __init__.py file from the distribution, they were not required
-        anymore (https://github.com/ansible-collections/amazon.aws/pull/1018).
-      - amazon.aws modules - the ``ec2_url`` parameter has been renamed to ``endpoint_url``
-        for consistency, ``ec2_url`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/992).
-      - aws_caller_info - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/968).
-      - aws_ec2 - introduce the ``allow_duplicated_hosts`` configuration key (https://github.com/ansible-collections/amazon.aws/pull/1026).
-      - cloudformation - avoid catching ``Exception``, catch more specific errors
-        instead (https://github.com/ansible-collections/amazon.aws/pull/968).
-      - cloudwatch_metric_alarm_info - Added a new module that describes the cloudwatch
-        metric alarms (https://github.com/ansible-collections/amazon.aws/pull/988).
-      - ec2_group - The ``ec2_group`` module has been renamed to ``ec2_security_group``,
-        ``ec2_group`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/897).
-      - ec2_group_info - The ``ec2_group_info`` module has been renamed to ``ec2_security_group_info``,
-        ``ec2_group_info`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/897).
-      - ec2_instance - Add hibernation_options and volumes->ebs->encrypted keys to
-        support stop-hibernate instance (https://github.com/ansible-collections/amazon.aws/pull/972).
-      - ec2_instance - expanded the use of the automatic retries to ``InsuffienctInstanceCapacity``
-        (https://github.com/ansible-collections/amazon.aws/issues/1038).
-      - ec2_metadata_facts - avoid catching ``Exception``, catch more specific errors
-        instead (https://github.com/ansible-collections/amazon.aws/pull/968).
-      - ec2_security_group - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/968).
-      - ec2_vpc_endpoint - avoid catching ``Exception``, catch more specific errors
-        instead (https://github.com/ansible-collections/amazon.aws/pull/968).
-      - ec2_vpc_nat_gateway - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/968).
-      - ec2_vpc_net_info - handle classic link check for shared VPCs by throwing a
-        warning instead of an error (https://github.com/ansible-collections/amazon.aws/pull/984).
-      - module_utils/acm - Move to jittered backoff (https://github.com/ansible-collections/amazon.aws/pull/946).
-      - module_utils/elbv2 - ensures that ``ip_address_type`` is set on creation rather
-        than re-setting it after creation (https://github.com/ansible-collections/amazon.aws/pull/940).
-      - module_utils/elbv2 - uses new waiters with retries for temporary failures
-        (https://github.com/ansible-collections/amazon.aws/pull/940).
-      - module_utils/waf - Move to jittered backoff (https://github.com/ansible-collections/amazon.aws/pull/946).
-      - module_utils/waiters - Add waiters to manage eks_nodegroup module (https://github.com/ansible-collections/community.aws/pull/1415).
-      - s3_bucket - ``rgw`` was added as an alias for the ``ceph`` parameter for consistency
-        with the ``s3_object`` module (https://github.com/ansible-collections/amazon.aws/pull/994).
-      - s3_bucket - the ``s3_url`` parameter was merged into the ``endpoint_url``
-        parameter, ``s3_url`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/994).
-      - s3_object - added the ``sig_v4`` paramater, enbling the user to opt in to
-        signature version 4 for download/get operations. (https://github.com/ansible-collections/amazon.aws/pull/1014)
-      - s3_object - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/968).
-      - s3_object - the ``rgw`` parameter was renamed to ``ceph`` for consistency
-        with the ``s3_bucket`` module, ``rgw`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/994).
-      - s3_object - the ``s3_url`` parameter was merged into the ``endpoint_url``
-        parameter, ``s3_url`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/994).
-      - s3_object - updated module to add support for handling file upload to a bucket
-        with ACL disabled (https://github.com/ansible-collections/amazon.aws/pull/921).
-      - s3_object_info - Added a new module that describes S3 Objects (https://github.com/ansible-collections/amazon.aws/pull/977).
-      release_summary: In this release we promoted many community modules to Red Hat
-        supported status. Those modules have been moved from the commuity.aws to amazon.aws
-        collection. This release also brings some new features, bugfixes, breaking
-        changes and deprecated features. The amazon.aws collection has dropped support
-        for ``botocore<1.21.0`` and ``boto3<1.18.0``. Support for ``ansible-core<2.11``
-        has also been dropped.
+        - Ability to record and replay the API interaction of a module for testing purpose. Show case the feature with an example (https://github.com/ansible-collections/amazon.aws/pull/998).
+        - Remove the empty __init__.py file from the distribution, they were not required anymore (https://github.com/ansible-collections/amazon.aws/pull/1018).
+        - amazon.aws modules - the ``ec2_url`` parameter has been renamed to ``endpoint_url`` for consistency, ``ec2_url`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/992).
+        - aws_caller_info - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/968).
+        - aws_ec2 - introduce the ``allow_duplicated_hosts`` configuration key (https://github.com/ansible-collections/amazon.aws/pull/1026).
+        - cloudformation - avoid catching ``Exception``, catch more specific errors instead (https://github.com/ansible-collections/amazon.aws/pull/968).
+        - cloudwatch_metric_alarm_info - Added a new module that describes the cloudwatch metric alarms (https://github.com/ansible-collections/amazon.aws/pull/988).
+        - ec2_group - The ``ec2_group`` module has been renamed to ``ec2_security_group``, ``ec2_group`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/897).
+        - ec2_group_info - The ``ec2_group_info`` module has been renamed to ``ec2_security_group_info``, ``ec2_group_info`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/897).
+        - ec2_instance - Add hibernation_options and volumes->ebs->encrypted keys to support stop-hibernate instance (https://github.com/ansible-collections/amazon.aws/pull/972).
+        - ec2_instance - expanded the use of the automatic retries to ``InsuffienctInstanceCapacity`` (https://github.com/ansible-collections/amazon.aws/issues/1038).
+        - ec2_metadata_facts - avoid catching ``Exception``, catch more specific errors instead (https://github.com/ansible-collections/amazon.aws/pull/968).
+        - ec2_security_group - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/968).
+        - ec2_vpc_endpoint - avoid catching ``Exception``, catch more specific errors instead (https://github.com/ansible-collections/amazon.aws/pull/968).
+        - ec2_vpc_nat_gateway - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/968).
+        - ec2_vpc_net_info - handle classic link check for shared VPCs by throwing a warning instead of an error (https://github.com/ansible-collections/amazon.aws/pull/984).
+        - module_utils/acm - Move to jittered backoff (https://github.com/ansible-collections/amazon.aws/pull/946).
+        - module_utils/elbv2 - ensures that ``ip_address_type`` is set on creation rather than re-setting it after creation (https://github.com/ansible-collections/amazon.aws/pull/940).
+        - module_utils/elbv2 - uses new waiters with retries for temporary failures (https://github.com/ansible-collections/amazon.aws/pull/940).
+        - module_utils/waf - Move to jittered backoff (https://github.com/ansible-collections/amazon.aws/pull/946).
+        - module_utils/waiters - Add waiters to manage eks_nodegroup module (https://github.com/ansible-collections/community.aws/pull/1415).
+        - s3_bucket - ``rgw`` was added as an alias for the ``ceph`` parameter for consistency with the ``s3_object`` module (https://github.com/ansible-collections/amazon.aws/pull/994).
+        - s3_bucket - the ``s3_url`` parameter was merged into the ``endpoint_url`` parameter, ``s3_url`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/994).
+        - s3_object - added the ``sig_v4`` paramater, enbling the user to opt in to signature version 4 for download/get operations. (https://github.com/ansible-collections/amazon.aws/pull/1014)
+        - s3_object - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/968).
+        - s3_object - the ``rgw`` parameter was renamed to ``ceph`` for consistency with the ``s3_bucket`` module, ``rgw`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/994).
+        - s3_object - the ``s3_url`` parameter was merged into the ``endpoint_url`` parameter, ``s3_url`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/994).
+        - s3_object - updated module to add support for handling file upload to a bucket with ACL disabled (https://github.com/ansible-collections/amazon.aws/pull/921).
+        - s3_object_info - Added a new module that describes S3 Objects (https://github.com/ansible-collections/amazon.aws/pull/977).
+      release_summary: In this release we promoted many community modules to Red Hat supported status. Those modules have been moved from the commuity.aws to amazon.aws
+        collection. This release also brings some new features, bugfixes, breaking changes and deprecated features. The amazon.aws collection has dropped support
+        for ``botocore<1.21.0`` and ``boto3<1.18.0``. Support for ``ansible-core<2.11`` has also been dropped.
     fragments:
-    - 1014-add-support-for-signature-version-4-to-the-s3_object-geturl-mode.yml
-    - 1038-ec2-insufficient-capacity.yml
-    - 1045-botocore_fail.yml
-    - 1047-docsite-changelog.yml
-    - 1055-bools.yml
-    - 1061-legacy_aliases.yml
-    - 1061-sanity.yml
-    - 1070-gitleaks-1.yml
-    - 1073-gitleaks-2.yml
-    - 1087-old-ansible.yml
-    - 1088-fix_key_error_TagsList_cloudtrail.yml
-    - 1094-revert.yml
-    - 604-elb_network_lb.yml
-    - 897-ec2_security_group.yml
-    - 908-s3_url.yml
-    - 913-deprecations.yml
-    - 916-purge_tags.yml
-    - 921-s3_object-handle-file-upload-to-acl-disabled-bucket.yml
-    - 943-ec2_metadata_facts-fix-NoneType-callable.yml
-    - 946-retries.yml
-    - 954-linting.yml
-    - 966-ignore_nonexistent_bucket_list.yml
-    - 968-sanity.yml
-    - 972-ec2_instance-stop-hibernate.yml
-    - 975-waiters-eks_nodegroup.yml
-    - 977-s3_object_info-add-new-module.yml
-    - 978-bools.yml
-    - 979-ec2_instance_tests_split.yaml
-    - 980-instance-type-deprecation-warning.yml
-    - 984-ec2_vpc_net_info_shared_vpc.yml
-    - 985-cleanup_doc_fragments.yml
-    - 988-cloudwatch_metric_alarm_info-add-new-module.yml
-    - 992-ec2_url.yml
-    - 994-s3_url.yml
-    - botocore.yml
-    - ec2_instance-test-duration.yaml
-    - inventory-aws_ec2-avoid-py38-syntax.yaml
-    - inventory-aws_ec2-include_extra_api_calls-is-deprecated.yaml
-    - inventory-aws_ec2_unit-tests.yaml
-    - inventory-multi-hosts.yaml
-    - migrate_autoscaling_group.yml
-    - migrate_cloudtrail.yml
-    - migrate_cloudtrail_tests.yml
-    - migrate_cloudwatch_metric_alarm.yml
-    - migrate_cloudwatchevent.yml
-    - migrate_cloudwatchlogs.yml
-    - migrate_ec2_eip.yml
-    - migrate_elb_application_lb.yml
-    - migrate_iam_policy.yml
-    - migrate_iam_user.yml
-    - migrate_kms_key.yml
-    - migrate_lambda.yml
-    - migrate_rds_cluster.yml
-    - migrate_rds_instance.yml
-    - migrate_rds_option_group.yml
-    - migrate_rds_param_group.yml
-    - migrate_rds_snapshot.yml
-    - migrate_rds_subnet_group.yml
-    - migrate_route53.yml
-    - migrate_route53_module_utils.yml
-    - placebo_record.yaml
-    - python.yml
-    - release_summary.yml
-    - remove__init__.py_file.yaml
-    - test-python3-unicode-string.yaml
-    - tests-cloud.yml
-    - unit-tests_test_rds_py37_only.yaml
+      - 1014-add-support-for-signature-version-4-to-the-s3_object-geturl-mode.yml
+      - 1038-ec2-insufficient-capacity.yml
+      - 1045-botocore_fail.yml
+      - 1047-docsite-changelog.yml
+      - 1055-bools.yml
+      - 1061-legacy_aliases.yml
+      - 1061-sanity.yml
+      - 1070-gitleaks-1.yml
+      - 1073-gitleaks-2.yml
+      - 1087-old-ansible.yml
+      - 1088-fix_key_error_TagsList_cloudtrail.yml
+      - 1094-revert.yml
+      - 604-elb_network_lb.yml
+      - 897-ec2_security_group.yml
+      - 908-s3_url.yml
+      - 913-deprecations.yml
+      - 916-purge_tags.yml
+      - 921-s3_object-handle-file-upload-to-acl-disabled-bucket.yml
+      - 943-ec2_metadata_facts-fix-NoneType-callable.yml
+      - 946-retries.yml
+      - 954-linting.yml
+      - 966-ignore_nonexistent_bucket_list.yml
+      - 968-sanity.yml
+      - 972-ec2_instance-stop-hibernate.yml
+      - 975-waiters-eks_nodegroup.yml
+      - 977-s3_object_info-add-new-module.yml
+      - 978-bools.yml
+      - 979-ec2_instance_tests_split.yaml
+      - 980-instance-type-deprecation-warning.yml
+      - 984-ec2_vpc_net_info_shared_vpc.yml
+      - 985-cleanup_doc_fragments.yml
+      - 988-cloudwatch_metric_alarm_info-add-new-module.yml
+      - 992-ec2_url.yml
+      - 994-s3_url.yml
+      - botocore.yml
+      - ec2_instance-test-duration.yaml
+      - inventory-aws_ec2-avoid-py38-syntax.yaml
+      - inventory-aws_ec2-include_extra_api_calls-is-deprecated.yaml
+      - inventory-aws_ec2_unit-tests.yaml
+      - inventory-multi-hosts.yaml
+      - migrate_autoscaling_group.yml
+      - migrate_cloudtrail.yml
+      - migrate_cloudtrail_tests.yml
+      - migrate_cloudwatch_metric_alarm.yml
+      - migrate_cloudwatchevent.yml
+      - migrate_cloudwatchlogs.yml
+      - migrate_ec2_eip.yml
+      - migrate_elb_application_lb.yml
+      - migrate_iam_policy.yml
+      - migrate_iam_user.yml
+      - migrate_kms_key.yml
+      - migrate_lambda.yml
+      - migrate_rds_cluster.yml
+      - migrate_rds_instance.yml
+      - migrate_rds_option_group.yml
+      - migrate_rds_param_group.yml
+      - migrate_rds_snapshot.yml
+      - migrate_rds_subnet_group.yml
+      - migrate_route53.yml
+      - migrate_route53_module_utils.yml
+      - placebo_record.yaml
+      - python.yml
+      - release_summary.yml
+      - remove__init__.py_file.yaml
+      - test-python3-unicode-string.yaml
+      - tests-cloud.yml
+      - unit-tests_test_rds_py37_only.yaml
     modules:
-    - description: Gather information about trails in AWS Cloud Trail.
-      name: cloudtrail_info
-      namespace: ''
-    - description: Gather information about the alarms for the specified metric
-      name: cloudwatch_metric_alarm_info
-      namespace: ''
-    - description: Gather information about objects in S3
-      name: s3_object_info
-      namespace: ''
-    release_date: '2022-10-04'
+      - description: Gather information about trails in AWS Cloud Trail.
+        name: cloudtrail_info
+        namespace: ""
+      - description: Gather information about the alarms for the specified metric
+        name: cloudwatch_metric_alarm_info
+        namespace: ""
+      - description: Gather information about objects in S3
+        name: s3_object_info
+        namespace: ""
+    release_date: "2022-10-04"
   5.0.1:
     changes:
       bugfixes:
-      - ec2_vpc_net_info - fix KeyError (https://github.com/ansible-collections/amazon.aws/pull/1109).
-      - ec2_vpc_net_info - remove hardcoded ``ClassicLinkEnabled`` parameter when
-        request for ``ClassicLinkDnsSupported`` failed (https://github.com/ansible-collections/amazon.aws/pull/1109).
-      - s3_object - be more defensive when checking the results of ``s3.get_bucket_ownership_controls``
-        (https://github.com/ansible-collections/amazon.aws/issues/1115).
+        - ec2_vpc_net_info - fix KeyError (https://github.com/ansible-collections/amazon.aws/pull/1109).
+        - ec2_vpc_net_info - remove hardcoded ``ClassicLinkEnabled`` parameter when request for ``ClassicLinkDnsSupported`` failed (https://github.com/ansible-collections/amazon.aws/pull/1109).
+        - s3_object - be more defensive when checking the results of ``s3.get_bucket_ownership_controls`` (https://github.com/ansible-collections/amazon.aws/issues/1115).
     fragments:
-    - 1109-ec2_vpc_net_info_keyerror.yml
-    - 1115-s3_object-scaleway.yml
-    release_date: '2022-10-06'
+      - 1109-ec2_vpc_net_info_keyerror.yml
+      - 1115-s3_object-scaleway.yml
+    release_date: "2022-10-06"
   5.0.2:
     changes:
       bugfixes:
-      - ec2_metadata_facts - fixed ``AttributeError`` (https://github.com/ansible-collections/amazon.aws/issues/1134).
+        - ec2_metadata_facts - fixed ``AttributeError`` (https://github.com/ansible-collections/amazon.aws/issues/1134).
     fragments:
-    - 1134-ec2_metadata_facts-AttributeError.yml
-    release_date: '2022-10-10'
+      - 1134-ec2_metadata_facts-AttributeError.yml
+    release_date: "2022-10-10"
   5.1.0:
     changes:
       bugfixes:
-      - ec2_instance - fixes ``Invalid type for parameter TagSpecifications, value
-        None`` error when tags aren't specified (https://github.com/ansible-collections/amazon.aws/issues/1148).
-      - module_utils.transformations - ensure that ``map_complex_type`` still returns
-        transformed items if items exists that are not in the type_map (https://github.com/ansible-collections/amazon.aws/pull/1163).
+        - ec2_instance - fixes ``Invalid type for parameter TagSpecifications, value None`` error when tags aren't specified (https://github.com/ansible-collections/amazon.aws/issues/1148).
+        - module_utils.transformations - ensure that ``map_complex_type`` still returns transformed items if items exists that are not in the type_map (https://github.com/ansible-collections/amazon.aws/pull/1163).
       deprecated_features:
-      - amazon.aws collection - Support for the ``EC2_ACCESS_KEY`` environment variable
-        has been deprecated and will be removed in a release after 2024-12-01.  Please
-        use the ``access_key`` parameter or ``AWS_ACCESS_KEY_ID`` environment variable
-        instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - amazon.aws collection - Support for the ``EC2_REGION`` environment variable
-        has been deprecated and will be removed in a release after 2024-12-01.  Please
-        use the ``region`` parameter or ``AWS_REGION`` environment variable instead
-        (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - amazon.aws collection - Support for the ``EC2_SECRET_KEY`` environment variable
-        has been deprecated and will be removed in a release after 2024-12-01.  Please
-        use the ``secret_key`` parameter or ``AWS_SECRET_ACCESS_KEY`` environment
-        variable instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - amazon.aws collection - Support for the ``EC2_SECURITY_TOKEN`` environment
-        variable has been deprecated and will be removed in a release after 2024-12-01.  Please
-        use the ``session_token`` parameter or ``AWS_SESSION_TOKEN`` environment variable
-        instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - amazon.aws collection - Support for the ``EC2_URL`` and ``S3_URL`` environment
-        variables has been deprecated and will be removed in a release after 2024-12-01.  Please
-        use the ``endpoint_url`` parameter or ``AWS_ENDPOINT_URL`` environment variable
-        instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - amazon.aws collection - The ``access_token`` alias for the ``session_token``
-        parameter has been deprecated and will be removed in a release after 2024-12-01.  Please
-        use the ``session_token`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - amazon.aws collection - The ``access_token`` alias for the ``session_token``
-        parameter has been deprecated and will be removed in a release after 2024-12-01.  Please
-        use the ``session_token`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - amazon.aws collection - The ``aws_security_token`` alias for the ``session_token``
-        parameter has been deprecated and will be removed in a release after 2024-12-01.  Please
-        use the ``session_token`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - amazon.aws collection - The ``ec2_access_key`` alias for the ``access_key``
-        parameter has been deprecated and will be removed in a release after 2024-12-01.  Please
-        use the ``access_key`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - amazon.aws collection - The ``ec2_region`` alias for the ``region`` parameter
-        has been deprecated and will be removed in a release after 2024-12-01.  Please
-        use the ``region`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - amazon.aws collection - The ``ec2_secret_key`` alias for the ``secret_key``
-        parameter has been deprecated and will be removed in a release after 2024-12-01.  Please
-        use the ``secret_key`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - amazon.aws collection - The ``security_token`` alias for the ``session_token``
-        parameter has been deprecated and will be removed in a release after 2024-12-01.  Please
-        use the ``session_token`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - 'ec2_security_group - support for passing nested lists to ``cidr_ip`` and
-        ``cidr_ipv6`` has been deprecated. Nested lists can be passed through the
-        ``flatten`` filter instead ``cidr_ip: ''{{ my_cidrs | flatten }}''`` (https://github.com/ansible-collections/amazon.aws/pull/1213).'
-      - module_utils.url - ``ansible_collections.amazon.aws.module_utils.urls`` is
-        believed to be unused and has been deprecated and will be removed in release
-        7.0.0.
+        - amazon.aws collection - Support for the ``EC2_ACCESS_KEY`` environment variable has been deprecated and will be removed in a release after 2024-12-01.  Please
+          use the ``access_key`` parameter or ``AWS_ACCESS_KEY_ID`` environment variable instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - amazon.aws collection - Support for the ``EC2_REGION`` environment variable has been deprecated and will be removed in a release after 2024-12-01.  Please
+          use the ``region`` parameter or ``AWS_REGION`` environment variable instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - amazon.aws collection - Support for the ``EC2_SECRET_KEY`` environment variable has been deprecated and will be removed in a release after 2024-12-01.  Please
+          use the ``secret_key`` parameter or ``AWS_SECRET_ACCESS_KEY`` environment variable instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - amazon.aws collection - Support for the ``EC2_SECURITY_TOKEN`` environment variable has been deprecated and will be removed in a release after 2024-12-01.  Please
+          use the ``session_token`` parameter or ``AWS_SESSION_TOKEN`` environment variable instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - amazon.aws collection - Support for the ``EC2_URL`` and ``S3_URL`` environment variables has been deprecated and will be removed in a release after 2024-12-01.  Please
+          use the ``endpoint_url`` parameter or ``AWS_ENDPOINT_URL`` environment variable instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - amazon.aws collection - The ``access_token`` alias for the ``session_token`` parameter has been deprecated and will be removed in a release after 2024-12-01.  Please
+          use the ``session_token`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - amazon.aws collection - The ``access_token`` alias for the ``session_token`` parameter has been deprecated and will be removed in a release after 2024-12-01.  Please
+          use the ``session_token`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - amazon.aws collection - The ``aws_security_token`` alias for the ``session_token`` parameter has been deprecated and will be removed in a release after
+          2024-12-01.  Please use the ``session_token`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - amazon.aws collection - The ``ec2_access_key`` alias for the ``access_key`` parameter has been deprecated and will be removed in a release after 2024-12-01.  Please
+          use the ``access_key`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - amazon.aws collection - The ``ec2_region`` alias for the ``region`` parameter has been deprecated and will be removed in a release after 2024-12-01.  Please
+          use the ``region`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - amazon.aws collection - The ``ec2_secret_key`` alias for the ``secret_key`` parameter has been deprecated and will be removed in a release after 2024-12-01.  Please
+          use the ``secret_key`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - amazon.aws collection - The ``security_token`` alias for the ``session_token`` parameter has been deprecated and will be removed in a release after 2024-12-01.  Please
+          use the ``session_token`` name instead (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - "ec2_security_group - support for passing nested lists to ``cidr_ip`` and ``cidr_ipv6`` has been deprecated. Nested lists can be passed through the ``flatten``
+          filter instead ``cidr_ip: '{{ my_cidrs | flatten }}'`` (https://github.com/ansible-collections/amazon.aws/pull/1213)."
+        - module_utils.url - ``ansible_collections.amazon.aws.module_utils.urls`` is believed to be unused and has been deprecated and will be removed in release
+          7.0.0.
       minor_changes:
-      - amazon.aws collection - The ``aws_access_key`` parameter has been renamed
-        to ``access_key``, ``access_key`` was previously an alias for this parameter
-        and ``aws_access_key`` remains as an alias.  This change should have no observable
-        effect for users outside the module/plugin documentation. (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - amazon.aws collection - The ``aws_secret_key`` parameter has been renamed
-        to ``secret_key``, ``secret_key`` was previously an alias for this parameter
-        and ``aws_secret_key`` remains as an alias.  This change should have no observable
-        effect for users outside the module/plugin documentation. (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - amazon.aws collection - The ``security_token`` parameter has been renamed
-        to ``session_token``, ``security_token`` was previously an alias for this
-        parameter and ``security_token`` remains as an alias.  This change should
-        have no observable effect for users outside the module/plugin documentation.
-        (https://github.com/ansible-collections/amazon.aws/pull/1172).
-      - aws_account_attribute lookup plugin - use ``missing_required_lib`` for more
-        consistent error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
-      - aws_ec2 inventory - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - aws_ec2 inventory plugin - use ``missing_required_lib`` for more consistent
-        error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
-      - aws_rds inventory plugin - use ``missing_required_lib`` for more consistent
-        error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
-      - aws_secret lookup plugin - use ``missing_required_lib`` for more consistent
-        error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
-      - aws_ssm lookup plugin - use ``missing_required_lib`` for more consistent error
-        message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
-      - ec2_instance - minor fix for launching an instance in specified AZ when ``vpc_subnet_id``
-        is not provided (https://github.com/ansible-collections/amazon.aws/pull/1150).
-      - ec2_instance - refacter ``tower_callback`` code to handle parameter validation
-        as part of the argument specification (https://github.com/ansible-collections/amazon.aws/pull/1199).
-      - ec2_instance - the ``instance_role`` parameter has been renamed to ``iam_instance_profile``
-        to better reflect what it is, ``instance_role`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/1151).
-      - ec2_instance - the ``tower_callback`` parameter has been renamed to ``aap_callback``,
-        ``tower_callback`` remains as an alias.  This change should have no observable
-        effect for users outside the module documentation (https://github.com/ansible-collections/amazon.aws/pull/1199).
-      - s3_object_info - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      release_summary: This release brings some minor changes, bugfixes, security
-        fixes and deprecated features.
+        - amazon.aws collection - The ``aws_access_key`` parameter has been renamed to ``access_key``, ``access_key`` was previously an alias for this parameter and
+          ``aws_access_key`` remains as an alias.  This change should have no observable effect for users outside the module/plugin documentation. (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - amazon.aws collection - The ``aws_secret_key`` parameter has been renamed to ``secret_key``, ``secret_key`` was previously an alias for this parameter and
+          ``aws_secret_key`` remains as an alias.  This change should have no observable effect for users outside the module/plugin documentation. (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - amazon.aws collection - The ``security_token`` parameter has been renamed to ``session_token``, ``security_token`` was previously an alias for this parameter
+          and ``security_token`` remains as an alias.  This change should have no observable effect for users outside the module/plugin documentation. (https://github.com/ansible-collections/amazon.aws/pull/1172).
+        - aws_account_attribute lookup plugin - use ``missing_required_lib`` for more consistent error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
+        - aws_ec2 inventory - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - aws_ec2 inventory plugin - use ``missing_required_lib`` for more consistent error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
+        - aws_rds inventory plugin - use ``missing_required_lib`` for more consistent error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
+        - aws_secret lookup plugin - use ``missing_required_lib`` for more consistent error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
+        - aws_ssm lookup plugin - use ``missing_required_lib`` for more consistent error message when boto3/botocore is not available (https://github.com/ansible-collections/amazon.aws/pull/1152).
+        - ec2_instance - minor fix for launching an instance in specified AZ when ``vpc_subnet_id`` is not provided (https://github.com/ansible-collections/amazon.aws/pull/1150).
+        - ec2_instance - refacter ``tower_callback`` code to handle parameter validation as part of the argument specification (https://github.com/ansible-collections/amazon.aws/pull/1199).
+        - ec2_instance - the ``instance_role`` parameter has been renamed to ``iam_instance_profile`` to better reflect what it is, ``instance_role`` remains as an
+          alias (https://github.com/ansible-collections/amazon.aws/pull/1151).
+        - ec2_instance - the ``tower_callback`` parameter has been renamed to ``aap_callback``, ``tower_callback`` remains as an alias.  This change should have no
+          observable effect for users outside the module documentation (https://github.com/ansible-collections/amazon.aws/pull/1199).
+        - s3_object_info - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+      release_summary: This release brings some minor changes, bugfixes, security fixes and deprecated features.
       security_fixes:
-      - ec2_instance - fixes leak of password into logs when using ``tower_callback.windows=True``
-        and ``tower_callback.set_password`` (https://github.com/ansible-collections/amazon.aws/pull/1199).
+        - ec2_instance - fixes leak of password into logs when using ``tower_callback.windows=True`` and ``tower_callback.set_password`` (https://github.com/ansible-collections/amazon.aws/pull/1199).
     fragments:
-    - 1148-build_run_instance_spec.yml
-    - 1150-ec2_instance-fix-instance-creation-in-az.yml
-    - 1152-missing-botocore.yml
-    - 1163-map_complex_type.yml
-    - 1172-credentials_parameters.yml
-    - 1181-stable-5-linting.yml
-    - 20221010-test-times.yml
-    - 20221021-ec2_instance-tower_callback.yml
-    - 20221026-pytest-forked.yml
-    - 20221027-ec2_security_group-nested.yml
-    - DEPRECATE-module_utils-urls.yml
-    - summary.yml
-    - version_added-5.yml
-    - workflows-add-intersphinx.yml
-    release_date: '2022-10-28'
+      - 1148-build_run_instance_spec.yml
+      - 1150-ec2_instance-fix-instance-creation-in-az.yml
+      - 1152-missing-botocore.yml
+      - 1163-map_complex_type.yml
+      - 1172-credentials_parameters.yml
+      - 1181-stable-5-linting.yml
+      - 20221010-test-times.yml
+      - 20221021-ec2_instance-tower_callback.yml
+      - 20221026-pytest-forked.yml
+      - 20221027-ec2_security_group-nested.yml
+      - DEPRECATE-module_utils-urls.yml
+      - summary.yml
+      - version_added-5.yml
+      - workflows-add-intersphinx.yml
+    release_date: "2022-10-28"
   5.2.0:
     changes:
       bugfixes:
-      - aws_rds - fixes bug in RDS inventory plugin where config file was ignored
-        (https://github.com/ansible-collections/amazon.aws/issues/1304).
-      - lambda - fix flaky integration test which assumes there are no other lambdas
-        in the account (https://github.com/ansible-collections/amazon.aws/issues/1277)
+        - aws_rds - fixes bug in RDS inventory plugin where config file was ignored (https://github.com/ansible-collections/amazon.aws/issues/1304).
+        - lambda - fix flaky integration test which assumes there are no other lambdas in the account (https://github.com/ansible-collections/amazon.aws/issues/1277)
       minor_changes:
-      - amazon.aws collection - refacterization of code to use argument specification
-        ``fallback`` when falling back to environment variables for security credentials
-        and AWS connection details (https://github.com/ansible-collections/amazon.aws/pull/1174).
-      - rds_instance - Split up the integration test-suite in a series of smaller
-        tests (https://github.com/ansible-collections/amazon.aws/pull/1185).
-      - rds_instance - add support for gp3 storage type (https://github.com/ansible-collections/amazon.aws/pull/1266).
-      release_summary: 'A minor release containing bugfixes for the ``ec2_eni_info``
-        module and the ``aws_rds`` inventory plugin, as well as improvements to the
-        ``rds_instance`` module.
-
-        '
+        - amazon.aws collection - refacterization of code to use argument specification ``fallback`` when falling back to environment variables for security credentials
+          and AWS connection details (https://github.com/ansible-collections/amazon.aws/pull/1174).
+        - rds_instance - Split up the integration test-suite in a series of smaller tests (https://github.com/ansible-collections/amazon.aws/pull/1185).
+        - rds_instance - add support for gp3 storage type (https://github.com/ansible-collections/amazon.aws/pull/1266).
+      release_summary: "A minor release containing bugfixes for the ``ec2_eni_info`` module and the ``aws_rds`` inventory plugin, as well as improvements to the ``rds_instance``
+        module.\n"
     fragments:
-    - 1174-module_params.yml
-    - 1266-rds_instance_gp3_support.yaml
-    - 1277-lambda-int-test-other-lambdas.yml
-    - 1283-aws_ec2_inventory_compose_doc_examples.yml
-    - 1304-aws_rds-config.yml
-    - 20230103-sanity-ec2_eni_info.yml
-    - 20230106-ec2_vol.yml
-    - integration_tests_max_duration_increase.yaml
-    - rds_instance_split_the_integration_test-suite.yaml
-    - rds_mariadb_version-10.6.10.yml
-    - release.yml
-    release_date: '2023-01-24'
+      - 1174-module_params.yml
+      - 1266-rds_instance_gp3_support.yaml
+      - 1277-lambda-int-test-other-lambdas.yml
+      - 1283-aws_ec2_inventory_compose_doc_examples.yml
+      - 1304-aws_rds-config.yml
+      - 20230103-sanity-ec2_eni_info.yml
+      - 20230106-ec2_vol.yml
+      - integration_tests_max_duration_increase.yaml
+      - rds_instance_split_the_integration_test-suite.yaml
+      - rds_mariadb_version-10.6.10.yml
+      - release.yml
+    release_date: "2023-01-24"
   5.3.0:
     changes:
       bugfixes:
-      - cloudtrail - support to disabling encryption using ``kms_key_id`` (https://github.com/ansible-collections/amazon.aws/pull/1384).
-      - ec2_key - fix issue when trying to update existing key pair with the same
-        key material (https://github.com/ansible-collections/amazon.aws/pull/1383).
-      - module_utils/elbv2 - fix change detection by adding default values for ``Scope``
-        and ``SessionTimeout`` parameters in ``authenticate-oidc`` rules (https://github.com/ansible-collections/amazon.aws/pull/1270).
-      - module_utils/elbv2 - respect ``UseExistingClientSecret`` parameter in ``authenticate-oidc``
-        rules (https://github.com/ansible-collections/amazon.aws/pull/1270).
-      - revert breaking change introduced in 5.2.0 when passing credentials through
-        a mix of environment variables and parameters (https://github.com/ansible-collections/amazon.aws/issues/1353).
-      - s3_bucket - empty bucket policy was throwing a JSONDecodeError - deal with
-        it gracefully instead (https://github.com/ansible-collections/amazon.aws/pull/1368)
+        - cloudtrail - support to disabling encryption using ``kms_key_id`` (https://github.com/ansible-collections/amazon.aws/pull/1384).
+        - ec2_key - fix issue when trying to update existing key pair with the same key material (https://github.com/ansible-collections/amazon.aws/pull/1383).
+        - module_utils/elbv2 - fix change detection by adding default values for ``Scope`` and ``SessionTimeout`` parameters in ``authenticate-oidc`` rules (https://github.com/ansible-collections/amazon.aws/pull/1270).
+        - module_utils/elbv2 - respect ``UseExistingClientSecret`` parameter in ``authenticate-oidc`` rules (https://github.com/ansible-collections/amazon.aws/pull/1270).
+        - revert breaking change introduced in 5.2.0 when passing credentials through a mix of environment variables and parameters (https://github.com/ansible-collections/amazon.aws/issues/1353).
+        - s3_bucket - empty bucket policy was throwing a JSONDecodeError - deal with it gracefully instead (https://github.com/ansible-collections/amazon.aws/pull/1368)
       deprecated_features:
-      - support for passing both profile and security tokens through a mix of environment
-        variables and parameters has been deprecated and support will be removed in
-        release 6.0.0. After release 6.0.0 it will only be possible to pass either
-        a profile or security tokens, regardless of mechanism used to pass them.  To
-        explicitly block a parameter coming from an environment variable pass an empty
-        string as the parameter value.  Support for passing profile and security tokens
-        together was originally deprecated in release 1.2.0, however only partially
-        implemented in release 5.0.0 (https://github.com/ansible-collections/amazon.aws/pull/1355).
+        - support for passing both profile and security tokens through a mix of environment variables and parameters has been deprecated and support will be removed
+          in release 6.0.0. After release 6.0.0 it will only be possible to pass either a profile or security tokens, regardless of mechanism used to pass them.  To
+          explicitly block a parameter coming from an environment variable pass an empty string as the parameter value.  Support for passing profile and security
+          tokens together was originally deprecated in release 1.2.0, however only partially implemented in release 5.0.0 (https://github.com/ansible-collections/amazon.aws/pull/1355).
       minor_changes:
-      - ec2_instance - more consistently return ``instances`` information (https://github.com/ansible-collections/amazon.aws/pull/964).
-      - ec2_instance - remove unused import (https://github.com/ansible-collections/amazon.aws/pull/1350).
-      - ec2_key - Add unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1288).
-      - ec2_vpc_nat_gateway - ensure allocation_id is defined before potential access
-        (https://github.com/ansible-collections/amazon.aws/pull/1350).
-      - route53_zone - added support for associating multiple VPCs to route53 hosted
-        zones (https://github.com/ansible-collections/amazon.aws/pull/1300).
-      - s3_bucket - add option to support creation of buckets with object lock enabled
-        (https://github.com/ansible-collections/amazon.aws/pull/1372).
-      release_summary: This release brings some minor changes, bugfixes, and deprecated
-        features.
+        - ec2_instance - more consistently return ``instances`` information (https://github.com/ansible-collections/amazon.aws/pull/964).
+        - ec2_instance - remove unused import (https://github.com/ansible-collections/amazon.aws/pull/1350).
+        - ec2_key - Add unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1288).
+        - ec2_vpc_nat_gateway - ensure allocation_id is defined before potential access (https://github.com/ansible-collections/amazon.aws/pull/1350).
+        - route53_zone - added support for associating multiple VPCs to route53 hosted zones (https://github.com/ansible-collections/amazon.aws/pull/1300).
+        - s3_bucket - add option to support creation of buckets with object lock enabled (https://github.com/ansible-collections/amazon.aws/pull/1372).
+      release_summary: This release brings some minor changes, bugfixes, and deprecated features.
     fragments:
-    - 1226-defaults.yml
-    - 1270-elbv2-fixes.yml
-    - 1299-route53_zone-multi-vpc.yml
-    - 1347-s3-object-lock-enabled.yml
-    - 1353-revert-env-fallback.yml
-    - 1357-subnet-example.yml
-    - 1368-empty_bucket_policy.yml
-    - 1383-ec2_key-fix-idempotency-issue-when-creating-existing-key-with-same-key-material.yaml
-    - 1384-cloudtrail-disable_encryption.yml
-    - 1395-s3-encryption.yml
-    - 1400-typo.yml
-    - 20230204-sanity.yml
-    - 20230220-inventory_docs_ec2_aws.yml
-    - 389-ssm_parameter-versioned_test.yml
-    - 964-ec2_instance-return-instances.yml
-    - release_summary.yml
-    - unit-tests_test_ec2_key_only.yaml
-    release_date: '2023-03-05'
+      - 1226-defaults.yml
+      - 1270-elbv2-fixes.yml
+      - 1299-route53_zone-multi-vpc.yml
+      - 1347-s3-object-lock-enabled.yml
+      - 1353-revert-env-fallback.yml
+      - 1357-subnet-example.yml
+      - 1368-empty_bucket_policy.yml
+      - 1383-ec2_key-fix-idempotency-issue-when-creating-existing-key-with-same-key-material.yaml
+      - 1384-cloudtrail-disable_encryption.yml
+      - 1395-s3-encryption.yml
+      - 1400-typo.yml
+      - 20230204-sanity.yml
+      - 20230220-inventory_docs_ec2_aws.yml
+      - 389-ssm_parameter-versioned_test.yml
+      - 964-ec2_instance-return-instances.yml
+      - release_summary.yml
+      - unit-tests_test_ec2_key_only.yaml
+    release_date: "2023-03-05"
   5.4.0:
     changes:
       bugfixes:
-      - ec2_metadata_facts - fix ``AttributeError`` when running the ec2_metadata_facts
-        module on Python 2 managed nodes (https://github.com/ansible-collections/amazon.aws/issues/1358).
-      - ec2_vol - handle ec2_vol.tags when the associated instance already exists
-        (https://github.com/ansible-collections/amazon.aws/pull/1071).
-      - rds_instance - Fixed ``TypeError`` when tagging RDS DB with storage type ``gp3``
-        (https://github.com/ansible-collections/amazon.aws/pull/1437).
-      - route53_info - Add new return key ``health_check_observations`` for health
-        check operations (https://github.com/ansible-collections/amazon.aws/pull/1419).
-      - route53_info - Fixed ``Key Error`` when getting status or failure_reason of
-        a health check (https://github.com/ansible-collections/amazon.aws/pull/1419).
+        - ec2_metadata_facts - fix ``AttributeError`` when running the ec2_metadata_facts module on Python 2 managed nodes (https://github.com/ansible-collections/amazon.aws/issues/1358).
+        - ec2_vol - handle ec2_vol.tags when the associated instance already exists (https://github.com/ansible-collections/amazon.aws/pull/1071).
+        - rds_instance - Fixed ``TypeError`` when tagging RDS DB with storage type ``gp3`` (https://github.com/ansible-collections/amazon.aws/pull/1437).
+        - route53_info - Add new return key ``health_check_observations`` for health check operations (https://github.com/ansible-collections/amazon.aws/pull/1419).
+        - route53_info - Fixed ``Key Error`` when getting status or failure_reason of a health check (https://github.com/ansible-collections/amazon.aws/pull/1419).
       minor_changes:
-      - ec2_spot_instance - add parameter ``terminate_instances`` to support terminate
-        instances associated with spot requests. (https://github.com/ansible-collections/amazon.aws/pull/1402).
-      - route53_health_check -  added support for enabling Latency graphs (MeasureLatency)
-        during creation of a Route53 Health Check. (https://github.com/ansible-collections/amazon.aws/pull/1201).
+        - ec2_spot_instance - add parameter ``terminate_instances`` to support terminate instances associated with spot requests. (https://github.com/ansible-collections/amazon.aws/pull/1402).
+        - route53_health_check -  added support for enabling Latency graphs (MeasureLatency) during creation of a Route53 Health Check. (https://github.com/ansible-collections/amazon.aws/pull/1201).
       release_summary: This minor release brings bugfixes and minor new features.
     fragments:
-    - 1071-ec2_vol_tags_idempotent.yaml
-    - 1201-route53_health_check-add-support-for-latency-graphs.yml
-    - 1358-ec2_metadata_facts.yml
-    - 1402-ec2_spot_instance-ability-to-terminate-instances.yml
-    - 1419-route53_info-fix-keyerror-for-healthcheck-operations.yml
-    - 1437-rds_instance-gp3-tagging-bugfix.yml
-    - 5.4.0-release.yml
-    - 5.4.0-route53_health_check.yml
-    release_date: '2023-03-27'
+      - 1071-ec2_vol_tags_idempotent.yaml
+      - 1201-route53_health_check-add-support-for-latency-graphs.yml
+      - 1358-ec2_metadata_facts.yml
+      - 1402-ec2_spot_instance-ability-to-terminate-instances.yml
+      - 1419-route53_info-fix-keyerror-for-healthcheck-operations.yml
+      - 1437-rds_instance-gp3-tagging-bugfix.yml
+      - 5.4.0-release.yml
+      - 5.4.0-route53_health_check.yml
+    release_date: "2023-03-27"
   5.5.0:
     changes:
       bugfixes:
-      - cloudwatch_metric_alarm - Don't consider ``StateTransitionedTimestamp`` in
-        change detection. (https://github.com/ansible-collections/amazon.aws/pull/1440).
-      - ec2_instance - Pick up ``app_callback -> set_password`` rather than ``app_callback
-        -> set_passwd`` (https://github.com/ansible-collections/amazon.aws/issues/1449).
-      - lambda_info - Do not convert environment variables to snake_case when querying
-        lambda config. (https://github.com/ansible-collections/amazon.aws/pull/1457).
-      - rds_instance - fix type of ``promotion_tier`` as passed to the APIs (https://github.com/ansible-collections/amazon.aws/pull/1475).
+        - cloudwatch_metric_alarm - Don't consider ``StateTransitionedTimestamp`` in change detection. (https://github.com/ansible-collections/amazon.aws/pull/1440).
+        - ec2_instance - Pick up ``app_callback -> set_password`` rather than ``app_callback -> set_passwd`` (https://github.com/ansible-collections/amazon.aws/issues/1449).
+        - lambda_info - Do not convert environment variables to snake_case when querying lambda config. (https://github.com/ansible-collections/amazon.aws/pull/1457).
+        - rds_instance - fix type of ``promotion_tier`` as passed to the APIs (https://github.com/ansible-collections/amazon.aws/pull/1475).
       minor_changes:
-      - Add connectivity_type to ec2_vpc_nat_gateway module (https://github.com/ansible-collections/amazon.aws/pull/1267).
-      - cloudwatch - Add metrics and extended_statistic keys to cloudwatch module
-        (https://github.com/ansible-collections/amazon.aws/pull/1133).
-      - ec2_ami - add support for BootMode, TpmSupport, UefiData params (https://github.com/ansible-collections/amazon.aws/pull/1037).
-      - ec2_metadata_facts - added support to query instance tags in metadata (https://github.com/ansible-collections/amazon.aws/pull/1186).
-      - kms_key - Add multi_region option to create_key (https://github.com/ansible-collections/amazon.aws/pull/1290).
-      - lambda -  add support for function layers when creating or updating lambda
-        function (https://github.com/ansible-collections/amazon.aws/pull/1118).
-      - lambda_event -  Added support to set FunctionResponseTypes when creating lambda
-        event source mappings (https://github.com/ansible-collections/amazon.aws/pull/1209).
-      - module_utils/elbv2 - removed compatibility code for ``botocore < 1.10.30``
-        (https://github.com/ansible-collections/amazon.aws/pull/1477).
-      - rds_cluster - New ``engine_mode`` parameter (https://github.com/ansible-collections/amazon.aws/pull/941).
-      - rds_cluster - add new options (e.g., ``db_cluster_instance_class``, ``allocated_storage``,
-        ``storage_type``, ``iops``) (https://github.com/ansible-collections/amazon.aws/pull/1191).
-      - rds_cluster - update list of supported engines with ``mysql`` and ``postgres``
-        (https://github.com/ansible-collections/amazon.aws/pull/1191).
-      - s3_bucket - ensure ``public_access`` is configured before updating policies
-        (https://github.com/ansible-collections/amazon.aws/pull/1511).
-      release_summary: 'This release contains a number of bugfixes, new features and
-        new modules.  This is the last planned minor release prior to the release
-        of version 6.0.0.
-
-        '
+        - Add connectivity_type to ec2_vpc_nat_gateway module (https://github.com/ansible-collections/amazon.aws/pull/1267).
+        - cloudwatch - Add metrics and extended_statistic keys to cloudwatch module (https://github.com/ansible-collections/amazon.aws/pull/1133).
+        - ec2_ami - add support for BootMode, TpmSupport, UefiData params (https://github.com/ansible-collections/amazon.aws/pull/1037).
+        - ec2_metadata_facts - added support to query instance tags in metadata (https://github.com/ansible-collections/amazon.aws/pull/1186).
+        - kms_key - Add multi_region option to create_key (https://github.com/ansible-collections/amazon.aws/pull/1290).
+        - lambda -  add support for function layers when creating or updating lambda function (https://github.com/ansible-collections/amazon.aws/pull/1118).
+        - lambda_event -  Added support to set FunctionResponseTypes when creating lambda event source mappings (https://github.com/ansible-collections/amazon.aws/pull/1209).
+        - module_utils/elbv2 - removed compatibility code for ``botocore < 1.10.30`` (https://github.com/ansible-collections/amazon.aws/pull/1477).
+        - rds_cluster - New ``engine_mode`` parameter (https://github.com/ansible-collections/amazon.aws/pull/941).
+        - rds_cluster - add new options (e.g., ``db_cluster_instance_class``, ``allocated_storage``, ``storage_type``, ``iops``) (https://github.com/ansible-collections/amazon.aws/pull/1191).
+        - rds_cluster - update list of supported engines with ``mysql`` and ``postgres`` (https://github.com/ansible-collections/amazon.aws/pull/1191).
+        - s3_bucket - ensure ``public_access`` is configured before updating policies (https://github.com/ansible-collections/amazon.aws/pull/1511).
+      release_summary: "This release contains a number of bugfixes, new features and new modules.  This is the last planned minor release prior to the release of
+        version 6.0.0.\n"
     fragments:
-    - 1037-ec2_ami-add-support-for-boot_mode-tpm_support-uefi_data.yml
-    - 1133-add_metrics_cloudwatch.yml
-    - 1186-ec2_metadata_facts-query-instance-metadata-tags.yml
-    - 1191-rds_cluster-new_options.yml
-    - 1209-lambda_event-add-support-for-function_response_types.yml
-    - 1258-ec2_instance.yml
-    - 1267-ec2_vpc_nat_gateway_connectivitytype.yml
-    - 1290-create_multi_region_key.yml
-    - 1440-cloudwatch_metric_alarm-fix-change-detection.yml
-    - 1457-lambda_info-fix-env-var-in-output.yml
-    - 1474-ec2_vol.yml
-    - 1475-rds_instance-promotion-tier.yml
-    - 1477-elbv2-botocore.yml
-    - 1505-ec2_instance_test_fixes.yml
-    - 1511-s3_bucket-public_access.yml
-    - 20230424-ec2_instance-app_callback.yml
-    - 20230502-rds_cluster-engine.yml
-    - 20230503-rds_cluster-engine-rds_cluster_snapshot.yml
-    - fix_version_added.yml
-    - lambda-add-support-for-layers.yml
-    - rds_cluster_engine_mode.yaml
-    - release-summary.yml
+      - 1037-ec2_ami-add-support-for-boot_mode-tpm_support-uefi_data.yml
+      - 1133-add_metrics_cloudwatch.yml
+      - 1186-ec2_metadata_facts-query-instance-metadata-tags.yml
+      - 1191-rds_cluster-new_options.yml
+      - 1209-lambda_event-add-support-for-function_response_types.yml
+      - 1258-ec2_instance.yml
+      - 1267-ec2_vpc_nat_gateway_connectivitytype.yml
+      - 1290-create_multi_region_key.yml
+      - 1440-cloudwatch_metric_alarm-fix-change-detection.yml
+      - 1457-lambda_info-fix-env-var-in-output.yml
+      - 1474-ec2_vol.yml
+      - 1475-rds_instance-promotion-tier.yml
+      - 1477-elbv2-botocore.yml
+      - 1505-ec2_instance_test_fixes.yml
+      - 1511-s3_bucket-public_access.yml
+      - 20230424-ec2_instance-app_callback.yml
+      - 20230502-rds_cluster-engine.yml
+      - 20230503-rds_cluster-engine-rds_cluster_snapshot.yml
+      - fix_version_added.yml
+      - lambda-add-support-for-layers.yml
+      - rds_cluster_engine_mode.yaml
+      - release-summary.yml
     modules:
-    - description: Creates an AWS Lambda layer or deletes an AWS Lambda layer version
-      name: lambda_layer
-      namespace: ''
-    - description: List lambda layer or lambda layer versions
-      name: lambda_layer_info
-      namespace: ''
-    release_date: '2023-05-04'
+      - description: Creates an AWS Lambda layer or deletes an AWS Lambda layer version
+        name: lambda_layer
+        namespace: ""
+      - description: List lambda layer or lambda layer versions
+        name: lambda_layer_info
+        namespace: ""
+    release_date: "2023-05-04"
   5.5.1:
     changes:
       bugfixes:
-      - autoscaling_group - fix ValidationError when describing an autoscaling group
-        that has more than 20 target groups attached to it by breaking the request
-        into chunks (https://github.com/ansible-collections/amazon.aws/pull/1593).
-      - autoscaling_group_info - fix ValidationError when describing an autoscaling
-        group that has more than 20 target groups attached to it by breaking the request
-        into chunks (https://github.com/ansible-collections/amazon.aws/pull/1593).
-      - aws_account_attribute - raise correct ``AnsibleLookupError`` rather than ``AnsibleError``
-        (https://github.com/ansible-collections/amazon.aws/issues/1528).
-      - aws_secret -  raise correct ``AnsibleLookupError`` rather than ``AnsibleError``
-        (https://github.com/ansible-collections/amazon.aws/issues/1528).
-      - aws_service_ip_ranges raise correct ``AnsibleLookupError`` rather than ``AnsibleError``
-        (https://github.com/ansible-collections/amazon.aws/issues/1528).
-      - aws_ssm - raise correct ``AnsibleLookupError`` rather than ``AnsibleError``
-        (https://github.com/ansible-collections/amazon.aws/issues/1528).
-      - ec2_instance - fix check_mode issue when adding network interfaces (https://github.com/ansible-collections/amazon.aws/issues/1403).
-      - elb_application_lb - fix missing attributes on creation of ALB. The ``create_or_update_alb()``
-        was including ALB-specific attributes when updating an existing ALB but not
-        when creating a new ALB (https://github.com/ansible-collections/amazon.aws/issues/1510).
-      release_summary: 'This release brings few bugfixes.
-
-        '
+        - autoscaling_group - fix ValidationError when describing an autoscaling group that has more than 20 target groups attached to it by breaking the request
+          into chunks (https://github.com/ansible-collections/amazon.aws/pull/1593).
+        - autoscaling_group_info - fix ValidationError when describing an autoscaling group that has more than 20 target groups attached to it by breaking the request
+          into chunks (https://github.com/ansible-collections/amazon.aws/pull/1593).
+        - aws_account_attribute - raise correct ``AnsibleLookupError`` rather than ``AnsibleError`` (https://github.com/ansible-collections/amazon.aws/issues/1528).
+        - aws_secret -  raise correct ``AnsibleLookupError`` rather than ``AnsibleError`` (https://github.com/ansible-collections/amazon.aws/issues/1528).
+        - aws_service_ip_ranges raise correct ``AnsibleLookupError`` rather than ``AnsibleError`` (https://github.com/ansible-collections/amazon.aws/issues/1528).
+        - aws_ssm - raise correct ``AnsibleLookupError`` rather than ``AnsibleError`` (https://github.com/ansible-collections/amazon.aws/issues/1528).
+        - ec2_instance - fix check_mode issue when adding network interfaces (https://github.com/ansible-collections/amazon.aws/issues/1403).
+        - elb_application_lb - fix missing attributes on creation of ALB. The ``create_or_update_alb()`` was including ALB-specific attributes when updating an existing
+          ALB but not when creating a new ALB (https://github.com/ansible-collections/amazon.aws/issues/1510).
+      release_summary: "This release brings few bugfixes.\n"
     fragments:
-    - 1510-elb_application_lb-fix-alb-specific-attributes-not-added-on-create.yml
-    - 1528-lookup-error.yml
-    - 1578-rds-instance-docs.yml
-    - 1593-autoscaling_group_info-20-target-groups-per-call.yml
-    - ec2_instance-eni-attach-idempotency.yml
-    - endpoint.yml
-    - release-summary.yml
-    - test-reqs.yml
-    release_date: '2023-06-07'
+      - 1510-elb_application_lb-fix-alb-specific-attributes-not-added-on-create.yml
+      - 1528-lookup-error.yml
+      - 1578-rds-instance-docs.yml
+      - 1593-autoscaling_group_info-20-target-groups-per-call.yml
+      - ec2_instance-eni-attach-idempotency.yml
+      - endpoint.yml
+      - release-summary.yml
+      - test-reqs.yml
+    release_date: "2023-06-07"
   5.5.2:
     changes:
       bugfixes:
-      - cloudwatchevent_rule - Fixes changed status to report False when no change
-        has been made. The module had incorrectly always reported a change. (https://github.com/ansible-collections/amazon.aws/pull/1589)
-      - ec2_vpc_nat_gateway - fixes to nat gateway so that when the user creates a
-        private NAT gateway, an Elastic IP address should not be allocated. The module
-        had inncorrectly always allocate elastic IP address when creating private
-        nat gateway (https://github.com/ansible-collections/amazon.aws/pull/1632).
-      - lambda_execute - Fixes to the stack trace output, where it does not contain
-        spaces between each character. The module had incorrectly always outputted
-        extra spaces between each character. (https://github.com/ansible-collections/amazon.aws/pull/1615)
+        - cloudwatchevent_rule - Fixes changed status to report False when no change has been made. The module had incorrectly always reported a change. (https://github.com/ansible-collections/amazon.aws/pull/1589)
+        - ec2_vpc_nat_gateway - fixes to nat gateway so that when the user creates a private NAT gateway, an Elastic IP address should not be allocated. The module
+          had inncorrectly always allocate elastic IP address when creating private nat gateway (https://github.com/ansible-collections/amazon.aws/pull/1632).
+        - lambda_execute - Fixes to the stack trace output, where it does not contain spaces between each character. The module had incorrectly always outputted extra
+          spaces between each character. (https://github.com/ansible-collections/amazon.aws/pull/1615)
     fragments:
-    - 1589-return_false_when_no_change..yml
-    - 1615-no_formatted_with_extra_space.yml
-    - 1632-changes-to-no-allocate-eip-when-connectivity_type=private.yml
-    - 20230627-ci-fixup.yml
-    - 20230704-add_github_workflow.yml
-    release_date: '2023-07-05'
+      - 1589-return_false_when_no_change..yml
+      - 1615-no_formatted_with_extra_space.yml
+      - 1632-changes-to-no-allocate-eip-when-connectivity_type=private.yml
+      - 20230627-ci-fixup.yml
+      - 20230704-add_github_workflow.yml
+    release_date: "2023-07-05"
   5.5.3:
     changes:
       bugfixes:
-      - rds_cluster - Add ``AllocatedStorage``, ``DBClusterInstanceClass``, ``StorageType``,
-        ``Iops``, and ``EngineMode`` to the list of parameters that can be passed
-        when creating or modifying a Multi-AZ RDS cluster (https://github.com/ansible-collections/amazon.aws/pull/1657).
-      - rds_cluster - Allow to pass GlobalClusterIdentifier to rds cluster on creation
-        (https://github.com/ansible-collections/amazon.aws/pull/1663).
+        - rds_cluster - Add ``AllocatedStorage``, ``DBClusterInstanceClass``, ``StorageType``, ``Iops``, and ``EngineMode`` to the list of parameters that can be
+          passed when creating or modifying a Multi-AZ RDS cluster (https://github.com/ansible-collections/amazon.aws/pull/1657).
+        - rds_cluster - Allow to pass GlobalClusterIdentifier to rds cluster on creation (https://github.com/ansible-collections/amazon.aws/pull/1663).
       release_summary: This release contains a few bugfixes for rds_cluster.
     fragments:
-    - 20230713-rds_cluster-fix_params_passage.yml
-    - 20230725-rds_cluster-fix.yml
-    release_date: '2023-08-02'
+      - 20230713-rds_cluster-fix_params_passage.yml
+      - 20230725-rds_cluster-fix.yml
+    release_date: "2023-08-02"
   6.0.0:
     changes:
       breaking_changes:
-      - The amazon.aws collection has dropped support for ``botocore<1.25.0`` and
-        ``boto3<1.22.0``. Most modules will continue to work with older versions of
-        the AWS SDK, however compatibility with older versions of the SDK is not guaranteed
-        and will not be tested. When using older versions of the SDK a warning will
-        be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/1342).
-      - amazon.aws - compatibility code for Python < 3.6 has been removed (https://github.com/ansible-collections/amazon.aws/pull/1257).
-      - ec2_eip - the previously deprecated ``instance_id`` alias for the ``device_id``
-        parameter has been removed. Please use the ``device_id`` parameter name instead
-        (https://github.com/ansible-collections/amazon.aws/issues/1176).
-      - ec2_instance - the default value for ``instance_type`` has been removed. At
-        least one of ``instance_type`` or ``launch_template`` must be specified when
-        launching new instances (https://github.com/ansible-collections/amazon.aws/pull/1315).
-      - ec2_vpc_dhcp_options - the ``new_options`` return value has been deprecated
-        after being renamed to ``dhcp_config``.  Please use the ``dhcp_config`` or
-        ``dhcp_options`` return values (https://github.com/ansible-collections/amazon.aws/pull/1327).
-      - ec2_vpc_endpoint - the ``policy_file`` parameter has been removed.  I(policy)
-        with a file lookup can be used instead (https://github.com/ansible-collections/amazon.aws/issues/1178).
-      - ec2_vpc_net - the ``classic_link_enabled`` return value has been removed.
-        Support for EC2 Classic networking was dropped by AWS (https://github.com/ansible-collections/amazon.aws/pull/1374).
-      - ec2_vpc_net_info - the ``classic_link_dns_status`` return value has been removed.
-        Support for EC2 Classic networking was dropped by AWS (https://github.com/ansible-collections/amazon.aws/pull/1374).
-      - ec2_vpc_net_info - the ``classic_link_enabled`` return value has been removed.
-        Support for EC2 Classic networking was dropped by AWS (https://github.com/ansible-collections/amazon.aws/pull/1374).
-      - module_utils.cloud - the previously deprecated ``CloudRetry.backoff`` has
-        been removed. Please use ``CloudRetry.exponential_backoff`` or ``CloudRetry.jittered_backoff``
-        instead (https://github.com/ansible-collections/amazon.aws/issues/1110).
+        - The amazon.aws collection has dropped support for ``botocore<1.25.0`` and ``boto3<1.22.0``. Most modules will continue to work with older versions of the
+          AWS SDK, however compatibility with older versions of the SDK is not guaranteed and will not be tested. When using older versions of the SDK a warning will
+          be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/1342).
+        - amazon.aws - compatibility code for Python < 3.6 has been removed (https://github.com/ansible-collections/amazon.aws/pull/1257).
+        - ec2_eip - the previously deprecated ``instance_id`` alias for the ``device_id`` parameter has been removed. Please use the ``device_id`` parameter name
+          instead (https://github.com/ansible-collections/amazon.aws/issues/1176).
+        - ec2_instance - the default value for ``instance_type`` has been removed. At least one of ``instance_type`` or ``launch_template`` must be specified when
+          launching new instances (https://github.com/ansible-collections/amazon.aws/pull/1315).
+        - ec2_vpc_dhcp_options - the ``new_options`` return value has been deprecated after being renamed to ``dhcp_config``.  Please use the ``dhcp_config`` or ``dhcp_options``
+          return values (https://github.com/ansible-collections/amazon.aws/pull/1327).
+        - ec2_vpc_endpoint - the ``policy_file`` parameter has been removed.  I(policy) with a file lookup can be used instead (https://github.com/ansible-collections/amazon.aws/issues/1178).
+        - ec2_vpc_net - the ``classic_link_enabled`` return value has been removed. Support for EC2 Classic networking was dropped by AWS (https://github.com/ansible-collections/amazon.aws/pull/1374).
+        - ec2_vpc_net_info - the ``classic_link_dns_status`` return value has been removed. Support for EC2 Classic networking was dropped by AWS (https://github.com/ansible-collections/amazon.aws/pull/1374).
+        - ec2_vpc_net_info - the ``classic_link_enabled`` return value has been removed. Support for EC2 Classic networking was dropped by AWS (https://github.com/ansible-collections/amazon.aws/pull/1374).
+        - module_utils.cloud - the previously deprecated ``CloudRetry.backoff`` has been removed. Please use ``CloudRetry.exponential_backoff`` or ``CloudRetry.jittered_backoff``
+          instead (https://github.com/ansible-collections/amazon.aws/issues/1110).
       bugfixes:
-      - ec2_security_group - file included unreachable code. Fix now removes unreachable
-        code by removing an inapproproate logic (https://github.com/ansible-collections/amazon.aws/pull/1348).
-      - ec2_vpc_dhcp_option - retry ``describe_dhcp_options`` after creation when
-        ``InvalidDhcpOptionID.NotFound`` is raised (https://github.com/ansible-collections/amazon.aws/pull/1320).
-      - lambda_execute - Fix waiter error when function_arn is passed instead of name(https://github.com/ansible-collections/amazon.aws/issues/1268).
-      - 'module_utils - fixes ``TypeError: deciding_wrapper() got multiple values
-        for argument ''aws_retry''`` when passing positional arguments to functions
-        wrapped by AnsibleAWSModule.client (https://github.com/ansible-collections/amazon.aws/pull/1230).'
-      - rds_param_group - added a check to fail the task while modifying/updating
-        rds_param_group if trying to change DB parameter group family. (https://github.com/ansible-collections/amazon.aws/pull/1169).
-      - route53_health_check - Fix ``Name`` tag key removal idempotentcy issue when
-        creating health_check with ``use_unique_names`` and ``tags`` set (https://github.com/ansible-collections/amazon.aws/pull/1253).
-      - s3_bucket - Handle setting of permissions while acl is disabled.(https://github.com/ansible-collections/amazon.aws/pull/1168).
+        - ec2_security_group - file included unreachable code. Fix now removes unreachable code by removing an inapproproate logic (https://github.com/ansible-collections/amazon.aws/pull/1348).
+        - ec2_vpc_dhcp_option - retry ``describe_dhcp_options`` after creation when ``InvalidDhcpOptionID.NotFound`` is raised (https://github.com/ansible-collections/amazon.aws/pull/1320).
+        - lambda_execute - Fix waiter error when function_arn is passed instead of name(https://github.com/ansible-collections/amazon.aws/issues/1268).
+        - "module_utils - fixes ``TypeError: deciding_wrapper() got multiple values for argument 'aws_retry'`` when passing positional arguments to functions wrapped
+          by AnsibleAWSModule.client (https://github.com/ansible-collections/amazon.aws/pull/1230)."
+        - rds_param_group - added a check to fail the task while modifying/updating rds_param_group if trying to change DB parameter group family. (https://github.com/ansible-collections/amazon.aws/pull/1169).
+        - route53_health_check - Fix ``Name`` tag key removal idempotentcy issue when creating health_check with ``use_unique_names`` and ``tags`` set (https://github.com/ansible-collections/amazon.aws/pull/1253).
+        - s3_bucket - Handle setting of permissions while acl is disabled.(https://github.com/ansible-collections/amazon.aws/pull/1168).
       deprecated_features:
-      - amazon.aws collection - due to the AWS SDKs Python support policies (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
-        support for Python less than 3.8 by this collection is expected to be removed
-        in a release after 2024-12-01 (https://github.com/ansible-collections/amazon.aws/pull/1342).
-      - amazon.aws collection - due to the AWS SDKs announcing the end of support
-        for Python less than 3.7 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
-        support for Python less than 3.7 by this collection has been deprecated and
-        will be removed in release 7.0.0. (https://github.com/ansible-collections/amazon.aws/pull/1342).
-      - amazon.aws lookup plugins - the ``boto3_profile`` alias for the ``profile``
-        option has been deprecated, please use ``profile`` instead (https://github.com/ansible-collections/amazon.aws/pull/1225).
-      - docs_fragments - ``amazon.aws.aws_credentials`` docs fragment has been deprecated
-        please use ``amazon.aws.common.plugins`` instead (https://github.com/ansible-collections/amazon.aws/pull/1248).
-      - docs_fragments - ``amazon.aws.aws_region`` docs fragment has been deprecated
-        please use ``amazon.aws.region.plugins`` instead (https://github.com/ansible-collections/amazon.aws/pull/1248).
-      - docs_fragments - ``amazon.aws.aws`` docs fragment has been deprecated please
-        use ``amazon.aws.common.modules`` instead (https://github.com/ansible-collections/amazon.aws/pull/1248).
-      - docs_fragments - ``amazon.aws.ec2`` docs fragment has been deprecated please
-        use ``amazon.aws.region.modules`` instead (https://github.com/ansible-collections/amazon.aws/pull/1248).
-      - module_utils.policy - ``ansible_collections.amazon.aws.module_utils.policy.sort_json_policy_dict``
-        has been deprecated consider using ``ansible_collections.amazon.aws.module_utils.poilcies.compare_policies``
-        instead (https://github.com/ansible-collections/amazon.aws/pull/1136).
-      - s3_object - Support for passing ``dualstack`` and ``endpoint_url`` at the
-        same time has been deprecated, the ``dualstack`` parameter is ignored when
-        ``endpoint_url`` is passed. Support will be removed in a release after 2024-12-01
-        (https://github.com/ansible-collections/amazon.aws/pull/1305).
-      - s3_object - Support for passing values of ``overwrite`` other than ``always``,
-        ``never``, ``different`` or last ``last`` has been deprecated.  Boolean values
-        should be replaced by the strings ``always`` or ``never`` Support will be
-        removed in a release after 2024-12-01 (https://github.com/ansible-collections/amazon.aws/pull/1305).
-      - s3_object_info - Support for passing ``dualstack`` and ``endpoint_url`` at
-        the same time has been deprecated, the ``dualstack`` parameter is ignored
-        when ``endpoint_url`` is passed. Support will be removed in a release after
-        2024-12-01 (https://github.com/ansible-collections/amazon.aws/pull/1305).
+        - amazon.aws collection - due to the AWS SDKs Python support policies (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
+          support for Python less than 3.8 by this collection is expected to be removed in a release after 2024-12-01 (https://github.com/ansible-collections/amazon.aws/pull/1342).
+        - amazon.aws collection - due to the AWS SDKs announcing the end of support for Python less than 3.7 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
+          support for Python less than 3.7 by this collection has been deprecated and will be removed in release 7.0.0. (https://github.com/ansible-collections/amazon.aws/pull/1342).
+        - amazon.aws lookup plugins - the ``boto3_profile`` alias for the ``profile`` option has been deprecated, please use ``profile`` instead (https://github.com/ansible-collections/amazon.aws/pull/1225).
+        - docs_fragments - ``amazon.aws.aws_credentials`` docs fragment has been deprecated please use ``amazon.aws.common.plugins`` instead (https://github.com/ansible-collections/amazon.aws/pull/1248).
+        - docs_fragments - ``amazon.aws.aws_region`` docs fragment has been deprecated please use ``amazon.aws.region.plugins`` instead (https://github.com/ansible-collections/amazon.aws/pull/1248).
+        - docs_fragments - ``amazon.aws.aws`` docs fragment has been deprecated please use ``amazon.aws.common.modules`` instead (https://github.com/ansible-collections/amazon.aws/pull/1248).
+        - docs_fragments - ``amazon.aws.ec2`` docs fragment has been deprecated please use ``amazon.aws.region.modules`` instead (https://github.com/ansible-collections/amazon.aws/pull/1248).
+        - module_utils.policy - ``ansible_collections.amazon.aws.module_utils.policy.sort_json_policy_dict`` has been deprecated consider using ``ansible_collections.amazon.aws.module_utils.poilcies.compare_policies``
+          instead (https://github.com/ansible-collections/amazon.aws/pull/1136).
+        - s3_object - Support for passing ``dualstack`` and ``endpoint_url`` at the same time has been deprecated, the ``dualstack`` parameter is ignored when ``endpoint_url``
+          is passed. Support will be removed in a release after 2024-12-01 (https://github.com/ansible-collections/amazon.aws/pull/1305).
+        - s3_object - Support for passing values of ``overwrite`` other than ``always``, ``never``, ``different`` or last ``last`` has been deprecated.  Boolean values
+          should be replaced by the strings ``always`` or ``never`` Support will be removed in a release after 2024-12-01 (https://github.com/ansible-collections/amazon.aws/pull/1305).
+        - s3_object_info - Support for passing ``dualstack`` and ``endpoint_url`` at the same time has been deprecated, the ``dualstack`` parameter is ignored when
+          ``endpoint_url`` is passed. Support will be removed in a release after 2024-12-01 (https://github.com/ansible-collections/amazon.aws/pull/1305).
       minor_changes:
-      - Add github actions to run unit and sanity tests.(https://github.com/ansible-collections/amazon.aws/pull/1393).
-      - AnsibleAWSModule - add support to the ``client`` and ``resource`` methods
-        for overriding the default parameters (https://github.com/ansible-collections/amazon.aws/pull/1303).
-      - CONTRIBUTING.md - refactors and adds to contributor documentation (https://github.com/ansible-collections/amazon.aws/issues/924)
-      - Refactor inventory plugins and add aws_rds inventory unit tests (https://github.com/ansible-collections/amazon.aws/pull/1218).
-      - Refactor module_utils/cloudfront_facts.py and add unit tests (https://github.com/ansible-collections/amazon.aws/pull/1265).
-      - The ``black`` code formatter has been run across the collection to improve
-        code consistency (https://github.com/ansible-collections/amazon.aws/pull/1465).
-      - amazon.aws inventory plugins - additional refactorization of inventory plugin
-        connection handling (https://github.com/ansible-collections/amazon.aws/pull/1271).
-      - amazon.aws lookup plugins - ``aws_access_key`` has been renamed to ``access_key``
-        for consistency between modules and plugins, ``aws_access_key`` remains as
-        an alias. This change should have no observable effect for users outside the
-        module/plugin documentation (https://github.com/ansible-collections/amazon.aws/pull/1225).
-      - amazon.aws lookup plugins - ``aws_profile`` has been renamed to ``profile``
-        for consistency between modules and plugins, ``aws_profile`` remains as an
-        alias. This change should have no observable effect for users outside the
-        module/plugin documentation (https://github.com/ansible-collections/amazon.aws/pull/1225).
-      - amazon.aws lookup plugins - ``aws_secret_key`` has been renamed to ``secret_key``
-        for consistency between modules and plugins, ``aws_secret_key`` remains as
-        an alias. This change should have no observable effect for users outside the
-        module/plugin documentation (https://github.com/ansible-collections/amazon.aws/pull/1225).
-      - amazon.aws lookup plugins - ``aws_security_token`` has been renamed to ``session_token``
-        for consistency between modules and plugins, ``aws_security_token`` remains
-        as an alias. This change should have no observable effect for users outside
-        the module/plugin documentation (https://github.com/ansible-collections/amazon.aws/pull/1225).
-      - amazon.aws modules - bulk update of import statements following various refactors
-        (https://github.com/ansible-collections/amazon.aws/pull/1310).
-      - autoscaling_group - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - aws_account_attribute - the ``aws_account_attribute`` lookup plugin has been
-        refactored to use ``AWSLookupBase`` as its base class (https://github.com/ansible-collections/amazon.aws/pull/1225).
-      - aws_ec2 inventory - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - aws_secret - the ``aws_secret`` lookup plugin has been refactored to use ``AWSLookupBase``
-        as its base class (https://github.com/ansible-collections/amazon.aws/pull/1225).
-      - aws_secret - the ``aws_secret`` lookup plugin has been renamed ``secretsmanager_secret``,
-        ``aws_secret`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/1225).
-      - aws_ssm - the ``aws_ssm`` lookup plugin has been refactored to use ``AWSLookupBase``
-        as its base class (https://github.com/ansible-collections/amazon.aws/pull/1225).
-      - aws_ssm - the ``aws_ssm`` lookup plugin has been renamed ``ssm_parameter``,
-        ``aws_ssm`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/1225).
-      - backup - Add logic for backup_selection* modules (https://github.com/ansible-collections/amazon.aws/pull/1530).
-      - bulk migration of ``%`` and ``.format()`` to fstrings (https://github.com/ansible-collections/amazon.aws/pull/1483).
-      - cloud module_utils - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - cloudtrail_info - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - cloudwatchlogs_log_group - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - docs_fragments - ``amazon.aws.boto3`` fragment now pulls the botocore version
-        requirements from ``module_utils.botocore`` (https://github.com/ansible-collections/amazon.aws/pull/1248).
-      - docs_fragments - common parameters for modules and plugins have been synchronised
-        and moved to ``amazon.aws.common.modules`` and ``amazon.aws.common.plugins``
-        (https://github.com/ansible-collections/amazon.aws/pull/1248).
-      - docs_fragments - region parameters for modules and plugins have been synchronised
-        and moved to ``amazon.aws.region.modules`` and ``amazon.aws.region.plugins``
-        (https://github.com/ansible-collections/amazon.aws/pull/1248).
-      - ec2_ami - Extend the unit-test coverage of the module (https://github.com/ansible-collections/amazon.aws/pull/1159).
-      - ec2_ami - allow ``ImageAvailable`` waiter to retry when the image can't be
-        found (https://github.com/ansible-collections/amazon.aws/pull/1321).
-      - ec2_ami_info - Add unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1252).
-      - ec2_eip - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - ec2_eni_info - Add unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1236).
-      - ec2_instance - avoid changing ``module.params`` (https://github.com/ansible-collections/amazon.aws/pull/1187).
-      - ec2_instance - updated to avoid manipulating ``module.params`` (https://github.com/ansible-collections/amazon.aws/pull/1337).
-      - ec2_security_group - added rule options to argument specifications to improve
-        handling of inputs (https://github.com/ansible-collections/amazon.aws/pull/1214).
-      - ec2_security_group - refacter ``get_target_from_rule()`` (https://github.com/ansible-collections/amazon.aws/pull/1221).
-      - ec2_security_group - refactor rule expansion and add unit tests (https://github.com/ansible-collections/amazon.aws/pull/1261).
-      - ec2_snapshot - Reenable the integration tests (https://github.com/ansible-collections/amazon.aws/pull/1235).
-      - ec2_snapshot_info - Add unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1211).
-      - ec2_vpc_route_table - add support for Carrier Gateway entry (https://github.com/ansible-collections/amazon.aws/pull/926).
-      - ec2_vpc_subnet - retry fetching subnet details after creation if the first
-        attempt fails (https://github.com/ansible-collections/amazon.aws/pull/1526).
-      - inventory aws ec2 - add parameter ``use_ssm_inventory`` allowing to query
-        ssm inventory information for configured EC2 instances and populate hostvars
-        (https://github.com/ansible-collections/amazon.aws/issues/704).
-      - inventory plugins - refactor cache handling (https://github.com/ansible-collections/amazon.aws/pull/1285).
-      - inventory plugins - refactor file verification handling (https://github.com/ansible-collections/amazon.aws/pull/1285).
-      - inventory_aws_ec2 integration tests - replace local module ``test_get_ssm_inventory``
-        by ``community.aws.ssm_inventory_info`` (https://github.com/ansible-collections/amazon.aws/pull/1416).
-      - kms_key_info - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - lambda - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - lambda - use common ``get_aws_account_info`` helper rather than reimplementing
-        (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - lambda_alias - refactored to avoid passing around the complex ``module`` resource
-        (https://github.com/ansible-collections/amazon.aws/pull/1336).
-      - lambda_alias - updated to avoid manipulating ``module.params`` (https://github.com/ansible-collections/amazon.aws/pull/1336).
-      - lambda_execute - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - lambda_info - updated to avoid manipulating ``module.params`` (https://github.com/ansible-collections/amazon.aws/pull/1336).
-      - lambda_layer_info -  add support for parameter version_number to retrieve
-        detailed information for a specific layer version (https://github.com/ansible-collections/amazon.aws/pull/1293).
-      - module_utils - move RetryingBotoClientWrapper into module_utils.retries for
-        reuse with other plugin types (https://github.com/ansible-collections/amazon.aws/pull/1230).
-      - module_utils - move exceptions into dedicated python module (https://github.com/ansible-collections/amazon.aws/pull/1246).
-      - module_utils - refacter botocore version validation into module_utils.botocore
-        for future reuse (https://github.com/ansible-collections/amazon.aws/pull/1227).
-      - module_utils.acm - Refactor ACMServiceManager class and add unit tests (https://github.com/ansible-collections/amazon.aws/pull/1273).
-      - module_utils.botocore - Add Ansible AWS User-Agent identification (https://github.com/ansible-collections/amazon.aws/pull/1306).
-      - module_utils.botocore - refactorization of ``get_aws_region``, ``get_aws_connection_info``
-        so that the code can be reused by non-module plugins (https://github.com/ansible-collections/amazon.aws/pull/1231).
-      - module_utils.policy - minor refacter of code to reduce complexity and improve
-        test coverage (https://github.com/ansible-collections/amazon.aws/pull/1136).
-      - module_utils.s3 - Refactor get_s3_connection into a module_utils for S3 modules
-        and expand module_utils.s3 unit tests (https://github.com/ansible-collections/amazon.aws/pull/1139).
-      - module_utils/botocore - added support to ``_boto3_conn`` for passing dictionaries
-        of configuration (https://github.com/ansible-collections/amazon.aws/pull/1307).
-      - plugin_utils - Added ``AWSConnectionBase`` to support refactoring connection
-        plugins (https://github.com/ansible-collections/amazon.aws/pull/1340).
-      - rds - AWS is phasing out aurora1. Integration tests use aurora2 (aurora-mysql)
-        by default (https://github.com/ansible-collections/amazon.aws/pull/1233).
-      - rds_cluster - Split up the functional tests in smaller targets (https://github.com/ansible-collections/amazon.aws/pull/1175).
-      - rds_cluster_snapshot - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - rds_instance - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - rds_instance_info - Add unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1132).
-      - rds_instance_snapshot - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - rds_param_group - drop Python2 import fallbacks (https://github.com/ansible-collections/amazon.aws/pull/1513).
-      - route53_health_check - Drop deprecation warning (https://github.com/ansible-collections/community.aws/pull/1335).
-      - route53_health_check - minor fix for returning health check info while updating
-        a Route53 health check (https://github.com/ansible-collections/amazon.aws/pull/1200).
-      - route53_health_check - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - route53_info - drop unused imports (https://github.com/ansible-collections/amazon.aws/pull/1462).
-      - s3_bucket - add support for S3 dualstack endpoint (https://github.com/ansible-collections/amazon.aws/pull/1305).
-      - s3_bucket - handle missing read permissions more gracefully when possible
-        (https://github.com/ansible-collections/amazon.aws/pull/1406).
-      - s3_bucket - refactor S3 connection code (https://github.com/ansible-collections/amazon.aws/pull/1305).
-      - s3_object - refactor S3 connection code (https://github.com/ansible-collections/amazon.aws/pull/1305).
-      - s3_object - refactor main to reduce complexity (https://github.com/ansible-collections/amazon.aws/pull/1193).
-      - s3_object_info - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
-      - s3_object_info - refactor S3 connection code (https://github.com/ansible-collections/amazon.aws/pull/1305).
-      release_summary: This release brings some new plugins and features. Several
-        bugfixes, breaking changes and deprecated features are also included. The
-        amazon.aws collection has dropped support for ``botocore<1.25.0`` and ``boto3<1.22.0``.
-        Support for Python 3.6 has also been dropped.
+        - Add github actions to run unit and sanity tests.(https://github.com/ansible-collections/amazon.aws/pull/1393).
+        - AnsibleAWSModule - add support to the ``client`` and ``resource`` methods for overriding the default parameters (https://github.com/ansible-collections/amazon.aws/pull/1303).
+        - CONTRIBUTING.md - refactors and adds to contributor documentation (https://github.com/ansible-collections/amazon.aws/issues/924)
+        - Refactor inventory plugins and add aws_rds inventory unit tests (https://github.com/ansible-collections/amazon.aws/pull/1218).
+        - Refactor module_utils/cloudfront_facts.py and add unit tests (https://github.com/ansible-collections/amazon.aws/pull/1265).
+        - The ``black`` code formatter has been run across the collection to improve code consistency (https://github.com/ansible-collections/amazon.aws/pull/1465).
+        - amazon.aws inventory plugins - additional refactorization of inventory plugin connection handling (https://github.com/ansible-collections/amazon.aws/pull/1271).
+        - amazon.aws lookup plugins - ``aws_access_key`` has been renamed to ``access_key`` for consistency between modules and plugins, ``aws_access_key`` remains
+          as an alias. This change should have no observable effect for users outside the module/plugin documentation (https://github.com/ansible-collections/amazon.aws/pull/1225).
+        - amazon.aws lookup plugins - ``aws_profile`` has been renamed to ``profile`` for consistency between modules and plugins, ``aws_profile`` remains as an alias.
+          This change should have no observable effect for users outside the module/plugin documentation (https://github.com/ansible-collections/amazon.aws/pull/1225).
+        - amazon.aws lookup plugins - ``aws_secret_key`` has been renamed to ``secret_key`` for consistency between modules and plugins, ``aws_secret_key`` remains
+          as an alias. This change should have no observable effect for users outside the module/plugin documentation (https://github.com/ansible-collections/amazon.aws/pull/1225).
+        - amazon.aws lookup plugins - ``aws_security_token`` has been renamed to ``session_token`` for consistency between modules and plugins, ``aws_security_token``
+          remains as an alias. This change should have no observable effect for users outside the module/plugin documentation (https://github.com/ansible-collections/amazon.aws/pull/1225).
+        - amazon.aws modules - bulk update of import statements following various refactors (https://github.com/ansible-collections/amazon.aws/pull/1310).
+        - autoscaling_group - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - aws_account_attribute - the ``aws_account_attribute`` lookup plugin has been refactored to use ``AWSLookupBase`` as its base class (https://github.com/ansible-collections/amazon.aws/pull/1225).
+        - aws_ec2 inventory - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - aws_secret - the ``aws_secret`` lookup plugin has been refactored to use ``AWSLookupBase`` as its base class (https://github.com/ansible-collections/amazon.aws/pull/1225).
+        - aws_secret - the ``aws_secret`` lookup plugin has been renamed ``secretsmanager_secret``, ``aws_secret`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/1225).
+        - aws_ssm - the ``aws_ssm`` lookup plugin has been refactored to use ``AWSLookupBase`` as its base class (https://github.com/ansible-collections/amazon.aws/pull/1225).
+        - aws_ssm - the ``aws_ssm`` lookup plugin has been renamed ``ssm_parameter``, ``aws_ssm`` remains as an alias (https://github.com/ansible-collections/amazon.aws/pull/1225).
+        - backup - Add logic for backup_selection* modules (https://github.com/ansible-collections/amazon.aws/pull/1530).
+        - bulk migration of ``%`` and ``.format()`` to fstrings (https://github.com/ansible-collections/amazon.aws/pull/1483).
+        - cloud module_utils - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - cloudtrail_info - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - cloudwatchlogs_log_group - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - docs_fragments - ``amazon.aws.boto3`` fragment now pulls the botocore version requirements from ``module_utils.botocore`` (https://github.com/ansible-collections/amazon.aws/pull/1248).
+        - docs_fragments - common parameters for modules and plugins have been synchronised and moved to ``amazon.aws.common.modules`` and ``amazon.aws.common.plugins``
+          (https://github.com/ansible-collections/amazon.aws/pull/1248).
+        - docs_fragments - region parameters for modules and plugins have been synchronised and moved to ``amazon.aws.region.modules`` and ``amazon.aws.region.plugins``
+          (https://github.com/ansible-collections/amazon.aws/pull/1248).
+        - ec2_ami - Extend the unit-test coverage of the module (https://github.com/ansible-collections/amazon.aws/pull/1159).
+        - ec2_ami - allow ``ImageAvailable`` waiter to retry when the image can't be found (https://github.com/ansible-collections/amazon.aws/pull/1321).
+        - ec2_ami_info - Add unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1252).
+        - ec2_eip - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - ec2_eni_info - Add unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1236).
+        - ec2_instance - avoid changing ``module.params`` (https://github.com/ansible-collections/amazon.aws/pull/1187).
+        - ec2_instance - updated to avoid manipulating ``module.params`` (https://github.com/ansible-collections/amazon.aws/pull/1337).
+        - ec2_security_group - added rule options to argument specifications to improve handling of inputs (https://github.com/ansible-collections/amazon.aws/pull/1214).
+        - ec2_security_group - refacter ``get_target_from_rule()`` (https://github.com/ansible-collections/amazon.aws/pull/1221).
+        - ec2_security_group - refactor rule expansion and add unit tests (https://github.com/ansible-collections/amazon.aws/pull/1261).
+        - ec2_snapshot - Reenable the integration tests (https://github.com/ansible-collections/amazon.aws/pull/1235).
+        - ec2_snapshot_info - Add unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1211).
+        - ec2_vpc_route_table - add support for Carrier Gateway entry (https://github.com/ansible-collections/amazon.aws/pull/926).
+        - ec2_vpc_subnet - retry fetching subnet details after creation if the first attempt fails (https://github.com/ansible-collections/amazon.aws/pull/1526).
+        - inventory aws ec2 - add parameter ``use_ssm_inventory`` allowing to query ssm inventory information for configured EC2 instances and populate hostvars (https://github.com/ansible-collections/amazon.aws/issues/704).
+        - inventory plugins - refactor cache handling (https://github.com/ansible-collections/amazon.aws/pull/1285).
+        - inventory plugins - refactor file verification handling (https://github.com/ansible-collections/amazon.aws/pull/1285).
+        - inventory_aws_ec2 integration tests - replace local module ``test_get_ssm_inventory`` by ``community.aws.ssm_inventory_info`` (https://github.com/ansible-collections/amazon.aws/pull/1416).
+        - kms_key_info - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - lambda - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - lambda - use common ``get_aws_account_info`` helper rather than reimplementing (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - lambda_alias - refactored to avoid passing around the complex ``module`` resource (https://github.com/ansible-collections/amazon.aws/pull/1336).
+        - lambda_alias - updated to avoid manipulating ``module.params`` (https://github.com/ansible-collections/amazon.aws/pull/1336).
+        - lambda_execute - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - lambda_info - updated to avoid manipulating ``module.params`` (https://github.com/ansible-collections/amazon.aws/pull/1336).
+        - lambda_layer_info -  add support for parameter version_number to retrieve detailed information for a specific layer version (https://github.com/ansible-collections/amazon.aws/pull/1293).
+        - module_utils - move RetryingBotoClientWrapper into module_utils.retries for reuse with other plugin types (https://github.com/ansible-collections/amazon.aws/pull/1230).
+        - module_utils - move exceptions into dedicated python module (https://github.com/ansible-collections/amazon.aws/pull/1246).
+        - module_utils - refacter botocore version validation into module_utils.botocore for future reuse (https://github.com/ansible-collections/amazon.aws/pull/1227).
+        - module_utils.acm - Refactor ACMServiceManager class and add unit tests (https://github.com/ansible-collections/amazon.aws/pull/1273).
+        - module_utils.botocore - Add Ansible AWS User-Agent identification (https://github.com/ansible-collections/amazon.aws/pull/1306).
+        - module_utils.botocore - refactorization of ``get_aws_region``, ``get_aws_connection_info`` so that the code can be reused by non-module plugins (https://github.com/ansible-collections/amazon.aws/pull/1231).
+        - module_utils.policy - minor refacter of code to reduce complexity and improve test coverage (https://github.com/ansible-collections/amazon.aws/pull/1136).
+        - module_utils.s3 - Refactor get_s3_connection into a module_utils for S3 modules and expand module_utils.s3 unit tests (https://github.com/ansible-collections/amazon.aws/pull/1139).
+        - module_utils/botocore - added support to ``_boto3_conn`` for passing dictionaries of configuration (https://github.com/ansible-collections/amazon.aws/pull/1307).
+        - plugin_utils - Added ``AWSConnectionBase`` to support refactoring connection plugins (https://github.com/ansible-collections/amazon.aws/pull/1340).
+        - rds - AWS is phasing out aurora1. Integration tests use aurora2 (aurora-mysql) by default (https://github.com/ansible-collections/amazon.aws/pull/1233).
+        - rds_cluster - Split up the functional tests in smaller targets (https://github.com/ansible-collections/amazon.aws/pull/1175).
+        - rds_cluster_snapshot - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - rds_instance - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - rds_instance_info - Add unit-tests coverage (https://github.com/ansible-collections/amazon.aws/pull/1132).
+        - rds_instance_snapshot - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - rds_param_group - drop Python2 import fallbacks (https://github.com/ansible-collections/amazon.aws/pull/1513).
+        - route53_health_check - Drop deprecation warning (https://github.com/ansible-collections/community.aws/pull/1335).
+        - route53_health_check - minor fix for returning health check info while updating a Route53 health check (https://github.com/ansible-collections/amazon.aws/pull/1200).
+        - route53_health_check - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - route53_info - drop unused imports (https://github.com/ansible-collections/amazon.aws/pull/1462).
+        - s3_bucket - add support for S3 dualstack endpoint (https://github.com/ansible-collections/amazon.aws/pull/1305).
+        - s3_bucket - handle missing read permissions more gracefully when possible (https://github.com/ansible-collections/amazon.aws/pull/1406).
+        - s3_bucket - refactor S3 connection code (https://github.com/ansible-collections/amazon.aws/pull/1305).
+        - s3_object - refactor S3 connection code (https://github.com/ansible-collections/amazon.aws/pull/1305).
+        - s3_object - refactor main to reduce complexity (https://github.com/ansible-collections/amazon.aws/pull/1193).
+        - s3_object_info - minor linting fixes (https://github.com/ansible-collections/amazon.aws/pull/1181).
+        - s3_object_info - refactor S3 connection code (https://github.com/ansible-collections/amazon.aws/pull/1305).
+      release_summary: This release brings some new plugins and features. Several bugfixes, breaking changes and deprecated features are also included. The amazon.aws
+        collection has dropped support for ``botocore<1.25.0`` and ``boto3<1.22.0``. Support for Python 3.6 has also been dropped.
       removed_features:
-      - ec2_vpc_endpoint_info - support for the ``query`` parameter was removed. The
-        ``amazon.aws.ec2_vpc_endpoint_info`` module now only queries for endpoints.
-        Services can be queried using the ``amazon.aws.ec2_vpc_endpoint_service_info``
-        module (https://github.com/ansible-collections/amazon.aws/pull/1308).
-      - s3_object - support for creating and deleting buckets using the ``s3_object``
-        module has been removed. S3 buckets can be created and deleted using the ``amazon.aws.s3_bucket``
-        module (https://github.com/ansible-collections/amazon.aws/issues/1112).
+        - ec2_vpc_endpoint_info - support for the ``query`` parameter was removed. The ``amazon.aws.ec2_vpc_endpoint_info`` module now only queries for endpoints.
+          Services can be queried using the ``amazon.aws.ec2_vpc_endpoint_service_info`` module (https://github.com/ansible-collections/amazon.aws/pull/1308).
+        - s3_object - support for creating and deleting buckets using the ``s3_object`` module has been removed. S3 buckets can be created and deleted using the ``amazon.aws.s3_bucket``
+          module (https://github.com/ansible-collections/amazon.aws/issues/1112).
     fragments:
-    - 1108-main-6.0.0.yml
-    - 1110-deprecation-complete-cloudretry-backoff.yml
-    - 1112-s3_object-delete-create.yml
-    - 1136-DEPRECATE-sort_json_policy_dict.yml
-    - 1168-s3_bucket_acl_disabled.yml
-    - 1169-rds_param_group-fail-on-updating-engine.yml
-    - 1180-december-deprecations.yml
-    - 1181-linting.yml
-    - 1187-ec2_instance.yml
-    - 1193-s3_object_refactor.yaml
-    - 1200-route53_health_check-return-health-check-info-on-updating.yml
-    - 1221-ec2_security_group.yml
-    - 1222-route53_health_check-bump-up-version_added.yml
-    - 1225-refacter-lookup.yml
-    - 1227-refacter-sdk-versions.yml
-    - 1230-move-RetryingBotoClientWrapper.yml
-    - 1231-boto3_connections.yml
-    - 1248-docs.yml
-    - 1253-route53_health_check-fix-name-tag-key-removal-idempotentcy-issue.yml
-    - 1255-async-tests.yml
-    - 1256-ec2_instance-running.yml
-    - 1257-python2-compat.yml
-    - 1258-slow.yml
-    - 1268-lambda-execute-arn.yml
-    - 1269-inventory_tests.yml
-    - 1271-inventory-connections.yml
-    - 1276-gitignore-inventory.yml
-    - 1285-inventory-refactor.yml
-    - 1303-client-override.yml
-    - 1305-s3-refactor.yml
-    - 1307-botocore-configs.yml
-    - 1308-ec2_vpc_endpoint_info-query.yml
-    - 1310-imports.yml
-    - 1315-ec2_instance-instance_type.yml
-    - 1320-ec2_vpc_dhcp_options-retrys.yaml
-    - 1321-ec2_ami.yaml
-    - 1327-ec2_vpc_dhcp_options.yml
-    - 1335-route53_health_check-rescind-deprecation-message.yml
-    - 1336-lambda-module_params.yml
-    - 1337-ec2_instance.yml
-    - 1348-remove-unreachable-code.yml
-    - 1352-s3-limited-permissions.yml
-    - 1369-inventory_aws_ec2-add-support-for-ssm-inventory.yml
-    - 1374-get_classic_link_status.yml
-    - 1375-lint.yml
-    - 1382-docs.yml
-    - 1394-lint.yml
-    - 1427-backup_tag-and_backup_tag_info-add-new-module.yml
-    - 1435-backup_restore_job_info-add-new-module.yml
-    - 1446-backup_plan-add-new-module.yml
-    - 1448-replace-pycrypto.yml
-    - 1462-sanity.yml
-    - 1465-black.yml
-    - 20221013-reenable-ec2_vpc_endpoint-tests.yml
-    - 20221024-ec2_eip-instance_id.yml
-    - 20221024-ec2_vpc_endpoint.yml
-    - 20221026-ec2_eip-instance_id-followup.yml
-    - 20221027-ec2_security_group-arg_spec.yml
-    - 20221103-ec2_security_group_-1.yml
-    - 20221103-tests.yml
-    - 20221104-exceptions.yml
-    - 20221107-metadata_test.yml
-    - 20221110-security_group.yml
-    - 20221124-docs-cleanup.yml
-    - 20230105-ec2_snapshot.yml
-    - 20230109-ec2_vpc_route_table.yml
-    - 20230306-headers.yml
-    - 20230423-update_readme_and_runtime.yml
-    - 20230502-rds_cluster-engine_version.yml
-    - 20230502-s3_object-permission.yml
-    - 924-contributing-docs.yml
-    - 926-ec2_vpc_route_table.yml
-    - add_github_actions_unitandsanity.yml
-    - add_linters_to_tox.yml
-    - aws_collection_constants.yml
-    - backup_add_backup_selections_logic.yml
-    - backup_resource.yml
-    - backup_selection-return_snake_case.yml
-    - botocore-add-custom-user-agent.yaml
-    - ec2_ami_test-coverage.yaml
-    - ec2_snapshot_reenable_the_integration_tests.yaml
-    - ec2_snapshot_tests_improve_reliability.yaml
-    - endpoint.yml
-    - fstring-1.yml
-    - fstring-2.yml
-    - fstring-3.yml
-    - fstring-4.yml
-    - fstring-ec2_inv.yml
-    - inventory_aws_ec2_update.yml
-    - lambda_layer_info-add-parameter-layer_version.yml
-    - module_utils_acm-unit-testing.yml
-    - module_utils_cloudfront_facts_unit_tests.yml
-    - module_utils_s3-unit-testing.yml
-    - python37.yml
-    - rds_cluster_split_functional_tests.yaml
-    - rds_instance_disable_aurora_integration_tests.yaml
-    - rds_use_aurora2_during_the_integration_tests.yaml
-    - refactor_connection_plugins.yml
-    - refactor_inventory_plugins.yml
-    - release-6-botocore.yml
-    - release_summary.yml
-    - remove-tests-integration-inventory-file.yml
-    - rename-cleanup-tests.yml
-    - unit-tests-tagging.yml
-    - unit-tests_test_ec2_ami_info_only.yaml
-    - unit-tests_test_ec2_eni_info_only.yaml
-    - unit-tests_test_ec2_snapshot_info_only.yaml
-    - unit-tests_test_rds_instance_info_only.yaml
-    - use_ec2_ami_to_test_ec2_snapshot_info.yaml
+      - 1108-main-6.0.0.yml
+      - 1110-deprecation-complete-cloudretry-backoff.yml
+      - 1112-s3_object-delete-create.yml
+      - 1136-DEPRECATE-sort_json_policy_dict.yml
+      - 1168-s3_bucket_acl_disabled.yml
+      - 1169-rds_param_group-fail-on-updating-engine.yml
+      - 1180-december-deprecations.yml
+      - 1181-linting.yml
+      - 1187-ec2_instance.yml
+      - 1193-s3_object_refactor.yaml
+      - 1200-route53_health_check-return-health-check-info-on-updating.yml
+      - 1221-ec2_security_group.yml
+      - 1222-route53_health_check-bump-up-version_added.yml
+      - 1225-refacter-lookup.yml
+      - 1227-refacter-sdk-versions.yml
+      - 1230-move-RetryingBotoClientWrapper.yml
+      - 1231-boto3_connections.yml
+      - 1248-docs.yml
+      - 1253-route53_health_check-fix-name-tag-key-removal-idempotentcy-issue.yml
+      - 1255-async-tests.yml
+      - 1256-ec2_instance-running.yml
+      - 1257-python2-compat.yml
+      - 1258-slow.yml
+      - 1268-lambda-execute-arn.yml
+      - 1269-inventory_tests.yml
+      - 1271-inventory-connections.yml
+      - 1276-gitignore-inventory.yml
+      - 1285-inventory-refactor.yml
+      - 1303-client-override.yml
+      - 1305-s3-refactor.yml
+      - 1307-botocore-configs.yml
+      - 1308-ec2_vpc_endpoint_info-query.yml
+      - 1310-imports.yml
+      - 1315-ec2_instance-instance_type.yml
+      - 1320-ec2_vpc_dhcp_options-retrys.yaml
+      - 1321-ec2_ami.yaml
+      - 1327-ec2_vpc_dhcp_options.yml
+      - 1335-route53_health_check-rescind-deprecation-message.yml
+      - 1336-lambda-module_params.yml
+      - 1337-ec2_instance.yml
+      - 1348-remove-unreachable-code.yml
+      - 1352-s3-limited-permissions.yml
+      - 1369-inventory_aws_ec2-add-support-for-ssm-inventory.yml
+      - 1374-get_classic_link_status.yml
+      - 1375-lint.yml
+      - 1382-docs.yml
+      - 1394-lint.yml
+      - 1427-backup_tag-and_backup_tag_info-add-new-module.yml
+      - 1435-backup_restore_job_info-add-new-module.yml
+      - 1446-backup_plan-add-new-module.yml
+      - 1448-replace-pycrypto.yml
+      - 1462-sanity.yml
+      - 1465-black.yml
+      - 20221013-reenable-ec2_vpc_endpoint-tests.yml
+      - 20221024-ec2_eip-instance_id.yml
+      - 20221024-ec2_vpc_endpoint.yml
+      - 20221026-ec2_eip-instance_id-followup.yml
+      - 20221027-ec2_security_group-arg_spec.yml
+      - 20221103-ec2_security_group_-1.yml
+      - 20221103-tests.yml
+      - 20221104-exceptions.yml
+      - 20221107-metadata_test.yml
+      - 20221110-security_group.yml
+      - 20221124-docs-cleanup.yml
+      - 20230105-ec2_snapshot.yml
+      - 20230109-ec2_vpc_route_table.yml
+      - 20230306-headers.yml
+      - 20230423-update_readme_and_runtime.yml
+      - 20230502-rds_cluster-engine_version.yml
+      - 20230502-s3_object-permission.yml
+      - 924-contributing-docs.yml
+      - 926-ec2_vpc_route_table.yml
+      - add_github_actions_unitandsanity.yml
+      - add_linters_to_tox.yml
+      - aws_collection_constants.yml
+      - backup_add_backup_selections_logic.yml
+      - backup_resource.yml
+      - backup_selection-return_snake_case.yml
+      - botocore-add-custom-user-agent.yaml
+      - ec2_ami_test-coverage.yaml
+      - ec2_snapshot_reenable_the_integration_tests.yaml
+      - ec2_snapshot_tests_improve_reliability.yaml
+      - endpoint.yml
+      - fstring-1.yml
+      - fstring-2.yml
+      - fstring-3.yml
+      - fstring-4.yml
+      - fstring-ec2_inv.yml
+      - inventory_aws_ec2_update.yml
+      - lambda_layer_info-add-parameter-layer_version.yml
+      - module_utils_acm-unit-testing.yml
+      - module_utils_cloudfront_facts_unit_tests.yml
+      - module_utils_s3-unit-testing.yml
+      - python37.yml
+      - rds_cluster_split_functional_tests.yaml
+      - rds_instance_disable_aurora_integration_tests.yaml
+      - rds_use_aurora2_during_the_integration_tests.yaml
+      - refactor_connection_plugins.yml
+      - refactor_inventory_plugins.yml
+      - release-6-botocore.yml
+      - release_summary.yml
+      - remove-tests-integration-inventory-file.yml
+      - rename-cleanup-tests.yml
+      - unit-tests-tagging.yml
+      - unit-tests_test_ec2_ami_info_only.yaml
+      - unit-tests_test_ec2_eni_info_only.yaml
+      - unit-tests_test_ec2_snapshot_info_only.yaml
+      - unit-tests_test_rds_instance_info_only.yaml
+      - use_ec2_ami_to_test_ec2_snapshot_info.yaml
     modules:
-    - description: Manage AWS Backup Plans
-      name: backup_plan
-      namespace: ''
-    - description: Describe AWS Backup Plans
-      name: backup_plan_info
-      namespace: ''
-    - description: List information about backup restore jobs
-      name: backup_restore_job_info
-      namespace: ''
-    - description: Create, delete and modify AWS Backup selection
-      name: backup_selection
-      namespace: ''
-    - description: Describe AWS Backup Selections
-      name: backup_selection_info
-      namespace: ''
-    - description: Manage tags on backup plan, backup vault, recovery point
-      name: backup_tag
-      namespace: ''
-    - description: List tags on AWS Backup resources
-      name: backup_tag_info
-      namespace: ''
-    - description: Manage AWS Backup Vaults
-      name: backup_vault
-      namespace: ''
-    - description: Describe AWS Backup Vaults
-      name: backup_vault_info
-      namespace: ''
+      - description: Manage AWS Backup Plans
+        name: backup_plan
+        namespace: ""
+      - description: Describe AWS Backup Plans
+        name: backup_plan_info
+        namespace: ""
+      - description: List information about backup restore jobs
+        name: backup_restore_job_info
+        namespace: ""
+      - description: Create, delete and modify AWS Backup selection
+        name: backup_selection
+        namespace: ""
+      - description: Describe AWS Backup Selections
+        name: backup_selection_info
+        namespace: ""
+      - description: Manage tags on backup plan, backup vault, recovery point
+        name: backup_tag
+        namespace: ""
+      - description: List tags on AWS Backup resources
+        name: backup_tag_info
+        namespace: ""
+      - description: Manage AWS Backup Vaults
+        name: backup_vault
+        namespace: ""
+      - description: Describe AWS Backup Vaults
+        name: backup_vault_info
+        namespace: ""
     plugins:
       lookup:
-      - description: expose various collection related constants
-        name: aws_collection_constants
-        namespace: null
-    release_date: '2023-05-09'
+        - description: expose various collection related constants
+          name: aws_collection_constants
+          namespace:
+    release_date: "2023-05-09"
   6.0.1:
     changes:
       bugfixes:
-      - aws_ec2 inventory plugin - fix ``NoRegionError`` when no regions are provided
-        and region isn't specified (https://github.com/ansible-collections/amazon.aws/issues/1551).
-      - s3_bucket - fixes issue when deleting a bucket with unversioned objects (https://github.com/ansible-collections/amazon.aws/issues/1533).
-      - s3_object - fixes regression related to objects with a leading ``/`` (https://github.com/ansible-collections/amazon.aws/issues/1548).
-      release_summary: This is a patch release that includes some bug fixes for the
-        aws_ec2 inventory plugin and the s3_bucket and s3_object modules.
+        - aws_ec2 inventory plugin - fix ``NoRegionError`` when no regions are provided and region isn't specified (https://github.com/ansible-collections/amazon.aws/issues/1551).
+        - s3_bucket - fixes issue when deleting a bucket with unversioned objects (https://github.com/ansible-collections/amazon.aws/issues/1533).
+        - s3_object - fixes regression related to objects with a leading ``/`` (https://github.com/ansible-collections/amazon.aws/issues/1548).
+      release_summary: This is a patch release that includes some bug fixes for the aws_ec2 inventory plugin and the s3_bucket and s3_object modules.
     fragments:
-    - 1538-s3-null.yml
-    - 1548-s3_object-leading-slash.yml
-    - 1551-ec2_inventory-no-region.yml
-    - 1560-revert_1546.yml
-    - release_summary.yml
-    release_date: '2023-05-19'
+      - 1538-s3-null.yml
+      - 1548-s3_object-leading-slash.yml
+      - 1551-ec2_inventory-no-region.yml
+      - 1560-revert_1546.yml
+      - release_summary.yml
+    release_date: "2023-05-19"
   6.1.0:
     changes:
       bugfixes:
-      - autoscaling_group - fix ValidationError when describing an autoscaling group
-        that has more than 20 target groups attached to it by breaking the request
-        into chunks (https://github.com/ansible-collections/amazon.aws/pull/1593).
-      - autoscaling_group_info - fix ValidationError when describing an autoscaling
-        group that has more than 20 target groups attached to it by breaking the request
-        into chunks (https://github.com/ansible-collections/amazon.aws/pull/1593).
-      - ec2_instance - fix check_mode issue when adding network interfaces (https://github.com/ansible-collections/amazon.aws/issues/1403).
-      - 'ec2_metadata_facts - Handle decompression when EC2 instance user-data is
-        gzip compressed. The fetch_url method from ansible.module_utils.urls does
-        not decompress the user-data unless the header explicitly contains ``Content-Encoding:
-        gzip`` (https://github.com/ansible-collections/amazon.aws/pull/1575).'
-      - elb_application_lb - fix missing attributes on creation of ALB. The ``create_or_update_alb()``
-        was including ALB-specific attributes when updating an existing ALB but not
-        when creating a new ALB (https://github.com/ansible-collections/amazon.aws/issues/1510).
-      - module_utils.acm - fixes list_certificates returning only RSA_2048 certificates
-        (https://github.com/ansible-collections/amazon.aws/issues/1567).
-      - rds_instance - add support for CACertificateIdentifier to create/update rds
-        instance (https://github.com/ansible-collections/amazon.aws/pull/1459).
+        - autoscaling_group - fix ValidationError when describing an autoscaling group that has more than 20 target groups attached to it by breaking the request
+          into chunks (https://github.com/ansible-collections/amazon.aws/pull/1593).
+        - autoscaling_group_info - fix ValidationError when describing an autoscaling group that has more than 20 target groups attached to it by breaking the request
+          into chunks (https://github.com/ansible-collections/amazon.aws/pull/1593).
+        - ec2_instance - fix check_mode issue when adding network interfaces (https://github.com/ansible-collections/amazon.aws/issues/1403).
+        - "ec2_metadata_facts - Handle decompression when EC2 instance user-data is gzip compressed. The fetch_url method from ansible.module_utils.urls does not
+          decompress the user-data unless the header explicitly contains ``Content-Encoding: gzip`` (https://github.com/ansible-collections/amazon.aws/pull/1575)."
+        - elb_application_lb - fix missing attributes on creation of ALB. The ``create_or_update_alb()`` was including ALB-specific attributes when updating an existing
+          ALB but not when creating a new ALB (https://github.com/ansible-collections/amazon.aws/issues/1510).
+        - module_utils.acm - fixes list_certificates returning only RSA_2048 certificates (https://github.com/ansible-collections/amazon.aws/issues/1567).
+        - rds_instance - add support for CACertificateIdentifier to create/update rds instance (https://github.com/ansible-collections/amazon.aws/pull/1459).
       deprecated_features:
-      - s3_object - support for passing object keys with a leading ``/`` has been
-        deprecated and will be removed in a release after 2025-12-01 (https://github.com/ansible-collections/amazon.aws/pull/1549).
+        - s3_object - support for passing object keys with a leading ``/`` has been deprecated and will be removed in a release after 2025-12-01 (https://github.com/ansible-collections/amazon.aws/pull/1549).
       minor_changes:
-      - ec2_snapshot - Add support for modifying createVolumePermission (https://github.com/ansible-collections/amazon.aws/pull/1464).
-      - ec2_snapshot_info - Add createVolumePermission to output result (https://github.com/ansible-collections/amazon.aws/pull/1464).
-      release_summary: This release brings some new features, several bugfixes, and
-        deprecated features are also included.
+        - ec2_snapshot - Add support for modifying createVolumePermission (https://github.com/ansible-collections/amazon.aws/pull/1464).
+        - ec2_snapshot_info - Add createVolumePermission to output result (https://github.com/ansible-collections/amazon.aws/pull/1464).
+      release_summary: This release brings some new features, several bugfixes, and deprecated features are also included.
     fragments:
-    - 1459-rds_instance-add-support-for-ca_certificate_identifier-to-create-update-instance.yml
-    - 1464-ec2_snapshot-ec2_snapshot_info-support-modifying-create-volume-permissions.yml
-    - 1510-elb_application_lb-fix-alb-specific-attributes-not-added-on-create.yml
-    - 1548-s3_object-leading-slash-deprecate.yml
-    - 1567-list-certificate-all-key-types.yml
-    - 1578-rds-instance-docs.yml
-    - 1593-autoscaling_group_info-20-target-groups-per-call.yml
-    - 20230526-ec2_mertadata_facts-handle_compressed_user_data.yml
-    - 20230531-aws_ec2-use_ssm_inventory_documentation.yml
-    - ec2-inventory-hostnames-doc.yml
-    - ec2_instance-eni-attach-idempotency.yml
-    - release_summary.yml
-    - test-reqs.yml
-    release_date: '2023-06-07'
+      - 1459-rds_instance-add-support-for-ca_certificate_identifier-to-create-update-instance.yml
+      - 1464-ec2_snapshot-ec2_snapshot_info-support-modifying-create-volume-permissions.yml
+      - 1510-elb_application_lb-fix-alb-specific-attributes-not-added-on-create.yml
+      - 1548-s3_object-leading-slash-deprecate.yml
+      - 1567-list-certificate-all-key-types.yml
+      - 1578-rds-instance-docs.yml
+      - 1593-autoscaling_group_info-20-target-groups-per-call.yml
+      - 20230526-ec2_mertadata_facts-handle_compressed_user_data.yml
+      - 20230531-aws_ec2-use_ssm_inventory_documentation.yml
+      - ec2-inventory-hostnames-doc.yml
+      - ec2_instance-eni-attach-idempotency.yml
+      - release_summary.yml
+      - test-reqs.yml
+    release_date: "2023-06-07"
   6.2.0:
     changes:
       bugfixes:
-      - backup_plan - Use existing ``scrub_none_values`` function from module_utils
-        to remove None values from nested dicts in supplied params. Nested None values
-        were being retained and causing an error when sent through to the boto3 client
-        operation (https://github.com/ansible-collections/amazon.aws/pull/1611).
-      - backup_vault - fix error when updating tags on a backup vault by using the
-        correct boto3 client methods for tagging and untagging backup resources (https://github.com/ansible-collections/amazon.aws/pull/1610).
-      - cloudwatchevent_rule - Fixes changed status to report False when no change
-        has been made. The module had incorrectly always reported a change. (https://github.com/ansible-collections/amazon.aws/pull/1589)
-      - ec2_vpc_nat_gateway - adding a boolean parameter called ``default_create``
-        to allow users to have the option to choose whether they want to display an
-        error message or create a NAT gateway when an EIP address is not found. The
-        module (ec2_vpc_nat_gateway) had incorrectly failed silently if EIP didn't
-        exist (https://github.com/ansible-collections/amazon.aws/issues/1295).
-      - ec2_vpc_nat_gateway - fixes to nat gateway so that when the user creates a
-        private NAT gateway, an Elastic IP address should not be allocated. The module
-        had inncorrectly always allocate elastic IP address when creating private
-        nat gateway (https://github.com/ansible-collections/amazon.aws/pull/1632).
-      - lambda_execute - Fixes to the stack trace output, where it does not contain
-        spaces between each character. The module had incorrectly always outputted
-        extra spaces between each character. (https://github.com/ansible-collections/amazon.aws/pull/1615)
-      - module_utils.backup - get_selection_details fix empty list returned when multiple
-        backup selections exist (https://github.com/ansible-collections/amazon.aws/pull/1633).
+        - backup_plan - Use existing ``scrub_none_values`` function from module_utils to remove None values from nested dicts in supplied params. Nested None values
+          were being retained and causing an error when sent through to the boto3 client operation (https://github.com/ansible-collections/amazon.aws/pull/1611).
+        - backup_vault - fix error when updating tags on a backup vault by using the correct boto3 client methods for tagging and untagging backup resources (https://github.com/ansible-collections/amazon.aws/pull/1610).
+        - cloudwatchevent_rule - Fixes changed status to report False when no change has been made. The module had incorrectly always reported a change. (https://github.com/ansible-collections/amazon.aws/pull/1589)
+        - ec2_vpc_nat_gateway - adding a boolean parameter called ``default_create`` to allow users to have the option to choose whether they want to display an error
+          message or create a NAT gateway when an EIP address is not found. The module (ec2_vpc_nat_gateway) had incorrectly failed silently if EIP didn't exist (https://github.com/ansible-collections/amazon.aws/issues/1295).
+        - ec2_vpc_nat_gateway - fixes to nat gateway so that when the user creates a private NAT gateway, an Elastic IP address should not be allocated. The module
+          had inncorrectly always allocate elastic IP address when creating private nat gateway (https://github.com/ansible-collections/amazon.aws/pull/1632).
+        - lambda_execute - Fixes to the stack trace output, where it does not contain spaces between each character. The module had incorrectly always outputted extra
+          spaces between each character. (https://github.com/ansible-collections/amazon.aws/pull/1615)
+        - module_utils.backup - get_selection_details fix empty list returned when multiple backup selections exist (https://github.com/ansible-collections/amazon.aws/pull/1633).
       minor_changes:
-      - backup_selection - add validation and documentation for all conditions suboptions
-        (https://github.com/ansible-collections/amazon.aws/pull/1633).
-      - ec2_instance - refactored ARN validation handling (https://github.com/ansible-collections/amazon.aws/pull/1619).
-      - iam_user - refactored ARN validation handling (https://github.com/ansible-collections/amazon.aws/pull/1619).
-      - module_utils.arn - add ``resource_id`` and ``resource_type`` to ``parse_aws_arn``
-        return values (https://github.com/ansible-collections/amazon.aws/pull/1619).
-      - module_utils.arn - added ``validate_aws_arn`` function to handle common pattern
-        matching for ARNs (https://github.com/ansible-collections/amazon.aws/pull/1619).
-      release_summary: This release brings some new modules, features, and several
-        bugfixes.
+        - backup_selection - add validation and documentation for all conditions suboptions (https://github.com/ansible-collections/amazon.aws/pull/1633).
+        - ec2_instance - refactored ARN validation handling (https://github.com/ansible-collections/amazon.aws/pull/1619).
+        - iam_user - refactored ARN validation handling (https://github.com/ansible-collections/amazon.aws/pull/1619).
+        - module_utils.arn - add ``resource_id`` and ``resource_type`` to ``parse_aws_arn`` return values (https://github.com/ansible-collections/amazon.aws/pull/1619).
+        - module_utils.arn - added ``validate_aws_arn`` function to handle common pattern matching for ARNs (https://github.com/ansible-collections/amazon.aws/pull/1619).
+      release_summary: This release brings some new modules, features, and several bugfixes.
     fragments:
-    - 1589-return_false_when_no_change..yml
-    - 1604-c2_vpc_nat_gateway-fails-silently.yml
-    - 1615-no_formatted_with_extra_space.yml
-    - 1632-changes-to-no-allocate-eip-when-connectivity_type=private.yml
-    - 1633-backup-selection-conditions.yml
-    - 1843-iam_instance_profile.yml
-    - 1846-arn-validation.yml
-    - 20230506-autoscaling_group-fix_sanity.yml
-    - 202306012-backup_plan-remove-none-from-nested-params.yml
-    - 20230612-backup_vault-fix-tag-update.yml
-    - 20230627-ci-fixup.yml
-    - release_summary.yml
+      - 1589-return_false_when_no_change..yml
+      - 1604-c2_vpc_nat_gateway-fails-silently.yml
+      - 1615-no_formatted_with_extra_space.yml
+      - 1632-changes-to-no-allocate-eip-when-connectivity_type=private.yml
+      - 1633-backup-selection-conditions.yml
+      - 1843-iam_instance_profile.yml
+      - 1846-arn-validation.yml
+      - 20230506-autoscaling_group-fix_sanity.yml
+      - 202306012-backup_plan-remove-none-from-nested-params.yml
+      - 20230612-backup_vault-fix-tag-update.yml
+      - 20230627-ci-fixup.yml
+      - release_summary.yml
     modules:
-    - description: manage IAM instance profiles
-      name: iam_instance_profile
-      namespace: ''
-    - description: gather information on IAM instance profiles
-      name: iam_instance_profile_info
-      namespace: ''
-    release_date: '2023-07-05'
+      - description: manage IAM instance profiles
+        name: iam_instance_profile
+        namespace: ""
+      - description: gather information on IAM instance profiles
+        name: iam_instance_profile_info
+        namespace: ""
+    release_date: "2023-07-05"
   6.3.0:
     changes:
       bugfixes:
-      - ec2_vpc_route_table_info - default filters to empty dictionary (https://github.com/ansible-collections/amazon.aws/issues/1668).
-      - rds_cluster - Add ``AllocatedStorage``, ``DBClusterInstanceClass``, ``StorageType``,
-        ``Iops``, and ``EngineMode`` to the list of parameters that can be passed
-        when creating or modifying a Multi-AZ RDS cluster (https://github.com/ansible-collections/amazon.aws/pull/1657).
-      - rds_cluster - Allow to pass GlobalClusterIdentifier to rds cluster on creation
-        (https://github.com/ansible-collections/amazon.aws/pull/1663).
+        - ec2_vpc_route_table_info - default filters to empty dictionary (https://github.com/ansible-collections/amazon.aws/issues/1668).
+        - rds_cluster - Add ``AllocatedStorage``, ``DBClusterInstanceClass``, ``StorageType``, ``Iops``, and ``EngineMode`` to the list of parameters that can be
+          passed when creating or modifying a Multi-AZ RDS cluster (https://github.com/ansible-collections/amazon.aws/pull/1657).
+        - rds_cluster - Allow to pass GlobalClusterIdentifier to rds cluster on creation (https://github.com/ansible-collections/amazon.aws/pull/1663).
       minor_changes:
-      - rds_cluster - add support for another ``state`` choice called ``started``.
-        This starts the rds cluster (https://github.com/ansible-collections/amazon.aws/pull/1647/files).
-      - rds_cluster - add support for another ``state`` choice called ``stopped``.
-        This stops the rds cluster (https://github.com/ansible-collections/amazon.aws/pull/1647/files).
-      - route53 - add a ``wait_id`` return value when a change is done (https://github.com/ansible-collections/amazon.aws/pull/1683).
-      - route53_health_check - add support for a string list parameter called ``child_health_checks``
-        to specify health checks that must be healthy for the calculated health check
-        (https://github.com/ansible-collections/amazon.aws/pull/1631).
-      - route53_health_check - add support for an integer parameter called ``health_threshold``
-        to specify the minimum number of healthy child health checks that must be
-        healthy for the calculated health check (https://github.com/ansible-collections/amazon.aws/pull/1631).
-      - route53_health_check - add support for another ``type`` choice called ``CALCULATED``
-        (https://github.com/ansible-collections/amazon.aws/pull/1631).
+        - rds_cluster - add support for another ``state`` choice called ``started``. This starts the rds cluster (https://github.com/ansible-collections/amazon.aws/pull/1647/files).
+        - rds_cluster - add support for another ``state`` choice called ``stopped``. This stops the rds cluster (https://github.com/ansible-collections/amazon.aws/pull/1647/files).
+        - route53 - add a ``wait_id`` return value when a change is done (https://github.com/ansible-collections/amazon.aws/pull/1683).
+        - route53_health_check - add support for a string list parameter called ``child_health_checks`` to specify health checks that must be healthy for the calculated
+          health check (https://github.com/ansible-collections/amazon.aws/pull/1631).
+        - route53_health_check - add support for an integer parameter called ``health_threshold`` to specify the minimum number of healthy child health checks that
+          must be healthy for the calculated health check (https://github.com/ansible-collections/amazon.aws/pull/1631).
+        - route53_health_check - add support for another ``type`` choice called ``CALCULATED`` (https://github.com/ansible-collections/amazon.aws/pull/1631).
       release_summary: This release brings some new features and several bugfixes.
     fragments:
-    - 1631-route53_health_check-added-calculcated.yml
-    - 1647-add-type-started-and-stopped.yml
-    - 1683-route53-wait_id.yml
-    - 20230704-add_github_workflow.yml
-    - 20230707-backup_selection-doc-fix.yml
-    - 20230713-rds_cluster-fix_params_passage.yml
-    - 20230725-rds_cluster-fix.yml
-    - ec2_vpc_route_table_info-filter-fix.yml
-    - release_summary.yml
-    release_date: '2023-08-03'
+      - 1631-route53_health_check-added-calculcated.yml
+      - 1647-add-type-started-and-stopped.yml
+      - 1683-route53-wait_id.yml
+      - 20230704-add_github_workflow.yml
+      - 20230707-backup_selection-doc-fix.yml
+      - 20230713-rds_cluster-fix_params_passage.yml
+      - 20230725-rds_cluster-fix.yml
+      - ec2_vpc_route_table_info-filter-fix.yml
+      - release_summary.yml
+    release_date: "2023-08-03"
   6.4.0:
     changes:
       bugfixes:
-      - backup_selection - ensures that updating an existing selection will add new
-        ``Conditions`` if there previously were not any (https://github.com/ansible-collections/amazon.aws/pull/1701).
+        - backup_selection - ensures that updating an existing selection will add new ``Conditions`` if there previously were not any (https://github.com/ansible-collections/amazon.aws/pull/1701).
       minor_changes:
-      - cloudformation - Add support for ``disable_rollback`` to update stack operation
-        (https://github.com/ansible-collections/amazon.aws/issues/1681).
-      - ec2_key - add support for new parameter ``file_name`` to save private key
-        in when new key is created by AWS. When this option is provided the generated
-        private key will be removed from the module return (https://github.com/ansible-collections/amazon.aws/pull/1704).
-      release_summary: This release brings a new module named ``amazon.aws.ec2_key_info``,
-        some documentation improvements, new features and bugfixes.
+        - cloudformation - Add support for ``disable_rollback`` to update stack operation (https://github.com/ansible-collections/amazon.aws/issues/1681).
+        - ec2_key - add support for new parameter ``file_name`` to save private key in when new key is created by AWS. When this option is provided the generated
+          private key will be removed from the module return (https://github.com/ansible-collections/amazon.aws/pull/1704).
+      release_summary: This release brings a new module named ``amazon.aws.ec2_key_info``, some documentation improvements, new features and bugfixes.
     fragments:
-    - 1681-cloudformation-add-support-for-disable_rollback-to-update.yml
-    - 1685-ssm_parameter-update-examples-to-use-fqcn.yml
-    - 1701-backup-selection-bugfix.yml
-    - doc_update_for_keypair_nolog.yml
-    - ec2_key-fix-security-vulnerability.yml
-    - release_summary.yml
+      - 1681-cloudformation-add-support-for-disable_rollback-to-update.yml
+      - 1685-ssm_parameter-update-examples-to-use-fqcn.yml
+      - 1701-backup-selection-bugfix.yml
+      - doc_update_for_keypair_nolog.yml
+      - ec2_key-fix-security-vulnerability.yml
+      - release_summary.yml
     modules:
-    - description: Gather information about EC2 key pairs in AWS
-      name: ec2_key_info
-      namespace: ''
-    release_date: '2023-09-05'
+      - description: Gather information about EC2 key pairs in AWS
+        name: ec2_key_info
+        namespace: ""
+    release_date: "2023-09-05"
   6.5.0:
     changes:
       bugfixes:
-      - elb_application_lb_info - ensure all API queries use the retry decorator (https://github.com/ansible-collections/amazon.aws/issues/1767).
+        - elb_application_lb_info - ensure all API queries use the retry decorator (https://github.com/ansible-collections/amazon.aws/issues/1767).
       minor_changes:
-      - ec2_ami - add support for ``org_arns`` and ``org_unit_arns`` in launch_permissions
-        (https://github.com/ansible-collections/amazon.aws/pull/1690).
-      - elb_application_lb_info - drop redundant ``describe_load_balancers`` call
-        fetching ``ip_address_type`` (https://github.com/ansible-collections/amazon.aws/pull/1768).
-      release_summary: 'This release is the last planned minor release of ``amazon.aws``
-        prior to the release of 7.0.0.
-
-        It includes documentation fixes as well as minor changes and bug fixes for
-        the ``ec2_ami`` and ``elb_application_lb_info`` modules.
-
-        '
+        - ec2_ami - add support for ``org_arns`` and ``org_unit_arns`` in launch_permissions (https://github.com/ansible-collections/amazon.aws/pull/1690).
+        - elb_application_lb_info - drop redundant ``describe_load_balancers`` call fetching ``ip_address_type`` (https://github.com/ansible-collections/amazon.aws/pull/1768).
+      release_summary: "This release is the last planned minor release of ``amazon.aws`` prior to the release of 7.0.0.\nIt includes documentation fixes as well as
+        minor changes and bug fixes for the ``ec2_ami`` and ``elb_application_lb_info`` modules.\n"
     fragments:
-    - 1690-ec2_ami-add-support-org_arn-orgu_arn.yml
-    - 1714-parameters.yml
-    - 1767-elb_application_lb_info-Throttling.yml
-    - 20230906-galaxy.yml
-    - 20230908-alias-cleanup.yml
-    - 20230911-ec2_ami-release.yml
-    - ec2_region.yml
-    - release-summary.yml
-    release_date: '2023-10-03'
+      - 1690-ec2_ami-add-support-org_arn-orgu_arn.yml
+      - 1714-parameters.yml
+      - 1767-elb_application_lb_info-Throttling.yml
+      - 20230906-galaxy.yml
+      - 20230908-alias-cleanup.yml
+      - 20230911-ec2_ami-release.yml
+      - ec2_region.yml
+      - release-summary.yml
+    release_date: "2023-10-03"
   7.0.0:
     changes:
       breaking_changes:
-      - The amazon.aws collection has dropped support for ``botocore<1.29.0`` and
-        ``boto3<1.26.0``. Most modules will continue to work with older versions of
-        the AWS SDK, however compatability with older versions of the SDK is not guaranteed
-        and will not be tested. When using older versions of the SDK a warning will
-        be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/1763).
-      - amazon.aws collection - due to the AWS SDKs announcing the end of support
-        for Python less than 3.7 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
-        support for Python less than 3.7 by this collection wss been deprecated in
-        release 6.0.0 and removed in release 7.0.0. (https://github.com/ansible-collections/amazon.aws/pull/1763).
-      - module_utils - ``module_utils.urls`` was previously deprecated and has been
-        removed (https://github.com/ansible-collections/amazon.aws/pull/1540).
-      - module_utils._version - vendored copy of distutils.version has been dropped
-        (https://github.com/ansible-collections/amazon.aws/pull/1587).
+        - The amazon.aws collection has dropped support for ``botocore<1.29.0`` and ``boto3<1.26.0``. Most modules will continue to work with older versions of the
+          AWS SDK, however compatability with older versions of the SDK is not guaranteed and will not be tested. When using older versions of the SDK a warning will
+          be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/1763).
+        - amazon.aws collection - due to the AWS SDKs announcing the end of support for Python less than 3.7 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
+          support for Python less than 3.7 by this collection wss been deprecated in release 6.0.0 and removed in release 7.0.0. (https://github.com/ansible-collections/amazon.aws/pull/1763).
+        - module_utils - ``module_utils.urls`` was previously deprecated and has been removed (https://github.com/ansible-collections/amazon.aws/pull/1540).
+        - module_utils._version - vendored copy of distutils.version has been dropped (https://github.com/ansible-collections/amazon.aws/pull/1587).
       bugfixes:
-      - aws_ec2 inventory plugin - fix ``NoRegionError`` when no regions are provided
-        and region isn't specified (https://github.com/ansible-collections/amazon.aws/issues/1551).
-      - ec2_instance - retry API call if we get ``InvalidInstanceID.NotFound`` error
-        (https://github.com/ansible-collections/amazon.aws/pull/1650).
-      - ec2_vpc_route_table_info - default filters to empty dictionary (https://github.com/ansible-collections/amazon.aws/issues/1668).
-      - s3_bucket - fixes issue when deleting a bucket with unversioned objects (https://github.com/ansible-collections/amazon.aws/issues/1533).
-      - s3_object - fixed ``NoSuchTagSet`` error when S3 endpoint doesn't support
-        tags (https://github.com/ansible-collections/amazon.aws/issues/1607).
-      - s3_object - fixes regression related to objects with a leading ``/`` (https://github.com/ansible-collections/amazon.aws/issues/1548).
+        - aws_ec2 inventory plugin - fix ``NoRegionError`` when no regions are provided and region isn't specified (https://github.com/ansible-collections/amazon.aws/issues/1551).
+        - ec2_instance - retry API call if we get ``InvalidInstanceID.NotFound`` error (https://github.com/ansible-collections/amazon.aws/pull/1650).
+        - ec2_vpc_route_table_info - default filters to empty dictionary (https://github.com/ansible-collections/amazon.aws/issues/1668).
+        - s3_bucket - fixes issue when deleting a bucket with unversioned objects (https://github.com/ansible-collections/amazon.aws/issues/1533).
+        - s3_object - fixed ``NoSuchTagSet`` error when S3 endpoint doesn't support tags (https://github.com/ansible-collections/amazon.aws/issues/1607).
+        - s3_object - fixes regression related to objects with a leading ``/`` (https://github.com/ansible-collections/amazon.aws/issues/1548).
       deprecated_features:
-      - ec2_instance - deprecation of ``tenancy`` and ``placement_group`` in favor
-        of ``placement`` attribute  (https://github.com/ansible-collections/amazon.aws/pull/1825).
+        - ec2_instance - deprecation of ``tenancy`` and ``placement_group`` in favor of ``placement`` attribute  (https://github.com/ansible-collections/amazon.aws/pull/1825).
       major_changes:
-      - aws_region_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.aws_region_info``.
-      - aws_s3_bucket_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.aws_s3_bucket_info``.
-      - iam_access_key - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.iam_access_key``.
-      - iam_access_key_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.iam_access_key_info``.
-      - iam_group - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.iam_group`` (https://github.com/ansible-collections/amazon.aws/pull/1755).
-      - iam_managed_policy - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.iam_managed_policy`` (https://github.com/ansible-collections/amazon.aws/pull/1762).
-      - iam_mfa_device_info - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.iam_mfa_device_info`` (https://github.com/ansible-collections/amazon.aws/pull/1761).
-      - iam_password_policy - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.iam_password_policy``.
-      - iam_role - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.iam_role`` (https://github.com/ansible-collections/amazon.aws/pull/1760).
-      - iam_role_info - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.iam_role_info`` (https://github.com/ansible-collections/amazon.aws/pull/1760).
-      - s3_bucket_info - The module has been migrated from the ``community.aws`` collection.
-        Playbooks using the Fully Qualified Collection Name for this module should
-        be updated to use ``amazon.aws.s3_bucket_info``.
-      - sts_assume_role - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.sts_assume_role``.
+        - aws_region_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.aws_region_info``.
+        - aws_s3_bucket_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.aws_s3_bucket_info``.
+        - iam_access_key - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.iam_access_key``.
+        - iam_access_key_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.iam_access_key_info``.
+        - iam_group - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.iam_group`` (https://github.com/ansible-collections/amazon.aws/pull/1755).
+        - iam_managed_policy - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.iam_managed_policy`` (https://github.com/ansible-collections/amazon.aws/pull/1762).
+        - iam_mfa_device_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.iam_mfa_device_info`` (https://github.com/ansible-collections/amazon.aws/pull/1761).
+        - iam_password_policy - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.iam_password_policy``.
+        - iam_role - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module should
+          be updated to use ``amazon.aws.iam_role`` (https://github.com/ansible-collections/amazon.aws/pull/1760).
+        - iam_role_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.iam_role_info`` (https://github.com/ansible-collections/amazon.aws/pull/1760).
+        - s3_bucket_info - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.s3_bucket_info``.
+        - sts_assume_role - The module has been migrated from the ``community.aws`` collection. Playbooks using the Fully Qualified Collection Name for this module
+          should be updated to use ``amazon.aws.sts_assume_role``.
       minor_changes:
-      - amazon.aws collection - apply isort code formatting to ensure consistent formatting
-        of code (https://github.com/ansible-collections/amazon.aws/pull/1771).
-      - ec2_instance - add support for additional ``placement`` options and ``license_specifications``
-        in run instance spec (https://github.com/ansible-collections/amazon.aws/issues/1824).
-      - ec2_instance_info - add new parameter ``include_attributes`` to describe instance
-        attributes (https://github.com/ansible-collections/amazon.aws/pull/1577).
-      - ec2_metadata_facts - use fstrings where appropriate (https://github.com/ansible-collections/amazon.aws/pull/1802).
-      - ec2_vpc_igw - Add ability to attach/detach VPC to/from internet gateway (https://github.com/ansible-collections/amazon.aws/pull/1786).
-      - ec2_vpc_igw - Add ability to change VPC attached to internet gateway (https://github.com/ansible-collections/amazon.aws/pull/1786).
-      - ec2_vpc_igw - Add ability to create an internet gateway without attaching
-        a VPC (https://github.com/ansible-collections/amazon.aws/pull/1786).
-      - ec2_vpc_igw - Add ability to delete a vpc internet gateway using the id of
-        the gateway (https://github.com/ansible-collections/amazon.aws/pull/1786).
-      - elb_application_lb_info - add new parameters ``include_attributes``, ``include_listeners``
-        and  ``include_listener_rules`` to optionally speed up module by fetching
-        less information (https://github.com/ansible-collections/amazon.aws/pull/1778).
-      - module_utils.botocore - migrate from vendored copy of LooseVersion to packaging.version.Version
-        (https://github.com/ansible-collections/amazon.aws/pull/1587).
-      - rds_cluster - Add support for removing cluster from global db (https://github.com/ansible-collections/amazon.aws/pull/1705).
-      - rds_cluster - add support for another ``state`` choice called ``started``.
-        This starts the rds cluster (https://github.com/ansible-collections/amazon.aws/pull/1647/files).
-      - rds_cluster - add support for another ``state`` choice called ``stopped``.
-        This stops the rds cluster (https://github.com/ansible-collections/amazon.aws/pull/1647/files).
-      - route53 - add a ``wait_id`` return value when a change is done (https://github.com/ansible-collections/amazon.aws/pull/1683).
-      - route53_health_check - add support for a string list parameter called ``child_health_checks``
-        to specify health checks that must be healthy for the calculated health check
-        (https://github.com/ansible-collections/amazon.aws/pull/1631).
-      - route53_health_check - add support for an integer parameter called ``health_threshold``
-        to specify the minimum number of healthy child health checks that must be
-        healthy for the calculated health check (https://github.com/ansible-collections/amazon.aws/pull/1631).
-      - route53_health_check - add support for another ``type`` choice called ``CALCULATED``
-        (https://github.com/ansible-collections/amazon.aws/pull/1631).
-      - s3_object - Allow recursive copy of objects in S3 bucket (https://github.com/ansible-collections/amazon.aws/issues/1379).
-      - s3_object - use fstrings where appropriate (https://github.com/ansible-collections/amazon.aws/pull/1802).
-      release_summary: This major release brings a new set of supported modules that
-        have been promoted from community.aws, several bugfixes, minor changes and
-        deprecated features. We also dropped support for ``botocore<1.29.0`` and ``boto3<1.26.0``.
-        Due to the AWS SDKs announcing the end of support for Python less than 3.7
-        (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/),
-        support for Python less than 3.7 by this collection was deprecated in release
-        6.0.0 and removed in this release.
+        - amazon.aws collection - apply isort code formatting to ensure consistent formatting of code (https://github.com/ansible-collections/amazon.aws/pull/1771).
+        - ec2_instance - add support for additional ``placement`` options and ``license_specifications`` in run instance spec (https://github.com/ansible-collections/amazon.aws/issues/1824).
+        - ec2_instance_info - add new parameter ``include_attributes`` to describe instance attributes (https://github.com/ansible-collections/amazon.aws/pull/1577).
+        - ec2_metadata_facts - use fstrings where appropriate (https://github.com/ansible-collections/amazon.aws/pull/1802).
+        - ec2_vpc_igw - Add ability to attach/detach VPC to/from internet gateway (https://github.com/ansible-collections/amazon.aws/pull/1786).
+        - ec2_vpc_igw - Add ability to change VPC attached to internet gateway (https://github.com/ansible-collections/amazon.aws/pull/1786).
+        - ec2_vpc_igw - Add ability to create an internet gateway without attaching a VPC (https://github.com/ansible-collections/amazon.aws/pull/1786).
+        - ec2_vpc_igw - Add ability to delete a vpc internet gateway using the id of the gateway (https://github.com/ansible-collections/amazon.aws/pull/1786).
+        - elb_application_lb_info - add new parameters ``include_attributes``, ``include_listeners`` and  ``include_listener_rules`` to optionally speed up module
+          by fetching less information (https://github.com/ansible-collections/amazon.aws/pull/1778).
+        - module_utils.botocore - migrate from vendored copy of LooseVersion to packaging.version.Version (https://github.com/ansible-collections/amazon.aws/pull/1587).
+        - rds_cluster - Add support for removing cluster from global db (https://github.com/ansible-collections/amazon.aws/pull/1705).
+        - rds_cluster - add support for another ``state`` choice called ``started``. This starts the rds cluster (https://github.com/ansible-collections/amazon.aws/pull/1647/files).
+        - rds_cluster - add support for another ``state`` choice called ``stopped``. This stops the rds cluster (https://github.com/ansible-collections/amazon.aws/pull/1647/files).
+        - route53 - add a ``wait_id`` return value when a change is done (https://github.com/ansible-collections/amazon.aws/pull/1683).
+        - route53_health_check - add support for a string list parameter called ``child_health_checks`` to specify health checks that must be healthy for the calculated
+          health check (https://github.com/ansible-collections/amazon.aws/pull/1631).
+        - route53_health_check - add support for an integer parameter called ``health_threshold`` to specify the minimum number of healthy child health checks that
+          must be healthy for the calculated health check (https://github.com/ansible-collections/amazon.aws/pull/1631).
+        - route53_health_check - add support for another ``type`` choice called ``CALCULATED`` (https://github.com/ansible-collections/amazon.aws/pull/1631).
+        - s3_object - Allow recursive copy of objects in S3 bucket (https://github.com/ansible-collections/amazon.aws/issues/1379).
+        - s3_object - use fstrings where appropriate (https://github.com/ansible-collections/amazon.aws/pull/1802).
+      release_summary: This major release brings a new set of supported modules that have been promoted from community.aws, several bugfixes, minor changes and deprecated
+        features. We also dropped support for ``botocore<1.29.0`` and ``boto3<1.26.0``. Due to the AWS SDKs announcing the end of support for Python less than 3.7
+        (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/), support for Python less than 3.7 by this collection was deprecated
+        in release 6.0.0 and removed in this release.
     fragments:
-    - 1538-s3-null.yml
-    - 1548-s3_object-leading-slash.yml
-    - 1551-ec2_inventory-no-region.yml
-    - 1587-LooseVersion.yml
-    - 1607-NoSuchTagSet.yml
-    - 1631-route53_health_check-added-calculcated.yml
-    - 1647-add-type-started-and-stopped.yml
-    - 1650-fix-invalidinstanceid-notfound.yml
-    - 1683-route53-wait_id.yml
-    - 1705-rds_cluster-add-support-remove-cluster-from-global-db.yml
-    - 1771-isort.yml
-    - 1778-elb_application_lb_info-fetch-subsets.yml
-    - 1799-s3_object-bucket.yml
-    - 1802-flynt.yml
-    - 1825-ec2_instances.yml
-    - 20230612-s3_object-support-copy-objects-recursively.yml
-    - 20230702-isort.yml
-    - 20231020-iam_server_certificate-revert.yml
-    - 7.0.0-urls.yml
-    - add-pytest-ansible.yml
-    - ansible_version_update.yml
-    - botocore.yml
-    - ec2_instance_info-support-new-attribute.yml
-    - ec2_vpc_igw-delete_unattached-gateway.yml
-    - ec2_vpc_route_table_info-filter-fix.yml
-    - migrate_aws_region_info.yml
-    - migrate_iam_access_key.yml
-    - migrate_iam_group.yml
-    - migrate_iam_managed_policy.yml
-    - migrate_iam_mfa_device_info.yml
-    - migrate_iam_password_policy.yml
-    - migrate_iam_role.yml
-    - migrate_s3_bucket_info.yml
-    - migrate_sts_assume_role.yml
-    - python37.yml
-    - release_summary.yml
+      - 1538-s3-null.yml
+      - 1548-s3_object-leading-slash.yml
+      - 1551-ec2_inventory-no-region.yml
+      - 1587-LooseVersion.yml
+      - 1607-NoSuchTagSet.yml
+      - 1631-route53_health_check-added-calculcated.yml
+      - 1647-add-type-started-and-stopped.yml
+      - 1650-fix-invalidinstanceid-notfound.yml
+      - 1683-route53-wait_id.yml
+      - 1705-rds_cluster-add-support-remove-cluster-from-global-db.yml
+      - 1771-isort.yml
+      - 1778-elb_application_lb_info-fetch-subsets.yml
+      - 1799-s3_object-bucket.yml
+      - 1802-flynt.yml
+      - 1825-ec2_instances.yml
+      - 20230612-s3_object-support-copy-objects-recursively.yml
+      - 20230702-isort.yml
+      - 20231020-iam_server_certificate-revert.yml
+      - 7.0.0-urls.yml
+      - add-pytest-ansible.yml
+      - ansible_version_update.yml
+      - botocore.yml
+      - ec2_instance_info-support-new-attribute.yml
+      - ec2_vpc_igw-delete_unattached-gateway.yml
+      - ec2_vpc_route_table_info-filter-fix.yml
+      - migrate_aws_region_info.yml
+      - migrate_iam_access_key.yml
+      - migrate_iam_group.yml
+      - migrate_iam_managed_policy.yml
+      - migrate_iam_mfa_device_info.yml
+      - migrate_iam_password_policy.yml
+      - migrate_iam_role.yml
+      - migrate_s3_bucket_info.yml
+      - migrate_sts_assume_role.yml
+      - python37.yml
+      - release_summary.yml
     modules:
-    - description: Manage AWS EC2 import image tasks
-      name: ec2_import_image
-      namespace: ''
-    - description: Gather information about import virtual machine tasks
-      name: ec2_import_image_info
-      namespace: ''
-    - description: Obtain information about Aurora global database clusters
-      name: rds_global_cluster_info
-      namespace: ''
-    release_date: '2023-11-02'
+      - description: Manage AWS EC2 import image tasks
+        name: ec2_import_image
+        namespace: ""
+      - description: Gather information about import virtual machine tasks
+        name: ec2_import_image_info
+        namespace: ""
+      - description: Obtain information about Aurora global database clusters
+        name: rds_global_cluster_info
+        namespace: ""
+    release_date: "2023-11-02"

--- a/changelogs/fragments/1828-ec2_instance_additional_info.yml
+++ b/changelogs/fragments/1828-ec2_instance_additional_info.yml
@@ -1,2 +1,3 @@
+---
 minor_changes:
   - modules/ec2_instance - add support for AdditionalInfo option when creating an instance (https://github.com/ansible-collections/amazon.aws/pull/1828).

--- a/changelogs/fragments/1829-is_boto3_error-tuple.yml
+++ b/changelogs/fragments/1829-is_boto3_error-tuple.yml
@@ -1,2 +1,3 @@
+---
 minor_changes:
-- module_uils/botocore - support sets and tuples of errors as well as lists (https://github.com/ansible-collections/amazon.aws/pull/1829).
+  - module_uils/botocore - support sets and tuples of errors as well as lists (https://github.com/ansible-collections/amazon.aws/pull/1829).

--- a/changelogs/fragments/1843-ec2_eip.yml
+++ b/changelogs/fragments/1843-ec2_eip.yml
@@ -1,2 +1,3 @@
+---
 minor_changes:
-- ec2_eip - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/issues/1843)
+  - ec2_eip - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/issues/1843)

--- a/changelogs/fragments/1843-ec2_security_group-tags.yml
+++ b/changelogs/fragments/1843-ec2_security_group-tags.yml
@@ -1,2 +1,3 @@
+---
 minor_changes:
-- ec2_security_group - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/pull/1844)
+  - ec2_security_group - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/pull/1844)

--- a/changelogs/fragments/1843-ec2_vpc_igw.yml
+++ b/changelogs/fragments/1843-ec2_vpc_igw.yml
@@ -1,2 +1,3 @@
+---
 minor_changes:
-- ec2_vpc_igw - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/issues/1843)
+  - ec2_vpc_igw - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/issues/1843)

--- a/changelogs/fragments/1843-ec2_vpc_route_table.yml
+++ b/changelogs/fragments/1843-ec2_vpc_route_table.yml
@@ -1,2 +1,3 @@
+---
 minor_changes:
-- ec2_vpc_route_table - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/issues/1843)
+  - ec2_vpc_route_table - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/issues/1843)

--- a/changelogs/fragments/1843-ec2_vpc_subnet.yml
+++ b/changelogs/fragments/1843-ec2_vpc_subnet.yml
@@ -1,4 +1,5 @@
+---
 minor_changes:
-- ec2_vpc_subnet - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/issues/1843)
-- ec2_vpc_subnet - the default value for ``tags`` has been changed from ``{}`` to ``None``, to remove tags from a subnet an empty map must
-  be explicitly passed to the module (https://github.com/ansible-collections/amazon.aws/pull/1876).
+  - ec2_vpc_subnet - use ``ResourceTags`` to set initial tags upon creation (https://github.com/ansible-collections/amazon.aws/issues/1843)
+  - ec2_vpc_subnet - the default value for ``tags`` has been changed from ``{}`` to ``None``, to remove tags from a subnet an empty map must be explicitly passed
+    to the module (https://github.com/ansible-collections/amazon.aws/pull/1876).

--- a/changelogs/fragments/1848-ec2_vpc_subnet-wait-creation.yml
+++ b/changelogs/fragments/1848-ec2_vpc_subnet-wait-creation.yml
@@ -1,4 +1,5 @@
+---
 bugfixes:
-- ec2_vpc_subnet - cleanly handle failure when subnet isn't created in time (https://github.com/ansible-collections/amazon.aws/pull/1848).
+  - ec2_vpc_subnet - cleanly handle failure when subnet isn't created in time (https://github.com/ansible-collections/amazon.aws/pull/1848).
 minor_changes:
-- ec2_vpc_subnet - use ``wait_timeout`` to also control maximum time to wait for initial creation of subnets (https://github.com/ansible-collections/amazon.aws/pull/1848).
+  - ec2_vpc_subnet - use ``wait_timeout`` to also control maximum time to wait for initial creation of subnets (https://github.com/ansible-collections/amazon.aws/pull/1848).

--- a/changelogs/fragments/1881-allow-s3_object-to-specify-content-type-in-metadata.yml
+++ b/changelogs/fragments/1881-allow-s3_object-to-specify-content-type-in-metadata.yml
@@ -1,3 +1,4 @@
+---
 bugfixes:
-  - s3_object - when doing a put and specifying ``Content-Type`` in metadata, this module (since 6.0.0) erroneously set the ``Content-Type`` to ``None`` causing the put to fail.
-    Fix now correctly honours the specified ``Content-Type`` (https://github.com/ansible-collections/amazon.aws/issues/1881).
+  - s3_object - when doing a put and specifying ``Content-Type`` in metadata, this module (since 6.0.0) erroneously set the ``Content-Type`` to ``None`` causing the
+    put to fail. Fix now correctly honours the specified ``Content-Type`` (https://github.com/ansible-collections/amazon.aws/issues/1881).

--- a/changelogs/fragments/20231110-sanity.yml
+++ b/changelogs/fragments/20231110-sanity.yml
@@ -1,4 +1,5 @@
+---
 minor_changes:
-- autoscaling_group - minor PEP8 whitespace sanity fixes (https://github.com/ansible-collections/amazon.aws/pull/1846).
-- rds_instance_snapshot - minor PEP8 whitespace sanity fixes (https://github.com/ansible-collections/amazon.aws/pull/1846).
-- ec2_ami_info - simplify parameters to ``get_image_attribute`` to only pass ID of image (https://github.com/ansible-collections/amazon.aws/pull/1846).
+  - autoscaling_group - minor PEP8 whitespace sanity fixes (https://github.com/ansible-collections/amazon.aws/pull/1846).
+  - rds_instance_snapshot - minor PEP8 whitespace sanity fixes (https://github.com/ansible-collections/amazon.aws/pull/1846).
+  - ec2_ami_info - simplify parameters to ``get_image_attribute`` to only pass ID of image (https://github.com/ansible-collections/amazon.aws/pull/1846).

--- a/changelogs/fragments/20231130-iam_group.yml
+++ b/changelogs/fragments/20231130-iam_group.yml
@@ -1,4 +1,5 @@
+---
 minor_changes:
-- iam_group - add support for setting group path (https://github.com/ansible-collections/amazon.aws/pull/1892).
-- iam_group - adds attached_policies return value (https://github.com/ansible-collections/amazon.aws/pull/1892).
-- iam_group - code refactored to avoid single long function (https://github.com/ansible-collections/amazon.aws/pull/1892).
+  - iam_group - add support for setting group path (https://github.com/ansible-collections/amazon.aws/pull/1892).
+  - iam_group - adds attached_policies return value (https://github.com/ansible-collections/amazon.aws/pull/1892).
+  - iam_group - code refactored to avoid single long function (https://github.com/ansible-collections/amazon.aws/pull/1892).

--- a/changelogs/fragments/8.0.0-dev0.yml
+++ b/changelogs/fragments/8.0.0-dev0.yml
@@ -1,2 +1,3 @@
+---
 trivial:
-- bump galaxy.yml to release 8.0.0-dev0
+  - bump galaxy.yml to release 8.0.0-dev0

--- a/docs/docsite/links.yml
+++ b/docs/docsite/links.yml
@@ -12,7 +12,7 @@ edit_on_github:
   # repository's root, you have to specify the path to the collection root here. For example,
   # if the collection root is in a subdirectory ansible_collections/community/REPO_NAME
   # in your repository, you have to set path_prefix to 'ansible_collections/community/REPO_NAME'.
-  path_prefix: ''
+  path_prefix: ""
 
 # Here you can add arbitrary extra links. Please keep the number of links down to a
 # minimum! Also please keep the description short, since this will be the text put on
@@ -34,8 +34,8 @@ edit_on_github:
 communication:
   matrix_rooms:
     - topic: General usage and support questions
-      room: '#aws:ansible.im'
+      room: "#aws:ansible.im"
   irc_channels:
     - topic: General usage and support questions
       network: Libera
-      channel: '#ansible-aws'
+      channel: "#ansible-aws"

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -13,6 +13,6 @@ documentation: https://ansible-collections.github.io/amazon.aws/branch/main/coll
 homepage: https://github.com/ansible-collections/amazon.aws
 issues: https://github.com/ansible-collections/amazon.aws/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc
 build_ignore:
-  - '*cloud-config-aws.ini'
-  - '*cloud-config-aws.yml'
-  - 'changelogs/.plugin-cache.yaml'
+  - "*cloud-config-aws.ini"
+  - "*cloud-config-aws.yml"
+  - changelogs/.plugin-cache.yaml

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.13.0'
+requires_ansible: ">=2.13.0"
 action_groups:
   aws:
     - autoscaling_group

--- a/tests/config.yml
+++ b/tests/config.yml
@@ -1,2 +1,3 @@
+---
 modules:
-    python_requires: '>=3.7'
+  python_requires: ">=3.7"

--- a/tests/integration/requirements.yml
+++ b/tests/integration/requirements.yml
@@ -1,5 +1,5 @@
 ---
 collections:
-- ansible.windows
-- ansible.utils  # ipv6 filter
-- amazon.cloud # used by integration tests - rds_cluster_modify
+  - ansible.windows
+  - ansible.utils # ipv6 filter
+  - amazon.cloud # used by integration tests - rds_cluster_modify

--- a/tests/integration/targets/autoscaling_group/main.yml
+++ b/tests/integration/targets/autoscaling_group/main.yml
@@ -1,35 +1,34 @@
+---
 # Beware: most of our tests here are run in parallel.
 # To add new tests you'll need to add a new host to the inventory and a matching
 # '{{ inventory_hostname }}'.yml file in roles/ec2_asg/tasks/
-
-
 # Prepare the VPC and figure out which AMI to use
 - hosts: all
-  gather_facts: no
+  gather_facts: false
   tasks:
-  - module_defaults:
-      group/aws:
-        access_key: '{{ aws_access_key }}'
-        secret_key: '{{ aws_secret_key }}'
-        session_token: '{{ security_token | default(omit) }}'
-        region: '{{ aws_region }}'
-    block:
-    - include_role:
-        name: setup_ec2_facts
-    - include_role:
-        name: ec2_asg
-        tasks_from: env_setup.yml
-    rescue:
-    - include_role:
-        name: ec2_asg
-        tasks_from: env_cleanup.yml
-      run_once: yes
-    - fail:
-        msg: Environment preparation failed
-      run_once: yes
+    - module_defaults:
+        group/aws:
+          access_key: "{{ aws_access_key }}"
+          secret_key: "{{ aws_secret_key }}"
+          session_token: "{{ security_token | default(omit) }}"
+          region: "{{ aws_region }}"
+      block:
+        - ansible.builtin.include_role:
+            name: setup_ec2_facts
+        - ansible.builtin.include_role:
+            name: ec2_asg
+            tasks_from: env_setup.yml
+      rescue:
+        - ansible.builtin.include_role:
+            name: ec2_asg
+            tasks_from: env_cleanup.yml
+          run_once: true
+        - ansible.builtin.fail:
+            msg: Environment preparation failed
+          run_once: true
 - hosts: all
-  gather_facts: no
+  gather_facts: false
   strategy: free
   serial: 6
   roles:
-  - ec2_asg
+    - ec2_asg

--- a/tests/integration/targets/autoscaling_group/meta/main.yml
+++ b/tests/integration/targets/autoscaling_group/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
-- setup_ec2_facts
+  - setup_ec2_facts

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/defaults/main.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/defaults/main.yml
@@ -1,2 +1,3 @@
-load_balancer_name: '{{ tiny_prefix }}-lb'
+---
+load_balancer_name: "{{ tiny_prefix }}-lb"
 ec2_asg_setup_run_once: true

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/create_update_delete.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/create_update_delete.yml
@@ -1,591 +1,582 @@
-    # ============================================================
+---
+# ============================================================
 
 - name: Test create/update/delete AutoScalingGroups with autoscaling_group
   block:
+    # ============================================================
+
+    - name: test without specifying required module options
+      autoscaling_group:
+        access_key: "{{ aws_access_key }}"
+        secret_key: "{{ aws_secret_key }}"
+        session_token: "{{ security_token | default(omit) }}"
+      ignore_errors: true
+      register: result
+    - name: assert name is a required module option
+      ansible.builtin.assert:
+        that:
+          - "result.msg == 'missing required arguments: name'"
+
+    - name: ensure launch configs exist
+      autoscaling_launch_config:
+        name: "{{ item }}"
+        assign_public_ip: true
+        image_id: "{{ ec2_ami_id }}"
+        user_data: |
+          #cloud-config
+          package_upgrade: true
+          package_update: true
+          packages:
+            - httpd
+          runcmd:
+            - "service httpd start"
+        security_groups: "{{ sg.group_id }}"
+        instance_type: t3.micro
+      loop:
+        - "{{ resource_prefix }}-lc"
+        - "{{ resource_prefix }}-lc-2"
 
     # ============================================================
 
-  - name: test without specifying required module options
-    autoscaling_group:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-    ignore_errors: true
-    register: result
-  - name: assert name is a required module option
-    assert:
-      that:
-      - "result.msg == 'missing required arguments: name'"
+    - name: launch asg and wait for instances to be deemed healthy (no ELB)
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        state: present
+        wait_for_instances: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.viable_instances == 1
 
+    - name: Enable metrics collection - check_mode
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        metrics_collection: true
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output is not failed
+          - '"autoscaling:UpdateAutoScalingGroup" not in output.resource_actions'
 
-  - name: ensure launch configs exist
-    autoscaling_launch_config:
-      name: '{{ item }}'
-      assign_public_ip: true
-      image_id: '{{ ec2_ami_id }}'
-      user_data: |
-        #cloud-config
-        package_upgrade: true
-        package_update: true
-        packages:
-          - httpd
-        runcmd:
-          - "service httpd start"
-      security_groups: '{{ sg.group_id }}'
-      instance_type: t3.micro
-    loop:
-    - '{{ resource_prefix }}-lc'
-    - '{{ resource_prefix }}-lc-2'
+    - name: Enable metrics collection
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        metrics_collection: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
 
-    # ============================================================
+    - name: Enable metrics collection (idempotency)
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        metrics_collection: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
 
-  - name: launch asg and wait for instances to be deemed healthy (no ELB)
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_config_name: '{{ resource_prefix }}-lc'
-      desired_capacity: 1
-      min_size: 1
-      max_size: 1
-      vpc_zone_identifier: '{{ testing_subnet.subnet.id }}'
-      state: present
-      wait_for_instances: yes
-    register: output
-  - assert:
-      that:
-      - output.viable_instances == 1
+    - name: Disable metrics collection - check_mode
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        metrics_collection: false
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output is not failed
+          - '"autoscaling:UpdateAutoScalingGroup" not in output.resource_actions'
 
-  - name: Enable metrics collection - check_mode
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      metrics_collection: yes
-    register: output
-    check_mode: true
-  - assert:
-      that:
-      - output is changed
-      - output is not failed
-      - '"autoscaling:UpdateAutoScalingGroup" not in output.resource_actions'
+    - name: Disable metrics collection
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        metrics_collection: false
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
 
-  - name: Enable metrics collection
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      metrics_collection: yes
-    register: output
-  - assert:
-      that:
-      - output is changed
+    - name: Disable metrics collection (idempotency)
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        metrics_collection: false
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
 
-  - name: Enable metrics collection (idempotency)
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      metrics_collection: yes
-    register: output
-  - assert:
-      that:
-      - output is not changed
+    - name: kill asg
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        state: absent
+        wait_timeout: 800
+      async: 400
+    - name: launch asg and do not wait for instances to be deemed healthy (no ELB)
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        wait_for_instances: false
+        state: present
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.viable_instances == 0
 
-  - name: Disable metrics collection - check_mode
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      metrics_collection: no
-    register: output
-    check_mode: true
-  - assert:
-      that:
-      - output is changed
-      - output is not failed
-      - '"autoscaling:UpdateAutoScalingGroup" not in output.resource_actions'
+    - name: kill asg
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        state: absent
+        wait_timeout: 800
+      register: output
+      retries: 3
+      until: output is succeeded
+      delay: 10
+      async: 400
+    - name: create asg with asg metrics enabled
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        metrics_collection: true
+        launch_config_name: "{{ resource_prefix }}-lc"
+        desired_capacity: 0
+        min_size: 0
+        max_size: 0
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        state: present
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - "'Group' in output.metrics_collection.0.Metric"
 
-
-  - name: Disable metrics collection
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      metrics_collection: no
-    register: output
-  - assert:
-      that:
-      - output is changed
-
-  - name: Disable metrics collection (idempotency)
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      metrics_collection: no
-    register: output
-  - assert:
-      that:
-      - output is not changed
-
-  - name: kill asg
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      state: absent
-      wait_timeout: 800
-    async: 400
-  - name: launch asg and do not wait for instances to be deemed healthy (no ELB)
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_config_name: '{{ resource_prefix }}-lc'
-      desired_capacity: 1
-      min_size: 1
-      max_size: 1
-      vpc_zone_identifier: '{{ testing_subnet.subnet.id }}'
-      wait_for_instances: no
-      state: present
-    register: output
-  - assert:
-      that:
-      - output.viable_instances == 0
-
-  - name: kill asg
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      state: absent
-      wait_timeout: 800
-    register: output
-    retries: 3
-    until: output is succeeded
-    delay: 10
-    async: 400
-  - name: create asg with asg metrics enabled
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      metrics_collection: true
-      launch_config_name: '{{ resource_prefix }}-lc'
-      desired_capacity: 0
-      min_size: 0
-      max_size: 0
-      vpc_zone_identifier: '{{ testing_subnet.subnet.id }}'
-      state: present
-    register: output
-  - assert:
-      that:
-      - "'Group' in output.metrics_collection.0.Metric"
-
-  - name: kill asg
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      state: absent
-      wait_timeout: 800
-    async: 400
-  - name: launch load balancer
-    elb_classic_lb:
-      name: '{{ load_balancer_name }}'
-      state: present
-      security_group_ids:
-      - '{{ sg.group_id }}'
-      subnets: '{{ testing_subnet.subnet.id }}'
-      connection_draining_timeout: 60
-      listeners:
-      - protocol: http
-        load_balancer_port: 80
-        instance_port: 80
-      health_check:
-        ping_protocol: tcp
-        ping_port: 80
-        ping_path: /
-        response_timeout: 5
-        interval: 10
-        unhealthy_threshold: 4
-        healthy_threshold: 2
-    register: load_balancer
-  - name: launch asg and wait for instances to be deemed healthy (ELB)
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_config_name: '{{ resource_prefix }}-lc'
-      health_check_type: ELB
-      desired_capacity: 1
-      min_size: 1
-      max_size: 1
-      health_check_period: 300
-      vpc_zone_identifier: '{{ testing_subnet.subnet.id }}'
-      load_balancers: '{{ load_balancer_name }}'
-      wait_for_instances: yes
-      wait_timeout: 900
-      state: present
-    register: output
-  - assert:
-      that:
-      - output.viable_instances == 1
+    - name: kill asg
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        state: absent
+        wait_timeout: 800
+      async: 400
+    - name: launch load balancer
+      amazon.aws.elb_classic_lb:
+        name: "{{ load_balancer_name }}"
+        state: present
+        security_group_ids:
+          - "{{ sg.group_id }}"
+        subnets: "{{ testing_subnet.subnet.id }}"
+        connection_draining_timeout: 60
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 80
+        health_check:
+          ping_protocol: tcp
+          ping_port: 80
+          ping_path: /
+          response_timeout: 5
+          interval: 10
+          unhealthy_threshold: 4
+          healthy_threshold: 2
+      register: load_balancer
+    - name: launch asg and wait for instances to be deemed healthy (ELB)
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc"
+        health_check_type: ELB
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        health_check_period: 300
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        load_balancers: "{{ load_balancer_name }}"
+        wait_for_instances: true
+        wait_timeout: 900
+        state: present
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.viable_instances == 1
 
     # ============================================================
 
     # grow scaling group to 3
-  - name: add 2 more instances wait for instances to be deemed healthy (ELB)
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_config_name: '{{ resource_prefix }}-lc'
-      health_check_type: ELB
-      desired_capacity: 3
-      min_size: 3
-      max_size: 5
-      health_check_period: 600
-      vpc_zone_identifier: '{{ testing_subnet.subnet.id }}'
-      load_balancers: '{{ load_balancer_name }}'
-      wait_for_instances: yes
-      wait_timeout: 1200
-      state: present
-    register: output
-  - assert:
-      that:
-      - output.viable_instances == 3
+    - name: add 2 more instances wait for instances to be deemed healthy (ELB)
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc"
+        health_check_type: ELB
+        desired_capacity: 3
+        min_size: 3
+        max_size: 5
+        health_check_period: 600
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        load_balancers: "{{ load_balancer_name }}"
+        wait_for_instances: true
+        wait_timeout: 1200
+        state: present
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.viable_instances == 3
 
     # ============================================================
 
     # Test max_instance_lifetime option
-  - name: enable asg max_instance_lifetime
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      max_instance_lifetime: 604801
-    register: output
-  - name: ensure max_instance_lifetime is set
-    assert:
-      that:
-      - output.max_instance_lifetime == 604801
+    - name: enable asg max_instance_lifetime
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        max_instance_lifetime: 604801
+      register: output
+    - name: ensure max_instance_lifetime is set
+      ansible.builtin.assert:
+        that:
+          - output.max_instance_lifetime == 604801
 
-  - name: run without max_instance_lifetime
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_config_name: '{{ resource_prefix }}-lc'
-  - name: ensure max_instance_lifetime not affected by defaults
-    assert:
-      that:
-      - output.max_instance_lifetime == 604801
+    - name: run without max_instance_lifetime
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc"
+    - name: ensure max_instance_lifetime not affected by defaults
+      ansible.builtin.assert:
+        that:
+          - output.max_instance_lifetime == 604801
 
-  - name: disable asg max_instance_lifetime
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_config_name: '{{ resource_prefix }}-lc'
-      max_instance_lifetime: 0
-    register: output
-  - name: ensure max_instance_lifetime is not set
-    assert:
-      that:
-      - not output.max_instance_lifetime
+    - name: disable asg max_instance_lifetime
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc"
+        max_instance_lifetime: 0
+      register: output
+    - name: ensure max_instance_lifetime is not set
+      ansible.builtin.assert:
+        that:
+          - not output.max_instance_lifetime
 
     # ============================================================
 
     # perform rolling replace with different launch configuration
-  - name: perform rolling update to new AMI
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_config_name: '{{ resource_prefix }}-lc-2'
-      health_check_type: ELB
-      desired_capacity: 3
-      min_size: 1
-      max_size: 5
-      health_check_period: 900
-      load_balancers: '{{ load_balancer_name }}'
-      vpc_zone_identifier: '{{ testing_subnet.subnet.id }}'
-      wait_for_instances: yes
-      replace_all_instances: yes
-      wait_timeout: 1800
-      state: present
-    register: output
-  - assert:
-      that:
-      - item.value.launch_config_name == '{{ resource_prefix }}-lc-2'
-    loop: '{{ output.instance_facts | dict2items }}'
-  - assert:
-      that:
-      - output.viable_instances == 3
+    - name: perform rolling update to new AMI
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc-2"
+        health_check_type: ELB
+        desired_capacity: 3
+        min_size: 1
+        max_size: 5
+        health_check_period: 900
+        load_balancers: "{{ load_balancer_name }}"
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        wait_for_instances: true
+        replace_all_instances: true
+        wait_timeout: 1800
+        state: present
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - item.value.launch_config_name == '{{ resource_prefix }}-lc-2'
+      loop: "{{ output.instance_facts | dict2items }}"
+    - ansible.builtin.assert:
+        that:
+          - output.viable_instances == 3
 
     # ============================================================
 
     # perform rolling replace with the original launch configuration
-  - name: perform rolling update to new AMI while removing the load balancer
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_config_name: '{{ resource_prefix }}-lc'
-      health_check_type: EC2
-      desired_capacity: 3
-      min_size: 1
-      max_size: 5
-      health_check_period: 900
-      load_balancers: []
-      vpc_zone_identifier: '{{ testing_subnet.subnet.id }}'
-      wait_for_instances: yes
-      replace_all_instances: yes
-      wait_timeout: 1800
-      state: present
-    register: output
-  - assert:
-      that:
-      - item.value.launch_config_name == '{{ resource_prefix }}-lc'
-    loop: '{{ output.instance_facts | dict2items }}'
-  - assert:
-      that:
-      - output.viable_instances == 3
+    - name: perform rolling update to new AMI while removing the load balancer
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc"
+        health_check_type: EC2
+        desired_capacity: 3
+        min_size: 1
+        max_size: 5
+        health_check_period: 900
+        load_balancers: []
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        wait_for_instances: true
+        replace_all_instances: true
+        wait_timeout: 1800
+        state: present
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - item.value.launch_config_name == '{{ resource_prefix }}-lc'
+      loop: "{{ output.instance_facts | dict2items }}"
+    - ansible.builtin.assert:
+        that:
+          - output.viable_instances == 3
 
     # ============================================================
 
     # perform rolling replace with new launch configuration and lc_check:false
-  - name: 'perform rolling update to new AMI with lc_check: false'
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_config_name: '{{ resource_prefix }}-lc-2'
-      health_check_type: EC2
-      desired_capacity: 3
-      min_size: 1
-      max_size: 5
-      health_check_period: 900
-      load_balancers: []
-      vpc_zone_identifier: '{{ testing_subnet.subnet.id }}'
-      wait_for_instances: yes
-      replace_all_instances: yes
-      replace_batch_size: 3
-      lc_check: false
-      wait_timeout: 1800
-      state: present
-  - name: get autoscaling_group info
-    autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg'
-    register: output
-  - assert:
-      that:
-      - output.results[0].instances | length == 3
+    - name: "perform rolling update to new AMI with lc_check: false"
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc-2"
+        health_check_type: EC2
+        desired_capacity: 3
+        min_size: 1
+        max_size: 5
+        health_check_period: 900
+        load_balancers: []
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        wait_for_instances: true
+        replace_all_instances: true
+        replace_batch_size: 3
+        lc_check: false
+        wait_timeout: 1800
+        state: present
+    - name: get autoscaling_group info
+      autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.results[0].instances | length == 3
 
     # ============================================================
 
-  - name: kill asg
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      state: absent
-      wait_timeout: 800
-    async: 400
-  - name: 'new asg with lc_check: false'
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_config_name: '{{ resource_prefix }}-lc'
-      health_check_type: EC2
-      desired_capacity: 3
-      min_size: 1
-      max_size: 5
-      health_check_period: 900
-      load_balancers: []
-      vpc_zone_identifier: '{{ testing_subnet.subnet.id }}'
-      wait_for_instances: yes
-      replace_all_instances: yes
-      replace_batch_size: 3
-      lc_check: false
-      wait_timeout: 1800
-      state: present
-  - name: get autoscaling_group information
-    autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg'
-    register: output
-  - assert:
-      that:
-      - output.results[0].instances | length == 3
+    - name: kill asg
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        state: absent
+        wait_timeout: 800
+      async: 400
+    - name: "new asg with lc_check: false"
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_config_name: "{{ resource_prefix }}-lc"
+        health_check_type: EC2
+        desired_capacity: 3
+        min_size: 1
+        max_size: 5
+        health_check_period: 900
+        load_balancers: []
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        wait_for_instances: true
+        replace_all_instances: true
+        replace_batch_size: 3
+        lc_check: false
+        wait_timeout: 1800
+        state: present
+    - name: get autoscaling_group information
+      autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.results[0].instances | length == 3
 
     # we need a launch template, otherwise we cannot test the mixed instance policy
-  - name: create launch template for autoscaling group to test its mixed instances
-      policy
-    ec2_launch_template:
-      template_name: '{{ resource_prefix }}-lt'
-      image_id: '{{ ec2_ami_id }}'
-      instance_type: t3.micro
-      credit_specification:
-        cpu_credits: standard
-      network_interfaces:
-      - associate_public_ip_address: yes
-        delete_on_termination: yes
-        device_index: 0
-        groups:
-        - '{{ sg.group_id }}'
+    - name: create launch template for autoscaling group to test its mixed instances policy
+      community.aws.ec2_launch_template:
+        template_name: "{{ resource_prefix }}-lt"
+        image_id: "{{ ec2_ami_id }}"
+        instance_type: t3.micro
+        credit_specification:
+          cpu_credits: standard
+        network_interfaces:
+          - associate_public_ip_address: true
+            delete_on_termination: true
+            device_index: 0
+            groups:
+              - "{{ sg.group_id }}"
 
-  - name: update autoscaling group with mixed-instances policy with mixed instances
-      types - check_mode
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_template:
-        launch_template_name: '{{ resource_prefix }}-lt'
-      desired_capacity: 1
-      min_size: 1
-      max_size: 1
-      vpc_zone_identifier: '{{ testing_subnet.subnet.id }}'
-      state: present
-      mixed_instances_policy:
-        instance_types:
-        - t3.micro
-        - t2.nano
-      wait_for_instances: yes
-    register: output
-    check_mode: true
-  - assert:
-      that:
-      - output is changed
-      - output is not failed
-      - '"autoscaling:CreateOrUpdateTags" not in output.resource_actions'
+    - name: update autoscaling group with mixed-instances policy with mixed instances types - check_mode
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_template:
+          launch_template_name: "{{ resource_prefix }}-lt"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        state: present
+        mixed_instances_policy:
+          instance_types:
+            - t3.micro
+            - t2.nano
+        wait_for_instances: true
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output is not failed
+          - '"autoscaling:CreateOrUpdateTags" not in output.resource_actions'
 
-  - name: update autoscaling group with mixed-instances policy with mixed instances
-      types
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_template:
-        launch_template_name: '{{ resource_prefix }}-lt'
-      desired_capacity: 1
-      min_size: 1
-      max_size: 1
-      vpc_zone_identifier: '{{ testing_subnet.subnet.id }}'
-      state: present
-      mixed_instances_policy:
-        instance_types:
-        - t3.micro
-        - t2.nano
-      wait_for_instances: yes
-    register: output
-  - assert:
-      that:
-      - output.mixed_instances_policy | length == 2
-      - output.mixed_instances_policy[0] == 't3.micro'
-      - output.mixed_instances_policy[1] == 't2.nano'
+    - name: update autoscaling group with mixed-instances policy with mixed instances types
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_template:
+          launch_template_name: "{{ resource_prefix }}-lt"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        state: present
+        mixed_instances_policy:
+          instance_types:
+            - t3.micro
+            - t2.nano
+        wait_for_instances: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.mixed_instances_policy | length == 2
+          - output.mixed_instances_policy[0] == 't3.micro'
+          - output.mixed_instances_policy[1] == 't2.nano'
 
-  - name: update autoscaling group with mixed-instances policy with instances_distribution
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_template:
-        launch_template_name: '{{ resource_prefix }}-lt'
-      desired_capacity: 1
-      min_size: 1
-      max_size: 1
-      vpc_zone_identifier: '{{ testing_subnet.subnet.id }}'
-      state: present
-      mixed_instances_policy:
-        instance_types:
-        - t3.micro
-        - t2.nano
-        instances_distribution:
-          on_demand_percentage_above_base_capacity: 0
-          spot_allocation_strategy: capacity-optimized
-      wait_for_instances: yes
-    register: output
-  - assert:
-      that:
-      - output.mixed_instances_policy_full['launch_template']['overrides'][0]['instance_type']
-        == 't3.micro'
-      - output.mixed_instances_policy_full['launch_template']['overrides'][1]['instance_type']
-        == 't2.nano'
-      - output.mixed_instances_policy_full['instances_distribution']['on_demand_percentage_above_base_capacity']
-        == 0
-      - output.mixed_instances_policy_full['instances_distribution']['spot_allocation_strategy']
-        == 'capacity-optimized'
+    - name: update autoscaling group with mixed-instances policy with instances_distribution
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_template:
+          launch_template_name: "{{ resource_prefix }}-lt"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        vpc_zone_identifier: "{{ testing_subnet.subnet.id }}"
+        state: present
+        mixed_instances_policy:
+          instance_types:
+            - t3.micro
+            - t2.nano
+          instances_distribution:
+            on_demand_percentage_above_base_capacity: 0
+            spot_allocation_strategy: capacity-optimized
+        wait_for_instances: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.mixed_instances_policy_full['launch_template']['overrides'][0]['instance_type'] == 't3.micro'
+          - output.mixed_instances_policy_full['launch_template']['overrides'][1]['instance_type'] == 't2.nano'
+          - output.mixed_instances_policy_full['instances_distribution']['on_demand_percentage_above_base_capacity'] == 0
+          - output.mixed_instances_policy_full['instances_distribution']['spot_allocation_strategy'] == 'capacity-optimized'
 
     # ============================================================
 
     # Target group names have max length of 32 characters
-  - set_fact:
-      tg1_name: "ansible-test-{{tiny_prefix}}-asg-t1"
-      tg2_name: "ansible-test-{{tiny_prefix}}-asg-t2"
-  - name: create target group 1
-    elb_target_group:
-      name: '{{ tg1_name }}'
-      protocol: tcp
-      port: 80
-      health_check_protocol: tcp
-      health_check_port: 80
-      healthy_threshold_count: 2
-      unhealthy_threshold_count: 2
-      vpc_id: '{{ testing_vpc.vpc.id }}'
-      state: present
-    register: out_tg1
-  - name: create target group 2
-    elb_target_group:
-      name: '{{ tg2_name }}'
-      protocol: tcp
-      port: 80
-      health_check_protocol: tcp
-      health_check_port: 80
-      healthy_threshold_count: 2
-      unhealthy_threshold_count: 2
-      vpc_id: '{{ testing_vpc.vpc.id }}'
-      state: present
-    register: out_tg2
-  - name: update autoscaling group with tg1
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_template:
-        launch_template_name: '{{ resource_prefix }}-lt'
-      target_group_arns:
-      - '{{ out_tg1.target_group_arn }}'
-      desired_capacity: 1
-      min_size: 1
-      max_size: 1
-      state: present
-      wait_for_instances: yes
-    register: output
-  - assert:
-      that:
-      - output.target_group_arns[0] == out_tg1.target_group_arn
+    - ansible.builtin.set_fact:
+        tg1_name: ansible-test-{{tiny_prefix}}-asg-t1
+        tg2_name: ansible-test-{{tiny_prefix}}-asg-t2
+    - name: create target group 1
+      community.aws.elb_target_group:
+        name: "{{ tg1_name }}"
+        protocol: tcp
+        port: 80
+        health_check_protocol: tcp
+        health_check_port: 80
+        healthy_threshold_count: 2
+        unhealthy_threshold_count: 2
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        state: present
+      register: out_tg1
+    - name: create target group 2
+      community.aws.elb_target_group:
+        name: "{{ tg2_name }}"
+        protocol: tcp
+        port: 80
+        health_check_protocol: tcp
+        health_check_port: 80
+        healthy_threshold_count: 2
+        unhealthy_threshold_count: 2
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        state: present
+      register: out_tg2
+    - name: update autoscaling group with tg1
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_template:
+          launch_template_name: "{{ resource_prefix }}-lt"
+        target_group_arns:
+          - "{{ out_tg1.target_group_arn }}"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        state: present
+        wait_for_instances: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.target_group_arns[0] == out_tg1.target_group_arn
 
-  - name: update autoscaling group add tg2
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_template:
-        launch_template_name: '{{ resource_prefix }}-lt'
-      target_group_arns:
-      - '{{ out_tg1.target_group_arn }}'
-      - '{{ out_tg2.target_group_arn }}'
-      desired_capacity: 1
-      min_size: 1
-      max_size: 1
-      state: present
-      wait_for_instances: yes
-    register: output
-  - assert:
-      that:
-      - output.target_group_arns | length == 2
+    - name: update autoscaling group add tg2
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_template:
+          launch_template_name: "{{ resource_prefix }}-lt"
+        target_group_arns:
+          - "{{ out_tg1.target_group_arn }}"
+          - "{{ out_tg2.target_group_arn }}"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        state: present
+        wait_for_instances: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.target_group_arns | length == 2
 
-  - name: update autoscaling group remove tg1
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_template:
-        launch_template_name: '{{ resource_prefix }}-lt'
-      target_group_arns:
-      - '{{ out_tg2.target_group_arn }}'
-      desired_capacity: 1
-      min_size: 1
-      max_size: 1
-      state: present
-      wait_for_instances: yes
-    register: output
-  - assert:
-      that:
-      - output.target_group_arns | length == 1
-      - output.target_group_arns[0] == out_tg2.target_group_arn
+    - name: update autoscaling group remove tg1
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_template:
+          launch_template_name: "{{ resource_prefix }}-lt"
+        target_group_arns:
+          - "{{ out_tg2.target_group_arn }}"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        state: present
+        wait_for_instances: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.target_group_arns | length == 1
+          - output.target_group_arns[0] == out_tg2.target_group_arn
 
-  - name: update autoscaling group remove tg2 and add tg1
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_template:
-        launch_template_name: '{{ resource_prefix }}-lt'
-      target_group_arns:
-      - '{{ out_tg1.target_group_arn }}'
-      desired_capacity: 1
-      min_size: 1
-      max_size: 1
-      state: present
-      wait_for_instances: yes
-    register: output
-  - assert:
-      that:
-      - output.target_group_arns | length == 1
-      - output.target_group_arns[0] == out_tg1.target_group_arn
+    - name: update autoscaling group remove tg2 and add tg1
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_template:
+          launch_template_name: "{{ resource_prefix }}-lt"
+        target_group_arns:
+          - "{{ out_tg1.target_group_arn }}"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        state: present
+        wait_for_instances: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.target_group_arns | length == 1
+          - output.target_group_arns[0] == out_tg1.target_group_arn
 
-  - name: target group no change
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg'
-      launch_template:
-        launch_template_name: '{{ resource_prefix }}-lt'
-      target_group_arns:
-      - '{{ out_tg1.target_group_arn }}'
-      desired_capacity: 1
-      min_size: 1
-      max_size: 1
-      state: present
-      wait_for_instances: yes
-    register: output
-  - assert:
-      that:
-      - output.target_group_arns | length == 1
-      - output.target_group_arns[0] == out_tg1.target_group_arn
-      - output.changed == false
+    - name: target group no change
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg"
+        launch_template:
+          launch_template_name: "{{ resource_prefix }}-lt"
+        target_group_arns:
+          - "{{ out_tg1.target_group_arn }}"
+        desired_capacity: 1
+        min_size: 1
+        max_size: 1
+        state: present
+        wait_for_instances: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.target_group_arns | length == 1
+          - output.target_group_arns[0] == out_tg1.target_group_arn
+          - output.changed == false

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/env_cleanup.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/env_cleanup.yml
@@ -1,36 +1,37 @@
+---
 - name: kill asg
   autoscaling_group:
-    name: '{{ resource_prefix }}-asg'
+    name: "{{ resource_prefix }}-asg"
     state: absent
   register: removed
   until: removed is not failed
   ignore_errors: true
   retries: 10
 - name: remove target group
-  elb_target_group:
-    name: '{{ item }}'
+  community.aws.elb_target_group:
+    name: "{{ item }}"
     state: absent
   register: removed
   until: removed is not failed
   ignore_errors: true
   retries: 10
   loop:
-  - '{{ tg1_name }}'
-  - '{{ tg2_name }}'
+    - "{{ tg1_name }}"
+    - "{{ tg2_name }}"
 
 - name: remove the load balancer
-  elb_classic_lb:
-    name: '{{ load_balancer_name }}'
+  amazon.aws.elb_classic_lb:
+    name: "{{ load_balancer_name }}"
     state: absent
     security_group_ids:
-    - '{{ sg.group_id }}'
-    subnets: '{{ testing_subnet.subnet.id }}'
+      - "{{ sg.group_id }}"
+    subnets: "{{ testing_subnet.subnet.id }}"
     wait: true
     connection_draining_timeout: 60
     listeners:
-    - protocol: http
-      load_balancer_port: 80
-      instance_port: 80
+      - protocol: http
+        load_balancer_port: 80
+        instance_port: 80
     health_check:
       ping_protocol: tcp
       ping_port: 80
@@ -45,19 +46,19 @@
   retries: 10
 - name: remove launch configs
   autoscaling_launch_config:
-    name: '{{ item }}'
+    name: "{{ item }}"
     state: absent
   register: removed
   until: removed is not failed
   ignore_errors: true
   retries: 10
   loop:
-  - '{{ resource_prefix }}-lc'
-  - '{{ resource_prefix }}-lc-2'
+    - "{{ resource_prefix }}-lc"
+    - "{{ resource_prefix }}-lc-2"
 
 - name: delete launch template
-  ec2_launch_template:
-    name: '{{ resource_prefix }}-lt'
+  community.aws.ec2_launch_template:
+    name: "{{ resource_prefix }}-lt"
     state: absent
   register: del_lt
   retries: 10
@@ -65,49 +66,49 @@
   ignore_errors: true
 - name: remove the security group
   ec2_security_group:
-    name: '{{ resource_prefix }}-sg'
+    name: "{{ resource_prefix }}-sg"
     description: a security group for ansible tests
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     state: absent
   register: removed
   until: removed is not failed
   ignore_errors: true
   retries: 10
 - name: remove routing rules
-  ec2_vpc_route_table:
+  amazon.aws.ec2_vpc_route_table:
     state: absent
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     tags:
-      created: '{{ resource_prefix }}-route'
+      created: "{{ resource_prefix }}-route"
     routes:
-    - dest: 0.0.0.0/0
-      gateway_id: '{{ igw.gateway_id }}'
+      - dest: "0.0.0.0/0"
+        gateway_id: "{{ igw.gateway_id }}"
     subnets:
-    - '{{ testing_subnet.subnet.id }}'
+      - "{{ testing_subnet.subnet.id }}"
   register: removed
   until: removed is not failed
   ignore_errors: true
   retries: 10
 - name: remove internet gateway
-  ec2_vpc_igw:
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+  amazon.aws.ec2_vpc_igw:
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     state: absent
   register: removed
   until: removed is not failed
   ignore_errors: true
   retries: 10
 - name: remove the subnet
-  ec2_vpc_subnet:
+  amazon.aws.ec2_vpc_subnet:
     state: absent
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     cidr: 10.55.77.0/24
   register: removed
   until: removed is not failed
   ignore_errors: true
   retries: 10
 - name: remove the VPC
-  ec2_vpc_net:
-    name: '{{ resource_prefix }}-vpc'
+  amazon.aws.ec2_vpc_net:
+    name: "{{ resource_prefix }}-vpc"
     cidr_block: 10.55.77.0/24
     state: absent
   register: removed

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/env_setup.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/env_setup.yml
@@ -1,51 +1,51 @@
+---
 - name: Run autoscaling_group integration tests.
-  run_once: '{{ ec2_asg_setup_run_once }}'
+  run_once: "{{ ec2_asg_setup_run_once }}"
   block:
-
     # Set up the testing dependencies: VPC, subnet, security group, and two launch configurations
-  - name: Create VPC for use in testing
-    ec2_vpc_net:
-      name: '{{ resource_prefix }}-vpc'
-      cidr_block: 10.55.77.0/24
-      tenancy: default
-    register: testing_vpc
-  - name: Create internet gateway for use in testing
-    ec2_vpc_igw:
-      vpc_id: '{{ testing_vpc.vpc.id }}'
-      state: present
-    register: igw
-  - name: Create subnet for use in testing
-    ec2_vpc_subnet:
-      state: present
-      vpc_id: '{{ testing_vpc.vpc.id }}'
-      cidr: 10.55.77.0/24
-      az: '{{ aws_region }}a'
-      resource_tags:
-        Name: '{{ resource_prefix }}-subnet'
-    register: testing_subnet
-  - name: create routing rules
-    ec2_vpc_route_table:
-      vpc_id: '{{ testing_vpc.vpc.id }}'
-      tags:
-        created: '{{ resource_prefix }}-route'
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: '{{ igw.gateway_id }}'
-      subnets:
-      - '{{ testing_subnet.subnet.id }}'
+    - name: Create VPC for use in testing
+      amazon.aws.ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: 10.55.77.0/24
+        tenancy: default
+      register: testing_vpc
+    - name: Create internet gateway for use in testing
+      amazon.aws.ec2_vpc_igw:
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        state: present
+      register: igw
+    - name: Create subnet for use in testing
+      amazon.aws.ec2_vpc_subnet:
+        state: present
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        cidr: 10.55.77.0/24
+        az: "{{ aws_region }}a"
+        resource_tags:
+          Name: "{{ resource_prefix }}-subnet"
+      register: testing_subnet
+    - name: create routing rules
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        tags:
+          created: "{{ resource_prefix }}-route"
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: "{{ igw.gateway_id }}"
+        subnets:
+          - "{{ testing_subnet.subnet.id }}"
 
-  - name: create a security group with the vpc created in the ec2_setup
-    ec2_security_group:
-      name: '{{ resource_prefix }}-sg'
-      description: a security group for ansible tests
-      vpc_id: '{{ testing_vpc.vpc.id }}'
-      rules:
-      - proto: tcp
-        from_port: 22
-        to_port: 22
-        cidr_ip: 0.0.0.0/0
-      - proto: tcp
-        from_port: 80
-        to_port: 80
-        cidr_ip: 0.0.0.0/0
-    register: sg
+    - name: create a security group with the vpc created in the ec2_setup
+      ec2_security_group:
+        name: "{{ resource_prefix }}-sg"
+        description: a security group for ansible tests
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        rules:
+          - proto: tcp
+            from_port: 22
+            to_port: 22
+            cidr_ip: "0.0.0.0/0"
+          - proto: tcp
+            from_port: 80
+            to_port: 80
+            cidr_ip: "0.0.0.0/0"
+      register: sg

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/instance_detach.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/instance_detach.yml
@@ -1,256 +1,249 @@
+---
 - name: Running instance detach tests
   block:
     #----------------------------------------------------------------------
-  - name: create a launch configuration
-    autoscaling_launch_config:
-      name: '{{ resource_prefix }}-lc-detach-test'
-      image_id: '{{ ec2_ami_id }}'
-      region: '{{ aws_region }}'
-      instance_type: t2.micro
-      assign_public_ip: yes
-    register: create_lc
-  - name: ensure that lc is created
-    assert:
-      that:
-      - create_lc is changed
-      - create_lc.failed is false
-      - '"autoscaling:CreateLaunchConfiguration" in create_lc.resource_actions'
+    - name: create a launch configuration
+      autoscaling_launch_config:
+        name: "{{ resource_prefix }}-lc-detach-test"
+        image_id: "{{ ec2_ami_id }}"
+        region: "{{ aws_region }}"
+        instance_type: t2.micro
+        assign_public_ip: true
+      register: create_lc
+    - name: ensure that lc is created
+      ansible.builtin.assert:
+        that:
+          - create_lc is changed
+          - create_lc.failed is false
+          - '"autoscaling:CreateLaunchConfiguration" in create_lc.resource_actions'
 
     #----------------------------------------------------------------------
 
-  - name: create a AutoScalingGroup to be used for instance_detach test - check_mode
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-detach-test'
-      launch_config_name: '{{ resource_prefix }}-lc-detach-test'
-      health_check_period: 60
-      health_check_type: ELB
-      replace_all_instances: yes
-      min_size: 3
-      max_size: 6
-      desired_capacity: 3
-      region: '{{ aws_region }}'
-    register: create_asg
-    check_mode: true
-  - assert:
-      that:
-      - create_asg is changed
-      - create_asg is not failed
-      - '"autoscaling:CreateAutoScalingGroup" not in create_asg.resource_actions'
+    - name: create a AutoScalingGroup to be used for instance_detach test - check_mode
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-detach-test"
+        launch_config_name: "{{ resource_prefix }}-lc-detach-test"
+        health_check_period: 60
+        health_check_type: ELB
+        replace_all_instances: true
+        min_size: 3
+        max_size: 6
+        desired_capacity: 3
+        region: "{{ aws_region }}"
+      register: create_asg
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - create_asg is changed
+          - create_asg is not failed
+          - '"autoscaling:CreateAutoScalingGroup" not in create_asg.resource_actions'
 
-  - name: create a AutoScalingGroup to be used for instance_detach test
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-detach-test'
-      launch_config_name: '{{ resource_prefix }}-lc-detach-test'
-      health_check_period: 60
-      health_check_type: ELB
-      replace_all_instances: yes
-      min_size: 3
-      max_size: 6
-      desired_capacity: 3
-      region: '{{ aws_region }}'
-    register: create_asg
-  - name: ensure that AutoScalingGroup is created
-    assert:
-      that:
-      - create_asg is changed
-      - create_asg.failed is false
-      - create_asg.instances | length == 3
-      - create_asg.desired_capacity == 3
-      - create_asg.in_service_instances == 3
-      - '"autoscaling:CreateAutoScalingGroup" in create_asg.resource_actions'
+    - name: create a AutoScalingGroup to be used for instance_detach test
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-detach-test"
+        launch_config_name: "{{ resource_prefix }}-lc-detach-test"
+        health_check_period: 60
+        health_check_type: ELB
+        replace_all_instances: true
+        min_size: 3
+        max_size: 6
+        desired_capacity: 3
+        region: "{{ aws_region }}"
+      register: create_asg
+    - name: ensure that AutoScalingGroup is created
+      ansible.builtin.assert:
+        that:
+          - create_asg is changed
+          - create_asg.failed is false
+          - create_asg.instances | length == 3
+          - create_asg.desired_capacity == 3
+          - create_asg.in_service_instances == 3
+          - '"autoscaling:CreateAutoScalingGroup" in create_asg.resource_actions'
 
-  - name: gather info about asg, get instance ids
-    autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg-detach-test'
-    register: asg_info
-  - set_fact:
-      init_instance_1: '{{ asg_info.results[0].instances[0].instance_id }}'
-      init_instance_2: '{{ asg_info.results[0].instances[1].instance_id }}'
-      init_instance_3: '{{ asg_info.results[0].instances[2].instance_id }}'
-  - name: Gather information about recently detached instances
-    amazon.aws.ec2_instance_info:
-      instance_ids:
-      - '{{ init_instance_1 }}'
-      - '{{ init_instance_2 }}'
-      - '{{ init_instance_3 }}'
-    register: instances_info
-  - assert:
-      that:
-      - asg_info.results[0].instances | length == 3
-      - "'{{ instances_info.instances[0].state.name }}' == 'running'"
-      - "'{{ instances_info.instances[1].state.name }}' == 'running'"
-      - "'{{ instances_info.instances[2].state.name }}' == 'running'"
+    - name: gather info about asg, get instance ids
+      autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg-detach-test"
+      register: asg_info
+    - ansible.builtin.set_fact:
+        init_instance_1: "{{ asg_info.results[0].instances[0].instance_id }}"
+        init_instance_2: "{{ asg_info.results[0].instances[1].instance_id }}"
+        init_instance_3: "{{ asg_info.results[0].instances[2].instance_id }}"
+    - name: Gather information about recently detached instances
+      amazon.aws.ec2_instance_info:
+        instance_ids:
+          - "{{ init_instance_1 }}"
+          - "{{ init_instance_2 }}"
+          - "{{ init_instance_3 }}"
+      register: instances_info
+    - ansible.builtin.assert:
+        that:
+          - asg_info.results[0].instances | length == 3
+          - "'{{ instances_info.instances[0].state.name }}' == 'running'"
+          - "'{{ instances_info.instances[1].state.name }}' == 'running'"
+          - "'{{ instances_info.instances[2].state.name }}' == 'running'"
 
     #----------------------------------------------------------------------
 
-  - name: detach 2 instance from the asg and replace with other instances - check_mode
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-detach-test'
-      launch_config_name: '{{ resource_prefix }}-lc-detach-test'
-      health_check_period: 60
-      health_check_type: ELB
-      min_size: 3
-      max_size: 3
-      desired_capacity: 3
-      region: '{{ aws_region }}'
-      detach_instances:
-      - '{{ init_instance_1 }}'
-      - '{{ init_instance_2 }}'
-    register: detach_result
-    check_mode: true
-  - assert:
-      that:
-      - detach_result is changed
-      - detach_result is not failed
-      - '"autoscaling:DetachInstances" not in detach_result.resource_actions'
+    - name: detach 2 instance from the asg and replace with other instances - check_mode
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-detach-test"
+        launch_config_name: "{{ resource_prefix }}-lc-detach-test"
+        health_check_period: 60
+        health_check_type: ELB
+        min_size: 3
+        max_size: 3
+        desired_capacity: 3
+        region: "{{ aws_region }}"
+        detach_instances:
+          - "{{ init_instance_1 }}"
+          - "{{ init_instance_2 }}"
+      register: detach_result
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - detach_result is changed
+          - detach_result is not failed
+          - '"autoscaling:DetachInstances" not in detach_result.resource_actions'
 
-  - name: detach 2 instance from the asg and replace with other instances
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-detach-test'
-      launch_config_name: '{{ resource_prefix }}-lc-detach-test'
-      health_check_period: 60
-      health_check_type: ELB
-      min_size: 3
-      max_size: 3
-      desired_capacity: 3
-      region: '{{ aws_region }}'
-      detach_instances:
-      - '{{ init_instance_1 }}'
-      - '{{ init_instance_2 }}'
+    - name: detach 2 instance from the asg and replace with other instances
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-detach-test"
+        launch_config_name: "{{ resource_prefix }}-lc-detach-test"
+        health_check_period: 60
+        health_check_type: ELB
+        min_size: 3
+        max_size: 3
+        desired_capacity: 3
+        region: "{{ aws_region }}"
+        detach_instances:
+          - "{{ init_instance_1 }}"
+          - "{{ init_instance_2 }}"
 
     # pause to allow completion of instance replacement
-  - name: Pause for 30 seconds
-    wait_for:
-      timeout: 30
-  - autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg-detach-test'
-    register: asg_info_replaced
-  - set_fact:
-      instance_replace_1: '{{ asg_info_replaced.results[0].instances[0].instance_id
-        }}'
-      instance_replace_2: '{{ asg_info_replaced.results[0].instances[1].instance_id
-        }}'
-      instance_replace_3: '{{ asg_info_replaced.results[0].instances[2].instance_id
-        }}'
-  - set_fact:
-      asg_instance_detach_replace: "{{ asg_info_replaced.results[0].instances | map(attribute='instance_id')\
-        \ | list }}"
-  - name: Gather information about recently detached instances
-    amazon.aws.ec2_instance_info:
-      instance_ids:
-      - '{{ init_instance_1 }}'
-      - '{{ init_instance_2 }}'
-    register: detached_instances_info
-  - assert:
-      that:
-      - asg_info_replaced.results[0].desired_capacity == 3
-      - asg_info_replaced.results[0].instances | length == 3
-      - init_instance_1 not in asg_instance_detach_replace
-      - init_instance_2  not in asg_instance_detach_replace
-      - detached_instances_info.instances[0].state.name == 'running'
-      - detached_instances_info.instances[1].state.name == 'running'
+    - name: Pause for 30 seconds
+      ansible.builtin.wait_for:
+        timeout: 30
+    - autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg-detach-test"
+      register: asg_info_replaced
+    - ansible.builtin.set_fact:
+        instance_replace_1: "{{ asg_info_replaced.results[0].instances[0].instance_id }}"
+        instance_replace_2: "{{ asg_info_replaced.results[0].instances[1].instance_id }}"
+        instance_replace_3: "{{ asg_info_replaced.results[0].instances[2].instance_id }}"
+    - ansible.builtin.set_fact:
+        asg_instance_detach_replace: "{{ asg_info_replaced.results[0].instances | map(attribute='instance_id') | list }}"
+    - name: Gather information about recently detached instances
+      amazon.aws.ec2_instance_info:
+        instance_ids:
+          - "{{ init_instance_1 }}"
+          - "{{ init_instance_2 }}"
+      register: detached_instances_info
+    - ansible.builtin.assert:
+        that:
+          - asg_info_replaced.results[0].desired_capacity == 3
+          - asg_info_replaced.results[0].instances | length == 3
+          - init_instance_1 not in asg_instance_detach_replace
+          - init_instance_2  not in asg_instance_detach_replace
+          - detached_instances_info.instances[0].state.name == 'running'
+          - detached_instances_info.instances[1].state.name == 'running'
 
     #----------------------------------------------------------------------
 
     # detach 2 instances from the asg and reduce the desired capacity from 3 to 1
-  - name: detach 2 instance from the asg and reduce the desired capacity from 3 to
-      1
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-detach-test'
-      launch_config_name: '{{ resource_prefix }}-lc-detach-test'
-      health_check_period: 60
-      health_check_type: ELB
-      min_size: 1
-      max_size: 5
-      desired_capacity: 3
-      region: '{{ aws_region }}'
-      decrement_desired_capacity: true
-      detach_instances:
-      - '{{ instance_replace_1 }}'
-      - '{{ instance_replace_2 }}'
+    - name: detach 2 instance from the asg and reduce the desired capacity from 3 to 1
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-detach-test"
+        launch_config_name: "{{ resource_prefix }}-lc-detach-test"
+        health_check_period: 60
+        health_check_type: ELB
+        min_size: 1
+        max_size: 5
+        desired_capacity: 3
+        region: "{{ aws_region }}"
+        decrement_desired_capacity: true
+        detach_instances:
+          - "{{ instance_replace_1 }}"
+          - "{{ instance_replace_2 }}"
 
-  - name: Pause for 30 seconds to allow completion of above task
-    wait_for:
-      timeout: 30
-  - autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg-detach-test'
-    register: asg_info_decrement
-  - set_fact:
-      instance_detach_decrement: '{{ asg_info_decrement.results[0].instances[0].instance_id
-        }}'
-  - set_fact:
-      asg_instance_detach_decrement: "{{ asg_info_decrement.results[0].instances |\
-        \ map(attribute='instance_id') | list }}"
-  - name: Gather information about recently detached instances
-    amazon.aws.ec2_instance_info:
-      instance_ids:
-      - '{{ instance_replace_1 }}'
-      - '{{ instance_replace_2 }}'
-    register: detached_instances_info
-  - assert:
-      that:
-      - asg_info_decrement.results[0].instances | length == 1
-      - asg_info_decrement.results[0].desired_capacity == 1
-      - instance_replace_1 not in asg_instance_detach_decrement
-      - instance_replace_2 not in asg_instance_detach_decrement
-      - detached_instances_info.instances[0].state.name == 'running'
-      - detached_instances_info.instances[1].state.name == 'running'
-      - instance_replace_3 == instance_detach_decrement
+    - name: Pause for 30 seconds to allow completion of above task
+      ansible.builtin.wait_for:
+        timeout: 30
+    - autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg-detach-test"
+      register: asg_info_decrement
+    - ansible.builtin.set_fact:
+        instance_detach_decrement: "{{ asg_info_decrement.results[0].instances[0].instance_id }}"
+    - ansible.builtin.set_fact:
+        asg_instance_detach_decrement: "{{ asg_info_decrement.results[0].instances | map(attribute='instance_id') | list }}"
+    - name: Gather information about recently detached instances
+      amazon.aws.ec2_instance_info:
+        instance_ids:
+          - "{{ instance_replace_1 }}"
+          - "{{ instance_replace_2 }}"
+      register: detached_instances_info
+    - ansible.builtin.assert:
+        that:
+          - asg_info_decrement.results[0].instances | length == 1
+          - asg_info_decrement.results[0].desired_capacity == 1
+          - instance_replace_1 not in asg_instance_detach_decrement
+          - instance_replace_2 not in asg_instance_detach_decrement
+          - detached_instances_info.instances[0].state.name == 'running'
+          - detached_instances_info.instances[1].state.name == 'running'
+          - instance_replace_3 == instance_detach_decrement
 
-    #----------------------------------------------------------------------
+  #----------------------------------------------------------------------
 
   always:
+    - name: terminate any instances created during this test
+      amazon.aws.ec2_instance:
+        instance_ids:
+          - "{{ item }}"
+        state: absent
+      loop:
+        - "{{ init_instance_1 }}"
+        - "{{ init_instance_2 }}"
+        - "{{ init_instance_3 }}"
+        - "{{ instance_replace_1 }}"
+        - "{{ instance_replace_2 }}"
+        - "{{ instance_replace_3 }}"
 
-  - name: terminate any instances created during this test
-    amazon.aws.ec2_instance:
-      instance_ids:
-      - '{{ item }}'
-      state: absent
-    loop:
-    - '{{ init_instance_1 }}'
-    - '{{ init_instance_2 }}'
-    - '{{ init_instance_3 }}'
-    - '{{ instance_replace_1 }}'
-    - '{{ instance_replace_2 }}'
-    - '{{ instance_replace_3 }}'
+    - name: kill asg created in this test - check_mode
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-detach-test"
+        state: absent
+      register: removed
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - removed is changed
+          - removed is not failed
+          - '"autoscaling:DeleteAutoScalingGroup" not in removed.resource_actions'
 
-  - name: kill asg created in this test - check_mode
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-detach-test'
-      state: absent
-    register: removed
-    check_mode: true
-  - assert:
-      that:
-      - removed is changed
-      - removed is not failed
-      - '"autoscaling:DeleteAutoScalingGroup" not in removed.resource_actions'
+    - name: kill asg created in this test
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-detach-test"
+        state: absent
+      register: removed
+      until: removed is not failed
+      ignore_errors: true
+      retries: 10
+    - name: kill asg created in this test - check_mode (idempotent)
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-detach-test"
+        state: absent
+      register: removed
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - removed is not changed
+          - removed is not failed
+          - '"autoscaling:DeleteAutoScalingGroup" not in removed.resource_actions'
 
-  - name: kill asg created in this test
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-detach-test'
-      state: absent
-    register: removed
-    until: removed is not failed
-    ignore_errors: yes
-    retries: 10
-  - name: kill asg created in this test - check_mode (idempotent)
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-detach-test'
-      state: absent
-    register: removed
-    check_mode: true
-  - assert:
-      that:
-      - removed is not changed
-      - removed is not failed
-      - '"autoscaling:DeleteAutoScalingGroup" not in removed.resource_actions'
-
-  - name: remove launch config created in this test
-    autoscaling_launch_config:
-      name: '{{ resource_prefix }}-lc-detach-test'
-      state: absent
-    register: removed
-    until: removed is not failed
-    ignore_errors: yes
-    retries: 10
+    - name: remove launch config created in this test
+      autoscaling_launch_config:
+        name: "{{ resource_prefix }}-lc-detach-test"
+        state: absent
+      register: removed
+      until: removed is not failed
+      ignore_errors: true
+      retries: 10

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/main.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 # Beware: most of our tests here are run in parallel.
 # To add new tests you'll need to add a new host to the inventory and a matching
 # '{{ inventory_hostname }}'.yml file in roles/ec2_asg/tasks/
@@ -5,42 +6,40 @@
 - name: Wrap up all tests and setup AWS credentials
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
       aws_config:
         retries:
           # Unfortunately AWSRetry doesn't support paginators and boto3's paginators
           # don't support any configuration of the delay between retries.
           max_attempts: 20
   collections:
-  - community.aws
+    - community.aws
   block:
   # https://github.com/ansible/ansible/issues/77257
-  - name: Set async_dir for HOME env
-    ansible.builtin.set_fact:
-      ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async_{{ tiny_prefix }}/"
-    when: (lookup('env', 'HOME'))
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async_{{ tiny_prefix }}/"
+      when: (lookup('env', 'HOME'))
 
-  - debug:
-      msg: "{{ inventory_hostname }} start: {{ lookup('pipe','date') }}"
-  - include_tasks: '{{ inventory_hostname }}.yml'
-  - debug:
-      msg: "{{ inventory_hostname }} finish: {{ lookup('pipe','date') }}"
+    - ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} start: {{ lookup('pipe','date') }}"
+    - ansible.builtin.include_tasks: "{{ inventory_hostname }}.yml"
+    - ansible.builtin.debug:
+        msg: "{{ inventory_hostname }} finish: {{ lookup('pipe','date') }}"
   always:
-  - set_fact:
-      _role_complete: true
-  - vars:
-      completed_hosts: '{{ ansible_play_hosts_all | map("extract", hostvars, "_role_complete")
-        | list | select("defined") | list | length }}'
-      hosts_in_play: '{{ ansible_play_hosts_all | length }}'
-    debug:
-      msg: '{{ completed_hosts }} of {{ hosts_in_play }} complete'
-  - include_tasks: env_cleanup.yml
-    vars:
-      completed_hosts: '{{ ansible_play_hosts_all | map("extract", hostvars, "_role_complete")
-        | list | select("defined") | list | length }}'
-      hosts_in_play: '{{ ansible_play_hosts_all | length }}'
-    when:
-    - completed_hosts == hosts_in_play
+    - ansible.builtin.set_fact:
+        _role_complete: true
+    - vars:
+        completed_hosts: '{{ ansible_play_hosts_all | map("extract", hostvars, "_role_complete") | list | select("defined") | list | length }}'
+        hosts_in_play: "{{ ansible_play_hosts_all | length }}"
+      ansible.builtin.debug:
+        msg: "{{ completed_hosts }} of {{ hosts_in_play }} complete"
+    - ansible.builtin.include_tasks: env_cleanup.yml
+      vars:
+        completed_hosts: '{{ ansible_play_hosts_all | map("extract", hostvars, "_role_complete") | list | select("defined") | list | length }}'
+        hosts_in_play: "{{ ansible_play_hosts_all | length }}"
+      when:
+        - completed_hosts == hosts_in_play

--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/tag_operations.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/tag_operations.yml
@@ -1,339 +1,337 @@
+---
 - name: Running AutoScalingGroup Tag operations test
   block:
     #----------------------------------------------------------------------
-  - name: create a launch configuration
-    autoscaling_launch_config:
-      name: '{{ resource_prefix }}-lc-tag-test'
-      image_id: '{{ ec2_ami_id }}'
-      region: '{{ aws_region }}'
-      instance_type: t2.micro
-      assign_public_ip: yes
-    register: create_lc
-  - name: ensure that lc is created
-    assert:
-      that:
-      - create_lc is changed
-      - create_lc.failed is false
-      - '"autoscaling:CreateLaunchConfiguration" in create_lc.resource_actions'
+    - name: create a launch configuration
+      autoscaling_launch_config:
+        name: "{{ resource_prefix }}-lc-tag-test"
+        image_id: "{{ ec2_ami_id }}"
+        region: "{{ aws_region }}"
+        instance_type: t2.micro
+        assign_public_ip: true
+      register: create_lc
+    - name: ensure that lc is created
+      ansible.builtin.assert:
+        that:
+          - create_lc is changed
+          - create_lc.failed is false
+          - '"autoscaling:CreateLaunchConfiguration" in create_lc.resource_actions'
 
     #----------------------------------------------------------------------
-  - name: create a AutoScalingGroup to be used for tag_operations test
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      launch_config_name: '{{ resource_prefix }}-lc-tag-test'
-      health_check_period: 60
-      health_check_type: ELB
-      replace_all_instances: yes
-      min_size: 1
-      max_size: 1
-      desired_capacity: 1
-      region: '{{ aws_region }}'
-    register: create_asg
-  - name: ensure that AutoScalingGroup is created
-    assert:
-      that:
-      - create_asg is changed
-      - create_asg.failed is false
-      - '"autoscaling:CreateAutoScalingGroup" in create_asg.resource_actions'
+    - name: create a AutoScalingGroup to be used for tag_operations test
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        launch_config_name: "{{ resource_prefix }}-lc-tag-test"
+        health_check_period: 60
+        health_check_type: ELB
+        replace_all_instances: true
+        min_size: 1
+        max_size: 1
+        desired_capacity: 1
+        region: "{{ aws_region }}"
+      register: create_asg
+    - name: ensure that AutoScalingGroup is created
+      ansible.builtin.assert:
+        that:
+          - create_asg is changed
+          - create_asg.failed is false
+          - '"autoscaling:CreateAutoScalingGroup" in create_asg.resource_actions'
 
     #----------------------------------------------------------------------
 
-  - name: Get asg info
-    autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg-tag-test'
-    register: info_result
-  - assert:
-      that:
-      - info_result.results[0].tags | length == 0
+    - name: Get asg info
+      autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg-tag-test"
+      register: info_result
+    - ansible.builtin.assert:
+        that:
+          - info_result.results[0].tags | length == 0
 
-  - name: Tag asg - check_mode
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      tags:
-      - tag_a: value 1
-        propagate_at_launch: no
-      - tag_b: value 2
-        propagate_at_launch: yes
-    register: output
-    check_mode: true
-  - assert:
-      that:
-      - output is changed
-      - output is not failed
-      - '"autoscaling:CreateOrUpdateTags" not in output.resource_actions'
+    - name: Tag asg - check_mode
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        tags:
+          - tag_a: value 1
+            propagate_at_launch: false
+          - tag_b: value 2
+            propagate_at_launch: true
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output is not failed
+          - '"autoscaling:CreateOrUpdateTags" not in output.resource_actions'
 
-  - name: Tag asg
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      tags:
-      - tag_a: value 1
-        propagate_at_launch: no
-      - tag_b: value 2
-        propagate_at_launch: yes
-    register: output
-  - assert:
-      that:
-      - output.tags | length == 2
-      - output is changed
+    - name: Tag asg
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        tags:
+          - tag_a: value 1
+            propagate_at_launch: false
+          - tag_b: value 2
+            propagate_at_launch: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.tags | length == 2
+          - output is changed
 
-  - name: Re-Tag asg (different order)
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      tags:
-      - tag_b: value 2
-        propagate_at_launch: yes
-      - tag_a: value 1
-        propagate_at_launch: no
-    register: output
-  - assert:
-      that:
-      - output.tags | length == 2
-      - output is not changed
+    - name: Re-Tag asg (different order)
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        tags:
+          - tag_b: value 2
+            propagate_at_launch: true
+          - tag_a: value 1
+            propagate_at_launch: false
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.tags | length == 2
+          - output is not changed
 
-  - name: Re-Tag asg new tags
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      tags:
-      - tag_c: value 3
-        propagate_at_launch: no
-      purge_tags: true
-    register: output
-  - assert:
-      that:
-      - output.tags | length == 1
-      - output is changed
+    - name: Re-Tag asg new tags
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        tags:
+          - tag_c: value 3
+            propagate_at_launch: false
+        purge_tags: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.tags | length == 1
+          - output is changed
 
-  - name: Re-Tag asg update propagate_at_launch
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      tags:
-      - tag_c: value 3
-        propagate_at_launch: yes
-    register: output
-  - assert:
-      that:
-      - output.tags | length == 1
-      - output is changed
+    - name: Re-Tag asg update propagate_at_launch
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        tags:
+          - tag_c: value 3
+            propagate_at_launch: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.tags | length == 1
+          - output is changed
 
-  - name: Remove all tags
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      tags: []
-      purge_tags: true
-    register: add_empty
-  - name: Get asg info
-    autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg-tag-test'
-    register: info_result
-  - set_fact:
-      tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
-  - assert:
-      that:
-      - add_empty is changed
-      - info_result.results[0].tags | length == 0
-      - '"autoscaling:CreateOrUpdateTags" not in add_empty.resource_actions'
-      - '"autoscaling:DeleteTags" in add_empty.resource_actions'
+    - name: Remove all tags
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        tags: []
+        purge_tags: true
+      register: add_empty
+    - name: Get asg info
+      autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg-tag-test"
+      register: info_result
+    - ansible.builtin.set_fact:
+        tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
+    - ansible.builtin.assert:
+        that:
+          - add_empty is changed
+          - info_result.results[0].tags | length == 0
+          - '"autoscaling:CreateOrUpdateTags" not in add_empty.resource_actions'
+          - '"autoscaling:DeleteTags" in add_empty.resource_actions'
 
-  - name: Add 4 new tags - do not purge existing tags
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      tags:
-      - lowercase spaced: hello cruel world
-        propagate_at_launch: no
-      - Title Case: Hello Cruel World
-        propagate_at_launch: yes
-      - CamelCase: SimpleCamelCase
-        propagate_at_launch: yes
-      - snake_case: simple_snake_case
-        propagate_at_launch: no
-    register: add_result
-  - name: Get asg info
-    autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg-tag-test'
-    register: info_result
-  - set_fact:
-      tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
-  - assert:
-      that:
-      - add_result is changed
-      - info_result.results[0].tags | length == 4
-      - '"lowercase spaced" in tag_keys'
-      - '"Title Case" in tag_keys'
-      - '"CamelCase" in tag_keys'
-      - '"snake_case" in tag_keys'
-      - '"autoscaling:CreateOrUpdateTags" in add_result.resource_actions'
+    - name: Add 4 new tags - do not purge existing tags
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        tags:
+          - lowercase spaced: hello cruel world
+            propagate_at_launch: false
+          - Title Case: Hello Cruel World
+            propagate_at_launch: true
+          - CamelCase: SimpleCamelCase
+            propagate_at_launch: true
+          - snake_case: simple_snake_case
+            propagate_at_launch: false
+      register: add_result
+    - name: Get asg info
+      autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg-tag-test"
+      register: info_result
+    - ansible.builtin.set_fact:
+        tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
+    - ansible.builtin.assert:
+        that:
+          - add_result is changed
+          - info_result.results[0].tags | length == 4
+          - '"lowercase spaced" in tag_keys'
+          - '"Title Case" in tag_keys'
+          - '"CamelCase" in tag_keys'
+          - '"snake_case" in tag_keys'
+          - '"autoscaling:CreateOrUpdateTags" in add_result.resource_actions'
 
-  - name: Add 4 new tags - do not purge existing tags - idempotency
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      tags:
-      - lowercase spaced: hello cruel world
-        propagate_at_launch: no
-      - Title Case: Hello Cruel World
-        propagate_at_launch: yes
-      - CamelCase: SimpleCamelCase
-        propagate_at_launch: yes
-      - snake_case: simple_snake_case
-        propagate_at_launch: no
-    register: add_result
-  - name: Get asg info
-    autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg-tag-test'
-    register: info_result
-  - assert:
-      that:
-      - add_result is not changed
-      - info_result.results[0].tags | length == 4
-      - '"autoscaling:CreateOrUpdateTags" not in add_result.resource_actions'
+    - name: Add 4 new tags - do not purge existing tags - idempotency
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        tags:
+          - lowercase spaced: hello cruel world
+            propagate_at_launch: false
+          - Title Case: Hello Cruel World
+            propagate_at_launch: true
+          - CamelCase: SimpleCamelCase
+            propagate_at_launch: true
+          - snake_case: simple_snake_case
+            propagate_at_launch: false
+      register: add_result
+    - name: Get asg info
+      autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg-tag-test"
+      register: info_result
+    - ansible.builtin.assert:
+        that:
+          - add_result is not changed
+          - info_result.results[0].tags | length == 4
+          - '"autoscaling:CreateOrUpdateTags" not in add_result.resource_actions'
 
-  - name: Add 2 new tags - purge existing tags
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      tags:
-      - tag_a: val_a
-        propagate_at_launch: no
-      - tag_b: val_b
-        propagate_at_launch: yes
-      purge_tags: true
-    register: add_purge_result
-  - name: Get asg info
-    autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg-tag-test'
-    register: info_result
-  - set_fact:
-      tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
-  - assert:
-      that:
-      - add_purge_result is changed
-      - info_result.results[0].tags | length == 2
-      - '"tag_a" in tag_keys'
-      - '"tag_b" in tag_keys'
-      - '"lowercase spaced" not in tag_keys'
-      - '"Title Case" not in tag_keys'
-      - '"CamelCase" not in tag_keys'
-      - '"snake_case" not in tag_keys'
-      - '"autoscaling:CreateOrUpdateTags" in add_purge_result.resource_actions'
+    - name: Add 2 new tags - purge existing tags
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        tags:
+          - tag_a: val_a
+            propagate_at_launch: false
+          - tag_b: val_b
+            propagate_at_launch: true
+        purge_tags: true
+      register: add_purge_result
+    - name: Get asg info
+      autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg-tag-test"
+      register: info_result
+    - ansible.builtin.set_fact:
+        tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
+    - ansible.builtin.assert:
+        that:
+          - add_purge_result is changed
+          - info_result.results[0].tags | length == 2
+          - '"tag_a" in tag_keys'
+          - '"tag_b" in tag_keys'
+          - '"lowercase spaced" not in tag_keys'
+          - '"Title Case" not in tag_keys'
+          - '"CamelCase" not in tag_keys'
+          - '"snake_case" not in tag_keys'
+          - '"autoscaling:CreateOrUpdateTags" in add_purge_result.resource_actions'
 
-  - name: Re-tag ASG - modify values
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      tags:
-      - tag_a: new_val_a
-        propagate_at_launch: no
-      - tag_b: new_val_b
-        propagate_at_launch: yes
-    register: add_purge_result
-  - name: Get asg info
-    autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg-tag-test'
-    register: info_result
-  - set_fact:
-      tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
-  - set_fact:
-      tag_values: "{{ info_result.results[0].tags | map(attribute='value') | list\
-        \ }}"
-  - assert:
-      that:
-      - add_purge_result is changed
-      - info_result.results[0].tags | length == 2
-      - '"tag_a" in tag_keys'
-      - '"tag_b" in tag_keys'
-      - '"new_val_a" in tag_values'
-      - '"new_val_b" in tag_values'
-      - '"lowercase spaced" not in tag_keys'
-      - '"Title Case" not in tag_keys'
-      - '"CamelCase" not in tag_keys'
-      - '"snake_case" not in tag_keys'
-      - '"autoscaling:CreateOrUpdateTags" in add_purge_result.resource_actions'
+    - name: Re-tag ASG - modify values
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        tags:
+          - tag_a: new_val_a
+            propagate_at_launch: false
+          - tag_b: new_val_b
+            propagate_at_launch: true
+      register: add_purge_result
+    - name: Get asg info
+      autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg-tag-test"
+      register: info_result
+    - ansible.builtin.set_fact:
+        tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
+    - ansible.builtin.set_fact:
+        tag_values: "{{ info_result.results[0].tags | map(attribute='value') | list }}"
+    - ansible.builtin.assert:
+        that:
+          - add_purge_result is changed
+          - info_result.results[0].tags | length == 2
+          - '"tag_a" in tag_keys'
+          - '"tag_b" in tag_keys'
+          - '"new_val_a" in tag_values'
+          - '"new_val_b" in tag_values'
+          - '"lowercase spaced" not in tag_keys'
+          - '"Title Case" not in tag_keys'
+          - '"CamelCase" not in tag_keys'
+          - '"snake_case" not in tag_keys'
+          - '"autoscaling:CreateOrUpdateTags" in add_purge_result.resource_actions'
 
-  - name: Add 2 more tags - do not purge existing tags
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      tags:
-      - lowercase spaced: hello cruel world
-        propagate_at_launch: no
-      - Title Case: Hello Cruel World
-        propagate_at_launch: yes
-    register: add_result
-  - name: Get asg info
-    autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg-tag-test'
-    register: info_result
-  - set_fact:
-      tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
-  - assert:
-      that:
-      - add_result is changed
-      - info_result.results[0].tags | length == 4
-      - '"tag_a" in tag_keys'
-      - '"tag_b" in tag_keys'
-      - '"lowercase spaced" in tag_keys'
-      - '"Title Case" in tag_keys'
-      - '"autoscaling:CreateOrUpdateTags" in add_result.resource_actions'
+    - name: Add 2 more tags - do not purge existing tags
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        tags:
+          - lowercase spaced: hello cruel world
+            propagate_at_launch: false
+          - Title Case: Hello Cruel World
+            propagate_at_launch: true
+      register: add_result
+    - name: Get asg info
+      autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg-tag-test"
+      register: info_result
+    - ansible.builtin.set_fact:
+        tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
+    - ansible.builtin.assert:
+        that:
+          - add_result is changed
+          - info_result.results[0].tags | length == 4
+          - '"tag_a" in tag_keys'
+          - '"tag_b" in tag_keys'
+          - '"lowercase spaced" in tag_keys'
+          - '"Title Case" in tag_keys'
+          - '"autoscaling:CreateOrUpdateTags" in add_result.resource_actions'
 
-  - name: Add empty tags with purge set to false to assert that existing tags are
-      retained
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      tags: []
-      purge_tags: false
-    register: add_empty
-  - name: Get asg info
-    autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg-tag-test'
-    register: info_result
-  - set_fact:
-      tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
-  - assert:
-      that:
-      - add_empty is not changed
-      - info_result.results[0].tags | length == 4
-      - '"tag_a" in tag_keys'
-      - '"tag_b" in tag_keys'
-      - '"lowercase spaced" in tag_keys'
-      - '"Title Case" in tag_keys'
-      - '"autoscaling:CreateOrUpdateTags" not in add_empty.resource_actions'
+    - name: Add empty tags with purge set to false to assert that existing tags are retained
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        tags: []
+        purge_tags: false
+      register: add_empty
+    - name: Get asg info
+      autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg-tag-test"
+      register: info_result
+    - ansible.builtin.set_fact:
+        tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
+    - ansible.builtin.assert:
+        that:
+          - add_empty is not changed
+          - info_result.results[0].tags | length == 4
+          - '"tag_a" in tag_keys'
+          - '"tag_b" in tag_keys'
+          - '"lowercase spaced" in tag_keys'
+          - '"Title Case" in tag_keys'
+          - '"autoscaling:CreateOrUpdateTags" not in add_empty.resource_actions'
 
-  - name: Add empty tags with purge set to true to assert that existing tags are removed
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      tags: []
-      purge_tags: true
-    register: add_empty
-  - name: Get asg info
-    autoscaling_group_info:
-      name: '{{ resource_prefix }}-asg-tag-test'
-    register: info_result
-  - set_fact:
-      tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
-  - assert:
-      that:
-      - add_empty is changed
-      - info_result.results[0].tags | length == 0
-      - '"tag_a" not in tag_keys'
-      - '"tag_b" not in tag_keys'
-      - '"lowercase spaced" not in tag_keys'
-      - '"Title Case" not in tag_keys'
-      - '"autoscaling:CreateOrUpdateTags" not in add_empty.resource_actions'
-      - '"autoscaling:DeleteTags" in add_empty.resource_actions'
+    - name: Add empty tags with purge set to true to assert that existing tags are removed
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        tags: []
+        purge_tags: true
+      register: add_empty
+    - name: Get asg info
+      autoscaling_group_info:
+        name: "{{ resource_prefix }}-asg-tag-test"
+      register: info_result
+    - ansible.builtin.set_fact:
+        tag_keys: "{{ info_result.results[0].tags | map(attribute='key') | list }}"
+    - ansible.builtin.assert:
+        that:
+          - add_empty is changed
+          - info_result.results[0].tags | length == 0
+          - '"tag_a" not in tag_keys'
+          - '"tag_b" not in tag_keys'
+          - '"lowercase spaced" not in tag_keys'
+          - '"Title Case" not in tag_keys'
+          - '"autoscaling:CreateOrUpdateTags" not in add_empty.resource_actions'
+          - '"autoscaling:DeleteTags" in add_empty.resource_actions'
 
-    #----------------------------------------------------------------------
+  #----------------------------------------------------------------------
 
   always:
-
-  - name: kill asg created in this test
-    autoscaling_group:
-      name: '{{ resource_prefix }}-asg-tag-test'
-      state: absent
-    register: removed
-    until: removed is not failed
-    ignore_errors: yes
-    retries: 10
-  - name: remove launch config created in this test
-    autoscaling_launch_config:
-      name: '{{ resource_prefix }}-lc-tag-test'
-      state: absent
-    register: removed
-    until: removed is not failed
-    ignore_errors: yes
-    retries: 10
+    - name: kill asg created in this test
+      autoscaling_group:
+        name: "{{ resource_prefix }}-asg-tag-test"
+        state: absent
+      register: removed
+      until: removed is not failed
+      ignore_errors: true
+      retries: 10
+    - name: remove launch config created in this test
+      autoscaling_launch_config:
+        name: "{{ resource_prefix }}-lc-tag-test"
+        state: absent
+      register: removed
+      until: removed is not failed
+      ignore_errors: true
+      retries: 10

--- a/tests/integration/targets/aws_az_info/main.yml
+++ b/tests/integration/targets/aws_az_info/main.yml
@@ -1,5 +1,6 @@
+---
 - hosts: localhost
   connection: local
   environment: "{{ ansible_test.environment }}"
   tasks:
-    - include_tasks: 'tasks/main.yml'
+    - ansible.builtin.include_tasks: tasks/main.yml

--- a/tests/integration/targets/aws_az_info/meta/main.yml
+++ b/tests/integration/targets/aws_az_info/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/aws_az_info/tasks/main.yml
+++ b/tests/integration/targets/aws_az_info/tasks/main.yml
@@ -1,183 +1,182 @@
 ---
 - module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
   block:
-  - name: 'List available AZs in current Region'
-    aws_az_info:
-    register: region_azs
+    - name: List available AZs in current Region
+      amazon.aws.aws_az_info:
+      register: region_azs
 
-  - name: check task return attributes
-    vars:
-      first_az: '{{ region_azs.availability_zones[0] }}'
-    assert:
-      that:
-      - region_azs is successful
-      - '"availability_zones" in region_azs'
-      - '"group_name" in first_az'
-      - '"messages" in first_az'
-      - '"network_border_group" in first_az'
-      - '"opt_in_status" in first_az'
-      - '"region_name" in first_az'
-      - '"state" in first_az'
-      - '"zone_id" in first_az'
-      - '"zone_name" in first_az'
-      - '"zone_type" in first_az'
+    - name: check task return attributes
+      vars:
+        first_az: "{{ region_azs.availability_zones[0] }}"
+      ansible.builtin.assert:
+        that:
+          - region_azs is successful
+          - '"availability_zones" in region_azs'
+          - '"group_name" in first_az'
+          - '"messages" in first_az'
+          - '"network_border_group" in first_az'
+          - '"opt_in_status" in first_az'
+          - '"region_name" in first_az'
+          - '"state" in first_az'
+          - '"zone_id" in first_az'
+          - '"zone_name" in first_az'
+          - '"zone_type" in first_az'
 
-  - name: 'List available AZs in current Region - check_mode'
-    aws_az_info:
-    check_mode: yes
-    register: check_azs
+    - name: List available AZs in current Region - check_mode
+      amazon.aws.aws_az_info:
+      check_mode: true
+      register: check_azs
 
-  - name: check task return attributes
-    vars:
-      first_az: '{{ check_azs.availability_zones[0] }}'
-    assert:
-      that:
-      - check_azs is successful
-      - '"availability_zones" in check_azs'
-      - '"group_name" in first_az'
-      - '"messages" in first_az'
-      - '"network_border_group" in first_az'
-      - '"opt_in_status" in first_az'
-      - '"region_name" in first_az'
-      - '"state" in first_az'
-      - '"zone_id" in first_az'
-      - '"zone_name" in first_az'
-      - '"zone_type" in first_az'
+    - name: check task return attributes
+      vars:
+        first_az: "{{ check_azs.availability_zones[0] }}"
+      ansible.builtin.assert:
+        that:
+          - check_azs is successful
+          - '"availability_zones" in check_azs'
+          - '"group_name" in first_az'
+          - '"messages" in first_az'
+          - '"network_border_group" in first_az'
+          - '"opt_in_status" in first_az'
+          - '"region_name" in first_az'
+          - '"state" in first_az'
+          - '"zone_id" in first_az'
+          - '"zone_name" in first_az'
+          - '"zone_type" in first_az'
 
+    # Be specific - aws_region isn't guaranteed to be any specific value
+    - name: List Available AZs in us-east-1
+      amazon.aws.aws_az_info:
+        region: us-east-1
+      register: us_east_1
 
-  # Be specific - aws_region isn't guaranteed to be any specific value
-  - name: 'List Available AZs in us-east-1'
-    aws_az_info:
-      region: 'us-east-1'
-    register: us_east_1
+    - name: Check that an AZ from us-east-1 has valid looking attributes
+      vars:
+        first_az: "{{ us_east_1.availability_zones[0] }}"
+      ansible.builtin.assert:
+        that:
+          - us_east_1 is successful
+          - '"availability_zones" in us_east_1'
+          - '"group_name" in first_az'
+          - '"messages" in first_az'
+          - '"network_border_group" in first_az'
+          - '"opt_in_status" in first_az'
+          - '"region_name" in first_az'
+          - '"state" in first_az'
+          - '"zone_id" in first_az'
+          - '"zone_name" in first_az'
+          - '"zone_type" in first_az'
+          - first_az.group_name.startswith('us-east-1')
+          - first_az.network_border_group.startswith('us-east-1')
+          - first_az.region_name == 'us-east-1'
+          - first_az.zone_id.startswith('use1-az')
+          - not first_az.zone_id == "use1-az"
+          - first_az.zone_name.startswith('us-east-1')
+          - not first_az.zone_name == 'us-east-1'
+          - first_az.zone_type == 'availability-zone'
 
-  - name: 'Check that an AZ from us-east-1 has valid looking attributes'
-    vars:
-      first_az: '{{ us_east_1.availability_zones[0] }}'
-    assert:
-      that:
-      - us_east_1 is successful
-      - '"availability_zones" in us_east_1'
-      - '"group_name" in first_az'
-      - '"messages" in first_az'
-      - '"network_border_group" in first_az'
-      - '"opt_in_status" in first_az'
-      - '"region_name" in first_az'
-      - '"state" in first_az'
-      - '"zone_id" in first_az'
-      - '"zone_name" in first_az'
-      - '"zone_type" in first_az'
-      - first_az.group_name.startswith('us-east-1')
-      - first_az.network_border_group.startswith('us-east-1')
-      - first_az.region_name == 'us-east-1'
-      - first_az.zone_id.startswith('use1-az')
-      - not first_az.zone_id == "use1-az"
-      - first_az.zone_name.startswith('us-east-1')
-      - not first_az.zone_name == 'us-east-1'
-      - first_az.zone_type == 'availability-zone'
+    - name: Filter Available AZs in us-west-2 using - ("zone-name")
+      amazon.aws.aws_az_info:
+        region: us-west-2
+        filters:
+          zone-name: us-west-2c
+      register: us_west_2
 
-  - name: 'Filter Available AZs in us-west-2 using - ("zone-name")'
-    aws_az_info:
-      region: 'us-west-2'
-      filters:
-        zone-name: 'us-west-2c'
-    register: us_west_2
+    - name: Check that an AZ from us-west-2 has attributes we expect
+      vars:
+        first_az: "{{ us_west_2.availability_zones[0] }}"
+      ansible.builtin.assert:
+        that:
+          - us_west_2 is successful
+          - '"availability_zones" in us_west_2'
+          - us_west_2.availability_zones | length == 1
+          - '"group_name" in first_az'
+          - '"messages" in first_az'
+          - '"network_border_group" in first_az'
+          - '"opt_in_status" in first_az'
+          - '"region_name" in first_az'
+          - '"state" in first_az'
+          - '"zone_id" in first_az'
+          - '"zone_name" in first_az'
+          - '"zone_type" in first_az'
+          - first_az.group_name == 'us-west-2'
+          - first_az.network_border_group == 'us-west-2'
+          - first_az.region_name == 'us-west-2'
+          # AZs are mapped to the 'real' AZs on a per-account basis
+          - first_az.zone_id.startswith('usw2-az')
+          - not first_az.zone_id == 'usw2-az'
+          - first_az.zone_name == 'us-west-2c'
+          - first_az.zone_type == 'availability-zone'
 
-  - name: 'Check that an AZ from us-west-2 has attributes we expect'
-    vars:
-      first_az: '{{ us_west_2.availability_zones[0] }}'
-    assert:
-      that:
-      - us_west_2 is successful
-      - '"availability_zones" in us_west_2'
-      - us_west_2.availability_zones | length == 1
-      - '"group_name" in first_az'
-      - '"messages" in first_az'
-      - '"network_border_group" in first_az'
-      - '"opt_in_status" in first_az'
-      - '"region_name" in first_az'
-      - '"state" in first_az'
-      - '"zone_id" in first_az'
-      - '"zone_name" in first_az'
-      - '"zone_type" in first_az'
-      - first_az.group_name == 'us-west-2'
-      - first_az.network_border_group == 'us-west-2'
-      - first_az.region_name == 'us-west-2'
-        # AZs are mapped to the 'real' AZs on a per-account basis
-      - first_az.zone_id.startswith('usw2-az')
-      - not first_az.zone_id == 'usw2-az'
-      - first_az.zone_name == 'us-west-2c'
-      - first_az.zone_type == 'availability-zone'
+    - name: Filter Available AZs in eu-central-1 using _ ("zone_name")
+      amazon.aws.aws_az_info:
+        region: eu-central-1
+        filters:
+          zone_name: eu-central-1b
+      register: eu_central_1
 
-  - name: 'Filter Available AZs in eu-central-1 using _ ("zone_name")'
-    aws_az_info:
-      region: 'eu-central-1'
-      filters:
-        zone_name: 'eu-central-1b'
-    register: eu_central_1
+    - name: Check that eu-central-1b has the attributes we expect
+      vars:
+        first_az: "{{ eu_central_1.availability_zones[0] }}"
+      ansible.builtin.assert:
+        that:
+          - eu_central_1 is successful
+          - '"availability_zones" in eu_central_1'
+          - eu_central_1.availability_zones | length == 1
+          - '"group_name" in first_az'
+          - '"messages" in first_az'
+          - '"network_border_group" in first_az'
+          - '"opt_in_status" in first_az'
+          - '"region_name" in first_az'
+          - '"state" in first_az'
+          - '"zone_id" in first_az'
+          - '"zone_name" in first_az'
+          - '"zone_type" in first_az'
+          - first_az.group_name == 'eu-central-1'
+          - first_az.network_border_group == 'eu-central-1'
+          - first_az.region_name == 'eu-central-1'
+          # AZs are mapped to the 'real' AZs on a per-account basis
+          - first_az.zone_id.startswith('euc1-az')
+          - not first_az.zone_id == "euc1-az"
+          - first_az.zone_name == 'eu-central-1b'
+          - first_az.zone_type == 'availability-zone'
 
-  - name: 'Check that eu-central-1b has the attributes we expect'
-    vars:
-      first_az: '{{ eu_central_1.availability_zones[0] }}'
-    assert:
-      that:
-      - eu_central_1 is successful
-      - '"availability_zones" in eu_central_1'
-      - eu_central_1.availability_zones | length == 1
-      - '"group_name" in first_az'
-      - '"messages" in first_az'
-      - '"network_border_group" in first_az'
-      - '"opt_in_status" in first_az'
-      - '"region_name" in first_az'
-      - '"state" in first_az'
-      - '"zone_id" in first_az'
-      - '"zone_name" in first_az'
-      - '"zone_type" in first_az'
-      - first_az.group_name == 'eu-central-1'
-      - first_az.network_border_group == 'eu-central-1'
-      - first_az.region_name == 'eu-central-1'
-        # AZs are mapped to the 'real' AZs on a per-account basis
-      - first_az.zone_id.startswith('euc1-az')
-      - not first_az.zone_id == "euc1-az"
-      - first_az.zone_name == 'eu-central-1b'
-      - first_az.zone_type == 'availability-zone'
+    - name: 'Filter Available AZs in eu-west-2 using _ and - ("zone_name" and "zone-name") : _ wins '
+      amazon.aws.aws_az_info:
+        region: eu-west-2
+        filters:
+          zone-name: eu-west-2a
+          zone_name: eu-west-2c
+      register: eu_west_2
 
-  - name: 'Filter Available AZs in eu-west-2 using _ and - ("zone_name" and "zone-name") : _ wins '
-    aws_az_info:
-      region: 'eu-west-2'
-      filters:
-        zone-name: 'eu-west-2a'
-        zone_name: 'eu-west-2c'
-    register: eu_west_2
-
-  - name: 'Check that we get the AZ specified by zone_name rather than zone-name'
-    vars:
-      first_az: '{{ eu_west_2.availability_zones[0] }}'
-    assert:
-      that:
-      - eu_west_2 is successful
-      - '"availability_zones" in eu_west_2'
-      - eu_west_2.availability_zones | length == 1
-      - '"group_name" in first_az'
-      - '"messages" in first_az'
-      - '"network_border_group" in first_az'
-      - '"opt_in_status" in first_az'
-      - '"region_name" in first_az'
-      - '"state" in first_az'
-      - '"zone_id" in first_az'
-      - '"zone_name" in first_az'
-      - '"zone_type" in first_az'
-      - first_az.group_name == 'eu-west-2'
-      - first_az.network_border_group == 'eu-west-2'
-      - first_az.region_name == 'eu-west-2'
-        # AZs are mapped to the 'real' AZs on a per-account basis
-      - first_az.zone_id.startswith('euw2-az')
-      - not first_az.zone_id == "euw2-az"
-      - first_az.zone_name == 'eu-west-2c'
-      - first_az.zone_type == 'availability-zone'
+    - name: Check that we get the AZ specified by zone_name rather than zone-name
+      vars:
+        first_az: "{{ eu_west_2.availability_zones[0] }}"
+      ansible.builtin.assert:
+        that:
+          - eu_west_2 is successful
+          - '"availability_zones" in eu_west_2'
+          - eu_west_2.availability_zones | length == 1
+          - '"group_name" in first_az'
+          - '"messages" in first_az'
+          - '"network_border_group" in first_az'
+          - '"opt_in_status" in first_az'
+          - '"region_name" in first_az'
+          - '"state" in first_az'
+          - '"zone_id" in first_az'
+          - '"zone_name" in first_az'
+          - '"zone_type" in first_az'
+          - first_az.group_name == 'eu-west-2'
+          - first_az.network_border_group == 'eu-west-2'
+          - first_az.region_name == 'eu-west-2'
+          # AZs are mapped to the 'real' AZs on a per-account basis
+          - first_az.zone_id.startswith('euw2-az')
+          - not first_az.zone_id == "euw2-az"
+          - first_az.zone_name == 'eu-west-2c'
+          - first_az.zone_type == 'availability-zone'

--- a/tests/integration/targets/aws_caller_info/meta/main.yml
+++ b/tests/integration/targets/aws_caller_info/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/aws_caller_info/tasks/main.yaml
+++ b/tests/integration/targets/aws_caller_info/tasks/main.yaml
@@ -1,18 +1,19 @@
+---
 - module_defaults:
     group/aws:
-        region: "{{ aws_region }}"
-        access_key: "{{ aws_access_key }}"
-        secret_key: "{{ aws_secret_key }}"
-        session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   block:
-  - name: retrieve caller facts
-    aws_caller_info:
-    register: result
+    - name: retrieve caller facts
+      amazon.aws.aws_caller_info:
+      register: result
 
-  - name: assert correct keys are returned
-    assert:
-      that:
-        - result.account is not none
-        - result.arn is not none
-        - result.user_id is not none
-        - result.account_alias is not none
+    - name: assert correct keys are returned
+      ansible.builtin.assert:
+        that:
+          - result.account is not none
+          - result.arn is not none
+          - result.user_id is not none
+          - result.account_alias is not none

--- a/tests/integration/targets/aws_region_info/main.yml
+++ b/tests/integration/targets/aws_region_info/main.yml
@@ -1,5 +1,0 @@
-- hosts: localhost
-  connection: local
-  environment: '{{ ansible_test.environment }}'
-  tasks:
-  - include_tasks: tasks/tests.yml

--- a/tests/integration/targets/aws_region_info/meta/main.yml
+++ b/tests/integration/targets/aws_region_info/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/aws_region_info/tasks/main.yml
+++ b/tests/integration/targets/aws_region_info/tasks/main.yml
@@ -1,100 +1,101 @@
+---
 - module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-  - name: List available Regions
-    aws_region_info:
-    register: regions
-  - name: check task return attributes
-    vars:
-      first_region: '{{ regions.regions[0] }}'
-    assert:
-      that:
-      - regions is successful
-      - regions is not changed
-      - '"regions" in regions'
-      - '"endpoint" in first_region'
-      - '"opt_in_status" in first_region'
-      - '"region_name" in first_region'
+    - name: List available Regions
+      community.aws.aws_region_info:
+      register: regions
+    - name: check task return attributes
+      vars:
+        first_region: "{{ regions.regions[0] }}"
+      ansible.builtin.assert:
+        that:
+          - regions is successful
+          - regions is not changed
+          - '"regions" in regions'
+          - '"endpoint" in first_region'
+          - '"opt_in_status" in first_region'
+          - '"region_name" in first_region'
 
-  - name: List available Regions - check_mode
-    aws_region_info:
-    register: check_regions
-  - name: check task return attributes - check_mode
-    vars:
-      first_region: '{{ check_regions.regions[0] }}'
-    assert:
-      that:
-      - check_regions is successful
-      - check_regions is not changed
-      - '"regions" in check_regions'
-      - '"endpoint" in first_region'
-      - '"opt_in_status" in first_region'
-      - '"region_name" in first_region'
+    - name: List available Regions - check_mode
+      community.aws.aws_region_info:
+      register: check_regions
+    - name: check task return attributes - check_mode
+      vars:
+        first_region: "{{ check_regions.regions[0] }}"
+      ansible.builtin.assert:
+        that:
+          - check_regions is successful
+          - check_regions is not changed
+          - '"regions" in check_regions'
+          - '"endpoint" in first_region'
+          - '"opt_in_status" in first_region'
+          - '"region_name" in first_region'
 
-  - name: Filter available Regions using - ("region-name")
-    aws_region_info:
-      filters:
-        region-name: us-west-1
-    register: us_west_1
-  - name: check task return attributes - filtering using -
-    vars:
-      first_region: '{{ us_west_1.regions[0] }}'
-    assert:
-      that:
-      - us_west_1 is successful
-      - us_west_1 is not changed
-      - '"regions" in us_west_1'
-      - us_west_1.regions | length == 1
-      - '"endpoint" in first_region'
-      - first_region.endpoint == 'ec2.us-west-1.amazonaws.com'
-      - '"opt_in_status" in first_region'
-      - first_region.opt_in_status == 'opt-in-not-required'
-      - '"region_name" in first_region'
-      - first_region.region_name == 'us-west-1'
+    - name: Filter available Regions using - ("region-name")
+      community.aws.aws_region_info:
+        filters:
+          region-name: us-west-1
+      register: us_west_1
+    - name: check task return attributes - filtering using -
+      vars:
+        first_region: "{{ us_west_1.regions[0] }}"
+      ansible.builtin.assert:
+        that:
+          - us_west_1 is successful
+          - us_west_1 is not changed
+          - '"regions" in us_west_1'
+          - us_west_1.regions | length == 1
+          - '"endpoint" in first_region'
+          - first_region.endpoint == 'ec2.us-west-1.amazonaws.com'
+          - '"opt_in_status" in first_region'
+          - first_region.opt_in_status == 'opt-in-not-required'
+          - '"region_name" in first_region'
+          - first_region.region_name == 'us-west-1'
 
-  - name: Filter available Regions using _ ("region_name")
-    aws_region_info:
-      filters:
-        region_name: us-west-2
-    register: us_west_2
-  - name: check task return attributes - filtering using _
-    vars:
-      first_region: '{{ us_west_2.regions[0] }}'
-    assert:
-      that:
-      - us_west_2 is successful
-      - us_west_2 is not changed
-      - '"regions" in us_west_2'
-      - us_west_2.regions | length == 1
-      - '"endpoint" in first_region'
-      - first_region.endpoint == 'ec2.us-west-2.amazonaws.com'
-      - '"opt_in_status" in first_region'
-      - first_region.opt_in_status == 'opt-in-not-required'
-      - '"region_name" in first_region'
-      - first_region.region_name == 'us-west-2'
+    - name: Filter available Regions using _ ("region_name")
+      community.aws.aws_region_info:
+        filters:
+          region_name: us-west-2
+      register: us_west_2
+    - name: check task return attributes - filtering using _
+      vars:
+        first_region: "{{ us_west_2.regions[0] }}"
+      ansible.builtin.assert:
+        that:
+          - us_west_2 is successful
+          - us_west_2 is not changed
+          - '"regions" in us_west_2'
+          - us_west_2.regions | length == 1
+          - '"endpoint" in first_region'
+          - first_region.endpoint == 'ec2.us-west-2.amazonaws.com'
+          - '"opt_in_status" in first_region'
+          - first_region.opt_in_status == 'opt-in-not-required'
+          - '"region_name" in first_region'
+          - first_region.region_name == 'us-west-2'
 
-  - name: Filter available Regions using _ and - to check precedence
-    aws_region_info:
-      filters:
-        region-name: eu-west-1
-        region_name: eu-central-1
-    register: regions_prededence
-  - name: check task return attributes - precedence
-    vars:
-      first_region: '{{ regions_prededence.regions[0] }}'
-    assert:
-      that:
-      - regions_prededence is successful
-      - regions_prededence is not changed
-      - '"regions" in regions_prededence'
-      - regions_prededence.regions | length == 1
-      - '"endpoint" in first_region'
-      - first_region.endpoint == 'ec2.eu-central-1.amazonaws.com'
-      - '"opt_in_status" in first_region'
-      - first_region.opt_in_status == 'opt-in-not-required'
-      - '"region_name" in first_region'
-      - first_region.region_name == 'eu-central-1'
+    - name: Filter available Regions using _ and - to check precedence
+      community.aws.aws_region_info:
+        filters:
+          region-name: eu-west-1
+          region_name: eu-central-1
+      register: regions_prededence
+    - name: check task return attributes - precedence
+      vars:
+        first_region: "{{ regions_prededence.regions[0] }}"
+      ansible.builtin.assert:
+        that:
+          - regions_prededence is successful
+          - regions_prededence is not changed
+          - '"regions" in regions_prededence'
+          - regions_prededence.regions | length == 1
+          - '"endpoint" in first_region'
+          - first_region.endpoint == 'ec2.eu-central-1.amazonaws.com'
+          - '"opt_in_status" in first_region'
+          - first_region.opt_in_status == 'opt-in-not-required'
+          - '"region_name" in first_region'
+          - first_region.region_name == 'eu-central-1'

--- a/tests/integration/targets/backup_plan/defaults/main.yml
+++ b/tests/integration/targets/backup_plan/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for test_backup_plan
-backup_vault_name: '{{ tiny_prefix }}-backup-vault'
-backup_plan_name: '{{ tiny_prefix }}-backup-plan'
+backup_vault_name: "{{ tiny_prefix }}-backup-vault"
+backup_plan_name: "{{ tiny_prefix }}-backup-plan"

--- a/tests/integration/targets/backup_plan/tasks/main.yml
+++ b/tests/integration/targets/backup_plan/tasks/main.yml
@@ -88,7 +88,7 @@
         rules:
           - rule_name: hourly
             target_backup_vault_name: "{{ backup_vault_name }}"
-            schedule_expression: "cron(0 * ? * * *)"
+            schedule_expression: cron(0 * ? * * *)
         tags:
           Environment: Dev
       check_mode: true
@@ -108,7 +108,7 @@
         rules:
           - rule_name: hourly
             target_backup_vault_name: "{{ backup_vault_name }}"
-            schedule_expression: "cron(0 * ? * * *)"
+            schedule_expression: cron(0 * ? * * *)
             start_window_minutes: 60
             completion_window_minutes: 150
             lifecycle:
@@ -149,7 +149,7 @@
         rules:
           - rule_name: hourly
             target_backup_vault_name: "{{ backup_vault_name }}"
-            schedule_expression: "cron(0 * ? * * *)"
+            schedule_expression: cron(0 * ? * * *)
             start_window_minutes: 60
             completion_window_minutes: 150
             lifecycle:
@@ -189,7 +189,7 @@
         rules:
           - rule_name: hourly
             target_backup_vault_name: "{{ backup_vault_name }}"
-            schedule_expression: "cron(0 * ? * * *)"
+            schedule_expression: cron(0 * ? * * *)
             start_window_minutes: 60
             completion_window_minutes: 150
             lifecycle:
@@ -237,7 +237,7 @@
         rules:
           - rule_name: hourly
             target_backup_vault_name: "{{ backup_vault_name }}"
-            schedule_expression: "cron(0 * ? * * *)"
+            schedule_expression: cron(0 * ? * * *)
             start_window_minutes: 60
             completion_window_minutes: 150
             lifecycle:

--- a/tests/integration/targets/backup_selection/defaults/main.yml
+++ b/tests/integration/targets/backup_selection/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for backup_selection integration tests
-backup_iam_role_name: 'ansible-test-{{ tiny_prefix }}-backup-iam-role'
-backup_vault_name: '{{ tiny_prefix }}-backup-vault'
-backup_plan_name: '{{ tiny_prefix }}-backup-plan'
-backup_selection_name: '{{ tiny_prefix }}-backup-selection'
+backup_iam_role_name: ansible-test-{{ tiny_prefix }}-backup-iam-role
+backup_vault_name: "{{ tiny_prefix }}-backup-vault"
+backup_plan_name: "{{ tiny_prefix }}-backup-plan"
+backup_selection_name: "{{ tiny_prefix }}-backup-selection"

--- a/tests/integration/targets/backup_selection/tasks/main.yml
+++ b/tests/integration/targets/backup_selection/tasks/main.yml
@@ -7,7 +7,6 @@
       region: "{{ aws_region }}"
 
   block:
-
   # ============================================================
   #   Setup
   # ============================================================
@@ -16,10 +15,10 @@
       community.aws.iam_role:
         name: "{{ backup_iam_role_name }}"
         assume_role_policy_document: '{{ lookup("file", "backup-policy.json") }}'
-        create_instance_profile: no
-        description: "Ansible AWS Backup Role"
+        create_instance_profile: false
+        description: Ansible AWS Backup Role
         managed_policy:
-          - "arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup"
+          - arn:aws:iam::aws:policy/service-role/AWSBackupServiceRolePolicyForBackup
         wait: true
       register: iam_role
 
@@ -43,7 +42,7 @@
         rules:
           - rule_name: DailyBackups
             target_backup_vault_name: "{{ backup_vault_name }}"
-            schedule_expression: "cron(0 5 ? * * *)"
+            schedule_expression: cron(0 5 ? * * *)
             start_window_minutes: 60
             completion_window_minutes: 1440
         tags:
@@ -54,17 +53,17 @@
       ansible.builtin.set_fact:
         backup_plan_id: "{{ _result_create_backup_plan.backup_plan_id }}"
 
-  # ============================================================
-  #   Create Selection Tests
-  # ============================================================
+    # ============================================================
+    #   Create Selection Tests
+    # ============================================================
 
-  #  Create selection with all options
-  # ------------------------------------------------------------
+    #  Create selection with all options
+    # ------------------------------------------------------------
 
     - name: Set input variable for create selection with all options tests
       ansible.builtin.set_fact:
         create_with_all_options_input:
-          selection_name: "all-options-{{ backup_selection_name }}"
+          selection_name: all-options-{{ backup_selection_name }}
           backup_plan_name: "{{ backup_plan_name }}"
           iam_role_arn: "{{ iam_role.iam_role.arn }}"
           resources:
@@ -72,26 +71,25 @@
           not_resources:
             - arn:aws:s3:::another-bucket
           list_of_tags:
-            - condition_type: "STRINGEQUALS"
-              condition_key: "backup"
-              condition_value: "daily"
+            - condition_type: STRINGEQUALS
+              condition_key: backup
+              condition_value: daily
           conditions:
             string_equals:
-              - condition_key: "aws:ResourceTag/environment"
-                condition_value: "prod"
+              - condition_key: aws:ResourceTag/environment
+                condition_value: prod
             string_like:
-              - condition_key: "aws:ResourceTag/environment"
-                condition_value: "prod*"
+              - condition_key: aws:ResourceTag/environment
+                condition_value: prod*
             string_not_equals:
-              - condition_key: "aws:ResourceTag/environment"
-                condition_value: "test"
+              - condition_key: aws:ResourceTag/environment
+                condition_value: test
             string_not_like:
-              - condition_key: "aws:ResourceTag/environment"
-                condition_value: "test*"
+              - condition_key: aws:ResourceTag/environment
+                condition_value: test*
 
     - name: Create an AWS Backup selection with all options (check_mode)
-      amazon.aws.backup_selection:
-        "{{ create_with_all_options_input }}"
+      amazon.aws.backup_selection: "{{ create_with_all_options_input }}"
       check_mode: true
       register: _result_create_selection_with_all_options_check_mode
 
@@ -104,7 +102,7 @@
       amazon.aws.backup_selection_info:
         backup_plan_name: "{{ backup_plan_name }}"
         selection_names:
-          - "all-options-{{ backup_selection_name }}"
+          - all-options-{{ backup_selection_name }}
       register: _result_backup_selection_info
 
     - name: Verify backup selection was not created in check mode
@@ -113,8 +111,7 @@
           - _result_backup_selection_info.backup_selections | length == 0
 
     - name: Create an AWS Backup selection with all options
-      amazon.aws.backup_selection:
-        "{{ create_with_all_options_input }}"
+      amazon.aws.backup_selection: "{{ create_with_all_options_input }}"
       register: _result_create_selection_with_all_options
 
     - name: Verify result
@@ -126,8 +123,7 @@
           - _result_create_selection_with_all_options.backup_selection.selection_name == "all-options-"+backup_selection_name
 
     - name: Create an AWS Backup selection with all options (idempotency)
-      amazon.aws.backup_selection:
-        "{{ create_with_all_options_input }}"
+      amazon.aws.backup_selection: "{{ create_with_all_options_input }}"
       register: _result_create_selection_with_all_options_idempotency
 
     - name: Verify result
@@ -142,7 +138,7 @@
       amazon.aws.backup_selection_info:
         backup_plan_name: "{{ backup_plan_name }}"
         selection_names:
-          - "all-options-{{ backup_selection_name }}"
+          - all-options-{{ backup_selection_name }}
       register: _result_backup_selection_info
 
     - name: Verify selection was created with all options
@@ -159,8 +155,8 @@
           - _result_backup_selection_info.backup_selections[0].conditions.string_not_equals | length == 1
           - _result_backup_selection_info.backup_selections[0].conditions.string_not_like | length == 1
 
-  #  Create selection with minimal options
-  # ------------------------------------------------------------
+    #  Create selection with minimal options
+    # ------------------------------------------------------------
 
     - name: Set input variable for create selection with minimal options tests
       ansible.builtin.set_fact:
@@ -172,8 +168,7 @@
             - arn:aws:s3:::a-bucket
 
     - name: Create an AWS Backup selection with minimal options (check_mode)
-      amazon.aws.backup_selection:
-        "{{ create_with_minimal_options_input }}"
+      amazon.aws.backup_selection: "{{ create_with_minimal_options_input }}"
       check_mode: true
       register: _result_create_selection_with_minimal_options_check_mode
 
@@ -195,8 +190,7 @@
           - _result_backup_selection_info.backup_selections | length == 0
 
     - name: Create an AWS Backup selection with minimal options
-      amazon.aws.backup_selection:
-        "{{ create_with_minimal_options_input }}"
+      amazon.aws.backup_selection: "{{ create_with_minimal_options_input }}"
       register: _result_create_selection_with_minimal_options
 
     - name: Verify result
@@ -208,8 +202,7 @@
           - _result_create_selection_with_minimal_options.backup_selection.selection_name == backup_selection_name
 
     - name: Create an AWS Backup selection with minimal options (idempotency)
-      amazon.aws.backup_selection:
-        "{{ create_with_minimal_options_input }}"
+      amazon.aws.backup_selection: "{{ create_with_minimal_options_input }}"
       register: _result_create_selection_with_minimal_options_idempotency
 
     - name: Verify result
@@ -241,12 +234,12 @@
           - _result_backup_selection_info.backup_selections[0].conditions.string_not_equals | length == 0
           - _result_backup_selection_info.backup_selections[0].conditions.string_not_like | length == 0
 
-  # ============================================================
-  #   Update Selection Tests
-  # ============================================================
+    # ============================================================
+    #   Update Selection Tests
+    # ============================================================
 
-  #  Add list_of_tags
-  # ------------------------------------------------------------
+    #  Add list_of_tags
+    # ------------------------------------------------------------
 
     - name: Set input variable for add list_of_tags tests
       ansible.builtin.set_fact:
@@ -257,13 +250,12 @@
           resources:
             - arn:aws:s3:::a-bucket
           list_of_tags:
-            - condition_type: "STRINGEQUALS"
-              condition_key: "backup"
-              condition_value: "weekly"
+            - condition_type: STRINGEQUALS
+              condition_key: backup
+              condition_value: weekly
 
     - name: Modify an AWS Backup selection - add list_of_tags (check_mode)
-      amazon.aws.backup_selection:
-        "{{ add_list_of_tags_input }}"
+      amazon.aws.backup_selection: "{{ add_list_of_tags_input }}"
       check_mode: true
       register: _result_add_list_of_tags_check_mode
 
@@ -286,8 +278,7 @@
           - _result_backup_selection_info.backup_selections[0].list_of_tags == []
 
     - name: Modify an AWS Backup selection - add list_of_tags
-      amazon.aws.backup_selection:
-        "{{ add_list_of_tags_input }}"
+      amazon.aws.backup_selection: "{{ add_list_of_tags_input }}"
       register: _result_add_list_of_tags
 
     - name: Verify result
@@ -296,8 +287,7 @@
           - _result_add_list_of_tags.changed
 
     - name: Modify an AWS Backup selection - add list_of_tags (idempotency)
-      amazon.aws.backup_selection:
-        "{{ add_list_of_tags_input }}"
+      amazon.aws.backup_selection: "{{ add_list_of_tags_input }}"
       register: _result_add_list_of_tags_idempotency
 
     - name: Verify result
@@ -322,8 +312,8 @@
           - _result_backup_selection_info.backup_selections[0].list_of_tags[0].condition_value == "weekly"
           - _result_backup_selection_info.backup_selections[0].conditions.string_not_equals == []
 
-  #  Add conditions
-  # ------------------------------------------------------------
+    #  Add conditions
+    # ------------------------------------------------------------
 
     - name: Set input variable for add conditions tests
       ansible.builtin.set_fact:
@@ -334,17 +324,16 @@
           resources:
             - arn:aws:s3:::a-bucket
           list_of_tags:
-            - condition_type: "STRINGEQUALS"
-              condition_key: "backup"
-              condition_value: "weekly"
+            - condition_type: STRINGEQUALS
+              condition_key: backup
+              condition_value: weekly
           conditions:
             string_not_equals:
-              - condition_key: "aws:ResourceTag/environment"
-                condition_value: "dev"
+              - condition_key: aws:ResourceTag/environment
+                condition_value: dev
 
     - name: Modify an AWS Backup selection - add conditions (check_mode)
-      amazon.aws.backup_selection:
-        "{{ add_conditions_input }}"
+      amazon.aws.backup_selection: "{{ add_conditions_input }}"
       check_mode: true
       register: _result_add_conditions_check_mode
 
@@ -367,8 +356,7 @@
           - _result_backup_selection_info.backup_selections[0].conditions.string_not_equals == []
 
     - name: Modify an AWS Backup selection - add conditions
-      amazon.aws.backup_selection:
-        "{{ add_conditions_input }}"
+      amazon.aws.backup_selection: "{{ add_conditions_input }}"
       register: _result_add_conditions
 
     - name: Verify result
@@ -377,8 +365,7 @@
           - _result_add_conditions.changed
 
     - name: Modify an AWS Backup selection - add conditions (idempotency)
-      amazon.aws.backup_selection:
-        "{{ add_conditions_input }}"
+      amazon.aws.backup_selection: "{{ add_conditions_input }}"
       register: _result_add_conditions_idempotency
 
     - name: Verify result
@@ -403,8 +390,8 @@
           - _result_backup_selection_info.backup_selections[0].list_of_tags[0].condition_value == "weekly"
           - _result_backup_selection_info.backup_selections[0].conditions.string_not_equals[0].condition_value == "dev"
 
-  #  Update all options
-  # ------------------------------------------------------------
+    #  Update all options
+    # ------------------------------------------------------------
 
     - name: Set input variable for update all options tests
       ansible.builtin.set_fact:
@@ -417,17 +404,16 @@
           not_resources:
             - arn:aws:s3:::a-bucket
           list_of_tags:
-            - condition_type: "STRINGEQUALS"
-              condition_key: "backup"
-              condition_value: "daily"
+            - condition_type: STRINGEQUALS
+              condition_key: backup
+              condition_value: daily
           conditions:
             string_not_equals:
-              - condition_key: "aws:ResourceTag/environment"
-                condition_value: "test"
+              - condition_key: aws:ResourceTag/environment
+                condition_value: test
 
     - name: Modify an AWS Backup selection - update all options (check_mode)
-      amazon.aws.backup_selection:
-        "{{ update_all_options_input }}"
+      amazon.aws.backup_selection: "{{ update_all_options_input }}"
       check_mode: true
       register: _result_update_all_options_check_mode
 
@@ -453,8 +439,7 @@
           - _result_backup_selection_info.backup_selections[0].conditions.string_not_equals[0].condition_value == "dev"
 
     - name: Modify an AWS Backup selection - update all options
-      amazon.aws.backup_selection:
-        "{{ update_all_options_input }}"
+      amazon.aws.backup_selection: "{{ update_all_options_input }}"
       register: _result_update_all_options
 
     - name: Verify result
@@ -463,8 +448,7 @@
           - _result_update_all_options.changed
 
     - name: Modify an AWS Backup selection - update_all_options (idempotency)
-      amazon.aws.backup_selection:
-        "{{ update_all_options_input }}"
+      amazon.aws.backup_selection: "{{ update_all_options_input }}"
       register: _result_update_all_options_idempotency
 
     - name: Verify result
@@ -489,8 +473,8 @@
           - _result_backup_selection_info.backup_selections[0].list_of_tags[0].condition_value == "daily"
           - _result_backup_selection_info.backup_selections[0].conditions.string_not_equals[0].condition_value == "test"
 
-  #  Remove list_of_tags
-  # ------------------------------------------------------------
+    #  Remove list_of_tags
+    # ------------------------------------------------------------
 
     - name: Set input variable for remove list_of_tags tests
       ansible.builtin.set_fact:
@@ -504,12 +488,11 @@
             - arn:aws:s3:::a-bucket
           conditions:
             string_not_equals:
-              - condition_key: "aws:ResourceTag/environment"
-                condition_value: "test"
+              - condition_key: aws:ResourceTag/environment
+                condition_value: test
 
     - name: Modify an AWS Backup selection - remove list_of_tags (check_mode)
-      amazon.aws.backup_selection:
-        "{{ remove_list_of_tags_input }}"
+      amazon.aws.backup_selection: "{{ remove_list_of_tags_input }}"
       check_mode: true
       register: _result_remove_list_of_tags_check_mode
 
@@ -535,8 +518,7 @@
           - _result_backup_selection_info.backup_selections[0].conditions.string_not_equals[0].condition_value == "test"
 
     - name: Modify an AWS Backup selection - remove list_of_tags
-      amazon.aws.backup_selection:
-        "{{ remove_list_of_tags_input }}"
+      amazon.aws.backup_selection: "{{ remove_list_of_tags_input }}"
       register: _result_remove_list_of_tags
 
     - name: Verify result
@@ -545,8 +527,7 @@
           - _result_remove_list_of_tags.changed
 
     - name: Modify an AWS Backup selection - remove list_of_tags (idempotency)
-      amazon.aws.backup_selection:
-        "{{ remove_list_of_tags_input }}"
+      amazon.aws.backup_selection: "{{ remove_list_of_tags_input }}"
       register: _result_remove_list_of_tags_idempotency
 
     - name: Verify result
@@ -571,8 +552,8 @@
           - _result_backup_selection_info.backup_selections[0].list_of_tags == []
           - _result_backup_selection_info.backup_selections[0].conditions.string_not_equals[0].condition_value == "test"
 
-  #  Remove conditions
-  # ------------------------------------------------------------
+    #  Remove conditions
+    # ------------------------------------------------------------
 
     - name: Set input variable for remove conditions tests
       ansible.builtin.set_fact:
@@ -586,8 +567,7 @@
             - arn:aws:s3:::a-bucket
 
     - name: Modify an AWS Backup selection - remove conditions (check_mode)
-      amazon.aws.backup_selection:
-        "{{ remove_conditions_input }}"
+      amazon.aws.backup_selection: "{{ remove_conditions_input }}"
       check_mode: true
       register: _result_remove_conditions_check_mode
 
@@ -613,8 +593,7 @@
           - _result_backup_selection_info.backup_selections[0].conditions.string_not_equals[0].condition_value == "test"
 
     - name: Modify an AWS Backup selection - remove conditions
-      amazon.aws.backup_selection:
-        "{{ remove_conditions_input }}"
+      amazon.aws.backup_selection: "{{ remove_conditions_input }}"
       register: _result_remove_conditions
 
     - name: Verify result
@@ -623,8 +602,7 @@
           - _result_remove_conditions.changed
 
     - name: Modify an AWS Backup selection - remove conditions (idempotency)
-      amazon.aws.backup_selection:
-        "{{ remove_conditions_input }}"
+      amazon.aws.backup_selection: "{{ remove_conditions_input }}"
       register: _result_remove_conditions_idempotency
 
     - name: Verify result
@@ -649,9 +627,9 @@
           - _result_backup_selection_info.backup_selections[0].list_of_tags == []
           - _result_backup_selection_info.backup_selections[0].conditions.string_not_equals == []
 
-  # ============================================================
-  #   List Selection Tests
-  # ============================================================
+    # ============================================================
+    #   List Selection Tests
+    # ============================================================
 
     - name: List all AWS Backup selections
       amazon.aws.backup_selection_info:
@@ -664,9 +642,9 @@
           - "'backup_selections' in _result_backup_selection_list"
           - _result_backup_selection_list.backup_selections | length == 2
 
-  # ============================================================
-  #   Delete Selection Tests
-  # ============================================================
+    # ============================================================
+    #   Delete Selection Tests
+    # ============================================================
 
     - name: Set input variable for delete selection tests
       ansible.builtin.set_fact:
@@ -676,8 +654,7 @@
           state: absent
 
     - name: Delete AWS Backup selection (check_mode)
-      amazon.aws.backup_selection:
-        "{{ delete_selection_input }}"
+      amazon.aws.backup_selection: "{{ delete_selection_input }}"
       check_mode: true
       register: _delete_result_backup_selection_check_mode
 
@@ -703,8 +680,7 @@
           - _result_backup_selection_info.backup_selections[0].selection_name == backup_selection_name
 
     - name: Delete AWS Backup selection
-      amazon.aws.backup_selection:
-        "{{ delete_selection_input }}"
+      amazon.aws.backup_selection: "{{ delete_selection_input }}"
       register: _delete_result_backup_selection
 
     - name: Verify result
@@ -727,8 +703,7 @@
           - _deleted_backup_selection_info.backup_selections | length == 0
 
     - name: Delete AWS Backup selection (idempotency)
-      amazon.aws.backup_selection:
-        "{{ delete_selection_input }}"
+      amazon.aws.backup_selection: "{{ delete_selection_input }}"
       register: _delete_result_backup_selection_idempotency
 
     - name: Verify result
@@ -738,9 +713,9 @@
           - not _delete_result_backup_selection_idempotency.exists
           - "'backup_selection' in _delete_result_backup_selection_idempotency"
 
-# ============================================================
-#   Teardown
-# ============================================================
+  # ============================================================
+  #   Teardown
+  # ============================================================
 
   always:
     - name: Delete minimal AWS Backup selection created during this test
@@ -752,7 +727,7 @@
 
     - name: Delete all options AWS Backup selection created during this test
       amazon.aws.backup_selection:
-        backup_selection_name: "all-options-{{ backup_selection_name }}"
+        backup_selection_name: all-options-{{ backup_selection_name }}
         backup_plan_name: "{{ backup_plan_name }}"
         state: absent
       ignore_errors: true

--- a/tests/integration/targets/backup_tag/defaults/main.yml
+++ b/tests/integration/targets/backup_tag/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
 # defaults file for test_backup_tag
-backup_vault_name: '{{ tiny_prefix }}-backup-vault'
+backup_vault_name: "{{ tiny_prefix }}-backup-vault"

--- a/tests/integration/targets/backup_tag/meta/main.yml
+++ b/tests/integration/targets/backup_tag/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/backup_tag/tasks/main.yml
+++ b/tests/integration/targets/backup_tag/tasks/main.yml
@@ -6,13 +6,12 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-
     - name: Create an AWS Backup Vault so we have something to tag
       amazon.aws.backup_vault:
         backup_vault_name: "{{ backup_vault_name }}"
       register: backup_vault_create_result
 
-    - set_fact:
+    - ansible.builtin.set_fact:
         vault_arn: "{{ backup_vault_create_result.vault.backup_vault_arn }}"
 
     - name: List tags on a backup vault
@@ -20,7 +19,7 @@
         resource: "{{ vault_arn }}"
       register: current_tags
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - '"tags" in current_tags'
           - current_tags.tags | length == 0
@@ -30,14 +29,14 @@
         resource: "{{ vault_arn }}"
         state: present
         tags:
-            CamelCaseKey: CamelCaseValue
-            pascalCaseKey: pascalCaseValue
-            snake_case_key: snake_case_value
-            test_tag_key_1: tag_tag_value_1
-            test_tag_key_2: tag_tag_value_2
+          CamelCaseKey: CamelCaseValue
+          pascalCaseKey: pascalCaseValue
+          snake_case_key: snake_case_value
+          test_tag_key_1: tag_tag_value_1
+          test_tag_key_2: tag_tag_value_2
       register: add_tags_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - add_tags_result is changed
           - add_tags_result.tags | length == 5
@@ -53,10 +52,10 @@
         resource: "{{ vault_arn }}"
         state: absent
         tags:
-            CamelCaseKey: CamelCaseValue
+          CamelCaseKey: CamelCaseValue
       register: remove_specified_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - remove_specified_result is changed
           - remove_specified_result.tags | length == 4
@@ -71,12 +70,12 @@
         resource: "{{ vault_arn }}"
         state: absent
         tags:
-            test_tag_key_1: tag_tag_value_1
-            test_tag_key_2: tag_tag_value_2
+          test_tag_key_1: tag_tag_value_1
+          test_tag_key_2: tag_tag_value_2
         purge_tags: true
       register: remove_except_specified_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - remove_except_specified_result is changed
           - remove_except_specified_result.tags | length == 2
@@ -89,10 +88,10 @@
         resource: "{{ vault_arn }}"
         state: present
         tags:
-            test_tag_key_1: test_tag_NEW_VALUE_1
+          test_tag_key_1: test_tag_NEW_VALUE_1
       register: update_specified_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_specified_result is changed
           - update_specified_result.tags | length == 2
@@ -107,7 +106,7 @@
         purge_tags: true
       register: remove_all_tags_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - '"tags" in remove_all_tags_result'
           - remove_all_tags_result.tags | length == 0

--- a/tests/integration/targets/backup_vault/defaults/main.yml
+++ b/tests/integration/targets/backup_vault/defaults/main.yml
@@ -1,5 +1,4 @@
 ---
 # defaults file for test_backup_vault
-backup_vault_name: '{{ tiny_prefix }}-backup-vault'
-kms_key_alias: ansible-test-{{ inventory_hostname | replace('_','-') }}{{ tiny_prefix
-  }}
+backup_vault_name: "{{ tiny_prefix }}-backup-vault"
+kms_key_alias: ansible-test-{{ inventory_hostname | replace('_','-') }}{{ tiny_prefix }}

--- a/tests/integration/targets/backup_vault/meta/main.yml
+++ b/tests/integration/targets/backup_vault/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/backup_vault/tasks/main.yml
+++ b/tests/integration/targets/backup_vault/tasks/main.yml
@@ -8,10 +8,10 @@
   block:
     - name: create a key
       kms_key:
-        alias: '{{ kms_key_alias }}'
+        alias: "{{ kms_key_alias }}"
         state: present
-        enabled: yes
-        enable_key_rotation: no
+        enabled: true
+        enable_key_rotation: false
       register: key
 
     - name: Create an AWS Backup Vault - check mode
@@ -21,9 +21,9 @@
         tags:
           environment: dev
       register: backup_vault_result_check
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - backup_vault_result_check is changed
           - backup_vault_result_check.vault.backup_vault_name == backup_vault_name
@@ -38,7 +38,7 @@
           environment: dev
       register: backup_vault_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - backup_vault_result is changed
           - backup_vault_result.vault.backup_vault_name == backup_vault_name
@@ -51,7 +51,7 @@
           - "{{ backup_vault_name }}"
       register: vault_info
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - vault_info.backup_vaults[0].backup_vault_name == backup_vault_result.vault.backup_vault_name
           - vault_info.backup_vaults[0].backup_vault_arn == backup_vault_result.vault.backup_vault_arn
@@ -65,7 +65,7 @@
           environment: dev
       register: backup_vault_result_idem
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - backup_vault_result_idem is not changed
           - backup_vault_result_idem.vault.backup_vault_name == backup_vault_name
@@ -82,7 +82,7 @@
       register: backup_vault_update_check_mode_result
 
     - name: Verify check mode update result
-      assert:
+      ansible.builtin.assert:
         that:
           - backup_vault_update_check_mode_result is changed
           - backup_vault_update_check_mode_result.vault.backup_vault_name == backup_vault_name
@@ -254,6 +254,6 @@
     - name: finish off by deleting keys
       kms_key:
         state: absent
-        alias: '{{ kms_key_alias }}'
+        alias: "{{ kms_key_alias }}"
         pending_window: 7
       ignore_errors: true

--- a/tests/integration/targets/callback_aws_resource_actions/main.yml
+++ b/tests/integration/targets/callback_aws_resource_actions/main.yml
@@ -1,7 +1,8 @@
+---
 - hosts: localhost
-  gather_facts: no
+  gather_facts: false
   collections:
-  - amazon.aws
+    - amazon.aws
   module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -9,27 +10,27 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   tasks:
-  - ec2_instance_info:
-    register: ec2_info
+    - amazon.aws.ec2_instance_info:
+      register: ec2_info
 
-  - assert:
-      that:
-      - '"resource_actions" in ec2_info'
-      - '"ec2:DescribeInstances" in ec2_info.resource_actions'
+    - ansible.builtin.assert:
+        that:
+          - '"resource_actions" in ec2_info'
+          - '"ec2:DescribeInstances" in ec2_info.resource_actions'
 
-  - aws_az_info:
-    register: az_info
+    - amazon.aws.aws_az_info:
+      register: az_info
 
-  - assert:
-      that:
-      - '"resource_actions" in az_info'
-      - '"ec2:DescribeAvailabilityZones" in az_info.resource_actions'
+    - ansible.builtin.assert:
+        that:
+          - '"resource_actions" in az_info'
+          - '"ec2:DescribeAvailabilityZones" in az_info.resource_actions'
 
-  - aws_caller_info:
-    register: caller_info
+    - amazon.aws.aws_caller_info:
+      register: caller_info
 
-  - assert:
-      that:
-      - '"resource_actions" in caller_info'
-      - '"sts:GetCallerIdentity" in caller_info.resource_actions'
-      - '"iam:ListAccountAliases" in caller_info.resource_actions'
+    - ansible.builtin.assert:
+        that:
+          - '"resource_actions" in caller_info'
+          - '"sts:GetCallerIdentity" in caller_info.resource_actions'
+          - '"iam:ListAccountAliases" in caller_info.resource_actions'

--- a/tests/integration/targets/callback_aws_resource_actions/meta/main.yml
+++ b/tests/integration/targets/callback_aws_resource_actions/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/cloudformation/defaults/main.yml
+++ b/tests/integration/targets/cloudformation/defaults/main.yml
@@ -1,10 +1,11 @@
+---
 stack_name: "{{ resource_prefix }}"
 stack_name_disable_rollback_true: "{{ resource_prefix }}-drb-true"
 stack_name_disable_rollback_false: "{{ resource_prefix }}-drb-false"
 
-availability_zone: '{{ ec2_availability_zone_names[0] }}'
+availability_zone: "{{ ec2_availability_zone_names[0] }}"
 
-vpc_name: '{{ resource_prefix }}-vpc'
-vpc_seed: '{{ resource_prefix }}'
-vpc_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.0.0/16'
-subnet_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.32.0/24'
+vpc_name: "{{ resource_prefix }}-vpc"
+vpc_seed: "{{ resource_prefix }}"
+vpc_cidr: 10.{{ 256 | random(seed=vpc_seed) }}.0.0/16
+subnet_cidr: 10.{{ 256 | random(seed=vpc_seed) }}.32.0/24

--- a/tests/integration/targets/cloudformation/meta/main.yml
+++ b/tests/integration/targets/cloudformation/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
-- role: setup_ec2_facts
+  - role: setup_ec2_facts

--- a/tests/integration/targets/cloudformation/tasks/main.yml
+++ b/tests/integration/targets/cloudformation/tasks/main.yml
@@ -1,17 +1,16 @@
 ---
 - module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
   block:
-
     # ==== Env setup ==========================================================
 
     - name: Create a test VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         name: "{{ vpc_name }}"
         cidr_block: "{{ vpc_cidr }}"
         tags:
@@ -19,7 +18,7 @@
       register: testing_vpc
 
     - name: Create a test subnet
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
@@ -27,50 +26,33 @@
 
     # ==== Cloudformation tests with disable_rollback ====================
 
-    - import_tasks: test_disable_rollback.yml
-
-    # ==== Cloudformation tests ===============================================
-
-    # 1. Basic stack creation (check mode, actual run and idempotency)
-    # 2. Tags
-    # 3. cloudformation_info tests (basic + all_facts)
-    # 4. termination_protection
-    # 5. create_changeset + changeset_name
-
-    # There is still scope to add tests for -
-    # 1. capabilities
-    # 2. stack_policy
-    # 3. on_create_failure (covered in unit tests)
-    # 4. Passing in a role
-    # 5. nested stacks?
-
-
+    - ansible.builtin.import_tasks: test_disable_rollback.yml
     - name: create a cloudformation stack (check mode)
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
         tags:
           Stack: "{{ stack_name }}"
           test: "{{ resource_prefix }}"
       register: cf_stack
-      check_mode: yes
+      check_mode: true
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - cf_stack.changed
           - "'msg' in cf_stack and 'New stack would be created' in cf_stack.msg"
 
     - name: create a cloudformation stack
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
         tags:
@@ -79,7 +61,7 @@
       register: cf_stack
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - cf_stack.changed
           - "'events' in cf_stack"
@@ -88,30 +70,30 @@
           - "'stack_resources' in cf_stack"
 
     - name: create a cloudformation stack (check mode) (idempotent)
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
         tags:
           Stack: "{{ stack_name }}"
           test: "{{ resource_prefix }}"
       register: cf_stack
-      check_mode: yes
+      check_mode: true
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - not cf_stack.changed
 
     - name: create a cloudformation stack (idempotent)
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
         tags:
@@ -120,7 +102,7 @@
       register: cf_stack
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - not cf_stack.changed
           - "'output' in cf_stack and 'Stack is already up-to-date.' in cf_stack.output"
@@ -128,57 +110,57 @@
           - "'stack_resources' in cf_stack"
 
     - name: get all stacks details
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
       register: all_stacks_info
 
     - name: assert all stacks info
-      assert:
+      ansible.builtin.assert:
         that:
           - all_stacks_info | length > 0
 
     - name: get stack details
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
     - name: assert stack info
-      assert:
+      ansible.builtin.assert:
         that:
           - "'cloudformation' in stack_info"
-          - "stack_info.cloudformation | length == 1"
-          - "stack_name in stack_info.cloudformation"
+          - stack_info.cloudformation | length == 1
+          - stack_name in stack_info.cloudformation
           - "'stack_description' in stack_info.cloudformation[stack_name]"
           - "'stack_outputs' in stack_info.cloudformation[stack_name]"
           - "'stack_parameters' in stack_info.cloudformation[stack_name]"
           - "'stack_tags' in stack_info.cloudformation[stack_name]"
-          - "stack_info.cloudformation[stack_name].stack_tags.Stack == stack_name"
+          - stack_info.cloudformation[stack_name].stack_tags.Stack == stack_name
 
     - name: get stack details (checkmode)
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
-      check_mode: yes
+      check_mode: true
 
     - name: assert stack info
-      assert:
+      ansible.builtin.assert:
         that:
           - "'cloudformation' in stack_info"
-          - "stack_info.cloudformation | length == 1"
-          - "stack_name in stack_info.cloudformation"
+          - stack_info.cloudformation | length == 1
+          - stack_name in stack_info.cloudformation
           - "'stack_description' in stack_info.cloudformation[stack_name]"
           - "'stack_outputs' in stack_info.cloudformation[stack_name]"
           - "'stack_parameters' in stack_info.cloudformation[stack_name]"
           - "'stack_tags' in stack_info.cloudformation[stack_name]"
-          - "stack_info.cloudformation[stack_name].stack_tags.Stack == stack_name"
+          - stack_info.cloudformation[stack_name].stack_tags.Stack == stack_name
 
     - name: get stack details (all_facts)
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
-        all_facts: yes
+        all_facts: true
       register: stack_info
 
     - name: assert stack info
-      assert:
+      ansible.builtin.assert:
         that:
           - "'stack_events' in stack_info.cloudformation[stack_name]"
           - "'stack_policy' in stack_info.cloudformation[stack_name]"
@@ -187,14 +169,14 @@
           - "'stack_template' in stack_info.cloudformation[stack_name]"
 
     - name: get stack details (all_facts) (checkmode)
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
-        all_facts: yes
+        all_facts: true
       register: stack_info
-      check_mode: yes
+      check_mode: true
 
     - name: assert stack info
-      assert:
+      ansible.builtin.assert:
         that:
           - "'stack_events' in stack_info.cloudformation[stack_name]"
           - "'stack_policy' in stack_info.cloudformation[stack_name]"
@@ -206,13 +188,13 @@
 
     # try to create a changeset by changing instance type
     - name: create a changeset
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
-        create_changeset: yes
-        changeset_name: "test-changeset"
+        create_changeset: true
+        changeset_name: test-changeset
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.micro"
+          InstanceType: t3.micro
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
         tags:
@@ -221,43 +203,43 @@
       register: create_changeset_result
 
     - name: assert changeset created
-      assert:
+      ansible.builtin.assert:
         that:
-          - "create_changeset_result.changed"
+          - create_changeset_result.changed
           - "'change_set_id' in create_changeset_result"
           - "'Stack CREATE_CHANGESET complete' in create_changeset_result.output"
 
     - name: get stack details with changesets
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
-        stack_change_sets: True
+        stack_change_sets: true
       register: stack_info
 
     - name: assert changesets in info
-      assert:
+      ansible.builtin.assert:
         that:
           - "'stack_change_sets' in stack_info.cloudformation[stack_name]"
 
     - name: get stack details with changesets (checkmode)
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
-        stack_change_sets: True
+        stack_change_sets: true
       register: stack_info
-      check_mode: yes
+      check_mode: true
 
     - name: assert changesets in info
-      assert:
+      ansible.builtin.assert:
         that:
           - "'stack_change_sets' in stack_info.cloudformation[stack_name]"
 
     # try to create an empty changeset by passing in unchanged template
     - name: create a changeset
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
-        create_changeset: yes
+        create_changeset: true
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
         tags:
@@ -266,20 +248,20 @@
       register: create_changeset_result
 
     - name: assert changeset created
-      assert:
+      ansible.builtin.assert:
         that:
-          - "not create_changeset_result.changed"
+          - not create_changeset_result.changed
           - "'The created Change Set did not contain any changes to this stack and was deleted.' in create_changeset_result.output"
 
     # ==== Cloudformation tests (termination_protection) ======================
 
     - name: set termination protection to true
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
-        termination_protection: yes
+        termination_protection: true
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
         tags:
@@ -287,40 +269,40 @@
           test: "{{ resource_prefix }}"
       register: cf_stack
 
-#    This fails - #65592
-#    - name: check task return attributes
-#      assert:
-#        that:
-#          - cf_stack.changed
+    #    This fails - #65592
+    #    - name: check task return attributes
+    #      assert:
+    #        that:
+    #          - cf_stack.changed
 
     - name: get stack details
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
     - name: assert stack info
-      assert:
+      ansible.builtin.assert:
         that:
-          - "stack_info.cloudformation[stack_name].stack_description.enable_termination_protection"
+          - stack_info.cloudformation[stack_name].stack_description.enable_termination_protection
 
     - name: get stack details (checkmode)
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
-      check_mode: yes
+      check_mode: true
 
     - name: assert stack info
-      assert:
+      ansible.builtin.assert:
         that:
-          - "stack_info.cloudformation[stack_name].stack_description.enable_termination_protection"
+          - stack_info.cloudformation[stack_name].stack_description.enable_termination_protection
 
     - name: set termination protection to false
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
-        termination_protection: no
+        termination_protection: false
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
         tags:
@@ -328,42 +310,42 @@
           test: "{{ resource_prefix }}"
       register: cf_stack
 
-#    This fails - #65592
-#    - name: check task return attributes
-#      assert:
-#        that:
-#          - cf_stack.changed
+    #    This fails - #65592
+    #    - name: check task return attributes
+    #      assert:
+    #        that:
+    #          - cf_stack.changed
 
     - name: get stack details
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
     - name: assert stack info
-      assert:
+      ansible.builtin.assert:
         that:
-          - "not stack_info.cloudformation[stack_name].stack_description.enable_termination_protection"
+          - not stack_info.cloudformation[stack_name].stack_description.enable_termination_protection
 
     - name: get stack details (checkmode)
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
-      check_mode: yes
+      check_mode: true
 
     - name: assert stack info
-      assert:
+      ansible.builtin.assert:
         that:
-          - "not stack_info.cloudformation[stack_name].stack_description.enable_termination_protection"
+          - not stack_info.cloudformation[stack_name].stack_description.enable_termination_protection
 
     # ==== Cloudformation tests (update_policy) ======================
 
     - name: setting an stack policy with json body
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         stack_policy_body: "{{ lookup('file','update_policy.json') }}"
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
         tags:
@@ -372,17 +354,17 @@
       register: cf_stack
 
     - name: get stack details
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
     - name: setting an stack policy on update
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         stack_policy_on_update_body: "{{ lookup('file','update_policy.json') }}"
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
         tags:
@@ -391,46 +373,46 @@
       register: cf_stack
 
     - name: get stack details
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
     # ==== Cloudformation tests (delete stack tests) ==========================
 
     - name: delete cloudformation stack (check mode)
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         state: absent
-      check_mode: yes
+      check_mode: true
       register: cf_stack
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - cf_stack.changed
           - "'msg' in cf_stack and 'Stack would be deleted' in cf_stack.msg"
 
     - name: delete cloudformation stack
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         state: absent
       register: cf_stack
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - cf_stack.changed
           - "'output' in cf_stack and 'Stack Deleted' in cf_stack.output"
 
     - name: delete cloudformation stack (check mode) (idempotent)
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         state: absent
-      check_mode: yes
+      check_mode: true
       register: cf_stack
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - not cf_stack.changed
           - "'msg' in cf_stack"
@@ -438,58 +420,57 @@
             "Stack doesn't exist" in cf_stack.msg
 
     - name: delete cloudformation stack (idempotent)
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         state: absent
       register: cf_stack
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - not cf_stack.changed
           - "'output' in cf_stack and 'Stack not found.' in cf_stack.output"
 
     - name: get stack details
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
     - name: assert stack info
-      assert:
+      ansible.builtin.assert:
         that:
-          - "not stack_info.cloudformation"
+          - not stack_info.cloudformation
 
     - name: get stack details (checkmode)
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
-      check_mode: yes
+      check_mode: true
 
     - name: assert stack info
-      assert:
+      ansible.builtin.assert:
         that:
-          - "not stack_info.cloudformation"
+          - not stack_info.cloudformation
 
-    # ==== Cleanup ============================================================
+  # ==== Cleanup ============================================================
 
   always:
-
     - name: delete stack
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Delete test subnet
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         cidr: "{{ subnet_cidr }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Delete test VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         name: "{{ vpc_name }}"
         cidr_block: "{{ vpc_cidr }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/cloudformation/tasks/test_disable_rollback.yml
+++ b/tests/integration/targets/cloudformation/tasks/test_disable_rollback.yml
@@ -1,7 +1,6 @@
 ---
 - name: Run cloudformation tests for `disable_rollback` parameter
   block:
-
     # disable rollback to true
     - name: create a cloudformation stack (disable_rollback=true) (check mode)
       amazon.aws.cloudformation:
@@ -10,14 +9,14 @@
         disable_rollback: true
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
-      check_mode: yes
+      check_mode: true
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - cf_stack.changed
           - "'msg' in cf_stack and 'New stack would be created' in cf_stack.msg"
@@ -29,18 +28,18 @@
         disable_rollback: true
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
 
     - name: get stack details
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name_disable_rollback_true }}"
       register: stack_info
 
     - name: assert stack info
-      assert:
+      ansible.builtin.assert:
         that:
           - "'cloudformation' in stack_info"
           - stack_info.cloudformation | length == 1
@@ -54,14 +53,14 @@
         disable_rollback: false
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
-      check_mode: yes
+      check_mode: true
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - cf_stack.changed
           - "'msg' in cf_stack and 'New stack would be created' in cf_stack.msg"
@@ -73,22 +72,22 @@
         disable_rollback: false
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
 
     - name: get stack details
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name_disable_rollback_false }}"
       register: stack_info
 
     - name: assert stack info
-      assert:
+      ansible.builtin.assert:
         that:
           - "'cloudformation' in stack_info"
-          - "stack_info.cloudformation | length == 1"
-          - "stack_info.cloudformation[stack_name_disable_rollback_false].stack_description.disable_rollback == false"
+          - stack_info.cloudformation | length == 1
+          - stack_info.cloudformation[stack_name_disable_rollback_false].stack_description.disable_rollback == false
 
     # disable rollback not set
     - name: create a cloudformation stack (disable_rollback not set) (check mode)
@@ -97,14 +96,14 @@
         state: present
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
-      check_mode: yes
+      check_mode: true
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - cf_stack.changed
           - "'msg' in cf_stack and 'New stack would be created' in cf_stack.msg"
@@ -115,22 +114,22 @@
         state: present
         template_body: "{{ lookup('file','cf_template.json') }}"
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
 
     - name: get stack details
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
     - name: assert stack info
-      assert:
+      ansible.builtin.assert:
         that:
           - "'cloudformation' in stack_info"
-          - "stack_info.cloudformation | length == 1"
-          - "stack_info.cloudformation[stack_name].stack_description.disable_rollback == false"
+          - stack_info.cloudformation | length == 1
+          - stack_info.cloudformation[stack_name].stack_description.disable_rollback == false
 
     # =============================================================================================
     # Test Scenario
@@ -147,20 +146,20 @@
         template_body: "{{ lookup('file','cf_template.json') }}"
         disable_rollback: false
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
       ignore_errors: true
 
-    - name:  Update the cloudformation stack with wrong ami (fails, does not delete failed as disable_rollback=true)
+    - name: Update the cloudformation stack with wrong ami (fails, does not delete failed as disable_rollback=true)
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}-failtest"
         state: present
         template_body: "{{ lookup('file','cf_template.json') }}"
         disable_rollback: true
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}1" # wrong ami provided
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
@@ -174,7 +173,7 @@
         template_body: "{{ lookup('file','cf_template.json') }}"
         disable_rollback: false
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
@@ -187,27 +186,26 @@
         template_body: "{{ lookup('file','cf_template.json') }}"
         disable_rollback: true
         template_parameters:
-          InstanceType: "t3.nano"
+          InstanceType: t3.nano
           ImageId: "{{ ec2_ami_id }}"
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
 
     - name: get stack details
-      cloudformation_info:
+      amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}-failtest"
       register: stack_info
 
     - name: Assert that update was successful
-      assert:
+      ansible.builtin.assert:
         that:
           - cf_stack.changed
           - cf_stack.output == "Stack UPDATE complete"
           - stack_info.cloudformation[stack_name+"-failtest"].stack_description.stack_status == "UPDATE_COMPLETE"
 
   always:
-
     - name: delete stack
-      cloudformation:
+      amazon.aws.cloudformation:
         stack_name: "{{ item }}"
         state: absent
       ignore_errors: true

--- a/tests/integration/targets/cloudtrail/defaults/main.yml
+++ b/tests/integration/targets/cloudtrail/defaults/main.yml
@@ -1,8 +1,9 @@
-cloudtrail_name: '{{ resource_prefix }}-cloudtrail'
-s3_bucket_name: '{{ resource_prefix }}-cloudtrail-bucket'
-kms_alias: '{{ resource_prefix }}-cloudtrail'
-sns_topic: '{{ resource_prefix }}-cloudtrail-notifications'
-cloudtrail_prefix: 'ansible-test-prefix'
-cloudwatch_log_group: '{{ resource_prefix }}-cloudtrail'
-cloudwatch_role: '{{ resource_prefix }}-cloudtrail'
-cloudwatch_no_kms_role: '{{ resource_prefix }}-cloudtrail2'
+---
+cloudtrail_name: "{{ resource_prefix }}-cloudtrail"
+s3_bucket_name: "{{ resource_prefix }}-cloudtrail-bucket"
+kms_alias: "{{ resource_prefix }}-cloudtrail"
+sns_topic: "{{ resource_prefix }}-cloudtrail-notifications"
+cloudtrail_prefix: ansible-test-prefix
+cloudwatch_log_group: "{{ resource_prefix }}-cloudtrail"
+cloudwatch_role: "{{ resource_prefix }}-cloudtrail"
+cloudwatch_no_kms_role: "{{ resource_prefix }}-cloudtrail2"

--- a/tests/integration/targets/cloudtrail/meta/main.yml
+++ b/tests/integration/targets/cloudtrail/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/cloudtrail/tasks/main.yml
+++ b/tests/integration/targets/cloudtrail/tasks/main.yml
@@ -28,1568 +28,1563 @@
 - module_defaults:
     # Add this as a default because we (almost) always need it
     amazon.aws.cloudtrail:
-      s3_bucket_name: '{{ s3_bucket_name }}'
-      region: '{{ aws_region }}'
+      s3_bucket_name: "{{ s3_bucket_name }}"
+      region: "{{ aws_region }}"
   collections:
     - amazon.aws
   block:
-
   # ============================================================
   #   Argument Tests
   # ============================================================
-  - name: 'S3 Bucket required when state is "present"'
-    module_defaults: { cloudtrail: {} }
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-    register: output
-    ignore_errors: yes
-  - assert:
-      that:
-      - output is failed
-
-  - name: 'CloudWatch cloudwatch_logs_log_group_arn required when cloudwatch_logs_role_arn passed'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      cloudwatch_logs_role_arn: 'SomeValue'
-    register: output
-    ignore_errors: yes
-  - assert:
-      that:
-      - output is failed
-      - '"parameters are required together" in output.msg'
-      - '"cloudwatch_logs_log_group_arn" in output.msg'
-
-  - name: 'CloudWatch cloudwatch_logs_role_arn required when cloudwatch_logs_log_group_arn passed'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      cloudwatch_logs_log_group_arn: 'SomeValue'
-    register: output
-    ignore_errors: yes
-  - assert:
-      that:
-      - output is failed
-      - '"parameters are required together" in output.msg'
-      - '"cloudwatch_logs_role_arn" in output.msg'
-
-  #- name: 'Global Logging must be enabled when enabling Multi-region'
-  #  cloudtrail:
-  #    state: present
-  #    name: '{{ cloudtrail_name }}'
-  #    include_global_events: no
-  #    is_multi_region_trail: yes
-  #  register: output
-  #  ignore_errors: yes
-  #- assert:
-  #    that:
-  #    - output is failed
-
-  # ============================================================
-  #   Preparation
-  # ============================================================
-  - name: 'Retrieve caller facts'
-    aws_caller_info: {}
-    register: aws_caller_info
-
-  - name: 'Create S3 bucket'
-    vars:
-      bucket_name: '{{ s3_bucket_name }}'
-    s3_bucket:
-      state: present
-      name: '{{ bucket_name }}'
-      policy: '{{ lookup("template", "s3-policy.j2") }}'
-  - name: 'Create second S3 bucket'
-    vars:
-      bucket_name: '{{ s3_bucket_name }}-2'
-    s3_bucket:
-      state: present
-      name: '{{ bucket_name }}'
-      policy: '{{ lookup("template", "s3-policy.j2") }}'
-
-  - name: 'Create SNS Topic'
-    vars:
-      sns_topic_name: '{{ sns_topic }}'
-    sns_topic:
-      state: present
-      name: '{{ sns_topic_name }}'
-      display_name: 'Used for testing SNS/CloudWatch integration'
-      policy: "{{ lookup('template', 'sns-policy.j2') | to_json }}"
-    register: output_sns_topic
-  - name: 'Create second SNS Topic'
-    vars:
-      sns_topic_name: '{{ sns_topic }}-2'
-    sns_topic:
-      state: present
-      name: '{{ sns_topic_name }}'
-      display_name: 'Used for testing SNS/CloudWatch integration'
-      policy: "{{ lookup('template', 'sns-policy.j2') | to_json }}"
-
-  - name: 'Create KMS Key'
-    kms_key:
-      state: present
-      alias: '{{ kms_alias }}'
-      enabled: yes
-      policy: "{{ lookup('template', 'kms-policy.j2') | to_json }}"
-    register: kms_key
-  - name: 'Create second KMS Key'
-    kms_key:
-      state: present
-      alias: '{{ kms_alias }}-2'
-      enabled: yes
-      policy: "{{ lookup('template', 'kms-policy.j2') | to_json }}"
-    register: kms_key2
-
-  - name: 'Create CloudWatch IAM Role'
-    iam_role:
-      state: present
-      name: '{{ cloudwatch_role }}'
-      assume_role_policy_document: "{{ lookup('template', 'cloudwatch-assume-policy.j2') }}"
-    register: output_cloudwatch_role
-  - name: 'Create CloudWatch Log Group'
-    cloudwatchlogs_log_group:
-      state: present
-      log_group_name: '{{ cloudwatch_log_group }}'
-      retention: 1
-    register: output_cloudwatch_log_group
-  - name: 'Create second CloudWatch Log Group'
-    cloudwatchlogs_log_group:
-      state: present
-      log_group_name: '{{ cloudwatch_log_group }}-2'
-      retention: 1
-    register: output_cloudwatch_log_group2
-  - name: 'Add inline policy to CloudWatch Role'
-    iam_policy:
-      state: present
-      iam_type: role
-      iam_name: '{{ cloudwatch_role }}'
-      policy_name: 'CloudWatch'
-      policy_json: "{{ lookup('template', 'cloudwatch-policy.j2') | to_json }}"
-
-  - name: 'Create CloudWatch IAM Role with no kms permissions'
-    iam_role:
-      state: present
-      name: '{{ cloudwatch_no_kms_role }}'
-      assume_role_policy_document: "{{ lookup('template', 'cloudtrail-no-kms-assume-policy.j2') }}"
-      managed_policies:
-        - "arn:aws:iam::aws:policy/AWSCloudTrail_FullAccess"
-    register: output_cloudwatch_no_kms_role
-
-  - name: pause to ensure role exists before attaching policy
-    pause:
-      seconds: 15
-
-  - name: 'Add inline policy to CloudWatch Role'
-    iam_policy:
-      state: present
-      iam_type: role
-      iam_name: '{{ cloudwatch_no_kms_role }}'
-      policy_name: 'CloudWatchNokms'
-      policy_json: "{{ lookup('template', 'cloudtrail-no-kms-policy.j2') }}"
-
-  # ============================================================
-  #   Tests
-  # ============================================================
-
-  - name: 'Create a trail (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Create a trail'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.exists == True
-      - output.trail.name == cloudtrail_name
-
-  - name: 'No-op update to trail'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.exists == True
-      # Check everything is what we expect before we start making changes
-      - output.trail.name == cloudtrail_name
-      - output.trail.home_region == aws_region
-      - output.trail.include_global_service_events == True
-      - output.trail.is_multi_region_trail == False
-      - output.trail.is_logging == True
-      - output.trail.log_file_validation_enabled == False
-      - output.trail.s3_bucket_name == s3_bucket_name
-      - output.trail.s3_key_prefix is none
-      - output.trail.kms_key_id is none
-      - output.trail.sns_topic_arn is none
-      - output.trail.sns_topic_name is none
-      - output.trail.tags | length == 0
-
-  - name: 'Get the trail info'
-    cloudtrail_info:
-    register: info
-
-  - name: 'Get the trail name from the cloud trail info'
-    set_fact:
-      trail_present: true
-      trail_arn: '{{ item.resource_id }}'
-    when: item.name == cloudtrail_name
-    loop: "{{ info.trail_list }}"
-
-  - name: 'Assert that the trail name is present in the info'
-    assert:
-      that:
-      - trail_present is defined
-      - trail_present == True
-
-  # ============================================================
-
-  - name: 'Set S3 prefix (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_key_prefix: '{{ cloudtrail_prefix }}'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Set S3 prefix'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_key_prefix: '{{ cloudtrail_prefix }}'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.s3_key_prefix == cloudtrail_prefix
-
-  - name: 'Set S3 prefix (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_key_prefix: '{{ cloudtrail_prefix }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.s3_key_prefix == cloudtrail_prefix
-
-  - name: 'No-op update to trail'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.s3_key_prefix == cloudtrail_prefix
-
-  - name: 'Get the trail info'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the s3_key_prefix is correct'
-    assert:
-      that:
-       - info.trail_list[0].s3_key_prefix == cloudtrail_prefix
-
-  - name: 'Update S3 prefix (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_key_prefix: '{{ cloudtrail_prefix }}-2'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Update S3 prefix'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_key_prefix: '{{ cloudtrail_prefix }}-2'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - 'output.trail.s3_key_prefix ==  cloudtrail_prefix+"-2"'
-
-  - name: 'Update S3 prefix (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_key_prefix: '{{ cloudtrail_prefix }}-2'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - 'output.trail.s3_key_prefix ==  cloudtrail_prefix+"-2"'
-
-  - name: 'Get the trail info after updating S3 prefix'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the s3_key_prefix is correct'
-    assert:
-      that:
-       - 'info.trail_list[0].s3_key_prefix == cloudtrail_prefix+"-2"'
-
-  - name: 'Remove S3 prefix (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_key_prefix: '/'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Remove S3 prefix'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_key_prefix: '/'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.s3_key_prefix is none
-
-  - name: 'Remove S3 prefix (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_key_prefix: '/'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.s3_key_prefix is none
-
-  - name: 'Get the trail info after removing S3 prefix'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the s3_key_prefix is None'
-    assert:
-      that:
-       - info.trail_list[0].s3_key_prefix is not defined
-
-  # ============================================================
-
-  - include_tasks: 'tagging.yml'
-
-  # ============================================================
-
-  - name: 'Set SNS Topic (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      sns_topic_name: '{{ sns_topic }}'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Set SNS Topic'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      sns_topic_name: '{{ sns_topic }}'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.sns_topic_name == sns_topic
-
-  - name: 'Set SNS Topic (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      sns_topic_name: '{{ sns_topic }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.sns_topic_name == sns_topic
-
-  - name: 'No-op update to trail'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.sns_topic_name == sns_topic
-
-  - name: 'Get the trail info with SNS topic'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the sns_topic is correctly set'
-    assert:
-      that:
-       - info.trail_list[0].sns_topic_name == sns_topic
-
-  - name: 'Update SNS Topic (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      sns_topic_name: '{{ sns_topic }}-2'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Update SNS Topic'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      sns_topic_name: '{{ sns_topic }}-2'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - 'output.trail.sns_topic_name ==  sns_topic+"-2"'
-
-  - name: 'Update SNS Topic (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      sns_topic_name: '{{ sns_topic }}-2'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - 'output.trail.sns_topic_name ==  sns_topic+"-2"'
-
-  - name: 'Get the trail info with SNS topic after update'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the sns_topic is correctly set'
-    assert:
-      that:
-       - 'info.trail_list[0].sns_topic_name == sns_topic+"-2"'
-
-  #- name: 'Remove SNS Topic (CHECK MODE)'
-  #  cloudtrail:
-  #    state: present
-  #    name: '{{ cloudtrail_name }}'
-  #    sns_topic_name: ''
-  #  register: output
-  #  check_mode: yes
-  #- assert:
-  #    that:
-  #    - output is changed
-
-  #- name: 'Remove SNS Topic'
-  #  cloudtrail:
-  #    state: present
-  #    name: '{{ cloudtrail_name }}'
-  #    sns_topic_name: ''
-  #  register: output
-  #- assert:
-  #    that:
-  #    - output is changed
-  #    - output.trail.name == cloudtrail_name
-  #    - output.trail.sns_topic_name is none
-
-  #- name: 'Remove SNS Topic (no change)'
-  #  cloudtrail:
-  #    state: present
-  #    name: '{{ cloudtrail_name }}'
-  #    sns_topic_name: ''
-  #  register: output
-  #- assert:
-  #    that:
-  #    - output is not changed
-  #    - output.trail.name == cloudtrail_name
-  #    - output.trail.sns_topic_name is none
-
-
-  # ============================================================
-
-  - name: 'Set CloudWatch Log Group (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      cloudwatch_logs_log_group_arn: '{{ output_cloudwatch_log_group.arn }}'
-      cloudwatch_logs_role_arn: '{{ output_cloudwatch_role.arn }}'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Set CloudWatch Log Group'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      cloudwatch_logs_log_group_arn: '{{ output_cloudwatch_log_group.arn }}'
-      cloudwatch_logs_role_arn: '{{ output_cloudwatch_role.arn }}'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.cloud_watch_logs_log_group_arn == output_cloudwatch_log_group.arn
-      - output.trail.cloud_watch_logs_role_arn == output_cloudwatch_role.arn
-
-  - name: 'Set CloudWatch Log Group (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      cloudwatch_logs_log_group_arn: '{{ output_cloudwatch_log_group.arn }}'
-      cloudwatch_logs_role_arn: '{{ output_cloudwatch_role.arn }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.cloud_watch_logs_log_group_arn == output_cloudwatch_log_group.arn
-      - output.trail.cloud_watch_logs_role_arn == output_cloudwatch_role.arn
-
-  - name: 'No-op update to trail'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.cloud_watch_logs_log_group_arn == output_cloudwatch_log_group.arn
-      - output.trail.cloud_watch_logs_role_arn == output_cloudwatch_role.arn
-
-  - name: 'Get the trail info with CloudWatch Log Group'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the cloud watch log group is correctly set'
-    assert:
-      that:
-       - info.trail_list[0].cloud_watch_logs_log_group_arn == output_cloudwatch_log_group.arn
-       - info.trail_list[0].cloud_watch_logs_role_arn == output_cloudwatch_role.arn
-
-  - name: 'Update CloudWatch Log Group (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      cloudwatch_logs_log_group_arn: '{{ output_cloudwatch_log_group2.arn }}'
-      cloudwatch_logs_role_arn: '{{ output_cloudwatch_role.arn }}'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-      - output.trail.cloud_watch_logs_log_group_arn == output_cloudwatch_log_group2.arn
-      - output.trail.cloud_watch_logs_role_arn == output_cloudwatch_role.arn
-
-  - name: 'Update CloudWatch Log Group'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      cloudwatch_logs_log_group_arn: '{{ output_cloudwatch_log_group2.arn }}'
-      cloudwatch_logs_role_arn: '{{ output_cloudwatch_role.arn }}'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.cloud_watch_logs_log_group_arn == output_cloudwatch_log_group2.arn
-      - output.trail.cloud_watch_logs_role_arn == output_cloudwatch_role.arn
-
-  - name: 'Update CloudWatch Log Group (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      cloudwatch_logs_log_group_arn: '{{ output_cloudwatch_log_group2.arn }}'
-      cloudwatch_logs_role_arn: '{{ output_cloudwatch_role.arn }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.cloud_watch_logs_log_group_arn == output_cloudwatch_log_group2.arn
-      - output.trail.cloud_watch_logs_role_arn == output_cloudwatch_role.arn
-
-  - name: 'Get the trail info with CloudWatch Log Group after update'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the cloud watch log group is correctly set after update'
-    assert:
-      that:
-       - info.trail_list[0].cloud_watch_logs_log_group_arn == output_cloudwatch_log_group2.arn
-       - info.trail_list[0].cloud_watch_logs_role_arn == output_cloudwatch_role.arn
-
-  #- name: 'Remove CloudWatch Log Group (CHECK MODE)'
-  #  cloudtrail:
-  #    state: present
-  #    name: '{{ cloudtrail_name }}'
-  #    cloudwatch_logs_log_group_arn: ''
-  #    cloudwatch_logs_role_arn: ''
-  #  register: output
-  #  check_mode: yes
-  #- assert:
-  #    that:
-  #    - output is changed
-  #    - output.trail.name == cloudtrail_name
-  #    - output.trail.cloud_watch_logs_log_group_arn is none
-  #    - output.trail.cloud_watch_logs_role_arn is none
-
-  #- name: 'Remove CloudWatch Log Group'
-  #  cloudtrail:
-  #    state: present
-  #    name: '{{ cloudtrail_name }}'
-  #    cloudwatch_logs_log_group_arn: ''
-  #    cloudwatch_logs_role_arn: ''
-  #  register: output
-  #- assert:
-  #    that:
-  #    - output is changed
-  #    - output.trail.name == cloudtrail_name
-  #    - output.trail.cloud_watch_logs_log_group_arn is none
-  #    - output.trail.cloud_watch_logs_role_arn is none
-
-  #- name: 'Remove CloudWatch Log Group (no change)'
-  #  cloudtrail:
-  #    state: present
-  #    name: '{{ cloudtrail_name }}'
-  #    cloudwatch_logs_log_group_arn: ''
-  #    cloudwatch_logs_role_arn: ''
-  #  register: output
-  #- assert:
-  #    that:
-  #    - output is not changed
-  #    - output.trail.name == cloudtrail_name
-  #    - output.trail.cloud_watch_logs_log_group_arn is none
-  #    - output.trail.cloud_watch_logs_role_arn is none
-
-  # ============================================================
-
-  - name: 'Update S3 bucket (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_bucket_name: '{{ s3_bucket_name }}-2'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Update S3 bucket'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_bucket_name: '{{ s3_bucket_name }}-2'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - 'output.trail.s3_bucket_name ==  s3_bucket_name+"-2"'
-
-  - name: 'Update S3 bucket (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_bucket_name: '{{ s3_bucket_name }}-2'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - 'output.trail.s3_bucket_name ==  s3_bucket_name+"-2"'
-
-  - name: 'Get the trail info with S3 bucket name'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the S3 Bucket name is correctly set'
-    assert:
-      that:
-      - 'info.trail_list[0].s3_bucket_name ==  s3_bucket_name+"-2"'
-      
-  - name: 'Reset S3 bucket'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-    register: output
-  - assert:
-      that:
-      - output.trail.name == cloudtrail_name
-      - output.trail.s3_bucket_name == s3_bucket_name
-
-  # ============================================================
-
-  - name: 'Disable logging (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      enable_logging: no
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Disable logging'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      enable_logging: no
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.is_logging == False
-
-  - name: 'Disable logging (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      enable_logging: no
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.is_logging == False
-
-  - name: 'Get the trail info to check the logging state'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the logging state is correctly set'
-    assert:
-      that:
-      - info.trail_list[0].is_logging ==  False
-
-  # Ansible Documentation lists logging as explicitly defaulting to enabled
-
-  - name: 'Enable logging (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      enable_logging: yes
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Enable logging'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      enable_logging: yes
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.is_logging == True
-
-  - name: 'Enable logging (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      enable_logging: yes
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.is_logging == True
-
-  - name: 'Get the trail info to check the logging state'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the logging state is correctly set'
-    assert:
-      that:
-      - info.trail_list[0].is_logging ==  True
-
-  # ============================================================
-
-  - name: 'Disable global logging (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      include_global_events: no
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Disable global logging'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      include_global_events: no
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.include_global_service_events == False
-
-  - name: 'Disable global logging (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      include_global_events: no
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.include_global_service_events == False
-
-  - name: 'Get the trail info to check the global logging state'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the global logging state is correctly set'
-    assert:
-      that:
-      - info.trail_list[0].include_global_service_events ==  False
-
-  # Ansible Documentation lists Global-logging as explicitly defaulting to enabled
-
-  - name: 'Enable global logging (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      include_global_events: yes
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Enable global logging'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      include_global_events: yes
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.include_global_service_events == True
-
-  - name: 'Enable global logging (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      include_global_events: yes
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.include_global_service_events == True
-
-  - name: 'Get the trail info to check the global logging state (default)'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the global logging state is correctly set (default)'
-    assert:
-      that:
-      - info.trail_list[0].include_global_service_events == True
-
-  # ============================================================
-
-  - name: 'Enable multi-region logging (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      is_multi_region_trail: yes
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Enable multi-region logging'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      is_multi_region_trail: yes
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.is_multi_region_trail == True
-
-  - name: 'Enable multi-region logging (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      is_multi_region_trail: yes
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.is_multi_region_trail == True
-
-  - name: 'Get the trail info to check the multi-region logging state (default)'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the global logging state is correctly set (default)'
-    assert:
-      that:
-      - info.trail_list[0].is_multi_region_trail == True
-
-  # Ansible Documentation lists Multi-Region-logging as explicitly defaulting to disabled
-
-  - name: 'Disable multi-region logging (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      is_multi_region_trail: no
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Disable multi-region logging'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      is_multi_region_trail: no
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.is_multi_region_trail == False
-
-  - name: 'Disable multi-region logging (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      is_multi_region_trail: no
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.is_multi_region_trail == False
-
-  - name: 'Get the trail info to check the multi-region logging state (default)'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the global logging state is correctly set (default)'
-    assert:
-      that:
-      - info.trail_list[0].is_multi_region_trail == False
-
-  # ============================================================
-
-  - name: 'Enable logfile validation (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      enable_log_file_validation: yes
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Enable logfile validation'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      enable_log_file_validation: yes
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.log_file_validation_enabled == True
-
-  - name: 'Enable logfile validation (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      enable_log_file_validation: yes
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.log_file_validation_enabled == True
-
-  - name: 'No-op update to trail'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.log_file_validation_enabled == True
-
-  - name: 'Get the trail info to check the log file validation'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the log file validation is correctly set'
-    assert:
-      that:
-      - info.trail_list[0].log_file_validation_enabled == True
-
-  - name: 'Disable logfile validation (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      enable_log_file_validation: no
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Disable logfile validation'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      enable_log_file_validation: no
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.log_file_validation_enabled == False
-
-  - name: 'Disable logfile validation (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      enable_log_file_validation: no
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.name == cloudtrail_name
-      - output.trail.log_file_validation_enabled == False
-
-  - name: 'Get the trail info to check the log file validation'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the log file validation is disabled'
-    assert:
-      that:
-      - info.trail_list[0].log_file_validation_enabled == False
-
-  # ============================================================
-
-  - name: 'Enable logging encryption (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: '{{ kms_key.key_arn }}'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Enable logging encryption'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: '{{ kms_key.key_arn }}'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.kms_key_id == kms_key.key_arn
-
-  - name: 'Enable logging encryption (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: '{{ kms_key.key_arn }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.kms_key_id == kms_key.key_arn
-
-  - name: 'Enable logging encryption (no change, check mode)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: '{{ kms_key.key_arn }}'
-    check_mode: yes
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.kms_key_id == kms_key.key_arn
-
-  - name: 'No-op update to trail'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.kms_key_id == kms_key.key_arn
-
-  - name: 'Get the trail info to check the logging encryption'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the logging encryption is correctly set'
-    assert:
-      that:
-      - info.trail_list[0].kms_key_id == kms_key.key_arn
-
-  - name: 'Update logging encryption key (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: '{{ kms_key2.key_arn }}'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Update logging encryption key'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: '{{ kms_key2.key_arn }}'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.kms_key_id == kms_key2.key_arn
-
-  - name: 'Update logging encryption key (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: '{{ kms_key2.key_arn }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.kms_key_id == kms_key2.key_arn
-
-  - name: 'Get the trail info to check the logging key encryption'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the logging key encryption is correctly set'
-    assert:
-      that:
-      - info.trail_list[0].kms_key_id == kms_key2.key_arn
-
-  - name: 'Update logging encryption to alias (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: 'alias/{{ kms_alias }}'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Update logging encryption to alias'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: 'alias/{{ kms_alias }}'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.trail.kms_key_id == kms_key.key_arn
-
-  - name: 'Update logging encryption to alias (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: 'alias/{{ kms_alias }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.kms_key_id == kms_key.key_arn
-
-  - name: 'Update logging encryption to alias (CHECK MODE, no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: '{{ kms_key.key_id }}' # Test when using key id
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is not changed
-      - output.trail.kms_key_id == kms_key.key_id
-
-  - debug:
-      msg: '{{ output }}'
-
-  - name: 'Get the trail info to check the logging key encryption after update'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the logging key encryption is correctly updated'
-    assert:
-      that:
-      - kms_key.key_id in info.trail_list[0].kms_key_id
-
-  # Assume role to a role with Denied access to KMS
-
-  - amazon.aws.sts_assume_role:
-      role_arn: '{{ output_cloudwatch_no_kms_role.arn }}'
-      role_session_name: "cloudtrailNoKms"
-      region: '{{ aws_region }}'
-    register: noKms_assumed_role
-
-  - name: 'Enable logging encryption w/ alias (no change, no kms permmissions, check mode)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: 'alias/{{ kms_alias }}'
-      access_key: "{{ noKms_assumed_role.sts_creds.access_key }}"
-      secret_key: "{{ noKms_assumed_role.sts_creds.secret_key }}"
-      session_token: "{{ noKms_assumed_role.sts_creds.session_token }}"
-    check_mode: yes
-    register: output
-  - assert:
-      that:
-      - output is changed
-      # when using check_mode, with no kms permissions, and not giving kms_key_id as a key arn
-      # output will always be marked as changed.
-
-  - name: 'Disable logging encryption (CHECK MODE)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: ''
-    register: output
-    check_mode: yes
-  - assert:
-     that:
-     - output is changed
-
-  - name: 'Disable logging encryption'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: ''
-    register: output
-  - assert:
-     that:
-     - output.trail.kms_key_id == ""
-     - output is changed
-
-  - name: 'Disable logging encryption (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      kms_key_id: ''
-    register: output
-  - assert:
-     that:
-     - output.kms_key_id == ""
-     - output is not changed
-
-  # ============================================================
-
-  - name: 'Delete a trail without providing bucket_name (CHECK MODE)'
-    module_defaults: { cloudtrail: {} }
-    cloudtrail:
-      state: absent
-      name: '{{ cloudtrail_name }}'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Delete a trail while providing bucket_name (CHECK MODE)'
-    cloudtrail:
-      state: absent
-      name: '{{ cloudtrail_name }}'
-    register: output
-    check_mode: yes
-  - assert:
-      that:
-      - output is changed
-
-  - name: 'Delete a trail'
-    cloudtrail:
-      state: absent
-      name: '{{ cloudtrail_name }}'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      - output.exists == False
-
-  - name: 'Delete a non-existent trail'
-    cloudtrail:
-      state: absent
-      name: '{{ cloudtrail_name }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.exists == False
-
-  # ============================================================
-
-  - name: 'Test creation of a complex Trail (all features)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_key_prefix: '{{ cloudtrail_prefix }}'
-      sns_topic_name: '{{ sns_topic }}'
-      cloudwatch_logs_log_group_arn: '{{ output_cloudwatch_log_group.arn }}'
-      cloudwatch_logs_role_arn: '{{ output_cloudwatch_role.arn }}'
-      is_multi_region_trail: yes
-      include_global_events: yes
-      enable_log_file_validation: yes
-      kms_key_id: '{{ kms_key.key_arn }}'
-    register: output
-  - assert:
-      that:
-      - output is changed
-      #- output.exists == True
-      - output.trail.name == cloudtrail_name
-      - output.trail.home_region == aws_region
-      - output.trail.include_global_service_events == True
-      - output.trail.is_multi_region_trail == True
-      - output.trail.is_logging == True
-      - output.trail.log_file_validation_enabled ==  True
-      - output.trail.s3_bucket_name == s3_bucket_name
-      - output.trail.s3_key_prefix == cloudtrail_prefix
-      - output.trail.kms_key_id == kms_key.key_arn
-      - output.trail.sns_topic_arn == output_sns_topic.sns_arn
-      - output.trail.sns_topic_name == sns_topic
-      - output.trail.tags | length == 0
-
-  - name: 'Test creation of a complex Trail (no change)'
-    cloudtrail:
-      state: present
-      name: '{{ cloudtrail_name }}'
-      s3_key_prefix: '{{ cloudtrail_prefix }}'
-      sns_topic_name: '{{ sns_topic }}'
-      cloudwatch_logs_log_group_arn: '{{ output_cloudwatch_log_group.arn }}'
-      cloudwatch_logs_role_arn: '{{ output_cloudwatch_role.arn }}'
-      is_multi_region_trail: yes
-      include_global_events: yes
-      enable_log_file_validation: yes
-      kms_key_id: '{{ kms_key.key_arn }}'
-    register: output
-  - assert:
-      that:
-      - output is not changed
-      - output.exists == True
-      - output.trail.name == cloudtrail_name
-      - output.trail.home_region == aws_region
-      - output.trail.include_global_service_events == True
-      - output.trail.is_multi_region_trail == True
-      - output.trail.is_logging == True
-      - output.trail.log_file_validation_enabled ==  True
-      - output.trail.s3_bucket_name == s3_bucket_name
-      - output.trail.s3_key_prefix == cloudtrail_prefix
-      - output.trail.kms_key_id == kms_key.key_arn
-      - output.trail.sns_topic_arn == output_sns_topic.sns_arn
-      - output.trail.sns_topic_name == sns_topic
-      - output.trail.tags | length == 0
-
-  - name: 'Get the trail info of the created trail'
-    cloudtrail_info:
-      trail_names:
-        - '{{ trail_arn }}'
-    register: info
-
-  - name: 'Assert that the logging key encryption is correctly updated'
-    assert:
-      that:
-      - info.trail_list[0].name == cloudtrail_name
-      - info.trail_list[0].home_region == aws_region
-      - info.trail_list[0].include_global_service_events == True
-      - info.trail_list[0].is_multi_region_trail == True
-      - info.trail_list[0].is_logging == True
-      - info.trail_list[0].log_file_validation_enabled ==  True
-      - info.trail_list[0].s3_bucket_name == s3_bucket_name
-      - info.trail_list[0].s3_key_prefix == cloudtrail_prefix
-      - info.trail_list[0].kms_key_id == kms_key.key_arn
-      - info.trail_list[0].sns_topic_arn == output_sns_topic.sns_arn
-      - info.trail_list[0].sns_topic_name == sns_topic
-      - info.trail_list[0].tags | length == 0
+    - name: S3 Bucket required when state is "present"
+      module_defaults: { cloudtrail: {}}
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+      register: output
+      ignore_errors: true
+    - ansible.builtin.assert:
+        that:
+          - output is failed
+
+    - name: CloudWatch cloudwatch_logs_log_group_arn required when cloudwatch_logs_role_arn passed
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        cloudwatch_logs_role_arn: SomeValue
+      register: output
+      ignore_errors: true
+    - ansible.builtin.assert:
+        that:
+          - output is failed
+          - '"parameters are required together" in output.msg'
+          - '"cloudwatch_logs_log_group_arn" in output.msg'
+
+    - name: CloudWatch cloudwatch_logs_role_arn required when cloudwatch_logs_log_group_arn passed
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        cloudwatch_logs_log_group_arn: SomeValue
+      register: output
+      ignore_errors: true
+    - ansible.builtin.assert:
+        that:
+          - output is failed
+          - '"parameters are required together" in output.msg'
+          - '"cloudwatch_logs_role_arn" in output.msg'
+
+    #- name: 'Global Logging must be enabled when enabling Multi-region'
+    #  cloudtrail:
+    #    state: present
+    #    name: '{{ cloudtrail_name }}'
+    #    include_global_events: no
+    #    is_multi_region_trail: yes
+    #  register: output
+    #  ignore_errors: yes
+    #- assert:
+    #    that:
+    #    - output is failed
+
+    # ============================================================
+    #   Preparation
+    # ============================================================
+    - name: Retrieve caller facts
+      amazon.aws.aws_caller_info: {}
+      register: aws_caller_info
+
+    - name: Create S3 bucket
+      vars:
+        bucket_name: "{{ s3_bucket_name }}"
+      amazon.aws.s3_bucket:
+        state: present
+        name: "{{ bucket_name }}"
+        policy: '{{ lookup("template", "s3-policy.j2") }}'
+    - name: Create second S3 bucket
+      vars:
+        bucket_name: "{{ s3_bucket_name }}-2"
+      amazon.aws.s3_bucket:
+        state: present
+        name: "{{ bucket_name }}"
+        policy: '{{ lookup("template", "s3-policy.j2") }}'
+
+    - name: Create SNS Topic
+      vars:
+        sns_topic_name: "{{ sns_topic }}"
+      community.aws.sns_topic:
+        state: present
+        name: "{{ sns_topic_name }}"
+        display_name: Used for testing SNS/CloudWatch integration
+        policy: "{{ lookup('template', 'sns-policy.j2') | to_json }}"
+      register: output_sns_topic
+    - name: Create second SNS Topic
+      vars:
+        sns_topic_name: "{{ sns_topic }}-2"
+      community.aws.sns_topic:
+        state: present
+        name: "{{ sns_topic_name }}"
+        display_name: Used for testing SNS/CloudWatch integration
+        policy: "{{ lookup('template', 'sns-policy.j2') | to_json }}"
+
+    - name: Create KMS Key
+      kms_key:
+        state: present
+        alias: "{{ kms_alias }}"
+        enabled: true
+        policy: "{{ lookup('template', 'kms-policy.j2') | to_json }}"
+      register: kms_key
+    - name: Create second KMS Key
+      kms_key:
+        state: present
+        alias: "{{ kms_alias }}-2"
+        enabled: true
+        policy: "{{ lookup('template', 'kms-policy.j2') | to_json }}"
+      register: kms_key2
+
+    - name: Create CloudWatch IAM Role
+      community.aws.iam_role:
+        state: present
+        name: "{{ cloudwatch_role }}"
+        assume_role_policy_document: "{{ lookup('template', 'cloudwatch-assume-policy.j2') }}"
+      register: output_cloudwatch_role
+    - name: Create CloudWatch Log Group
+      amazon.aws.cloudwatchlogs_log_group:
+        state: present
+        log_group_name: "{{ cloudwatch_log_group }}"
+        retention: 1
+      register: output_cloudwatch_log_group
+    - name: Create second CloudWatch Log Group
+      amazon.aws.cloudwatchlogs_log_group:
+        state: present
+        log_group_name: "{{ cloudwatch_log_group }}-2"
+        retention: 1
+      register: output_cloudwatch_log_group2
+    - name: Add inline policy to CloudWatch Role
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: role
+        iam_name: "{{ cloudwatch_role }}"
+        policy_name: CloudWatch
+        policy_json: "{{ lookup('template', 'cloudwatch-policy.j2') | to_json }}"
+
+    - name: Create CloudWatch IAM Role with no kms permissions
+      community.aws.iam_role:
+        state: present
+        name: "{{ cloudwatch_no_kms_role }}"
+        assume_role_policy_document: "{{ lookup('template', 'cloudtrail-no-kms-assume-policy.j2') }}"
+        managed_policies:
+          - arn:aws:iam::aws:policy/AWSCloudTrail_FullAccess
+      register: output_cloudwatch_no_kms_role
+
+    - name: pause to ensure role exists before attaching policy
+      ansible.builtin.pause:
+        seconds: 15
+
+    - name: Add inline policy to CloudWatch Role
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: role
+        iam_name: "{{ cloudwatch_no_kms_role }}"
+        policy_name: CloudWatchNokms
+        policy_json: "{{ lookup('template', 'cloudtrail-no-kms-policy.j2') }}"
+
+    # ============================================================
+    #   Tests
+    # ============================================================
+
+    - name: Create a trail (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Create a trail
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.exists == True
+          - output.trail.name == cloudtrail_name
+
+    - name: No-op update to trail
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.exists == True
+          # Check everything is what we expect before we start making changes
+          - output.trail.name == cloudtrail_name
+          - output.trail.home_region == aws_region
+          - output.trail.include_global_service_events == True
+          - output.trail.is_multi_region_trail == False
+          - output.trail.is_logging == True
+          - output.trail.log_file_validation_enabled == False
+          - output.trail.s3_bucket_name == s3_bucket_name
+          - output.trail.s3_key_prefix is none
+          - output.trail.kms_key_id is none
+          - output.trail.sns_topic_arn is none
+          - output.trail.sns_topic_name is none
+          - output.trail.tags | length == 0
+
+    - name: Get the trail info
+      cloudtrail_info:
+      register: info
+
+    - name: Get the trail name from the cloud trail info
+      ansible.builtin.set_fact:
+        trail_present: true
+        trail_arn: "{{ item.resource_id }}"
+      when: item.name == cloudtrail_name
+      loop: "{{ info.trail_list }}"
+
+    - name: Assert that the trail name is present in the info
+      ansible.builtin.assert:
+        that:
+          - trail_present is defined
+          - trail_present == True
+
+    # ============================================================
+
+    - name: Set S3 prefix (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_key_prefix: "{{ cloudtrail_prefix }}"
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Set S3 prefix
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_key_prefix: "{{ cloudtrail_prefix }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.s3_key_prefix == cloudtrail_prefix
+
+    - name: Set S3 prefix (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_key_prefix: "{{ cloudtrail_prefix }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.s3_key_prefix == cloudtrail_prefix
+
+    - name: No-op update to trail
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.s3_key_prefix == cloudtrail_prefix
+
+    - name: Get the trail info
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the s3_key_prefix is correct
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].s3_key_prefix == cloudtrail_prefix
+
+    - name: Update S3 prefix (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_key_prefix: "{{ cloudtrail_prefix }}-2"
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Update S3 prefix
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_key_prefix: "{{ cloudtrail_prefix }}-2"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.s3_key_prefix ==  cloudtrail_prefix+"-2"
+
+    - name: Update S3 prefix (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_key_prefix: "{{ cloudtrail_prefix }}-2"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.s3_key_prefix ==  cloudtrail_prefix+"-2"
+
+    - name: Get the trail info after updating S3 prefix
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the s3_key_prefix is correct
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].s3_key_prefix == cloudtrail_prefix+"-2"
+
+    - name: Remove S3 prefix (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_key_prefix: /
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Remove S3 prefix
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_key_prefix: /
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.s3_key_prefix is none
+
+    - name: Remove S3 prefix (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_key_prefix: /
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.s3_key_prefix is none
+
+    - name: Get the trail info after removing S3 prefix
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the s3_key_prefix is None
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].s3_key_prefix is not defined
+
+    # ============================================================
+
+    - ansible.builtin.include_tasks: tagging.yml
+    - name: Set SNS Topic (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        sns_topic_name: "{{ sns_topic }}"
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Set SNS Topic
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        sns_topic_name: "{{ sns_topic }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.sns_topic_name == sns_topic
+
+    - name: Set SNS Topic (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        sns_topic_name: "{{ sns_topic }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.sns_topic_name == sns_topic
+
+    - name: No-op update to trail
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.sns_topic_name == sns_topic
+
+    - name: Get the trail info with SNS topic
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the sns_topic is correctly set
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].sns_topic_name == sns_topic
+
+    - name: Update SNS Topic (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        sns_topic_name: "{{ sns_topic }}-2"
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Update SNS Topic
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        sns_topic_name: "{{ sns_topic }}-2"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.sns_topic_name ==  sns_topic+"-2"
+
+    - name: Update SNS Topic (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        sns_topic_name: "{{ sns_topic }}-2"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.sns_topic_name ==  sns_topic+"-2"
+
+    - name: Get the trail info with SNS topic after update
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the sns_topic is correctly set
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].sns_topic_name == sns_topic+"-2"
+
+    #- name: 'Remove SNS Topic (CHECK MODE)'
+    #  cloudtrail:
+    #    state: present
+    #    name: '{{ cloudtrail_name }}'
+    #    sns_topic_name: ''
+    #  register: output
+    #  check_mode: yes
+    #- assert:
+    #    that:
+    #    - output is changed
+
+    #- name: 'Remove SNS Topic'
+    #  cloudtrail:
+    #    state: present
+    #    name: '{{ cloudtrail_name }}'
+    #    sns_topic_name: ''
+    #  register: output
+    #- assert:
+    #    that:
+    #    - output is changed
+    #    - output.trail.name == cloudtrail_name
+    #    - output.trail.sns_topic_name is none
+
+    #- name: 'Remove SNS Topic (no change)'
+    #  cloudtrail:
+    #    state: present
+    #    name: '{{ cloudtrail_name }}'
+    #    sns_topic_name: ''
+    #  register: output
+    #- assert:
+    #    that:
+    #    - output is not changed
+    #    - output.trail.name == cloudtrail_name
+    #    - output.trail.sns_topic_name is none
+
+    # ============================================================
+
+    - name: Set CloudWatch Log Group (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        cloudwatch_logs_log_group_arn: "{{ output_cloudwatch_log_group.arn }}"
+        cloudwatch_logs_role_arn: "{{ output_cloudwatch_role.arn }}"
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Set CloudWatch Log Group
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        cloudwatch_logs_log_group_arn: "{{ output_cloudwatch_log_group.arn }}"
+        cloudwatch_logs_role_arn: "{{ output_cloudwatch_role.arn }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.cloud_watch_logs_log_group_arn == output_cloudwatch_log_group.arn
+          - output.trail.cloud_watch_logs_role_arn == output_cloudwatch_role.arn
+
+    - name: Set CloudWatch Log Group (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        cloudwatch_logs_log_group_arn: "{{ output_cloudwatch_log_group.arn }}"
+        cloudwatch_logs_role_arn: "{{ output_cloudwatch_role.arn }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.cloud_watch_logs_log_group_arn == output_cloudwatch_log_group.arn
+          - output.trail.cloud_watch_logs_role_arn == output_cloudwatch_role.arn
+
+    - name: No-op update to trail
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.cloud_watch_logs_log_group_arn == output_cloudwatch_log_group.arn
+          - output.trail.cloud_watch_logs_role_arn == output_cloudwatch_role.arn
+
+    - name: Get the trail info with CloudWatch Log Group
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the cloud watch log group is correctly set
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].cloud_watch_logs_log_group_arn == output_cloudwatch_log_group.arn
+          - info.trail_list[0].cloud_watch_logs_role_arn == output_cloudwatch_role.arn
+
+    - name: Update CloudWatch Log Group (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        cloudwatch_logs_log_group_arn: "{{ output_cloudwatch_log_group2.arn }}"
+        cloudwatch_logs_role_arn: "{{ output_cloudwatch_role.arn }}"
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.cloud_watch_logs_log_group_arn == output_cloudwatch_log_group2.arn
+          - output.trail.cloud_watch_logs_role_arn == output_cloudwatch_role.arn
+
+    - name: Update CloudWatch Log Group
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        cloudwatch_logs_log_group_arn: "{{ output_cloudwatch_log_group2.arn }}"
+        cloudwatch_logs_role_arn: "{{ output_cloudwatch_role.arn }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.cloud_watch_logs_log_group_arn == output_cloudwatch_log_group2.arn
+          - output.trail.cloud_watch_logs_role_arn == output_cloudwatch_role.arn
+
+    - name: Update CloudWatch Log Group (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        cloudwatch_logs_log_group_arn: "{{ output_cloudwatch_log_group2.arn }}"
+        cloudwatch_logs_role_arn: "{{ output_cloudwatch_role.arn }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.cloud_watch_logs_log_group_arn == output_cloudwatch_log_group2.arn
+          - output.trail.cloud_watch_logs_role_arn == output_cloudwatch_role.arn
+
+    - name: Get the trail info with CloudWatch Log Group after update
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the cloud watch log group is correctly set after update
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].cloud_watch_logs_log_group_arn == output_cloudwatch_log_group2.arn
+          - info.trail_list[0].cloud_watch_logs_role_arn == output_cloudwatch_role.arn
+
+    #- name: 'Remove CloudWatch Log Group (CHECK MODE)'
+    #  cloudtrail:
+    #    state: present
+    #    name: '{{ cloudtrail_name }}'
+    #    cloudwatch_logs_log_group_arn: ''
+    #    cloudwatch_logs_role_arn: ''
+    #  register: output
+    #  check_mode: yes
+    #- assert:
+    #    that:
+    #    - output is changed
+    #    - output.trail.name == cloudtrail_name
+    #    - output.trail.cloud_watch_logs_log_group_arn is none
+    #    - output.trail.cloud_watch_logs_role_arn is none
+
+    #- name: 'Remove CloudWatch Log Group'
+    #  cloudtrail:
+    #    state: present
+    #    name: '{{ cloudtrail_name }}'
+    #    cloudwatch_logs_log_group_arn: ''
+    #    cloudwatch_logs_role_arn: ''
+    #  register: output
+    #- assert:
+    #    that:
+    #    - output is changed
+    #    - output.trail.name == cloudtrail_name
+    #    - output.trail.cloud_watch_logs_log_group_arn is none
+    #    - output.trail.cloud_watch_logs_role_arn is none
+
+    #- name: 'Remove CloudWatch Log Group (no change)'
+    #  cloudtrail:
+    #    state: present
+    #    name: '{{ cloudtrail_name }}'
+    #    cloudwatch_logs_log_group_arn: ''
+    #    cloudwatch_logs_role_arn: ''
+    #  register: output
+    #- assert:
+    #    that:
+    #    - output is not changed
+    #    - output.trail.name == cloudtrail_name
+    #    - output.trail.cloud_watch_logs_log_group_arn is none
+    #    - output.trail.cloud_watch_logs_role_arn is none
+
+    # ============================================================
+
+    - name: Update S3 bucket (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_bucket_name: "{{ s3_bucket_name }}-2"
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Update S3 bucket
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_bucket_name: "{{ s3_bucket_name }}-2"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.s3_bucket_name ==  s3_bucket_name+"-2"
+
+    - name: Update S3 bucket (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_bucket_name: "{{ s3_bucket_name }}-2"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.s3_bucket_name ==  s3_bucket_name+"-2"
+
+    - name: Get the trail info with S3 bucket name
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the S3 Bucket name is correctly set
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].s3_bucket_name ==  s3_bucket_name+"-2"
+
+    - name: Reset S3 bucket
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.trail.name == cloudtrail_name
+          - output.trail.s3_bucket_name == s3_bucket_name
+
+    # ============================================================
+
+    - name: Disable logging (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        enable_logging: false
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Disable logging
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        enable_logging: false
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.is_logging == False
+
+    - name: Disable logging (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        enable_logging: false
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.is_logging == False
+
+    - name: Get the trail info to check the logging state
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the logging state is correctly set
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].is_logging ==  False
+
+    # Ansible Documentation lists logging as explicitly defaulting to enabled
+
+    - name: Enable logging (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        enable_logging: true
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Enable logging
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        enable_logging: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.is_logging == True
+
+    - name: Enable logging (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        enable_logging: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.is_logging == True
+
+    - name: Get the trail info to check the logging state
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the logging state is correctly set
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].is_logging ==  True
+
+    # ============================================================
+
+    - name: Disable global logging (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        include_global_events: false
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Disable global logging
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        include_global_events: false
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.include_global_service_events == False
+
+    - name: Disable global logging (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        include_global_events: false
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.include_global_service_events == False
+
+    - name: Get the trail info to check the global logging state
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the global logging state is correctly set
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].include_global_service_events ==  False
+
+    # Ansible Documentation lists Global-logging as explicitly defaulting to enabled
+
+    - name: Enable global logging (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        include_global_events: true
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Enable global logging
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        include_global_events: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.include_global_service_events == True
+
+    - name: Enable global logging (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        include_global_events: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.include_global_service_events == True
+
+    - name: Get the trail info to check the global logging state (default)
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the global logging state is correctly set (default)
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].include_global_service_events == True
+
+    # ============================================================
+
+    - name: Enable multi-region logging (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        is_multi_region_trail: true
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Enable multi-region logging
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        is_multi_region_trail: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.is_multi_region_trail == True
+
+    - name: Enable multi-region logging (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        is_multi_region_trail: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.is_multi_region_trail == True
+
+    - name: Get the trail info to check the multi-region logging state (default)
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the global logging state is correctly set (default)
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].is_multi_region_trail == True
+
+    # Ansible Documentation lists Multi-Region-logging as explicitly defaulting to disabled
+
+    - name: Disable multi-region logging (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        is_multi_region_trail: false
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Disable multi-region logging
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        is_multi_region_trail: false
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.is_multi_region_trail == False
+
+    - name: Disable multi-region logging (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        is_multi_region_trail: false
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.is_multi_region_trail == False
+
+    - name: Get the trail info to check the multi-region logging state (default)
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the global logging state is correctly set (default)
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].is_multi_region_trail == False
+
+    # ============================================================
+
+    - name: Enable logfile validation (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        enable_log_file_validation: true
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Enable logfile validation
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        enable_log_file_validation: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.log_file_validation_enabled == True
+
+    - name: Enable logfile validation (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        enable_log_file_validation: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.log_file_validation_enabled == True
+
+    - name: No-op update to trail
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.log_file_validation_enabled == True
+
+    - name: Get the trail info to check the log file validation
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the log file validation is correctly set
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].log_file_validation_enabled == True
+
+    - name: Disable logfile validation (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        enable_log_file_validation: false
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Disable logfile validation
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        enable_log_file_validation: false
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.log_file_validation_enabled == False
+
+    - name: Disable logfile validation (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        enable_log_file_validation: false
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.name == cloudtrail_name
+          - output.trail.log_file_validation_enabled == False
+
+    - name: Get the trail info to check the log file validation
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the log file validation is disabled
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].log_file_validation_enabled == False
+
+    # ============================================================
+
+    - name: Enable logging encryption (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: "{{ kms_key.key_arn }}"
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Enable logging encryption
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: "{{ kms_key.key_arn }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.kms_key_id == kms_key.key_arn
+
+    - name: Enable logging encryption (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: "{{ kms_key.key_arn }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.kms_key_id == kms_key.key_arn
+
+    - name: Enable logging encryption (no change, check mode)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: "{{ kms_key.key_arn }}"
+      check_mode: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.kms_key_id == kms_key.key_arn
+
+    - name: No-op update to trail
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.kms_key_id == kms_key.key_arn
+
+    - name: Get the trail info to check the logging encryption
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the logging encryption is correctly set
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].kms_key_id == kms_key.key_arn
+
+    - name: Update logging encryption key (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: "{{ kms_key2.key_arn }}"
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Update logging encryption key
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: "{{ kms_key2.key_arn }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.kms_key_id == kms_key2.key_arn
+
+    - name: Update logging encryption key (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: "{{ kms_key2.key_arn }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.kms_key_id == kms_key2.key_arn
+
+    - name: Get the trail info to check the logging key encryption
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the logging key encryption is correctly set
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].kms_key_id == kms_key2.key_arn
+
+    - name: Update logging encryption to alias (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: alias/{{ kms_alias }}
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Update logging encryption to alias
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: alias/{{ kms_alias }}
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.trail.kms_key_id == kms_key.key_arn
+
+    - name: Update logging encryption to alias (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: alias/{{ kms_alias }}
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.kms_key_id == kms_key.key_arn
+
+    - name: Update logging encryption to alias (CHECK MODE, no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: "{{ kms_key.key_id }}" # Test when using key id
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.trail.kms_key_id == kms_key.key_id
+
+    - ansible.builtin.debug:
+        msg: "{{ output }}"
+
+    - name: Get the trail info to check the logging key encryption after update
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the logging key encryption is correctly updated
+      ansible.builtin.assert:
+        that:
+          - kms_key.key_id in info.trail_list[0].kms_key_id
+
+    # Assume role to a role with Denied access to KMS
+
+    - amazon.aws.sts_assume_role:
+        role_arn: "{{ output_cloudwatch_no_kms_role.arn }}"
+        role_session_name: cloudtrailNoKms
+        region: "{{ aws_region }}"
+      register: noKms_assumed_role
+
+    - name: Enable logging encryption w/ alias (no change, no kms permmissions, check mode)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: alias/{{ kms_alias }}
+        access_key: "{{ noKms_assumed_role.sts_creds.access_key }}"
+        secret_key: "{{ noKms_assumed_role.sts_creds.secret_key }}"
+        session_token: "{{ noKms_assumed_role.sts_creds.session_token }}"
+      check_mode: true
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+    # when using check_mode, with no kms permissions, and not giving kms_key_id as a key arn
+    # output will always be marked as changed.
+
+    - name: Disable logging encryption (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: ""
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Disable logging encryption
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: ""
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.trail.kms_key_id == ""
+          - output is changed
+
+    - name: Disable logging encryption (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        kms_key_id: ""
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output.kms_key_id == ""
+          - output is not changed
+
+    # ============================================================
+
+    - name: Delete a trail without providing bucket_name (CHECK MODE)
+      module_defaults: { cloudtrail: {}}
+      amazon.aws.cloudtrail:
+        state: absent
+        name: "{{ cloudtrail_name }}"
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Delete a trail while providing bucket_name (CHECK MODE)
+      amazon.aws.cloudtrail:
+        state: absent
+        name: "{{ cloudtrail_name }}"
+      register: output
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+
+    - name: Delete a trail
+      amazon.aws.cloudtrail:
+        state: absent
+        name: "{{ cloudtrail_name }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          - output.exists == False
+
+    - name: Delete a non-existent trail
+      amazon.aws.cloudtrail:
+        state: absent
+        name: "{{ cloudtrail_name }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.exists == False
+
+    # ============================================================
+
+    - name: Test creation of a complex Trail (all features)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_key_prefix: "{{ cloudtrail_prefix }}"
+        sns_topic_name: "{{ sns_topic }}"
+        cloudwatch_logs_log_group_arn: "{{ output_cloudwatch_log_group.arn }}"
+        cloudwatch_logs_role_arn: "{{ output_cloudwatch_role.arn }}"
+        is_multi_region_trail: true
+        include_global_events: true
+        enable_log_file_validation: true
+        kms_key_id: "{{ kms_key.key_arn }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is changed
+          #- output.exists == True
+          - output.trail.name == cloudtrail_name
+          - output.trail.home_region == aws_region
+          - output.trail.include_global_service_events == True
+          - output.trail.is_multi_region_trail == True
+          - output.trail.is_logging == True
+          - output.trail.log_file_validation_enabled ==  True
+          - output.trail.s3_bucket_name == s3_bucket_name
+          - output.trail.s3_key_prefix == cloudtrail_prefix
+          - output.trail.kms_key_id == kms_key.key_arn
+          - output.trail.sns_topic_arn == output_sns_topic.sns_arn
+          - output.trail.sns_topic_name == sns_topic
+          - output.trail.tags | length == 0
+
+    - name: Test creation of a complex Trail (no change)
+      amazon.aws.cloudtrail:
+        state: present
+        name: "{{ cloudtrail_name }}"
+        s3_key_prefix: "{{ cloudtrail_prefix }}"
+        sns_topic_name: "{{ sns_topic }}"
+        cloudwatch_logs_log_group_arn: "{{ output_cloudwatch_log_group.arn }}"
+        cloudwatch_logs_role_arn: "{{ output_cloudwatch_role.arn }}"
+        is_multi_region_trail: true
+        include_global_events: true
+        enable_log_file_validation: true
+        kms_key_id: "{{ kms_key.key_arn }}"
+      register: output
+    - ansible.builtin.assert:
+        that:
+          - output is not changed
+          - output.exists == True
+          - output.trail.name == cloudtrail_name
+          - output.trail.home_region == aws_region
+          - output.trail.include_global_service_events == True
+          - output.trail.is_multi_region_trail == True
+          - output.trail.is_logging == True
+          - output.trail.log_file_validation_enabled ==  True
+          - output.trail.s3_bucket_name == s3_bucket_name
+          - output.trail.s3_key_prefix == cloudtrail_prefix
+          - output.trail.kms_key_id == kms_key.key_arn
+          - output.trail.sns_topic_arn == output_sns_topic.sns_arn
+          - output.trail.sns_topic_name == sns_topic
+          - output.trail.tags | length == 0
+
+    - name: Get the trail info of the created trail
+      cloudtrail_info:
+        trail_names:
+          - "{{ trail_arn }}"
+      register: info
+
+    - name: Assert that the logging key encryption is correctly updated
+      ansible.builtin.assert:
+        that:
+          - info.trail_list[0].name == cloudtrail_name
+          - info.trail_list[0].home_region == aws_region
+          - info.trail_list[0].include_global_service_events == True
+          - info.trail_list[0].is_multi_region_trail == True
+          - info.trail_list[0].is_logging == True
+          - info.trail_list[0].log_file_validation_enabled ==  True
+          - info.trail_list[0].s3_bucket_name == s3_bucket_name
+          - info.trail_list[0].s3_key_prefix == cloudtrail_prefix
+          - info.trail_list[0].kms_key_id == kms_key.key_arn
+          - info.trail_list[0].sns_topic_arn == output_sns_topic.sns_arn
+          - info.trail_list[0].sns_topic_name == sns_topic
+          - info.trail_list[0].tags | length == 0
 
   always:
   # ============================================================
   #   Cleanup
   # ============================================================
-  - name: 'Delete test trail'
-    cloudtrail:
-      state: absent
-      name: '{{ cloudtrail_name }}'
-    ignore_errors: yes
-  - name: 'Delete S3 bucket'
-    s3_bucket:
-      state: absent
-      name: '{{ s3_bucket_name }}'
-      force: yes
-    ignore_errors: yes
-  - name: 'Delete second S3 bucket'
-    s3_bucket:
-      state: absent
-      name: '{{ s3_bucket_name }}-2'
-      force: yes
-    ignore_errors: yes
-  - name: 'Delete KMS Key'
-    kms_key:
-      state: absent
-      alias: '{{ kms_alias }}'
-    ignore_errors: yes
-  - name: 'Delete second KMS Key'
-    kms_key:
-      state: absent
-      alias: '{{ kms_alias }}-2'
-    ignore_errors: yes
-  - name: 'Delete SNS Topic'
-    sns_topic:
-      state: absent
-      name: '{{ sns_topic }}'
-    ignore_errors: yes
-  - name: 'Delete second SNS Topic'
-    sns_topic:
-      state: absent
-      name: '{{ sns_topic }}-2'
-    ignore_errors: yes
-  - name: 'Delete CloudWatch Log Group'
-    cloudwatchlogs_log_group:
-      state: absent
-      log_group_name: '{{ cloudwatch_log_group }}'
-    ignore_errors: yes
-  - name: 'Delete second CloudWatch Log Group'
-    cloudwatchlogs_log_group:
-      state: absent
-      log_group_name: '{{ cloudwatch_log_group }}-2'
-    ignore_errors: yes
-  - name: 'Remove inline policy to CloudWatch Role'
-    iam_policy:
-      state: absent
-      iam_type: role
-      iam_name: '{{ cloudwatch_role }}'
-      policy_name: 'CloudWatch'
-    ignore_errors: yes
-  - name: 'Delete CloudWatch IAM Role'
-    iam_role:
-      state: absent
-      name: '{{ cloudwatch_role }}'
-    ignore_errors: yes
-  - name: 'Remove inline policy to CloudWatch Role'
-    iam_policy:
-      state: absent
-      iam_type: role
-      iam_name: '{{ cloudwatch_no_kms_role }}'
-      policy_name: 'CloudWatchNokms'
-    ignore_errors: yes
-  - name: 'Delete CloudWatch No KMS IAM Role'
-    iam_role:
-      state: absent
-      name: '{{ cloudwatch_no_kms_role }}'
-    ignore_errors: yes
+    - name: Delete test trail
+      amazon.aws.cloudtrail:
+        state: absent
+        name: "{{ cloudtrail_name }}"
+      ignore_errors: true
+    - name: Delete S3 bucket
+      amazon.aws.s3_bucket:
+        state: absent
+        name: "{{ s3_bucket_name }}"
+        force: true
+      ignore_errors: true
+    - name: Delete second S3 bucket
+      amazon.aws.s3_bucket:
+        state: absent
+        name: "{{ s3_bucket_name }}-2"
+        force: true
+      ignore_errors: true
+    - name: Delete KMS Key
+      kms_key:
+        state: absent
+        alias: "{{ kms_alias }}"
+      ignore_errors: true
+    - name: Delete second KMS Key
+      kms_key:
+        state: absent
+        alias: "{{ kms_alias }}-2"
+      ignore_errors: true
+    - name: Delete SNS Topic
+      community.aws.sns_topic:
+        state: absent
+        name: "{{ sns_topic }}"
+      ignore_errors: true
+    - name: Delete second SNS Topic
+      community.aws.sns_topic:
+        state: absent
+        name: "{{ sns_topic }}-2"
+      ignore_errors: true
+    - name: Delete CloudWatch Log Group
+      amazon.aws.cloudwatchlogs_log_group:
+        state: absent
+        log_group_name: "{{ cloudwatch_log_group }}"
+      ignore_errors: true
+    - name: Delete second CloudWatch Log Group
+      amazon.aws.cloudwatchlogs_log_group:
+        state: absent
+        log_group_name: "{{ cloudwatch_log_group }}-2"
+      ignore_errors: true
+    - name: Remove inline policy to CloudWatch Role
+      amazon.aws.iam_policy:
+        state: absent
+        iam_type: role
+        iam_name: "{{ cloudwatch_role }}"
+        policy_name: CloudWatch
+      ignore_errors: true
+    - name: Delete CloudWatch IAM Role
+      community.aws.iam_role:
+        state: absent
+        name: "{{ cloudwatch_role }}"
+      ignore_errors: true
+    - name: Remove inline policy to CloudWatch Role
+      amazon.aws.iam_policy:
+        state: absent
+        iam_type: role
+        iam_name: "{{ cloudwatch_no_kms_role }}"
+        policy_name: CloudWatchNokms
+      ignore_errors: true
+    - name: Delete CloudWatch No KMS IAM Role
+      community.aws.iam_role:
+        state: absent
+        name: "{{ cloudwatch_no_kms_role }}"
+      ignore_errors: true

--- a/tests/integration/targets/cloudtrail/tasks/tagging.yml
+++ b/tests/integration/targets/cloudtrail/tasks/tagging.yml
@@ -1,252 +1,251 @@
+---
 - name: Tests relating to tagging cloudtrails
   vars:
     first_tags:
-      'Key with Spaces': Value with spaces
+      Key with Spaces: Value with spaces
       CamelCaseKey: CamelCaseValue
       pascalCaseKey: pascalCaseValue
       snake_case_key: snake_case_value
     second_tags:
-      'New Key with Spaces': Value with spaces
+      New Key with Spaces: Value with spaces
       NewCamelCaseKey: CamelCaseValue
       newPascalCaseKey: pascalCaseValue
       new_snake_case_key: snake_case_value
     third_tags:
-      'Key with Spaces': Value with spaces
+      Key with Spaces: Value with spaces
       CamelCaseKey: CamelCaseValue
       pascalCaseKey: pascalCaseValue
       snake_case_key: snake_case_value
-      'New Key with Spaces': Updated Value with spaces
+      New Key with Spaces: Updated Value with spaces
     final_tags:
-      'Key with Spaces': Value with spaces
+      Key with Spaces: Value with spaces
       CamelCaseKey: CamelCaseValue
       pascalCaseKey: pascalCaseValue
       snake_case_key: snake_case_value
-      'New Key with Spaces': Updated Value with spaces
+      New Key with Spaces: Updated Value with spaces
       NewCamelCaseKey: CamelCaseValue
       newPascalCaseKey: pascalCaseValue
       new_snake_case_key: snake_case_value
   # Mandatory settings
   module_defaults:
     amazon.aws.cloudtrail:
-      name: '{{ cloudtrail_name }}'
-      s3_bucket_name: '{{ s3_bucket_name }}'
+      name: "{{ cloudtrail_name }}"
+      s3_bucket_name: "{{ s3_bucket_name }}"
       state: present
-#    community.aws.cloudtrail_info:
-#      name: '{{ cloudtrail_name }}'
+  #    community.aws.cloudtrail_info:
+  #      name: '{{ cloudtrail_name }}'
   block:
-
   ###
 
-  - name: test adding tags to cloudtrail (check mode)
-    cloudtrail:
-      tags: '{{ first_tags }}'
-      purge_tags: True
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
+    - name: test adding tags to cloudtrail (check mode)
+      amazon.aws.cloudtrail:
+        tags: "{{ first_tags }}"
+        purge_tags: true
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
 
-  - name: test adding tags to cloudtrail
-    cloudtrail:
-      tags: '{{ first_tags }}'
-      purge_tags: True
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - update_result.trail.tags == first_tags
+    - name: test adding tags to cloudtrail
+      amazon.aws.cloudtrail:
+        tags: "{{ first_tags }}"
+        purge_tags: true
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - update_result.trail.tags == first_tags
 
-  - name: test adding tags to cloudtrail - idempotency (check mode)
-    cloudtrail:
-      tags: '{{ first_tags }}'
-      purge_tags: True
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
+    - name: test adding tags to cloudtrail - idempotency (check mode)
+      amazon.aws.cloudtrail:
+        tags: "{{ first_tags }}"
+        purge_tags: true
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
 
-  - name: test adding tags to cloudtrail - idempotency
-    cloudtrail:
-      tags: '{{ first_tags }}'
-      purge_tags: True
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.trail.tags == first_tags
+    - name: test adding tags to cloudtrail - idempotency
+      amazon.aws.cloudtrail:
+        tags: "{{ first_tags }}"
+        purge_tags: true
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.trail.tags == first_tags
 
-  ###
+    ###
 
-  - name: test updating tags with purge on cloudtrail (check mode)
-    cloudtrail:
-      tags: '{{ second_tags }}'
-      purge_tags: True
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
+    - name: test updating tags with purge on cloudtrail (check mode)
+      amazon.aws.cloudtrail:
+        tags: "{{ second_tags }}"
+        purge_tags: true
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
 
-  - name: test updating tags with purge on cloudtrail
-    cloudtrail:
-      tags: '{{ second_tags }}'
-      purge_tags: True
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - update_result.trail.tags == second_tags
+    - name: test updating tags with purge on cloudtrail
+      amazon.aws.cloudtrail:
+        tags: "{{ second_tags }}"
+        purge_tags: true
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - update_result.trail.tags == second_tags
 
-  - name: test updating tags with purge on cloudtrail - idempotency (check mode)
-    cloudtrail:
-      tags: '{{ second_tags }}'
-      purge_tags: True
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
+    - name: test updating tags with purge on cloudtrail - idempotency (check mode)
+      amazon.aws.cloudtrail:
+        tags: "{{ second_tags }}"
+        purge_tags: true
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
 
-  - name: test updating tags with purge on cloudtrail - idempotency
-    cloudtrail:
-      tags: '{{ second_tags }}'
-      purge_tags: True
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.trail.tags == second_tags
+    - name: test updating tags with purge on cloudtrail - idempotency
+      amazon.aws.cloudtrail:
+        tags: "{{ second_tags }}"
+        purge_tags: true
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.trail.tags == second_tags
 
-  ###
+    ###
 
-  - name: test updating tags without purge on cloudtrail (check mode)
-    cloudtrail:
-      tags: '{{ third_tags }}'
-      purge_tags: False
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
+    - name: test updating tags without purge on cloudtrail (check mode)
+      amazon.aws.cloudtrail:
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
 
-  - name: test updating tags without purge on cloudtrail
-    cloudtrail:
-      tags: '{{ third_tags }}'
-      purge_tags: False
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - update_result.trail.tags == final_tags
+    - name: test updating tags without purge on cloudtrail
+      amazon.aws.cloudtrail:
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - update_result.trail.tags == final_tags
 
-  - name: test updating tags without purge on cloudtrail - idempotency (check mode)
-    cloudtrail:
-      tags: '{{ third_tags }}'
-      purge_tags: False
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
+    - name: test updating tags without purge on cloudtrail - idempotency (check mode)
+      amazon.aws.cloudtrail:
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
 
-  - name: test updating tags without purge on cloudtrail - idempotency
-    cloudtrail:
-      tags: '{{ third_tags }}'
-      purge_tags: False
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.trail.tags == final_tags
+    - name: test updating tags without purge on cloudtrail - idempotency
+      amazon.aws.cloudtrail:
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.trail.tags == final_tags
 
-#  ###
-#
-#  - name: test that cloudtrail_info returns the tags
-#    cloudtrail_info:
-#    register: tag_info
-#  - name: assert tags present
-#    assert:
-#      that:
-#      - tag_info.trail.tags == final_tags
-#
-#  ###
+    #  ###
+    #
+    #  - name: test that cloudtrail_info returns the tags
+    #    cloudtrail_info:
+    #    register: tag_info
+    #  - name: assert tags present
+    #    assert:
+    #      that:
+    #      - tag_info.trail.tags == final_tags
+    #
+    #  ###
 
-  - name: test no tags param cloudtrail (check mode)
-    cloudtrail: {}
-    register: update_result
-    check_mode: yes
-  - name: assert no change
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.trail.tags == final_tags
+    - name: test no tags param cloudtrail (check mode)
+      amazon.aws.cloudtrail: {}
+      register: update_result
+      check_mode: true
+    - name: assert no change
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.trail.tags == final_tags
 
+    - name: test no tags param cloudtrail
+      amazon.aws.cloudtrail: {}
+      register: update_result
+    - name: assert no change
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.trail.tags == final_tags
 
-  - name: test no tags param cloudtrail
-    cloudtrail: {}
-    register: update_result
-  - name: assert no change
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.trail.tags == final_tags
+    ###
 
-  ###
+    - name: test removing tags from cloudtrail (check mode)
+      amazon.aws.cloudtrail:
+        tags: {}
+        purge_tags: true
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
 
-  - name: test removing tags from cloudtrail (check mode)
-    cloudtrail:
-      tags: {}
-      purge_tags: True
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
+    - name: test removing tags from cloudtrail
+      amazon.aws.cloudtrail:
+        tags: {}
+        purge_tags: true
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - update_result.trail.tags == {}
 
-  - name: test removing tags from cloudtrail
-    cloudtrail:
-      tags: {}
-      purge_tags: True
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - update_result.trail.tags == {}
+    - name: test removing tags from cloudtrail - idempotency (check mode)
+      amazon.aws.cloudtrail:
+        tags: {}
+        purge_tags: true
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
 
-  - name: test removing tags from cloudtrail - idempotency (check mode)
-    cloudtrail:
-      tags: {}
-      purge_tags: True
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-
-  - name: test removing tags from cloudtrail - idempotency
-    cloudtrail:
-      tags: {}
-      purge_tags: True
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.trail.tags == {}
+    - name: test removing tags from cloudtrail - idempotency
+      amazon.aws.cloudtrail:
+        tags: {}
+        purge_tags: true
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.trail.tags == {}

--- a/tests/integration/targets/cloudwatch_metric_alarm/defaults/main.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/defaults/main.yml
@@ -1,4 +1,5 @@
+---
 # defaults file for ec2_instance
-ec2_instance_name: '{{ resource_prefix }}-node'
+ec2_instance_name: "{{ resource_prefix }}-node"
 ec2_instance_owner: integration-run-{{ resource_prefix }}
 alarm_prefix: ansible-test

--- a/tests/integration/targets/cloudwatch_metric_alarm/meta/main.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
-- setup_ec2_facts
+  - setup_ec2_facts

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/env_cleanup.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/env_cleanup.yml
@@ -1,88 +1,89 @@
+---
 - name: remove any instances in the test VPC
-  ec2_instance:
+  amazon.aws.ec2_instance:
     filters:
-      vpc_id: '{{ testing_vpc.vpc.id }}'
+      vpc_id: "{{ testing_vpc.vpc.id }}"
     state: absent
   register: removed
   until: removed is not failed
-  ignore_errors: yes
+  ignore_errors: true
   retries: 10
 
 - name: remove ENIs
-  ec2_eni_info:
+  amazon.aws.ec2_eni_info:
     filters:
-      vpc-id: '{{ testing_vpc.vpc.id }}'
+      vpc-id: "{{ testing_vpc.vpc.id }}"
   register: enis
 
 - name: delete all ENIs
-  ec2_eni:
-    eni_id: '{{ item.id }}'
+  amazon.aws.ec2_eni:
+    eni_id: "{{ item.id }}"
     state: absent
   until: removed is not failed
-  with_items: '{{ enis.network_interfaces }}'
-  ignore_errors: yes
+  with_items: "{{ enis.network_interfaces }}"
+  ignore_errors: true
   retries: 10
 
 - name: remove the security group
   ec2_security_group:
-    name: '{{ resource_prefix }}-sg'
+    name: "{{ resource_prefix }}-sg"
     description: a security group for ansible tests
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     state: absent
   register: removed
   until: removed is not failed
-  ignore_errors: yes
+  ignore_errors: true
   retries: 10
 
 - name: remove routing rules
-  ec2_vpc_route_table:
+  amazon.aws.ec2_vpc_route_table:
     state: absent
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     tags:
-      created: '{{ resource_prefix }}-route'
+      created: "{{ resource_prefix }}-route"
     routes:
-    - dest: 0.0.0.0/0
-      gateway_id: '{{ igw.gateway_id }}'
+      - dest: "0.0.0.0/0"
+        gateway_id: "{{ igw.gateway_id }}"
     subnets:
-    - '{{ testing_subnet_a.subnet.id }}'
-    - '{{ testing_subnet_b.subnet.id }}'
+      - "{{ testing_subnet_a.subnet.id }}"
+      - "{{ testing_subnet_b.subnet.id }}"
   register: removed
   until: removed is not failed
-  ignore_errors: yes
+  ignore_errors: true
   retries: 10
 
 - name: remove internet gateway
-  ec2_vpc_igw:
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+  amazon.aws.ec2_vpc_igw:
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     state: absent
   register: removed
   until: removed is not failed
-  ignore_errors: yes
+  ignore_errors: true
   retries: 10
 
 - name: remove subnet A
-  ec2_vpc_subnet:
+  amazon.aws.ec2_vpc_subnet:
     state: absent
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     cidr: 10.22.32.0/24
   register: removed
   until: removed is not failed
-  ignore_errors: yes
+  ignore_errors: true
   retries: 10
 
 - name: remove subnet B
-  ec2_vpc_subnet:
+  amazon.aws.ec2_vpc_subnet:
     state: absent
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     cidr: 10.22.33.0/24
   register: removed
   until: removed is not failed
-  ignore_errors: yes
+  ignore_errors: true
   retries: 10
 
 - name: remove the VPC
-  ec2_vpc_net:
-    name: '{{ resource_prefix }}-vpc'
+  amazon.aws.ec2_vpc_net:
+    name: "{{ resource_prefix }}-vpc"
     cidr_block: 10.22.32.0/23
     state: absent
     tags:
@@ -90,5 +91,5 @@
     tenancy: default
   register: removed
   until: removed is not failed
-  ignore_errors: yes
+  ignore_errors: true
   retries: 10

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/env_setup.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/env_setup.yml
@@ -1,6 +1,7 @@
+---
 - name: Create VPC for use in testing
-  ec2_vpc_net:
-    name: '{{ resource_prefix }}-vpc'
+  amazon.aws.ec2_vpc_net:
+    name: "{{ resource_prefix }}-vpc"
     cidr_block: 10.22.32.0/23
     tags:
       Name: Ansible ec2_instance Testing VPC
@@ -8,55 +9,55 @@
   register: testing_vpc
 
 - name: Create internet gateway for use in testing
-  ec2_vpc_igw:
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+  amazon.aws.ec2_vpc_igw:
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     state: present
   register: igw
 
 - name: Create default subnet in zone A
-  ec2_vpc_subnet:
+  amazon.aws.ec2_vpc_subnet:
     state: present
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     cidr: 10.22.32.0/24
-    az: '{{ aws_region }}a'
+    az: "{{ aws_region }}a"
     resource_tags:
-      Name: '{{ resource_prefix }}-subnet-a'
+      Name: "{{ resource_prefix }}-subnet-a"
   register: testing_subnet_a
 
 - name: Create secondary subnet in zone B
-  ec2_vpc_subnet:
+  amazon.aws.ec2_vpc_subnet:
     state: present
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     cidr: 10.22.33.0/24
-    az: '{{ aws_region }}b'
+    az: "{{ aws_region }}b"
     resource_tags:
-      Name: '{{ resource_prefix }}-subnet-b'
+      Name: "{{ resource_prefix }}-subnet-b"
   register: testing_subnet_b
 
 - name: create routing rules
-  ec2_vpc_route_table:
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+  amazon.aws.ec2_vpc_route_table:
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     tags:
-      created: '{{ resource_prefix }}-route'
+      created: "{{ resource_prefix }}-route"
     routes:
-    - dest: 0.0.0.0/0
-      gateway_id: '{{ igw.gateway_id }}'
+      - dest: "0.0.0.0/0"
+        gateway_id: "{{ igw.gateway_id }}"
     subnets:
-    - '{{ testing_subnet_a.subnet.id }}'
-    - '{{ testing_subnet_b.subnet.id }}'
+      - "{{ testing_subnet_a.subnet.id }}"
+      - "{{ testing_subnet_b.subnet.id }}"
 
 - name: create a security group with the vpc
   ec2_security_group:
-    name: '{{ resource_prefix }}-sg'
+    name: "{{ resource_prefix }}-sg"
     description: a security group for ansible tests
-    vpc_id: '{{ testing_vpc.vpc.id }}'
+    vpc_id: "{{ testing_vpc.vpc.id }}"
     rules:
-    - proto: tcp
-      from_port: 22
-      to_port: 22
-      cidr_ip: 0.0.0.0/0
-    - proto: tcp
-      from_port: 80
-      to_port: 80
-      cidr_ip: 0.0.0.0/0
+      - proto: tcp
+        from_port: 22
+        to_port: 22
+        cidr_ip: "0.0.0.0/0"
+      - proto: tcp
+        from_port: 80
+        to_port: 80
+        cidr_ip: "0.0.0.0/0"
   register: sg

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
@@ -1,518 +1,508 @@
+---
 - name: run cloudwatch_metric_alarm tests
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-  - set_fact:
-      alarm_full_name: '{{ alarm_prefix }}-{{ resource_prefix }}-cpu-low'
+    - ansible.builtin.set_fact:
+        alarm_full_name: "{{ alarm_prefix }}-{{ resource_prefix }}-cpu-low"
 
-  - name: set up environment for testing.
-    include_tasks: env_setup.yml
+    - name: set up environment for testing.
+      ansible.builtin.include_tasks: env_setup.yml
+    - name: get info on alarms
+      amazon.aws.cloudwatch_metric_alarm_info:
+        alarm_names:
+          - "{{ alarm_full_name }}"
+      register: alarm_info_query
 
-  - name: get info on alarms
-    amazon.aws.cloudwatch_metric_alarm_info:
-      alarm_names:
-        - "{{ alarm_full_name }}"
-    register: alarm_info_query
+    - name: Make instance in a default subnet of the VPC
+      amazon.aws.ec2_instance:
+        name: "{{ resource_prefix }}-test-default-vpc"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ resource_prefix }}"
+        security_groups: "{{ sg.group_id }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        instance_type: t2.micro
+        wait: true
+      register: ec2_instance_results
 
-  - name: Make instance in a default subnet of the VPC
-    ec2_instance:
-      name: '{{ resource_prefix }}-test-default-vpc'
-      image_id: '{{ ec2_ami_id }}'
-      tags:
-        TestId: '{{ resource_prefix }}'
-      security_groups: '{{ sg.group_id }}'
-      vpc_subnet_id: '{{ testing_subnet_a.subnet.id }}'
-      instance_type: t2.micro
-      wait: true
-    register: ec2_instance_results
+    - name: ensure alarm doesn't exist for a clean test
+      cloudwatch_metric_alarm:
+        state: absent
+        name: "{{ alarm_full_name }}"
 
-  - name: ensure alarm doesn't exist for a clean test
-    cloudwatch_metric_alarm:
-      state: absent
-      name: '{{ alarm_full_name }}'
+    - name: create ec2 metric alarm on ec2 instance (check mode)
+      cloudwatch_metric_alarm:
+        dimensions:
+          InstanceId: "{{ ec2_instance_results.instances[0].instance_id }}"
+        state: present
+        name: "{{ alarm_full_name }}"
+        metric: CPUUtilization
+        namespace: AWS/EC2
+        treat_missing_data: missing
+        statistic: Average
+        comparison: LessThanOrEqualToThreshold
+        threshold: 5.0
+        period: 300
+        evaluation_periods: 3
+        unit: Percent
+        description: This will alarm when an instance's cpu usage average is lower than 5% for 15 minutes
+      check_mode: true
+      register: ec2_instance_metric_alarm_check
 
-  - name: create ec2 metric alarm on ec2 instance (check mode)
-    cloudwatch_metric_alarm:
-      dimensions:
-        InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
-      state: present
-      name: '{{ alarm_full_name }}'
-      metric: CPUUtilization
-      namespace: AWS/EC2
-      treat_missing_data: missing
-      statistic: Average
-      comparison: LessThanOrEqualToThreshold
-      threshold: 5.0
-      period: 300
-      evaluation_periods: 3
-      unit: Percent
-      description: This will alarm when an instance's cpu usage average is lower than
-        5% for 15 minutes
-    check_mode: true
-    register: ec2_instance_metric_alarm_check
+    - name: get info on alarms
+      amazon.aws.cloudwatch_metric_alarm_info:
+        alarm_names:
+          - "{{ alarm_full_name }}"
+      register: alarm_info_check
 
-  - name: get info on alarms
-    amazon.aws.cloudwatch_metric_alarm_info:
-      alarm_names:
-        - "{{ alarm_full_name }}"
-    register: alarm_info_check
+    - name: verify that an alarm was not created in check mode
+      ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_alarm_check.changed
+          - not ec2_instance_metric_alarm_check.alarm_arn
+          - alarm_info_check.metric_alarms | length == 0
 
-  - name: "verify that an alarm was not created in check mode"
-    assert:
-      that:
-        - 'ec2_instance_metric_alarm_check.changed'
-        - 'not ec2_instance_metric_alarm_check.alarm_arn'
-        - 'alarm_info_check.metric_alarms | length == 0'
+    - name: create ec2 metric alarm on ec2 instance
+      cloudwatch_metric_alarm:
+        dimensions:
+          InstanceId: "{{ ec2_instance_results.instances[0].instance_id }}"
+        state: present
+        name: "{{ alarm_full_name }}"
+        metric: CPUUtilization
+        namespace: AWS/EC2
+        treat_missing_data: missing
+        statistic: Average
+        comparison: LessThanOrEqualToThreshold
+        threshold: 5.0
+        period: 300
+        evaluation_periods: 3
+        unit: Percent
+        description: This will alarm when an instance's cpu usage average is lower than 5% for 15 minutes
+      register: ec2_instance_metric_alarm
 
-  - name: create ec2 metric alarm on ec2 instance
-    cloudwatch_metric_alarm:
-      dimensions:
-        InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
-      state: present
-      name: '{{ alarm_full_name }}'
-      metric: CPUUtilization
-      namespace: AWS/EC2
-      treat_missing_data: missing
-      statistic: Average
-      comparison: LessThanOrEqualToThreshold
-      threshold: 5.0
-      period: 300
-      evaluation_periods: 3
-      unit: Percent
-      description: This will alarm when an instance's cpu usage average is lower than
-        5% for 15 minutes
-    register: ec2_instance_metric_alarm
+    - name: get info on alarms
+      amazon.aws.cloudwatch_metric_alarm_info:
+        alarm_names:
+          - "{{ alarm_full_name }}"
+      register: alarm_info
 
-  - name: get info on alarms
-    amazon.aws.cloudwatch_metric_alarm_info:
-      alarm_names:
-        - "{{ alarm_full_name }}"
-    register: alarm_info
+    - name: verify that an alarm was created
+      ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_alarm.changed
+          - ec2_instance_metric_alarm.alarm_arn
+          - ec2_instance_metric_alarm.statistic == alarm_info.metric_alarms[0].statistic
+          - ec2_instance_metric_alarm.name  == alarm_info.metric_alarms[0].alarm_name
+          - ec2_instance_metric_alarm.metric == alarm_info.metric_alarms[0].metric_name
+          - ec2_instance_metric_alarm.namespace == alarm_info.metric_alarms[0].namespace
+          - ec2_instance_metric_alarm.comparison == alarm_info.metric_alarms[0].comparison_operator
+          - ec2_instance_metric_alarm.threshold == alarm_info.metric_alarms[0].threshold
+          - ec2_instance_metric_alarm.period == alarm_info.metric_alarms[0].period
+          - ec2_instance_metric_alarm.unit == alarm_info.metric_alarms[0].unit
+          - ec2_instance_metric_alarm.evaluation_periods == alarm_info.metric_alarms[0].evaluation_periods
+          - ec2_instance_metric_alarm.description == alarm_info.metric_alarms[0].alarm_description
+          - ec2_instance_metric_alarm.treat_missing_data == alarm_info.metric_alarms[0].treat_missing_data
 
-  - name: "verify that an alarm was created"
-    assert:
-      that:
-        - 'ec2_instance_metric_alarm.changed'
-        - 'ec2_instance_metric_alarm.alarm_arn'
-        - 'ec2_instance_metric_alarm.statistic == alarm_info.metric_alarms[0].statistic'
-        - 'ec2_instance_metric_alarm.name  == alarm_info.metric_alarms[0].alarm_name'
-        - 'ec2_instance_metric_alarm.metric == alarm_info.metric_alarms[0].metric_name'
-        - 'ec2_instance_metric_alarm.namespace == alarm_info.metric_alarms[0].namespace'
-        - 'ec2_instance_metric_alarm.comparison == alarm_info.metric_alarms[0].comparison_operator'
-        - 'ec2_instance_metric_alarm.threshold == alarm_info.metric_alarms[0].threshold'
-        - 'ec2_instance_metric_alarm.period == alarm_info.metric_alarms[0].period'
-        - 'ec2_instance_metric_alarm.unit == alarm_info.metric_alarms[0].unit'
-        - 'ec2_instance_metric_alarm.evaluation_periods == alarm_info.metric_alarms[0].evaluation_periods'
-        - 'ec2_instance_metric_alarm.description == alarm_info.metric_alarms[0].alarm_description'
-        - 'ec2_instance_metric_alarm.treat_missing_data == alarm_info.metric_alarms[0].treat_missing_data'
+    - name: create ec2 metric alarm on ec2 instance (idempotent) (check mode)
+      cloudwatch_metric_alarm:
+        dimensions:
+          InstanceId: "{{ ec2_instance_results.instances[0].instance_id }}"
+        state: present
+        name: "{{ alarm_full_name }}"
+        metric: CPUUtilization
+        namespace: AWS/EC2
+        treat_missing_data: missing
+        statistic: Average
+        comparison: LessThanOrEqualToThreshold
+        threshold: 5.0
+        period: 300
+        evaluation_periods: 3
+        unit: Percent
+        description: This will alarm when an instance's cpu usage average is lower than 5% for 15 minutes
+      check_mode: true
+      register: ec2_instance_metric_alarm_idempotent_check
 
-  - name: create ec2 metric alarm on ec2 instance (idempotent) (check mode)
-    cloudwatch_metric_alarm:
-      dimensions:
-        InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
-      state: present
-      name: '{{ alarm_full_name }}'
-      metric: CPUUtilization
-      namespace: AWS/EC2
-      treat_missing_data: missing
-      statistic: Average
-      comparison: LessThanOrEqualToThreshold
-      threshold: 5.0
-      period: 300
-      evaluation_periods: 3
-      unit: Percent
-      description: This will alarm when an instance's cpu usage average is lower than
-        5% for 15 minutes
-    check_mode: true
-    register: ec2_instance_metric_alarm_idempotent_check
+    - name: get info on alarms
+      amazon.aws.cloudwatch_metric_alarm_info:
+        alarm_names:
+          - "{{ alarm_full_name }}"
+      register: alarm_info_idempotent_check
 
-  - name: get info on alarms
-    amazon.aws.cloudwatch_metric_alarm_info:
-      alarm_names:
-        - "{{ alarm_full_name }}"
-    register: alarm_info_idempotent_check
+    - name: Verify alarm does not register as changed after update in check mode
+      ansible.builtin.assert:
+        that:
+          - not ec2_instance_metric_alarm_idempotent_check.changed
 
-  - name: "Verify alarm does not register as changed after update in check mode"
-    assert:
-      that:
-        - not ec2_instance_metric_alarm_idempotent_check.changed
+    - name: Verify alarm did not change after updating in check mode
+      ansible.builtin.assert:
+        that:
+          - alarm_info.metric_alarms[0]['{{item}}'] == alarm_info_idempotent_check.metric_alarms[0]['{{ item }}']
+      with_items:
+        - alarm_arn
+        - statistic
+        - alarm_name
+        - metric_name
+        - namespace
+        - comparison_operator
+        - threshold
+        - period
+        - unit
+        - evaluation_periods
+        - alarm_description
+        - treat_missing_data
 
-  - name: "Verify alarm did not change after updating in check mode"
-    assert:
-      that:
-        - "alarm_info.metric_alarms[0]['{{item}}'] == alarm_info_idempotent_check.metric_alarms[0]['{{ item }}']"
-    with_items:
-      - alarm_arn
-      - statistic
-      - alarm_name
-      - metric_name
-      - namespace
-      - comparison_operator
-      - threshold
-      - period
-      - unit
-      - evaluation_periods
-      - alarm_description
-      - treat_missing_data
+    - name: create ec2 metric alarm on ec2 instance (idempotent)
+      cloudwatch_metric_alarm:
+        dimensions:
+          InstanceId: "{{ ec2_instance_results.instances[0].instance_id }}"
+        state: present
+        name: "{{ alarm_full_name }}"
+        metric: CPUUtilization
+        namespace: AWS/EC2
+        treat_missing_data: missing
+        statistic: Average
+        comparison: LessThanOrEqualToThreshold
+        threshold: 5.0
+        period: 300
+        evaluation_periods: 3
+        unit: Percent
+        description: This will alarm when an instance's cpu usage average is lower than 5% for 15 minutes
+      register: ec2_instance_metric_alarm_idempotent
 
-  - name: create ec2 metric alarm on ec2 instance (idempotent)
-    cloudwatch_metric_alarm:
-      dimensions:
-        InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
-      state: present
-      name: '{{ alarm_full_name }}'
-      metric: CPUUtilization
-      namespace: AWS/EC2
-      treat_missing_data: missing
-      statistic: Average
-      comparison: LessThanOrEqualToThreshold
-      threshold: 5.0
-      period: 300
-      evaluation_periods: 3
-      unit: Percent
-      description: This will alarm when an instance's cpu usage average is lower than
-        5% for 15 minutes
-    register: ec2_instance_metric_alarm_idempotent
+    - name: get info on alarms
+      amazon.aws.cloudwatch_metric_alarm_info:
+        alarm_names:
+          - "{{ alarm_full_name }}"
+      register: alarm_info_idempotent_check
 
-  - name: get info on alarms
-    amazon.aws.cloudwatch_metric_alarm_info:
-      alarm_names:
-        - "{{ alarm_full_name }}"
-    register: alarm_info_idempotent_check
+    - name: Verify alarm does not register as changed after update in check mode
+      ansible.builtin.assert:
+        that:
+          - not ec2_instance_metric_alarm_idempotent_check.changed
 
-  - name: "Verify alarm does not register as changed after update in check mode"
-    assert:
-      that:
-        - not ec2_instance_metric_alarm_idempotent_check.changed
+    - name: Verify alarm did not change after updating in check mode
+      ansible.builtin.assert:
+        that:
+          - alarm_info.metric_alarms[0]['{{item}}'] == alarm_info_idempotent_check.metric_alarms[0]['{{ item }}']
+      with_items:
+        - alarm_arn
+        - statistic
+        - alarm_name
+        - metric_name
+        - namespace
+        - comparison_operator
+        - threshold
+        - period
+        - unit
+        - evaluation_periods
+        - alarm_description
+        - treat_missing_data
 
-  - name: "Verify alarm did not change after updating in check mode"
-    assert:
-      that:
-        - "alarm_info.metric_alarms[0]['{{item}}'] == alarm_info_idempotent_check.metric_alarms[0]['{{ item }}']"
-    with_items:
-      - alarm_arn
-      - statistic
-      - alarm_name
-      - metric_name
-      - namespace
-      - comparison_operator
-      - threshold
-      - period
-      - unit
-      - evaluation_periods
-      - alarm_description
-      - treat_missing_data
+    - name: update alarm (check mode)
+      cloudwatch_metric_alarm:
+        dimensions:
+          InstanceId: "{{ ec2_instance_results.instances[0].instance_id }}"
+        state: present
+        name: "{{ alarm_full_name }}"
+        metric: CPUUtilization
+        namespace: AWS/EC2
+        statistic: Average
+        comparison: LessThanOrEqualToThreshold
+        threshold: 5.0
+        period: 60
+        evaluation_periods: 3
+        unit: Percent
+        description: This will alarm when an instance's cpu usage average is lower than 5% for 3 minutes
+      check_mode: true
+      register: ec2_instance_metric_alarm_update_check
 
-  - name: update alarm (check mode)
-    cloudwatch_metric_alarm:
-      dimensions:
-        InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
-      state: present
-      name: '{{ alarm_full_name }}'
-      metric: CPUUtilization
-      namespace: AWS/EC2
-      statistic: Average
-      comparison: LessThanOrEqualToThreshold
-      threshold: 5.0
-      period: 60
-      evaluation_periods: 3
-      unit: Percent
-      description: This will alarm when an instance's cpu usage average is lower than
-        5% for 3 minutes
-    check_mode: true
-    register: ec2_instance_metric_alarm_update_check
+    - name: verify that alarm registers as updated in check mode
+      ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_alarm_check.changed
 
-  - name: verify that alarm registers as updated in check mode
-    assert:
-      that:
-      - ec2_instance_metric_alarm_check.changed
+    - name: verify that properties were not changed in check mode
+      ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_alarm_update_check.changed
+          - ec2_instance_metric_alarm_update_check.period == alarm_info.metric_alarms[0].period # Period of actual alarm should not change
+          - ec2_instance_metric_alarm_update_check.alarm_arn == ec2_instance_metric_alarm.alarm_arn
+          - ec2_instance_metric_alarm_update_check.statistic == alarm_info.metric_alarms[0].statistic
+          - ec2_instance_metric_alarm_update_check.name  == alarm_info.metric_alarms[0].alarm_name
+          - ec2_instance_metric_alarm_update_check.metric == alarm_info.metric_alarms[0].metric_name
+          - ec2_instance_metric_alarm_update_check.namespace == alarm_info.metric_alarms[0].namespace
+          - ec2_instance_metric_alarm_update_check.statistic == alarm_info.metric_alarms[0].statistic
+          - ec2_instance_metric_alarm_update_check.comparison == alarm_info.metric_alarms[0].comparison_operator
+          - ec2_instance_metric_alarm_update_check.threshold == alarm_info.metric_alarms[0].threshold
+          - ec2_instance_metric_alarm_update_check.unit == alarm_info.metric_alarms[0].unit
+          - ec2_instance_metric_alarm_update_check.evaluation_periods == alarm_info.metric_alarms[0].evaluation_periods
+          - ec2_instance_metric_alarm_update_check.treat_missing_data == alarm_info.metric_alarms[0].treat_missing_data
 
-  - name: verify that properties were not changed in check mode
-    assert:
-      that:
-      - ec2_instance_metric_alarm_update_check.changed
-      - 'ec2_instance_metric_alarm_update_check.period == alarm_info.metric_alarms[0].period'        # Period of actual alarm should not change
-      - 'ec2_instance_metric_alarm_update_check.alarm_arn == ec2_instance_metric_alarm.alarm_arn'
-      - 'ec2_instance_metric_alarm_update_check.statistic == alarm_info.metric_alarms[0].statistic'
-      - 'ec2_instance_metric_alarm_update_check.name  == alarm_info.metric_alarms[0].alarm_name'
-      - 'ec2_instance_metric_alarm_update_check.metric == alarm_info.metric_alarms[0].metric_name'
-      - 'ec2_instance_metric_alarm_update_check.namespace == alarm_info.metric_alarms[0].namespace'
-      - 'ec2_instance_metric_alarm_update_check.statistic == alarm_info.metric_alarms[0].statistic'
-      - 'ec2_instance_metric_alarm_update_check.comparison == alarm_info.metric_alarms[0].comparison_operator'
-      - 'ec2_instance_metric_alarm_update_check.threshold == alarm_info.metric_alarms[0].threshold'
-      - 'ec2_instance_metric_alarm_update_check.unit == alarm_info.metric_alarms[0].unit'
-      - 'ec2_instance_metric_alarm_update_check.evaluation_periods == alarm_info.metric_alarms[0].evaluation_periods'
-      - 'ec2_instance_metric_alarm_update_check.treat_missing_data == alarm_info.metric_alarms[0].treat_missing_data'
+    - name: update alarm
+      cloudwatch_metric_alarm:
+        dimensions:
+          InstanceId: "{{ ec2_instance_results.instances[0].instance_id }}"
+        state: present
+        name: "{{ alarm_full_name }}"
+        metric: CPUUtilization
+        namespace: AWS/EC2
+        statistic: Average
+        comparison: LessThanOrEqualToThreshold
+        threshold: 5.0
+        period: 60
+        evaluation_periods: 3
+        unit: Percent
+        description: This will alarm when an instance's cpu usage average is lower than 5% for 3 minutes
+      register: ec2_instance_metric_alarm_update
 
-  - name: update alarm
-    cloudwatch_metric_alarm:
-      dimensions:
-        InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
-      state: present
-      name: '{{ alarm_full_name }}'
-      metric: CPUUtilization
-      namespace: AWS/EC2
-      statistic: Average
-      comparison: LessThanOrEqualToThreshold
-      threshold: 5.0
-      period: 60
-      evaluation_periods: 3
-      unit: Percent
-      description: This will alarm when an instance's cpu usage average is lower than
-        5% for 3 minutes
-    register: ec2_instance_metric_alarm_update
+    - name: verify that alarm registers as updated
+      ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_alarm.changed
 
-  - name: verify that alarm registers as updated
-    assert:
-      that:
-      - ec2_instance_metric_alarm.changed
+    - name: verify that properties were changed
+      ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_alarm_update.changed
+          - ec2_instance_metric_alarm_update.period == 60 # Period should be 60, not matching old value
+          - ec2_instance_metric_alarm_update.alarm_arn == ec2_instance_metric_alarm.alarm_arn
+          - ec2_instance_metric_alarm_update.statistic == alarm_info.metric_alarms[0].statistic
+          - ec2_instance_metric_alarm_update.name  == alarm_info.metric_alarms[0].alarm_name
+          - ec2_instance_metric_alarm_update.metric == alarm_info.metric_alarms[0].metric_name
+          - ec2_instance_metric_alarm_update.namespace == alarm_info.metric_alarms[0].namespace
+          - ec2_instance_metric_alarm_update.statistic == alarm_info.metric_alarms[0].statistic
+          - ec2_instance_metric_alarm_update.comparison == alarm_info.metric_alarms[0].comparison_operator
+          - ec2_instance_metric_alarm_update.threshold == alarm_info.metric_alarms[0].threshold
+          - ec2_instance_metric_alarm_update.unit == alarm_info.metric_alarms[0].unit
+          - ec2_instance_metric_alarm_update.evaluation_periods == alarm_info.metric_alarms[0].evaluation_periods
+          - ec2_instance_metric_alarm_update.treat_missing_data == alarm_info.metric_alarms[0].treat_missing_data
 
-  - name: verify that properties were changed
-    assert:
-      that:
-      - ec2_instance_metric_alarm_update.changed
-      - ec2_instance_metric_alarm_update.period == 60        # Period should be 60, not matching old value
-      - ec2_instance_metric_alarm_update.alarm_arn == ec2_instance_metric_alarm.alarm_arn
-      - 'ec2_instance_metric_alarm_update.statistic == alarm_info.metric_alarms[0].statistic'
-      - 'ec2_instance_metric_alarm_update.name  == alarm_info.metric_alarms[0].alarm_name'
-      - 'ec2_instance_metric_alarm_update.metric == alarm_info.metric_alarms[0].metric_name'
-      - 'ec2_instance_metric_alarm_update.namespace == alarm_info.metric_alarms[0].namespace'
-      - 'ec2_instance_metric_alarm_update.statistic == alarm_info.metric_alarms[0].statistic'
-      - 'ec2_instance_metric_alarm_update.comparison == alarm_info.metric_alarms[0].comparison_operator'
-      - 'ec2_instance_metric_alarm_update.threshold == alarm_info.metric_alarms[0].threshold'
-      - 'ec2_instance_metric_alarm_update.unit == alarm_info.metric_alarms[0].unit'
-      - 'ec2_instance_metric_alarm_update.evaluation_periods == alarm_info.metric_alarms[0].evaluation_periods'
-      - 'ec2_instance_metric_alarm_update.treat_missing_data == alarm_info.metric_alarms[0].treat_missing_data'
+    - name: try to remove the alarm (check mode)
+      cloudwatch_metric_alarm:
+        state: absent
+        name: "{{ alarm_full_name }}"
+      check_mode: true
+      register: ec2_instance_metric_alarm_deletion_check
 
-  - name: try to remove the alarm (check mode)
-    cloudwatch_metric_alarm:
-      state: absent
-      name: '{{ alarm_full_name }}'
-    check_mode: true
-    register: ec2_instance_metric_alarm_deletion_check
+    - name: Verify that the alarm reports deleted/changed
+      ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_alarm_deletion_check.changed
 
-  - name: Verify that the alarm reports deleted/changed
-    assert:
-      that:
-      - ec2_instance_metric_alarm_deletion_check.changed
+    - name: get info on alarms
+      amazon.aws.cloudwatch_metric_alarm_info:
+        alarm_names:
+          - "{{ alarm_full_name }}"
+      register: alarm_info_query_check
 
-  - name: get info on alarms
-    amazon.aws.cloudwatch_metric_alarm_info:
-      alarm_names:
-        - "{{ alarm_full_name }}"
-    register: alarm_info_query_check
+    - name: Verify that the alarm was not deleted in check mode using cli
+      ansible.builtin.assert:
+        that:
+          - alarm_info.metric_alarms | length > 0
 
-  - name: Verify that the alarm was not deleted in check mode using cli
-    assert:
-      that:
-        - 'alarm_info.metric_alarms | length > 0'
+    - name: try to remove the alarm
+      cloudwatch_metric_alarm:
+        state: absent
+        name: "{{ alarm_full_name }}"
+      register: ec2_instance_metric_alarm_deletion
 
-  - name: try to remove the alarm
-    cloudwatch_metric_alarm:
-      state: absent
-      name: '{{ alarm_full_name }}'
-    register: ec2_instance_metric_alarm_deletion
+    - name: Verify that the alarm reports deleted/changed
+      ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_alarm_deletion.changed
 
-  - name: Verify that the alarm reports deleted/changed
-    assert:
-      that:
-      - ec2_instance_metric_alarm_deletion.changed
+    - name: get info on alarms
+      amazon.aws.cloudwatch_metric_alarm_info:
+        alarm_names:
+          - "{{ alarm_full_name }}"
+      register: alarm_info
 
-  - name: get info on alarms
-    amazon.aws.cloudwatch_metric_alarm_info:
-      alarm_names:
-        - "{{ alarm_full_name }}"
-    register: alarm_info
+    - name: Verify that the alarm was deleted using cli
+      ansible.builtin.assert:
+        that:
+          - alarm_info.metric_alarms | length == 0
 
-  - name: Verify that the alarm was deleted using cli
-    assert:
-      that:
-        - 'alarm_info.metric_alarms | length == 0'
+    - name: create ec2 metric alarm with no unit on ec2 instance
+      cloudwatch_metric_alarm:
+        dimensions:
+          InstanceId: "{{ ec2_instance_results.instances[0].instance_id }}"
+        state: present
+        name: "{{ alarm_full_name }}"
+        metric: CPUUtilization
+        namespace: AWS/EC2
+        treat_missing_data: missing
+        statistic: Average
+        comparison: LessThanOrEqualToThreshold
+        threshold: 5.0
+        period: 300
+        evaluation_periods: 3
+        description: This will alarm when an instance's cpu usage average is lower than 5% for 15 minutes
+      register: ec2_instance_metric_alarm_no_unit
 
-  - name: create ec2 metric alarm with no unit on ec2 instance
-    cloudwatch_metric_alarm:
-      dimensions:
-        InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
-      state: present
-      name: '{{ alarm_full_name }}'
-      metric: CPUUtilization
-      namespace: AWS/EC2
-      treat_missing_data: missing
-      statistic: Average
-      comparison: LessThanOrEqualToThreshold
-      threshold: 5.0
-      period: 300
-      evaluation_periods: 3
-      description: This will alarm when an instance's cpu usage average is lower than
-        5% for 15 minutes
-    register: ec2_instance_metric_alarm_no_unit
+    - name: get info on alarms
+      amazon.aws.cloudwatch_metric_alarm_info:
+        alarm_names:
+          - "{{ alarm_full_name }}"
+      register: alarm_info_no_unit
 
-  - name: get info on alarms
-    amazon.aws.cloudwatch_metric_alarm_info:
-      alarm_names:
-        - "{{ alarm_full_name }}"
-    register: alarm_info_no_unit
+    - name: verify that an alarm was created
+      ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_alarm_no_unit.changed
+          - ec2_instance_metric_alarm_no_unit.alarm_arn
+          - ec2_instance_metric_alarm_no_unit.statistic == alarm_info_no_unit.metric_alarms[0].statistic
+          - ec2_instance_metric_alarm_no_unit.name  == alarm_info_no_unit.metric_alarms[0].alarm_name
+          - ec2_instance_metric_alarm_no_unit.metric == alarm_info_no_unit.metric_alarms[0].metric_name
+          - ec2_instance_metric_alarm_no_unit.namespace == alarm_info_no_unit.metric_alarms[0].namespace
+          - ec2_instance_metric_alarm_no_unit.comparison == alarm_info_no_unit.metric_alarms[0].comparison_operator
+          - ec2_instance_metric_alarm_no_unit.threshold == alarm_info_no_unit.metric_alarms[0].threshold
+          - ec2_instance_metric_alarm_no_unit.period == alarm_info_no_unit.metric_alarms[0].period
+          - alarm_info_no_unit.metric_alarms[0].Unit is not defined
+          - ec2_instance_metric_alarm_no_unit.evaluation_periods == alarm_info_no_unit.metric_alarms[0].evaluation_periods
+          - ec2_instance_metric_alarm_no_unit.description == alarm_info_no_unit.metric_alarms[0].alarm_description
+          - ec2_instance_metric_alarm_no_unit.treat_missing_data == alarm_info_no_unit.metric_alarms[0].treat_missing_data
 
-  - name: verify that an alarm was created
-    assert:
-      that:
-      - ec2_instance_metric_alarm_no_unit.changed
-      - ec2_instance_metric_alarm_no_unit.alarm_arn
-      - 'ec2_instance_metric_alarm_no_unit.statistic == alarm_info_no_unit.metric_alarms[0].statistic'
-      - 'ec2_instance_metric_alarm_no_unit.name  == alarm_info_no_unit.metric_alarms[0].alarm_name'
-      - 'ec2_instance_metric_alarm_no_unit.metric == alarm_info_no_unit.metric_alarms[0].metric_name'
-      - 'ec2_instance_metric_alarm_no_unit.namespace == alarm_info_no_unit.metric_alarms[0].namespace'
-      - 'ec2_instance_metric_alarm_no_unit.comparison == alarm_info_no_unit.metric_alarms[0].comparison_operator'
-      - 'ec2_instance_metric_alarm_no_unit.threshold == alarm_info_no_unit.metric_alarms[0].threshold'
-      - 'ec2_instance_metric_alarm_no_unit.period == alarm_info_no_unit.metric_alarms[0].period'
-      - 'alarm_info_no_unit.metric_alarms[0].Unit is not defined'
-      - 'ec2_instance_metric_alarm_no_unit.evaluation_periods == alarm_info_no_unit.metric_alarms[0].evaluation_periods'
-      - 'ec2_instance_metric_alarm_no_unit.description == alarm_info_no_unit.metric_alarms[0].alarm_description'
-      - 'ec2_instance_metric_alarm_no_unit.treat_missing_data == alarm_info_no_unit.metric_alarms[0].treat_missing_data'
+    - name: try to remove the alarm
+      cloudwatch_metric_alarm:
+        state: absent
+        name: "{{ alarm_full_name }}"
+      register: ec2_instance_metric_alarm_deletion
 
-  - name: try to remove the alarm
-    cloudwatch_metric_alarm:
-      state: absent
-      name: '{{ alarm_full_name }}'
-    register: ec2_instance_metric_alarm_deletion
+    - name: Verify that the alarm reports deleted/changed
+      ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_alarm_deletion.changed
 
-  - name: Verify that the alarm reports deleted/changed
-    assert:
-      that:
-      - ec2_instance_metric_alarm_deletion.changed
+    - name: get info on alarms
+      amazon.aws.cloudwatch_metric_alarm_info:
+        alarm_names:
+          - "{{ alarm_full_name }}"
+      register: alarm_info
 
-  - name: get info on alarms
-    amazon.aws.cloudwatch_metric_alarm_info:
-      alarm_names:
-        - "{{ alarm_full_name }}"
-    register: alarm_info
+    - name: Verify that the alarm was deleted using cli
+      ansible.builtin.assert:
+        that:
+          - alarm_info.metric_alarms | length == 0
 
-  - name: Verify that the alarm was deleted using cli
-    assert:
-      that:
-        - 'alarm_info.metric_alarms | length == 0'
-
-  - name: create ec2 metric alarm with metrics
-    cloudwatch_metric_alarm:
-      state: present
-      name: '{{ alarm_full_name }}'
-      treat_missing_data: missing
-      comparison: LessThanOrEqualToThreshold
-      threshold: 5.0
-      evaluation_periods: 3
-      description: This will alarm when an instance's cpu usage average is lower than
-        5% for 15 minutes
-      metrics:
-        - id: cpu
-          metric_stat:
+    - name: create ec2 metric alarm with metrics
+      cloudwatch_metric_alarm:
+        state: present
+        name: "{{ alarm_full_name }}"
+        treat_missing_data: missing
+        comparison: LessThanOrEqualToThreshold
+        threshold: 5.0
+        evaluation_periods: 3
+        description: This will alarm when an instance's cpu usage average is lower than 5% for 15 minutes
+        metrics:
+          - id: cpu
+            metric_stat:
               metric:
-                  dimensions:
-                    - name: "InstanceId"
-                      value: "{{ ec2_instance_results.instances[0].instance_id }}"
-                  metric_name: "CPUUtilization"
-                  namespace: "AWS/EC2"
+                dimensions:
+                  - name: InstanceId
+                    value: "{{ ec2_instance_results.instances[0].instance_id }}"
+                metric_name: CPUUtilization
+                namespace: AWS/EC2
               period: 300
-              stat: "Average"
-              unit: "Percent"
-          return_data: true
-    register: ec2_instance_metric_alarm_metrics
+              stat: Average
+              unit: Percent
+            return_data: true
+      register: ec2_instance_metric_alarm_metrics
 
-  - name: get info on alarms
-    amazon.aws.cloudwatch_metric_alarm_info:
-      alarm_names:
-        - "{{ alarm_full_name }}"
-    register: alarm_info_metrics
+    - name: get info on alarms
+      amazon.aws.cloudwatch_metric_alarm_info:
+        alarm_names:
+          - "{{ alarm_full_name }}"
+      register: alarm_info_metrics
 
-  - name: verify that an alarm was created
-    assert:
-      that:
-      - ec2_instance_metric_alarm_metrics.changed
-      - ec2_instance_metric_alarm_metrics.alarm_arn
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.stat == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.stat'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.namespace == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.metric.namespace'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.metric_name == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.metric.metric_name'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.dimensions[0].name == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.metric.dimensions[0].name'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.dimensions[0].value == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.metric.dimensions[0].value'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].id == alarm_info_metrics.metric_alarms[0].metrics[0].id'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.period == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.period'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.unit == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.unit'
-      - 'ec2_instance_metric_alarm_metrics.metrics[0].return_data == alarm_info_metrics.metric_alarms[0].metrics[0].return_data'
+    - name: verify that an alarm was created
+      ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_alarm_metrics.changed
+          - ec2_instance_metric_alarm_metrics.alarm_arn
+          - ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.stat == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.stat
+          - ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.namespace == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.metric.namespace
+          - ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.metric_name == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.metric.metric_name
+          - ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.dimensions[0].name == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.metric.dimensions[0].name
+          - ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.metric.dimensions[0].value == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.metric.dimensions[0].value
+          - ec2_instance_metric_alarm_metrics.metrics[0].id == alarm_info_metrics.metric_alarms[0].metrics[0].id
+          - ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.period == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.period
+          - ec2_instance_metric_alarm_metrics.metrics[0].metric_stat.unit == alarm_info_metrics.metric_alarms[0].metrics[0].metric_stat.unit
+          - ec2_instance_metric_alarm_metrics.metrics[0].return_data == alarm_info_metrics.metric_alarms[0].metrics[0].return_data
 
+    - name: try to remove the alarm
+      cloudwatch_metric_alarm:
+        state: absent
+        name: "{{ alarm_full_name }}"
+      register: ec2_instance_metric_alarm_deletion_no_unit
 
-  - name: try to remove the alarm
-    cloudwatch_metric_alarm:
-      state: absent
-      name: '{{ alarm_full_name }}'
-    register: ec2_instance_metric_alarm_deletion_no_unit
+    - name: Verify that the alarm reports deleted/changed
+      ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_alarm_deletion_no_unit.changed
 
-  - name: Verify that the alarm reports deleted/changed
-    assert:
-      that:
-      - ec2_instance_metric_alarm_deletion_no_unit.changed
+    - name: get info on alarms
+      amazon.aws.cloudwatch_metric_alarm_info:
+        alarm_names:
+          - "{{ alarm_full_name }}"
+      register: alarm_info_no_unit
 
-  - name: get info on alarms
-    amazon.aws.cloudwatch_metric_alarm_info:
-      alarm_names:
-        - "{{ alarm_full_name }}"
-    register: alarm_info_no_unit
+    - name: Verify that the alarm was deleted using cli
+      ansible.builtin.assert:
+        that:
+          - alarm_info_no_unit.metric_alarms | length == 0
 
-  - name: Verify that the alarm was deleted using cli
-    assert:
-      that:
-        - 'alarm_info_no_unit.metric_alarms | length == 0'
-
-  - name: create ec2 metric alarm by providing mutually exclusive values
-    cloudwatch_metric_alarm:
-      dimensions:
-        InstanceId: '{{ ec2_instance_results.instances[0].instance_id }}'
-      state: present
-      name: '{{ alarm_full_name }}'
-      metric: CPUUtilization
-      namespace: AWS/EC2
-      treat_missing_data: missing
-      statistic: Average
-      comparison: LessThanOrEqualToThreshold
-      threshold: 5.0
-      period: 300
-      evaluation_periods: 3
-      description: This will alarm when an instance's cpu usage average is lower than
-        5% for 15 minutes
-      metrics:
-        - id: cpu
-          metric_stat:
+    - name: create ec2 metric alarm by providing mutually exclusive values
+      cloudwatch_metric_alarm:
+        dimensions:
+          InstanceId: "{{ ec2_instance_results.instances[0].instance_id }}"
+        state: present
+        name: "{{ alarm_full_name }}"
+        metric: CPUUtilization
+        namespace: AWS/EC2
+        treat_missing_data: missing
+        statistic: Average
+        comparison: LessThanOrEqualToThreshold
+        threshold: 5.0
+        period: 300
+        evaluation_periods: 3
+        description: This will alarm when an instance's cpu usage average is lower than 5% for 15 minutes
+        metrics:
+          - id: cpu
+            metric_stat:
               metric:
-                  dimensions:
-                    - name: "InstanceId"
-                      value: "{{ ec2_instance_results.instances[0].instance_id }}"
-                  metric_name: "CPUUtilization"
-                  namespace: "AWS/EC2"
+                dimensions:
+                  - name: InstanceId
+                    value: "{{ ec2_instance_results.instances[0].instance_id }}"
+                metric_name: CPUUtilization
+                namespace: AWS/EC2
               period: 300
-              stat: "Average"
-              unit: "Percent"
-          return_data: true
-    register: ec2_instance_metric_mutually_exclusive
-    ignore_errors: true
+              stat: Average
+              unit: Percent
+            return_data: true
+      register: ec2_instance_metric_mutually_exclusive
+      ignore_errors: true
 
-  - assert:
-      that:
-      - ec2_instance_metric_mutually_exclusive.failed
-      - '"parameters are mutually exclusive" in ec2_instance_metric_mutually_exclusive.msg'
+    - ansible.builtin.assert:
+        that:
+          - ec2_instance_metric_mutually_exclusive.failed
+          - '"parameters are mutually exclusive" in ec2_instance_metric_mutually_exclusive.msg'
 
   always:
-  - name: try to delete the alarm
-    cloudwatch_metric_alarm:
-      state: absent
-      name: '{{ alarm_full_name }}'
-    ignore_errors: true
+    - name: try to delete the alarm
+      cloudwatch_metric_alarm:
+        state: absent
+        name: "{{ alarm_full_name }}"
+      ignore_errors: true
 
-  - name: try to stop the ec2 instance
-    ec2_instance:
-      instance_ids: '{{ ec2_instance_results.instances[0].instance_id }}'
-      state: terminated
-    ignore_errors: true
+    - name: try to stop the ec2 instance
+      amazon.aws.ec2_instance:
+        instance_ids: "{{ ec2_instance_results.instances[0].instance_id }}"
+        state: terminated
+      ignore_errors: true
 
-  - include_tasks: env_cleanup.yml
+    - ansible.builtin.include_tasks: env_cleanup.yml

--- a/tests/integration/targets/cloudwatchevent_rule/defaults/main.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-name_pattern: "cloudwatch_event_rule-{{ tiny_prefix }}"
+name_pattern: cloudwatch_event_rule-{{ tiny_prefix }}
 
 test_event_names:
   - "{{ name_pattern }}-1"

--- a/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -7,18 +8,18 @@
 
   block:
     - name: Create SNS topic
-      sns_topic:
-        name: "TestSNSTopic"
+      community.aws.sns_topic:
+        name: TestSNSTopic
         state: present
-        display_name: "Test SNS Topic"
+        display_name: Test SNS Topic
       register: sns_topic_output
 
     - name: Create classic cloudwatch event rules
-      cloudwatchevent_rule:
+      amazon.aws.cloudwatchevent_rule:
         name: "{{ item }}"
-        description: "Rule for {{ item }}"
+        description: Rule for {{ item }}
         state: present
-        schedule_expression: "cron(0 20 * * ? *)"
+        schedule_expression: cron(0 20 * * ? *)
         targets:
           - id: "{{ sns_topic_output.sns_topic.name }}"
             arn: "{{ sns_topic_output.sns_topic.topic_arn }}"
@@ -26,15 +27,15 @@
       loop: "{{ test_event_names }}"
 
     - name: Assert that classic event rules were created
-      assert:
+      ansible.builtin.assert:
         that:
           - event_rules_classic_output.changed
           - event_rules_classic_output.msg == "All items completed"
 
     - name: Create cloudwatch event rule with input transformer
-      cloudwatchevent_rule:
+      amazon.aws.cloudwatchevent_rule:
         name: "{{ input_transformer_event_name }}"
-        description: "Event rule with input transformer configuration"
+        description: Event rule with input transformer configuration
         state: present
         event_pattern: '{"source":["aws.ec2"],"detail-type":["EC2 Instance State-change Notification"],"detail":{"state":["pending"]}}'
         targets:
@@ -42,20 +43,20 @@
             arn: "{{ sns_topic_output.sns_topic.topic_arn }}"
             input_transformer:
               input_paths_map:
-                instance: "$.detail.instance-id"
-                state: "$.detail.state"
-              input_template: "<instance> is in state <state>"
+                instance: $.detail.instance-id
+                state: $.detail.state
+              input_template: <instance> is in state <state>
       register: event_rule_input_transformer_output
 
     - name: Assert that input transformer event rule was created
-      assert:
+      ansible.builtin.assert:
         that:
           - event_rule_input_transformer_output.changed
 
     - name: Create cloudwatch event rule with input transformer (idempotent)
-      cloudwatchevent_rule:
+      amazon.aws.cloudwatchevent_rule:
         name: "{{ input_transformer_event_name }}"
-        description: "Event rule with input transformer configuration"
+        description: Event rule with input transformer configuration
         state: present
         event_pattern: '{"source":["aws.ec2"],"detail-type":["EC2 Instance State-change Notification"],"detail":{"state":["pending"]}}'
         targets:
@@ -63,48 +64,47 @@
             arn: "{{ sns_topic_output.sns_topic.topic_arn }}"
             input_transformer:
               input_paths_map:
-                instance: "$.detail.instance-id"
-                state: "$.detail.state"
-              input_template: "<instance> is in state <state>"
+                instance: $.detail.instance-id
+                state: $.detail.state
+              input_template: <instance> is in state <state>
       register: event_rule_input_transformer_output
 
     - name: Assert that no changes were made to the rule
-      assert:
+      ansible.builtin.assert:
         that:
           - event_rule_input_transformer_output is not changed
 
     - name: Create cloudwatch event rule with inputs
-      cloudwatchevent_rule:
+      amazon.aws.cloudwatchevent_rule:
         name: "{{ input_event_name }}"
-        description: "Event rule with input configuration"
+        description: Event rule with input configuration
         state: present
         event_pattern: '{"source":["aws.ec2"],"detail-type":["EC2 Instance State-change Notification"],"detail":{"state":["pending"]}}'
         targets:
           - id: "{{ sns_topic_output.sns_topic.name }}"
             arn: "{{ sns_topic_output.sns_topic.topic_arn }}"
-            input: 'Hello World'
+            input: Hello World
           - id: "{{ sns_topic_output.sns_topic.name }}2"
             arn: "{{ sns_topic_output.sns_topic.topic_arn }}"
             input:
-              start: 'Hello World'
-              end: 'Goodbye oh cruel World'
+              start: Hello World
+              end: Goodbye oh cruel World
       register: event_rule_input_transformer_output
 
     - name: Assert that input transformer event rule was created
-      assert:
+      ansible.builtin.assert:
         that:
           - event_rule_input_transformer_output.changed
 
   always:
-
     - name: Delete classic CloudWatch event rules
-      cloudwatchevent_rule:
+      amazon.aws.cloudwatchevent_rule:
         name: "{{ item }}"
         state: absent
       loop: "{{ test_event_names }}"
 
     - name: Delete input transformer CloudWatch event rules
-      cloudwatchevent_rule:
+      amazon.aws.cloudwatchevent_rule:
         name: "{{ item }}"
         state: absent
       loop:
@@ -112,6 +112,6 @@
         - "{{ input_event_name }}"
 
     - name: Delete SNS topic
-      sns_topic:
-        name: "TestSNSTopic"
+      community.aws.sns_topic:
+        name: TestSNSTopic
         state: absent

--- a/tests/integration/targets/cloudwatchlogs/defaults/main.yml
+++ b/tests/integration/targets/cloudwatchlogs/defaults/main.yml
@@ -1,2 +1,3 @@
-log_group_name: '{{ resource_prefix }}/integrationtest'
-filter_name: '{{ resource_prefix }}/AnsibleTest'
+---
+log_group_name: "{{ resource_prefix }}/integrationtest"
+filter_name: "{{ resource_prefix }}/AnsibleTest"

--- a/tests/integration/targets/cloudwatchlogs/meta/main.yml
+++ b/tests/integration/targets/cloudwatchlogs/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/cloudwatchlogs/tasks/cloudwatchlogs_tests.yml
+++ b/tests/integration/targets/cloudwatchlogs/tasks/cloudwatchlogs_tests.yml
@@ -1,151 +1,151 @@
+---
 # Tests for changes to the cloudwatchlogs_log_group and cloudwatchlogs_log_group_metric_filter
 
 - block:
+    - name: create cloudwatch log group for integration test
+      amazon.aws.cloudwatchlogs_log_group:
+        state: present
+        log_group_name: "{{ log_group_name }}"
+        retention: 1
 
-  - name: create cloudwatch log group for integration test
-    cloudwatchlogs_log_group:
-      state: present
-      log_group_name: '{{ log_group_name }}'
-      retention: 1
+    - name: check_mode set metric filter on '{{ log_group_name }}'
+      amazon.aws.cloudwatchlogs_log_group_metric_filter:
+        log_group_name: "{{ log_group_name }}"
+        filter_name: "{{ filter_name }}"
+        filter_pattern: '{ ($.value = *) && ($.hostname = "box")}'
+        state: present
+        metric_transformation:
+          metric_name: box_free_space
+          metric_namespace: fluentd_metrics
+          metric_value: $.value
+      check_mode: true
+      register: out
 
-  - name: check_mode set metric filter on '{{ log_group_name }}'
-    cloudwatchlogs_log_group_metric_filter:
-      log_group_name: '{{ log_group_name }}'
-      filter_name: '{{ filter_name }}'
-      filter_pattern: '{ ($.value = *) && ($.hostname = "box")}'
-      state: present
-      metric_transformation:
-        metric_name: box_free_space
-        metric_namespace: fluentd_metrics
-        metric_value: $.value
-    check_mode: yes
-    register: out
+    - name: check_mode state must be changed
+      ansible.builtin.assert:
+        that:
+          - out is changed
+          - out.metric_filters | count == 1
 
-  - name: check_mode state must be changed
-    assert:
-      that:
-      - out is changed
-      - out.metric_filters | count == 1
+    - name: set metric filter on '{{ log_group_name }}'
+      amazon.aws.cloudwatchlogs_log_group_metric_filter:
+        log_group_name: "{{ log_group_name }}"
+        filter_name: "{{ filter_name }}"
+        filter_pattern: '{ ($.value = *) && ($.hostname = "box")}'
+        state: present
+        metric_transformation:
+          metric_name: box_free_space
+          metric_namespace: fluentd_metrics
+          metric_value: $.value
+      register: out
 
-  - name: set metric filter on '{{ log_group_name }}'
-    cloudwatchlogs_log_group_metric_filter:
-      log_group_name: '{{ log_group_name }}'
-      filter_name: '{{ filter_name }}'
-      filter_pattern: '{ ($.value = *) && ($.hostname = "box")}'
-      state: present
-      metric_transformation:
-        metric_name: box_free_space
-        metric_namespace: fluentd_metrics
-        metric_value: $.value
-    register: out
+    - name: create metric filter
+      ansible.builtin.assert:
+        that:
+          - out is changed
+          - out.metric_filters | count == 1
 
-  - name: create metric filter
-    assert:
-      that:
-      - out is changed
-      - out.metric_filters | count == 1
+    - name: re-set metric filter on '{{ log_group_name }}'
+      amazon.aws.cloudwatchlogs_log_group_metric_filter:
+        log_group_name: "{{ log_group_name }}"
+        filter_name: "{{ filter_name }}"
+        filter_pattern: '{ ($.value = *) && ($.hostname = "box")}'
+        state: present
+        metric_transformation:
+          metric_name: box_free_space
+          metric_namespace: fluentd_metrics
+          metric_value: $.value
+      register: out
 
-  - name: re-set metric filter on '{{ log_group_name }}'
-    cloudwatchlogs_log_group_metric_filter:
-      log_group_name: '{{ log_group_name }}'
-      filter_name: '{{ filter_name }}'
-      filter_pattern: '{ ($.value = *) && ($.hostname = "box")}'
-      state: present
-      metric_transformation:
-        metric_name: box_free_space
-        metric_namespace: fluentd_metrics
-        metric_value: $.value
-    register: out
+    - name: metric filter must not change
+      ansible.builtin.assert:
+        that:
+          - out is not changed
 
-  - name: metric filter must not change
-    assert:
-      that:
-      - out is not changed
+    - name: update metric transformation on '{{ log_group_name }}'
+      amazon.aws.cloudwatchlogs_log_group_metric_filter:
+        log_group_name: "{{ log_group_name }}"
+        filter_name: "{{ filter_name }}"
+        filter_pattern: '{ ($.value = *) && ($.hostname = "box")}'
+        state: present
+        metric_transformation:
+          metric_name: box_free_space
+          metric_namespace: made_with_ansible
+          metric_value: $.value
+          default_value: 3.1415
+      register: out
 
-  - name: update metric transformation on '{{ log_group_name }}'
-    cloudwatchlogs_log_group_metric_filter:
-      log_group_name: '{{ log_group_name }}'
-      filter_name: '{{ filter_name }}'
-      filter_pattern: '{ ($.value = *) && ($.hostname = "box")}'
-      state: present
-      metric_transformation:
-        metric_name: box_free_space
-        metric_namespace: made_with_ansible
-        metric_value: $.value
-        default_value: 3.1415
-    register: out
+    - name: update metric filter
+      ansible.builtin.assert:
+        that:
+          - out is changed
+          - out.metric_filters[0].metric_namespace == "made_with_ansible"
+          - out.metric_filters[0].default_value == 3.1415
 
-  - name: update metric filter
-    assert:
-      that:
-      - out is changed
-      - out.metric_filters[0].metric_namespace == "made_with_ansible"
-      - out.metric_filters[0].default_value == 3.1415
+    - name: update filter_pattern on '{{ log_group_name }}'
+      amazon.aws.cloudwatchlogs_log_group_metric_filter:
+        log_group_name: "{{ log_group_name }}"
+        filter_name: "{{ filter_name }}"
+        filter_pattern: '{ ($.value = *) && ($.hostname = "ansible")}'
+        state: present
+        metric_transformation:
+          metric_name: box_free_space
+          metric_namespace: made_with_ansible
+          metric_value: $.value
+      register: out
 
-  - name: update filter_pattern on '{{ log_group_name }}'
-    cloudwatchlogs_log_group_metric_filter:
-      log_group_name: '{{ log_group_name }}'
-      filter_name: '{{ filter_name }}'
-      filter_pattern: '{ ($.value = *) && ($.hostname = "ansible")}'
-      state: present
-      metric_transformation:
-        metric_name: box_free_space
-        metric_namespace: made_with_ansible
-        metric_value: $.value
-    register: out
+    - name: update metric filter
+      ansible.builtin.assert:
+        that:
+          - out is changed
+          - out.metric_filters[0].metric_namespace == "made_with_ansible"
 
-  - name: update metric filter
-    assert:
-      that:
-      - out is changed
-      - out.metric_filters[0].metric_namespace == "made_with_ansible"
+    - name: checkmode delete metric filter on '{{ log_group_name }}'
+      amazon.aws.cloudwatchlogs_log_group_metric_filter:
+        log_group_name: "{{ log_group_name }}"
+        filter_name: "{{ filter_name }}"
+        state: absent
+      check_mode: true
+      register: out
 
-  - name: checkmode delete metric filter on '{{ log_group_name }}'
-    cloudwatchlogs_log_group_metric_filter:
-      log_group_name: '{{ log_group_name }}'
-      filter_name: '{{ filter_name }}'
-      state: absent
-    check_mode: yes
-    register: out
+    - name: check_mode state must be changed
+      ansible.builtin.assert:
+        that:
+          - out is changed
 
-  - name: check_mode state must be changed
-    assert:
-      that:
-      - out is changed
+    - name: delete metric filter on '{{ log_group_name }}'
+      amazon.aws.cloudwatchlogs_log_group_metric_filter:
+        log_group_name: "{{ log_group_name }}"
+        filter_name: "{{ filter_name }}"
+        state: absent
+      register: out
 
-  - name: delete metric filter on '{{ log_group_name }}'
-    cloudwatchlogs_log_group_metric_filter:
-      log_group_name: '{{ log_group_name }}'
-      filter_name: '{{ filter_name }}'
-      state: absent
-    register: out
+    - name: delete metric filter
+      ansible.builtin.assert:
+        that:
+          - out is changed
 
-  - name: delete metric filter
-    assert:
-      that:
-      - out is changed
+    - name: delete metric filter on '{{ log_group_name }}' which does not exist
+      amazon.aws.cloudwatchlogs_log_group_metric_filter:
+        log_group_name: "{{ log_group_name }}"
+        filter_name: "{{ filter_name }}"
+        state: absent
+      register: out
 
-  - name: delete metric filter on '{{ log_group_name }}' which does not exist
-    cloudwatchlogs_log_group_metric_filter:
-      log_group_name: '{{ log_group_name }}'
-      filter_name: '{{ filter_name }}'
-      state: absent
-    register: out
-
-  - name: delete metric filter
-    assert:
-      that:
-      - out is not changed
+    - name: delete metric filter
+      ansible.builtin.assert:
+        that:
+          - out is not changed
 
   always:
-  - name: delete metric filter
-    cloudwatchlogs_log_group_metric_filter:
-      log_group_name: '{{ log_group_name }}'
-      filter_name: '{{ filter_name }}'
-      state: absent
+    - name: delete metric filter
+      amazon.aws.cloudwatchlogs_log_group_metric_filter:
+        log_group_name: "{{ log_group_name }}"
+        filter_name: "{{ filter_name }}"
+        state: absent
 
-  - name: delete cloudwatch log group for integration test
-    cloudwatchlogs_log_group:
-      state: absent
-      log_group_name: '{{ log_group_name }}'
+    - name: delete cloudwatch log group for integration test
+      amazon.aws.cloudwatchlogs_log_group:
+        state: absent
+        log_group_name: "{{ log_group_name }}"
   ignore_errors: true

--- a/tests/integration/targets/cloudwatchlogs/tasks/create-delete-tags.yml
+++ b/tests/integration/targets/cloudwatchlogs/tasks/create-delete-tags.yml
@@ -1,3 +1,4 @@
+---
 # Tests relating to create/delete and set tags on cloudwatchlogs_log_group
 
 - name: Tests relating to setting tags on cloudwatchlogs_log_group
@@ -31,414 +32,410 @@
   module_defaults:
     amazon.aws.cloudwatchlogs_log_group:
       state: present
-      log_group_name: '{{ log_group_name }}'
+      log_group_name: "{{ log_group_name }}"
     amazon.aws.cloudwatchlogs_log_group_info:
-      log_group_name: '{{ log_group_name }}'
+      log_group_name: "{{ log_group_name }}"
   block:
+    - name: create cloudwatch log group for integration test (check_mode)
+      amazon.aws.cloudwatchlogs_log_group:
+        state: present
+        log_group_name: "{{ log_group_name }}"
+        retention: 1
+        tags:
+          CamelCase: Value
+          snake_case: value
+      check_mode: true
+      register: result
 
-  - name: create cloudwatch log group for integration test (check_mode)
-    cloudwatchlogs_log_group:
-      state: present
-      log_group_name: '{{ log_group_name }}'
-      retention: 1
-      tags:
-        CamelCase: Value
-        snake_case: value
-    check_mode: true
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - result is changed
+          - '"log_groups" not in result'
+          - '"logs:CreateLogGroup" not in result.resource_actions'
 
-  - assert:
-      that:
-      - result is changed
-      - '"log_groups" not in result'
-      - '"logs:CreateLogGroup" not in result.resource_actions'
+    - name: create cloudwatch log group for integration test
+      amazon.aws.cloudwatchlogs_log_group:
+        state: present
+        log_group_name: "{{ log_group_name }}"
+        retention: 1
+        tags:
+          CamelCase: Value
+          snake_case: value
+      register: result
 
-  - name: create cloudwatch log group for integration test
-    cloudwatchlogs_log_group:
-      state: present
-      log_group_name: '{{ log_group_name }}'
-      retention: 1
-      tags:
-        CamelCase: Value
-        snake_case: value
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - result is changed
+          - '"log_groups" in result'
+          - result.log_groups | length == 1
+          - '"log_group_name" in log_group'
+          - '"creation_time" in log_group'
+          - '"retention_in_days" in log_group'
+          - '"metric_filter_count" in log_group'
+          - '"arn" in log_group'
+          - '"stored_bytes" in log_group'
+          # - '"kms_key_id" in log_group'
+          # pre-4.0.0 upgrade compatibility
+          - '"log_group_name" in result'
+          - '"creation_time" in result'
+          - '"retention_in_days" in result'
+          - '"metric_filter_count" in result'
+          - '"arn" in result'
+          - '"stored_bytes" in result'
+          # - '"kms_key_id" in result'
+          - '"CamelCase" in log_group.tags'
+          - '"snake_case" in log_group.tags'
+      vars:
+        log_group: "{{ result.log_groups[0] }}"
 
-  - assert:
-      that:
-      - result is changed
-      - '"log_groups" in result'
-      - result.log_groups | length == 1
-      - '"log_group_name" in log_group'
-      - '"creation_time" in log_group'
-      - '"retention_in_days" in log_group'
-      - '"metric_filter_count" in log_group'
-      - '"arn" in log_group'
-      - '"stored_bytes" in log_group'
-      # - '"kms_key_id" in log_group'
-      # pre-4.0.0 upgrade compatibility
-      - '"log_group_name" in result'
-      - '"creation_time" in result'
-      - '"retention_in_days" in result'
-      - '"metric_filter_count" in result'
-      - '"arn" in result'
-      - '"stored_bytes" in result'
-      # - '"kms_key_id" in result'
-      - '"CamelCase" in log_group.tags'
-      - '"snake_case" in log_group.tags'
-    vars:
-      log_group: '{{ result.log_groups[0] }}'
+    - name: create cloudwatch log group for integration test (check_mode - idempotent)
+      amazon.aws.cloudwatchlogs_log_group:
+        state: present
+        log_group_name: "{{ log_group_name }}"
+        retention: 1
+      check_mode: true
+      register: result
 
-  - name: create cloudwatch log group for integration test (check_mode - idempotent)
-    cloudwatchlogs_log_group:
-      state: present
-      log_group_name: '{{ log_group_name }}'
-      retention: 1
-    check_mode: true
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
+          - '"log_groups" in result'
+          - result.log_groups | length == 1
 
-  - assert:
-      that:
-      - result is not changed
-      - '"log_groups" in result'
-      - result.log_groups | length == 1
+    - name: create cloudwatch log group for integration test (idempotent)
+      amazon.aws.cloudwatchlogs_log_group:
+        state: present
+        log_group_name: "{{ log_group_name }}"
+        retention: 1
+      register: result
 
-  - name: create cloudwatch log group for integration test (idempotent)
-    cloudwatchlogs_log_group:
-      state: present
-      log_group_name: '{{ log_group_name }}'
-      retention: 1
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
+          - '"log_groups" in result'
+          - result.log_groups | length == 1
+      vars:
+        log_group: "{{ result.log_groups[0] }}"
 
-  - assert:
-      that:
-      - result is not changed
-      - '"log_groups" in result'
-      - result.log_groups | length == 1
-    vars:
-      log_group: '{{ result.log_groups[0] }}'
+    - name: describe all log groups
+      amazon.aws.cloudwatchlogs_log_group_info: {}
+      register: result
 
-  - name: describe all log groups
-    cloudwatchlogs_log_group_info: {}
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - '"log_groups" in result'
+          - result.log_groups | length >= 1
 
-  - assert:
-      that:
-      - '"log_groups" in result'
-      - result.log_groups | length >= 1
+    - name: describe log group
+      amazon.aws.cloudwatchlogs_log_group_info:
+        log_group_name: "{{ log_group_name }}"
+      register: result
 
-  - name: describe log group
-    cloudwatchlogs_log_group_info:
-      log_group_name: '{{ log_group_name }}'
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - '"log_groups" in result'
+          - result.log_groups | length == 1
+          - '"log_group_name" in log_group'
+          - '"creation_time" in log_group'
+          - '"retention_in_days" in log_group'
+          - '"metric_filter_count" in log_group'
+          - '"arn" in log_group'
+          - '"stored_bytes" in log_group'
+          # - '"kms_key_id" in log_group'
+          - '"tags" in log_group'
+      vars:
+        log_group: "{{ result.log_groups[0] }}"
+    - name: test adding tags to cloudwatchlogs_log_group (check_mode)
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: "{{ first_tags }}"
+        purge_tags: true
+      check_mode: true
+      register: update_result
 
-  - assert:
-      that:
-      - '"log_groups" in result'
-      - result.log_groups | length == 1
-      - '"log_group_name" in log_group'
-      - '"creation_time" in log_group'
-      - '"retention_in_days" in log_group'
-      - '"metric_filter_count" in log_group'
-      - '"arn" in log_group'
-      - '"stored_bytes" in log_group'
-      # - '"kms_key_id" in log_group'
-      - '"tags" in log_group'
-    vars:
-      log_group: '{{ result.log_groups[0] }}'
-  - name: test adding tags to cloudwatchlogs_log_group (check_mode)
-    cloudwatchlogs_log_group:
-      tags: '{{ first_tags }}'
-      purge_tags: true
-    check_mode: true
-    register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - '"logs:UntagLogGroup" not in update_result'
+          - '"logs:TagLogGroup" not in update_result'
 
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - '"logs:UntagLogGroup" not in update_result'
-      - '"logs:TagLogGroup" not in update_result'
+    - name: test adding tags to cloudwatchlogs_log_group
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: "{{ first_tags }}"
+        purge_tags: true
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - update_result.log_groups[0].tags == first_tags
 
-  - name: test adding tags to cloudwatchlogs_log_group
-    cloudwatchlogs_log_group:
-      tags: '{{ first_tags }}'
-      purge_tags: true
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - update_result.log_groups[0].tags == first_tags
+    - name: test adding tags to cloudwatchlogs_log_group - idempotency (check mode)
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: "{{ first_tags }}"
+        purge_tags: true
+      check_mode: true
+      register: update_result
 
-  - name: test adding tags to cloudwatchlogs_log_group - idempotency (check mode)
-    cloudwatchlogs_log_group:
-      tags: '{{ first_tags }}'
-      purge_tags: true
-    check_mode: true
-    register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - '"logs:UntagLogGroup" not in update_result'
+          - '"logs:TagLogGroup" not in update_result'
 
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - '"logs:UntagLogGroup" not in update_result'
-      - '"logs:TagLogGroup" not in update_result'
+    - name: test adding tags to cloudwatchlogs_log_group - idempotency
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: "{{ first_tags }}"
+        purge_tags: true
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.log_groups[0].tags == first_tags
 
-  - name: test adding tags to cloudwatchlogs_log_group - idempotency
-    cloudwatchlogs_log_group:
-      tags: '{{ first_tags }}'
-      purge_tags: true
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.log_groups[0].tags == first_tags
+    ###
 
-  ###
+    - name: test updating tags with purge on cloudwatchlogs_log_group (check mode)
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: "{{ second_tags }}"
+        purge_tags: true
+      check_mode: true
+      register: update_result
 
-  - name: test updating tags with purge on cloudwatchlogs_log_group (check mode)
-    cloudwatchlogs_log_group:
-      tags: '{{ second_tags }}'
-      purge_tags: true
-    check_mode: true
-    register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - '"logs:UntagLogGroup" not in update_result'
+          - '"logs:TagLogGroup" not in update_result'
 
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - '"logs:UntagLogGroup" not in update_result'
-      - '"logs:TagLogGroup" not in update_result'
+    - name: test updating tags with purge on cloudwatchlogs_log_group
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: "{{ second_tags }}"
+        purge_tags: true
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - update_result.log_groups[0].tags == second_tags
 
-  - name: test updating tags with purge on cloudwatchlogs_log_group
-    cloudwatchlogs_log_group:
-      tags: '{{ second_tags }}'
-      purge_tags: true
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - update_result.log_groups[0].tags == second_tags
+    - name: test updating tags with purge on cloudwatchlogs_log_group - idempotency (check mode)
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: "{{ second_tags }}"
+        purge_tags: true
+      check_mode: true
+      register: update_result
 
-  - name: test updating tags with purge on cloudwatchlogs_log_group - idempotency
-      (check mode)
-    cloudwatchlogs_log_group:
-      tags: '{{ second_tags }}'
-      purge_tags: true
-    check_mode: true
-    register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - '"logs:UntagLogGroup" not in update_result'
+          - '"logs:TagLogGroup" not in update_result'
 
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - '"logs:UntagLogGroup" not in update_result'
-      - '"logs:TagLogGroup" not in update_result'
+    - name: test updating tags with purge on cloudwatchlogs_log_group - idempotency
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: "{{ second_tags }}"
+        purge_tags: true
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.log_groups[0].tags == second_tags
 
-  - name: test updating tags with purge on cloudwatchlogs_log_group - idempotency
-    cloudwatchlogs_log_group:
-      tags: '{{ second_tags }}'
-      purge_tags: true
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.log_groups[0].tags == second_tags
+    ###
 
-  ###
+    - name: test updating tags without purge on cloudwatchlogs_log_group (check mode)
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      check_mode: true
+      register: update_result
 
-  - name: test updating tags without purge on cloudwatchlogs_log_group (check mode)
-    cloudwatchlogs_log_group:
-      tags: '{{ third_tags }}'
-      purge_tags: false
-    check_mode: true
-    register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - '"logs:UntagLogGroup" not in update_result'
+          - '"logs:TagLogGroup" not in update_result'
 
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - '"logs:UntagLogGroup" not in update_result'
-      - '"logs:TagLogGroup" not in update_result'
+    - name: test updating tags without purge on cloudwatchlogs_log_group
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - update_result.log_groups[0].tags == final_tags
 
-  - name: test updating tags without purge on cloudwatchlogs_log_group
-    cloudwatchlogs_log_group:
-      tags: '{{ third_tags }}'
-      purge_tags: false
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - update_result.log_groups[0].tags == final_tags
+    - name: test updating tags without purge on cloudwatchlogs_log_group - idempotency (check mode)
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      check_mode: true
+      register: update_result
 
-  - name: test updating tags without purge on cloudwatchlogs_log_group - idempotency
-      (check mode)
-    cloudwatchlogs_log_group:
-      tags: '{{ third_tags }}'
-      purge_tags: false
-    check_mode: true
-    register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - '"logs:UntagLogGroup" not in update_result'
+          - '"logs:TagLogGroup" not in update_result'
 
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - '"logs:UntagLogGroup" not in update_result'
-      - '"logs:TagLogGroup" not in update_result'
+    - name: test updating tags without purge on cloudwatchlogs_log_group - idempotency
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.log_groups[0].tags == final_tags
 
-  - name: test updating tags without purge on cloudwatchlogs_log_group - idempotency
-    cloudwatchlogs_log_group:
-      tags: '{{ third_tags }}'
-      purge_tags: false
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.log_groups[0].tags == final_tags
+    ###
 
-  ###
+    - name: test that cloudwatchlogs_log_group_info returns the tags
+      amazon.aws.cloudwatchlogs_log_group_info:
+      register: tag_info
+    - name: assert tags present
+      ansible.builtin.assert:
+        that:
+          - tag_info.log_groups | length == 1
+          - tag_info.log_groups[0].tags == final_tags
 
-  - name: test that cloudwatchlogs_log_group_info returns the tags
-    cloudwatchlogs_log_group_info:
-    register: tag_info
-  - name: assert tags present
-    assert:
-      that:
-      - tag_info.log_groups | length == 1
-      - tag_info.log_groups[0].tags == final_tags
+    ###
 
-  ###
+    - name: test no tags param cloudwatchlogs_log_group (check mode)
+      amazon.aws.cloudwatchlogs_log_group: {}
+      check_mode: true
+      register: update_result
 
-  - name: test no tags param cloudwatchlogs_log_group (check mode)
-    cloudwatchlogs_log_group: {}
-    check_mode: true
-    register: update_result
+    - name: assert no change
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.log_groups[0].tags == final_tags
 
-  - name: assert no change
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.log_groups[0].tags == final_tags
+    - name: test no tags param cloudwatchlogs_log_group
+      amazon.aws.cloudwatchlogs_log_group: {}
+      register: update_result
+    - name: assert no change
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.log_groups[0].tags == final_tags
 
-  - name: test no tags param cloudwatchlogs_log_group
-    cloudwatchlogs_log_group: {}
-    register: update_result
-  - name: assert no change
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.log_groups[0].tags == final_tags
+    ###
 
-  ###
+    - name: test removing tags from cloudwatchlogs_log_group (check mode)
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: {}
+        purge_tags: true
+      check_mode: true
+      register: update_result
 
-  - name: test removing tags from cloudwatchlogs_log_group (check mode)
-    cloudwatchlogs_log_group:
-      tags: {}
-      purge_tags: true
-    check_mode: true
-    register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
 
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
+    - name: test removing tags from cloudwatchlogs_log_group
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: {}
+        purge_tags: true
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - update_result.log_groups[0].tags == {}
 
-  - name: test removing tags from cloudwatchlogs_log_group
-    cloudwatchlogs_log_group:
-      tags: {}
-      purge_tags: true
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - update_result.log_groups[0].tags == {}
+    - name: test removing tags from cloudwatchlogs_log_group - idempotency (check mode)
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: {}
+        purge_tags: true
+      check_mode: true
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
 
-  - name: test removing tags from cloudwatchlogs_log_group - idempotency (check mode)
-    cloudwatchlogs_log_group:
-      tags: {}
-      purge_tags: true
-    check_mode: true
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
+    - name: test removing tags from cloudwatchlogs_log_group - idempotency
+      amazon.aws.cloudwatchlogs_log_group:
+        tags: {}
+        purge_tags: true
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.log_groups[0].tags == {}
 
-  - name: test removing tags from cloudwatchlogs_log_group - idempotency
-    cloudwatchlogs_log_group:
-      tags: {}
-      purge_tags: true
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.log_groups[0].tags == {}
+    - name: delete cloudwatch log group for integration test (check_mode)
+      amazon.aws.cloudwatchlogs_log_group:
+        state: absent
+        log_group_name: "{{ log_group_name }}"
+      check_mode: true
+      register: result
 
-  - name: delete cloudwatch log group for integration test (check_mode)
-    cloudwatchlogs_log_group:
-      state: absent
-      log_group_name: '{{ log_group_name }}'
-    check_mode: true
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - result is changed
+          - '"logs:DeleteLogGroup" not in result.resource_actions'
 
-  - assert:
-      that:
-      - result is changed
-      - '"logs:DeleteLogGroup" not in result.resource_actions'
+    - name: delete cloudwatch log group for integration test
+      amazon.aws.cloudwatchlogs_log_group:
+        state: absent
+        log_group_name: "{{ log_group_name }}"
+      register: result
 
-  - name: delete cloudwatch log group for integration test
-    cloudwatchlogs_log_group:
-      state: absent
-      log_group_name: '{{ log_group_name }}'
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - result is changed
 
-  - assert:
-      that:
-      - result is changed
+    - name: delete cloudwatch log group for integration test (check_mode - idempotent)
+      amazon.aws.cloudwatchlogs_log_group:
+        state: absent
+        log_group_name: "{{ log_group_name }}"
+      check_mode: true
+      register: result
 
-  - name: delete cloudwatch log group for integration test (check_mode - idempotent)
-    cloudwatchlogs_log_group:
-      state: absent
-      log_group_name: '{{ log_group_name }}'
-    check_mode: true
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
+          - '"logs:DeleteLogGroup" not in result.resource_actions'
 
-  - assert:
-      that:
-      - result is not changed
-      - '"logs:DeleteLogGroup" not in result.resource_actions'
+    - name: delete cloudwatch log group for integration test (idempotent)
+      amazon.aws.cloudwatchlogs_log_group:
+        state: absent
+        log_group_name: "{{ log_group_name }}"
+      register: result
 
-  - name: delete cloudwatch log group for integration test (idempotent)
-    cloudwatchlogs_log_group:
-      state: absent
-      log_group_name: '{{ log_group_name }}'
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
 
-  - assert:
-      that:
-      - result is not changed
+    - name: describe missing log group
+      amazon.aws.cloudwatchlogs_log_group_info:
+        log_group_name: "{{ log_group_name }}"
+      register: result
 
-  - name: describe missing log group
-    cloudwatchlogs_log_group_info:
-      log_group_name: '{{ log_group_name }}'
-    register: result
-
-  - assert:
-      that:
-      - '"log_groups" in result'
-      - result.log_groups | length == 0
+    - ansible.builtin.assert:
+        that:
+          - '"log_groups" in result'
+          - result.log_groups | length == 0
 
   always:
-
-  - name: delete cloudwatch log group for integration test
-    cloudwatchlogs_log_group:
-      state: absent
-      log_group_name: '{{ log_group_name }}'
-    ignore_errors: true
+    - name: delete cloudwatch log group for integration test
+      amazon.aws.cloudwatchlogs_log_group:
+        state: absent
+        log_group_name: "{{ log_group_name }}"
+      ignore_errors: true

--- a/tests/integration/targets/cloudwatchlogs/tasks/main.yml
+++ b/tests/integration/targets/cloudwatchlogs/tasks/main.yml
@@ -1,16 +1,15 @@
+---
 # Tests for cloudwatchlogs_log_group, cloudwatchlogs_log_group_info, and cloudwatchlogs_log_group_metric_filter modules
 
 - module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
   block:
-
-  - name: Run tests for changes to the cloudwatchlogs_log_group and cloudwatchlogs_log_group_metric_filter
-    include_tasks: cloudwatchlogs_tests.yml
-
-  - name: Run tests relating to create/delete and set tags on cloudwatchlogs_log_group
-    include_tasks: create-delete-tags.yml
+    - name: Run tests for changes to the cloudwatchlogs_log_group and cloudwatchlogs_log_group_metric_filter
+      ansible.builtin.include_tasks: cloudwatchlogs_tests.yml
+    - name: Run tests relating to create/delete and set tags on cloudwatchlogs_log_group
+      ansible.builtin.include_tasks: create-delete-tags.yml

--- a/tests/integration/targets/ec2_ami/defaults/main.yml
+++ b/tests/integration/targets/ec2_ami/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
-availability_zone: '{{ ec2_availability_zone_names[0] }}'
+availability_zone: "{{ ec2_availability_zone_names[0] }}"
 
 # defaults file for test_ec2_ami
-ec2_ami_name: '{{resource_prefix}}'
-ec2_ami_description: 'Created by ansible integration tests'
+ec2_ami_name: "{{resource_prefix}}"
+ec2_ami_description: Created by ansible integration tests
 
-ec2_ami_image: '{{ ec2_ami_id }}'
+ec2_ami_image: "{{ ec2_ami_id }}"
 
-vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'
-subnet_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.1.0/24'
+vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/16
+subnet_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.1.0/24

--- a/tests/integration/targets/ec2_ami/meta/main.yml
+++ b/tests/integration/targets/ec2_ami/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
   - setup_ec2_facts

--- a/tests/integration/targets/ec2_ami/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami/tasks/main.yml
@@ -2,75 +2,74 @@
 # Test suite for ec2_ami
 - module_defaults:
     group/aws:
-      aws_region: '{{ aws_region }}'
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
+      aws_region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   collections:
     - amazon.aws
   block:
-
     # ============================================================
 
     # SETUP: vpc, ec2 key pair, subnet, security group, ec2 instance, snapshot
     - name: create a VPC to work in
-      ec2_vpc_net:
-        cidr_block: '{{ vpc_cidr }}'
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ vpc_cidr }}"
         state: present
-        name: '{{ ec2_ami_name }}_setup'
+        name: "{{ ec2_ami_name }}_setup"
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
+          Name: "{{ ec2_ami_name }}_setup"
       register: setup_vpc
 
     - name: create a key pair to use for creating an ec2 instance
-      ec2_key:
-        name: '{{ ec2_ami_name }}_setup'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_ami_name }}_setup"
         state: present
       register: setup_key
 
     - name: create a subnet to use for creating an ec2 instance
-      ec2_vpc_subnet:
-        az: '{{ availability_zone }}'
-        tags: '{{ ec2_ami_name }}_setup'
-        vpc_id: '{{ setup_vpc.vpc.id }}'
-        cidr: '{{ subnet_cidr }}'
+      amazon.aws.ec2_vpc_subnet:
+        az: "{{ availability_zone }}"
+        tags: "{{ ec2_ami_name }}_setup"
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+        cidr: "{{ subnet_cidr }}"
         state: present
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
+          Name: "{{ ec2_ami_name }}_setup"
       register: setup_subnet
 
     - name: create a security group to use for creating an ec2 instance
       ec2_security_group:
-        name: '{{ ec2_ami_name }}_setup'
-        description: 'created by Ansible integration tests'
+        name: "{{ ec2_ami_name }}_setup"
+        description: created by Ansible integration tests
         state: present
-        vpc_id: '{{ setup_vpc.vpc.id }}'
+        vpc_id: "{{ setup_vpc.vpc.id }}"
       register: setup_sg
 
     - name: provision ec2 instance to create an image
-      ec2_instance:
+      amazon.aws.ec2_instance:
         state: running
-        key_name: '{{ setup_key.key.name }}'
+        key_name: "{{ setup_key.key.name }}"
         instance_type: t2.micro
-        image_id: '{{ ec2_ami_id }}'
+        image_id: "{{ ec2_ami_id }}"
         tags:
-          '{{ec2_ami_name}}_instance_setup': 'integration_tests'
-        security_group: '{{ setup_sg.group_id }}'
-        vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
+          "{{ec2_ami_name}}_instance_setup": integration_tests
+        security_group: "{{ setup_sg.group_id }}"
+        vpc_subnet_id: "{{ setup_subnet.subnet.id }}"
         volumes:
           - device_name: /dev/sdc
             virtual_name: ephemeral1
-        wait: yes
+        wait: true
       register: setup_instance
 
     - name: Store EC2 Instance ID
-      set_fact:
-        ec2_instance_id: '{{ setup_instance.instances[0].instance_id }}'
+      ansible.builtin.set_fact:
+        ec2_instance_id: "{{ setup_instance.instances[0].instance_id }}"
 
     - name: take a snapshot of the instance to create an image
-      ec2_snapshot:
-        instance_id: '{{ ec2_instance_id }}'
-        device_name: '{{ ec2_ami_root_disk }}'
+      amazon.aws.ec2_snapshot:
+        instance_id: "{{ ec2_instance_id }}"
+        device_name: "{{ ec2_ami_root_disk }}"
         state: present
       register: setup_snapshot
 
@@ -92,19 +91,19 @@
     # ============================================================
 
     - name: test clean failure if not providing image_id or name with state=present
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: present
-        description: '{{ ec2_ami_description }}'
+        description: "{{ ec2_ami_description }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
-        root_device_name: '{{ ec2_ami_root_disk }}'
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
+        root_device_name: "{{ ec2_ami_root_disk }}"
       register: result
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: assert error message is helpful
-      assert:
+      ansible.builtin.assert:
         that:
           - result.failed
           - "result.msg == 'one of the following is required: name, image_id'"
@@ -112,54 +111,54 @@
     # ============================================================
 
     - name: create an image from the instance (check mode)
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: present
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}'
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
-        root_device_name: '{{ ec2_ami_root_disk }}'
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
+        root_device_name: "{{ ec2_ami_root_disk }}"
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is changed
 
     - name: create an image from the instance
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: present
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}'
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
-        root_device_name: '{{ ec2_ami_root_disk }}'
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
+        root_device_name: "{{ ec2_ami_root_disk }}"
       register: result
 
     - name: set image id fact for deletion later
-      set_fact:
+      ansible.builtin.set_fact:
         ec2_ami_image_id: "{{ result.image_id }}"
 
     - name: assert that image has been created
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
-          - "result.image_id.startswith('ami-')"
+          - result.changed
+          - result.image_id.startswith('ami-')
           - "'Name' in result.tags and result.tags.Name == ec2_ami_name + '_ami'"
 
     - name: get related snapshot info and ensure the tags have been propagated
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ result.block_device_mapping[ec2_ami_root_disk].snapshot_id }}"
       register: snapshot_result
 
     - name: ensure the tags have been propagated to the snapshot
-      assert:
+      ansible.builtin.assert:
         that:
           - "'tags' in snapshot_result.snapshots[0]"
           - "'Name' in snapshot_result.snapshots[0].tags and snapshot_result.snapshots[0].tags.Name == ec2_ami_name + '_ami'"
@@ -167,125 +166,125 @@
     # ============================================================
 
     - name: create an image from the instance with attached devices with no_device true (check mode)
-      ec2_ami:
-        name: '{{ ec2_ami_name }}_no_device_true_ami'
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        name: "{{ ec2_ami_name }}_no_device_true_ami"
+        instance_id: "{{ ec2_instance_id }}"
         device_mapping:
           - device_name: /dev/sda1
             volume_size: 10
             delete_on_termination: true
             volume_type: gp2
           - device_name: /dev/sdf
-            no_device: yes
+            no_device: true
         state: present
-        wait: yes
-        root_device_name: '{{ ec2_ami_root_disk }}'
+        wait: true
+        root_device_name: "{{ ec2_ami_root_disk }}"
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is changed
 
     - name: create an image from the instance with attached devices with no_device true
-      ec2_ami:
-        name: '{{ ec2_ami_name }}_no_device_true_ami'
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        name: "{{ ec2_ami_name }}_no_device_true_ami"
+        instance_id: "{{ ec2_instance_id }}"
         device_mapping:
           - device_name: /dev/sda1
             volume_size: 10
             delete_on_termination: true
             volume_type: gp2
           - device_name: /dev/sdf
-            no_device: yes
+            no_device: true
         state: present
-        wait: yes
-        root_device_name: '{{ ec2_ami_root_disk }}'
+        wait: true
+        root_device_name: "{{ ec2_ami_root_disk }}"
       register: result_no_device_true
 
     - name: set image id fact for deletion later
-      set_fact:
+      ansible.builtin.set_fact:
         ec2_ami_no_device_true_image_id: "{{ result_no_device_true.image_id }}"
 
     - name: assert that image with no_device option yes has been created
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result_no_device_true.changed"
+          - result_no_device_true.changed
           - "'/dev/sdf' not in result_no_device_true.block_device_mapping"
 
     - name: create an image from the instance with attached devices with no_device false
-      ec2_ami:
-        name: '{{ ec2_ami_name }}_no_device_false_ami'
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        name: "{{ ec2_ami_name }}_no_device_false_ami"
+        instance_id: "{{ ec2_instance_id }}"
         device_mapping:
           - device_name: /dev/sda1
             volume_size: 10
             delete_on_termination: true
             volume_type: gp2
-            no_device: no
+            no_device: false
         state: present
-        wait: yes
-        root_device_name: '{{ ec2_ami_root_disk }}'
+        wait: true
+        root_device_name: "{{ ec2_ami_root_disk }}"
       register: result_no_device_false
 
     - name: set image id fact for deletion later
-      set_fact:
+      ansible.builtin.set_fact:
         ec2_ami_no_device_false_image_id: "{{ result_no_device_false.image_id }}"
 
     - name: assert that image with no_device option no has been created
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result_no_device_false.changed"
+          - result_no_device_false.changed
           - "'/dev/sda1' in result_no_device_false.block_device_mapping"
 
     # ============================================================
 
     - name: gather facts about the image created
-      ec2_ami_info:
-        image_ids: '{{ ec2_ami_image_id }}'
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ ec2_ami_image_id }}"
       register: ami_facts_result
       ignore_errors: true
 
     - name: assert that the right image was found
-      assert:
+      ansible.builtin.assert:
         that:
-          - "ami_facts_result.images[0].image_id == ec2_ami_image_id"
+          - ami_facts_result.images[0].image_id == ec2_ami_image_id
 
-   # some ec2_ami_info tests to test if the filtering is working fine.
-   # ============================================================
+    # some ec2_ami_info tests to test if the filtering is working fine.
+    # ============================================================
 
     - name: gather info about the image
-      ec2_ami_info:
-        image_ids: '{{ ec2_region_images[ec2_region] }}'
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ ec2_region_images[ec2_region] }}"
       register: ami_info_result
       ignore_errors: true
 
     - name: assert that the right image was found
-      assert:
+      ansible.builtin.assert:
         that:
-          - "ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'"
+          - ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'
 
     # ============================================================
 
     - name: gather info about the image using boolean filter
-      ec2_ami_info:
-        image_ids: '{{ ec2_region_images[ec2_region] }}'
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ ec2_region_images[ec2_region] }}"
         filters:
           is-public: true
       register: ami_info_result
       ignore_errors: true
 
     - name: assert that the right image was found
-      assert:
+      ansible.builtin.assert:
         that:
-          - "ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'"
+          - ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'
 
     # ============================================================
 
     - name: gather info about the image using integer filter
-      ec2_ami_info:
-        image_ids: '{{ ec2_region_images[ec2_region] }}'
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ ec2_region_images[ec2_region] }}"
         filters:
           # Amazon owned
           owner-id: 137112412989
@@ -293,198 +292,198 @@
       ignore_errors: true
 
     - name: assert that the right image was found
-      assert:
+      ansible.builtin.assert:
         that:
-          - "ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'"
+          - ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'
 
     # ============================================================
 
     - name: gather info about the image using string filter
-      ec2_ami_info:
-        image_ids: '{{ ec2_region_images[ec2_region] }}'
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ ec2_region_images[ec2_region] }}"
         filters:
-          name: 'amzn-ami-hvm-2017.09.0.20170930-x86_64-gp2'
+          name: amzn-ami-hvm-2017.09.0.20170930-x86_64-gp2
       register: ami_info_result
       ignore_errors: true
 
     - name: assert that the right image was found
-      assert:
+      ansible.builtin.assert:
         that:
-          - "ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'"
+          - ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'
 
     # e2_ami_info filtering tests ends
     # ============================================================
 
     - name: delete the image (check mode)
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: absent
-        delete_snapshot: yes
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}'
-        image_id: '{{ result.image_id }}'
+        delete_snapshot: true
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}"
+        image_id: "{{ result.image_id }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
       ignore_errors: true
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is changed
 
     - name: delete the image
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: absent
-        delete_snapshot: yes
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}'
-        image_id: '{{ result.image_id }}'
+        delete_snapshot: true
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}"
+        image_id: "{{ result.image_id }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
       ignore_errors: true
       register: result
 
     - name: assert that the image has been deleted
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
+          - result.changed
           - "'image_id' not in result"
-          - "result.snapshots_deleted"
+          - result.snapshots_deleted
 
     # ==============================================================
 
     - name: test removing an ami if no image ID is provided (expected failed=true)
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: absent
       register: result
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: assert that an image ID is required
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.failed"
+          - result.failed
           - "result.msg == 'state is absent but all of the following are missing: image_id'"
 
     # ============================================================
 
     - name: create an image from the snapshot
-      ec2_ami:
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}'
+      amazon.aws.ec2_ami:
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}"
         state: present
         launch_permissions:
           user_ids: []
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        root_device_name: '{{ ec2_ami_root_disk }}'
+          Name: "{{ ec2_ami_name }}_ami"
+        root_device_name: "{{ ec2_ami_root_disk }}"
         device_mapping:
-          - device_name: '{{ ec2_ami_root_disk }}'
+          - device_name: "{{ ec2_ami_root_disk }}"
             volume_type: gp2
             size: 8
             delete_on_termination: true
-            snapshot_id: '{{ setup_snapshot.snapshot_id }}'
+            snapshot_id: "{{ setup_snapshot.snapshot_id }}"
       register: result
       ignore_errors: true
 
     - name: set image id fact for deletion later
-      set_fact:
+      ansible.builtin.set_fact:
         ec2_ami_image_id: "{{ result.image_id }}"
         ec2_ami_snapshot: "{{ result.block_device_mapping[ec2_ami_root_disk].snapshot_id }}"
 
     - name: assert a new ami has been created
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
-          - "result.image_id.startswith('ami-')"
+          - result.changed
+          - result.image_id.startswith('ami-')
 
     # ============================================================
 
     - name: test default launch permissions idempotence (check mode)
-      ec2_ami:
-        description: '{{ ec2_ami_description }}'
+      amazon.aws.ec2_ami:
+        description: "{{ ec2_ami_description }}"
         state: present
-        name: '{{ ec2_ami_name }}_ami'
+        name: "{{ ec2_ami_name }}_ami"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        root_device_name: '{{ ec2_ami_root_disk }}'
-        image_id: '{{ result.image_id }}'
+          Name: "{{ ec2_ami_name }}_ami"
+        root_device_name: "{{ ec2_ami_root_disk }}"
+        image_id: "{{ result.image_id }}"
         launch_permissions:
           user_ids: []
         device_mapping:
-          - device_name: '{{ ec2_ami_root_disk }}'
+          - device_name: "{{ ec2_ami_root_disk }}"
             volume_type: gp2
             size: 8
             delete_on_termination: true
-            snapshot_id: '{{ setup_snapshot.snapshot_id }}'
+            snapshot_id: "{{ setup_snapshot.snapshot_id }}"
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is not changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is not changed
 
     - name: test default launch permissions idempotence
-      ec2_ami:
-        description: '{{ ec2_ami_description }}'
+      amazon.aws.ec2_ami:
+        description: "{{ ec2_ami_description }}"
         state: present
-        name: '{{ ec2_ami_name }}_ami'
+        name: "{{ ec2_ami_name }}_ami"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        root_device_name: '{{ ec2_ami_root_disk }}'
-        image_id: '{{ result.image_id }}'
+          Name: "{{ ec2_ami_name }}_ami"
+        root_device_name: "{{ ec2_ami_root_disk }}"
+        image_id: "{{ result.image_id }}"
         launch_permissions:
           user_ids: []
         device_mapping:
-          - device_name: '{{ ec2_ami_root_disk }}'
+          - device_name: "{{ ec2_ami_root_disk }}"
             volume_type: gp2
             size: 8
             delete_on_termination: true
-            snapshot_id: '{{ setup_snapshot.snapshot_id }}'
+            snapshot_id: "{{ setup_snapshot.snapshot_id }}"
       register: result
 
     - name: assert a new ami has not been created
-      assert:
+      ansible.builtin.assert:
         that:
-          - "not result.changed"
-          - "result.image_id.startswith('ami-')"
+          - not result.changed
+          - result.image_id.startswith('ami-')
 
     # ============================================================
 
     - name: add a tag to the AMI
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        description: '{{ ec2_ami_description }}'
-        image_id: '{{ result.image_id }}'
-        name: '{{ ec2_ami_name }}_ami'
+        description: "{{ ec2_ami_description }}"
+        image_id: "{{ result.image_id }}"
+        name: "{{ ec2_ami_name }}_ami"
         tags:
           New: Tag
-        purge_tags: no
+        purge_tags: false
       register: result
 
     - name: assert a tag was added
-      assert:
+      ansible.builtin.assert:
         that:
           - "'Name' in result.tags and result.tags.Name == ec2_ami_name + '_ami'"
           - "'New' in result.tags and result.tags.New == 'Tag'"
 
     - name: use purge_tags to remove a tag from the AMI
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        description: '{{ ec2_ami_description }}'
-        image_id: '{{ result.image_id }}'
-        name: '{{ ec2_ami_name }}_ami'
+        description: "{{ ec2_ami_description }}"
+        image_id: "{{ result.image_id }}"
+        name: "{{ ec2_ami_name }}_ami"
         tags:
           New: Tag
       register: result
 
     - name: assert a tag was removed
-      assert:
+      ansible.builtin.assert:
         that:
           - "'Name' not in result.tags"
           - "'New' in result.tags and result.tags.New == 'Tag'"
@@ -492,154 +491,154 @@
     # ============================================================
 
     - name: update AMI launch permissions (check mode)
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        image_id: '{{ result.image_id }}'
-        description: '{{ ec2_ami_description }}'
+        image_id: "{{ result.image_id }}"
+        description: "{{ ec2_ami_description }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
+          Name: "{{ ec2_ami_name }}_ami"
         launch_permissions:
-          group_names: ['all']
+          group_names: [all]
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is changed
 
     - name: update AMI launch permissions
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        image_id: '{{ result.image_id }}'
-        description: '{{ ec2_ami_description }}'
+        image_id: "{{ result.image_id }}"
+        description: "{{ ec2_ami_description }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
+          Name: "{{ ec2_ami_name }}_ami"
         launch_permissions:
-          group_names: ['all']
+          group_names: [all]
       register: result
 
     - name: assert launch permissions were updated
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
+          - result.changed
 
     # ============================================================
 
     - name: modify the AMI description (check mode)
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        image_id: '{{ result.image_id }}'
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}CHANGED'
+        image_id: "{{ result.image_id }}"
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}CHANGED"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
+          Name: "{{ ec2_ami_name }}_ami"
         launch_permissions:
-          group_names: ['all']
+          group_names: [all]
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is changed
 
     - name: modify the AMI description
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        image_id: '{{ result.image_id }}'
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}CHANGED'
+        image_id: "{{ result.image_id }}"
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}CHANGED"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
+          Name: "{{ ec2_ami_name }}_ami"
         launch_permissions:
-          group_names: ['all']
+          group_names: [all]
       register: result
 
     - name: assert the description changed
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
+          - result.changed
 
     # ============================================================
 
     - name: remove public launch permissions
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        image_id: '{{ result.image_id }}'
-        name: '{{ ec2_ami_name }}_ami'
+        image_id: "{{ result.image_id }}"
+        name: "{{ ec2_ami_name }}_ami"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
+          Name: "{{ ec2_ami_name }}_ami"
         launch_permissions:
           group_names: []
       register: result
 
     - name: assert launch permissions were updated
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
+          - result.changed
 
     # ============================================================
 
     - name: delete ami without deleting the snapshot (default is not to delete)
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: absent
-        name: '{{ ec2_ami_name }}_ami'
-        image_id: '{{ ec2_ami_image_id }}'
+        name: "{{ ec2_ami_name }}_ami"
+        image_id: "{{ ec2_ami_image_id }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
       ignore_errors: true
       register: result
 
     - name: assert that the image has been deleted
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
+          - result.changed
           - "'image_id' not in result"
 
     - name: ensure the snapshot still exists
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
-          - '{{ ec2_ami_snapshot }}'
+          - "{{ ec2_ami_snapshot }}"
       register: snapshot_result
 
     - name: assert the snapshot wasn't deleted
-      assert:
+      ansible.builtin.assert:
         that:
-          - "snapshot_result.snapshots[0].snapshot_id == ec2_ami_snapshot"
+          - snapshot_result.snapshots[0].snapshot_id == ec2_ami_snapshot
 
     - name: delete ami for a second time (check mode)
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: absent
-        name: '{{ ec2_ami_name }}_ami'
-        image_id: '{{ ec2_ami_image_id }}'
+        name: "{{ ec2_ami_name }}_ami"
+        image_id: "{{ ec2_ami_image_id }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is not changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is not changed
 
     - name: delete ami for a second time
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: absent
-        name: '{{ ec2_ami_name }}_ami'
-        image_id: '{{ ec2_ami_image_id }}'
+        name: "{{ ec2_ami_name }}_ami"
+        image_id: "{{ ec2_ami_image_id }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
       register: result
 
     - name: assert that image does not exist
-      assert:
+      ansible.builtin.assert:
         that:
           - not result.changed
           - not result.failed
@@ -647,42 +646,42 @@
     # ============================================================
 
     - name: create an image from the snapshot with boot_mode and tpm_support
-      ec2_ami:
-        name: '{{ ec2_ami_name }}_ami-boot-tpm'
-        description: '{{ ec2_ami_description }}'
+      amazon.aws.ec2_ami:
+        name: "{{ ec2_ami_name }}_ami-boot-tpm"
+        description: "{{ ec2_ami_description }}"
         state: present
         boot_mode: uefi
         tpm_support: v2.0
         launch_permissions:
           user_ids: []
         tags:
-          Name: '{{ ec2_ami_name }}_ami-boot-tpm'
-        root_device_name: '{{ ec2_ami_root_disk }}'
+          Name: "{{ ec2_ami_name }}_ami-boot-tpm"
+        root_device_name: "{{ ec2_ami_root_disk }}"
         device_mapping:
-          - device_name: '{{ ec2_ami_root_disk }}'
+          - device_name: "{{ ec2_ami_root_disk }}"
             volume_type: gp2
             size: 8
             delete_on_termination: true
-            snapshot_id: '{{ setup_snapshot.snapshot_id }}'
+            snapshot_id: "{{ setup_snapshot.snapshot_id }}"
       register: result
       ignore_errors: true
 
     - name: set image id fact for deletion later
-      set_fact:
+      ansible.builtin.set_fact:
         ec2_ami_image_id_boot_tpm: "{{ result.image_id }}"
         ec2_ami_snapshot_boot_tpm: "{{ result.block_device_mapping[ec2_ami_root_disk].snapshot_id }}"
 
     - name: gather facts about the image created
-      ec2_ami_info:
-        image_ids: '{{ ec2_ami_image_id_boot_tpm }}'
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ ec2_ami_image_id_boot_tpm }}"
       register: ami_facts_result_boot_tpm
       ignore_errors: true
 
     - name: assert that new ami has been created with desired options
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
-          - "result.image_id.startswith('ami-')"
+          - result.changed
+          - result.image_id.startswith('ami-')
           - ami_facts_result_boot_tpm.images[0].image_id | length != 0
           - ami_facts_result_boot_tpm.images[0].boot_mode == 'uefi'
           - ami_facts_result_boot_tpm.images[0].tpm_support == 'v2.0'
@@ -690,137 +689,135 @@
     # === Test modify launch permissions org_arns and org_unit_arns=========================
 
     - name: create an image from the instance
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: present
-        name: '{{ ec2_ami_name }}_permissions'
-        description: '{{ ec2_ami_description }}'
+        name: "{{ ec2_ami_name }}_permissions"
+        description: "{{ ec2_ami_description }}"
         tags:
-          Name: '{{ ec2_ami_name }}_permissions'
-        wait: yes
-        root_device_name: '{{ ec2_ami_root_disk }}'
+          Name: "{{ ec2_ami_name }}_permissions"
+        wait: true
+        root_device_name: "{{ ec2_ami_root_disk }}"
       register: permissions_create_result
 
     - name: modify the AMI launch permissions
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        image_id: '{{ permissions_create_result.image_id }}'
-        name: '{{ ec2_ami_name }}_permissions'
+        image_id: "{{ permissions_create_result.image_id }}"
+        name: "{{ ec2_ami_name }}_permissions"
         tags:
-          Name: '{{ ec2_ami_name }}_permissions'
+          Name: "{{ ec2_ami_name }}_permissions"
         launch_permissions:
-          org_arns: ['arn:aws:organizations::123456789012:organization/o-123ab4cdef']
-          org_unit_arns: ['arn:aws:organizations::123456789012:ou/o-123example/ou-1234-5exampld']
+          org_arns: [arn:aws:organizations::123456789012:organization/o-123ab4cdef]
+          org_unit_arns: [arn:aws:organizations::123456789012:ou/o-123example/ou-1234-5exampld]
       register: permissions_update_result
 
     - name: Get ami info
       amazon.aws.ec2_ami_info:
-        image_ids: '{{ permissions_create_result.image_id }}'
+        image_ids: "{{ permissions_create_result.image_id }}"
         describe_image_attributes: true
       register: permissions_info_result
 
     - name: assert that launch permissions have changed
-      assert:
+      ansible.builtin.assert:
         that:
-          - "permissions_update_result.changed"
+          - permissions_update_result.changed
           - "'organization_arn' in permissions_info_result.images[0].launch_permissions[0]"
-          - "permissions_info_result.images[0].launch_permissions[0]['organization_arn'] == 'arn:aws:organizations::123456789012:organization/o-123ab4cdef'"
+          - permissions_info_result.images[0].launch_permissions[0]['organization_arn'] == 'arn:aws:organizations::123456789012:organization/o-123ab4cdef'
           - "'organizational_unit_arn' in permissions_info_result.images[0].launch_permissions[1]"
-          - "permissions_info_result.images[0].launch_permissions[1]['organizational_unit_arn'] == 'arn:aws:organizations::123456789012:ou/o-123example/ou-1234-5exampld'"
+          - permissions_info_result.images[0].launch_permissions[1]['organizational_unit_arn'] == 'arn:aws:organizations::123456789012:ou/o-123example/ou-1234-5exampld'
 
-
-    # ============================================================
+  # ============================================================
 
   always:
-
     # ============================================================
 
     # TEAR DOWN: snapshot, ec2 instance, ec2 key pair, security group, vpc
     - name: Announce teardown start
-      debug:
+      ansible.builtin.debug:
         msg: "***** TESTING COMPLETE. COMMENCE TEARDOWN *****"
 
     - name: delete ami
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: absent
         image_id: "{{ ec2_ami_image_id_boot_tpm }}"
-        wait: yes
-      ignore_errors: yes
+        wait: true
+      ignore_errors: true
 
     - name: delete ami
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: absent
         image_id: "{{ ec2_ami_image_id }}"
-        name: '{{ ec2_ami_name }}_ami'
-        wait: yes
-      ignore_errors: yes
+        name: "{{ ec2_ami_name }}_ami"
+        wait: true
+      ignore_errors: true
 
     - name: delete ami
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: absent
         image_id: "{{ ec2_ami_no_device_true_image_id }}"
-        wait: yes
-      ignore_errors: yes
+        wait: true
+      ignore_errors: true
 
     - name: delete ami
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: absent
         image_id: "{{ ec2_ami_no_device_false_image_id }}"
-        wait: yes
-      ignore_errors: yes
+        wait: true
+      ignore_errors: true
 
     - name: delete ami
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: absent
         image_id: "{{ ec2_ami_image_id }}"
-        name: '{{ ec2_ami_name }}_permissions'
-        wait: yes
-      ignore_errors: yes
+        name: "{{ ec2_ami_name }}_permissions"
+        wait: true
+      ignore_errors: true
 
     - name: remove setup snapshot of ec2 instance
-      ec2_snapshot:
+      amazon.aws.ec2_snapshot:
         state: absent
-        snapshot_id: '{{ setup_snapshot.snapshot_id }}'
-      ignore_errors: yes
+        snapshot_id: "{{ setup_snapshot.snapshot_id }}"
+      ignore_errors: true
 
     - name: remove setup ec2 instance
-      ec2_instance:
+      amazon.aws.ec2_instance:
         state: absent
         instance_ids:
-        - '{{ ec2_instance_id }}'
+          - "{{ ec2_instance_id }}"
         wait: true
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: remove setup keypair
-      ec2_key:
-        name: '{{ec2_ami_name}}_setup'
+      amazon.aws.ec2_key:
+        name: "{{ec2_ami_name}}_setup"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: remove setup security group
       ec2_security_group:
-        name: '{{ ec2_ami_name }}_setup'
-        description: 'created by Ansible integration tests'
+        name: "{{ ec2_ami_name }}_setup"
+        description: created by Ansible integration tests
         state: absent
-        vpc_id: '{{ setup_vpc.vpc.id }}'
-      ignore_errors: yes
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+      ignore_errors: true
 
     - name: remove setup subnet
-      ec2_vpc_subnet:
-        az: '{{ availability_zone }}'
-        tags: '{{ec2_ami_name}}_setup'
-        vpc_id: '{{ setup_vpc.vpc.id }}'
-        cidr: '{{ subnet_cidr }}'
+      amazon.aws.ec2_vpc_subnet:
+        az: "{{ availability_zone }}"
+        tags: "{{ec2_ami_name}}_setup"
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+        cidr: "{{ subnet_cidr }}"
         state: absent
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
-      ignore_errors: yes
+          Name: "{{ ec2_ami_name }}_setup"
+      ignore_errors: true
 
     - name: remove setup VPC
-      ec2_vpc_net:
-        cidr_block: '{{ vpc_cidr }}'
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ vpc_cidr }}"
         state: absent
-        name: '{{ ec2_ami_name }}_setup'
+        name: "{{ ec2_ami_name }}_setup"
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
-      ignore_errors: yes
+          Name: "{{ ec2_ami_name }}_setup"
+      ignore_errors: true

--- a/tests/integration/targets/ec2_ami_instance/defaults/main.yml
+++ b/tests/integration/targets/ec2_ami_instance/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
-availability_zone: '{{ ec2_availability_zone_names[0] }}'
+availability_zone: "{{ ec2_availability_zone_names[0] }}"
 
 # defaults file for test_ec2_ami
-ec2_ami_name: '{{ resource_prefix }}-ec2-ami'
-ec2_ami_description: 'Created by Ansible ec2_ami integration tests'
+ec2_ami_name: "{{ resource_prefix }}-ec2-ami"
+ec2_ami_description: Created by Ansible ec2_ami integration tests
 
-ec2_ami_image: '{{ ec2_ami_id }}'
+ec2_ami_image: "{{ ec2_ami_id }}"
 
-vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'
-subnet_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.1.0/24'
+vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/16
+subnet_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.1.0/24

--- a/tests/integration/targets/ec2_ami_instance/meta/main.yml
+++ b/tests/integration/targets/ec2_ami_instance/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
   - setup_ec2_facts

--- a/tests/integration/targets/ec2_ami_instance/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami_instance/tasks/main.yml
@@ -2,87 +2,86 @@
 # Test suite for ec2_ami
 - module_defaults:
     group/aws:
-      aws_region: '{{ aws_region }}'
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
+      aws_region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   collections:
     - amazon.aws
   block:
-
     # ============================================================
 
     # SETUP: vpc, ec2 key pair, subnet, security group, ec2 instance, snapshot
     - name: create a VPC to work in
-      ec2_vpc_net:
-        cidr_block: '{{ vpc_cidr }}'
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ vpc_cidr }}"
         state: present
-        name: '{{ ec2_ami_name }}_setup'
+        name: "{{ ec2_ami_name }}_setup"
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
+          Name: "{{ ec2_ami_name }}_setup"
       register: setup_vpc
 
     - name: create a key pair to use for creating an ec2 instance
-      ec2_key:
-        name: '{{ ec2_ami_name }}_setup'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_ami_name }}_setup"
         state: present
       register: setup_key
 
     - name: create a subnet to use for creating an ec2 instance
-      ec2_vpc_subnet:
-        az: '{{ availability_zone }}'
-        tags: '{{ ec2_ami_name }}_setup'
-        vpc_id: '{{ setup_vpc.vpc.id }}'
-        cidr: '{{ subnet_cidr }}'
+      amazon.aws.ec2_vpc_subnet:
+        az: "{{ availability_zone }}"
+        tags: "{{ ec2_ami_name }}_setup"
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+        cidr: "{{ subnet_cidr }}"
         state: present
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
+          Name: "{{ ec2_ami_name }}_setup"
       register: setup_subnet
 
     - name: create a security group to use for creating an ec2 instance
       ec2_security_group:
-        name: '{{ ec2_ami_name }}_setup'
-        description: 'created by Ansible integration tests'
+        name: "{{ ec2_ami_name }}_setup"
+        description: created by Ansible integration tests
         state: present
-        vpc_id: '{{ setup_vpc.vpc.id }}'
+        vpc_id: "{{ setup_vpc.vpc.id }}"
       register: setup_sg
 
     - name: provision ec2 instance to create an image
-      ec2_instance:
+      amazon.aws.ec2_instance:
         state: running
-        key_name: '{{ setup_key.key.name }}'
+        key_name: "{{ setup_key.key.name }}"
         instance_type: t2.micro
-        image_id: '{{ ec2_ami_id }}'
+        image_id: "{{ ec2_ami_id }}"
         tags:
-          '{{ec2_ami_name}}_instance_setup': 'integration_tests'
-        security_group: '{{ setup_sg.group_id }}'
-        vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
+          "{{ec2_ami_name}}_instance_setup": integration_tests
+        security_group: "{{ setup_sg.group_id }}"
+        vpc_subnet_id: "{{ setup_subnet.subnet.id }}"
         volumes:
           - device_name: /dev/sdc
             virtual_name: ephemeral1
-        wait: yes
+        wait: true
       register: setup_instance
 
     - name: Store EC2 Instance ID
-      set_fact:
-        ec2_instance_id: '{{ setup_instance.instances[0].instance_id }}'
+      ansible.builtin.set_fact:
+        ec2_instance_id: "{{ setup_instance.instances[0].instance_id }}"
 
     # ============================================================
 
     - name: test clean failure if not providing image_id or name with state=present
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: present
-        description: '{{ ec2_ami_description }}'
+        description: "{{ ec2_ami_description }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
-        root_device_name: '{{ ec2_ami_root_disk }}'
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
+        root_device_name: "{{ ec2_ami_root_disk }}"
       register: result
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: assert error message is helpful
-      assert:
+      ansible.builtin.assert:
         that:
           - result.failed
           - "result.msg == 'one of the following is required: name, image_id'"
@@ -90,54 +89,54 @@
     # ============================================================
 
     - name: create an image from the instance (check mode)
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: present
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}'
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
-        root_device_name: '{{ ec2_ami_root_disk }}'
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
+        root_device_name: "{{ ec2_ami_root_disk }}"
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is changed
 
     - name: create an image from the instance
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: present
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}'
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
-        root_device_name: '{{ ec2_ami_root_disk }}'
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
+        root_device_name: "{{ ec2_ami_root_disk }}"
       register: result
 
     - name: set image id fact for deletion later
-      set_fact:
+      ansible.builtin.set_fact:
         ec2_ami_image_id_simple: "{{ result.image_id }}"
 
     - name: assert that image has been created
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
-          - "result.image_id.startswith('ami-')"
+          - result.changed
+          - result.image_id.startswith('ami-')
           - "'Name' in result.tags and result.tags.Name == ec2_ami_name + '_ami'"
 
     - name: get related snapshot info and ensure the tags have been propagated
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ result.block_device_mapping[ec2_ami_root_disk].snapshot_id }}"
       register: snapshot_result
 
     - name: ensure the tags have been propagated to the snapshot
-      assert:
+      ansible.builtin.assert:
         that:
           - "'tags' in snapshot_result.snapshots[0]"
           - "'Name' in snapshot_result.snapshots[0].tags and snapshot_result.snapshots[0].tags.Name == ec2_ami_name + '_ami'"
@@ -145,125 +144,125 @@
     # ============================================================
 
     - name: create an image from the instance with attached devices with no_device true (check mode)
-      ec2_ami:
-        name: '{{ ec2_ami_name }}_no_device_true_ami'
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        name: "{{ ec2_ami_name }}_no_device_true_ami"
+        instance_id: "{{ ec2_instance_id }}"
         device_mapping:
           - device_name: /dev/sda1
             volume_size: 10
             delete_on_termination: true
             volume_type: gp2
           - device_name: /dev/sdf
-            no_device: yes
+            no_device: true
         state: present
-        wait: yes
-        root_device_name: '{{ ec2_ami_root_disk }}'
+        wait: true
+        root_device_name: "{{ ec2_ami_root_disk }}"
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is changed
 
     - name: create an image from the instance with attached devices with no_device true
-      ec2_ami:
-        name: '{{ ec2_ami_name }}_no_device_true_ami'
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        name: "{{ ec2_ami_name }}_no_device_true_ami"
+        instance_id: "{{ ec2_instance_id }}"
         device_mapping:
           - device_name: /dev/sda1
             volume_size: 10
             delete_on_termination: true
             volume_type: gp2
           - device_name: /dev/sdf
-            no_device: yes
+            no_device: true
         state: present
-        wait: yes
-        root_device_name: '{{ ec2_ami_root_disk }}'
+        wait: true
+        root_device_name: "{{ ec2_ami_root_disk }}"
       register: result_no_device_true
 
     - name: set image id fact for deletion later
-      set_fact:
+      ansible.builtin.set_fact:
         ec2_ami_no_device_true_image_id: "{{ result_no_device_true.image_id }}"
 
     - name: assert that image with no_device option yes has been created
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result_no_device_true.changed"
+          - result_no_device_true.changed
           - "'/dev/sdf' not in result_no_device_true.block_device_mapping"
 
     - name: create an image from the instance with attached devices with no_device false
-      ec2_ami:
-        name: '{{ ec2_ami_name }}_no_device_false_ami'
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        name: "{{ ec2_ami_name }}_no_device_false_ami"
+        instance_id: "{{ ec2_instance_id }}"
         device_mapping:
           - device_name: /dev/sda1
             volume_size: 10
             delete_on_termination: true
             volume_type: gp2
-            no_device: no
+            no_device: false
         state: present
-        wait: yes
-        root_device_name: '{{ ec2_ami_root_disk }}'
+        wait: true
+        root_device_name: "{{ ec2_ami_root_disk }}"
       register: result_no_device_false
 
     - name: set image id fact for deletion later
-      set_fact:
+      ansible.builtin.set_fact:
         ec2_ami_no_device_false_image_id: "{{ result_no_device_false.image_id }}"
 
     - name: assert that image with no_device option no has been created
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result_no_device_false.changed"
+          - result_no_device_false.changed
           - "'/dev/sda1' in result_no_device_false.block_device_mapping"
 
     # ============================================================
 
     - name: gather facts about the image created
-      ec2_ami_info:
-        image_ids: '{{ ec2_ami_image_id_simple }}'
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ ec2_ami_image_id_simple }}"
       register: ami_facts_result
       ignore_errors: true
 
     - name: assert that the right image was found
-      assert:
+      ansible.builtin.assert:
         that:
-          - "ami_facts_result.images[0].image_id == ec2_ami_image_id_simple"
+          - ami_facts_result.images[0].image_id == ec2_ami_image_id_simple
 
-   # some ec2_ami_info tests to test if the filtering is working fine.
-   # ============================================================
+    # some ec2_ami_info tests to test if the filtering is working fine.
+    # ============================================================
 
     - name: gather info about the image
-      ec2_ami_info:
-        image_ids: '{{ ec2_region_images[ec2_region] }}'
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ ec2_region_images[ec2_region] }}"
       register: ami_info_result
       ignore_errors: true
 
     - name: assert that the right image was found
-      assert:
+      ansible.builtin.assert:
         that:
-          - "ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'"
+          - ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'
 
     # ============================================================
 
     - name: gather info about the image using boolean filter
-      ec2_ami_info:
-        image_ids: '{{ ec2_region_images[ec2_region] }}'
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ ec2_region_images[ec2_region] }}"
         filters:
           is-public: true
       register: ami_info_result
       ignore_errors: true
 
     - name: assert that the right image was found
-      assert:
+      ansible.builtin.assert:
         that:
-          - "ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'"
+          - ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'
 
     # ============================================================
 
     - name: gather info about the image using integer filter
-      ec2_ami_info:
-        image_ids: '{{ ec2_region_images[ec2_region] }}'
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ ec2_region_images[ec2_region] }}"
         filters:
           # Amazon owned
           owner-id: 137112412989
@@ -271,152 +270,151 @@
       ignore_errors: true
 
     - name: assert that the right image was found
-      assert:
+      ansible.builtin.assert:
         that:
-          - "ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'"
+          - ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'
 
     # ============================================================
 
     - name: gather info about the image using string filter
-      ec2_ami_info:
-        image_ids: '{{ ec2_region_images[ec2_region] }}'
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ ec2_region_images[ec2_region] }}"
         filters:
-          name: 'amzn-ami-hvm-2017.09.0.20170930-x86_64-gp2'
+          name: amzn-ami-hvm-2017.09.0.20170930-x86_64-gp2
       register: ami_info_result
       ignore_errors: true
 
     - name: assert that the right image was found
-      assert:
+      ansible.builtin.assert:
         that:
-          - "ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'"
+          - ami_info_result.images[0].image_id == '{{ ec2_region_images[ec2_region] }}'
 
     # ec2_ami_info filtering tests ends
     # ============================================================
 
     - name: delete the image (check mode)
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: absent
-        delete_snapshot: yes
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}'
-        image_id: '{{ result.image_id }}'
+        delete_snapshot: true
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}"
+        image_id: "{{ result.image_id }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
       ignore_errors: true
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is changed
 
     - name: delete the image
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: absent
-        delete_snapshot: yes
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}'
-        image_id: '{{ result.image_id }}'
+        delete_snapshot: true
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}"
+        image_id: "{{ result.image_id }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
       ignore_errors: true
       register: result
 
     - name: assert that the image has been deleted
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
+          - result.changed
           - "'image_id' not in result"
-          - "result.snapshots_deleted"
+          - result.snapshots_deleted
 
     # ==============================================================
 
     - name: test removing an ami if no image ID is provided (expected failed=true)
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: absent
       register: result
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: assert that an image ID is required
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.failed"
+          - result.failed
           - "result.msg == 'state is absent but all of the following are missing: image_id'"
 
   always:
-
     # ============================================================
 
     # TEAR DOWN: snapshot, ec2 instance, ec2 key pair, security group, vpc
     - name: Announce teardown start
-      debug:
+      ansible.builtin.debug:
         msg: "***** TESTING COMPLETE. COMMENCE TEARDOWN *****"
 
     - name: remove setup ec2 instance
-      ec2_instance:
+      amazon.aws.ec2_instance:
         state: absent
         instance_ids:
-        - '{{ ec2_instance_id }}'
+          - "{{ ec2_instance_id }}"
         wait: true
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: remove setup security group
       ec2_security_group:
-        name: '{{ ec2_ami_name }}_setup'
-        description: 'created by Ansible integration tests'
+        name: "{{ ec2_ami_name }}_setup"
+        description: created by Ansible integration tests
         state: absent
-        vpc_id: '{{ setup_vpc.vpc.id }}'
-      ignore_errors: yes
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+      ignore_errors: true
 
     - name: delete ami
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: absent
         image_id: "{{ ec2_ami_image_id_simple }}"
-        name: '{{ ec2_ami_name }}_ami'
-        wait: yes
-      ignore_errors: yes
+        name: "{{ ec2_ami_name }}_ami"
+        wait: true
+      ignore_errors: true
 
     - name: delete ami
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: absent
         image_id: "{{ ec2_ami_no_device_true_image_id }}"
-        wait: yes
-      ignore_errors: yes
+        wait: true
+      ignore_errors: true
 
     - name: delete ami
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: absent
         image_id: "{{ ec2_ami_no_device_false_image_id }}"
-        wait: yes
-      ignore_errors: yes
+        wait: true
+      ignore_errors: true
 
     - name: remove setup keypair
-      ec2_key:
-        name: '{{ec2_ami_name}}_setup'
+      amazon.aws.ec2_key:
+        name: "{{ec2_ami_name}}_setup"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: remove setup subnet
-      ec2_vpc_subnet:
-        az: '{{ availability_zone }}'
-        tags: '{{ec2_ami_name}}_setup'
-        vpc_id: '{{ setup_vpc.vpc.id }}'
-        cidr: '{{ subnet_cidr }}'
+      amazon.aws.ec2_vpc_subnet:
+        az: "{{ availability_zone }}"
+        tags: "{{ec2_ami_name}}_setup"
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+        cidr: "{{ subnet_cidr }}"
         state: absent
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
-      ignore_errors: yes
+          Name: "{{ ec2_ami_name }}_setup"
+      ignore_errors: true
 
     - name: remove setup VPC
-      ec2_vpc_net:
-        cidr_block: '{{ vpc_cidr }}'
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ vpc_cidr }}"
         state: absent
-        name: '{{ ec2_ami_name }}_setup'
+        name: "{{ ec2_ami_name }}_setup"
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
-      ignore_errors: yes
+          Name: "{{ ec2_ami_name }}_setup"
+      ignore_errors: true

--- a/tests/integration/targets/ec2_ami_snapshot/defaults/main.yml
+++ b/tests/integration/targets/ec2_ami_snapshot/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
-availability_zone: '{{ ec2_availability_zone_names[0] }}'
+availability_zone: "{{ ec2_availability_zone_names[0] }}"
 
 # defaults file for test_ec2_ami
-ec2_ami_name: '{{ resource_prefix }}-ec2-ami'
-ec2_ami_description: 'Created by Ansible ec2_ami integration tests'
+ec2_ami_name: "{{ resource_prefix }}-ec2-ami"
+ec2_ami_description: Created by Ansible ec2_ami integration tests
 
-ec2_ami_image: '{{ ec2_ami_id }}'
+ec2_ami_image: "{{ ec2_ami_id }}"
 
-vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'
-subnet_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.1.0/24'
+vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/16
+subnet_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.1.0/24

--- a/tests/integration/targets/ec2_ami_snapshot/meta/main.yml
+++ b/tests/integration/targets/ec2_ami_snapshot/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
   - setup_ec2_facts

--- a/tests/integration/targets/ec2_ami_snapshot/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami_snapshot/tasks/main.yml
@@ -2,193 +2,192 @@
 # Test suite for ec2_ami
 - module_defaults:
     group/aws:
-      aws_region: '{{ aws_region }}'
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
+      aws_region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   collections:
     - amazon.aws
   block:
-
     # ============================================================
 
     # SETUP: vpc, ec2 key pair, subnet, security group, ec2 instance, snapshot
     - name: create a VPC to work in
-      ec2_vpc_net:
-        cidr_block: '{{ vpc_cidr }}'
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ vpc_cidr }}"
         state: present
-        name: '{{ ec2_ami_name }}_setup'
+        name: "{{ ec2_ami_name }}_setup"
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
+          Name: "{{ ec2_ami_name }}_setup"
       register: setup_vpc
 
     - name: create a key pair to use for creating an ec2 instance
-      ec2_key:
-        name: '{{ ec2_ami_name }}_setup'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_ami_name }}_setup"
         state: present
       register: setup_key
 
     - name: create a subnet to use for creating an ec2 instance
-      ec2_vpc_subnet:
-        az: '{{ availability_zone }}'
-        tags: '{{ ec2_ami_name }}_setup'
-        vpc_id: '{{ setup_vpc.vpc.id }}'
-        cidr: '{{ subnet_cidr }}'
+      amazon.aws.ec2_vpc_subnet:
+        az: "{{ availability_zone }}"
+        tags: "{{ ec2_ami_name }}_setup"
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+        cidr: "{{ subnet_cidr }}"
         state: present
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
+          Name: "{{ ec2_ami_name }}_setup"
       register: setup_subnet
 
     - name: create a security group to use for creating an ec2 instance
       ec2_security_group:
-        name: '{{ ec2_ami_name }}_setup'
-        description: 'created by Ansible integration tests'
+        name: "{{ ec2_ami_name }}_setup"
+        description: created by Ansible integration tests
         state: present
-        vpc_id: '{{ setup_vpc.vpc.id }}'
+        vpc_id: "{{ setup_vpc.vpc.id }}"
       register: setup_sg
 
     - name: provision ec2 instance to create an image
-      ec2_instance:
+      amazon.aws.ec2_instance:
         state: running
-        key_name: '{{ setup_key.key.name }}'
+        key_name: "{{ setup_key.key.name }}"
         instance_type: t2.micro
-        image_id: '{{ ec2_ami_id }}'
+        image_id: "{{ ec2_ami_id }}"
         tags:
-          '{{ec2_ami_name}}_instance_setup': 'integration_tests'
-        security_group: '{{ setup_sg.group_id }}'
-        vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
+          "{{ec2_ami_name}}_instance_setup": integration_tests
+        security_group: "{{ setup_sg.group_id }}"
+        vpc_subnet_id: "{{ setup_subnet.subnet.id }}"
         volumes:
           - device_name: /dev/sdc
             virtual_name: ephemeral1
-        wait: yes
+        wait: true
       register: setup_instance
 
     - name: Store EC2 Instance ID
-      set_fact:
-        ec2_instance_id: '{{ setup_instance.instances[0].instance_id }}'
+      ansible.builtin.set_fact:
+        ec2_instance_id: "{{ setup_instance.instances[0].instance_id }}"
 
     - name: take a snapshot of the instance to create an image
-      ec2_snapshot:
-        instance_id: '{{ ec2_instance_id }}'
-        device_name: '{{ ec2_ami_root_disk }}'
+      amazon.aws.ec2_snapshot:
+        instance_id: "{{ ec2_instance_id }}"
+        device_name: "{{ ec2_ami_root_disk }}"
         state: present
       register: setup_snapshot
 
     # ============================================================
 
     - name: create an image from the snapshot
-      ec2_ami:
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}'
+      amazon.aws.ec2_ami:
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}"
         state: present
         launch_permissions:
           user_ids: []
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        root_device_name: '{{ ec2_ami_root_disk }}'
+          Name: "{{ ec2_ami_name }}_ami"
+        root_device_name: "{{ ec2_ami_root_disk }}"
         device_mapping:
-          - device_name: '{{ ec2_ami_root_disk }}'
+          - device_name: "{{ ec2_ami_root_disk }}"
             volume_type: gp2
             size: 8
             delete_on_termination: true
-            snapshot_id: '{{ setup_snapshot.snapshot_id }}'
+            snapshot_id: "{{ setup_snapshot.snapshot_id }}"
       register: result
       ignore_errors: true
 
     - name: set image id fact for deletion later
-      set_fact:
+      ansible.builtin.set_fact:
         ec2_ami_image_id: "{{ result.image_id }}"
         ec2_ami_snapshot: "{{ result.block_device_mapping[ec2_ami_root_disk].snapshot_id }}"
 
     - name: assert a new ami has been created
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
-          - "result.image_id.startswith('ami-')"
+          - result.changed
+          - result.image_id.startswith('ami-')
 
     # ============================================================
 
     - name: test default launch permissions idempotence (check mode)
-      ec2_ami:
-        description: '{{ ec2_ami_description }}'
+      amazon.aws.ec2_ami:
+        description: "{{ ec2_ami_description }}"
         state: present
-        name: '{{ ec2_ami_name }}_ami'
+        name: "{{ ec2_ami_name }}_ami"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        root_device_name: '{{ ec2_ami_root_disk }}'
-        image_id: '{{ result.image_id }}'
+          Name: "{{ ec2_ami_name }}_ami"
+        root_device_name: "{{ ec2_ami_root_disk }}"
+        image_id: "{{ result.image_id }}"
         launch_permissions:
           user_ids: []
         device_mapping:
-          - device_name: '{{ ec2_ami_root_disk }}'
+          - device_name: "{{ ec2_ami_root_disk }}"
             volume_type: gp2
             size: 8
             delete_on_termination: true
-            snapshot_id: '{{ setup_snapshot.snapshot_id }}'
+            snapshot_id: "{{ setup_snapshot.snapshot_id }}"
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is not changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is not changed
 
     - name: test default launch permissions idempotence
-      ec2_ami:
-        description: '{{ ec2_ami_description }}'
+      amazon.aws.ec2_ami:
+        description: "{{ ec2_ami_description }}"
         state: present
-        name: '{{ ec2_ami_name }}_ami'
+        name: "{{ ec2_ami_name }}_ami"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        root_device_name: '{{ ec2_ami_root_disk }}'
-        image_id: '{{ result.image_id }}'
+          Name: "{{ ec2_ami_name }}_ami"
+        root_device_name: "{{ ec2_ami_root_disk }}"
+        image_id: "{{ result.image_id }}"
         launch_permissions:
           user_ids: []
         device_mapping:
-          - device_name: '{{ ec2_ami_root_disk }}'
+          - device_name: "{{ ec2_ami_root_disk }}"
             volume_type: gp2
             size: 8
             delete_on_termination: true
-            snapshot_id: '{{ setup_snapshot.snapshot_id }}'
+            snapshot_id: "{{ setup_snapshot.snapshot_id }}"
       register: result
 
     - name: assert a new ami has not been created
-      assert:
+      ansible.builtin.assert:
         that:
-          - "not result.changed"
-          - "result.image_id.startswith('ami-')"
+          - not result.changed
+          - result.image_id.startswith('ami-')
 
     # ============================================================
 
     - name: add a tag to the AMI
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        description: '{{ ec2_ami_description }}'
-        image_id: '{{ result.image_id }}'
-        name: '{{ ec2_ami_name }}_ami'
+        description: "{{ ec2_ami_description }}"
+        image_id: "{{ result.image_id }}"
+        name: "{{ ec2_ami_name }}_ami"
         tags:
           New: Tag
-        purge_tags: no
+        purge_tags: false
       register: result
 
     - name: assert a tag was added
-      assert:
+      ansible.builtin.assert:
         that:
           - "'Name' in result.tags and result.tags.Name == ec2_ami_name + '_ami'"
           - "'New' in result.tags and result.tags.New == 'Tag'"
 
     - name: use purge_tags to remove a tag from the AMI
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        description: '{{ ec2_ami_description }}'
-        image_id: '{{ result.image_id }}'
-        name: '{{ ec2_ami_name }}_ami'
+        description: "{{ ec2_ami_description }}"
+        image_id: "{{ result.image_id }}"
+        name: "{{ ec2_ami_name }}_ami"
         tags:
           New: Tag
       register: result
 
     - name: assert a tag was removed
-      assert:
+      ansible.builtin.assert:
         that:
           - "'Name' not in result.tags"
           - "'New' in result.tags and result.tags.New == 'Tag'"
@@ -196,219 +195,218 @@
     # ============================================================
 
     - name: update AMI launch permissions (check mode)
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        image_id: '{{ result.image_id }}'
-        description: '{{ ec2_ami_description }}'
+        image_id: "{{ result.image_id }}"
+        description: "{{ ec2_ami_description }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
+          Name: "{{ ec2_ami_name }}_ami"
         launch_permissions:
-          group_names: ['all']
+          group_names: [all]
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is changed
 
     - name: update AMI launch permissions
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        image_id: '{{ result.image_id }}'
-        description: '{{ ec2_ami_description }}'
+        image_id: "{{ result.image_id }}"
+        description: "{{ ec2_ami_description }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
+          Name: "{{ ec2_ami_name }}_ami"
         launch_permissions:
-          group_names: ['all']
+          group_names: [all]
       register: result
 
     - name: assert launch permissions were updated
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
+          - result.changed
 
     # ============================================================
 
     - name: modify the AMI description (check mode)
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        image_id: '{{ result.image_id }}'
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}CHANGED'
+        image_id: "{{ result.image_id }}"
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}CHANGED"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
+          Name: "{{ ec2_ami_name }}_ami"
         launch_permissions:
-          group_names: ['all']
+          group_names: [all]
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is changed
 
     - name: modify the AMI description
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        image_id: '{{ result.image_id }}'
-        name: '{{ ec2_ami_name }}_ami'
-        description: '{{ ec2_ami_description }}CHANGED'
+        image_id: "{{ result.image_id }}"
+        name: "{{ ec2_ami_name }}_ami"
+        description: "{{ ec2_ami_description }}CHANGED"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
+          Name: "{{ ec2_ami_name }}_ami"
         launch_permissions:
-          group_names: ['all']
+          group_names: [all]
       register: result
 
     - name: assert the description changed
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
+          - result.changed
 
     # ============================================================
 
     - name: remove public launch permissions
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: present
-        image_id: '{{ result.image_id }}'
-        name: '{{ ec2_ami_name }}_ami'
+        image_id: "{{ result.image_id }}"
+        name: "{{ ec2_ami_name }}_ami"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
+          Name: "{{ ec2_ami_name }}_ami"
         launch_permissions:
           group_names: []
       register: result
 
     - name: assert launch permissions were updated
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
+          - result.changed
 
     # ============================================================
 
     - name: delete ami without deleting the snapshot (default is not to delete)
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: absent
-        name: '{{ ec2_ami_name }}_ami'
-        image_id: '{{ ec2_ami_image_id }}'
+        name: "{{ ec2_ami_name }}_ami"
+        image_id: "{{ ec2_ami_image_id }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
       ignore_errors: true
       register: result
 
     - name: assert that the image has been deleted
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
+          - result.changed
           - "'image_id' not in result"
 
     - name: ensure the snapshot still exists
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
-          - '{{ ec2_ami_snapshot }}'
+          - "{{ ec2_ami_snapshot }}"
       register: snapshot_result
 
     - name: assert the snapshot wasn't deleted
-      assert:
+      ansible.builtin.assert:
         that:
-          - "snapshot_result.snapshots[0].snapshot_id == ec2_ami_snapshot"
+          - snapshot_result.snapshots[0].snapshot_id == ec2_ami_snapshot
 
     - name: delete ami for a second time (check mode)
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: absent
-        name: '{{ ec2_ami_name }}_ami'
-        image_id: '{{ ec2_ami_image_id }}'
+        name: "{{ ec2_ami_name }}_ami"
+        image_id: "{{ ec2_ami_image_id }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
       check_mode: true
       register: check_mode_result
 
     - name: assert that check_mode result is not changed
-      assert:
+      ansible.builtin.assert:
         that:
           - check_mode_result is not changed
 
     - name: delete ami for a second time
-      ec2_ami:
-        instance_id: '{{ ec2_instance_id }}'
+      amazon.aws.ec2_ami:
+        instance_id: "{{ ec2_instance_id }}"
         state: absent
-        name: '{{ ec2_ami_name }}_ami'
-        image_id: '{{ ec2_ami_image_id }}'
+        name: "{{ ec2_ami_name }}_ami"
+        image_id: "{{ ec2_ami_image_id }}"
         tags:
-          Name: '{{ ec2_ami_name }}_ami'
-        wait: yes
+          Name: "{{ ec2_ami_name }}_ami"
+        wait: true
       register: result
 
     - name: assert that image does not exist
-      assert:
+      ansible.builtin.assert:
         that:
           - not result.changed
           - not result.failed
 
   always:
-
     # ============================================================
 
     # TEAR DOWN: snapshot, ec2 instance, ec2 key pair, security group, vpc
     - name: Announce teardown start
-      debug:
+      ansible.builtin.debug:
         msg: "***** TESTING COMPLETE. COMMENCE TEARDOWN *****"
 
     - name: remove setup ec2 instance
-      ec2_instance:
+      amazon.aws.ec2_instance:
         state: absent
         instance_ids:
-        - '{{ ec2_instance_id }}'
+          - "{{ ec2_instance_id }}"
         wait: true
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: delete ami
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: absent
         image_id: "{{ ec2_ami_image_id }}"
-        name: '{{ ec2_ami_name }}_ami'
-        wait: yes
-      ignore_errors: yes
+        name: "{{ ec2_ami_name }}_ami"
+        wait: true
+      ignore_errors: true
 
     - name: remove setup snapshot of ec2 instance
-      ec2_snapshot:
+      amazon.aws.ec2_snapshot:
         state: absent
-        snapshot_id: '{{ setup_snapshot.snapshot_id }}'
-      ignore_errors: yes
+        snapshot_id: "{{ setup_snapshot.snapshot_id }}"
+      ignore_errors: true
 
     - name: remove setup keypair
-      ec2_key:
-        name: '{{ec2_ami_name}}_setup'
+      amazon.aws.ec2_key:
+        name: "{{ec2_ami_name}}_setup"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: remove setup security group
       ec2_security_group:
-        name: '{{ ec2_ami_name }}_setup'
-        description: 'created by Ansible integration tests'
+        name: "{{ ec2_ami_name }}_setup"
+        description: created by Ansible integration tests
         state: absent
-        vpc_id: '{{ setup_vpc.vpc.id }}'
-      ignore_errors: yes
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+      ignore_errors: true
 
     - name: remove setup subnet
-      ec2_vpc_subnet:
-        az: '{{ availability_zone }}'
-        tags: '{{ec2_ami_name}}_setup'
-        vpc_id: '{{ setup_vpc.vpc.id }}'
-        cidr: '{{ subnet_cidr }}'
+      amazon.aws.ec2_vpc_subnet:
+        az: "{{ availability_zone }}"
+        tags: "{{ec2_ami_name}}_setup"
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+        cidr: "{{ subnet_cidr }}"
         state: absent
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
-      ignore_errors: yes
+          Name: "{{ ec2_ami_name }}_setup"
+      ignore_errors: true
 
     - name: remove setup VPC
-      ec2_vpc_net:
-        cidr_block: '{{ vpc_cidr }}'
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ vpc_cidr }}"
         state: absent
-        name: '{{ ec2_ami_name }}_setup'
+        name: "{{ ec2_ami_name }}_setup"
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
-      ignore_errors: yes
+          Name: "{{ ec2_ami_name }}_setup"
+      ignore_errors: true

--- a/tests/integration/targets/ec2_ami_tpm/defaults/main.yml
+++ b/tests/integration/targets/ec2_ami_tpm/defaults/main.yml
@@ -1,11 +1,11 @@
 ---
-availability_zone: '{{ ec2_availability_zone_names[0] }}'
+availability_zone: "{{ ec2_availability_zone_names[0] }}"
 
 # defaults file for test_ec2_ami
-ec2_ami_name: '{{resource_prefix}}'
-ec2_ami_description: 'Created by ansible integration tests'
+ec2_ami_name: "{{resource_prefix}}"
+ec2_ami_description: Created by ansible integration tests
 
-ec2_ami_image: '{{ ec2_ami_id }}'
+ec2_ami_image: "{{ ec2_ami_id }}"
 
-vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'
-subnet_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.1.0/24'
+vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/16
+subnet_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.1.0/24

--- a/tests/integration/targets/ec2_ami_tpm/meta/main.yml
+++ b/tests/integration/targets/ec2_ami_tpm/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
   - setup_ec2_facts

--- a/tests/integration/targets/ec2_ami_tpm/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami_tpm/tasks/main.yml
@@ -2,183 +2,181 @@
 # Test suite for ec2_ami
 - module_defaults:
     group/aws:
-      aws_region: '{{ aws_region }}'
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
+      aws_region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   collections:
     - amazon.aws
   block:
-
     # ============================================================
 
     # SETUP: vpc, ec2 key pair, subnet, security group, ec2 instance, snapshot
     - name: create a VPC to work in
-      ec2_vpc_net:
-        cidr_block: '{{ vpc_cidr }}'
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ vpc_cidr }}"
         state: present
-        name: '{{ ec2_ami_name }}_setup'
+        name: "{{ ec2_ami_name }}_setup"
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
+          Name: "{{ ec2_ami_name }}_setup"
       register: setup_vpc
 
     - name: create a key pair to use for creating an ec2 instance
-      ec2_key:
-        name: '{{ ec2_ami_name }}_setup'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_ami_name }}_setup"
         state: present
       register: setup_key
 
     - name: create a subnet to use for creating an ec2 instance
-      ec2_vpc_subnet:
-        az: '{{ availability_zone }}'
-        tags: '{{ ec2_ami_name }}_setup'
-        vpc_id: '{{ setup_vpc.vpc.id }}'
-        cidr: '{{ subnet_cidr }}'
+      amazon.aws.ec2_vpc_subnet:
+        az: "{{ availability_zone }}"
+        tags: "{{ ec2_ami_name }}_setup"
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+        cidr: "{{ subnet_cidr }}"
         state: present
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
+          Name: "{{ ec2_ami_name }}_setup"
       register: setup_subnet
 
     - name: create a security group to use for creating an ec2 instance
       ec2_security_group:
-        name: '{{ ec2_ami_name }}_setup'
-        description: 'created by Ansible integration tests'
+        name: "{{ ec2_ami_name }}_setup"
+        description: created by Ansible integration tests
         state: present
-        vpc_id: '{{ setup_vpc.vpc.id }}'
+        vpc_id: "{{ setup_vpc.vpc.id }}"
       register: setup_sg
 
     - name: provision ec2 instance to create an image
-      ec2_instance:
+      amazon.aws.ec2_instance:
         state: running
-        key_name: '{{ setup_key.key.name }}'
+        key_name: "{{ setup_key.key.name }}"
         instance_type: t2.micro
-        image_id: '{{ ec2_ami_id }}'
+        image_id: "{{ ec2_ami_id }}"
         tags:
-          '{{ec2_ami_name}}_instance_setup': 'integration_tests'
-        security_group: '{{ setup_sg.group_id }}'
-        vpc_subnet_id: '{{ setup_subnet.subnet.id }}'
+          "{{ec2_ami_name}}_instance_setup": integration_tests
+        security_group: "{{ setup_sg.group_id }}"
+        vpc_subnet_id: "{{ setup_subnet.subnet.id }}"
         volumes:
           - device_name: /dev/sdc
             virtual_name: ephemeral1
-        wait: yes
+        wait: true
       register: setup_instance
 
     - name: Store EC2 Instance ID
-      set_fact:
-        ec2_instance_id: '{{ setup_instance.instances[0].instance_id }}'
+      ansible.builtin.set_fact:
+        ec2_instance_id: "{{ setup_instance.instances[0].instance_id }}"
 
     - name: take a snapshot of the instance to create an image
-      ec2_snapshot:
-        instance_id: '{{ ec2_instance_id }}'
-        device_name: '{{ ec2_ami_root_disk }}'
+      amazon.aws.ec2_snapshot:
+        instance_id: "{{ ec2_instance_id }}"
+        device_name: "{{ ec2_ami_root_disk }}"
         state: present
       register: setup_snapshot
 
     # ============================================================
 
     - name: create an image from the snapshot with boot_mode and tpm_support
-      ec2_ami:
-        name: '{{ ec2_ami_name }}_ami-boot-tpm'
-        description: '{{ ec2_ami_description }}'
+      amazon.aws.ec2_ami:
+        name: "{{ ec2_ami_name }}_ami-boot-tpm"
+        description: "{{ ec2_ami_description }}"
         state: present
         boot_mode: uefi
         tpm_support: v2.0
         launch_permissions:
           user_ids: []
         tags:
-          Name: '{{ ec2_ami_name }}_ami-boot-tpm'
-        root_device_name: '{{ ec2_ami_root_disk }}'
+          Name: "{{ ec2_ami_name }}_ami-boot-tpm"
+        root_device_name: "{{ ec2_ami_root_disk }}"
         device_mapping:
-          - device_name: '{{ ec2_ami_root_disk }}'
+          - device_name: "{{ ec2_ami_root_disk }}"
             volume_type: gp2
             size: 8
             delete_on_termination: true
-            snapshot_id: '{{ setup_snapshot.snapshot_id }}'
+            snapshot_id: "{{ setup_snapshot.snapshot_id }}"
       register: result
       ignore_errors: true
 
     - name: set image id fact for deletion later
-      set_fact:
+      ansible.builtin.set_fact:
         ec2_ami_image_id_boot_tpm: "{{ result.image_id }}"
         ec2_ami_snapshot_boot_tpm: "{{ result.block_device_mapping[ec2_ami_root_disk].snapshot_id }}"
 
     - name: gather facts about the image created
-      ec2_ami_info:
-        image_ids: '{{ ec2_ami_image_id_boot_tpm }}'
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ ec2_ami_image_id_boot_tpm }}"
       register: ami_facts_result_boot_tpm
       ignore_errors: true
 
     - name: assert that new ami has been created with desired options
-      assert:
+      ansible.builtin.assert:
         that:
-          - "result.changed"
-          - "result.image_id.startswith('ami-')"
+          - result.changed
+          - result.image_id.startswith('ami-')
           - ami_facts_result_boot_tpm.images[0].image_id | length != 0
           - ami_facts_result_boot_tpm.images[0].boot_mode == 'uefi'
           - ami_facts_result_boot_tpm.images[0].tpm_support == 'v2.0'
 
-    # ============================================================
+  # ============================================================
 
   always:
-
     # ============================================================
 
     # TEAR DOWN: snapshot, ec2 instance, ec2 key pair, security group, vpc
     - name: Announce teardown start
-      debug:
+      ansible.builtin.debug:
         msg: "***** TESTING COMPLETE. COMMENCE TEARDOWN *****"
 
     - name: remove setup ec2 instance
-      ec2_instance:
+      amazon.aws.ec2_instance:
         state: absent
         instance_ids:
-        - '{{ ec2_instance_id }}'
+          - "{{ ec2_instance_id }}"
         wait: true
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: delete ami
-      ec2_ami:
+      amazon.aws.ec2_ami:
         state: absent
         image_id: "{{ ec2_ami_image_id_boot_tpm }}"
-        wait: yes
-      ignore_errors: yes
+        wait: true
+      ignore_errors: true
 
     - name: remove setup snapshot of ec2 instance
-      ec2_snapshot:
+      amazon.aws.ec2_snapshot:
         state: absent
-        snapshot_id: '{{ setup_snapshot.snapshot_id }}'
-      ignore_errors: yes
+        snapshot_id: "{{ setup_snapshot.snapshot_id }}"
+      ignore_errors: true
 
     - name: remove setup keypair
-      ec2_key:
-        name: '{{ec2_ami_name}}_setup'
+      amazon.aws.ec2_key:
+        name: "{{ec2_ami_name}}_setup"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: remove setup security group
       ec2_security_group:
-        name: '{{ ec2_ami_name }}_setup'
-        description: 'created by Ansible integration tests'
+        name: "{{ ec2_ami_name }}_setup"
+        description: created by Ansible integration tests
         state: absent
-        vpc_id: '{{ setup_vpc.vpc.id }}'
-      ignore_errors: yes
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+      ignore_errors: true
 
     - name: remove setup subnet
-      ec2_vpc_subnet:
-        az: '{{ availability_zone }}'
-        tags: '{{ec2_ami_name}}_setup'
-        vpc_id: '{{ setup_vpc.vpc.id }}'
-        cidr: '{{ subnet_cidr }}'
+      amazon.aws.ec2_vpc_subnet:
+        az: "{{ availability_zone }}"
+        tags: "{{ec2_ami_name}}_setup"
+        vpc_id: "{{ setup_vpc.vpc.id }}"
+        cidr: "{{ subnet_cidr }}"
         state: absent
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
-      ignore_errors: yes
+          Name: "{{ ec2_ami_name }}_setup"
+      ignore_errors: true
 
     - name: remove setup VPC
-      ec2_vpc_net:
-        cidr_block: '{{ vpc_cidr }}'
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ vpc_cidr }}"
         state: absent
-        name: '{{ ec2_ami_name }}_setup'
+        name: "{{ ec2_ami_name }}_setup"
         resource_tags:
-          Name: '{{ ec2_ami_name }}_setup'
-      ignore_errors: yes
+          Name: "{{ ec2_ami_name }}_setup"
+      ignore_errors: true

--- a/tests/integration/targets/ec2_eip/defaults/main.yml
+++ b/tests/integration/targets/ec2_eip/defaults/main.yml
@@ -1,5 +1,6 @@
+---
 # VPCs are identified by the CIDR.  Don't hard code the CIDR.  CI may
 # run multiple copies of the test concurrently.
 vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/16
 subnet_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.42.0/24
-subnet_az: '{{ ec2_availability_zone_names[0] }}'
+subnet_az: "{{ ec2_availability_zone_names[0] }}"

--- a/tests/integration/targets/ec2_eip/meta/main.yml
+++ b/tests/integration/targets/ec2_eip/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
-- setup_ec2_facts
+  - setup_ec2_facts

--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -1,1444 +1,1398 @@
+---
 - name: Integration testing for ec2_eip
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
     amazon.aws.ec2_eip:
       in_vpc: true
 
   block:
-  - name: Get the current caller identity facts
-    aws_caller_info:
-    register: caller_info
+    - name: Get the current caller identity facts
+      amazon.aws.aws_caller_info:
+      register: caller_info
 
-  - name: List available AZs
-    aws_az_info:
-    register: region_azs
+    - name: List available AZs
+      amazon.aws.aws_az_info:
+      register: region_azs
 
-  - name: Create a VPC
-    ec2_vpc_net:
-      name: '{{ resource_prefix }}-vpc'
-      state: present
-      cidr_block: '{{ vpc_cidr }}'
-      tags:
-        AnsibleEIPTest: Pending
-        AnsibleEIPTestPrefix: '{{ resource_prefix }}'
-    register: vpc_result
+    - name: Create a VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        state: present
+        cidr_block: "{{ vpc_cidr }}"
+        tags:
+          AnsibleEIPTest: Pending
+          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
+      register: vpc_result
 
-  - name: Look for signs of concurrent EIP tests.  Pause if they are running or their
-      prefix comes before ours.
-    vars:
-      running_query: vpcs[?tags.AnsibleEIPTest=='Running']
-      pending_query: vpcs[?tags.AnsibleEIPTest=='Pending'].tags.AnsibleEIPTestPrefix
-    ec2_vpc_net_info:
-      filters:
-        tag:AnsibleEIPTest:
-        - Pending
-        - Running
-    register: vpc_info
-    retries: 10
-    delay: 5
-    until:
-    - ( vpc_info.vpcs | map(attribute='tags') | selectattr('AnsibleEIPTest', 'equalto',
-      'Running') | length == 0 )
-    - ( vpc_info.vpcs | map(attribute='tags') | selectattr('AnsibleEIPTest', 'equalto',
-      'Pending') | map(attribute='AnsibleEIPTestPrefix') | sort | first == resource_prefix
-      )
+    - name: Look for signs of concurrent EIP tests.  Pause if they are running or their prefix comes before ours.
+      vars:
+        running_query: vpcs[?tags.AnsibleEIPTest=='Running']
+        pending_query: vpcs[?tags.AnsibleEIPTest=='Pending'].tags.AnsibleEIPTestPrefix
+      amazon.aws.ec2_vpc_net_info:
+        filters:
+          tag:AnsibleEIPTest:
+            - Pending
+            - Running
+      register: vpc_info
+      retries: 10
+      delay: 5
+      until:
+        - ( vpc_info.vpcs | map(attribute='tags') | selectattr('AnsibleEIPTest', 'equalto', 'Running') | length == 0 )
+        - ( vpc_info.vpcs | map(attribute='tags') | selectattr('AnsibleEIPTest', 'equalto', 'Pending') | map(attribute='AnsibleEIPTestPrefix') | sort | first == resource_prefix
+          )
 
-  - name: Create subnet
-    ec2_vpc_subnet:
-      cidr: '{{ subnet_cidr }}'
-      az: '{{ subnet_az }}'
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      state: present
-    register: vpc_subnet_create
+    - name: Create subnet
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ subnet_cidr }}"
+        az: "{{ subnet_az }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        state: present
+      register: vpc_subnet_create
 
-  - name: Create internet gateway
-    amazon.aws.ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-    register: vpc_igw
+    - name: Create internet gateway
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      register: vpc_igw
 
-  - name: Create security group
-    ec2_security_group:
-      state: present
-      name: '{{ resource_prefix }}-sg'
-      description: a security group for ansible tests
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      rules:
-      - proto: tcp
-        from_port: 22
-        to_port: 22
-        cidr_ip: 0.0.0.0/0
-    register: security_group
+    - name: Create security group
+      ec2_security_group:
+        state: present
+        name: "{{ resource_prefix }}-sg"
+        description: a security group for ansible tests
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        rules:
+          - proto: tcp
+            from_port: 22
+            to_port: 22
+            cidr_ip: "0.0.0.0/0"
+      register: security_group
 
-  - name: Create instance for attaching
-    ec2_instance:
-      name: '{{ resource_prefix }}-instance'
-      image_id: '{{ ec2_ami_id }}'
-      security_group: '{{ security_group.group_id }}'
-      vpc_subnet_id: '{{ vpc_subnet_create.subnet.id }}'
-      wait: yes
-      state: running
-    register: create_ec2_instance_result
+    - name: Create instance for attaching
+      amazon.aws.ec2_instance:
+        name: "{{ resource_prefix }}-instance"
+        image_id: "{{ ec2_ami_id }}"
+        security_group: "{{ security_group.group_id }}"
+        vpc_subnet_id: "{{ vpc_subnet_create.subnet.id }}"
+        wait: true
+        state: running
+      register: create_ec2_instance_result
 
-  - name: Create ENI A
-    ec2_eni:
-      subnet_id: '{{ vpc_subnet_create.subnet.id }}'
-    register: eni_create_a
+    - name: Create ENI A
+      amazon.aws.ec2_eni:
+        subnet_id: "{{ vpc_subnet_create.subnet.id }}"
+      register: eni_create_a
 
-  - name: Create ENI B
-    ec2_eni:
-      subnet_id: '{{ vpc_subnet_create.subnet.id }}'
-    register: eni_create_b
+    - name: Create ENI B
+      amazon.aws.ec2_eni:
+        subnet_id: "{{ vpc_subnet_create.subnet.id }}"
+      register: eni_create_b
 
-  - name: Make a crude lock
-    ec2_vpc_net:
-      name: '{{ resource_prefix }}-vpc'
-      state: present
-      cidr_block: '{{ vpc_cidr }}'
-      tags:
-        AnsibleEIPTest: Running
-        AnsibleEIPTestPrefix: '{{ resource_prefix }}'
+    - name: Make a crude lock
+      amazon.aws.ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        state: present
+        cidr_block: "{{ vpc_cidr }}"
+        tags:
+          AnsibleEIPTest: Running
+          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
 
-  - name: Get current state of EIPs
-    ec2_eip_info:
-    register: eip_info_start
+    - name: Get current state of EIPs
+      amazon.aws.ec2_eip_info:
+      register: eip_info_start
 
-  - name: Require that there are no free IPs when we start, otherwise we can't test
-      things properly
-    assert:
-      that:
-      - '"addresses" in eip_info_start'
-      - ( eip_info_start.addresses | length ) == ( eip_info_start.addresses | select('match',
-        'association_id') | length )
+    - name: Require that there are no free IPs when we start, otherwise we can't test things properly
+      ansible.builtin.assert:
+        that:
+          - '"addresses" in eip_info_start'
+          - ( eip_info_start.addresses | length ) == ( eip_info_start.addresses | select('match', 'association_id') | length )
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Allocate a new EIP with no conditions - check_mode
-    ec2_eip:
-      state: present
-      tags:
-        AnsibleEIPTestPrefix: '{{ resource_prefix }}'
-    register: eip
-    check_mode: yes
+    - name: Allocate a new EIP with no conditions - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        tags:
+          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
+      register: eip
+      check_mode: true
 
-  - assert:
-      that:
-      - eip is changed
+    - ansible.builtin.assert:
+        that:
+          - eip is changed
 
-  - name: Allocate a new EIP with no conditions
-    ec2_eip:
-      state: present
-      tags:
-        AnsibleEIPTestPrefix: '{{ resource_prefix }}'
-    register: eip
+    - name: Allocate a new EIP with no conditions
+      amazon.aws.ec2_eip:
+        state: present
+        tags:
+          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
+      register: eip
 
-  - ec2_eip_info:
-    register: eip_info
-    check_mode: yes
+    - amazon.aws.ec2_eip_info:
+      register: eip_info
+      check_mode: true
 
-  - assert:
-      that:
-      - eip is changed
-      - "'ec2:CreateTags' not in eip.resource_actions"
-      - "'ec2:DeleteTags' not in eip.resource_actions"
-      - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
-      - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
-      - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length
-        )
+    - ansible.builtin.assert:
+        that:
+          - eip is changed
+          - "'ec2:CreateTags' not in eip.resource_actions"
+          - "'ec2:DeleteTags' not in eip.resource_actions"
+          - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
+          - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
+          - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length )
 
-  - name: Get EIP info via public ip
-    ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
+    - name: Get EIP info via public ip
+      amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
 
-  - assert:
-      that:
-      - '"addresses" in eip_info'
-      - eip_info.addresses | length == 1
-      - eip_info.addresses[0].allocation_id == eip.allocation_id
-      - eip_info.addresses[0].domain == "vpc"
-      - eip_info.addresses[0].public_ip == eip.public_ip
-      - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
-      - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
+    - ansible.builtin.assert:
+        that:
+          - '"addresses" in eip_info'
+          - eip_info.addresses | length == 1
+          - eip_info.addresses[0].allocation_id == eip.allocation_id
+          - eip_info.addresses[0].domain == "vpc"
+          - eip_info.addresses[0].public_ip == eip.public_ip
+          - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
+          - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
 
-  - name: Get EIP info via allocation id
-    ec2_eip_info:
-      filters:
-        allocation-id: '{{ eip.allocation_id }}'
-    register: eip_info
+    - name: Get EIP info via allocation id
+      amazon.aws.ec2_eip_info:
+        filters:
+          allocation-id: "{{ eip.allocation_id }}"
+      register: eip_info
 
-  - assert:
-      that:
-      - '"addresses" in eip_info'
-      - eip_info.addresses | length == 1
-      - eip_info.addresses[0].allocation_id == eip.allocation_id
-      - eip_info.addresses[0].domain == "vpc"
-      - eip_info.addresses[0].public_ip == eip.public_ip
-      - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
-      - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
+    - ansible.builtin.assert:
+        that:
+          - '"addresses" in eip_info'
+          - eip_info.addresses | length == 1
+          - eip_info.addresses[0].allocation_id == eip.allocation_id
+          - eip_info.addresses[0].domain == "vpc"
+          - eip_info.addresses[0].public_ip == eip.public_ip
+          - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
+          - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
 
-  - name: Allocate a new ip (idempotence) - check_mode
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-    register: eip
-    check_mode: yes
+    - name: Allocate a new ip (idempotence) - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+      register: eip
+      check_mode: true
 
-  - assert:
-      that:
-      - eip is not changed
+    - ansible.builtin.assert:
+        that:
+          - eip is not changed
 
-  - name: Allocate a new ip (idempotence)
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-    register: eip
+    - name: Allocate a new ip (idempotence)
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+      register: eip
 
-  - ec2_eip_info:
-    register: eip_info
+    - amazon.aws.ec2_eip_info:
+      register: eip_info
 
-  - assert:
-      that:
-      - eip is not changed
-      - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
-      - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
-      - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length
-        )
+    - ansible.builtin.assert:
+        that:
+          - eip is not changed
+          - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
+          - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
+          - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length )
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Release EIP - check_mode
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-    register: eip_release
-    check_mode: yes
+    - name: Release EIP - check_mode
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
+      register: eip_release
+      check_mode: true
 
-  - assert:
-      that:
-      - eip_release.changed
+    - ansible.builtin.assert:
+        that:
+          - eip_release.changed
 
-  - name: Release eip
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-    register: eip_release
+    - name: Release eip
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
+      register: eip_release
 
-  - ec2_eip_info:
-    register: eip_info
+    - amazon.aws.ec2_eip_info:
+      register: eip_info
 
-  - assert:
-      that:
-      - eip_release.changed
-      - not eip_release.disassociated
-      - eip_release.released
-      - ( eip_info_start.addresses | length ) == ( eip_info.addresses | length )
+    - ansible.builtin.assert:
+        that:
+          - eip_release.changed
+          - not eip_release.disassociated
+          - eip_release.released
+          - ( eip_info_start.addresses | length ) == ( eip_info.addresses | length )
 
-  - name: Release EIP (idempotence) - check_mode
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-    register: eip_release
-    check_mode: yes
+    - name: Release EIP (idempotence) - check_mode
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
+      register: eip_release
+      check_mode: true
 
-  - assert:
-      that:
-      - eip_release is not changed
+    - ansible.builtin.assert:
+        that:
+          - eip_release is not changed
 
-  - name: Release EIP (idempotence)
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-    register: eip_release
+    - name: Release EIP (idempotence)
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
+      register: eip_release
 
-  - ec2_eip_info:
-    register: eip_info
+    - amazon.aws.ec2_eip_info:
+      register: eip_info
 
-  - assert:
-      that:
-      - not eip_release.changed
-      - not eip_release.disassociated
-      - not eip_release.released
-      - ( eip_info_start.addresses | length ) == ( eip_info.addresses | length )
-
-    # ------------------------------------------------------------------------------------------
-
-  - name: Allocate a new EIP - attempt reusing unallocated ones (none available) -
-      check_mode
-    ec2_eip:
-      state: present
-      reuse_existing_ip_allowed: true
-    register: eip
-    check_mode: yes
-
-  - assert:
-      that:
-      - eip is changed
-
-  - name: Allocate a new EIP - attempt reusing unallocated ones (none available)
-    ec2_eip:
-      state: present
-      reuse_existing_ip_allowed: true
-    register: eip
-
-  - ec2_eip_info:
-    register: eip_info
-
-  - assert:
-      that:
-      - eip is changed
-      - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
-      - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
-      - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length
-        )
-
-  - name: Re-Allocate a new EIP - attempt reusing unallocated ones (one available)
-      - check_mode
-    ec2_eip:
-      state: present
-      reuse_existing_ip_allowed: true
-    register: reallocate_eip
-    check_mode: yes
-
-  - assert:
-      that:
-      - reallocate_eip is not changed
-
-  - name: Re-Allocate a new EIP - attempt reusing unallocated ones (one available)
-    ec2_eip:
-      state: present
-      reuse_existing_ip_allowed: true
-    register: reallocate_eip
-
-  - ec2_eip_info:
-    register: eip_info
-
-  - assert:
-      that:
-      - reallocate_eip is not changed
-      - reallocate_eip.public_ip is defined and ( reallocate_eip.public_ip | ansible.utils.ipaddr
-        )
-      - reallocate_eip.allocation_id is defined and reallocate_eip.allocation_id.startswith("eipalloc-")
-      - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length
-        )
+    - ansible.builtin.assert:
+        that:
+          - not eip_release.changed
+          - not eip_release.disassociated
+          - not eip_release.released
+          - ( eip_info_start.addresses | length ) == ( eip_info.addresses | length )
 
     # ------------------------------------------------------------------------------------------
 
-  - name: attempt reusing an existing EIP with a tag (No match available) - check_mode
-    ec2_eip:
-      state: present
-      reuse_existing_ip_allowed: true
-      tag_name: Team
-    register: no_tagged_eip
-    check_mode: yes
+    - name: Allocate a new EIP - attempt reusing unallocated ones (none available) - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        reuse_existing_ip_allowed: true
+      register: eip
+      check_mode: true
 
-  - assert:
-      that:
-      - no_tagged_eip is changed
+    - ansible.builtin.assert:
+        that:
+          - eip is changed
 
-  - name: attempt reusing an existing EIP with a tag (No match available)
-    ec2_eip:
-      state: present
-      reuse_existing_ip_allowed: true
-      tag_name: Team
-    register: no_tagged_eip
+    - name: Allocate a new EIP - attempt reusing unallocated ones (none available)
+      amazon.aws.ec2_eip:
+        state: present
+        reuse_existing_ip_allowed: true
+      register: eip
 
-  - ec2_eip_info:
-    register: eip_info
+    - amazon.aws.ec2_eip_info:
+      register: eip_info
 
-  - assert:
-      that:
-      - no_tagged_eip is changed
-      - no_tagged_eip.public_ip is defined and ( no_tagged_eip.public_ip | ansible.utils.ipaddr
-        )
-      - no_tagged_eip.allocation_id is defined and no_tagged_eip.allocation_id.startswith("eipalloc-")
-      - ( eip_info_start.addresses | length ) + 2  == ( eip_info.addresses | length
-        )
+    - ansible.builtin.assert:
+        that:
+          - eip is changed
+          - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
+          - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
+          - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length )
 
-    # ------------------------------------------------------------------------------------------
+    - name: Re-Allocate a new EIP - attempt reusing unallocated ones (one available) - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        reuse_existing_ip_allowed: true
+      register: reallocate_eip
+      check_mode: true
 
-  - name: Tag EIP so we can try matching it
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        Team: Frontend
+    - ansible.builtin.assert:
+        that:
+          - reallocate_eip is not changed
 
-  - name: Attempt reusing an existing EIP with a tag (Match available) - check_mode
-    ec2_eip:
-      state: present
-      reuse_existing_ip_allowed: true
-      tag_name: Team
-    register: reallocate_eip
-    check_mode: yes
+    - name: Re-Allocate a new EIP - attempt reusing unallocated ones (one available)
+      amazon.aws.ec2_eip:
+        state: present
+        reuse_existing_ip_allowed: true
+      register: reallocate_eip
 
-  - assert:
-      that:
-      - reallocate_eip is not changed
+    - amazon.aws.ec2_eip_info:
+      register: eip_info
 
-  - name: Attempt reusing an existing EIP with a tag (Match available)
-    ec2_eip:
-      state: present
-      reuse_existing_ip_allowed: true
-      tag_name: Team
-    register: reallocate_eip
-
-  - ec2_eip_info:
-    register: eip_info
-
-  - assert:
-      that:
-      - reallocate_eip is not changed
-      - reallocate_eip.public_ip is defined and ( reallocate_eip.public_ip | ansible.utils.ipaddr
-        )
-      - reallocate_eip.allocation_id is defined and reallocate_eip.allocation_id.startswith("eipalloc-")
-      - ( eip_info_start.addresses | length ) + 2  == ( eip_info.addresses | length
-        )
-
-  - name: Attempt reusing an existing EIP with a tag and it's value (no match available)
-      - check_mode
-    ec2_eip:
-      state: present
-      reuse_existing_ip_allowed: true
-      tag_name: Team
-      tag_value: Backend
-    register: backend_eip
-    check_mode: yes
-
-  - assert:
-      that:
-      - backend_eip is changed
-
-  - name: Attempt reusing an existing EIP with a tag and it's value (no match available)
-    ec2_eip:
-      state: present
-      reuse_existing_ip_allowed: true
-      tag_name: Team
-      tag_value: Backend
-    register: backend_eip
-
-  - ec2_eip_info:
-    register: eip_info
-
-  - assert:
-      that:
-      - backend_eip is changed
-      - backend_eip.public_ip is defined and ( backend_eip.public_ip | ansible.utils.ipaddr
-        )
-      - backend_eip.allocation_id is defined and backend_eip.allocation_id.startswith("eipalloc-")
-      - ( eip_info_start.addresses | length ) + 3  == ( eip_info.addresses | length
-        )
+    - ansible.builtin.assert:
+        that:
+          - reallocate_eip is not changed
+          - reallocate_eip.public_ip is defined and ( reallocate_eip.public_ip | ansible.utils.ipaddr )
+          - reallocate_eip.allocation_id is defined and reallocate_eip.allocation_id.startswith("eipalloc-")
+          - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length )
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Tag EIP so we can try matching it
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        Team: Backend
+    - name: attempt reusing an existing EIP with a tag (No match available) - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        reuse_existing_ip_allowed: true
+        tag_name: Team
+      register: no_tagged_eip
+      check_mode: true
 
-  - name: Attempt reusing an existing EIP with a tag and it's value (match available)
-      - check_mode
-    ec2_eip:
-      state: present
-      reuse_existing_ip_allowed: true
-      tag_name: Team
-      tag_value: Backend
-    register: reallocate_eip
-    check_mode: yes
+    - ansible.builtin.assert:
+        that:
+          - no_tagged_eip is changed
 
-  - assert:
-      that:
-      - reallocate_eip is not changed
+    - name: attempt reusing an existing EIP with a tag (No match available)
+      amazon.aws.ec2_eip:
+        state: present
+        reuse_existing_ip_allowed: true
+        tag_name: Team
+      register: no_tagged_eip
 
-  - name: Attempt reusing an existing EIP with a tag and it's value (match available)
-    ec2_eip:
-      state: present
-      reuse_existing_ip_allowed: true
-      tag_name: Team
-      tag_value: Backend
-    register: reallocate_eip
+    - amazon.aws.ec2_eip_info:
+      register: eip_info
 
-  - ec2_eip_info:
-    register: eip_info
-
-  - assert:
-      that:
-      - reallocate_eip is not changed
-      - reallocate_eip.public_ip is defined and reallocate_eip.public_ip != ""
-      - reallocate_eip.allocation_id is defined and reallocate_eip.allocation_id !=
-        ""
-      - ( eip_info_start.addresses | length ) + 3  == ( eip_info.addresses | length
-        )
-
-  - name: Release backend_eip
-    ec2_eip:
-      state: absent
-      public_ip: '{{ backend_eip.public_ip }}'
-
-  - name: Release no_tagged_eip
-    ec2_eip:
-      state: absent
-      public_ip: '{{ no_tagged_eip.public_ip }}'
-
-  - name: Release eip
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-
-  - ec2_eip_info:
-    register: eip_info
-
-  - assert:
-      that:
-      - ( eip_info_start.addresses | length ) == ( eip_info.addresses | length )
+    - ansible.builtin.assert:
+        that:
+          - no_tagged_eip is changed
+          - no_tagged_eip.public_ip is defined and ( no_tagged_eip.public_ip | ansible.utils.ipaddr )
+          - no_tagged_eip.allocation_id is defined and no_tagged_eip.allocation_id.startswith("eipalloc-")
+          - ( eip_info_start.addresses | length ) + 2  == ( eip_info.addresses | length )
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Allocate a new EIP from a pool - check_mode
-    ec2_eip:
-      state: present
-      public_ipv4_pool: amazon
-    register: eip
-    check_mode: yes
+    - name: Tag EIP so we can try matching it
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          Team: Frontend
 
-  - assert:
-      that:
-      - eip is changed
+    - name: Attempt reusing an existing EIP with a tag (Match available) - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        reuse_existing_ip_allowed: true
+        tag_name: Team
+      register: reallocate_eip
+      check_mode: true
 
-  - name: Allocate a new EIP from a pool
-    ec2_eip:
-      state: present
-      public_ipv4_pool: amazon
-    register: eip
+    - ansible.builtin.assert:
+        that:
+          - reallocate_eip is not changed
 
-  - ec2_eip_info:
-    register: eip_info
+    - name: Attempt reusing an existing EIP with a tag (Match available)
+      amazon.aws.ec2_eip:
+        state: present
+        reuse_existing_ip_allowed: true
+        tag_name: Team
+      register: reallocate_eip
 
-  - assert:
-      that:
-      - eip is changed
-      - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
-      - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
-      - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length
-        )
+    - amazon.aws.ec2_eip_info:
+      register: eip_info
 
-    # ------------------------------------------------------------------------------------------
+    - ansible.builtin.assert:
+        that:
+          - reallocate_eip is not changed
+          - reallocate_eip.public_ip is defined and ( reallocate_eip.public_ip | ansible.utils.ipaddr )
+          - reallocate_eip.allocation_id is defined and reallocate_eip.allocation_id.startswith("eipalloc-")
+          - ( eip_info_start.addresses | length ) + 2  == ( eip_info.addresses | length )
 
-  - name: Attach EIP to ENI A - check_mode
-    ec2_eip:
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_a.interface.id }}'
-    register: associate_eip
-    check_mode: yes
+    - name: Attempt reusing an existing EIP with a tag and it's value (no match available) - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        reuse_existing_ip_allowed: true
+        tag_name: Team
+        tag_value: Backend
+      register: backend_eip
+      check_mode: true
 
-  - assert:
-      that:
-      - associate_eip is changed
+    - ansible.builtin.assert:
+        that:
+          - backend_eip is changed
 
-  - name: Attach EIP to ENI A
-    ec2_eip:
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_a.interface.id }}'
-    register: associate_eip
+    - name: Attempt reusing an existing EIP with a tag and it's value (no match available)
+      amazon.aws.ec2_eip:
+        state: present
+        reuse_existing_ip_allowed: true
+        tag_name: Team
+        tag_value: Backend
+      register: backend_eip
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
+    - amazon.aws.ec2_eip_info:
+      register: eip_info
 
-  - assert:
-      that:
-      - associate_eip is changed
-      - eip_info.addresses | length == 1
-      - associate_eip.public_ip is defined and eip.public_ip == associate_eip.public_ip
-      - associate_eip.allocation_id is defined and eip.allocation_id == associate_eip.allocation_id
-      - eip_info.addresses[0].allocation_id == eip.allocation_id
-      - eip_info.addresses[0].domain == "vpc"
-      - eip_info.addresses[0].public_ip == eip.public_ip
-      - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
-      - eip_info.addresses[0].network_interface_id == eni_create_a.interface.id
-      - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address
-        | ansible.utils.ipaddr )
-      - eip_info.addresses[0].network_interface_owner_id == caller_info.account
-
-  - name: Attach EIP to ENI A (idempotence) - check_mode
-    ec2_eip:
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_a.interface.id }}'
-    register: associate_eip
-    check_mode: yes
-
-  - assert:
-      that:
-      - associate_eip is not changed
-
-  - name: Attach EIP to ENI A (idempotence)
-    ec2_eip:
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_a.interface.id }}'
-    register: associate_eip
-
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
-
-  - assert:
-      that:
-      - associate_eip is not changed
-      - associate_eip.public_ip is defined and eip.public_ip == associate_eip.public_ip
-      - associate_eip.allocation_id is defined and eip.allocation_id == associate_eip.allocation_id
-      - eip_info.addresses | length == 1
-      - eip_info.addresses[0].allocation_id == eip.allocation_id
-      - eip_info.addresses[0].domain == "vpc"
-      - eip_info.addresses[0].public_ip == eip.public_ip
-      - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
-      - eip_info.addresses[0].network_interface_id == eni_create_a.interface.id
-      - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address
-        | ansible.utils.ipaddr )
+    - ansible.builtin.assert:
+        that:
+          - backend_eip is changed
+          - backend_eip.public_ip is defined and ( backend_eip.public_ip | ansible.utils.ipaddr )
+          - backend_eip.allocation_id is defined and backend_eip.allocation_id.startswith("eipalloc-")
+          - ( eip_info_start.addresses | length ) + 3  == ( eip_info.addresses | length )
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Attach EIP to ENI B (should fail, already associated)
-    ec2_eip:
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_b.interface.id }}'
-    register: associate_eip
-    ignore_errors: true
+    - name: Tag EIP so we can try matching it
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          Team: Backend
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
+    - name: Attempt reusing an existing EIP with a tag and it's value (match available) - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        reuse_existing_ip_allowed: true
+        tag_name: Team
+        tag_value: Backend
+      register: reallocate_eip
+      check_mode: true
 
-  - assert:
-      that:
-      - associate_eip is failed
-      - eip_info.addresses | length == 1
-      - eip_info.addresses[0].allocation_id == eip.allocation_id
-      - eip_info.addresses[0].domain == "vpc"
-      - eip_info.addresses[0].public_ip == eip.public_ip
-      - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
-      - eip_info.addresses[0].network_interface_id == eni_create_a.interface.id
-      - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address
-        | ansible.utils.ipaddr )
+    - ansible.builtin.assert:
+        that:
+          - reallocate_eip is not changed
 
-  - name: Attach EIP to ENI B - check_mode
-    ec2_eip:
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_b.interface.id }}'
-      allow_reassociation: true
-    register: associate_eip
-    check_mode: yes
+    - name: Attempt reusing an existing EIP with a tag and it's value (match available)
+      amazon.aws.ec2_eip:
+        state: present
+        reuse_existing_ip_allowed: true
+        tag_name: Team
+        tag_value: Backend
+      register: reallocate_eip
 
-  - assert:
-      that:
-      - associate_eip is changed
+    - amazon.aws.ec2_eip_info:
+      register: eip_info
 
-  - name: Attach EIP to ENI B
-    ec2_eip:
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_b.interface.id }}'
-      allow_reassociation: true
-    register: associate_eip
+    - ansible.builtin.assert:
+        that:
+          - reallocate_eip is not changed
+          - reallocate_eip.public_ip is defined and reallocate_eip.public_ip != ""
+          - reallocate_eip.allocation_id is defined and reallocate_eip.allocation_id != ""
+          - ( eip_info_start.addresses | length ) + 3  == ( eip_info.addresses | length )
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
+    - name: Release backend_eip
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ backend_eip.public_ip }}"
 
-  - assert:
-      that:
-      - associate_eip is changed
-      - associate_eip.public_ip is defined and eip.public_ip == associate_eip.public_ip
-      - associate_eip.allocation_id is defined and eip.allocation_id == associate_eip.allocation_id
-      - eip_info.addresses | length == 1
-      - eip_info.addresses[0].allocation_id == eip.allocation_id
-      - eip_info.addresses[0].domain == "vpc"
-      - eip_info.addresses[0].public_ip == eip.public_ip
-      - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
-      - eip_info.addresses[0].network_interface_id == eni_create_b.interface.id
-      - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address
-        | ansible.utils.ipaddr )
+    - name: Release no_tagged_eip
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ no_tagged_eip.public_ip }}"
 
-  - name: Attach EIP to ENI B (idempotence) - check_mode
-    ec2_eip:
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_b.interface.id }}'
-      allow_reassociation: true
-    register: associate_eip
-    check_mode: yes
+    - name: Release eip
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
 
-  - assert:
-      that:
-      - associate_eip is not changed
+    - amazon.aws.ec2_eip_info:
+      register: eip_info
 
-  - name: Attach EIP to ENI B (idempotence)
-    ec2_eip:
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_b.interface.id }}'
-      allow_reassociation: true
-    register: associate_eip
-
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
-
-  - assert:
-      that:
-      - associate_eip is not changed
-      - associate_eip.public_ip is defined and eip.public_ip == associate_eip.public_ip
-      - associate_eip.allocation_id is defined and eip.allocation_id == associate_eip.allocation_id
-      - eip_info.addresses | length == 1
-      - eip_info.addresses[0].allocation_id == eip.allocation_id
-      - eip_info.addresses[0].domain == "vpc"
-      - eip_info.addresses[0].public_ip == eip.public_ip
-      - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
-      - eip_info.addresses[0].network_interface_id == eni_create_b.interface.id
-      - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address
-        | ansible.utils.ipaddr )
+    - ansible.builtin.assert:
+        that:
+          - ( eip_info_start.addresses | length ) == ( eip_info.addresses | length )
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Detach EIP from ENI B, without enabling release on disassociation - check_mode
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_b.interface.id }}'
-    register: disassociate_eip
-    check_mode: yes
+    - name: Allocate a new EIP from a pool - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        public_ipv4_pool: amazon
+      register: eip
+      check_mode: true
 
-  - assert:
-      that:
-      - disassociate_eip is changed
+    - ansible.builtin.assert:
+        that:
+          - eip is changed
 
-  - name: Detach EIP from ENI B, without enabling release on disassociation
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_b.interface.id }}'
-    register: disassociate_eip
+    - name: Allocate a new EIP from a pool
+      amazon.aws.ec2_eip:
+        state: present
+        public_ipv4_pool: amazon
+      register: eip
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
+    - amazon.aws.ec2_eip_info:
+      register: eip_info
 
-  - assert:
-      that:
-      - disassociate_eip.changed
-      - disassociate_eip.disassociated
-      - not disassociate_eip.released
-      - eip_info.addresses | length == 1
-
-  - name: Detach EIP from ENI B, without enabling release on disassociation (idempotence)
-      - check_mode
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_b.interface.id }}'
-    register: disassociate_eip
-    check_mode: yes
-
-  - assert:
-      that:
-      - disassociate_eip is not changed
-
-  - name: Detach EIP from ENI B, without enabling release on disassociation (idempotence)
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_b.interface.id }}'
-    register: disassociate_eip
-
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
-
-  - assert:
-      that:
-      - not disassociate_eip.changed
-      - not disassociate_eip.disassociated
-      - not disassociate_eip.released
-      - eip_info.addresses | length == 1
+    - ansible.builtin.assert:
+        that:
+          - eip is changed
+          - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
+          - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
+          - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length )
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Attach EIP to ENI A
-    ec2_eip:
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_a.interface.id }}'
-    register: associate_eip
+    - name: Attach EIP to ENI A - check_mode
+      amazon.aws.ec2_eip:
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_a.interface.id }}"
+      register: associate_eip
+      check_mode: true
 
-  - name: Detach EIP from ENI A, enabling release on disassociation - check_mode
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_a.interface.id }}'
-      release_on_disassociation: true
-    register: disassociate_eip
-    check_mode: yes
+    - ansible.builtin.assert:
+        that:
+          - associate_eip is changed
 
-  - assert:
-      that:
-      - disassociate_eip is changed
+    - name: Attach EIP to ENI A
+      amazon.aws.ec2_eip:
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_a.interface.id }}"
+      register: associate_eip
 
-  - name: Detach EIP from ENI A, enabling release on disassociation
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_a.interface.id }}'
-      release_on_disassociation: true
-    register: disassociate_eip
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
+    - ansible.builtin.assert:
+        that:
+          - associate_eip is changed
+          - eip_info.addresses | length == 1
+          - associate_eip.public_ip is defined and eip.public_ip == associate_eip.public_ip
+          - associate_eip.allocation_id is defined and eip.allocation_id == associate_eip.allocation_id
+          - eip_info.addresses[0].allocation_id == eip.allocation_id
+          - eip_info.addresses[0].domain == "vpc"
+          - eip_info.addresses[0].public_ip == eip.public_ip
+          - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
+          - eip_info.addresses[0].network_interface_id == eni_create_a.interface.id
+          - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
+          - eip_info.addresses[0].network_interface_owner_id == caller_info.account
 
-  - assert:
-      that:
-      - disassociate_eip.changed
-      - disassociate_eip.disassociated
-      - disassociate_eip.released
-      - eip_info.addresses | length == 0
+    - name: Attach EIP to ENI A (idempotence) - check_mode
+      amazon.aws.ec2_eip:
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_a.interface.id }}"
+      register: associate_eip
+      check_mode: true
 
-  - name: Detach EIP from ENI A, enabling release on disassociation (idempotence)
-      - check_mode
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_a.interface.id }}'
-      release_on_disassociation: true
-    register: disassociate_eip
-    check_mode: yes
+    - ansible.builtin.assert:
+        that:
+          - associate_eip is not changed
 
-  - assert:
-      that:
-      - disassociate_eip is not changed
+    - name: Attach EIP to ENI A (idempotence)
+      amazon.aws.ec2_eip:
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_a.interface.id }}"
+      register: associate_eip
 
-  - name: Detach EIP from ENI A, enabling release on disassociation (idempotence)
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-      device_id: '{{ eni_create_a.interface.id }}'
-      release_on_disassociation: true
-    register: disassociate_eip
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
-
-  - assert:
-      that:
-      - not disassociate_eip.changed
-      - not disassociate_eip.disassociated
-      - not disassociate_eip.released
-      - eip_info.addresses | length == 0
+    - ansible.builtin.assert:
+        that:
+          - associate_eip is not changed
+          - associate_eip.public_ip is defined and eip.public_ip == associate_eip.public_ip
+          - associate_eip.allocation_id is defined and eip.allocation_id == associate_eip.allocation_id
+          - eip_info.addresses | length == 1
+          - eip_info.addresses[0].allocation_id == eip.allocation_id
+          - eip_info.addresses[0].domain == "vpc"
+          - eip_info.addresses[0].public_ip == eip.public_ip
+          - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
+          - eip_info.addresses[0].network_interface_id == eni_create_a.interface.id
+          - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Attach EIP to an EC2 instance - check_mode
-    ec2_eip:
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-      state: present
-      release_on_disassociation: yes
-    register: instance_eip
-    check_mode: yes
+    - name: Attach EIP to ENI B (should fail, already associated)
+      amazon.aws.ec2_eip:
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_b.interface.id }}"
+      register: associate_eip
+      ignore_errors: true
 
-  - assert:
-      that:
-      - instance_eip is changed
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
 
-  - name: Attach EIP to an EC2 instance
-    ec2_eip:
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-      state: present
-      release_on_disassociation: yes
-    register: instance_eip
+    - ansible.builtin.assert:
+        that:
+          - associate_eip is failed
+          - eip_info.addresses | length == 1
+          - eip_info.addresses[0].allocation_id == eip.allocation_id
+          - eip_info.addresses[0].domain == "vpc"
+          - eip_info.addresses[0].public_ip == eip.public_ip
+          - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
+          - eip_info.addresses[0].network_interface_id == eni_create_a.interface.id
+          - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ instance_eip.public_ip }}'
-    register: eip_info
+    - name: Attach EIP to ENI B - check_mode
+      amazon.aws.ec2_eip:
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_b.interface.id }}"
+        allow_reassociation: true
+      register: associate_eip
+      check_mode: true
 
-  - assert:
-      that:
-      - instance_eip is changed
-      - eip_info.addresses[0].allocation_id is defined
-      - eip_info.addresses[0].instance_id == '{{ create_ec2_instance_result.instance_ids[0]
-        }}'
+    - ansible.builtin.assert:
+        that:
+          - associate_eip is changed
 
-  - name: Attach EIP to an EC2 instance (idempotence) - check_mode
-    ec2_eip:
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-      state: present
-      release_on_disassociation: yes
-    register: instance_eip
-    check_mode: yes
+    - name: Attach EIP to ENI B
+      amazon.aws.ec2_eip:
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_b.interface.id }}"
+        allow_reassociation: true
+      register: associate_eip
 
-  - assert:
-      that:
-      - instance_eip is not changed
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
 
-  - name: Attach EIP to an EC2 instance (idempotence)
-    ec2_eip:
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-      state: present
-      release_on_disassociation: yes
-    register: instance_eip
+    - ansible.builtin.assert:
+        that:
+          - associate_eip is changed
+          - associate_eip.public_ip is defined and eip.public_ip == associate_eip.public_ip
+          - associate_eip.allocation_id is defined and eip.allocation_id == associate_eip.allocation_id
+          - eip_info.addresses | length == 1
+          - eip_info.addresses[0].allocation_id == eip.allocation_id
+          - eip_info.addresses[0].domain == "vpc"
+          - eip_info.addresses[0].public_ip == eip.public_ip
+          - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
+          - eip_info.addresses[0].network_interface_id == eni_create_b.interface.id
+          - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ instance_eip.public_ip }}'
-    register: eip_info
+    - name: Attach EIP to ENI B (idempotence) - check_mode
+      amazon.aws.ec2_eip:
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_b.interface.id }}"
+        allow_reassociation: true
+      register: associate_eip
+      check_mode: true
 
-  - assert:
-      that:
-      - instance_eip is not changed
-      - eip_info.addresses[0].allocation_id is defined
-      - eip_info.addresses[0].instance_id == '{{ create_ec2_instance_result.instance_ids[0]
-        }}'
+    - ansible.builtin.assert:
+        that:
+          - associate_eip is not changed
 
-    # ------------------------------------------------------------------------------------------
+    - name: Attach EIP to ENI B (idempotence)
+      amazon.aws.ec2_eip:
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_b.interface.id }}"
+        allow_reassociation: true
+      register: associate_eip
 
-  - name: Detach EIP from EC2 instance, without enabling release on disassociation
-      - check_mode
-    ec2_eip:
-      state: absent
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-    register: detach_eip
-    check_mode: yes
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
 
-  - assert:
-      that:
-      - detach_eip is changed
-
-  - name: Detach EIP from EC2 instance, without enabling release on disassociation
-    ec2_eip:
-      state: absent
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-    register: detach_eip
-
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ instance_eip.public_ip }}'
-    register: eip_info
-
-  - assert:
-      that:
-      - detach_eip.changed
-      - detach_eip.disassociated
-      - not detach_eip.released
-      - eip_info.addresses | length == 1
-
-  - name: Detach EIP from EC2 instance, without enabling release on disassociation
-      (idempotence) - check_mode
-    ec2_eip:
-      state: absent
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-    register: detach_eip
-    check_mode: yes
-
-  - assert:
-      that:
-      - detach_eip is not changed
-
-  - name: Detach EIP from EC2 instance, without enabling release on disassociation
-      (idempotence)
-    ec2_eip:
-      state: absent
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-    register: detach_eip
-
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ instance_eip.public_ip }}'
-    register: eip_info
-
-  - assert:
-      that:
-      - not detach_eip.changed
-      - not detach_eip.disassociated
-      - not detach_eip.released
-      - eip_info.addresses | length == 1
-
-  - name: Release EIP
-    ec2_eip:
-      state: absent
-      public_ip: '{{ instance_eip.public_ip }}'
+    - ansible.builtin.assert:
+        that:
+          - associate_eip is not changed
+          - associate_eip.public_ip is defined and eip.public_ip == associate_eip.public_ip
+          - associate_eip.allocation_id is defined and eip.allocation_id == associate_eip.allocation_id
+          - eip_info.addresses | length == 1
+          - eip_info.addresses[0].allocation_id == eip.allocation_id
+          - eip_info.addresses[0].domain == "vpc"
+          - eip_info.addresses[0].public_ip == eip.public_ip
+          - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
+          - eip_info.addresses[0].network_interface_id == eni_create_b.interface.id
+          - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Attach EIP to an EC2 instance with private Ip specified - check_mode
-    ec2_eip:
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-      private_ip_address: '{{ create_ec2_instance_result.instances[0].private_ip_address
-        }}'
-      state: present
-      release_on_disassociation: yes
-    register: instance_eip
-    check_mode: yes
+    - name: Detach EIP from ENI B, without enabling release on disassociation - check_mode
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_b.interface.id }}"
+      register: disassociate_eip
+      check_mode: true
 
-  - assert:
-      that:
-      - instance_eip is changed
+    - ansible.builtin.assert:
+        that:
+          - disassociate_eip is changed
 
-  - name: Attach EIP to an EC2 instance with private Ip specified
-    ec2_eip:
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-      private_ip_address: '{{ create_ec2_instance_result.instances[0].private_ip_address
-        }}'
-      state: present
-      release_on_disassociation: yes
-    register: instance_eip
+    - name: Detach EIP from ENI B, without enabling release on disassociation
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_b.interface.id }}"
+      register: disassociate_eip
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ instance_eip.public_ip }}'
-    register: eip_info
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
 
-  - assert:
-      that:
-      - instance_eip is changed
-      - eip_info.addresses[0].allocation_id is defined
-      - eip_info.addresses[0].instance_id == '{{ create_ec2_instance_result.instance_ids[0]
-        }}'
+    - ansible.builtin.assert:
+        that:
+          - disassociate_eip.changed
+          - disassociate_eip.disassociated
+          - not disassociate_eip.released
+          - eip_info.addresses | length == 1
 
-  - name: Attach EIP to an EC2 instance with private Ip specified (idempotence) -
-      check_mode
-    ec2_eip:
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-      private_ip_address: '{{ create_ec2_instance_result.instances[0].private_ip_address
-        }}'
-      state: present
-      release_on_disassociation: yes
-    register: instance_eip
-    check_mode: yes
+    - name: Detach EIP from ENI B, without enabling release on disassociation (idempotence) - check_mode
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_b.interface.id }}"
+      register: disassociate_eip
+      check_mode: true
 
-  - assert:
-      that:
-      - instance_eip is not changed
+    - ansible.builtin.assert:
+        that:
+          - disassociate_eip is not changed
 
-  - name: Attach EIP to an EC2 instance with private Ip specified (idempotence)
-    ec2_eip:
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-      private_ip_address: '{{ create_ec2_instance_result.instances[0].private_ip_address
-        }}'
-      state: present
-      release_on_disassociation: yes
-    register: instance_eip
+    - name: Detach EIP from ENI B, without enabling release on disassociation (idempotence)
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_b.interface.id }}"
+      register: disassociate_eip
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ instance_eip.public_ip }}'
-    register: eip_info
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
 
-  - assert:
-      that:
-      - instance_eip is not changed
-      - eip_info.addresses[0].allocation_id is defined
-      - eip_info.addresses[0].instance_id == '{{ create_ec2_instance_result.instance_ids[0]
-        }}'
+    - ansible.builtin.assert:
+        that:
+          - not disassociate_eip.changed
+          - not disassociate_eip.disassociated
+          - not disassociate_eip.released
+          - eip_info.addresses | length == 1
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Detach EIP from EC2 instance, enabling release on disassociation - check_mode
-    ec2_eip:
-      state: absent
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-      release_on_disassociation: yes
-    register: disassociate_eip
-    check_mode: yes
+    - name: Attach EIP to ENI A
+      amazon.aws.ec2_eip:
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_a.interface.id }}"
+      register: associate_eip
 
-  - assert:
-      that:
-      - disassociate_eip is changed
+    - name: Detach EIP from ENI A, enabling release on disassociation - check_mode
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_a.interface.id }}"
+        release_on_disassociation: true
+      register: disassociate_eip
+      check_mode: true
 
-  - name: Detach EIP from EC2 instance, enabling release on disassociation
-    ec2_eip:
-      state: absent
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-      release_on_disassociation: yes
-    register: disassociate_eip
+    - ansible.builtin.assert:
+        that:
+          - disassociate_eip is changed
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ instance_eip.public_ip }}'
-    register: eip_info
+    - name: Detach EIP from ENI A, enabling release on disassociation
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_a.interface.id }}"
+        release_on_disassociation: true
+      register: disassociate_eip
 
-  - assert:
-      that:
-      - disassociate_eip.changed
-      - disassociate_eip.disassociated
-      - disassociate_eip.released
-      - eip_info.addresses | length == 0
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
 
-  - name: Detach EIP from EC2 instance, enabling release on disassociation (idempotence)
-      - check_mode
-    ec2_eip:
-      state: absent
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-      release_on_disassociation: yes
-    register: disassociate_eip
-    check_mode: yes
+    - ansible.builtin.assert:
+        that:
+          - disassociate_eip.changed
+          - disassociate_eip.disassociated
+          - disassociate_eip.released
+          - eip_info.addresses | length == 0
 
-  - assert:
-      that:
-      - disassociate_eip is not changed
+    - name: Detach EIP from ENI A, enabling release on disassociation (idempotence) - check_mode
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_a.interface.id }}"
+        release_on_disassociation: true
+      register: disassociate_eip
+      check_mode: true
 
-  - name: Detach EIP from EC2 instance, enabling release on disassociation (idempotence)
-    ec2_eip:
-      state: absent
-      device_id: '{{ create_ec2_instance_result.instance_ids[0] }}'
-      release_on_disassociation: yes
-    register: disassociate_eip
+    - ansible.builtin.assert:
+        that:
+          - disassociate_eip is not changed
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ instance_eip.public_ip }}'
-    register: eip_info
+    - name: Detach EIP from ENI A, enabling release on disassociation (idempotence)
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
+        device_id: "{{ eni_create_a.interface.id }}"
+        release_on_disassociation: true
+      register: disassociate_eip
 
-  - assert:
-      that:
-      - not disassociate_eip.changed
-      - not disassociate_eip.disassociated
-      - not disassociate_eip.released
-      - eip_info.addresses | length == 0
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
 
-    # ------------------------------------------------------------------------------------------
-
-  - name: Allocate a new eip
-    ec2_eip:
-      state: present
-    register: eip
-
-  - name: Tag EIP - check_mode
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        AnsibleEIPTestPrefix: '{{ resource_prefix }}'
-        another_tag: another Value {{ resource_prefix }}
-    register: tag_eip
-    check_mode: yes
-
-  - assert:
-      that:
-      - tag_eip is changed
-
-  - name: Tag EIP
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        AnsibleEIPTestPrefix: '{{ resource_prefix }}'
-        another_tag: another Value {{ resource_prefix }}
-    register: tag_eip
-
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
-
-  - assert:
-      that:
-      - tag_eip is changed
-      - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
-      - '"another_tag" in eip_info.addresses[0].tags'
-      - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
-      - eip_info.addresses[0].tags['another_tag'] == 'another Value ' + resource_prefix
-      - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length
-        )
-
-  - name: Tag EIP (idempotence) - check_mode
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        AnsibleEIPTestPrefix: '{{ resource_prefix }}'
-        another_tag: another Value {{ resource_prefix }}
-    register: tag_eip
-    check_mode: yes
-
-  - assert:
-      that:
-      - tag_eip is not changed
-
-  - name: Tag EIP (idempotence)
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        AnsibleEIPTestPrefix: '{{ resource_prefix }}'
-        another_tag: another Value {{ resource_prefix }}
-    register: tag_eip
-
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
-
-  - assert:
-      that:
-      - tag_eip is not changed
-      - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
-      - '"another_tag" in eip_info.addresses[0].tags'
-      - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
-      - eip_info.addresses[0].tags['another_tag'] == 'another Value ' + resource_prefix
-      - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length
-        )
+    - ansible.builtin.assert:
+        that:
+          - not disassociate_eip.changed
+          - not disassociate_eip.disassociated
+          - not disassociate_eip.released
+          - eip_info.addresses | length == 0
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Add another Tag - check_mode
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        third tag: Third tag - {{ resource_prefix }}
-      purge_tags: false
-    register: tag_eip
-    check_mode: yes
+    - name: Attach EIP to an EC2 instance - check_mode
+      amazon.aws.ec2_eip:
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+        state: present
+        release_on_disassociation: true
+      register: instance_eip
+      check_mode: true
 
-  - assert:
-      that:
-      - tag_eip is changed
+    - ansible.builtin.assert:
+        that:
+          - instance_eip is changed
 
-  - name: Add another Tag
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        third tag: Third tag - {{ resource_prefix }}
-      purge_tags: false
-    register: tag_eip
+    - name: Attach EIP to an EC2 instance
+      amazon.aws.ec2_eip:
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+        state: present
+        release_on_disassociation: true
+      register: instance_eip
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ instance_eip.public_ip }}"
+      register: eip_info
 
-  - assert:
-      that:
-      - tag_eip is changed
-      - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
-      - '"another_tag" in eip_info.addresses[0].tags'
-      - '"third tag" in eip_info.addresses[0].tags'
-      - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
-      - eip_info.addresses[0].tags['another_tag'] == 'another Value ' + resource_prefix
-      - eip_info.addresses[0].tags['third tag'] == 'Third tag - ' + resource_prefix
-      - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length
-        )
+    - ansible.builtin.assert:
+        that:
+          - instance_eip is changed
+          - eip_info.addresses[0].allocation_id is defined
+          - eip_info.addresses[0].instance_id == '{{ create_ec2_instance_result.instance_ids[0] }}'
 
-  - name: Add another Tag (idempotence) - check_mode
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        third tag: Third tag - {{ resource_prefix }}
-      purge_tags: false
-    register: tag_eip
-    check_mode: yes
+    - name: Attach EIP to an EC2 instance (idempotence) - check_mode
+      amazon.aws.ec2_eip:
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+        state: present
+        release_on_disassociation: true
+      register: instance_eip
+      check_mode: true
 
-  - assert:
-      that:
-      - tag_eip is not changed
+    - ansible.builtin.assert:
+        that:
+          - instance_eip is not changed
 
-  - name: Add another Tag (idempotence)
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        third tag: Third tag - {{ resource_prefix }}
-      purge_tags: false
-    register: tag_eip
+    - name: Attach EIP to an EC2 instance (idempotence)
+      amazon.aws.ec2_eip:
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+        state: present
+        release_on_disassociation: true
+      register: instance_eip
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ instance_eip.public_ip }}"
+      register: eip_info
 
-  - assert:
-      that:
-      - tag_eip is not changed
-      - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
-      - '"another_tag" in eip_info.addresses[0].tags'
-      - '"third tag" in eip_info.addresses[0].tags'
-      - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
-      - eip_info.addresses[0].tags['another_tag'] == 'another Value ' + resource_prefix
-      - eip_info.addresses[0].tags['third tag'] == 'Third tag - ' + resource_prefix
+    - ansible.builtin.assert:
+        that:
+          - instance_eip is not changed
+          - eip_info.addresses[0].allocation_id is defined
+          - eip_info.addresses[0].instance_id == '{{ create_ec2_instance_result.instance_ids[0] }}'
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Purge tags - check_mode
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        third tag: Third tag - {{ resource_prefix }}
-      purge_tags: true
-    register: tag_eip
-    check_mode: yes
+    - name: Detach EIP from EC2 instance, without enabling release on disassociation - check_mode
+      amazon.aws.ec2_eip:
+        state: absent
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+      register: detach_eip
+      check_mode: true
 
-  - assert:
-      that:
-      - tag_eip is changed
+    - ansible.builtin.assert:
+        that:
+          - detach_eip is changed
 
-  - name: Purge tags
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        third tag: Third tag - {{ resource_prefix }}
-      purge_tags: true
-    register: tag_eip
+    - name: Detach EIP from EC2 instance, without enabling release on disassociation
+      amazon.aws.ec2_eip:
+        state: absent
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+      register: detach_eip
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ instance_eip.public_ip }}"
+      register: eip_info
 
-  - assert:
-      that:
-      - tag_eip is changed
-      - '"AnsibleEIPTestPrefix" not in eip_info.addresses[0].tags'
-      - '"another_tag" not in eip_info.addresses[0].tags'
-      - '"third tag" in eip_info.addresses[0].tags'
-      - eip_info.addresses[0].tags['third tag'] == 'Third tag - ' + resource_prefix
+    - ansible.builtin.assert:
+        that:
+          - detach_eip.changed
+          - detach_eip.disassociated
+          - not detach_eip.released
+          - eip_info.addresses | length == 1
 
-  - name: Purge tags (idempotence) - check_mode
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        third tag: Third tag - {{ resource_prefix }}
-      purge_tags: true
-    register: tag_eip
-    check_mode: yes
+    - name: Detach EIP from EC2 instance, without enabling release on disassociation (idempotence) - check_mode
+      amazon.aws.ec2_eip:
+        state: absent
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+      register: detach_eip
+      check_mode: true
 
-  - assert:
-      that:
-      - tag_eip is not changed
+    - ansible.builtin.assert:
+        that:
+          - detach_eip is not changed
 
-  - name: Purge tags (idempotence)
-    ec2_eip:
-      state: present
-      public_ip: '{{ eip.public_ip }}'
-      tags:
-        third tag: Third tag - {{ resource_prefix }}
-      purge_tags: true
-    register: tag_eip
+    - name: Detach EIP from EC2 instance, without enabling release on disassociation (idempotence)
+      amazon.aws.ec2_eip:
+        state: absent
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+      register: detach_eip
 
-  - ec2_eip_info:
-      filters:
-        public-ip: '{{ eip.public_ip }}'
-    register: eip_info
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ instance_eip.public_ip }}"
+      register: eip_info
 
-  - assert:
-      that:
-      - tag_eip is not changed
-      - '"AnsibleEIPTestPrefix" not in eip_info.addresses[0].tags'
-      - '"another_tag" not in eip_info.addresses[0].tags'
-      - '"third tag" in eip_info.addresses[0].tags'
-      - eip_info.addresses[0].tags['third tag'] == 'Third tag - ' + resource_prefix
+    - ansible.builtin.assert:
+        that:
+          - not detach_eip.changed
+          - not detach_eip.disassociated
+          - not detach_eip.released
+          - eip_info.addresses | length == 1
+
+    - name: Release EIP
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ instance_eip.public_ip }}"
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Attach EIP to an EC2 instance with private Ip specified - check_mode
+      amazon.aws.ec2_eip:
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+        private_ip_address: "{{ create_ec2_instance_result.instances[0].private_ip_address }}"
+        state: present
+        release_on_disassociation: true
+      register: instance_eip
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - instance_eip is changed
+
+    - name: Attach EIP to an EC2 instance with private Ip specified
+      amazon.aws.ec2_eip:
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+        private_ip_address: "{{ create_ec2_instance_result.instances[0].private_ip_address }}"
+        state: present
+        release_on_disassociation: true
+      register: instance_eip
+
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ instance_eip.public_ip }}"
+      register: eip_info
+
+    - ansible.builtin.assert:
+        that:
+          - instance_eip is changed
+          - eip_info.addresses[0].allocation_id is defined
+          - eip_info.addresses[0].instance_id == '{{ create_ec2_instance_result.instance_ids[0] }}'
+
+    - name: Attach EIP to an EC2 instance with private Ip specified (idempotence) - check_mode
+      amazon.aws.ec2_eip:
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+        private_ip_address: "{{ create_ec2_instance_result.instances[0].private_ip_address }}"
+        state: present
+        release_on_disassociation: true
+      register: instance_eip
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - instance_eip is not changed
+
+    - name: Attach EIP to an EC2 instance with private Ip specified (idempotence)
+      amazon.aws.ec2_eip:
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+        private_ip_address: "{{ create_ec2_instance_result.instances[0].private_ip_address }}"
+        state: present
+        release_on_disassociation: true
+      register: instance_eip
+
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ instance_eip.public_ip }}"
+      register: eip_info
+
+    - ansible.builtin.assert:
+        that:
+          - instance_eip is not changed
+          - eip_info.addresses[0].allocation_id is defined
+          - eip_info.addresses[0].instance_id == '{{ create_ec2_instance_result.instance_ids[0] }}'
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Detach EIP from EC2 instance, enabling release on disassociation - check_mode
+      amazon.aws.ec2_eip:
+        state: absent
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+        release_on_disassociation: true
+      register: disassociate_eip
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - disassociate_eip is changed
+
+    - name: Detach EIP from EC2 instance, enabling release on disassociation
+      amazon.aws.ec2_eip:
+        state: absent
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+        release_on_disassociation: true
+      register: disassociate_eip
+
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ instance_eip.public_ip }}"
+      register: eip_info
+
+    - ansible.builtin.assert:
+        that:
+          - disassociate_eip.changed
+          - disassociate_eip.disassociated
+          - disassociate_eip.released
+          - eip_info.addresses | length == 0
+
+    - name: Detach EIP from EC2 instance, enabling release on disassociation (idempotence) - check_mode
+      amazon.aws.ec2_eip:
+        state: absent
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+        release_on_disassociation: true
+      register: disassociate_eip
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - disassociate_eip is not changed
+
+    - name: Detach EIP from EC2 instance, enabling release on disassociation (idempotence)
+      amazon.aws.ec2_eip:
+        state: absent
+        device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
+        release_on_disassociation: true
+      register: disassociate_eip
+
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ instance_eip.public_ip }}"
+      register: eip_info
+
+    - ansible.builtin.assert:
+        that:
+          - not disassociate_eip.changed
+          - not disassociate_eip.disassociated
+          - not disassociate_eip.released
+          - eip_info.addresses | length == 0
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Allocate a new eip
+      amazon.aws.ec2_eip:
+        state: present
+      register: eip
+
+    - name: Tag EIP - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
+          another_tag: another Value {{ resource_prefix }}
+      register: tag_eip
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - tag_eip is changed
+
+    - name: Tag EIP
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
+          another_tag: another Value {{ resource_prefix }}
+      register: tag_eip
+
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
+
+    - ansible.builtin.assert:
+        that:
+          - tag_eip is changed
+          - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
+          - '"another_tag" in eip_info.addresses[0].tags'
+          - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
+          - eip_info.addresses[0].tags['another_tag'] == 'another Value ' + resource_prefix
+          - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length )
+
+    - name: Tag EIP (idempotence) - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
+          another_tag: another Value {{ resource_prefix }}
+      register: tag_eip
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - tag_eip is not changed
+
+    - name: Tag EIP (idempotence)
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
+          another_tag: another Value {{ resource_prefix }}
+      register: tag_eip
+
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
+
+    - ansible.builtin.assert:
+        that:
+          - tag_eip is not changed
+          - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
+          - '"another_tag" in eip_info.addresses[0].tags'
+          - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
+          - eip_info.addresses[0].tags['another_tag'] == 'another Value ' + resource_prefix
+          - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length )
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Add another Tag - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          third tag: Third tag - {{ resource_prefix }}
+        purge_tags: false
+      register: tag_eip
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - tag_eip is changed
+
+    - name: Add another Tag
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          third tag: Third tag - {{ resource_prefix }}
+        purge_tags: false
+      register: tag_eip
+
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
+
+    - ansible.builtin.assert:
+        that:
+          - tag_eip is changed
+          - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
+          - '"another_tag" in eip_info.addresses[0].tags'
+          - '"third tag" in eip_info.addresses[0].tags'
+          - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
+          - eip_info.addresses[0].tags['another_tag'] == 'another Value ' + resource_prefix
+          - eip_info.addresses[0].tags['third tag'] == 'Third tag - ' + resource_prefix
+          - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length )
+
+    - name: Add another Tag (idempotence) - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          third tag: Third tag - {{ resource_prefix }}
+        purge_tags: false
+      register: tag_eip
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - tag_eip is not changed
+
+    - name: Add another Tag (idempotence)
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          third tag: Third tag - {{ resource_prefix }}
+        purge_tags: false
+      register: tag_eip
+
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
+
+    - ansible.builtin.assert:
+        that:
+          - tag_eip is not changed
+          - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
+          - '"another_tag" in eip_info.addresses[0].tags'
+          - '"third tag" in eip_info.addresses[0].tags'
+          - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
+          - eip_info.addresses[0].tags['another_tag'] == 'another Value ' + resource_prefix
+          - eip_info.addresses[0].tags['third tag'] == 'Third tag - ' + resource_prefix
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Purge tags - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          third tag: Third tag - {{ resource_prefix }}
+        purge_tags: true
+      register: tag_eip
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - tag_eip is changed
+
+    - name: Purge tags
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          third tag: Third tag - {{ resource_prefix }}
+        purge_tags: true
+      register: tag_eip
+
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
+
+    - ansible.builtin.assert:
+        that:
+          - tag_eip is changed
+          - '"AnsibleEIPTestPrefix" not in eip_info.addresses[0].tags'
+          - '"another_tag" not in eip_info.addresses[0].tags'
+          - '"third tag" in eip_info.addresses[0].tags'
+          - eip_info.addresses[0].tags['third tag'] == 'Third tag - ' + resource_prefix
+
+    - name: Purge tags (idempotence) - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          third tag: Third tag - {{ resource_prefix }}
+        purge_tags: true
+      register: tag_eip
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - tag_eip is not changed
+
+    - name: Purge tags (idempotence)
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        tags:
+          third tag: Third tag - {{ resource_prefix }}
+        purge_tags: true
+      register: tag_eip
+
+    - amazon.aws.ec2_eip_info:
+        filters:
+          public-ip: "{{ eip.public_ip }}"
+      register: eip_info
+
+    - ansible.builtin.assert:
+        that:
+          - tag_eip is not changed
+          - '"AnsibleEIPTestPrefix" not in eip_info.addresses[0].tags'
+          - '"another_tag" not in eip_info.addresses[0].tags'
+          - '"third tag" in eip_info.addresses[0].tags'
+          - eip_info.addresses[0].tags['third tag'] == 'Third tag - ' + resource_prefix
 
   # ----- Cleanup ------------------------------------------------------------------------------
 
   always:
+    - name: Cleanup instance (by id)
+      amazon.aws.ec2_instance:
+        instance_ids: "{{ create_ec2_instance_result.instance_ids }}"
+        state: absent
+        wait: true
+      ignore_errors: true
 
-  - name: Cleanup instance (by id)
-    ec2_instance:
-      instance_ids: '{{ create_ec2_instance_result.instance_ids }}'
-      state: absent
-      wait: true
-    ignore_errors: true
+    - name: Cleanup instance (by name)
+      amazon.aws.ec2_instance:
+        name: "{{ resource_prefix }}-instance"
+        state: absent
+        wait: true
+      ignore_errors: true
 
-  - name: Cleanup instance (by name)
-    ec2_instance:
-      name: '{{ resource_prefix }}-instance'
-      state: absent
-      wait: true
-    ignore_errors: true
+    - name: Cleanup ENI A
+      amazon.aws.ec2_eni:
+        state: absent
+        eni_id: "{{ eni_create_a.interface.id }}"
+      ignore_errors: true
 
-  - name: Cleanup ENI A
-    ec2_eni:
-      state: absent
-      eni_id: '{{ eni_create_a.interface.id }}'
-    ignore_errors: true
+    - name: Cleanup ENI B
+      amazon.aws.ec2_eni:
+        state: absent
+        eni_id: "{{ eni_create_b.interface.id }}"
+      ignore_errors: true
 
-  - name: Cleanup ENI B
-    ec2_eni:
-      state: absent
-      eni_id: '{{ eni_create_b.interface.id }}'
-    ignore_errors: true
+    - name: Cleanup instance eip
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ instance_eip.public_ip }}"
+      retries: 5
+      delay: 5
+      until: eip_cleanup is successful
+      ignore_errors: true
 
-  - name: Cleanup instance eip
-    ec2_eip:
-      state: absent
-      public_ip: '{{ instance_eip.public_ip }}'
-    retries: 5
-    delay: 5
-    until: eip_cleanup is successful
-    ignore_errors: true
+    - name: Cleanup IGW
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      register: vpc_igw
+      ignore_errors: true
 
-  - name: Cleanup IGW
-    ec2_vpc_igw:
-      state: absent
-      vpc_id: '{{ vpc_result.vpc.id }}'
-    register: vpc_igw
-    ignore_errors: true
+    - name: Cleanup security group
+      ec2_security_group:
+        state: absent
+        name: "{{ resource_prefix }}-sg"
+      ignore_errors: true
 
-  - name: Cleanup security group
-    ec2_security_group:
-      state: absent
-      name: '{{ resource_prefix }}-sg'
-    ignore_errors: true
+    - name: Cleanup Subnet
+      amazon.aws.ec2_vpc_subnet:
+        state: absent
+        cidr: "{{ subnet_cidr }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      ignore_errors: true
 
-  - name: Cleanup Subnet
-    ec2_vpc_subnet:
-      state: absent
-      cidr: '{{ subnet_cidr }}'
-      vpc_id: '{{ vpc_result.vpc.id }}'
-    ignore_errors: true
+    - name: Cleanup eip
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ eip.public_ip }}"
+      ignore_errors: true
 
-  - name: Cleanup eip
-    ec2_eip:
-      state: absent
-      public_ip: '{{ eip.public_ip }}'
-    ignore_errors: true
+    - name: Cleanup reallocate_eip
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ reallocate_eip.public_ip }}"
+      ignore_errors: true
 
-  - name: Cleanup reallocate_eip
-    ec2_eip:
-      state: absent
-      public_ip: '{{ reallocate_eip.public_ip }}'
-    ignore_errors: true
+    - name: Cleanup backend_eip
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ backend_eip.public_ip }}"
+      ignore_errors: true
 
-  - name: Cleanup backend_eip
-    ec2_eip:
-      state: absent
-      public_ip: '{{ backend_eip.public_ip }}'
-    ignore_errors: true
+    - name: Cleanup no_tagged_eip
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ no_tagged_eip.public_ip }}"
+      ignore_errors: true
 
-  - name: Cleanup no_tagged_eip
-    ec2_eip:
-      state: absent
-      public_ip: '{{ no_tagged_eip.public_ip }}'
-    ignore_errors: true
-
-  - name: Cleanup VPC
-    ec2_vpc_net:
-      state: absent
-      name: '{{ resource_prefix }}-vpc'
-      cidr_block: '{{ vpc_cidr }}'
-    ignore_errors: true
+    - name: Cleanup VPC
+      amazon.aws.ec2_vpc_net:
+        state: absent
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: "{{ vpc_cidr }}"
+      ignore_errors: true

--- a/tests/integration/targets/ec2_eni/defaults/main.yml
+++ b/tests/integration/targets/ec2_eni/defaults/main.yml
@@ -1,10 +1,10 @@
 ---
-availability_zone: '{{ ec2_availability_zone_names[0] }}'
+availability_zone: "{{ ec2_availability_zone_names[0] }}"
 
-vpc_seed_a: '{{ resource_prefix }}'
-vpc_seed_b: '{{ resource_prefix }}-ec2_eni'
-vpc_prefix: '10.{{ 256 | random(seed=vpc_seed_a) }}.{{ 256 | random(seed=vpc_seed_b ) }}'
-vpc_cidr: '{{ vpc_prefix}}.128/26'
+vpc_seed_a: "{{ resource_prefix }}"
+vpc_seed_b: "{{ resource_prefix }}-ec2_eni"
+vpc_prefix: 10.{{ 256 | random(seed=vpc_seed_a) }}.{{ 256 | random(seed=vpc_seed_b ) }}
+vpc_cidr: "{{ vpc_prefix}}.128/26"
 ip_1: "{{ vpc_prefix }}.132"
 ip_2: "{{ vpc_prefix }}.133"
 ip_3: "{{ vpc_prefix }}.134"
@@ -12,5 +12,5 @@ ip_4: "{{ vpc_prefix }}.135"
 ip_5: "{{ vpc_prefix }}.136"
 
 ec2_ips:
-- "{{ vpc_prefix }}.137"
-- "{{ vpc_prefix }}.138"
+  - "{{ vpc_prefix }}.137"
+  - "{{ vpc_prefix }}.138"

--- a/tests/integration/targets/ec2_eni/meta/main.yml
+++ b/tests/integration/targets/ec2_eni/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
-- role: setup_ec2_facts
+  - role: setup_ec2_facts

--- a/tests/integration/targets/ec2_eni/tasks/main.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/main.yaml
@@ -7,153 +7,143 @@
       region: "{{ aws_region }}"
 
   collections:
-  - amazon.aws
-  - ansible.utils
-  - community.aws
+    - amazon.aws
+    - ansible.utils
+    - community.aws
 
   block:
-
   # ============================================================
-  - name: create a VPC
-    ec2_vpc_net:
-      name: "{{ resource_prefix }}-vpc"
-      state: present
-      cidr_block: "{{ vpc_cidr }}"
-      tags:
-        Name: "{{ resource_prefix }}-vpc"
-        Description: "Created by ansible-test"
-    register: vpc_result
+    - name: create a VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        state: present
+        cidr_block: "{{ vpc_cidr }}"
+        tags:
+          Name: "{{ resource_prefix }}-vpc"
+          Description: Created by ansible-test
+      register: vpc_result
 
-  - name: create a subnet
-    ec2_vpc_subnet:
-      cidr: "{{ vpc_cidr }}"
-      az: "{{ availability_zone }}"
-      vpc_id: "{{ vpc_result.vpc.id }}"
-      tags:
-        Name: "{{ resource_prefix }}-vpc"
-        Description: "Created by ansible-test"
-      state: present
-    register: vpc_subnet_result
+    - name: create a subnet
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ vpc_cidr }}"
+        az: "{{ availability_zone }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          Name: "{{ resource_prefix }}-vpc"
+          Description: Created by ansible-test
+        state: present
+      register: vpc_subnet_result
 
-  - name: create a security group
-    ec2_security_group:
-      name: "{{ resource_prefix }}-sg"
-      description: "Created by {{ resource_prefix }}"
-      rules: []
-      state: present
-      vpc_id: "{{ vpc_result.vpc.id }}"
-    register: vpc_sg_result
+    - name: create a security group
+      ec2_security_group:
+        name: "{{ resource_prefix }}-sg"
+        description: Created by {{ resource_prefix }}
+        rules: []
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      register: vpc_sg_result
 
-  - name: Set facts to simplify use of extra resources
-    set_fact:
-      vpc_id: "{{ vpc_result.vpc.id }}"
-      vpc_subnet_id: "{{ vpc_subnet_result.subnet.id }}"
-      vpc_sg_id: "{{ vpc_sg_result.group_id }}"
+    - name: Set facts to simplify use of extra resources
+      ansible.builtin.set_fact:
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        vpc_subnet_id: "{{ vpc_subnet_result.subnet.id }}"
+        vpc_sg_id: "{{ vpc_sg_result.group_id }}"
 
-  # ============================================================
+    # ============================================================
 
-  - name: Create 2 instances to test attaching and detaching network interfaces
-    ec2_instance:
-      name: "{{ resource_prefix }}-eni-instance-{{ item }}"
-      image_id: "{{ ec2_ami_id }}"
-      vpc_subnet_id: "{{ vpc_subnet_id }}"
-      instance_type: t2.micro
-      wait: false
-      security_group: "{{ vpc_sg_id }}"
-      network:
-        private_ip_address: '{{ ec2_ips[item] }}'
-    register: ec2_instances
-    loop:
-      - 0
-      - 1
+    - name: Create 2 instances to test attaching and detaching network interfaces
+      amazon.aws.ec2_instance:
+        name: "{{ resource_prefix }}-eni-instance-{{ item }}"
+        image_id: "{{ ec2_ami_id }}"
+        vpc_subnet_id: "{{ vpc_subnet_id }}"
+        instance_type: t2.micro
+        wait: false
+        security_group: "{{ vpc_sg_id }}"
+        network:
+          private_ip_address: "{{ ec2_ips[item] }}"
+      register: ec2_instances
+      loop:
+        - 0
+        - 1
 
-  # We only need these instances to be running
-  - name: set variables for the instance IDs
-    set_fact:
-      instance_id_1: "{{ ec2_instances.results[0].instance_ids[0] }}"
-      instance_id_2: "{{ ec2_instances.results[1].instance_ids[0] }}"
+    # We only need these instances to be running
+    - name: set variables for the instance IDs
+      ansible.builtin.set_fact:
+        instance_id_1: "{{ ec2_instances.results[0].instance_ids[0] }}"
+        instance_id_2: "{{ ec2_instances.results[1].instance_ids[0] }}"
 
-  # ============================================================
-  - name: test attaching and detaching network interfaces
-    include_tasks: ./test_eni_basic_creation.yaml
-
-  - name: test attaching and detaching network interfaces
-    include_tasks: ./test_ipaddress_assign.yaml
-
-  - name: test attaching and detaching network interfaces
-    include_tasks: ./test_attachment.yaml
-
-  - name: test attaching and detaching multiple network interfaces
-    include_tasks: ./test_create_attached_multiple.yml
-
-  - name: test modifying source_dest_check
-    include_tasks: ./test_modifying_source_dest_check.yaml
-
-  - name: test modifying tags
-    include_tasks: ./test_modifying_tags.yaml
-
-  # Note: will delete *both* EC2 instances
-  - name: test modifying delete_on_termination
-    include_tasks: ./test_modifying_delete_on_termination.yaml
-
-  - name: test deleting ENIs
-    include_tasks: ./test_deletion.yaml
-
+    # ============================================================
+    - name: test attaching and detaching network interfaces
+      ansible.builtin.include_tasks: ./test_eni_basic_creation.yaml
+    - name: test attaching and detaching network interfaces
+      ansible.builtin.include_tasks: ./test_ipaddress_assign.yaml
+    - name: test attaching and detaching network interfaces
+      ansible.builtin.include_tasks: ./test_attachment.yaml
+    - name: test attaching and detaching multiple network interfaces
+      ansible.builtin.include_tasks: ./test_create_attached_multiple.yml
+    - name: test modifying source_dest_check
+      ansible.builtin.include_tasks: ./test_modifying_source_dest_check.yaml
+    - name: test modifying tags
+      ansible.builtin.include_tasks: ./test_modifying_tags.yaml
+    - name: test modifying delete_on_termination
+      ansible.builtin.include_tasks: ./test_modifying_delete_on_termination.yaml
+    - name: test deleting ENIs
+      ansible.builtin.include_tasks: ./test_deletion.yaml
   always:
     # ============================================================
-      # Some test problems are caused by "eventual consistency"
-      # describe the ENIs in the account so we can see what's happening
-      - name: Describe ENIs in account
-        ec2_eni_info: {}
+    # Some test problems are caused by "eventual consistency"
+    # describe the ENIs in the account so we can see what's happening
+    - name: Describe ENIs in account
+      amazon.aws.ec2_eni_info: {}
 
     # ============================================================
-      - name: remove the network interfaces
-        ec2_eni:
-          eni_id: "{{ item }}"
-          force_detach: True
-          state: absent
-        ignore_errors: true
-        retries: 5
-        loop:
-          - "{{ eni_id_1 | default(omit) }}"
-          - "{{ eni_id_2 | default(omit) }}"
-          - "{{ eni_id_3 | default(omit) }}"
+    - name: remove the network interfaces
+      amazon.aws.ec2_eni:
+        eni_id: "{{ item }}"
+        force_detach: true
+        state: absent
+      ignore_errors: true
+      retries: 5
+      loop:
+        - "{{ eni_id_1 | default(omit) }}"
+        - "{{ eni_id_2 | default(omit) }}"
+        - "{{ eni_id_3 | default(omit) }}"
 
-      - name: terminate the instances
-        ec2_instance:
-          state: absent
-          instance_ids:
-            - "{{ instance_id_1 }}"
-            - "{{ instance_id_2 }}"
-          wait: True
-        ignore_errors: true
-        retries: 5
-        when: instance_id_1 is defined and instance_id_2 is defined
+    - name: terminate the instances
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ instance_id_1 }}"
+          - "{{ instance_id_2 }}"
+        wait: true
+      ignore_errors: true
+      retries: 5
+      when: instance_id_1 is defined and instance_id_2 is defined
 
-      - name: remove the security group
-        ec2_security_group:
-          name: "{{ resource_prefix }}-sg"
-          description: "{{ resource_prefix }}"
-          rules: []
-          state: absent
-          vpc_id: "{{ vpc_result.vpc.id }}"
-        ignore_errors: true
-        retries: 5
+    - name: remove the security group
+      ec2_security_group:
+        name: "{{ resource_prefix }}-sg"
+        description: "{{ resource_prefix }}"
+        rules: []
+        state: absent
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      ignore_errors: true
+      retries: 5
 
-      - name: remove the subnet
-        ec2_vpc_subnet:
-          cidr: "{{ vpc_cidr }}"
-          az: "{{ availability_zone }}"
-          vpc_id: "{{ vpc_result.vpc.id }}"
-          state: absent
-        ignore_errors: true
-        retries: 5
-        when: vpc_subnet_result is defined
+    - name: remove the subnet
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ vpc_cidr }}"
+        az: "{{ availability_zone }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        state: absent
+      ignore_errors: true
+      retries: 5
+      when: vpc_subnet_result is defined
 
-      - name: remove the VPC
-        ec2_vpc_net:
-          name: "{{ resource_prefix }}-vpc"
-          cidr_block: "{{ vpc_cidr }}"
-          state: absent
-        ignore_errors: true
-        retries: 5
+    - name: remove the VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: "{{ vpc_cidr }}"
+        state: absent
+      ignore_errors: true
+      retries: 5

--- a/tests/integration/targets/ec2_eni/tasks/test_attachment.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/test_attachment.yaml
@@ -1,42 +1,43 @@
-  # ============================================================
+---
+# ============================================================
 # If we don't stop the instances they can get stuck "detaching"
 - name: Ensure test instances are stopped
-  ec2_instance:
+  amazon.aws.ec2_instance:
     state: stopped
     instance_ids:
       - "{{ instance_id_1 }}"
       - "{{ instance_id_2 }}"
-    wait: True
+    wait: true
 
 - name: attach the network interface to instance 1 (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_1 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: True
+    attached: true
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result_check_mode.changed
 
 - name: attach the network interface to instance 1
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_1 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: True
+    attached: true
   register: result
-- ec2_eni_info:
-    eni_id: '{{ eni_id_1 }}'
+- amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.attachment is defined
@@ -59,22 +60,22 @@
       - '"status" in _interface_0.attachment'
       - _interface_0.attachment.status == "attached"
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
 - name: verify the eni is attached
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_1 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: True
+    attached: true
   register: result
-- ec2_eni_info:
-    eni_id: '{{ eni_id_1 }}'
+- amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.attachment is defined
@@ -96,38 +97,38 @@
       - '"status" in _interface_0.attachment'
       - _interface_0.attachment.status == "attached"
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
-  # ============================================================
+# ============================================================
 - name: test attaching the network interface to a different instance (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_2 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: True
+    attached: true
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result_check_mode.changed
 
 - name: test attaching the network interface to a different instance
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_2 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: True
+    attached: true
   register: result
-- ec2_eni_info:
-    eni_id: '{{ eni_id_1 }}'
+- amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.attachment is defined
@@ -136,143 +137,143 @@
       - '"instance_id" in _interface_0.attachment'
       - _interface_0.attachment.instance_id == instance_id_2
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
-  # ============================================================
+# ============================================================
 - name: detach the network interface (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_2 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: False
+    attached: false
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result_check_mode.changed
 
 - name: detach the network interface
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_2 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: False
+    attached: false
   register: result
-- ec2_eni_info:
-    eni_id: '{{ eni_id_1 }}'
+- amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.attachment is undefined
       - _interface_0.attachment is undefined
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
 - name: verify the network interface was detached
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_2 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: False
+    attached: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.attachment is undefined
 
-  # ============================================================
+# ============================================================
 - name: reattach the network interface to test deleting it
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_2 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: True
+    attached: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.attachment is defined
       - result.interface.attachment.instance_id == instance_id_2
 
 - name: test that deleting the network interface while attached must be intentional
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     state: absent
   register: result
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.failed
       - '"currently in use" in result.msg'
 
 # ============================================================
 - name: Ensure test instances is running (will block non-forced detachment)
-  ec2_instance:
+  amazon.aws.ec2_instance:
     state: running
     instance_ids:
       - "{{ instance_id_2 }}"
-    wait: True
+    wait: true
 
 - name: delete an attached network interface with force_detach (check mode)
-  ec2_eni:
-    force_detach: True
+  amazon.aws.ec2_eni:
+    force_detach: true
     eni_id: "{{ eni_id_1 }}"
     state: absent
   check_mode: true
   register: result_check_mode
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result_check_mode.changed
 
 - name: delete an attached network interface with force_detach
-  ec2_eni:
-    force_detach: True
+  amazon.aws.ec2_eni:
+    force_detach: true
     eni_id: "{{ eni_id_1 }}"
     state: absent
   register: result
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.attachment is undefined
 
 - name: test removing a network interface that does not exist
-  ec2_eni:
-    force_detach: True
+  amazon.aws.ec2_eni:
+    force_detach: true
     eni_id: "{{ eni_id_1 }}"
     state: absent
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.attachment is undefined
 
 # ============================================================
 - name: recreate the network interface
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: present
   register: result
 
-- set_fact:
+- ansible.builtin.set_fact:
     eni_id_1: "{{ result.interface.id }}"

--- a/tests/integration/targets/ec2_eni/tasks/test_create_attached_multiple.yml
+++ b/tests/integration/targets/ec2_eni/tasks/test_create_attached_multiple.yml
@@ -1,121 +1,121 @@
 ---
-  - name: Create instance to test attaching and detaching network interfaces for this test
-    ec2_instance:
-      name: "{{ resource_prefix }}-instance"
-      image_id: "{{ ec2_ami_id }}"
-      vpc_subnet_id: "{{ vpc_subnet_id }}"
-      instance_type: t2.micro
-    register: ec2_instances
+- name: Create instance to test attaching and detaching network interfaces for this test
+  amazon.aws.ec2_instance:
+    name: "{{ resource_prefix }}-instance"
+    image_id: "{{ ec2_ami_id }}"
+    vpc_subnet_id: "{{ vpc_subnet_id }}"
+    instance_type: t2.micro
+  register: ec2_instances
 
-  - name: set variable for the instance ID
-    set_fact:
-      instance_id_3: "{{ ec2_instances.instances[0].instance_id }}"
-
-#=================================================================
-
-  - name: Create and attach another interface to above instance - check_mode
-    amazon.aws.ec2_eni:
-      name: "{{ resource_prefix }}-eni"
-      instance_id: "{{ instance_id_3 }}"
-      device_index: 1
-      subnet_id: "{{ vpc_subnet_id }}"
-      state: present
-      attached: true
-      delete_on_termination: true
-    check_mode: true
-    register: result
-
-  # Get the instance info and ENI info to verify attachment of second eni
-  - ec2_instance_info:
-      instance_ids:
-        - "{{ instance_id_3 }}"
-    register: instance_info_result
-
-  - assert:
-      that:
-        - result is changed
-        - result is not failed
-        - instance_info_result.instances[0].network_interfaces | length == 1
-        - '"Would have created ENI if not in check mode." in result.msg'
-        - "'ec2:CreateNetworkInterface' not in result.resource_actions"
-
-  - name: Create and attach another interface to above instance
-    amazon.aws.ec2_eni:
-      name: "{{ resource_prefix }}-eni"
-      instance_id: "{{ instance_id_3 }}"
-      device_index: 1
-      subnet_id: "{{ vpc_subnet_id }}"
-      state: present
-      attached: true
-      delete_on_termination: true
-    register: result
-
-  - name: Set variable for the ENI ID
-    set_fact:
-      eni_id_attached_multiple: "{{ result.interface.id }}"
-
-  # Get the instance info and ENI info to verify attachment of second eni
-  - ec2_instance_info:
-      instance_ids:
-        - "{{ instance_id_3 }}"
-    register: instance_info_result
-  - ec2_eni_info:
-      eni_id: "{{ eni_id_attached_multiple }}"
-    register: eni_info
-
-  - name: Assert that the interface attachment was successful
-    assert:
-      that:
-        - result is changed
-        - result is not failed
-        - instance_info_result.instances[0].network_interfaces | length == 2
-        - eni_info.network_interfaces[0].attachment.instance_id == instance_id_3
-        - eni_info.network_interfaces[0].attachment.device_index == 1
-
-  - name: Create and attach another interface to above instance - check_mode - idempotent
-    amazon.aws.ec2_eni:
-      name: "{{ resource_prefix }}-eni"
-      instance_id: "{{ instance_id_3 }}"
-      device_index: 1
-      subnet_id: "{{ vpc_subnet_id }}"
-      state: present
-      attached: true
-      delete_on_termination: true
-    check_mode: true
-    register: result
-
-  # Get the instance info and ENI info to verify attachment of second eni
-  - ec2_instance_info:
-      instance_ids:
-        - "{{ instance_id_3 }}"
-    register: instance_info_result
-
-  - name: Assert that the interface would have been modified if not in check_mode
-    assert:
-      that:
-        - result is changed
-        - result is not failed
-        - instance_info_result.instances[0].network_interfaces | length == 2
-        - '"Would have modified ENI: "+eni_id_attached_multiple+" if not in check mode" in result.msg'
-        - "'ec2:CreateNetworkInterface' not in result.resource_actions"
-        - "'ec2:ModifyNetworkInterfaceAttribute' not in result.resource_actions"
+- name: set variable for the instance ID
+  ansible.builtin.set_fact:
+    instance_id_3: "{{ ec2_instances.instances[0].instance_id }}"
 
 #=================================================================
 
-  - name: remove the network interface created in this test
-    ec2_eni:
-      eni_id: "{{ eni_id_attached_multiple }}"
-      force_detach: True
-      state: absent
-    ignore_errors: true
-    retries: 5
+- name: Create and attach another interface to above instance - check_mode
+  amazon.aws.ec2_eni:
+    name: "{{ resource_prefix }}-eni"
+    instance_id: "{{ instance_id_3 }}"
+    device_index: 1
+    subnet_id: "{{ vpc_subnet_id }}"
+    state: present
+    attached: true
+    delete_on_termination: true
+  check_mode: true
+  register: result
 
-  - name: terminate the instance created in this test
-    ec2_instance:
-      state: absent
-      instance_ids:
-        - "{{ instance_id_3 }}"
-      wait: True
-    ignore_errors: true
-    retries: 5
-    when: instance_id_3 is defined
+# Get the instance info and ENI info to verify attachment of second eni
+- amazon.aws.ec2_instance_info:
+    instance_ids:
+      - "{{ instance_id_3 }}"
+  register: instance_info_result
+
+- ansible.builtin.assert:
+    that:
+      - result is changed
+      - result is not failed
+      - instance_info_result.instances[0].network_interfaces | length == 1
+      - '"Would have created ENI if not in check mode." in result.msg'
+      - "'ec2:CreateNetworkInterface' not in result.resource_actions"
+
+- name: Create and attach another interface to above instance
+  amazon.aws.ec2_eni:
+    name: "{{ resource_prefix }}-eni"
+    instance_id: "{{ instance_id_3 }}"
+    device_index: 1
+    subnet_id: "{{ vpc_subnet_id }}"
+    state: present
+    attached: true
+    delete_on_termination: true
+  register: result
+
+- name: Set variable for the ENI ID
+  ansible.builtin.set_fact:
+    eni_id_attached_multiple: "{{ result.interface.id }}"
+
+# Get the instance info and ENI info to verify attachment of second eni
+- amazon.aws.ec2_instance_info:
+    instance_ids:
+      - "{{ instance_id_3 }}"
+  register: instance_info_result
+- amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_attached_multiple }}"
+  register: eni_info
+
+- name: Assert that the interface attachment was successful
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result is not failed
+      - instance_info_result.instances[0].network_interfaces | length == 2
+      - eni_info.network_interfaces[0].attachment.instance_id == instance_id_3
+      - eni_info.network_interfaces[0].attachment.device_index == 1
+
+- name: Create and attach another interface to above instance - check_mode - idempotent
+  amazon.aws.ec2_eni:
+    name: "{{ resource_prefix }}-eni"
+    instance_id: "{{ instance_id_3 }}"
+    device_index: 1
+    subnet_id: "{{ vpc_subnet_id }}"
+    state: present
+    attached: true
+    delete_on_termination: true
+  check_mode: true
+  register: result
+
+# Get the instance info and ENI info to verify attachment of second eni
+- amazon.aws.ec2_instance_info:
+    instance_ids:
+      - "{{ instance_id_3 }}"
+  register: instance_info_result
+
+- name: Assert that the interface would have been modified if not in check_mode
+  ansible.builtin.assert:
+    that:
+      - result is changed
+      - result is not failed
+      - instance_info_result.instances[0].network_interfaces | length == 2
+      - '"Would have modified ENI: "+eni_id_attached_multiple+" if not in check mode" in result.msg'
+      - "'ec2:CreateNetworkInterface' not in result.resource_actions"
+      - "'ec2:ModifyNetworkInterfaceAttribute' not in result.resource_actions"
+
+#=================================================================
+
+- name: remove the network interface created in this test
+  amazon.aws.ec2_eni:
+    eni_id: "{{ eni_id_attached_multiple }}"
+    force_detach: true
+    state: absent
+  ignore_errors: true
+  retries: 5
+
+- name: terminate the instance created in this test
+  amazon.aws.ec2_instance:
+    state: absent
+    instance_ids:
+      - "{{ instance_id_3 }}"
+    wait: true
+  ignore_errors: true
+  retries: 5
+  when: instance_id_3 is defined

--- a/tests/integration/targets/ec2_eni/tasks/test_deletion.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/test_deletion.yaml
@@ -1,30 +1,30 @@
 ---
 # ============================================================
 - name: test deleting the unattached network interface by using the ID (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     name: "{{ resource_prefix }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: absent
-  check_mode: True
+  check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result_check_mode.changed
 
 - name: test deleting the unattached network interface by using the ID
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     name: "{{ resource_prefix }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: absent
   register: result
-- ec2_eni_info:
+- amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface is undefined
@@ -32,49 +32,49 @@
       - eni_id_1 not in ( eni_info.network_interfaces | selectattr('id') | map(attribute='id') | list )
 
 - name: test removing the network interface by ID is idempotent (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     name: "{{ resource_prefix }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: absent
-  check_mode: True
+  check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result_check_mode.changed
 
 - name: test removing the network interface by ID is idempotent
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     name: "{{ resource_prefix }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: absent
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface is undefined
 
 # ============================================================
 - name: add a name tag to the other network interface before deleting it
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_2 }}"
     name: "{{ resource_prefix }}"
     state: present
 
 - name: test deleting the unattached network interface by using the name
-  ec2_eni:
+  amazon.aws.ec2_eni:
     name: "{{ resource_prefix }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: absent
   register: result
-- ec2_eni_info:
+- amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_2 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface is undefined
@@ -82,24 +82,24 @@
       - eni_id_2 not in ( eni_info.network_interfaces | selectattr('id') | map(attribute='id') | list )
 
 - name: test removing the network interface by name is idempotent
-  ec2_eni:
+  amazon.aws.ec2_eni:
     name: "{{ resource_prefix }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: absent
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface is undefined
 
 - name: verify that the network interface ID does not exist (retry-delete by ID)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_2 }}"
     state: absent
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface is undefined
@@ -107,11 +107,11 @@
 # ============================================================
 
 - name: Fetch ENI info without filter
-  ec2_eni_info:
+  amazon.aws.ec2_eni_info:
   register: eni_info
 
 - name: Assert that ec2_eni_info doesn't contain the two interfaces we just deleted
-  assert:
+  ansible.builtin.assert:
     that:
       - '"network_interfaces" in eni_info'
       - eni_id_1 not in ( eni_info.network_interfaces | selectattr('id') | map(attribute='id') | list )

--- a/tests/integration/targets/ec2_eni/tasks/test_eni_basic_creation.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/test_eni_basic_creation.yaml
@@ -1,7 +1,7 @@
 ---
 # ============================================================
 - name: create a network interface (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_id }}"
@@ -9,35 +9,35 @@
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result_check_mode.changed
 
 - name: create a network interface
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: present
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.private_ip_addresses | length == 1
 
-- set_fact:
+- ansible.builtin.set_fact:
     eni_id_1: "{{ result.interface.id }}"
 
 - name: Fetch ENI info (by ID)
-  ec2_eni_info:
-    eni_id: '{{ eni_id_1 }}'
+  amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
 - name: Assert that ec2_eni_info returns all the values we expect
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
-  assert:
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
+  ansible.builtin.assert:
     that:
       - '"network_interfaces" in eni_info'
       - eni_info.network_interfaces | length == 1
@@ -91,7 +91,7 @@
       - _interface_0.vpc_id == vpc_id
 
 - name: test idempotence by using the same private_ip_address (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_id }}"
@@ -99,19 +99,19 @@
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result_check_mode.changed
 
 - name: test idempotence by using the same private_ip_address
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: present
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.id == eni_id_1
@@ -120,32 +120,32 @@
 # ============================================================
 
 - name: create a second network interface to test IP reassignment
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     private_ip_address: "{{ ip_5 }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: present
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.id != eni_id_1
 
 - name: save the second network interface ID for cleanup
-  set_fact:
+  ansible.builtin.set_fact:
     eni_id_2: "{{ result.interface.id }}"
 
 - name: Fetch ENI info (using filter)
-  ec2_eni_info:
+  amazon.aws.ec2_eni_info:
     filters:
-      network-interface-id: '{{ eni_id_2 }}'
+      network-interface-id: "{{ eni_id_2 }}"
   register: eni_info
 
 - name: Assert that ec2_eni_info returns all the values we expect
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
-  assert:
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
+  ansible.builtin.assert:
     that:
       - '"network_interfaces" in eni_info'
       - eni_info.network_interfaces | length == 1
@@ -199,11 +199,11 @@
       - _interface_0.vpc_id == vpc_id
 
 - name: Fetch ENI info without filter
-  ec2_eni_info:
+  amazon.aws.ec2_eni_info:
   register: eni_info
 
 - name: Assert that ec2_eni_info contains at least the two interfaces we expect
-  assert:
+  ansible.builtin.assert:
     that:
       - '"network_interfaces" in eni_info'
       - eni_info.network_interfaces | length >= 2
@@ -214,14 +214,14 @@
 # Run some VPC filter based tests of ec2_eni_info
 
 - name: Fetch ENI info with VPC filters - Available
-  ec2_eni_info:
+  amazon.aws.ec2_eni_info:
     filters:
-      vpc-id: '{{ vpc_id }}'
-      status: 'available'
+      vpc-id: "{{ vpc_id }}"
+      status: available
   register: eni_info
 
 - name: Assert that ec2_eni_info contains at least the two interfaces we expect
-  assert:
+  ansible.builtin.assert:
     that:
       - '"network_interfaces" in eni_info'
       - eni_info.network_interfaces | length == 2
@@ -229,13 +229,13 @@
       - eni_id_2 in ( eni_info.network_interfaces | selectattr('id') | map(attribute='id') | list )
 
 - name: Fetch ENI info with VPC filters - VPC
-  ec2_eni_info:
+  amazon.aws.ec2_eni_info:
     filters:
-      vpc-id: '{{ vpc_id }}'
+      vpc-id: "{{ vpc_id }}"
   register: eni_info
 
 - name: Assert that ec2_eni_info contains at least the two interfaces we expect
-  assert:
+  ansible.builtin.assert:
     that:
       - '"network_interfaces" in eni_info'
       - eni_info.network_interfaces | length == 4
@@ -244,20 +244,19 @@
       - ec2_ips[0] in ( eni_info.network_interfaces | map(attribute='private_ip_addresses') | flatten | map(attribute='private_ip_address') | list )
       - ec2_ips[1] in ( eni_info.network_interfaces | map(attribute='private_ip_addresses') | flatten | map(attribute='private_ip_address') | list )
 
-
 # =========================================================
 
 - name: create another network interface without private_ip_address
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     subnet_id: "{{ vpc_subnet_id }}"
     state: present
   register: result_no_private_ip
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result_no_private_ip.changed
 
 - name: save the third network interface ID for cleanup
-  set_fact:
+  ansible.builtin.set_fact:
     eni_id_3: "{{ result_no_private_ip.interface.id }}"

--- a/tests/integration/targets/ec2_eni/tasks/test_ipaddress_assign.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/test_ipaddress_assign.yaml
@@ -1,7 +1,7 @@
 ---
 # ============================================================
 - name: add two implicit secondary IPs (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_id }}"
@@ -10,23 +10,23 @@
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result_check_mode.changed
 
 - name: add two implicit secondary IPs
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: present
     secondary_private_ip_address_count: 2
   register: result
-- ec2_eni_info:
-    eni_id: '{{ eni_id_1 }}'
+- amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.id == eni_id_1
@@ -34,10 +34,10 @@
       - _interface_0.private_ip_addresses | length == 3
       - ip_1 in ( eni_info.network_interfaces | map(attribute='private_ip_addresses') | flatten | map(attribute='private_ip_address') | list )
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
 - name: test idempotence with two implicit secondary IPs (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_id }}"
@@ -46,23 +46,23 @@
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result_check_mode.changed
 
 - name: test idempotence with two implicit secondary IPs
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: present
     secondary_private_ip_address_count: 2
   register: result
-- ec2_eni_info:
-    eni_id: '{{ eni_id_1 }}'
+- amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.id == eni_id_1
@@ -70,11 +70,11 @@
       - _interface_0.private_ip_addresses | length == 3
       - ip_1 in ( eni_info.network_interfaces | map(attribute='private_ip_addresses') | flatten | map(attribute='private_ip_address') | list )
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
 # ============================================================
 - name: ensure secondary addresses are only removed if purge is set to true
-  ec2_eni:
+  amazon.aws.ec2_eni:
     purge_secondary_private_ip_addresses: false
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
@@ -82,11 +82,11 @@
     state: present
     secondary_private_ip_addresses: []
   register: result
-- ec2_eni_info:
-    eni_id: '{{ eni_id_1 }}'
+- amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.id == eni_id_1
@@ -94,7 +94,7 @@
       - _interface_0.private_ip_addresses | length == 3
       - ip_1 in ( eni_info.network_interfaces | map(attribute='private_ip_addresses') | flatten | map(attribute='private_ip_address') | list )
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
 # ============================================================
 
@@ -102,15 +102,15 @@
 # For the following test, first find an IP that has not been used yet
 
 - name: save the list of private IPs in use
-  set_fact:
+  ansible.builtin.set_fact:
     current_private_ips: "{{ result.interface | json_query('private_ip_addresses[*].private_ip_address') | list }}"
 
 - name: set new_secondary_ip to an IP that has not been used
-  set_fact:
+  ansible.builtin.set_fact:
     new_secondary_ip: "{{ [ip_2, ip_3, ip_4] | difference(current_private_ips) | first }}"
 
 - name: add an explicit secondary address without purging the ones added implicitly
-  ec2_eni:
+  amazon.aws.ec2_eni:
     purge_secondary_private_ip_addresses: false
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
@@ -119,11 +119,11 @@
     secondary_private_ip_addresses:
       - "{{ new_secondary_ip }}"
   register: result
-- ec2_eni_info:
-    eni_id: '{{ eni_id_1 }}'
+- amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.id == eni_id_1
@@ -133,12 +133,12 @@
       - ip_1 in _private_ips
       - new_secondary_ip in _private_ips
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
     _private_ips: "{{ eni_info.network_interfaces | map(attribute='private_ip_addresses') | flatten | map(attribute='private_ip_address') | list }}"
 
 # ============================================================
 - name: remove secondary address (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     purge_secondary_private_ip_addresses: true
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
@@ -148,12 +148,12 @@
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result_check_mode.changed
 
 - name: remove secondary address
-  ec2_eni:
+  amazon.aws.ec2_eni:
     purge_secondary_private_ip_addresses: true
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
@@ -161,11 +161,11 @@
     state: present
     secondary_private_ip_addresses: []
   register: result
-- ec2_eni_info:
-    eni_id: '{{ eni_id_1 }}'
+- amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.id == eni_id_1
@@ -173,10 +173,10 @@
       - _interface_0.private_ip_addresses | length == 1
       - ip_1 in ( eni_info.network_interfaces | map(attribute='private_ip_addresses') | flatten | map(attribute='private_ip_address') | list )
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
 - name: test idempotent behavior purging secondary addresses (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     purge_secondary_private_ip_addresses: true
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
@@ -186,12 +186,12 @@
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result_check_mode.changed
 
 - name: test idempotent behavior purging secondary addresses
-  ec2_eni:
+  amazon.aws.ec2_eni:
     purge_secondary_private_ip_addresses: true
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
@@ -199,11 +199,11 @@
     state: present
     secondary_private_ip_addresses: []
   register: result
-- ec2_eni_info:
-    eni_id: '{{ eni_id_1 }}'
+- amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.id == eni_id_1
@@ -212,12 +212,12 @@
       - _interface_0.private_ip_addresses | length == 1
       - ip_1 in ( eni_info.network_interfaces | map(attribute='private_ip_addresses') | flatten | map(attribute='private_ip_address') | list )
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
 # ============================================================
 
 - name: Assign secondary IP addess to second ENI
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     private_ip_address: "{{ ip_5 }}"
     subnet_id: "{{ vpc_subnet_id }}"
@@ -225,11 +225,11 @@
     secondary_private_ip_addresses:
       - "{{ ip_4 }}"
   register: result
-- ec2_eni_info:
-    eni_id: '{{ eni_id_2 }}'
+- amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_2 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.id == eni_id_2
@@ -238,10 +238,10 @@
       - ip_5 in ( eni_info.network_interfaces | map(attribute='private_ip_addresses') | flatten | map(attribute='private_ip_address') | list )
       - ip_4 in ( eni_info.network_interfaces | map(attribute='private_ip_addresses') | flatten | map(attribute='private_ip_address') | list )
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
 - name: test that reassignment of an IP already in use fails when not explcitly allowed (default for allow_reassignment == False)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_id }}"
@@ -251,16 +251,16 @@
       - "{{ ip_3 }}"
       - "{{ ip_4 }}"
   register: result
-  ignore_errors: yes
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.failed
       - '"move is not allowed" in result.msg'
 
 # ============================================================
 - name: allow reassignment to add the list of secondary addresses
-  ec2_eni:
+  amazon.aws.ec2_eni:
     allow_reassignment: true
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
@@ -272,14 +272,14 @@
       - "{{ ip_4 }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.id == eni_id_1
       - result.interface.private_ip_addresses | length == 4
 
 - name: test reassigment is idempotent
-  ec2_eni:
+  amazon.aws.ec2_eni:
     allow_reassignment: true
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
@@ -291,7 +291,7 @@
       - "{{ ip_4 }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.id == eni_id_1
@@ -299,7 +299,7 @@
 # ============================================================
 
 - name: purge all the secondary addresses
-  ec2_eni:
+  amazon.aws.ec2_eni:
     purge_secondary_private_ip_addresses: true
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
@@ -307,19 +307,19 @@
     state: present
     secondary_private_ip_addresses: []
   register: result
-- ec2_eni_info:
-    eni_id: '{{ eni_id_1 }}'
+- amazon.aws.ec2_eni_info:
+    eni_id: "{{ eni_id_1 }}"
   register: eni_info
   until: _interface_0.private_ip_addresses | length == 1
   retries: 5
   delay: 2
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - _interface_0.private_ip_addresses | length == 1
       - ip_1 in ( eni_info.network_interfaces | map(attribute='private_ip_addresses') | flatten | map(attribute='private_ip_address') | list )
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"

--- a/tests/integration/targets/ec2_eni/tasks/test_modifying_delete_on_termination.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/test_modifying_delete_on_termination.yaml
@@ -1,94 +1,95 @@
+---
 # ============================================================
 
 - name: ensure delete_on_termination defaults to False
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_2 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: True
+    attached: true
   register: result
-- ec2_eni_info:
+- amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is successful
       - result.interface.attachment.delete_on_termination == false
       - _interface_0.attachment.delete_on_termination == False
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
 # ============================================================
 
 - name: enable delete_on_termination (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_2 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: True
-    delete_on_termination: True
+    attached: true
+    delete_on_termination: true
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result_check_mode.changed
 
 - name: enable delete_on_termination
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_2 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: True
-    delete_on_termination: True
+    attached: true
+    delete_on_termination: true
   register: result
-- ec2_eni_info:
+- amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.attachment.delete_on_termination == true
       - _interface_0.attachment.delete_on_termination == True
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
 - name: test idempotent behavior enabling delete_on_termination (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_2 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: True
-    delete_on_termination: True
+    attached: true
+    delete_on_termination: true
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result_check_mode.changed
 
 - name: test idempotent behavior enabling delete_on_termination
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_2 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: True
-    delete_on_termination: True
+    attached: true
+    delete_on_termination: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.attachment.delete_on_termination == true
@@ -96,59 +97,59 @@
 # ============================================================
 
 - name: disable delete_on_termination (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_2 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: True
-    delete_on_termination: False
+    attached: true
+    delete_on_termination: false
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result_check_mode.changed
 
 - name: disable delete_on_termination
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_2 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     state: present
-    attached: True
-    delete_on_termination: False
+    attached: true
+    delete_on_termination: false
   register: result
-- ec2_eni_info:
+- amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.attachment.delete_on_termination == false
       - _interface_0.attachment.delete_on_termination == False
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
 # ============================================================
 
 - name: terminate the instance to make sure the attached ENI remains
-  ec2_instance:
+  amazon.aws.ec2_instance:
     state: absent
     instance_ids:
       - "{{ instance_id_2 }}"
-    wait: True
+    wait: true
 
 - name: verify the eni still exists
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     state: present
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.id == eni_id_1
@@ -157,42 +158,42 @@
 # ============================================================
 
 - name: ensure the network interface is attached
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_1 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: present
-    attached: True
+    attached: true
   register: result
 
 - name: ensure delete_on_termination is true
-  ec2_eni:
+  amazon.aws.ec2_eni:
     instance_id: "{{ instance_id_1 }}"
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: present
-    attached: True
-    delete_on_termination: True
+    attached: true
+    delete_on_termination: true
   register: result
 
 - name: test terminating the instance after setting delete_on_termination to true
-  ec2_instance:
+  amazon.aws.ec2_instance:
     state: absent
     instance_ids:
       - "{{ instance_id_1 }}"
-    wait: True
+    wait: true
 
 - name: verify the eni was also removed
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     state: absent
   register: result
-- ec2_eni_info:
+- amazon.aws.ec2_eni_info:
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - '"network_interfaces" in eni_info'
@@ -203,12 +204,12 @@
 # ============================================================
 
 - name: recreate the network interface
-  ec2_eni:
+  amazon.aws.ec2_eni:
     device_index: 1
     private_ip_address: "{{ ip_1 }}"
     subnet_id: "{{ vpc_subnet_id }}"
     state: present
   register: result
 
-- set_fact:
+- ansible.builtin.set_fact:
     eni_id_1: "{{ result.interface.id }}"

--- a/tests/integration/targets/ec2_eni/tasks/test_modifying_source_dest_check.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/test_modifying_source_dest_check.yaml
@@ -1,31 +1,32 @@
-  # ============================================================
+---
+# ============================================================
 - name: test source_dest_check defaults to true (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     source_dest_check: true
     state: present
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result_check_mode.changed
 
 - name: test source_dest_check defaults to true
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     source_dest_check: true
     state: present
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.source_dest_check == true
 
-  # ============================================================
+# ============================================================
 - name: disable source_dest_check
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     source_dest_check: false
     state: present
@@ -33,48 +34,48 @@
 
 - name: Check source_dest_check state
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
-  ec2_eni_info:
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
+  amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_1 }}"
   register: eni_info
   until: _interface_0.source_dest_check == False
   retries: 5
   delay: 2
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - _interface_0.source_dest_check == False
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
 - name: test idempotence disabling source_dest_check (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     source_dest_check: false
     state: present
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result_check_mode.changed
 
 - name: test idempotence disabling source_dest_check
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     source_dest_check: false
     state: present
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.source_dest_check == false
 
-  # ============================================================
+# ============================================================
 - name: enable source_dest_check
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     source_dest_check: true
     state: present
@@ -82,17 +83,17 @@
 
 - name: Check source_dest_check state
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
-  ec2_eni_info:
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
+  amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_1 }}"
   register: eni_info
   until: _interface_0.source_dest_check == True
   retries: 5
   delay: 2
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - _interface_0.source_dest_check == True
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"

--- a/tests/integration/targets/ec2_eni/tasks/test_modifying_tags.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/test_modifying_tags.yaml
@@ -1,20 +1,21 @@
-  # ============================================================
+---
+# ============================================================
 - name: verify there are no tags associated with the network interface
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     state: present
     tags: {}
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - not result.interface.tags
       - result.interface.name is undefined
 
-  # ============================================================
+# ============================================================
 - name: add tags to the network interface (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     state: present
     name: "{{ resource_prefix }}"
@@ -23,23 +24,23 @@
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result_check_mode.changed
 
 - name: add tags to the network interface
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     state: present
     name: "{{ resource_prefix }}"
     tags:
       CreatedBy: "{{ resource_prefix }}"
   register: result
-- ec2_eni_info:
+- amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.id == eni_id_1
@@ -55,57 +56,57 @@
       - _interface_0.tag_set.Name == resource_prefix
       - _interface_0.name == resource_prefix
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
-  # ============================================================
+# ============================================================
 - name: test idempotence by using the Name tag and the subnet (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     name: "{{ resource_prefix }}"
     state: present
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result_check_mode.changed
 
 - name: test idempotence by using the Name tag and the subnet
-  ec2_eni:
+  amazon.aws.ec2_eni:
     name: "{{ resource_prefix }}"
     state: present
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.id == eni_id_1
 
-  # ============================================================
+# ============================================================
 - name: test tags are not purged if tags are null even if name is provided (check mode)
-  ec2_eni:
+  amazon.aws.ec2_eni:
     name: "{{ resource_prefix }}"
     state: present
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
   check_mode: true
   register: result_check_mode
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result_check_mode.changed
 
 - name: test tags are not purged if tags are null even if name is provided
-  ec2_eni:
+  amazon.aws.ec2_eni:
     name: "{{ resource_prefix }}"
     state: present
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
   register: result
-- ec2_eni_info:
+- amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.id == eni_id_1
@@ -118,21 +119,21 @@
       - _interface_0.tag_set.Name == resource_prefix
       - _interface_0.name == resource_prefix
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
-  # ============================================================
+# ============================================================
 - name: test setting purge tags to false
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     state: present
     purge_tags: false
     tags: {}
   register: result
-- ec2_eni_info:
+- amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.tags | length == 2
@@ -144,22 +145,22 @@
       - _interface_0.tag_set.Name == resource_prefix
       - _interface_0.name == resource_prefix
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
-  # ============================================================
+# ============================================================
 - name: test adding a new tag without removing any others
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     state: present
     purge_tags: false
     tags:
       environment: test
   register: result
-- ec2_eni_info:
+- amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.tags | length == 3
@@ -173,22 +174,22 @@
       - _interface_0.tag_set.Name == resource_prefix
       - _interface_0.name == resource_prefix
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
-  # ============================================================
+# ============================================================
 - name: test purging tags and adding a new one
-  ec2_eni:
+  amazon.aws.ec2_eni:
     name: "{{ resource_prefix }}"
     state: present
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     tags:
       Description: "{{ resource_prefix }}"
   register: result
-- ec2_eni_info:
+- amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - result.interface.id == eni_id_1
@@ -201,21 +202,21 @@
       - _interface_0.tag_set.Name == resource_prefix
       - _interface_0.name == resource_prefix
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
 - name: test purging tags and adding a new one is idempotent
-  ec2_eni:
+  amazon.aws.ec2_eni:
     name: "{{ resource_prefix }}"
     state: present
     subnet_id: "{{ vpc_subnet_result.subnet.id }}"
     tags:
       Description: "{{ resource_prefix }}"
   register: result
-- ec2_eni_info:
+- amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - not result.changed
       - result.interface.id == eni_id_1
@@ -228,24 +229,24 @@
       - _interface_0.tag_set.Name == resource_prefix
       - _interface_0.name == resource_prefix
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"
 
-  # ============================================================
+# ============================================================
 - name: test purging all tags
-  ec2_eni:
+  amazon.aws.ec2_eni:
     eni_id: "{{ eni_id_1 }}"
     state: present
     tags: {}
   register: result
-- ec2_eni_info:
+- amazon.aws.ec2_eni_info:
     eni_id: "{{ eni_id_1 }}"
   register: eni_info
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result.changed
       - not result.interface.tags
       - result.interface.name is undefined
       - _interface_0.tag_set | length == 0
   vars:
-    _interface_0: '{{ eni_info.network_interfaces[0] }}'
+    _interface_0: "{{ eni_info.network_interfaces[0] }}"

--- a/tests/integration/targets/ec2_instance_checkmode_tests/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_checkmode_tests/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_checkmode_tests
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-instance-checkmode'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-checkmode"

--- a/tests/integration/targets/ec2_instance_checkmode_tests/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_checkmode_tests/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: check_mode
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: check_mode

--- a/tests/integration/targets/ec2_instance_checkmode_tests/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_checkmode_tests/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -5,204 +6,204 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: "Make basic instance"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-checkmode-comparison"
-      image_id: "{{ ec2_ami_id }}"
-      security_groups: "{{ sg.group_id }}"
-      instance_type: "{{ ec2_instance_type }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      wait: false
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        TestTag: "Some Value"
-    register: basic_instance
+    - name: Make basic instance
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        image_id: "{{ ec2_ami_id }}"
+        security_groups: "{{ sg.group_id }}"
+        instance_type: "{{ ec2_instance_type }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        wait: false
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          TestTag: Some Value
+      register: basic_instance
 
-  - name: "Make basic instance (check mode)"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-checkmode-comparison-checkmode"
-      image_id: "{{ ec2_ami_id }}"
-      security_groups: "{{ sg.group_id }}"
-      instance_type: "{{ ec2_instance_type }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        TestTag: "Some Value"
-    check_mode: yes
+    - name: Make basic instance (check mode)
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-checkmode-comparison-checkmode"
+        image_id: "{{ ec2_ami_id }}"
+        security_groups: "{{ sg.group_id }}"
+        instance_type: "{{ ec2_instance_type }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          TestTag: Some Value
+      check_mode: true
 
-  - name: "fact presented ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
-    register: presented_instance_fact
+    - name: fact presented ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-checkmode-comparison"
+      register: presented_instance_fact
 
-  - name: "fact checkmode ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-checkmode-comparison-checkmode"
-    register: checkmode_instance_fact
+    - name: fact checkmode ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-checkmode-comparison-checkmode"
+      register: checkmode_instance_fact
 
-  - name: "Confirm whether the check mode is working normally."
-    assert:
-      that:
-        - presented_instance_fact.instances | length > 0
-        - checkmode_instance_fact.instances | length == 0
+    - name: Confirm whether the check mode is working normally.
+      ansible.builtin.assert:
+        that:
+          - presented_instance_fact.instances | length > 0
+          - checkmode_instance_fact.instances | length == 0
 
-  - name: "Stop instance (check mode)"
-    ec2_instance:
-      state: stopped
-      name: "{{ resource_prefix }}-checkmode-comparison"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        TestTag: "Some Value"
-    check_mode: yes
+    - name: Stop instance (check mode)
+      amazon.aws.ec2_instance:
+        state: stopped
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          TestTag: Some Value
+      check_mode: true
 
-  - name: "fact ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
-    register: confirm_checkmode_stopinstance_fact
+    - name: fact ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-checkmode-comparison"
+      register: confirm_checkmode_stopinstance_fact
 
-  - name: "Verify that it was not stopped."
-    assert:
-      that:
-        - confirm_checkmode_stopinstance_fact.instances[0].state.name not in ["stopped", "stopping"]
+    - name: Verify that it was not stopped.
+      ansible.builtin.assert:
+        that:
+          - confirm_checkmode_stopinstance_fact.instances[0].state.name not in ["stopped", "stopping"]
 
-  - name: "Stop instance."
-    ec2_instance:
-      state: stopped
-      name: "{{ resource_prefix }}-checkmode-comparison"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        TestTag: "Some Value"
-      wait: true
-    register: instance_stop
+    - name: Stop instance.
+      amazon.aws.ec2_instance:
+        state: stopped
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          TestTag: Some Value
+        wait: true
+      register: instance_stop
 
-  - name: "fact stopped ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
-    register: confirm_stopinstance_fact
+    - name: fact stopped ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-checkmode-comparison"
+      register: confirm_stopinstance_fact
 
-  - name: "Verify that it was stopped."
-    assert:
-      that:
-        - confirm_stopinstance_fact.instances[0].state.name  in ["stopped", "stopping"]
+    - name: Verify that it was stopped.
+      ansible.builtin.assert:
+        that:
+          - confirm_stopinstance_fact.instances[0].state.name  in ["stopped", "stopping"]
 
-  - name: "Running instance in check mode."
-    ec2_instance:
-      state: running
-      name: "{{ resource_prefix }}-checkmode-comparison"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        TestTag: "Some Value"
-    check_mode: yes
+    - name: Running instance in check mode.
+      amazon.aws.ec2_instance:
+        state: running
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          TestTag: Some Value
+      check_mode: true
 
-  - name: "fact ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
-    register: confirm_checkmode_runninginstance_fact
+    - name: fact ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-checkmode-comparison"
+      register: confirm_checkmode_runninginstance_fact
 
-  - name: "Verify that it was not running."
-    assert:
-      that:
-        - confirm_checkmode_runninginstance_fact.instances[0].state.name != "running"
+    - name: Verify that it was not running.
+      ansible.builtin.assert:
+        that:
+          - confirm_checkmode_runninginstance_fact.instances[0].state.name != "running"
 
-  - name: "Running instance."
-    ec2_instance:
-      state: running
-      name: "{{ resource_prefix }}-checkmode-comparison"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        TestTag: "Some Value"
+    - name: Running instance.
+      amazon.aws.ec2_instance:
+        state: running
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          TestTag: Some Value
 
-  - name: "fact ec2 instance."
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
-    register: confirm_runninginstance_fact
+    - name: fact ec2 instance.
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-checkmode-comparison"
+      register: confirm_runninginstance_fact
 
-  - name: "Verify that it was running."
-    assert:
-      that:
-        - confirm_runninginstance_fact.instances[0].state.name == "running"
+    - name: Verify that it was running.
+      ansible.builtin.assert:
+        that:
+          - confirm_runninginstance_fact.instances[0].state.name == "running"
 
-  - name: "Tag instance."
-    ec2_instance:
-      state: running
-      name: "{{ resource_prefix }}-checkmode-comparison"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        TestTag: "Some Other Value"
-    check_mode: yes
+    - name: Tag instance.
+      amazon.aws.ec2_instance:
+        state: running
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          TestTag: Some Other Value
+      check_mode: true
 
-  - name: "fact ec2 instance."
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
-    register: confirm_not_tagged
+    - name: fact ec2 instance.
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-checkmode-comparison"
+      register: confirm_not_tagged
 
-  - name: "Verify that it hasn't been re-tagged."
-    assert:
-      that:
-        - confirm_not_tagged.instances[0].tags.TestTag == "Some Value"
+    - name: Verify that it hasn't been re-tagged.
+      ansible.builtin.assert:
+        that:
+          - confirm_not_tagged.instances[0].tags.TestTag == "Some Value"
 
-  - name: "Terminate instance in check mode."
-    ec2_instance:
-      state: absent
-      name: "{{ resource_prefix }}-checkmode-comparison"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        TestTag: "Some Value"
-      wait: True
-    check_mode: yes
+    - name: Terminate instance in check mode.
+      amazon.aws.ec2_instance:
+        state: absent
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          TestTag: Some Value
+        wait: true
+      check_mode: true
 
-  - name: "fact ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
-    register: confirm_checkmode_terminatedinstance_fact
+    - name: fact ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-checkmode-comparison"
+      register: confirm_checkmode_terminatedinstance_fact
 
-  - name: "Verify that it was not terminated,"
-    assert:
-      that:
-        - confirm_checkmode_terminatedinstance_fact.instances[0].state.name != "terminated"
+    - name: Verify that it was not terminated,
+      ansible.builtin.assert:
+        that:
+          - confirm_checkmode_terminatedinstance_fact.instances[0].state.name != "terminated"
 
-  - name: "Terminate instance."
-    ec2_instance:
-      state: absent
-      name: "{{ resource_prefix }}-checkmode-comparison"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        TestTag: "Some Value"
-      wait: True
+    - name: Terminate instance.
+      amazon.aws.ec2_instance:
+        state: absent
+        name: "{{ resource_prefix }}-checkmode-comparison"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          TestTag: Some Value
+        wait: true
 
-  - name: "fact ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-checkmode-comparison"
-    register: confirm_terminatedinstance_fact
+    - name: fact ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-checkmode-comparison"
+      register: confirm_terminatedinstance_fact
 
-  - name: "Verify that it was terminated,"
-    assert:
-      that:
-        - confirm_terminatedinstance_fact.instances[0].state.name == "terminated"
+    - name: Verify that it was terminated,
+      ansible.builtin.assert:
+        that:
+          - confirm_terminatedinstance_fact.instances[0].state.name == "terminated"
 
   always:
-  - name: "Terminate checkmode instances"
-    ec2_instance:
-      state: absent
-      filters:
-        "tag:TestId": "{{ ec2_instance_tag_TestId }}"
-      wait: yes
-    ignore_errors: yes
+    - name: Terminate checkmode instances
+      amazon.aws.ec2_instance:
+        state: absent
+        filters:
+          tag:TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      ignore_errors: true

--- a/tests/integration/targets/ec2_instance_cpu_options/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_cpu_options/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_cpu_options
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-cpu-options'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-cpu-options"

--- a/tests/integration/targets/ec2_instance_cpu_options/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_cpu_options/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: cpu_options
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: cpu_options

--- a/tests/integration/targets/ec2_instance_cpu_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_cpu_options/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -5,81 +6,81 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: "create t3.nano instance with cpu_options"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-t3nano-1-threads-per-core"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      instance_type: t3.nano
-      cpu_options:
+    - name: create t3.nano instance with cpu_options
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-t3nano-1-threads-per-core"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        instance_type: t3.nano
+        cpu_options:
           core_count: 1
           threads_per_core: 1
-      wait: true
-    register: instance_creation
+        wait: true
+      register: instance_creation
 
-  - name: "instance with cpu_options created with the right options"
-    assert:
-      that:
-        - instance_creation is success
-        - instance_creation is changed
+    - name: instance with cpu_options created with the right options
+      ansible.builtin.assert:
+        that:
+          - instance_creation is success
+          - instance_creation is changed
 
-  - name: "modify cpu_options on existing instance (warning displayed)"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-t3nano-1-threads-per-core"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      instance_type: t3.nano
-      cpu_options:
+    - name: modify cpu_options on existing instance (warning displayed)
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-t3nano-1-threads-per-core"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        instance_type: t3.nano
+        cpu_options:
           core_count: 1
           threads_per_core: 2
-      wait: true
-    register: cpu_options_update
-    ignore_errors: yes
+        wait: true
+      register: cpu_options_update
+      ignore_errors: true
 
-  - name: "fact presented ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-t3nano-1-threads-per-core"
-    register: presented_instance_fact
+    - name: fact presented ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-t3nano-1-threads-per-core"
+      register: presented_instance_fact
 
-  - name: "modify cpu_options has no effect on existing instance"
-    assert:
-      that:
-        - cpu_options_update is success
-        - cpu_options_update is not changed
-        - presented_instance_fact.instances | length > 0
-        - presented_instance_fact.instances.0.state.name in ['running','pending']
-        - presented_instance_fact.instances.0.cpu_options.core_count == 1
-        - presented_instance_fact.instances.0.cpu_options.threads_per_core == 1
+    - name: modify cpu_options has no effect on existing instance
+      ansible.builtin.assert:
+        that:
+          - cpu_options_update is success
+          - cpu_options_update is not changed
+          - presented_instance_fact.instances | length > 0
+          - presented_instance_fact.instances.0.state.name in ['running','pending']
+          - presented_instance_fact.instances.0.cpu_options.core_count == 1
+          - presented_instance_fact.instances.0.cpu_options.threads_per_core == 1
 
-  - name: "create t3.nano instance with cpu_options(check mode)"
-    ec2_instance:
-      state: running
-      name: "{{ resource_prefix }}-test-t3nano-1-threads-per-core-checkmode"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      instance_type: t3.nano
-      cpu_options:
+    - name: create t3.nano instance with cpu_options(check mode)
+      amazon.aws.ec2_instance:
+        state: running
+        name: "{{ resource_prefix }}-test-t3nano-1-threads-per-core-checkmode"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        instance_type: t3.nano
+        cpu_options:
           core_count: 1
           threads_per_core: 1
-      wait: true
-    check_mode: yes
+        wait: true
+      check_mode: true
 
-  - name: "fact checkmode ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-t3nano-1-threads-per-core-checkmode"
-    register: checkmode_instance_fact
+    - name: fact checkmode ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-t3nano-1-threads-per-core-checkmode"
+      register: checkmode_instance_fact
 
-  - name: "Confirm existence of instance id."
-    assert:
-      that:
-        - checkmode_instance_fact.instances | length == 0
+    - name: Confirm existence of instance id.
+      ansible.builtin.assert:
+        that:
+          - checkmode_instance_fact.instances | length == 0

--- a/tests/integration/targets/ec2_instance_default_vpc_tests/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_default_vpc_tests/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_default_vpc
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-default-vpc'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-default-vpc"

--- a/tests/integration/targets/ec2_instance_default_vpc_tests/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_default_vpc_tests/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: default_vpc
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: default_vpc

--- a/tests/integration/targets/ec2_instance_default_vpc_tests/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_default_vpc_tests/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -5,59 +6,59 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: "Make instance in a default subnet of the VPC"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-default-vpc"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      security_group: "default"
-      instance_type: "{{ ec2_instance_type }}"
-      wait: false
-    register: in_default_vpc
+    - name: Make instance in a default subnet of the VPC
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-default-vpc"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        security_group: default
+        instance_type: "{{ ec2_instance_type }}"
+        wait: false
+      register: in_default_vpc
 
-  - name: "Make instance in a default subnet of the VPC(check mode)"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-default-vpc-checkmode"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      security_group: "default"
-      instance_type: "{{ ec2_instance_type }}"
-    check_mode: yes
+    - name: Make instance in a default subnet of the VPC(check mode)
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-default-vpc-checkmode"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        security_group: default
+        instance_type: "{{ ec2_instance_type }}"
+      check_mode: true
 
-  - name: "fact presented ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-default-vpc"
-    register: presented_instance_fact
+    - name: fact presented ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-default-vpc"
+      register: presented_instance_fact
 
-  - name: "fact checkmode ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-default-vpc-checkmode"
-    register: checkmode_instance_fact
+    - name: fact checkmode ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-default-vpc-checkmode"
+      register: checkmode_instance_fact
 
-  - name: "Confirm whether the check mode is working normally."
-    assert:
-      that:
-        - presented_instance_fact.instances | length > 0
-        - checkmode_instance_fact.instances | length == 0
+    - name: Confirm whether the check mode is working normally.
+      ansible.builtin.assert:
+        that:
+          - presented_instance_fact.instances | length > 0
+          - checkmode_instance_fact.instances | length == 0
 
-  - name: "Terminate instances"
-    ec2_instance:
-      state: absent
-      instance_ids: "{{ in_default_vpc.instance_ids }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
+    - name: Terminate instances
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids: "{{ in_default_vpc.instance_ids }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
 
   always:
-  - name: "Terminate vpc_tests instances"
-    ec2_instance:
-      state: absent
-      filters:
-        "tag:TestId": "{{ ec2_instance_tag_TestId }}"
-      wait: yes
-    ignore_errors: yes
+    - name: Terminate vpc_tests instances
+      amazon.aws.ec2_instance:
+        state: absent
+        filters:
+          tag:TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      ignore_errors: true

--- a/tests/integration/targets/ec2_instance_ebs_optimized/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_ebs_optimized/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_ebs_optimized
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-ebs-optimized'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-ebs-optimized"

--- a/tests/integration/targets/ec2_instance_ebs_optimized/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_ebs_optimized/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: ebs_optimized
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: ebs_optimized

--- a/tests/integration/targets/ec2_instance_ebs_optimized/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_ebs_optimized/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -5,27 +6,27 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: "Make EBS optimized instance in the testing subnet of the test VPC"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-ebs-optimized-instance-in-vpc"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      security_groups: "{{ sg.group_id }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      ebs_optimized: true
-      instance_type: t3.nano
-      wait: false
-    register: ebs_opt_in_vpc
+    - name: Make EBS optimized instance in the testing subnet of the test VPC
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-ebs-optimized-instance-in-vpc"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        security_groups: "{{ sg.group_id }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        ebs_optimized: true
+        instance_type: t3.nano
+        wait: false
+      register: ebs_opt_in_vpc
 
-  - name: "Get ec2 instance info"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-ebs-optimized-instance-in-vpc"
-    register: ebs_opt_instance_info
+    - name: Get ec2 instance info
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-ebs-optimized-instance-in-vpc"
+      register: ebs_opt_instance_info
 
-  - name: "Assert instance is ebs_optimized"
-    assert:
-      that:
-        - ebs_opt_instance_info.instances.0.ebs_optimized
+    - name: Assert instance is ebs_optimized
+      ansible.builtin.assert:
+        that:
+          - ebs_opt_instance_info.instances.0.ebs_optimized

--- a/tests/integration/targets/ec2_instance_external_resource_attach/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_external_resource_attach/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_external_resource_attach
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-external-attach'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-external-attach"

--- a/tests/integration/targets/ec2_instance_external_resource_attach/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_external_resource_attach/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: external_resources
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: external_resources

--- a/tests/integration/targets/ec2_instance_external_resource_attach/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_external_resource_attach/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -6,156 +7,156 @@
       region: "{{ aws_region }}"
   block:
   # Make custom ENIs and attach via the `network` parameter
-  - ec2_eni:
-      state: present
-      delete_on_termination: true
-      subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      security_groups:
-        - "{{ sg.group_id }}"
-    register: eni_a
+    - amazon.aws.ec2_eni:
+        state: present
+        delete_on_termination: true
+        subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        security_groups:
+          - "{{ sg.group_id }}"
+      register: eni_a
 
-  - ec2_eni:
-      state: present
-      delete_on_termination: true
-      subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      security_groups:
-        - "{{ sg.group_id }}"
-    register: eni_b
+    - amazon.aws.ec2_eni:
+        state: present
+        delete_on_termination: true
+        subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        security_groups:
+          - "{{ sg.group_id }}"
+      register: eni_b
 
-  - ec2_eni:
-      state: present
-      delete_on_termination: true
-      subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      security_groups:
-        - "{{ sg.group_id }}"
-    register: eni_c
+    - amazon.aws.ec2_eni:
+        state: present
+        delete_on_termination: true
+        subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        security_groups:
+          - "{{ sg.group_id }}"
+      register: eni_c
 
-  - ec2_key:
-      name: "{{ resource_prefix }}_test_key"
+    - amazon.aws.ec2_key:
+        name: "{{ resource_prefix }}_test_key"
 
-  - name: "Make instance in the testing subnet created in the test VPC"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-eni-vpc"
-      key_name: "{{ resource_prefix }}_test_key"
-      network:
-        interfaces:
-          - id: "{{ eni_a.interface.id }}"
-      image_id: "{{ ec2_ami_id }}"
-      availability_zone: '{{ subnet_b_az }}'
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      instance_type: "{{ ec2_instance_type }}"
-      wait: false
-    register: in_test_vpc
+    - name: Make instance in the testing subnet created in the test VPC
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-eni-vpc"
+        key_name: "{{ resource_prefix }}_test_key"
+        network:
+          interfaces:
+            - id: "{{ eni_a.interface.id }}"
+        image_id: "{{ ec2_ami_id }}"
+        availability_zone: "{{ subnet_b_az }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        instance_type: "{{ ec2_instance_type }}"
+        wait: false
+      register: in_test_vpc
 
-  - name: "Gather {{ resource_prefix }}-test-eni-vpc info"
-    ec2_instance_info:
-      filters:
-        "tag:Name": '{{ resource_prefix }}-test-eni-vpc'
-    register: in_test_vpc_instance
+    - name: Gather {{ resource_prefix }}-test-eni-vpc info
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-eni-vpc"
+      register: in_test_vpc_instance
 
-  - assert:
-      that:
-        - in_test_vpc_instance.instances.0.key_name == resource_prefix+"_test_key"
-        - '(in_test_vpc_instance.instances.0.network_interfaces | length) == 1'
+    - ansible.builtin.assert:
+        that:
+          - in_test_vpc_instance.instances.0.key_name == resource_prefix+"_test_key"
+          - (in_test_vpc_instance.instances.0.network_interfaces | length) == 1
 
-  - name: "Add a second interface (check_mode=true)"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-eni-vpc"
-      network:
-        interfaces:
-          - id: "{{ eni_a.interface.id }}"
-          - id: "{{ eni_b.interface.id }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      instance_type: "{{ ec2_instance_type }}"
-      wait: false
-    register: add_interface_check_mode
-    check_mode: true
+    - name: Add a second interface (check_mode=true)
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-eni-vpc"
+        network:
+          interfaces:
+            - id: "{{ eni_a.interface.id }}"
+            - id: "{{ eni_b.interface.id }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        instance_type: "{{ ec2_instance_type }}"
+        wait: false
+      register: add_interface_check_mode
+      check_mode: true
 
-  - name: Validate task reported changed
-    assert:
-      that:
-        - add_interface_check_mode is changed
+    - name: Validate task reported changed
+      ansible.builtin.assert:
+        that:
+          - add_interface_check_mode is changed
 
-  - name: "Gather {{ resource_prefix }}-test-eni-vpc info"
-    ec2_instance_info:
-      filters:
-        "tag:Name": '{{ resource_prefix }}-test-eni-vpc'
-    register: in_test_vpc_instance
+    - name: Gather {{ resource_prefix }}-test-eni-vpc info
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-eni-vpc"
+      register: in_test_vpc_instance
 
-  - name: Validate that only 1 ENI is attached to instance as we run using check_mode=true
-    assert:
-      that:
-        - 'in_test_vpc_instance.instances.0.key_name == resource_prefix+"_test_key"'
-        - '(in_test_vpc_instance.instances.0.network_interfaces | length) == 1'
+    - name: Validate that only 1 ENI is attached to instance as we run using check_mode=true
+      ansible.builtin.assert:
+        that:
+          - in_test_vpc_instance.instances.0.key_name == resource_prefix+"_test_key"
+          - (in_test_vpc_instance.instances.0.network_interfaces | length) == 1
 
-  - name: "Add a second interface"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-eni-vpc"
-      network:
-        interfaces:
-          - id: "{{ eni_a.interface.id }}"
-          - id: "{{ eni_b.interface.id }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      instance_type: "{{ ec2_instance_type }}"
-      wait: false
-    register: add_interface
-    until: add_interface is not failed
-    ignore_errors: true
-    retries: 10
+    - name: Add a second interface
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-eni-vpc"
+        network:
+          interfaces:
+            - id: "{{ eni_a.interface.id }}"
+            - id: "{{ eni_b.interface.id }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        instance_type: "{{ ec2_instance_type }}"
+        wait: false
+      register: add_interface
+      until: add_interface is not failed
+      ignore_errors: true
+      retries: 10
 
-  - name: Validate that the instance has now 2 interfaces attached
-    block:
-      - name: "Gather {{ resource_prefix }}-test-eni-vpc info"
-        ec2_instance_info:
-          filters:
-            "tag:Name": '{{ resource_prefix }}-test-eni-vpc'
-        register: in_test_vpc_instance
+    - name: Validate that the instance has now 2 interfaces attached
+      block:
+        - name: Gather {{ resource_prefix }}-test-eni-vpc info
+          amazon.aws.ec2_instance_info:
+            filters:
+              tag:Name: "{{ resource_prefix }}-test-eni-vpc"
+          register: in_test_vpc_instance
 
-      - name: Validate that only 1 ENI is attached to instance as we run using check_mode=true
-        assert:
-          that:
-            - 'in_test_vpc_instance.instances.0.key_name == resource_prefix+"_test_key"'
-            - '(in_test_vpc_instance.instances.0.network_interfaces | length) == 2'
+        - name: Validate that only 1 ENI is attached to instance as we run using check_mode=true
+          ansible.builtin.assert:
+            that:
+              - in_test_vpc_instance.instances.0.key_name == resource_prefix+"_test_key"
+              - (in_test_vpc_instance.instances.0.network_interfaces | length) == 2
 
-    when: add_interface is successful
+      when: add_interface is successful
 
-  - name: "Make instance in the testing subnet created in the test VPC(check mode)"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-eni-vpc-checkmode"
-      key_name: "{{ resource_prefix }}_test_key"
-      network:
-        interfaces:
-          - id: "{{ eni_c.interface.id }}"
-      image_id: "{{ ec2_ami_id }}"
-      availability_zone: '{{ subnet_b_az }}'
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      instance_type: "{{ ec2_instance_type }}"
-    check_mode: yes
+    - name: Make instance in the testing subnet created in the test VPC(check mode)
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-eni-vpc-checkmode"
+        key_name: "{{ resource_prefix }}_test_key"
+        network:
+          interfaces:
+            - id: "{{ eni_c.interface.id }}"
+        image_id: "{{ ec2_ami_id }}"
+        availability_zone: "{{ subnet_b_az }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        instance_type: "{{ ec2_instance_type }}"
+      check_mode: true
 
-  - name: "fact presented ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-eni-vpc"
-    register: presented_instance_fact
+    - name: fact presented ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-eni-vpc"
+      register: presented_instance_fact
 
-  - name: "fact checkmode ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-eni-vpc-checkmode"
-    register: checkmode_instance_fact
+    - name: fact checkmode ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-eni-vpc-checkmode"
+      register: checkmode_instance_fact
 
-  - name: "Confirm existence of instance id."
-    assert:
-      that:
-        - presented_instance_fact.instances | length > 0
-        - checkmode_instance_fact.instances | length == 0
+    - name: Confirm existence of instance id.
+      ansible.builtin.assert:
+        that:
+          - presented_instance_fact.instances | length > 0
+          - checkmode_instance_fact.instances | length == 0

--- a/tests/integration/targets/ec2_instance_hibernation_options/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_hibernation_options/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_hibernation_options
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-instance-hibernation-options'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-hibernation-options"

--- a/tests/integration/targets/ec2_instance_hibernation_options/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_hibernation_options/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: hibernation_options
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: hibernation_options

--- a/tests/integration/targets/ec2_instance_hibernation_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_hibernation_options/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -6,7 +7,7 @@
       region: "{{ aws_region }}"
   block:
     - name: Create instance with hibernation option (check mode)
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-hibernation-options"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -21,18 +22,18 @@
               delete_on_termination: true
               encrypted: true
         state: running
-        wait: yes
-      check_mode: yes
+        wait: true
+      check_mode: true
       register: create_instance_check_mode_results
 
     - name: Check the returned value for the earlier task
-      assert:
+      ansible.builtin.assert:
         that:
           - create_instance_check_mode_results is changed
           - create_instance_check_mode_results.spec.HibernationOptions.Configured == True
 
     - name: Create instance with hibernation config
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-hibernation-options"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -47,32 +48,32 @@
               delete_on_termination: true
               encrypted: true
         state: running
-        wait: yes
+        wait: true
       register: create_instance_results
 
-    - set_fact:
-        instance_id: '{{ create_instance_results.instances[0].instance_id }}'
+    - ansible.builtin.set_fact:
+        instance_id: "{{ create_instance_results.instances[0].instance_id }}"
 
     - name: Check return values of the create instance task
-      assert:
+      ansible.builtin.assert:
         that:
           - create_instance_results.instances | length > 0
           - create_instance_results.instances.0.state.name == 'running'
           - create_instance_results.spec.HibernationOptions.Configured
 
     - name: Gather information about the instance to get the hibernation status
-      ec2_instance_info:
+      amazon.aws.ec2_instance_info:
         filters:
-          "tag:Name": "{{ resource_prefix }}-hibernation-options"
+          tag:Name: "{{ resource_prefix }}-hibernation-options"
       register: instance_hibernation_status
 
     - name: Assert hibernation options is true
-      assert:
+      ansible.builtin.assert:
         that:
           - instance_hibernation_status.instances[0].hibernation_options.configured == true
 
     - name: Create instance with hibernation option (check mode) (idempotent)
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-hibernation-options"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -87,17 +88,17 @@
               delete_on_termination: true
               encrypted: true
         state: running
-        wait: yes
-      check_mode: yes
+        wait: true
+      check_mode: true
       register: create_instance_check_mode_results
 
     - name: Check the returned value for the earlier task
-      assert:
+      ansible.builtin.assert:
         that:
           - create_instance_check_mode_results is not changed
 
     - name: Create instance with hibernation options configured (idempotent)
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-hibernation-options"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -112,17 +113,17 @@
               delete_on_termination: true
               encrypted: true
         state: running
-        wait: yes
+        wait: true
       register: create_instance_results
 
     - name: Check return values of the create instance task
-      assert:
+      ansible.builtin.assert:
         that:
           - not create_instance_results.changed
           - create_instance_results.instances | length > 0
 
     - name: Create instance with hibernation options configured with unencrypted volume
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-hibernation-options-error"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -139,7 +140,7 @@
       failed_when: "'Hibernation prerequisites not satisfied' not in create_instance_results.msg"
 
     - name: Terminate the instance
-      ec2_instance:
+      amazon.aws.ec2_instance:
         filters:
           tag:TestId: "{{ resource_prefix }}"
         state: absent

--- a/tests/integration/targets/ec2_instance_iam_instance_role/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_iam_instance_role/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for ec2_instance_iam_instance_profile
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-instance-profile'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-profile"
 
-first_iam_role: "ansible-test-{{ tiny_prefix }}-instance_role"
-second_iam_role: "ansible-test-{{ tiny_prefix }}-instance_role-2"
+first_iam_role: ansible-test-{{ tiny_prefix }}-instance_role
+second_iam_role: ansible-test-{{ tiny_prefix }}-instance_role-2

--- a/tests/integration/targets/ec2_instance_iam_instance_role/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_iam_instance_role/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: instance_role
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: instance_role

--- a/tests/integration/targets/ec2_instance_iam_instance_role/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_iam_instance_role/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -5,127 +6,127 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: "Create IAM role for test"
-    iam_role:
-      state: present
-      name: '{{ first_iam_role }}'
-      assume_role_policy_document: "{{ lookup('file','assume-role-policy.json') }}"
-      create_instance_profile: yes
-      managed_policy:
-      - AmazonEC2ContainerServiceRole
-    register: iam_role
+    - name: Create IAM role for test
+      community.aws.iam_role:
+        state: present
+        name: "{{ first_iam_role }}"
+        assume_role_policy_document: "{{ lookup('file','assume-role-policy.json') }}"
+        create_instance_profile: true
+        managed_policy:
+          - AmazonEC2ContainerServiceRole
+      register: iam_role
 
-  - name: "Create second IAM role for test"
-    iam_role:
-      state: present
-      name: '{{ second_iam_role }}'
-      assume_role_policy_document: "{{ lookup('file','assume-role-policy.json') }}"
-      create_instance_profile: yes
-      managed_policy:
-      - AmazonEC2ContainerServiceRole
-    register: iam_role_2
+    - name: Create second IAM role for test
+      community.aws.iam_role:
+        state: present
+        name: "{{ second_iam_role }}"
+        assume_role_policy_document: "{{ lookup('file','assume-role-policy.json') }}"
+        create_instance_profile: true
+        managed_policy:
+          - AmazonEC2ContainerServiceRole
+      register: iam_role_2
 
-  - name: "wait 10 seconds for roles to become available"
-    wait_for:
-      timeout: 10
-    delegate_to: localhost
+    - name: wait 10 seconds for roles to become available
+      ansible.builtin.wait_for:
+        timeout: 10
+      delegate_to: localhost
 
-  - name: "Make instance with an instance_role"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-instance-role"
-      image_id: "{{ ec2_ami_id }}"
-      security_groups: "{{ sg.group_id }}"
-      instance_type: "{{ ec2_instance_type }}"
-      instance_role: "{{ first_iam_role }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-    register: instance_with_role
+    - name: Make instance with an instance_role
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-instance-role"
+        image_id: "{{ ec2_ami_id }}"
+        security_groups: "{{ sg.group_id }}"
+        instance_type: "{{ ec2_instance_type }}"
+        instance_role: "{{ first_iam_role }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+      register: instance_with_role
 
-  - assert:
-      that:
-        - 'instance_with_role.instances[0].iam_instance_profile.arn == iam_role.arn.replace(":role/", ":instance-profile/")'
+    - ansible.builtin.assert:
+        that:
+          - instance_with_role.instances[0].iam_instance_profile.arn == iam_role.arn.replace(":role/", ":instance-profile/")
 
-  - name: "Make instance with an instance_role(check mode)"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-instance-role-checkmode"
-      image_id: "{{ ec2_ami_id }}"
-      security_groups: "{{ sg.group_id }}"
-      instance_type: "{{ ec2_instance_type }}"
-      instance_role: "{{ iam_role.arn.replace(':role/', ':instance-profile/') }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-    check_mode: yes
+    - name: Make instance with an instance_role(check mode)
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-instance-role-checkmode"
+        image_id: "{{ ec2_ami_id }}"
+        security_groups: "{{ sg.group_id }}"
+        instance_type: "{{ ec2_instance_type }}"
+        instance_role: "{{ iam_role.arn.replace(':role/', ':instance-profile/') }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+      check_mode: true
 
-  - name: "fact presented ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-instance-role"
-    register: presented_instance_fact
+    - name: fact presented ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-instance-role"
+      register: presented_instance_fact
 
-  - name: "fact checkmode ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-instance-role-checkmode"
-    register: checkmode_instance_fact
+    - name: fact checkmode ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-instance-role-checkmode"
+      register: checkmode_instance_fact
 
-  - name: "Confirm whether the check mode is working normally."
-    assert:
-      that:
-        - presented_instance_fact.instances | length > 0
-        - checkmode_instance_fact.instances | length == 0
+    - name: Confirm whether the check mode is working normally.
+      ansible.builtin.assert:
+        that:
+          - presented_instance_fact.instances | length > 0
+          - checkmode_instance_fact.instances | length == 0
 
-  - name: "Update instance with new instance_role"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-instance-role"
-      image_id: "{{ ec2_ami_id }}"
-      security_groups: "{{ sg.group_id }}"
-      instance_type: "{{ ec2_instance_type }}"
-      instance_role: "{{ iam_role_2.arn.replace(':role/', ':instance-profile/') }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-    register: instance_with_updated_role
+    - name: Update instance with new instance_role
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-instance-role"
+        image_id: "{{ ec2_ami_id }}"
+        security_groups: "{{ sg.group_id }}"
+        instance_type: "{{ ec2_instance_type }}"
+        instance_role: "{{ iam_role_2.arn.replace(':role/', ':instance-profile/') }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+      register: instance_with_updated_role
 
-  - name: "wait 10 seconds for role update to complete"
-    wait_for:
-      timeout: 10
-    delegate_to: localhost
+    - name: wait 10 seconds for role update to complete
+      ansible.builtin.wait_for:
+        timeout: 10
+      delegate_to: localhost
 
-  - name: "fact checkmode ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-instance-role"
-    register: updates_instance_info
+    - name: fact checkmode ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-instance-role"
+      register: updates_instance_info
 
-  - assert:
-      that:
-        - 'updates_instance_info.instances[0].iam_instance_profile.arn == iam_role_2.arn.replace(":role/", ":instance-profile/")'
-        - 'updates_instance_info.instances[0].instance_id == instance_with_role.instances[0].instance_id'
+    - ansible.builtin.assert:
+        that:
+          - updates_instance_info.instances[0].iam_instance_profile.arn == iam_role_2.arn.replace(":role/", ":instance-profile/")
+          - updates_instance_info.instances[0].instance_id == instance_with_role.instances[0].instance_id
 
   always:
   # We need to delete the instances before we can delete the roles
-  - name: "Terminate iam_instance_role instances"
-    ec2_instance:
-      state: absent
-      filters:
-        "tag:TestId": "{{ ec2_instance_tag_TestId }}"
-      wait: yes
-    ignore_errors: yes
+    - name: Terminate iam_instance_role instances
+      amazon.aws.ec2_instance:
+        state: absent
+        filters:
+          tag:TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      ignore_errors: true
 
-  - name: "Delete IAM role for test"
-    iam_role:
-      state: absent
-      name: "{{ item }}"
-      delete_instance_profile: true
-    loop:
-      - '{{ first_iam_role }}'
-      - '{{ second_iam_role }}'
-    register: removed
-    until: removed is not failed
-    ignore_errors: yes
-    retries: 10
+    - name: Delete IAM role for test
+      community.aws.iam_role:
+        state: absent
+        name: "{{ item }}"
+        delete_instance_profile: true
+      loop:
+        - "{{ first_iam_role }}"
+        - "{{ second_iam_role }}"
+      register: removed
+      until: removed is not failed
+      ignore_errors: true
+      retries: 10

--- a/tests/integration/targets/ec2_instance_info/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_info/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
-ec2_instance_type: 't2.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-instance-info'
+ec2_instance_type: t2.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-info"
 ec2_instance_name: "{{ resource_prefix }}-test-instance-info"
 ec2_instance_user_data: |
   packages:

--- a/tests/integration/targets/ec2_instance_info/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_info/meta/main.yml
@@ -1,4 +1,5 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env

--- a/tests/integration/targets/ec2_instance_info/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_info/tasks/main.yml
@@ -6,71 +6,71 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: "Make instance in the testing subnet created in the test VPC"
-    ec2_instance:
-      state: present
-      name: "{{ ec2_instance_name }}"
-      image_id: "{{ ec2_ami_id }}"
-      availability_zone: '{{ subnet_b_az }}'
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      user_data: "{{ ec2_instance_user_data }}"
-      instance_type: "{{ ec2_instance_type }}"
-      wait: false
+    - name: Make instance in the testing subnet created in the test VPC
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ ec2_instance_name }}"
+        image_id: "{{ ec2_ami_id }}"
+        availability_zone: "{{ subnet_b_az }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        user_data: "{{ ec2_instance_user_data }}"
+        instance_type: "{{ ec2_instance_type }}"
+        wait: false
 
-  - name: "Gather {{ ec2_instance_name }} info"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ ec2_instance_name }}"
-      include_attributes:
-        - instanceType
-        - kernel
-        - ramdisk
-        - userData
-        - disableApiTermination
-        - instanceInitiatedShutdownBehavior
-        - rootDeviceName
-        - blockDeviceMapping
-        - productCodes
-        - sourceDestCheck
-        - groupSet
-        - ebsOptimized
-        - sriovNetSupport
-        - enclaveOptions
-    register: _instance_info
+    - name: Gather {{ ec2_instance_name }} info
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ ec2_instance_name }}"
+        include_attributes:
+          - instanceType
+          - kernel
+          - ramdisk
+          - userData
+          - disableApiTermination
+          - instanceInitiatedShutdownBehavior
+          - rootDeviceName
+          - blockDeviceMapping
+          - productCodes
+          - sourceDestCheck
+          - groupSet
+          - ebsOptimized
+          - sriovNetSupport
+          - enclaveOptions
+      register: _instance_info
 
-  - name: Validate that returned value contains required attributes
-    assert:
-      that:
-        - _instance_info.instances | length > 0
-        - '"attributes" in _instance_info.instances[0]'
-        # instance type
-        - _instance_info.instances[0].attributes.instance_type.value == ec2_instance_type
-        # User data
-        - _instance_info.instances[0].attributes.user_data.value | b64decode == ec2_instance_user_data
-        # kernel
-        - '"kernel_id" in _instance_info.instances[0].attributes'
-        # Ram disk
-        - '"ramdisk_id" in _instance_info.instances[0].attributes'
-        # Disable API termination
-        - not (_instance_info.instances[0].attributes.disable_api_termination.value | bool)
-        # Instance Initiated Shutdown Behavior
-        - '"instance_initiated_shutdown_behavior" in _instance_info.instances[0].attributes'
-        # Root Device Name
-        - _instance_info.instances[0].attributes.root_device_name.value == "/dev/sda1"
-        # Block Device Mapping
-        - '"block_device_mappings" in _instance_info.instances[0].attributes'
-        - _instance_info.instances[0].attributes.block_device_mappings[0].device_name == "/dev/sda1"
-        - '"ebs" in _instance_info.instances[0].attributes.block_device_mappings[0]'
-        # Product Codes
-        - '"product_codes" in _instance_info.instances[0].attributes'
-        # Source Dest Check
-        - _instance_info.instances[0].attributes.source_dest_check.value | bool
-        # GroupSet
-        - '"groups" in _instance_info.instances[0].attributes'
-        # Ebs Optimized
-        - not (_instance_info.instances[0].attributes.ebs_optimized.value | bool)
-        # Sriov Net Support
-        - '"sriov_net_support" in _instance_info.instances[0].attributes'
-        # Enclave Options
-        - not (_instance_info.instances[0].attributes.enclave_options.enabled | bool)
+    - name: Validate that returned value contains required attributes
+      ansible.builtin.assert:
+        that:
+          - _instance_info.instances | length > 0
+          - '"attributes" in _instance_info.instances[0]'
+          # instance type
+          - _instance_info.instances[0].attributes.instance_type.value == ec2_instance_type
+          # User data
+          - _instance_info.instances[0].attributes.user_data.value | b64decode == ec2_instance_user_data
+          # kernel
+          - '"kernel_id" in _instance_info.instances[0].attributes'
+          # Ram disk
+          - '"ramdisk_id" in _instance_info.instances[0].attributes'
+          # Disable API termination
+          - not (_instance_info.instances[0].attributes.disable_api_termination.value | bool)
+          # Instance Initiated Shutdown Behavior
+          - '"instance_initiated_shutdown_behavior" in _instance_info.instances[0].attributes'
+          # Root Device Name
+          - _instance_info.instances[0].attributes.root_device_name.value == "/dev/sda1"
+          # Block Device Mapping
+          - '"block_device_mappings" in _instance_info.instances[0].attributes'
+          - _instance_info.instances[0].attributes.block_device_mappings[0].device_name == "/dev/sda1"
+          - '"ebs" in _instance_info.instances[0].attributes.block_device_mappings[0]'
+          # Product Codes
+          - '"product_codes" in _instance_info.instances[0].attributes'
+          # Source Dest Check
+          - _instance_info.instances[0].attributes.source_dest_check.value | bool
+          # GroupSet
+          - '"groups" in _instance_info.instances[0].attributes'
+          # Ebs Optimized
+          - not (_instance_info.instances[0].attributes.ebs_optimized.value | bool)
+          # Sriov Net Support
+          - '"sriov_net_support" in _instance_info.instances[0].attributes'
+          # Enclave Options
+          - not (_instance_info.instances[0].attributes.enclave_options.enabled | bool)

--- a/tests/integration/targets/ec2_instance_instance_minimal/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_minimal/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_minimal
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-instance-minimal'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-minimal"

--- a/tests/integration/targets/ec2_instance_instance_minimal/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_minimal/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: minimal
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: minimal

--- a/tests/integration/targets/ec2_instance_instance_minimal/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_minimal/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -5,695 +6,695 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: "Create a new instance (check_mode)"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic"
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance
-    check_mode: true
-
-  - assert:
-      that:
-      - create_instance is not failed
-      - create_instance is changed
-      - '"instance_ids" not in create_instance'
-      - '"ec2:RunInstances" not in create_instance.resource_actions'
-
-  - name: "Create a new instance"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic"
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance
-
-  - assert:
-      that:
-      - create_instance is not failed
-      - create_instance is changed
-      - '"ec2:RunInstances" in create_instance.resource_actions'
-      - '"instance_ids" in create_instance'
-      - create_instance.instance_ids | length == 1
-      - create_instance.instance_ids[0].startswith("i-")
-
-  - name: "Save instance ID"
-    set_fact:
-      create_instance_id_1: "{{ create_instance.instance_ids[0] }}"
-
-  - name: "Create a new instance - idempotency (check_mode)"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic"
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance
-    check_mode: true
-
-  - assert:
-      that:
-      - create_instance is not failed
-      - create_instance is not changed
-      - '"ec2:RunInstances" not in create_instance.resource_actions'
-      - '"instance_ids" in create_instance'
-      - create_instance.instance_ids | length == 1
-      - create_instance.instance_ids[0] == create_instance_id_1
-
-  - name: "Create a new instance - idempotency"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic"
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance
-
-  - assert:
-      that:
-      - create_instance is not failed
-      - create_instance is not changed
-      - '"ec2:RunInstances" not in create_instance.resource_actions'
-      - '"instance_ids" in create_instance'
-      - create_instance.instance_ids | length == 1
-      - create_instance.instance_ids[0] == create_instance_id_1
-
-################################################################
-
-  - name: "Create a new instance with a different name (check_mode)"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic-2"
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance_2
-    check_mode: true
-
-  - assert:
-      that:
-      - create_instance_2 is not failed
-      - create_instance_2 is changed
-      - '"instance_ids" not in create_instance_2'
-      - '"ec2:RunInstances" not in create_instance_2.resource_actions'
-
-  - name: "Create a new instance with a different name"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic-2"
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance_2
-
-  - assert:
-      that:
-      - create_instance_2 is not failed
-      - create_instance_2 is changed
-      - '"ec2:RunInstances" in create_instance_2.resource_actions'
-      - '"instance_ids" in create_instance_2'
-      - create_instance_2.instance_ids | length == 1
-      - create_instance_2.instance_ids[0].startswith("i-")
-      - create_instance_2.instance_ids[0] != create_instance_id_1
-
-  - name: "Save instance ID"
-    set_fact:
-      create_instance_id_2: "{{ create_instance_2.instance_ids[0] }}"
-
-  - name: "Create a new instance with a different name - idempotency (check_mode)"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic-2"
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance_2
-    check_mode: true
-
-  - assert:
-      that:
-      - create_instance_2 is not failed
-      - create_instance_2 is not changed
-      - '"ec2:RunInstances" not in create_instance_2.resource_actions'
-      - '"instance_ids" in create_instance_2'
-      - create_instance_2.instance_ids | length == 1
-      - create_instance_2.instance_ids[0] == create_instance_id_2
-
-  - name: "Create a new instance with a different name - idempotency"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic-2"
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance_2
-
-  - assert:
-      that:
-      - create_instance_2 is not failed
-      - create_instance_2 is not changed
-      - '"ec2:RunInstances" not in create_instance_2.resource_actions'
-      - '"instance_ids" in create_instance_2'
-      - create_instance_2.instance_ids | length == 1
-      - create_instance_2.instance_ids[0] == create_instance_id_2
-
-################################################################
-
-  - name: "Create a new instance with a different name in tags (check_mode)"
-    ec2_instance:
-      state: present
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        Name: "{{ resource_prefix }}-test-basic-tag"
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance_tag
-    check_mode: true
-
-  - assert:
-      that:
-      - create_instance_tag is not failed
-      - create_instance_tag is changed
-      - '"instance_ids" not in create_instance_tag'
-      - '"ec2:RunInstances" not in create_instance_tag.resource_actions'
-
-  - name: "Create a new instance with a different name in tags"
-    ec2_instance:
-      state: present
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        Name: "{{ resource_prefix }}-test-basic-tag"
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance_tag
-
-  - assert:
-      that:
-      - create_instance_tag is not failed
-      - create_instance_tag is changed
-      - '"ec2:RunInstances" in create_instance_tag.resource_actions'
-      - '"instance_ids" in create_instance_tag'
-      - create_instance_tag.instance_ids | length == 1
-      - create_instance_tag.instance_ids[0].startswith("i-")
-      - create_instance_tag.instance_ids[0] != create_instance_id_1
-      - create_instance_tag.instance_ids[0] != create_instance_id_2
-
-  - name: "Save instance ID"
-    set_fact:
-      create_instance_id_tag: "{{ create_instance_tag.instance_ids[0] }}"
-
-  - name: "Create a new instance with a different name in tags - idempotency (check_mode)"
-    ec2_instance:
-      state: present
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        Name: "{{ resource_prefix }}-test-basic-tag"
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance_tag
-    check_mode: true
-
-  - assert:
-      that:
-      - create_instance_tag is not failed
-      - create_instance_tag is not changed
-      - '"ec2:RunInstances" not in create_instance_tag.resource_actions'
-      - '"instance_ids" in create_instance_tag'
-      - create_instance_tag.instance_ids | length == 1
-      - create_instance_tag.instance_ids[0] == create_instance_id_tag
-
-  - name: "Create a new instance with a different name in tags - idempotency"
-    ec2_instance:
-      state: present
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        Name: "{{ resource_prefix }}-test-basic-tag"
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance_tag
-
-  - assert:
-      that:
-      - create_instance_tag is not failed
-      - create_instance_tag is not changed
-      - '"ec2:RunInstances" not in create_instance_tag.resource_actions'
-      - '"instance_ids" in create_instance_tag'
-      - create_instance_tag.instance_ids | length == 1
-      - create_instance_tag.instance_ids[0] == create_instance_id_tag
-
-###############################################################
-
-  - name: "Create a new instance in AZ {{ aws_region }}a"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic-{{ aws_region }}a"
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      region: "{{ aws_region }}"
-      availability_zone: "{{ aws_region }}a"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance
-
-  - name: "Save instance ID"
-    set_fact:
-      create_instance_id_3: "{{ create_instance.instance_ids[0] }}"
-
-  - name: Get instance info
-    ec2_instance_info:
-      instance_ids:
-        - "{{ create_instance_id_3 }}"
-    register: info_result
-
-  - assert:
-      that:
-      - create_instance is not failed
-      - create_instance is changed
-      - '"ec2:RunInstances" in create_instance.resource_actions'
-      - '"instance_ids" in create_instance'
-      - create_instance.instance_ids | length == 1
-      - create_instance.instance_ids[0].startswith("i-")
-      - info_result.instances[0].placement.availability_zone == '{{ aws_region }}a'
-
-  - name: "Create a new instance in AZ {{ aws_region }}b"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic-{{ aws_region }}b"
-      instance_type: "{{ ec2_instance_type }}"
-      image_id: "{{ ec2_ami_id }}"
-      region: "{{ aws_region }}"
-      availability_zone: "{{ aws_region }}b"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_instance
-
-  - name: "Save instance ID"
-    set_fact:
-      create_instance_id_4: "{{ create_instance.instance_ids[0] }}"
-
-  - name: Get instance info
-    ec2_instance_info:
-      instance_ids:
-        - "{{ create_instance_id_4 }}"
-    register: info_result
-
-  - assert:
-      that:
-      - create_instance is not failed
-      - create_instance is changed
-      - '"ec2:RunInstances" in create_instance.resource_actions'
-      - '"instance_ids" in create_instance'
-      - create_instance.instance_ids | length == 1
-      - create_instance.instance_ids[0].startswith("i-")
-      - info_result.instances[0].placement.availability_zone == '{{ aws_region }}b'
-
-################################################################
-
-  - name: "Terminate instance based on name parameter (check_mode)"
-    ec2_instance:
-      state: absent
-      name: "{{ resource_prefix }}-test-basic"
-      wait: true
-    register: terminate_name
-    check_mode: true
-
-  - assert:
-      that:
-      - terminate_name is not failed
-      - terminate_name is changed
-      - '"ec2:TerminateInstances" not in terminate_name.resource_actions'
-      - '"terminate_failed" in terminate_name'
-      - '"terminate_success" in terminate_name'
-      - terminate_name.terminate_failed | length == 0
-      - terminate_name.terminate_success | length == 1
-      - terminate_name.terminate_success[0] == create_instance_id_1
-
-  - name: "Terminate instance based on name parameter"
-    ec2_instance:
-      state: absent
-      name: "{{ resource_prefix }}-test-basic"
-      wait: true
-    register: terminate_name
-
-  - assert:
-      that:
-      - terminate_name is not failed
-      - terminate_name is changed
-      - '"ec2:TerminateInstances" in terminate_name.resource_actions'
-      - '"terminate_failed" in terminate_name'
-      - '"terminate_success" in terminate_name'
-      - terminate_name.terminate_failed | length == 0
-      - terminate_name.terminate_success | length == 1
-      - terminate_name.terminate_success[0] == create_instance_id_1
-
-  - name: "Terminate instance based on name parameter - idempotency (check_mode)"
-    ec2_instance:
-      state: absent
-      name: "{{ resource_prefix }}-test-basic"
-      wait: true
-    register: terminate_name
-    check_mode: true
-
-  - assert:
-      that:
-      - terminate_name is not failed
-      - terminate_name is not changed
-      - '"ec2:TerminateInstances" not in terminate_name.resource_actions'
-      - '"terminate_failed" not in terminate_name'
-      - '"terminate_success" not in terminate_name'
-
-  - name: "Terminate instance based on name parameter - idempotency"
-    ec2_instance:
-      state: absent
-      name: "{{ resource_prefix }}-test-basic"
-      wait: true
-    register: terminate_name
-
-  - assert:
-      that:
-      - terminate_name is not failed
-      - terminate_name is not changed
-      - '"ec2:TerminateInstances" not in terminate_name.resource_actions'
-      - '"terminate_failed" not in terminate_name'
-      - '"terminate_success" not in terminate_name'
-
-################################################################
-
-  - name: "Terminate instance based on name tag (check_mode)"
-    ec2_instance:
-      state: absent
-      tags:
-        Name: "{{ resource_prefix }}-test-basic-tag"
-      wait: true
-    register: terminate_tag
-    check_mode: true
-
-  - assert:
-      that:
-      - terminate_tag is not failed
-      - terminate_tag is changed
-      - '"ec2:TerminateInstances" not in terminate_tag.resource_actions'
-      - '"terminate_failed" in terminate_tag'
-      - '"terminate_success" in terminate_tag'
-      - terminate_tag.terminate_failed | length == 0
-      - terminate_tag.terminate_success | length == 1
-      - terminate_tag.terminate_success[0] == create_instance_id_tag
-
-  - name: "Terminate instance based on name tag"
-    ec2_instance:
-      state: absent
-      tags:
-        Name: "{{ resource_prefix }}-test-basic-tag"
-      wait: true
-    register: terminate_tag
-
-  - assert:
-      that:
-      - terminate_tag is not failed
-      - terminate_tag is changed
-      - '"ec2:TerminateInstances" in terminate_tag.resource_actions'
-      - '"terminate_failed" in terminate_tag'
-      - '"terminate_success" in terminate_tag'
-      - terminate_tag.terminate_failed | length == 0
-      - terminate_tag.terminate_success | length == 1
-      - terminate_tag.terminate_success[0] == create_instance_id_tag
-
-  - name: "Terminate instance based on name tag - idempotency (check_mode)"
-    ec2_instance:
-      state: absent
-      tags:
-        Name: "{{ resource_prefix }}-test-basic-tag"
-      wait: true
-    register: terminate_tag
-    check_mode: true
-
-  - assert:
-      that:
-      - terminate_tag is not failed
-      - terminate_tag is not changed
-      - '"ec2:TerminateInstances" not in terminate_tag.resource_actions'
-      - '"terminate_failed" not in terminate_tag'
-      - '"terminate_success" not in terminate_tag'
-
-  - name: "Terminate instance based on name tag - idempotency"
-    ec2_instance:
-      state: absent
-      tags:
-        Name: "{{ resource_prefix }}-test-basic-tag"
-      wait: true
-    register: terminate_tag
-
-  - assert:
-      that:
-      - terminate_tag is not failed
-      - terminate_tag is not changed
-      - '"ec2:TerminateInstances" not in terminate_tag.resource_actions'
-      - '"terminate_failed" not in terminate_tag'
-      - '"terminate_success" not in terminate_tag'
-
-################################################################
-
-  - name: "Terminate instance based on id (check_mode)"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ create_instance_id_2 }}"
-      wait: true
-    register: terminate_id
-    check_mode: true
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is changed
-      - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
-      - '"terminate_failed" in terminate_id'
-      - '"terminate_success" in terminate_id'
-      - terminate_id.terminate_failed | length == 0
-      - terminate_id.terminate_success | length == 1
-      - terminate_id.terminate_success[0] == create_instance_id_2
-
-  - name: "Terminate instance based on id"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ create_instance_id_2 }}"
-      wait: true
-    register: terminate_id
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is changed
-      - '"ec2:TerminateInstances" in terminate_id.resource_actions'
-      - '"terminate_failed" in terminate_id'
-      - '"terminate_success" in terminate_id'
-      - terminate_id.terminate_failed | length == 0
-      - terminate_id.terminate_success | length == 1
-      - terminate_id.terminate_success[0] == create_instance_id_2
-
-  - name: "Terminate instance based on id - idempotency (check_mode)"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ create_instance_id_2 }}"
-      wait: true
-    register: terminate_id
-    check_mode: true
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is not changed
-      - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
-      - '"terminate_failed" not in terminate_id'
-      - '"terminate_success" not in terminate_id'
-
-  - name: "Terminate instance based on id - idempotency"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ create_instance_id_2 }}"
-      wait: true
-    register: terminate_id
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is not changed
-      - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
-      - '"terminate_failed" not in terminate_id'
-      - '"terminate_success" not in terminate_id'
-
-################################################################
-
-  - name: "Terminate instance based on id (check_mode)"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ create_instance_id_3 }}"
-      wait: true
-    register: terminate_id
-    check_mode: true
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is changed
-      - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
-      - '"terminate_failed" in terminate_id'
-      - '"terminate_success" in terminate_id'
-      - terminate_id.terminate_failed | length == 0
-      - terminate_id.terminate_success | length == 1
-      - terminate_id.terminate_success[0] == create_instance_id_3
-
-  - name: "Terminate instance based on id"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ create_instance_id_3 }}"
-      wait: true
-    register: terminate_id
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is changed
-      - '"ec2:TerminateInstances" in terminate_id.resource_actions'
-      - '"terminate_failed" in terminate_id'
-      - '"terminate_success" in terminate_id'
-      - terminate_id.terminate_failed | length == 0
-      - terminate_id.terminate_success | length == 1
-      - terminate_id.terminate_success[0] == create_instance_id_3
-
-  - name: "Terminate instance based on id - idempotency (check_mode)"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ create_instance_id_3 }}"
-      wait: true
-    register: terminate_id
-    check_mode: true
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is not changed
-      - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
-      - '"terminate_failed" not in terminate_id'
-      - '"terminate_success" not in terminate_id'
-
-  - name: "Terminate instance based on id - idempotency"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ create_instance_id_3 }}"
-      wait: true
-    register: terminate_id
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is not changed
-      - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
-      - '"terminate_failed" not in terminate_id'
-      - '"terminate_success" not in terminate_id'
-
-################################################################
-
-  - name: "Terminate instance based on id (check_mode)"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ create_instance_id_4 }}"
-      wait: true
-    register: terminate_id
-    check_mode: true
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is changed
-      - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
-      - '"terminate_failed" in terminate_id'
-      - '"terminate_success" in terminate_id'
-      - terminate_id.terminate_failed | length == 0
-      - terminate_id.terminate_success | length == 1
-      - terminate_id.terminate_success[0] == create_instance_id_4
-
-  - name: "Terminate instance based on id"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ create_instance_id_4 }}"
-      wait: true
-    register: terminate_id
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is changed
-      - '"ec2:TerminateInstances" in terminate_id.resource_actions'
-      - '"terminate_failed" in terminate_id'
-      - '"terminate_success" in terminate_id'
-      - terminate_id.terminate_failed | length == 0
-      - terminate_id.terminate_success | length == 1
-      - terminate_id.terminate_success[0] == create_instance_id_4
-
-  - name: "Terminate instance based on id - idempotency (check_mode)"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ create_instance_id_4 }}"
-      wait: true
-    register: terminate_id
-    check_mode: true
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is not changed
-      - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
-      - '"terminate_failed" not in terminate_id'
-      - '"terminate_success" not in terminate_id'
-
-  - name: "Terminate instance based on id - idempotency"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ create_instance_id_4 }}"
-      wait: true
-    register: terminate_id
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is not changed
-      - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
-      - '"terminate_failed" not in terminate_id'
-      - '"terminate_success" not in terminate_id'
+    - name: Create a new instance (check_mode)
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic"
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance is not failed
+          - create_instance is changed
+          - '"instance_ids" not in create_instance'
+          - '"ec2:RunInstances" not in create_instance.resource_actions'
+
+    - name: Create a new instance
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic"
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance is not failed
+          - create_instance is changed
+          - '"ec2:RunInstances" in create_instance.resource_actions'
+          - '"instance_ids" in create_instance'
+          - create_instance.instance_ids | length == 1
+          - create_instance.instance_ids[0].startswith("i-")
+
+    - name: Save instance ID
+      ansible.builtin.set_fact:
+        create_instance_id_1: "{{ create_instance.instance_ids[0] }}"
+
+    - name: Create a new instance - idempotency (check_mode)
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic"
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance is not failed
+          - create_instance is not changed
+          - '"ec2:RunInstances" not in create_instance.resource_actions'
+          - '"instance_ids" in create_instance'
+          - create_instance.instance_ids | length == 1
+          - create_instance.instance_ids[0] == create_instance_id_1
+
+    - name: Create a new instance - idempotency
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic"
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance is not failed
+          - create_instance is not changed
+          - '"ec2:RunInstances" not in create_instance.resource_actions'
+          - '"instance_ids" in create_instance'
+          - create_instance.instance_ids | length == 1
+          - create_instance.instance_ids[0] == create_instance_id_1
+
+    ################################################################
+
+    - name: Create a new instance with a different name (check_mode)
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic-2"
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance_2
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance_2 is not failed
+          - create_instance_2 is changed
+          - '"instance_ids" not in create_instance_2'
+          - '"ec2:RunInstances" not in create_instance_2.resource_actions'
+
+    - name: Create a new instance with a different name
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic-2"
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance_2
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance_2 is not failed
+          - create_instance_2 is changed
+          - '"ec2:RunInstances" in create_instance_2.resource_actions'
+          - '"instance_ids" in create_instance_2'
+          - create_instance_2.instance_ids | length == 1
+          - create_instance_2.instance_ids[0].startswith("i-")
+          - create_instance_2.instance_ids[0] != create_instance_id_1
+
+    - name: Save instance ID
+      ansible.builtin.set_fact:
+        create_instance_id_2: "{{ create_instance_2.instance_ids[0] }}"
+
+    - name: Create a new instance with a different name - idempotency (check_mode)
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic-2"
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance_2
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance_2 is not failed
+          - create_instance_2 is not changed
+          - '"ec2:RunInstances" not in create_instance_2.resource_actions'
+          - '"instance_ids" in create_instance_2'
+          - create_instance_2.instance_ids | length == 1
+          - create_instance_2.instance_ids[0] == create_instance_id_2
+
+    - name: Create a new instance with a different name - idempotency
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic-2"
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance_2
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance_2 is not failed
+          - create_instance_2 is not changed
+          - '"ec2:RunInstances" not in create_instance_2.resource_actions'
+          - '"instance_ids" in create_instance_2'
+          - create_instance_2.instance_ids | length == 1
+          - create_instance_2.instance_ids[0] == create_instance_id_2
+
+    ################################################################
+
+    - name: Create a new instance with a different name in tags (check_mode)
+      amazon.aws.ec2_instance:
+        state: present
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          Name: "{{ resource_prefix }}-test-basic-tag"
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance_tag
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance_tag is not failed
+          - create_instance_tag is changed
+          - '"instance_ids" not in create_instance_tag'
+          - '"ec2:RunInstances" not in create_instance_tag.resource_actions'
+
+    - name: Create a new instance with a different name in tags
+      amazon.aws.ec2_instance:
+        state: present
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          Name: "{{ resource_prefix }}-test-basic-tag"
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance_tag
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance_tag is not failed
+          - create_instance_tag is changed
+          - '"ec2:RunInstances" in create_instance_tag.resource_actions'
+          - '"instance_ids" in create_instance_tag'
+          - create_instance_tag.instance_ids | length == 1
+          - create_instance_tag.instance_ids[0].startswith("i-")
+          - create_instance_tag.instance_ids[0] != create_instance_id_1
+          - create_instance_tag.instance_ids[0] != create_instance_id_2
+
+    - name: Save instance ID
+      ansible.builtin.set_fact:
+        create_instance_id_tag: "{{ create_instance_tag.instance_ids[0] }}"
+
+    - name: Create a new instance with a different name in tags - idempotency (check_mode)
+      amazon.aws.ec2_instance:
+        state: present
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          Name: "{{ resource_prefix }}-test-basic-tag"
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance_tag
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance_tag is not failed
+          - create_instance_tag is not changed
+          - '"ec2:RunInstances" not in create_instance_tag.resource_actions'
+          - '"instance_ids" in create_instance_tag'
+          - create_instance_tag.instance_ids | length == 1
+          - create_instance_tag.instance_ids[0] == create_instance_id_tag
+
+    - name: Create a new instance with a different name in tags - idempotency
+      amazon.aws.ec2_instance:
+        state: present
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          Name: "{{ resource_prefix }}-test-basic-tag"
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance_tag
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance_tag is not failed
+          - create_instance_tag is not changed
+          - '"ec2:RunInstances" not in create_instance_tag.resource_actions'
+          - '"instance_ids" in create_instance_tag'
+          - create_instance_tag.instance_ids | length == 1
+          - create_instance_tag.instance_ids[0] == create_instance_id_tag
+
+    ###############################################################
+
+    - name: Create a new instance in AZ {{ aws_region }}a
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic-{{ aws_region }}a"
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        region: "{{ aws_region }}"
+        availability_zone: "{{ aws_region }}a"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance
+
+    - name: Save instance ID
+      ansible.builtin.set_fact:
+        create_instance_id_3: "{{ create_instance.instance_ids[0] }}"
+
+    - name: Get instance info
+      amazon.aws.ec2_instance_info:
+        instance_ids:
+          - "{{ create_instance_id_3 }}"
+      register: info_result
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance is not failed
+          - create_instance is changed
+          - '"ec2:RunInstances" in create_instance.resource_actions'
+          - '"instance_ids" in create_instance'
+          - create_instance.instance_ids | length == 1
+          - create_instance.instance_ids[0].startswith("i-")
+          - info_result.instances[0].placement.availability_zone == '{{ aws_region }}a'
+
+    - name: Create a new instance in AZ {{ aws_region }}b
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic-{{ aws_region }}b"
+        instance_type: "{{ ec2_instance_type }}"
+        image_id: "{{ ec2_ami_id }}"
+        region: "{{ aws_region }}"
+        availability_zone: "{{ aws_region }}b"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_instance
+
+    - name: Save instance ID
+      ansible.builtin.set_fact:
+        create_instance_id_4: "{{ create_instance.instance_ids[0] }}"
+
+    - name: Get instance info
+      amazon.aws.ec2_instance_info:
+        instance_ids:
+          - "{{ create_instance_id_4 }}"
+      register: info_result
+
+    - ansible.builtin.assert:
+        that:
+          - create_instance is not failed
+          - create_instance is changed
+          - '"ec2:RunInstances" in create_instance.resource_actions'
+          - '"instance_ids" in create_instance'
+          - create_instance.instance_ids | length == 1
+          - create_instance.instance_ids[0].startswith("i-")
+          - info_result.instances[0].placement.availability_zone == '{{ aws_region }}b'
+
+    ################################################################
+
+    - name: Terminate instance based on name parameter (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        name: "{{ resource_prefix }}-test-basic"
+        wait: true
+      register: terminate_name
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_name is not failed
+          - terminate_name is changed
+          - '"ec2:TerminateInstances" not in terminate_name.resource_actions'
+          - '"terminate_failed" in terminate_name'
+          - '"terminate_success" in terminate_name'
+          - terminate_name.terminate_failed | length == 0
+          - terminate_name.terminate_success | length == 1
+          - terminate_name.terminate_success[0] == create_instance_id_1
+
+    - name: Terminate instance based on name parameter
+      amazon.aws.ec2_instance:
+        state: absent
+        name: "{{ resource_prefix }}-test-basic"
+        wait: true
+      register: terminate_name
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_name is not failed
+          - terminate_name is changed
+          - '"ec2:TerminateInstances" in terminate_name.resource_actions'
+          - '"terminate_failed" in terminate_name'
+          - '"terminate_success" in terminate_name'
+          - terminate_name.terminate_failed | length == 0
+          - terminate_name.terminate_success | length == 1
+          - terminate_name.terminate_success[0] == create_instance_id_1
+
+    - name: Terminate instance based on name parameter - idempotency (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        name: "{{ resource_prefix }}-test-basic"
+        wait: true
+      register: terminate_name
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_name is not failed
+          - terminate_name is not changed
+          - '"ec2:TerminateInstances" not in terminate_name.resource_actions'
+          - '"terminate_failed" not in terminate_name'
+          - '"terminate_success" not in terminate_name'
+
+    - name: Terminate instance based on name parameter - idempotency
+      amazon.aws.ec2_instance:
+        state: absent
+        name: "{{ resource_prefix }}-test-basic"
+        wait: true
+      register: terminate_name
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_name is not failed
+          - terminate_name is not changed
+          - '"ec2:TerminateInstances" not in terminate_name.resource_actions'
+          - '"terminate_failed" not in terminate_name'
+          - '"terminate_success" not in terminate_name'
+
+    ################################################################
+
+    - name: Terminate instance based on name tag (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        tags:
+          Name: "{{ resource_prefix }}-test-basic-tag"
+        wait: true
+      register: terminate_tag
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_tag is not failed
+          - terminate_tag is changed
+          - '"ec2:TerminateInstances" not in terminate_tag.resource_actions'
+          - '"terminate_failed" in terminate_tag'
+          - '"terminate_success" in terminate_tag'
+          - terminate_tag.terminate_failed | length == 0
+          - terminate_tag.terminate_success | length == 1
+          - terminate_tag.terminate_success[0] == create_instance_id_tag
+
+    - name: Terminate instance based on name tag
+      amazon.aws.ec2_instance:
+        state: absent
+        tags:
+          Name: "{{ resource_prefix }}-test-basic-tag"
+        wait: true
+      register: terminate_tag
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_tag is not failed
+          - terminate_tag is changed
+          - '"ec2:TerminateInstances" in terminate_tag.resource_actions'
+          - '"terminate_failed" in terminate_tag'
+          - '"terminate_success" in terminate_tag'
+          - terminate_tag.terminate_failed | length == 0
+          - terminate_tag.terminate_success | length == 1
+          - terminate_tag.terminate_success[0] == create_instance_id_tag
+
+    - name: Terminate instance based on name tag - idempotency (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        tags:
+          Name: "{{ resource_prefix }}-test-basic-tag"
+        wait: true
+      register: terminate_tag
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_tag is not failed
+          - terminate_tag is not changed
+          - '"ec2:TerminateInstances" not in terminate_tag.resource_actions'
+          - '"terminate_failed" not in terminate_tag'
+          - '"terminate_success" not in terminate_tag'
+
+    - name: Terminate instance based on name tag - idempotency
+      amazon.aws.ec2_instance:
+        state: absent
+        tags:
+          Name: "{{ resource_prefix }}-test-basic-tag"
+        wait: true
+      register: terminate_tag
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_tag is not failed
+          - terminate_tag is not changed
+          - '"ec2:TerminateInstances" not in terminate_tag.resource_actions'
+          - '"terminate_failed" not in terminate_tag'
+          - '"terminate_success" not in terminate_tag'
+
+    ################################################################
+
+    - name: Terminate instance based on id (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ create_instance_id_2 }}"
+        wait: true
+      register: terminate_id
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is changed
+          - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
+          - '"terminate_failed" in terminate_id'
+          - '"terminate_success" in terminate_id'
+          - terminate_id.terminate_failed | length == 0
+          - terminate_id.terminate_success | length == 1
+          - terminate_id.terminate_success[0] == create_instance_id_2
+
+    - name: Terminate instance based on id
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ create_instance_id_2 }}"
+        wait: true
+      register: terminate_id
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is changed
+          - '"ec2:TerminateInstances" in terminate_id.resource_actions'
+          - '"terminate_failed" in terminate_id'
+          - '"terminate_success" in terminate_id'
+          - terminate_id.terminate_failed | length == 0
+          - terminate_id.terminate_success | length == 1
+          - terminate_id.terminate_success[0] == create_instance_id_2
+
+    - name: Terminate instance based on id - idempotency (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ create_instance_id_2 }}"
+        wait: true
+      register: terminate_id
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is not changed
+          - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
+          - '"terminate_failed" not in terminate_id'
+          - '"terminate_success" not in terminate_id'
+
+    - name: Terminate instance based on id - idempotency
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ create_instance_id_2 }}"
+        wait: true
+      register: terminate_id
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is not changed
+          - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
+          - '"terminate_failed" not in terminate_id'
+          - '"terminate_success" not in terminate_id'
+
+    ################################################################
+
+    - name: Terminate instance based on id (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ create_instance_id_3 }}"
+        wait: true
+      register: terminate_id
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is changed
+          - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
+          - '"terminate_failed" in terminate_id'
+          - '"terminate_success" in terminate_id'
+          - terminate_id.terminate_failed | length == 0
+          - terminate_id.terminate_success | length == 1
+          - terminate_id.terminate_success[0] == create_instance_id_3
+
+    - name: Terminate instance based on id
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ create_instance_id_3 }}"
+        wait: true
+      register: terminate_id
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is changed
+          - '"ec2:TerminateInstances" in terminate_id.resource_actions'
+          - '"terminate_failed" in terminate_id'
+          - '"terminate_success" in terminate_id'
+          - terminate_id.terminate_failed | length == 0
+          - terminate_id.terminate_success | length == 1
+          - terminate_id.terminate_success[0] == create_instance_id_3
+
+    - name: Terminate instance based on id - idempotency (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ create_instance_id_3 }}"
+        wait: true
+      register: terminate_id
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is not changed
+          - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
+          - '"terminate_failed" not in terminate_id'
+          - '"terminate_success" not in terminate_id'
+
+    - name: Terminate instance based on id - idempotency
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ create_instance_id_3 }}"
+        wait: true
+      register: terminate_id
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is not changed
+          - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
+          - '"terminate_failed" not in terminate_id'
+          - '"terminate_success" not in terminate_id'
+
+    ################################################################
+
+    - name: Terminate instance based on id (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ create_instance_id_4 }}"
+        wait: true
+      register: terminate_id
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is changed
+          - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
+          - '"terminate_failed" in terminate_id'
+          - '"terminate_success" in terminate_id'
+          - terminate_id.terminate_failed | length == 0
+          - terminate_id.terminate_success | length == 1
+          - terminate_id.terminate_success[0] == create_instance_id_4
+
+    - name: Terminate instance based on id
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ create_instance_id_4 }}"
+        wait: true
+      register: terminate_id
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is changed
+          - '"ec2:TerminateInstances" in terminate_id.resource_actions'
+          - '"terminate_failed" in terminate_id'
+          - '"terminate_success" in terminate_id'
+          - terminate_id.terminate_failed | length == 0
+          - terminate_id.terminate_success | length == 1
+          - terminate_id.terminate_success[0] == create_instance_id_4
+
+    - name: Terminate instance based on id - idempotency (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ create_instance_id_4 }}"
+        wait: true
+      register: terminate_id
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is not changed
+          - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
+          - '"terminate_failed" not in terminate_id'
+          - '"terminate_success" not in terminate_id'
+
+    - name: Terminate instance based on id - idempotency
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ create_instance_id_4 }}"
+        wait: true
+      register: terminate_id
+
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is not changed
+          - '"ec2:TerminateInstances" not in terminate_id.resource_actions'
+          - '"terminate_failed" not in terminate_id'
+          - '"terminate_success" not in terminate_id'

--- a/tests/integration/targets/ec2_instance_instance_multiple/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_multiple/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_multiple
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-instance-multiple'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-multiple"

--- a/tests/integration/targets/ec2_instance_instance_multiple/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_multiple/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: multiple_instances
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: multiple_instances

--- a/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -5,440 +6,435 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-################################################################
+    ################################################################
 
-  - name: "Create multiple instance (check_mode)"
-    ec2_instance:
-      instance_type: "{{ ec2_instance_type }}"
-      count: 5
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      state: present
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      filters:
-        "tag:TestId": "{{ ec2_instance_tag_TestId }}"
-    register: create_multiple_instances
-    check_mode: true
+    - name: Create multiple instance (check_mode)
+      amazon.aws.ec2_instance:
+        instance_type: "{{ ec2_instance_type }}"
+        count: 5
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        state: present
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        filters:
+          tag:TestId: "{{ ec2_instance_tag_TestId }}"
+      register: create_multiple_instances
+      check_mode: true
 
-  - assert:
-      that:
-      - create_multiple_instances is not failed
-      - create_multiple_instances is changed
-      - '"instance_ids" not in create_multiple_instances'
-      - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
+    - ansible.builtin.assert:
+        that:
+          - create_multiple_instances is not failed
+          - create_multiple_instances is changed
+          - '"instance_ids" not in create_multiple_instances'
+          - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
 
-  - name: "Create multiple instances"
-    ec2_instance:
-      instance_type: "{{ ec2_instance_type }}"
-      count: 5
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      state: present
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      filters:
-       "tag:TestId": "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_multiple_instances
+    - name: Create multiple instances
+      amazon.aws.ec2_instance:
+        instance_type: "{{ ec2_instance_type }}"
+        count: 5
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        state: present
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        filters:
+          tag:TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_multiple_instances
 
-  - assert:
-      that:
-      - create_multiple_instances is not failed
-      - create_multiple_instances is changed
-      - '"ec2:RunInstances" in create_multiple_instances.resource_actions'
-      - '"instance_ids" in create_multiple_instances'
-      - create_multiple_instances.instance_ids | length == 5
+    - ansible.builtin.assert:
+        that:
+          - create_multiple_instances is not failed
+          - create_multiple_instances is changed
+          - '"ec2:RunInstances" in create_multiple_instances.resource_actions'
+          - '"instance_ids" in create_multiple_instances'
+          - create_multiple_instances.instance_ids | length == 5
 
-  - name: "Save instance IDs"
-    set_fact:
-      created_instance_ids: "{{ create_multiple_instances.instance_ids }}"
+    - name: Save instance IDs
+      ansible.builtin.set_fact:
+        created_instance_ids: "{{ create_multiple_instances.instance_ids }}"
 
-# Terminate instances created in count test
+    # Terminate instances created in count test
 
-  - name: "Terminate instance based on id (check_mode)"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ item }}"
-    register: terminate_id
-    check_mode: true
-    with_items: "{{ created_instance_ids }}"
+    - name: Terminate instance based on id (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ item }}"
+      register: terminate_id
+      check_mode: true
+      with_items: "{{ created_instance_ids }}"
 
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is changed
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is changed
 
-  - name: "Terminate instance based on id"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ item }}"
-      wait: true
-    register: terminate_id
-    with_items: "{{ created_instance_ids }}"
+    - name: Terminate instance based on id
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ item }}"
+        wait: true
+      register: terminate_id
+      with_items: "{{ created_instance_ids }}"
 
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is changed
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is changed
 
-  - name: "Terminate instance based on id - Idempotency (check_mode)"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ item }}"
-    register: terminate_id
-    check_mode: true
-    with_items: "{{ created_instance_ids }}"
+    - name: Terminate instance based on id - Idempotency (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ item }}"
+      register: terminate_id
+      check_mode: true
+      with_items: "{{ created_instance_ids }}"
 
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is not changed
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is not changed
 
-  - name: "Terminate instance based on id - Idempotency"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ item }}"
-    register: terminate_id
-    with_items: "{{ created_instance_ids }}"
+    - name: Terminate instance based on id - Idempotency
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ item }}"
+      register: terminate_id
+      with_items: "{{ created_instance_ids }}"
 
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is not changed
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is not changed
 
-################################################################
+    ################################################################
 
-  - name: "Enforce instance count - launch 5 instances (check_mode)"
-    ec2_instance:
-      instance_type: "{{ ec2_instance_type }}"
-      exact_count: 5
-      region: "{{ aws_region }}"
-      name: "{{ resource_prefix }}-test-enf_cnt"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-    register: create_multiple_instances
-    check_mode: true
+    - name: Enforce instance count - launch 5 instances (check_mode)
+      amazon.aws.ec2_instance:
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 5
+        region: "{{ aws_region }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+      register: create_multiple_instances
+      check_mode: true
 
-  - assert:
-      that:
-      - create_multiple_instances is not failed
-      - create_multiple_instances is changed
-      - '"instance_ids" not in create_multiple_instances'
-      - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
+    - ansible.builtin.assert:
+        that:
+          - create_multiple_instances is not failed
+          - create_multiple_instances is changed
+          - '"instance_ids" not in create_multiple_instances'
+          - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
 
-  - name: "Enforce instance count - launch 5 instances"
-    ec2_instance:
-      instance_type: "{{ ec2_instance_type }}"
-      exact_count: 5
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      name: "{{ resource_prefix }}-test-enf_cnt"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_multiple_instances
+    - name: Enforce instance count - launch 5 instances
+      amazon.aws.ec2_instance:
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 5
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_multiple_instances
 
-  - assert:
-      that:
-      - create_multiple_instances is not failed
-      - create_multiple_instances is changed
-      - '"ec2:RunInstances" in create_multiple_instances.resource_actions'
-      - '"instance_ids" in create_multiple_instances'
-      - create_multiple_instances.instance_ids | length == 5
+    - ansible.builtin.assert:
+        that:
+          - create_multiple_instances is not failed
+          - create_multiple_instances is changed
+          - '"ec2:RunInstances" in create_multiple_instances.resource_actions'
+          - '"instance_ids" in create_multiple_instances'
+          - create_multiple_instances.instance_ids | length == 5
 
-  - name: "Enforce instance count - launch 5 instances (check_mode - Idempotency)"
-    ec2_instance:
-      instance_type: "{{ ec2_instance_type }}"
-      exact_count: 5
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      name: "{{ resource_prefix }}-test-enf_cnt"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-    register: create_multiple_instances
-    check_mode: true
+    - name: Enforce instance count - launch 5 instances (check_mode - Idempotency)
+      amazon.aws.ec2_instance:
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 5
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+      register: create_multiple_instances
+      check_mode: true
 
-  - assert:
-      that:
-      - create_multiple_instances is not failed
-      - create_multiple_instances is not changed
-      - '"instance_ids" in create_multiple_instances'
-      - create_multiple_instances.instance_ids | length == 5
-      - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
+    - ansible.builtin.assert:
+        that:
+          - create_multiple_instances is not failed
+          - create_multiple_instances is not changed
+          - '"instance_ids" in create_multiple_instances'
+          - create_multiple_instances.instance_ids | length == 5
+          - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
 
-  - name: "Enforce instance count - launch 5 instances (Idempotency)"
-    ec2_instance:
-      instance_type: "{{ ec2_instance_type }}"
-      exact_count: 5
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      name: "{{ resource_prefix }}-test-enf_cnt"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_multiple_instances
+    - name: Enforce instance count - launch 5 instances (Idempotency)
+      amazon.aws.ec2_instance:
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 5
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_multiple_instances
 
-  - assert:
-      that:
-      - create_multiple_instances is not failed
-      - create_multiple_instances is not changed
-      - '"instance_ids" in create_multiple_instances'
-      - create_multiple_instances.instance_ids | length == 5
-      - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
+    - ansible.builtin.assert:
+        that:
+          - create_multiple_instances is not failed
+          - create_multiple_instances is not changed
+          - '"instance_ids" in create_multiple_instances'
+          - create_multiple_instances.instance_ids | length == 5
+          - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
 
-  - name: "Enforce instance count to 3 - Terminate 2 instances (check_mode)"
-    ec2_instance:
-      instance_type: "{{ ec2_instance_type }}"
-      exact_count: 3
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      name: "{{ resource_prefix }}-test-enf_cnt"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-    register: terminate_multiple_instances
-    check_mode: true
+    - name: Enforce instance count to 3 - Terminate 2 instances (check_mode)
+      amazon.aws.ec2_instance:
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 3
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+      register: terminate_multiple_instances
+      check_mode: true
 
-  - assert:
-      that:
-      - terminate_multiple_instances is not failed
-      - terminate_multiple_instances is changed
-      - '"instance_ids" in terminate_multiple_instances'
-      - terminate_multiple_instances.instance_ids | length == 5
-      - '"terminated_ids" in terminate_multiple_instances'
-      - terminate_multiple_instances.terminated_ids | length == 2
-      - '"ec2:RunInstances" not in terminate_multiple_instances.resource_actions'
+    - ansible.builtin.assert:
+        that:
+          - terminate_multiple_instances is not failed
+          - terminate_multiple_instances is changed
+          - '"instance_ids" in terminate_multiple_instances'
+          - terminate_multiple_instances.instance_ids | length == 5
+          - '"terminated_ids" in terminate_multiple_instances'
+          - terminate_multiple_instances.terminated_ids | length == 2
+          - '"ec2:RunInstances" not in terminate_multiple_instances.resource_actions'
 
-  - name: "Enforce instance count to 3 - Terminate 2 instances"
-    ec2_instance:
-      instance_type: "{{ ec2_instance_type }}"
-      exact_count: 3
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      name: "{{ resource_prefix }}-test-enf_cnt"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: terminate_multiple_instances
+    - name: Enforce instance count to 3 - Terminate 2 instances
+      amazon.aws.ec2_instance:
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 3
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: terminate_multiple_instances
 
-  - assert:
-      that:
-      - terminate_multiple_instances is not failed
-      - terminate_multiple_instances is changed
-      - '"instance_ids" in terminate_multiple_instances'
-      - terminate_multiple_instances.instance_ids | length == 5
-      - '"terminated_ids" in terminate_multiple_instances'
-      - terminate_multiple_instances.terminated_ids | length == 2
+    - ansible.builtin.assert:
+        that:
+          - terminate_multiple_instances is not failed
+          - terminate_multiple_instances is changed
+          - '"instance_ids" in terminate_multiple_instances'
+          - terminate_multiple_instances.instance_ids | length == 5
+          - '"terminated_ids" in terminate_multiple_instances'
+          - terminate_multiple_instances.terminated_ids | length == 2
 
-  - name: "Enforce instance count to 3 - Terminate 2 instances (check_mode - Idempotency)"
-    ec2_instance:
-      instance_type: "{{ ec2_instance_type }}"
-      exact_count: 3
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      name: "{{ resource_prefix }}-test-enf_cnt"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-    register: terminate_multiple_instances
-    check_mode: true
+    - name: Enforce instance count to 3 - Terminate 2 instances (check_mode - Idempotency)
+      amazon.aws.ec2_instance:
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 3
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+      register: terminate_multiple_instances
+      check_mode: true
 
-  - assert:
-      that:
-      - terminate_multiple_instances is not failed
-      - terminate_multiple_instances is not changed
-      - '"instance_ids" in terminate_multiple_instances'
-      - terminate_multiple_instances.instance_ids | length == 3
-      - '"terminated_ids" not in terminate_multiple_instances'
-      - '"ec2:TerminateInstances" not in terminate_multiple_instances.resource_actions'
+    - ansible.builtin.assert:
+        that:
+          - terminate_multiple_instances is not failed
+          - terminate_multiple_instances is not changed
+          - '"instance_ids" in terminate_multiple_instances'
+          - terminate_multiple_instances.instance_ids | length == 3
+          - '"terminated_ids" not in terminate_multiple_instances'
+          - '"ec2:TerminateInstances" not in terminate_multiple_instances.resource_actions'
 
-  - name: "Enforce instance count to 3 - Terminate 2 instances (Idempotency)"
-    ec2_instance:
-      instance_type: "{{ ec2_instance_type }}"
-      exact_count: 3
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      name: "{{ resource_prefix }}-test-enf_cnt"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-    register: terminate_multiple_instances
+    - name: Enforce instance count to 3 - Terminate 2 instances (Idempotency)
+      amazon.aws.ec2_instance:
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 3
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+      register: terminate_multiple_instances
 
-  - assert:
-      that:
-      - terminate_multiple_instances is not failed
-      - terminate_multiple_instances is not changed
-      - '"instance_ids" in terminate_multiple_instances'
-      - terminate_multiple_instances.instance_ids | length == 3
-      - '"terminated_ids" not in terminate_multiple_instances'
-      - '"ec2:TerminateInstances" not in terminate_multiple_instances.resource_actions'
+    - ansible.builtin.assert:
+        that:
+          - terminate_multiple_instances is not failed
+          - terminate_multiple_instances is not changed
+          - '"instance_ids" in terminate_multiple_instances'
+          - terminate_multiple_instances.instance_ids | length == 3
+          - '"terminated_ids" not in terminate_multiple_instances'
+          - '"ec2:TerminateInstances" not in terminate_multiple_instances.resource_actions'
 
-  - name: "Enforce instance count to 6 - Launch 3 more instances (check_mode)"
-    ec2_instance:
-      instance_type: "{{ ec2_instance_type }}"
-      exact_count: 6
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      name: "{{ resource_prefix }}-test-enf_cnt"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    check_mode: true
-    register: create_multiple_instances
+    - name: Enforce instance count to 6 - Launch 3 more instances (check_mode)
+      amazon.aws.ec2_instance:
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 6
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      check_mode: true
+      register: create_multiple_instances
 
-  - assert:
-      that:
-      - create_multiple_instances is not failed
-      - create_multiple_instances is changed
-      - '"instance_ids" in create_multiple_instances'
-      - create_multiple_instances.instance_ids | length == 3
-      - '"changed_ids" not in create_multiple_instances'
-      - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
+    - ansible.builtin.assert:
+        that:
+          - create_multiple_instances is not failed
+          - create_multiple_instances is changed
+          - '"instance_ids" in create_multiple_instances'
+          - create_multiple_instances.instance_ids | length == 3
+          - '"changed_ids" not in create_multiple_instances'
+          - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
 
-  - name: "Enforce instance count to 6 - Launch 3 more instances"
-    ec2_instance:
-      state: 'running'
-      instance_type: "{{ ec2_instance_type }}"
-      exact_count: 6
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      name: "{{ resource_prefix }}-test-enf_cnt"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_multiple_instances
+    - name: Enforce instance count to 6 - Launch 3 more instances
+      amazon.aws.ec2_instance:
+        state: running
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 6
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_multiple_instances
 
-  - name: debug is here
-    debug: msg="{{ create_multiple_instances.instance_ids }}"
+    - name: debug is here
+      ansible.builtin.debug: msg="{{ create_multiple_instances.instance_ids }}"
+    - ansible.builtin.assert:
+        that:
+          - create_multiple_instances is not failed
+          - create_multiple_instances is changed
+          - '"instance_ids" in create_multiple_instances'
+          - create_multiple_instances.instance_ids | length == 6
+          - '"changed_ids" in create_multiple_instances'
+          - create_multiple_instances.changed_ids | length == 3
 
-  - assert:
-      that:
-      - create_multiple_instances is not failed
-      - create_multiple_instances is changed
-      - '"instance_ids" in create_multiple_instances'
-      - create_multiple_instances.instance_ids | length == 6
-      - '"changed_ids" in create_multiple_instances'
-      - create_multiple_instances.changed_ids | length == 3
+    - name: Enforce instance count to 6 - Launch 3 more instances (check_mode - Idempotency)
+      amazon.aws.ec2_instance:
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 6
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      check_mode: true
+      register: create_multiple_instances
 
-  - name: "Enforce instance count to 6 - Launch 3 more instances (check_mode - Idempotency)"
-    ec2_instance:
-      instance_type: "{{ ec2_instance_type }}"
-      exact_count: 6
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      name: "{{ resource_prefix }}-test-enf_cnt"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    check_mode: true
-    register: create_multiple_instances
+    - ansible.builtin.assert:
+        that:
+          - create_multiple_instances is not failed
+          - create_multiple_instances is not changed
+          - '"instance_ids" in create_multiple_instances'
+          - create_multiple_instances.instance_ids | length == 6
+          - '"changed_ids" not in create_multiple_instances'
+          - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
 
-  - assert:
-      that:
-      - create_multiple_instances is not failed
-      - create_multiple_instances is not changed
-      - '"instance_ids" in create_multiple_instances'
-      - create_multiple_instances.instance_ids | length == 6
-      - '"changed_ids" not in create_multiple_instances'
-      - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
+    - name: Enforce instance count to 6 - Launch 3 more instances (Idempotency)
+      amazon.aws.ec2_instance:
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 6
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: create_multiple_instances
 
-  - name: "Enforce instance count to 6 - Launch 3 more instances (Idempotency)"
-    ec2_instance:
-      instance_type: "{{ ec2_instance_type }}"
-      exact_count: 6
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      name: "{{ resource_prefix }}-test-enf_cnt"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: true
-    register: create_multiple_instances
+    - ansible.builtin.assert:
+        that:
+          - create_multiple_instances is not failed
+          - create_multiple_instances is not changed
+          - '"instance_ids" in create_multiple_instances'
+          - create_multiple_instances.instance_ids | length == 6
+          - '"changed_ids" not in create_multiple_instances'
+          - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
 
-  - assert:
-      that:
-      - create_multiple_instances is not failed
-      - create_multiple_instances is not changed
-      - '"instance_ids" in create_multiple_instances'
-      - create_multiple_instances.instance_ids | length == 6
-      - '"changed_ids" not in create_multiple_instances'
-      - '"ec2:RunInstances" not in create_multiple_instances.resource_actions'
+    - name: Gather information about any running instance with Name ending with "-test-enf_cnt"
+      amazon.aws.ec2_instance_info:
+        region: "{{ aws_region }}"
+        filters:
+          tag:Name: "*-test-enf_cnt"
+          instance-state-name: [running]
+      register: test_instances
 
+    - name: set fact
+      ansible.builtin.set_fact: test_instances_ids="{{ test_instances.instances[item].instance_id }}"
+      loop: "{{ range(0, test_instances.instances | length) | list }}"
+      register: test_instances_list
 
-  - name: Gather information about any running instance with Name ending with "-test-enf_cnt"
-    ec2_instance_info:
-      region: "{{ aws_region }}"
-      filters:
-        "tag:Name": "*-test-enf_cnt"
-        instance-state-name: [ "running"]
-    register: test_instances
+    - name: Make a list of ids
+      ansible.builtin.set_fact: instances_to_terminate="{{ test_instances_list.results | map(attribute='ansible_facts.test_instances_ids') | list }}"
+    - name: Terminate instance based on id (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ item }}"
+        wait: true
+      register: terminate_id
+      check_mode: true
+      with_items: "{{ instances_to_terminate }}"
 
-  - name: set fact
-    set_fact: test_instances_ids="{{ test_instances.instances[item].instance_id }}"
-    loop: "{{ range(0, test_instances.instances | length) | list }}"
-    register: test_instances_list
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is changed
 
-  - name: Make a list of ids
-    set_fact: instances_to_terminate="{{ test_instances_list.results | map(attribute='ansible_facts.test_instances_ids') | list }}"
+    - name: Terminate instance based on id
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ item }}"
+        wait: true
+      register: terminate_id
+      with_items: "{{ instances_to_terminate }}"
 
-# Terminate instances created in enforce count test
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is changed
 
-  - name: "Terminate instance based on id (check_mode)"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ item }}"
-      wait: true
-    register: terminate_id
-    check_mode: true
-    with_items: "{{ instances_to_terminate }}"
+    - name: Terminate instance based on id - Idempotency (check_mode)
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ item }}"
+        wait: true
+      register: terminate_id
+      check_mode: true
+      with_items: "{{ instances_to_terminate }}"
 
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is changed
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is not changed
 
-  - name: "Terminate instance based on id"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ item }}"
-      wait: true
-    register: terminate_id
-    with_items: "{{ instances_to_terminate }}"
+    - name: Terminate instance based on id - Idempotency
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ item }}"
+        wait: true
+      register: terminate_id
+      with_items: "{{ instances_to_terminate }}"
 
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is changed
-
-  - name: "Terminate instance based on id - Idempotency (check_mode)"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ item }}"
-      wait: true
-    register: terminate_id
-    check_mode: true
-    with_items: "{{ instances_to_terminate }}"
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is not changed
-
-  - name: "Terminate instance based on id - Idempotency"
-    ec2_instance:
-      state: absent
-      instance_ids:
-      - "{{ item }}"
-      wait: true
-    register: terminate_id
-    with_items: "{{ instances_to_terminate }}"
-
-  - assert:
-      that:
-      - terminate_id is not failed
-      - terminate_id is not changed
+    - ansible.builtin.assert:
+        that:
+          - terminate_id is not failed
+          - terminate_id is not changed

--- a/tests/integration/targets/ec2_instance_instance_no_wait/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_no_wait/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_no_wait
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-instance-no-wait'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-no-wait"

--- a/tests/integration/targets/ec2_instance_instance_no_wait/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_no_wait/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: no_wait
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: no_wait

--- a/tests/integration/targets/ec2_instance_instance_no_wait/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_no_wait/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -5,54 +6,54 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: "New instance and don't wait for it to complete"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-no-wait"
-      image_id: "{{ ec2_ami_id }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: false
-      instance_type: "{{ ec2_instance_type }}"
-    register: in_test_vpc
+    - name: New instance and don't wait for it to complete
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-no-wait"
+        image_id: "{{ ec2_ami_id }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: false
+        instance_type: "{{ ec2_instance_type }}"
+      register: in_test_vpc
 
-  - assert:
-      that:
-      - in_test_vpc is not failed
-      - in_test_vpc is changed
-      - in_test_vpc.instances is not defined
-      - in_test_vpc.instance_ids is defined
-      - in_test_vpc.instance_ids | length > 0
+    - ansible.builtin.assert:
+        that:
+          - in_test_vpc is not failed
+          - in_test_vpc is changed
+          - in_test_vpc.instances is not defined
+          - in_test_vpc.instance_ids is defined
+          - in_test_vpc.instance_ids | length > 0
 
-  - name: "New instance and don't wait for it to complete ( check mode )"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-no-wait-checkmode"
-      image_id: "{{ ec2_ami_id }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      wait: false
-      instance_type: "{{ ec2_instance_type }}"
-    check_mode: yes
+    - name: New instance and don't wait for it to complete ( check mode )
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-no-wait-checkmode"
+        image_id: "{{ ec2_ami_id }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: false
+        instance_type: "{{ ec2_instance_type }}"
+      check_mode: true
 
-  - name: "Facts for ec2 test instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-no-wait"
-    register: real_instance_fact
-    until: real_instance_fact.instances | length > 0
-    retries: 10
+    - name: Facts for ec2 test instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-no-wait"
+      register: real_instance_fact
+      until: real_instance_fact.instances | length > 0
+      retries: 10
 
-  - name: "Facts for checkmode ec2 test instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-no-wait-checkmode"
-    register: checkmode_instance_fact
+    - name: Facts for checkmode ec2 test instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-no-wait-checkmode"
+      register: checkmode_instance_fact
 
-  - name: "Confirm whether the check mode is working normally."
-    assert:
-      that:
-        - real_instance_fact.instances | length > 0
-        - checkmode_instance_fact.instances | length == 0
+    - name: Confirm whether the check mode is working normally.
+      ansible.builtin.assert:
+        that:
+          - real_instance_fact.instances | length > 0
+          - checkmode_instance_fact.instances | length == 0

--- a/tests/integration/targets/ec2_instance_license_specifications/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_license_specifications/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for ec2_instance_block_devices
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-license-specifications'
-ec2_host_resource_group_arn: 'arn:aws:resource-groups:{{ aws_region }}:123456789012:group/{{ resource_prefix }}-resource-group'
-ec2_license_configuration_arn: 'arn:aws:license-manager:{{ aws_region }}:123456789012:license-configuration:lic-0123456789'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-license-specifications"
+ec2_host_resource_group_arn: arn:aws:resource-groups:{{ aws_region }}:123456789012:group/{{ resource_prefix }}-resource-group
+ec2_license_configuration_arn: arn:aws:license-manager:{{ aws_region }}:123456789012:license-configuration:lic-0123456789

--- a/tests/integration/targets/ec2_instance_license_specifications/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_license_specifications/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: license_specifications
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: license_specifications

--- a/tests/integration/targets/ec2_instance_license_specifications/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_license_specifications/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -5,25 +6,25 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: "New instance with license specifications"
-    ec2_instance:
-      state: running
-      name: "{{ resource_prefix }}-test-ebs-vols"
-      image_id: "{{ ec2_ami_id }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      placement:
-        host_resource_group_arn: "{{ ec2_host_resource_group_arn }}"
-      license_specifications:
-        - license_configuration_arn: "{{ ec2_license_configuration_arn }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      instance_type: "{{ ec2_instance_type }}"
-      wait: true
-    ignore_errors: true
-    register: instance_creation
+    - name: New instance with license specifications
+      amazon.aws.ec2_instance:
+        state: running
+        name: "{{ resource_prefix }}-test-ebs-vols"
+        image_id: "{{ ec2_ami_id }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        placement:
+          host_resource_group_arn: "{{ ec2_host_resource_group_arn }}"
+        license_specifications:
+          - license_configuration_arn: "{{ ec2_license_configuration_arn }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        instance_type: "{{ ec2_instance_type }}"
+        wait: true
+      ignore_errors: true
+      register: instance_creation
 
-  - name: "Validate instance with license specifications"
-    assert:
-      that:
-        - instance_creation is failed
-        - '"An instance is associated with one or more unshared license configurations." in instance_creation.msg'
+    - name: Validate instance with license specifications
+      ansible.builtin.assert:
+        that:
+          - instance_creation is failed
+          - '"An instance is associated with one or more unshared license configurations." in instance_creation.msg'

--- a/tests/integration/targets/ec2_instance_metadata_options/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_metadata_options
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-instance-metadata'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-metadata"

--- a/tests/integration/targets/ec2_instance_metadata_options/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: metadata
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: metadata

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - name: test with boto3 version that supports instance_metadata_tags
   module_defaults:
     group/aws:
@@ -6,59 +7,59 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: "create t3.nano instance with metadata_options"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-t3nano-enabled-required"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      instance_type: t3.nano
-      metadata_options:
+    - name: create t3.nano instance with metadata_options
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-t3nano-enabled-required"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        instance_type: t3.nano
+        metadata_options:
           http_endpoint: enabled
           http_tokens: required
           instance_metadata_tags: enabled
-      wait: false
-    register: instance_creation
+        wait: false
+      register: instance_creation
 
-  - name: "instance with metadata_options created with the right options"
-    assert:
-      that:
-        - instance_creation is success
-        - instance_creation is changed
-        - "'{{ instance_creation.spec.MetadataOptions.HttpEndpoint }}' == 'enabled'"
-        - "'{{ instance_creation.spec.MetadataOptions.HttpTokens }}' == 'required'"
-        - "'{{ instance_creation.spec.MetadataOptions.InstanceMetadataTags }}' == 'enabled'"
+    - name: instance with metadata_options created with the right options
+      ansible.builtin.assert:
+        that:
+          - instance_creation is success
+          - instance_creation is changed
+          - "'{{ instance_creation.spec.MetadataOptions.HttpEndpoint }}' == 'enabled'"
+          - "'{{ instance_creation.spec.MetadataOptions.HttpTokens }}' == 'required'"
+          - "'{{ instance_creation.spec.MetadataOptions.InstanceMetadataTags }}' == 'enabled'"
 
-  - name: "modify metadata_options on existing instance"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-t3nano-enabled-required"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      instance_type: t3.nano
-      metadata_options:
+    - name: modify metadata_options on existing instance
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-t3nano-enabled-required"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        instance_type: t3.nano
+        metadata_options:
           http_endpoint: enabled
           http_tokens: optional
-      wait: false
-    register: metadata_options_update
-    ignore_errors: yes
+        wait: false
+      register: metadata_options_update
+      ignore_errors: true
 
-  - name: "fact presented ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-t3nano-enabled-required"
-    register: presented_instance_fact
+    - name: fact presented ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-t3nano-enabled-required"
+      register: presented_instance_fact
 
-  - name: "modify metadata_options has no effect on existing instance"
-    assert:
-      that:
-        - metadata_options_update is success
-        - metadata_options_update is not changed
-        - presented_instance_fact.instances | length > 0
-        - presented_instance_fact.instances.0.state.name in ['running','pending']
-        - presented_instance_fact.instances.0.metadata_options.http_endpoint == 'enabled'
-        - presented_instance_fact.instances.0.metadata_options.http_tokens == 'required'
+    - name: modify metadata_options has no effect on existing instance
+      ansible.builtin.assert:
+        that:
+          - metadata_options_update is success
+          - metadata_options_update is not changed
+          - presented_instance_fact.instances | length > 0
+          - presented_instance_fact.instances.0.state.name in ['running','pending']
+          - presented_instance_fact.instances.0.metadata_options.http_endpoint == 'enabled'
+          - presented_instance_fact.instances.0.metadata_options.http_tokens == 'required'

--- a/tests/integration/targets/ec2_instance_placement_options/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_placement_options/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for ec2_instance_block_devices
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-placement-group'
-ec2_tenancy: 'dedicated'
-ec2_placement_group_name: '{{ resource_prefix}}-placement-group'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-placement-group"
+ec2_tenancy: dedicated
+ec2_placement_group_name: "{{ resource_prefix}}-placement-group"

--- a/tests/integration/targets/ec2_instance_placement_options/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_placement_options/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: placement_options
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: placement_options

--- a/tests/integration/targets/ec2_instance_placement_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_placement_options/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -5,76 +6,76 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: New placement group
-    community.aws.ec2_placement_group:
-      name: "{{ ec2_placement_group_name }}"
-      strategy: partition
-      partition_count: 1
-      state: present
+    - name: New placement group
+      community.aws.ec2_placement_group:
+        name: "{{ ec2_placement_group_name }}"
+        strategy: partition
+        partition_count: 1
+        state: present
 
-  - name: New instance with placement group name
-    ec2_instance:
-      state: running
-      name: "{{ resource_prefix }}-test-placement-group-name"
-      image_id: "{{ ec2_ami_id }}"
-      placement:
-        group_name: "{{ ec2_placement_group_name }}"
-      tags:
-        Name: "{{ resource_prefix }}-test-placement-group-name"
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      security_group: default
-      instance_type: "{{ ec2_instance_type }}"
-      wait: true
-    ignore_errors: true
-    register: instance_creation
+    - name: New instance with placement group name
+      amazon.aws.ec2_instance:
+        state: running
+        name: "{{ resource_prefix }}-test-placement-group-name"
+        image_id: "{{ ec2_ami_id }}"
+        placement:
+          group_name: "{{ ec2_placement_group_name }}"
+        tags:
+          Name: "{{ resource_prefix }}-test-placement-group-name"
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        security_group: default
+        instance_type: "{{ ec2_instance_type }}"
+        wait: true
+      ignore_errors: true
+      register: instance_creation
 
-  - name: Gather ec2 facts to check placement group options
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-placement-group-name"
-        "tag:TestId": "{{ ec2_instance_tag_TestId }}"
-        "instance-state-name": "running"
-    ignore_errors: true
-    register: instance_facts
+    - name: Gather ec2 facts to check placement group options
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-placement-group-name"
+          tag:TestId: "{{ ec2_instance_tag_TestId }}"
+          instance-state-name: running
+      ignore_errors: true
+      register: instance_facts
 
-  - name: Validate instance with placement group name
-    assert:
-      that:
-        - instance_creation is success
-        - instance_creation is changed
-        - instance_facts.instances[0].placement.group_name == ec2_placement_group_name
-        # - instance_creation is failed
-        # - '"You are not authorized to perform this operation." in instance_creation.msg'
+    - name: Validate instance with placement group name
+      ansible.builtin.assert:
+        that:
+          - instance_creation is success
+          - instance_creation is changed
+          - instance_facts.instances[0].placement.group_name == ec2_placement_group_name
+    # - instance_creation is failed
+    # - '"You are not authorized to perform this operation." in instance_creation.msg'
 
-  - name: New instance with dedicated tenancy
-    ec2_instance:
-      state: running
-      name: "{{ resource_prefix }}-test-dedicated-tenancy"
-      image_id: "{{ ec2_ami_id }}"
-      placement:
-        tenancy: "{{ ec2_tenancy }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      security_group: default
-      instance_type: "{{ ec2_instance_type }}"
-      wait: true
-    ignore_errors: true
-    register: instance_creation
+    - name: New instance with dedicated tenancy
+      amazon.aws.ec2_instance:
+        state: running
+        name: "{{ resource_prefix }}-test-dedicated-tenancy"
+        image_id: "{{ ec2_ami_id }}"
+        placement:
+          tenancy: "{{ ec2_tenancy }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        security_group: default
+        instance_type: "{{ ec2_instance_type }}"
+        wait: true
+      ignore_errors: true
+      register: instance_creation
 
-  - name: Gather ec2 facts to check placement tenancy
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-dedicated-tenancy"
-        "tag:TestId": "{{ ec2_instance_tag_TestId }}"
-        "instance-state-name": "running"
-    ignore_errors: true
-    register: instance_facts
+    - name: Gather ec2 facts to check placement tenancy
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-dedicated-tenancy"
+          tag:TestId: "{{ ec2_instance_tag_TestId }}"
+          instance-state-name: running
+      ignore_errors: true
+      register: instance_facts
 
-  - name: Validate instance with dedicated tenancy
-    assert:
-      that:
-        - instance_creation is success
-        - instance_creation is changed
-        - instance_facts.instances[0].placement.tenancy == ec2_tenancy
+    - name: Validate instance with dedicated tenancy
+      ansible.builtin.assert:
+        that:
+          - instance_creation is success
+          - instance_creation is changed
+          - instance_facts.instances[0].placement.tenancy == ec2_tenancy
         # - instance_creation is failed
         # - '"You are not authorized to perform this operation." in instance_creation.msg'

--- a/tests/integration/targets/ec2_instance_security_group/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_security_group/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_security_group
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-instance-sg'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-sg"

--- a/tests/integration/targets/ec2_instance_security_group/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_security_group/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: security_groups
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: security_groups

--- a/tests/integration/targets/ec2_instance_security_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_security_group/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -5,84 +6,84 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: "New instance with 2 security groups"
-    ec2_instance:
-      state: 'running'
-      name: "{{ resource_prefix }}-test-security-groups"
-      image_id: "{{ ec2_ami_id }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ resource_prefix }}"
-      instance_type: t2.micro
-      wait: true
-      security_groups:
-        - "{{ sg.group_id }}"
-        - "{{ sg2.group_id }}"
-    register: security_groups_test
+    - name: New instance with 2 security groups
+      amazon.aws.ec2_instance:
+        state: running
+        name: "{{ resource_prefix }}-test-security-groups"
+        image_id: "{{ ec2_ami_id }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ resource_prefix }}"
+        instance_type: t2.micro
+        wait: true
+        security_groups:
+          - "{{ sg.group_id }}"
+          - "{{ sg2.group_id }}"
+      register: security_groups_test
 
-  - name: "Recreate same instance with 2 security groups ( Idempotency )"
-    ec2_instance:
-      name: "{{ resource_prefix }}-test-security-groups"
-      image_id: "{{ ec2_ami_id }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ resource_prefix }}"
-      instance_type: t2.micro
-      wait: false
-      security_groups:
-        - "{{ sg.group_id }}"
-        - "{{ sg2.group_id }}"
-    register: security_groups_test_idempotency
+    - name: Recreate same instance with 2 security groups ( Idempotency )
+      amazon.aws.ec2_instance:
+        name: "{{ resource_prefix }}-test-security-groups"
+        image_id: "{{ ec2_ami_id }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ resource_prefix }}"
+        instance_type: t2.micro
+        wait: false
+        security_groups:
+          - "{{ sg.group_id }}"
+          - "{{ sg2.group_id }}"
+      register: security_groups_test_idempotency
 
-  - name: "Gather ec2 facts to check SGs have been added"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-security-groups"
-        "instance-state-name": "running"
-    register: dual_sg_instance_facts
-    until: dual_sg_instance_facts.instances | length > 0
-    retries: 10
+    - name: Gather ec2 facts to check SGs have been added
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-security-groups"
+          instance-state-name: running
+      register: dual_sg_instance_facts
+      until: dual_sg_instance_facts.instances | length > 0
+      retries: 10
 
-  - name: "Remove secondary security group from instance"
-    ec2_instance:
-      name: "{{ resource_prefix }}-test-security-groups"
-      image_id: "{{ ec2_ami_id }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ resource_prefix }}"
-      instance_type: t2.micro
-      security_groups:
-        - "{{ sg.group_id }}"
-    register: remove_secondary_security_group
+    - name: Remove secondary security group from instance
+      amazon.aws.ec2_instance:
+        name: "{{ resource_prefix }}-test-security-groups"
+        image_id: "{{ ec2_ami_id }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ resource_prefix }}"
+        instance_type: t2.micro
+        security_groups:
+          - "{{ sg.group_id }}"
+      register: remove_secondary_security_group
 
-  - name: "Gather ec2 facts to check seconday SG has been removed"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-security-groups"
-        "instance-state-name": "running"
-    register: single_sg_instance_facts
-    until: single_sg_instance_facts.instances | length > 0
-    retries: 10
+    - name: Gather ec2 facts to check seconday SG has been removed
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-security-groups"
+          instance-state-name: running
+      register: single_sg_instance_facts
+      until: single_sg_instance_facts.instances | length > 0
+      retries: 10
 
-  - name: "Add secondary security group to instance"
-    ec2_instance:
-      name: "{{ resource_prefix }}-test-security-groups"
-      image_id: "{{ ec2_ami_id }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      tags:
-        TestId: "{{ resource_prefix }}"
-      instance_type: t2.micro
-      security_groups:
-        - "{{ sg.group_id }}"
-        - "{{ sg2.group_id }}"
-    register: add_secondary_security_group
+    - name: Add secondary security group to instance
+      amazon.aws.ec2_instance:
+        name: "{{ resource_prefix }}-test-security-groups"
+        image_id: "{{ ec2_ami_id }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        tags:
+          TestId: "{{ resource_prefix }}"
+        instance_type: t2.micro
+        security_groups:
+          - "{{ sg.group_id }}"
+          - "{{ sg2.group_id }}"
+      register: add_secondary_security_group
 
-  - assert:
-      that:
-      - security_groups_test is not failed
-      - security_groups_test is changed
-      - security_groups_test_idempotency is not changed
-      - remove_secondary_security_group is changed
-      - single_sg_instance_facts.instances.0.security_groups | length == 1
-      - dual_sg_instance_facts.instances.0.security_groups | length == 2
-      - add_secondary_security_group is changed
+    - ansible.builtin.assert:
+        that:
+          - security_groups_test is not failed
+          - security_groups_test is changed
+          - security_groups_test_idempotency is not changed
+          - remove_secondary_security_group is changed
+          - single_sg_instance_facts.instances.0.security_groups | length == 1
+          - dual_sg_instance_facts.instances.0.security_groups | length == 2
+          - add_secondary_security_group is changed

--- a/tests/integration/targets/ec2_instance_tags_and_vpc_settings/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_tags_and_vpc_settings/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_tags_and_vpc_settings
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-instance-tags-vpc'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-tags-vpc"

--- a/tests/integration/targets/ec2_instance_tags_and_vpc_settings/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_tags_and_vpc_settings/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: tags_and_vpc
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: tags_and_vpc

--- a/tests/integration/targets/ec2_instance_tags_and_vpc_settings/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_tags_and_vpc_settings/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -5,175 +6,175 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: "Make instance in the testing subnet created in the test VPC"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_id }}"
-      user_data: |
-        #cloud-config
-        package_upgrade: true
-        package_update: true
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        Something: else
-      security_groups: "{{ sg.group_id }}"
-      network:
-        source_dest_check: false
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      instance_type: "{{ ec2_instance_type }}"
-      wait: false
-    register: in_test_vpc
+    - name: Make instance in the testing subnet created in the test VPC
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic-vpc-create"
+        image_id: "{{ ec2_ami_id }}"
+        user_data: |
+          #cloud-config
+          package_upgrade: true
+          package_update: true
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          Something: else
+        security_groups: "{{ sg.group_id }}"
+        network:
+          source_dest_check: false
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        instance_type: "{{ ec2_instance_type }}"
+        wait: false
+      register: in_test_vpc
 
-  - name: "Make instance in the testing subnet created in the test VPC(check mode)"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic-vpc-create-checkmode"
-      image_id: "{{ ec2_ami_id }}"
-      user_data: |
-        #cloud-config
-        package_upgrade: true
-        package_update: true
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        Something: else
-      security_groups: "{{ sg.group_id }}"
-      network:
-        source_dest_check: false
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      instance_type: "{{ ec2_instance_type }}"
-    check_mode: yes
+    - name: Make instance in the testing subnet created in the test VPC(check mode)
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic-vpc-create-checkmode"
+        image_id: "{{ ec2_ami_id }}"
+        user_data: |
+          #cloud-config
+          package_upgrade: true
+          package_update: true
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          Something: else
+        security_groups: "{{ sg.group_id }}"
+        network:
+          source_dest_check: false
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        instance_type: "{{ ec2_instance_type }}"
+      check_mode: true
 
-  - name: "Try to re-make the instance, hopefully this shows changed=False"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_id }}"
-      user_data: |
-        #cloud-config
-        package_upgrade: true
-        package_update: true
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        Something: else
-      security_groups: "{{ sg.group_id }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      instance_type: "{{ ec2_instance_type }}"
-    register: remake_in_test_vpc
-  - name: "Remaking the same instance resulted in no changes"
-    assert:
-      that: not remake_in_test_vpc.changed
-  - name: "check that instance IDs match anyway"
-    assert:
-      that: 'remake_in_test_vpc.instance_ids[0] == in_test_vpc.instance_ids[0]'
-  - name: "check that source_dest_check was set to false"
-    assert:
-      that: 'not remake_in_test_vpc.instances[0].source_dest_check'
+    - name: Try to re-make the instance, hopefully this shows changed=False
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic-vpc-create"
+        image_id: "{{ ec2_ami_id }}"
+        user_data: |
+          #cloud-config
+          package_upgrade: true
+          package_update: true
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          Something: else
+        security_groups: "{{ sg.group_id }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        instance_type: "{{ ec2_instance_type }}"
+      register: remake_in_test_vpc
+    - name: Remaking the same instance resulted in no changes
+      ansible.builtin.assert:
+        that: not remake_in_test_vpc.changed
+    - name: check that instance IDs match anyway
+      ansible.builtin.assert:
+        that: remake_in_test_vpc.instance_ids[0] == in_test_vpc.instance_ids[0]
+    - name: check that source_dest_check was set to false
+      ansible.builtin.assert:
+        that: not remake_in_test_vpc.instances[0].source_dest_check
 
-  - name: "fact presented ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-basic-vpc-create"
-    register: presented_instance_fact
+    - name: fact presented ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-basic-vpc-create"
+      register: presented_instance_fact
 
-  - name: "fact checkmode ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-basic-vpc-create-checkmode"
-    register: checkmode_instance_fact
+    - name: fact checkmode ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-basic-vpc-create-checkmode"
+      register: checkmode_instance_fact
 
-  - name: "Confirm whether the check mode is working normally."
-    assert:
-      that:
-        - presented_instance_fact.instances | length > 0
-        - checkmode_instance_fact.instances | length == 0
+    - name: Confirm whether the check mode is working normally.
+      ansible.builtin.assert:
+        that:
+          - presented_instance_fact.instances | length > 0
+          - checkmode_instance_fact.instances | length == 0
 
-  - name: "Alter it by adding tags"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        Another: thing
-      purge_tags: false
-      security_groups: "{{ sg.group_id }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      instance_type: "{{ ec2_instance_type }}"
-    register: add_another_tag
+    - name: Alter it by adding tags
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic-vpc-create"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          Another: thing
+        purge_tags: false
+        security_groups: "{{ sg.group_id }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        instance_type: "{{ ec2_instance_type }}"
+      register: add_another_tag
 
-  - ec2_instance_info:
-      instance_ids: "{{ add_another_tag.instance_ids }}"
-    register: check_tags
-  - name: "Remaking the same instance resulted in no changes"
-    assert:
-      that:
-        - check_tags.instances[0].tags.Another == 'thing'
-        - check_tags.instances[0].tags.Something == 'else'
+    - amazon.aws.ec2_instance_info:
+        instance_ids: "{{ add_another_tag.instance_ids }}"
+      register: check_tags
+    - name: Remaking the same instance resulted in no changes
+      ansible.builtin.assert:
+        that:
+          - check_tags.instances[0].tags.Another == 'thing'
+          - check_tags.instances[0].tags.Something == 'else'
 
-  - name: "Purge a tag"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-        Another: thing
-      security_groups: "{{ sg.group_id }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      instance_type: "{{ ec2_instance_type }}"
+    - name: Purge a tag
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic-vpc-create"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+          Another: thing
+        security_groups: "{{ sg.group_id }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        instance_type: "{{ ec2_instance_type }}"
 
-  - ec2_instance_info:
-      instance_ids: "{{ add_another_tag.instance_ids }}"
-    register: check_tags
+    - amazon.aws.ec2_instance_info:
+        instance_ids: "{{ add_another_tag.instance_ids }}"
+      register: check_tags
 
-  - name: "Remaking the same instance resulted in no changes"
-    assert:
-      that:
-        - "'Something' not in check_tags.instances[0].tags"
+    - name: Remaking the same instance resulted in no changes
+      ansible.builtin.assert:
+        that:
+          - "'Something' not in check_tags.instances[0].tags"
 
-  - name: "check that subnet-default public IP rule was followed"
-    assert:
-      that:
-        - check_tags.instances[0].public_dns_name == ""
-        - check_tags.instances[0].private_ip_address.startswith(subnet_b_startswith)
-        - check_tags.instances[0].subnet_id == testing_subnet_b.subnet.id
-  - name: "check that tags were applied"
-    assert:
-      that:
-        - check_tags.instances[0].tags.Name.startswith(resource_prefix)
-        - check_tags.instances[0].state.name in  ['pending', 'running']
+    - name: check that subnet-default public IP rule was followed
+      ansible.builtin.assert:
+        that:
+          - check_tags.instances[0].public_dns_name == ""
+          - check_tags.instances[0].private_ip_address.startswith(subnet_b_startswith)
+          - check_tags.instances[0].subnet_id == testing_subnet_b.subnet.id
+    - name: check that tags were applied
+      ansible.builtin.assert:
+        that:
+          - check_tags.instances[0].tags.Name.startswith(resource_prefix)
+          - check_tags.instances[0].state.name in  ['pending', 'running']
 
-  - name: "Try setting purge_tags to True without specifiying tags (should NOT purge tags)"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_id }}"
-      purge_tags: true
-      security_groups: "{{ sg.group_id }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      instance_type: "{{ ec2_instance_type }}"
-    register: _purge_tags_without_tags
+    - name: Try setting purge_tags to True without specifiying tags (should NOT purge tags)
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic-vpc-create"
+        image_id: "{{ ec2_ami_id }}"
+        purge_tags: true
+        security_groups: "{{ sg.group_id }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        instance_type: "{{ ec2_instance_type }}"
+      register: _purge_tags_without_tags
 
-  - name: Assert tags were not purged
-    assert:
-      that:
-        - _purge_tags_without_tags.instances[0].tags | length > 1
+    - name: Assert tags were not purged
+      ansible.builtin.assert:
+        that:
+          - _purge_tags_without_tags.instances[0].tags | length > 1
 
-  - name: "Purge all tags (aside from Name)"
-    ec2_instance:
-      state: present
-      name: "{{ resource_prefix }}-test-basic-vpc-create"
-      image_id: "{{ ec2_ami_id }}"
-      purge_tags: true
-      tags: {}
-      security_groups: "{{ sg.group_id }}"
-      vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      instance_type: "{{ ec2_instance_type }}"
-    register: _purge_tags
+    - name: Purge all tags (aside from Name)
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ resource_prefix }}-test-basic-vpc-create"
+        image_id: "{{ ec2_ami_id }}"
+        purge_tags: true
+        tags: {}
+        security_groups: "{{ sg.group_id }}"
+        vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
+        instance_type: "{{ ec2_instance_type }}"
+      register: _purge_tags
 
-  - name: Assert tags were purged
-    assert:
-      that:
-        - _purge_tags.instances[0].tags | length == 1
-        - _purge_tags.instances[0].tags.Name.startswith(resource_prefix)
+    - name: Assert tags were purged
+      ansible.builtin.assert:
+        that:
+          - _purge_tags.instances[0].tags | length == 1
+          - _purge_tags.instances[0].tags.Name.startswith(resource_prefix)

--- a/tests/integration/targets/ec2_instance_termination_protection/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_termination_protection/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_termination_protection
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-instance-temination'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-temination"

--- a/tests/integration/targets/ec2_instance_termination_protection/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_termination_protection/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: terminaion_protection
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: terminaion_protection

--- a/tests/integration/targets/ec2_instance_termination_protection/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_termination_protection/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -6,7 +7,7 @@
       region: "{{ aws_region }}"
   block:
     - name: Create instance with termination protection (check mode)
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -16,18 +17,18 @@
         termination_protection: true
         instance_type: "{{ ec2_instance_type }}"
         state: running
-        wait: yes
-      check_mode: yes
+        wait: true
+      check_mode: true
       register: create_instance_check_mode_results
 
     - name: Check the returned value for the earlier task
-      assert:
+      ansible.builtin.assert:
         that:
           - create_instance_check_mode_results is changed
           - create_instance_check_mode_results.spec.DisableApiTermination == True
 
     - name: Create instance with termination protection
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -37,21 +38,21 @@
         termination_protection: true
         instance_type: "{{ ec2_instance_type }}"
         state: running
-        wait: yes
+        wait: true
       register: create_instance_results
 
-    - set_fact:
-        instance_id: '{{ create_instance_results.instances[0].instance_id }}'
+    - ansible.builtin.set_fact:
+        instance_id: "{{ create_instance_results.instances[0].instance_id }}"
 
     - name: Check return values of the create instance task
-      assert:
+      ansible.builtin.assert:
         that:
           - create_instance_results.instances | length > 0
           - create_instance_results.instances.0.state.name == 'running'
           - create_instance_results.spec.DisableApiTermination
 
     - name: Get info on termination protection
-      command: 'aws ec2 describe-instance-attribute --attribute disableApiTermination --instance-id {{ instance_id }}'
+      ansible.builtin.command: aws ec2 describe-instance-attribute --attribute disableApiTermination --instance-id {{ instance_id }}
       environment:
         AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
         AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
@@ -60,16 +61,16 @@
       register: instance_termination_check
 
     - name: convert it to an object
-      set_fact:
+      ansible.builtin.set_fact:
         instance_termination_status: "{{ instance_termination_check.stdout | from_json }}"
 
     - name: Assert termination protection status did not change in check_mode
-      assert:
+      ansible.builtin.assert:
         that:
           - instance_termination_status.DisableApiTermination.Value == true
 
     - name: Create instance with termination protection (check mode) (idempotent)
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -79,17 +80,17 @@
         termination_protection: true
         instance_type: "{{ ec2_instance_type }}"
         state: running
-        wait: yes
-      check_mode: yes
+        wait: true
+      check_mode: true
       register: create_instance_check_mode_results
 
     - name: Check the returned value for the earlier task
-      assert:
+      ansible.builtin.assert:
         that:
           - create_instance_check_mode_results is not changed
 
     - name: Create instance with termination protection (idempotent)
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -99,17 +100,17 @@
         termination_protection: true
         instance_type: "{{ ec2_instance_type }}"
         state: running
-        wait: yes
+        wait: true
       register: create_instance_results
 
     - name: Check return values of the create instance task
-      assert:
+      ansible.builtin.assert:
         that:
           - not create_instance_results.changed
           - create_instance_results.instances | length > 0
 
     - name: Try to terminate the instance (expected to fail)
-      ec2_instance:
+      amazon.aws.ec2_instance:
         filters:
           tag:Name: "{{ resource_prefix }}-termination-protection"
         state: absent
@@ -117,7 +118,7 @@
       register: terminate_instance_results
 
     - name: Set termination protection to false (check_mode)
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -125,16 +126,16 @@
         termination_protection: false
         instance_type: "{{ ec2_instance_type }}"
         vpc_subnet_id: "{{ testing_subnet_b.subnet.id }}"
-      check_mode: True
+      check_mode: true
       register: set_termination_protectioncheck_mode_results
 
     - name: Check return value
-      assert:
+      ansible.builtin.assert:
         that:
           - set_termination_protectioncheck_mode_results.changed
 
     - name: Get info on termination protection
-      command: 'aws ec2 describe-instance-attribute --attribute disableApiTermination --instance-id {{ instance_id }}'
+      ansible.builtin.command: aws ec2 describe-instance-attribute --attribute disableApiTermination --instance-id {{ instance_id }}
       environment:
         AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
         AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
@@ -143,15 +144,15 @@
       register: instance_termination_check
 
     - name: convert it to an object
-      set_fact:
+      ansible.builtin.set_fact:
         instance_termination_status: "{{ instance_termination_check.stdout | from_json }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - instance_termination_status.DisableApiTermination.Value == true
 
     - name: Set termination protection to false
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -162,12 +163,12 @@
       register: set_termination_protection_results
 
     - name: Check return value
-      assert:
+      ansible.builtin.assert:
         that:
           - set_termination_protection_results.changed
 
     - name: Get info on termination protection
-      command: 'aws ec2 describe-instance-attribute --attribute disableApiTermination --instance-id {{ instance_id }}'
+      ansible.builtin.command: aws ec2 describe-instance-attribute --attribute disableApiTermination --instance-id {{ instance_id }}
       environment:
         AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
         AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
@@ -176,15 +177,15 @@
       register: instance_termination_check
 
     - name: convert it to an object
-      set_fact:
+      ansible.builtin.set_fact:
         instance_termination_status: "{{ instance_termination_check.stdout | from_json }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - instance_termination_status.DisableApiTermination.Value == false
 
     - name: Set termination protection to false (idempotent)
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -195,12 +196,12 @@
       register: set_termination_protection_results
 
     - name: Check return value
-      assert:
+      ansible.builtin.assert:
         that:
           - not set_termination_protection_results.changed
 
     - name: Set termination protection to true
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -211,13 +212,13 @@
       register: set_termination_protection_results
 
     - name: Check return value
-      assert:
+      ansible.builtin.assert:
         that:
           - set_termination_protection_results.changed
           - set_termination_protection_results.changes[0].DisableApiTermination.Value
 
     - name: Set termination protection to true (idempotent)
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -228,12 +229,12 @@
       register: set_termination_protection_results
 
     - name: Check return value
-      assert:
+      ansible.builtin.assert:
         that:
           - not set_termination_protection_results.changed
 
     - name: Set termination protection to false (so we can terminate instance)
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ resource_prefix }}-termination-protection"
         image_id: "{{ ec2_ami_id }}"
         tags:
@@ -244,7 +245,7 @@
       register: set_termination_protection_results
 
     - name: Terminate the instance
-      ec2_instance:
+      amazon.aws.ec2_instance:
         filters:
           tag:TestId: "{{ resource_prefix }}"
         state: absent

--- a/tests/integration/targets/ec2_instance_uptime/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_uptime/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_uptime
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-instance-uptime'
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-uptime"

--- a/tests/integration/targets/ec2_instance_uptime/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_uptime/meta/main.yml
@@ -1,6 +1,7 @@
+---
 # this just makes sure they're in the right place
 dependencies:
-- role: setup_ec2_facts
-- role: setup_ec2_instance_env
-  vars:
-    ec2_instance_test_name: uptime
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env
+    vars:
+      ec2_instance_test_name: uptime

--- a/tests/integration/targets/ec2_instance_uptime/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_uptime/tasks/main.yml
@@ -6,59 +6,59 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: "create t3.nano instance"
-    ec2_instance:
-      state: 'running'
-      name: "{{ resource_prefix }}-test-uptime"
-      region: "{{ aws_region }}"
-      image_id: "{{ ec2_ami_id }}"
-      tags:
-        TestId: "{{ ec2_instance_tag_TestId }}"
-      vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-      instance_type: t3.nano
-      wait: yes
+    - name: create t3.nano instance
+      amazon.aws.ec2_instance:
+        state: running
+        name: "{{ resource_prefix }}-test-uptime"
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        instance_type: t3.nano
+        wait: true
 
-  - name: "check ec2 instance"
-    ec2_instance_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}-test-uptime"
-        instance-state-name: [ "running"]
-    register: instance_facts
+    - name: check ec2 instance
+      amazon.aws.ec2_instance_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}-test-uptime"
+          instance-state-name: [running]
+      register: instance_facts
 
-  - name: "Confirm existence of instance id."
-    assert:
-      that:
-        - instance_facts.instances | length == 1
+    - name: Confirm existence of instance id.
+      ansible.builtin.assert:
+        that:
+          - instance_facts.instances | length == 1
 
-  - name: "check using uptime 100 hours - should find nothing"
-    ec2_instance_info:
-      region: "{{ aws_region }}"
-      uptime: 6000
-      filters:
-        instance-state-name: [ "running"]
-        "tag:Name": "{{ resource_prefix }}-test-uptime"
-    register: instance_facts
+    - name: check using uptime 100 hours - should find nothing
+      amazon.aws.ec2_instance_info:
+        region: "{{ aws_region }}"
+        uptime: 6000
+        filters:
+          instance-state-name: [running]
+          tag:Name: "{{ resource_prefix }}-test-uptime"
+      register: instance_facts
 
-  - name: "Confirm there is no running instance"
-    assert:
-      that:
-        - instance_facts.instances | length == 0
+    - name: Confirm there is no running instance
+      ansible.builtin.assert:
+        that:
+          - instance_facts.instances | length == 0
 
-  - name: Sleep for 61 seconds and continue with play
-    wait_for:
-      timeout: 61
-    delegate_to: localhost
+    - name: Sleep for 61 seconds and continue with play
+      ansible.builtin.wait_for:
+        timeout: 61
+      delegate_to: localhost
 
-  - name: "check using uptime 1 minute"
-    ec2_instance_info:
-      region: "{{ aws_region }}"
-      uptime: 1
-      filters:
-        instance-state-name: [ "running"]
-        "tag:Name": "{{ resource_prefix }}-test-uptime"
-    register: instance_facts
+    - name: check using uptime 1 minute
+      amazon.aws.ec2_instance_info:
+        region: "{{ aws_region }}"
+        uptime: 1
+        filters:
+          instance-state-name: [running]
+          tag:Name: "{{ resource_prefix }}-test-uptime"
+      register: instance_facts
 
-  - name: "Confirm there is one running instance"
-    assert:
-      that:
-        - instance_facts.instances | length == 1
+    - name: Confirm there is one running instance
+      ansible.builtin.assert:
+        that:
+          - instance_facts.instances | length == 1

--- a/tests/integration/targets/ec2_key/defaults/main.yml
+++ b/tests/integration/targets/ec2_key/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for test_ec2_key
-ec2_key_name: '{{resource_prefix}}'
-ec2_key_name_rsa: '{{resource_prefix}}-rsa'
+ec2_key_name: "{{resource_prefix}}"
+ec2_key_name_rsa: "{{resource_prefix}}-rsa"

--- a/tests/integration/targets/ec2_key/meta/main.yml
+++ b/tests/integration/targets/ec2_key/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
   - setup_sshkey

--- a/tests/integration/targets/ec2_key/tasks/main.yml
+++ b/tests/integration/targets/ec2_key/tasks/main.yml
@@ -4,13 +4,13 @@
 
 - module_defaults:
     group/aws:
-      region: '{{ aws_region }}'
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   block:
     - name: Create temporary directory
-      tempfile:
+      ansible.builtin.tempfile:
         suffix: .private_key
         state: directory
       register: _tmpdir
@@ -21,78 +21,78 @@
 
     # ============================================================
     - name: test with no parameters
-      ec2_key:
+      amazon.aws.ec2_key:
       register: result
       ignore_errors: true
 
     - name: assert failure when called with no parameters
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.failed'
-           - 'result.msg == "missing required arguments: name"'
+          - result.failed
+          - 'result.msg == "missing required arguments: name"'
 
     # ============================================================
     - name: test removing a non-existent key pair (check mode)
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: absent
       register: result
       check_mode: true
 
     - name: assert removing a non-existent key pair
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'not result.changed'
+          - not result.changed
 
     - name: test removing a non-existent key pair
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: absent
       register: result
 
     - name: assert removing a non-existent key pair
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'not result.changed'
+          - not result.changed
 
     # ============================================================
     # Test: create new key by AWS (key_material not provided)
     # ============================================================
     - name: test creating a new key pair (check_mode)
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: present
         tags:
-          snake_case: 'a_snake_case_value'
-          CamelCase: 'CamelCaseValue'
-          "spaced key": 'Spaced value'
+          snake_case: a_snake_case_value
+          CamelCase: CamelCaseValue
+          spaced key: Spaced value
       register: result
       check_mode: true
 
     - name: assert creating a new key pair
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is changed
+          - result is changed
 
     - name: assert that key pair was not created
       ec2_key_info:
         names:
-          - '{{ ec2_key_name }}'
+          - "{{ ec2_key_name }}"
       register: aws_keypair
       failed_when: aws_keypair.keypairs | length > 0
 
     - name: test creating a new key pair
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: present
         tags:
-          snake_case: 'a_snake_case_value'
-          CamelCase: 'CamelCaseValue'
-          "spaced key": 'Spaced value'
+          snake_case: a_snake_case_value
+          CamelCase: CamelCaseValue
+          spaced key: Spaced value
       register: result
 
     - name: assert creating a new key pair
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - '"key" in result'
@@ -113,17 +113,17 @@
     - name: assert that key pair was created
       ec2_key_info:
         names:
-          - '{{ ec2_key_name }}'
+          - "{{ ec2_key_name }}"
       register: aws_keypair
       failed_when: aws_keypair.keypairs | length == 0
 
     - name: Gather info about the key pair
       ec2_key_info:
-        names: '{{ ec2_key_name }}'
+        names: "{{ ec2_key_name }}"
       register: key_info
 
     - name: assert the gathered key info
-      assert:
+      ansible.builtin.assert:
         that:
           - key_info.keypairs[0].key_name == ec2_key_name
           - key_info.keypairs[0].key_pair_id.startswith('key-')
@@ -134,39 +134,39 @@
           - '"spaced key" in key_info.keypairs[0].tags'
           - key_info.keypairs[0].tags['spaced key'] == 'Spaced value'
 
-    - set_fact:
-        key_id_1: '{{ result.key.id }}'
+    - ansible.builtin.set_fact:
+        key_id_1: "{{ result.key.id }}"
 
-    - name: 'test re-"creating" the same key (check_mode)'
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+    - name: test re-"creating" the same key (check_mode)
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: present
         tags:
-          snake_case: 'a_snake_case_value'
-          CamelCase: 'CamelCaseValue'
-          "spaced key": 'Spaced value'
+          snake_case: a_snake_case_value
+          CamelCase: CamelCaseValue
+          spaced key: Spaced value
       register: result
       check_mode: true
 
     - name: assert re-creating the same key
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is not changed
+          - result is not changed
 
-    - name: 'test re-"creating" the same key'
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+    - name: test re-"creating" the same key
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: present
         tags:
-          snake_case: 'a_snake_case_value'
-          CamelCase: 'CamelCaseValue'
-          "spaced key": 'Spaced value'
+          snake_case: a_snake_case_value
+          CamelCase: CamelCaseValue
+          spaced key: Spaced value
       register: result
 
     - name: assert re-creating the same key
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is not changed
+          - result is not changed
 
     # ============================================================
     # Test: create new key by AWS (key_material not provided)
@@ -178,27 +178,27 @@
         path: "{{ priv_key_file_name }}"
 
     - name: test creating a new key pair (check_mode)
-      ec2_key:
-        name: '{{ ec2_key_name_rsa }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name_rsa }}"
         state: present
         file_name: "{{ priv_key_file_name }}"
         tags:
-          snake_case: 'a_snake_case_value'
-          CamelCase: 'CamelCaseValue'
-          "spaced key": 'Spaced value'
+          snake_case: a_snake_case_value
+          CamelCase: CamelCaseValue
+          spaced key: Spaced value
       register: result
       check_mode: true
       no_log: true
 
     - name: assert creating a new key pair
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is changed
+          - result is changed
 
     - name: assert that key pair was not created
       ec2_key_info:
         names:
-          - '{{ ec2_key_name_rsa }}'
+          - "{{ ec2_key_name_rsa }}"
       register: aws_keypair
       failed_when: aws_keypair.keypairs | length > 0
 
@@ -209,18 +209,18 @@
       failed_when: result.stat.exists
 
     - name: test creating a new key pair
-      ec2_key:
-        name: '{{ ec2_key_name_rsa }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name_rsa }}"
         state: present
         file_name: "{{ priv_key_file_name }}"
         tags:
-          snake_case: 'a_snake_case_value'
-          CamelCase: 'CamelCaseValue'
-          "spaced key": 'Spaced value'
+          snake_case: a_snake_case_value
+          CamelCase: CamelCaseValue
+          spaced key: Spaced value
       register: result
 
     - name: assert creating a new key pair
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - '"key" in result'
@@ -238,11 +238,10 @@
           - '"spaced key" in result.key.tags'
           - result.key.tags['spaced key'] == 'Spaced value'
 
-
     - name: assert that key pair was created
       ec2_key_info:
         names:
-          - '{{ ec2_key_name_rsa }}'
+          - "{{ ec2_key_name_rsa }}"
       register: aws_keypair
       failed_when: aws_keypair.keypairs | length == 0
 
@@ -252,66 +251,66 @@
       register: result
       failed_when: (not result.stat.exists) or (result.stat.size == 0)
 
-    - name: 'test re-"creating" the same key (check_mode)'
-      ec2_key:
-        name: '{{ ec2_key_name_rsa }}'
+    - name: test re-"creating" the same key (check_mode)
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name_rsa }}"
         state: present
         file_name: "{{ priv_key_file_name }}"
         tags:
-          snake_case: 'a_snake_case_value'
-          CamelCase: 'CamelCaseValue'
-          "spaced key": 'Spaced value'
+          snake_case: a_snake_case_value
+          CamelCase: CamelCaseValue
+          spaced key: Spaced value
       register: result
       check_mode: true
 
     - name: assert re-creating the same key
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is not changed
+          - result is not changed
 
-    - name: 'test re-"creating" the same key'
-      ec2_key:
-        name: '{{ ec2_key_name_rsa }}'
+    - name: test re-"creating" the same key
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name_rsa }}"
         state: present
         file_name: "{{ priv_key_file_name }}"
         tags:
-          snake_case: 'a_snake_case_value'
-          CamelCase: 'CamelCaseValue'
-          "spaced key": 'Spaced value'
+          snake_case: a_snake_case_value
+          CamelCase: CamelCaseValue
+          spaced key: Spaced value
       register: result
 
     - name: assert re-creating the same key
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is not changed
+          - result is not changed
 
     # ============================================================
     - name: test updating tags without purge (check mode)
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: present
         tags:
-          newKey: 'Another value'
+          newKey: Another value
         purge_tags: false
       register: result
       check_mode: true
 
     - name: assert updated tags
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is changed
+          - result is changed
 
     - name: test updating tags without purge
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: present
         tags:
-          newKey: 'Another value'
+          newKey: Another value
         purge_tags: false
       register: result
 
     - name: assert updated tags
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - '"key" in result'
@@ -333,11 +332,11 @@
 
     - name: Gather info about the updated tags
       ec2_key_info:
-        names: '{{ ec2_key_name }}'
+        names: "{{ ec2_key_name }}"
       register: key_info
 
     - name: assert the gathered key info
-      assert:
+      ansible.builtin.assert:
         that:
           - key_info.keypairs[0].key_name == ec2_key_name
           - key_info.keypairs[0].key_pair_id == key_id_1
@@ -351,31 +350,31 @@
           - key_info.keypairs[0].tags['newKey'] == 'Another value'
 
     - name: test updating tags without purge - idempotency (check mode)
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: present
         tags:
-          newKey: 'Another value'
+          newKey: Another value
         purge_tags: false
       register: result
       check_mode: true
 
     - name: assert updated tags
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is not changed
+          - result is not changed
 
     - name: test updating tags without purge - idempotency
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: present
         tags:
-          newKey: 'Another value'
+          newKey: Another value
         purge_tags: false
       register: result
 
     - name: assert updated tags
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
           - '"key" in result'
@@ -397,31 +396,31 @@
 
     # ============================================================
     - name: test updating tags with purge (check mode)
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: present
         tags:
-          newKey: 'Another value'
+          newKey: Another value
         purge_tags: true
       register: result
       check_mode: true
 
     - name: assert updated tags
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is changed
+          - result is changed
 
     - name: test updating tags with purge
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: present
         tags:
-          newKey: 'Another value'
+          newKey: Another value
         purge_tags: true
       register: result
 
     - name: assert updated tags
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - '"key" in result'
@@ -439,31 +438,31 @@
           - result.key.tags['newKey'] == 'Another value'
 
     - name: test updating tags with purge - idempotency (check mode)
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: present
         tags:
-          newKey: 'Another value'
+          newKey: Another value
         purge_tags: true
       register: result
       check_mode: true
 
     - name: assert updated tags
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is not changed
+          - result is not changed
 
     - name: test updating tags with purge - idempotency
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: present
         tags:
-          newKey: 'Another value'
+          newKey: Another value
         purge_tags: true
       register: result
 
     - name: assert updated tags
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
           - '"key" in result'
@@ -482,64 +481,64 @@
 
     # ============================================================
     - name: test removing an existent key (check mode)
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: absent
       register: result
       check_mode: true
 
     - name: assert removing an existent key
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is changed
+          - result is changed
 
     - name: assert using check_mode did not removed key pair
       ec2_key_info:
         names:
-          - '{{ ec2_key_name }}'
+          - "{{ ec2_key_name }}"
       register: keys
       failed_when: keys.keypairs | length == 0
 
     - name: test removing an existent key
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: absent
       register: result
 
     - name: assert removing an existent key
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is changed
-           - '"key" in result'
-           - result.key == None
+          - result is changed
+          - '"key" in result'
+          - result.key == None
 
     - name: assert that key pair was removed
       ec2_key_info:
         names:
-          - '{{ ec2_key_name }}'
+          - "{{ ec2_key_name }}"
       register: keys
       failed_when: keys.keypairs | length > 0
 
     # ============================================================
     - name: test state=present with key_material
-      ec2_key:
-        name: '{{ ec2_key_name }}'
-        key_material: '{{ key_material }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
+        key_material: "{{ key_material }}"
         state: present
       register: result
 
     - name: assert state=present with key_material
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed == True'
+          - result.changed == True
           - '"key" in result'
           - '"name" in result.key'
           - '"fingerprint" in result.key'
           - '"private_key" not in result.key'
           - '"id" in result.key'
           - '"tags" in result.key'
-          - 'result.key.name == "{{ec2_key_name}}"'
-          - 'result.key.fingerprint == "{{fingerprint}}"'
+          - result.key.name == "{{ec2_key_name}}"
+          - result.key.fingerprint == "{{fingerprint}}"
 
     - name: Gather key info with fingerprint
       ec2_key_info:
@@ -548,24 +547,24 @@
       register: key_info
 
     - name: assert gathered key info
-      assert:
+      ansible.builtin.assert:
         that:
           - '"key_fingerprint" in key_info.keypairs[0]'
           - '"private_key" not in key_info.keypairs[0]'
           - '"key_pair_id" in key_info.keypairs[0]'
           - '"tags" in key_info.keypairs[0]'
-          - 'key_info.keypairs[0].key_name == "{{ec2_key_name}}"'
-          - 'key_info.keypairs[0].key_fingerprint == "{{fingerprint}}"'
+          - key_info.keypairs[0].key_name == "{{ec2_key_name}}"
+          - key_info.keypairs[0].key_fingerprint == "{{fingerprint}}"
     # ============================================================
     - name: test state=present with key_material (idempotency)
-      ec2_key:
-        name: '{{ ec2_key_name }}'
-        key_material: '{{ key_material }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
+        key_material: "{{ key_material }}"
         state: present
       register: result
 
     - name: assert state=present with key_material
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
           - '"key" in result'
@@ -574,91 +573,90 @@
           - '"private_key" not in result.key'
           - '"id" in result.key'
           - '"tags" in result.key'
-          - 'result.key.name == "{{ec2_key_name}}"'
-          - 'result.key.fingerprint == "{{fingerprint}}"'
-          - 'result.msg == "key pair already exists"'
+          - result.key.name == "{{ec2_key_name}}"
+          - result.key.fingerprint == "{{fingerprint}}"
+          - result.msg == "key pair already exists"
 
     # ============================================================
 
     - name: test force=no with another_key_material (expect changed=false)
-      ec2_key:
-        name: '{{ ec2_key_name }}'
-        key_material: '{{ another_key_material }}'
-        force: no
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
+        key_material: "{{ another_key_material }}"
+        force: false
       register: result
 
     - name: assert force=no with another_key_material (expect changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'not result.changed'
-          - 'result.key.fingerprint == fingerprint'
+          - not result.changed
+          - result.key.fingerprint == fingerprint
 
     # ============================================================
 
     - name: test updating a key pair using another_key_material (expect changed=True)
-      ec2_key:
-        name: '{{ ec2_key_name }}'
-        key_material: '{{ another_key_material }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
+        key_material: "{{ another_key_material }}"
       register: result
 
     - name: assert updating a key pair using another_key_material (expect changed=True)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
-          - 'result.key.fingerprint != fingerprint'
+          - result.changed
+          - result.key.fingerprint != fingerprint
 
     # ============================================================
     - name: test state=absent (expect changed=true)
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         state: absent
       register: result
 
     - name: assert state=absent with key_material (expect changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.changed'
-           - '"key" in result'
-           - 'result.key == None'
+          - result.changed
+          - '"key" in result'
+          - result.key == None
 
     # ============================================================
     - name: test create ED25519 key pair type
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         key_type: ed25519
       register: result
 
     - name: assert that task succeed
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
-          - 'result.key.type == "ed25519"'
+          - result.changed
+          - result.key.type == "ed25519"
 
     - name: Update key pair type from ED25519 to RSA
-      ec2_key:
-        name: '{{ ec2_key_name }}'
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
         key_type: rsa
       register: result
 
     - name: assert that task succeed
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
-          - 'result.key.type == "rsa"'
+          - result.changed
+          - result.key.type == "rsa"
 
   always:
-
     # ============================================================
     - name: Always delete the key we might create
-      ec2_key:
-        name: '{{ item }}'
+      amazon.aws.ec2_key:
+        name: "{{ item }}"
         state: absent
       with_items:
-        - '{{ ec2_key_name }}'
-        - '{{ ec2_key_name_rsa }}'
+        - "{{ ec2_key_name }}"
+        - "{{ ec2_key_name_rsa }}"
 
     - name: Delete the temporary directory
-      file:
-        path: '{{ _tmpdir.path }}'
+      ansible.builtin.file:
+        path: "{{ _tmpdir.path }}"
         state: absent
       ignore_errors: true

--- a/tests/integration/targets/ec2_metadata_facts/meta/main.yml
+++ b/tests/integration/targets/ec2_metadata_facts/meta/main.yml
@@ -1,3 +1,4 @@
+---
 dependencies:
   - setup_ec2_facts
   - setup_sshkey

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -9,166 +9,166 @@
   hosts: localhost
 
   collections:
-  - amzon.aws
-  - community.aws
+    - amzon.aws
+    - community.aws
 
   vars:
-    vpc_name: '{{ resource_prefix }}-vpc'
-    vpc_seed: '{{ resource_prefix }}'
-    vpc_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.0.0/16'
-    subnet_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.32.0/24'
+    vpc_name: "{{ resource_prefix }}-vpc"
+    vpc_seed: "{{ resource_prefix }}"
+    vpc_cidr: 10.{{ 256 | random(seed=vpc_seed) }}.0.0/16
+    subnet_cidr: 10.{{ 256 | random(seed=vpc_seed) }}.32.0/24
 
   tasks:
-  - set_fact:
-      # As lookup plugins don't have access to module_defaults
-      connection_args:
-        region: "{{ aws_region }}"
-        access_key: "{{ aws_access_key }}"
-        secret_key: "{{ aws_secret_key }}"
-        session_token: "{{ security_token | default(omit) }}"
+    - ansible.builtin.set_fact:
+        # As lookup plugins don't have access to module_defaults
+        connection_args:
+          region: "{{ aws_region }}"
+          access_key: "{{ aws_access_key }}"
+          secret_key: "{{ aws_secret_key }}"
+          session_token: "{{ security_token | default(omit) }}"
 
-  - include_role:
-      name: '../setup_sshkey'
-  - include_role:
-      name: '../setup_ec2_facts'
+    - ansible.builtin.include_role:
+        name: ../setup_sshkey
+    - ansible.builtin.include_role:
+        name: ../setup_ec2_facts
 
-  - set_fact:
-      availability_zone: '{{ ec2_availability_zone_names[0] }}'
+    - ansible.builtin.set_fact:
+        availability_zone: "{{ ec2_availability_zone_names[0] }}"
 
-  # ============================================================
-  - name: create a VPC
-    ec2_vpc_net:
-      name: "{{ resource_prefix }}-vpc"
-      state: present
-      cidr_block: "{{ vpc_cidr }}"
-      tags:
-        Name: "{{ resource_prefix }}-vpc"
-        Description: "Created by ansible-test"
-    register: vpc_result
+    # ============================================================
+    - name: create a VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        state: present
+        cidr_block: "{{ vpc_cidr }}"
+        tags:
+          Name: "{{ resource_prefix }}-vpc"
+          Description: Created by ansible-test
+      register: vpc_result
 
-  - set_fact:
-      vpc_id: "{{ vpc_result.vpc.id }}"
+    - ansible.builtin.set_fact:
+        vpc_id: "{{ vpc_result.vpc.id }}"
 
-  - name: create an internet gateway
-    ec2_vpc_igw:
-      vpc_id: "{{ vpc_id }}"
-      state: present
-      tags:
-        "Name": "{{ resource_prefix }}"
-    register: igw_result
+    - name: create an internet gateway
+      amazon.aws.ec2_vpc_igw:
+        vpc_id: "{{ vpc_id }}"
+        state: present
+        tags:
+          Name: "{{ resource_prefix }}"
+      register: igw_result
 
-  - name: create a subnet
-    ec2_vpc_subnet:
-      cidr: "{{ vpc_cidr }}"
-      az: "{{ availability_zone }}"
-      vpc_id: "{{ vpc_id }}"
-      tags:
-        Name: "{{ resource_prefix }}-vpc"
-        Description: "Created by ansible-test"
-      state: present
-    register: vpc_subnet_result
+    - name: create a subnet
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ vpc_cidr }}"
+        az: "{{ availability_zone }}"
+        vpc_id: "{{ vpc_id }}"
+        tags:
+          Name: "{{ resource_prefix }}-vpc"
+          Description: Created by ansible-test
+        state: present
+      register: vpc_subnet_result
 
-  - name: create a public route table
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc_id }}"
-      tags:
-        "Name": "{{ resource_prefix }}"
-      subnets:
-        - "{{ vpc_subnet_result.subnet.id }}"
-      routes:
-        - dest: 0.0.0.0/0
-          gateway_id: "{{ igw_result.gateway_id }}"
-    register: public_route_table
+    - name: create a public route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc_id }}"
+        tags:
+          Name: "{{ resource_prefix }}"
+        subnets:
+          - "{{ vpc_subnet_result.subnet.id }}"
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: "{{ igw_result.gateway_id }}"
+      register: public_route_table
 
-  - name: create a security group
-    ec2_security_group:
-      name: "{{ resource_prefix }}-sg"
-      description: "Created by {{ resource_prefix }}"
-      rules:
-        - proto: tcp
-          ports: 22
-          cidr_ip: 0.0.0.0/0
-        - proto: icmp
-          from_port: -1
-          to_port: -1
-          cidr_ip: 0.0.0.0/0
-      state: present
-      vpc_id: "{{ vpc_result.vpc.id }}"
-    register: vpc_sg_result
+    - name: create a security group
+      ec2_security_group:
+        name: "{{ resource_prefix }}-sg"
+        description: Created by {{ resource_prefix }}
+        rules:
+          - proto: tcp
+            ports: 22
+            cidr_ip: "0.0.0.0/0"
+          - proto: icmp
+            from_port: -1
+            to_port: -1
+            cidr_ip: "0.0.0.0/0"
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      register: vpc_sg_result
 
-  - name: Create a key
-    ec2_key:
-      name: '{{ resource_prefix }}'
-      key_material: '{{ key_material }}'
-      state: present
-    register: ec2_key_result
+    - name: Create a key
+      amazon.aws.ec2_key:
+        name: "{{ resource_prefix }}"
+        key_material: "{{ key_material }}"
+        state: present
+      register: ec2_key_result
 
-  - name: Set facts to simplify use of extra resources
-    set_fact:
-      vpc_subnet_id: "{{ vpc_subnet_result.subnet.id }}"
-      vpc_sg_id: "{{ vpc_sg_result.group_id }}"
-      vpc_igw_id: "{{ igw_result.gateway_id }}"
-      vpc_route_table_id: "{{ public_route_table.route_table.id }}"
-      ec2_key_name: "{{ ec2_key_result.key.name }}"
+    - name: Set facts to simplify use of extra resources
+      ansible.builtin.set_fact:
+        vpc_subnet_id: "{{ vpc_subnet_result.subnet.id }}"
+        vpc_sg_id: "{{ vpc_sg_result.group_id }}"
+        vpc_igw_id: "{{ igw_result.gateway_id }}"
+        vpc_route_table_id: "{{ public_route_table.route_table.id }}"
+        ec2_key_name: "{{ ec2_key_result.key.name }}"
 
-  - name: Create an instance to test with
-    ec2_instance:
-      state: running
-      name: "{{ resource_prefix }}-ec2-metadata-facts"
-      image_id: "{{ ec2_ami_id }}"
-      vpc_subnet_id: "{{ vpc_subnet_id }}"
-      security_group: "{{ vpc_sg_id }}"
-      instance_type: t2.micro
-      key_name: "{{ ec2_key_name }}"
-      network:
-        assign_public_ip: true
-        delete_on_termination: true
-      metadata_options:
+    - name: Create an instance to test with
+      amazon.aws.ec2_instance:
+        state: running
+        name: "{{ resource_prefix }}-ec2-metadata-facts"
+        image_id: "{{ ec2_ami_id }}"
+        vpc_subnet_id: "{{ vpc_subnet_id }}"
+        security_group: "{{ vpc_sg_id }}"
+        instance_type: t2.micro
+        key_name: "{{ ec2_key_name }}"
+        network:
+          assign_public_ip: true
+          delete_on_termination: true
+        metadata_options:
           instance_metadata_tags: enabled
-      tags:
-        snake_case_key: a_snake_case_value
-        camelCaseKey: aCamelCaseValue
-    register: ec2_instance
+        tags:
+          snake_case_key: a_snake_case_value
+          camelCaseKey: aCamelCaseValue
+      register: ec2_instance
 
-  - set_fact:
-      ec2_ami_id_py2: "{{ lookup('aws_ssm', '/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2', **connection_args) }}"
-      ec2_ami_ssh_user_py2: "ec2-user"
+    - ansible.builtin.set_fact:
+        ec2_ami_id_py2: "{{ lookup('aws_ssm', '/aws/service/ami-amazon-linux-latest/amzn-ami-hvm-x86_64-gp2', **connection_args) }}"
+        ec2_ami_ssh_user_py2: ec2-user
 
-  - name: Create an instance to test with using Python 2
-    ec2_instance:
-      state: running
-      name: "{{ resource_prefix }}-ec2-metadata-facts-py2"
-      image_id: "{{ ec2_ami_id_py2 }}"
-      vpc_subnet_id: "{{ vpc_subnet_id }}"
-      security_group: "{{ vpc_sg_id }}"
-      instance_type: t2.micro
-      key_name: "{{ ec2_key_name }}"
-      network:
-        assign_public_ip: true
-        delete_on_termination: true
-      metadata_options:
+    - name: Create an instance to test with using Python 2
+      amazon.aws.ec2_instance:
+        state: running
+        name: "{{ resource_prefix }}-ec2-metadata-facts-py2"
+        image_id: "{{ ec2_ami_id_py2 }}"
+        vpc_subnet_id: "{{ vpc_subnet_id }}"
+        security_group: "{{ vpc_sg_id }}"
+        instance_type: t2.micro
+        key_name: "{{ ec2_key_name }}"
+        network:
+          assign_public_ip: true
+          delete_on_termination: true
+        metadata_options:
           instance_metadata_tags: enabled
-      tags:
-        snake_case_key: a_snake_case_value
-        camelCaseKey: aCamelCaseValue
-      wait: True
-    register: ec2_instance_py2
+        tags:
+          snake_case_key: a_snake_case_value
+          camelCaseKey: aCamelCaseValue
+        wait: true
+      register: ec2_instance_py2
 
-  - set_fact:
-      ec2_instance_id: "{{ ec2_instance.instances[0].instance_id }}"
-      ec2_instance_id_py2: "{{ ec2_instance_py2.instances[0].instance_id }}"
+    - ansible.builtin.set_fact:
+        ec2_instance_id: "{{ ec2_instance.instances[0].instance_id }}"
+        ec2_instance_id_py2: "{{ ec2_instance_py2.instances[0].instance_id }}"
 
-  - name: Create inventory file
-    template:
-      src: ../templates/inventory.j2
-      dest: ../inventory
+    - name: Create inventory file
+      ansible.builtin.template:
+        src: ../templates/inventory.j2
+        dest: ../inventory
 
-  - wait_for:
-      port: 22
-      host: '{{ ec2_instance.instances[0].public_ip_address }}'
-      timeout: 1200
+    - ansible.builtin.wait_for:
+        port: 22
+        host: "{{ ec2_instance.instances[0].public_ip_address }}"
+        timeout: 1200
 
-  - wait_for:
-      port: 22
-      host: '{{ ec2_instance_py2.instances[0].public_ip_address }}'
-      timeout: 1200
+    - ansible.builtin.wait_for:
+        port: 22
+        host: "{{ ec2_instance_py2.instances[0].public_ip_address }}"
+        timeout: 1200

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/teardown.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/teardown.yml
@@ -9,76 +9,76 @@
   hosts: localhost
 
   collections:
-  - amazon.aws
-  - community.aws
+    - amazon.aws
+    - community.aws
 
   tasks:
   # ============================================================
 
-  - name: terminate the instance
-    ec2_instance:
-      state: absent
-      instance_ids:
-        - "{{ ec2_instance_id }}"
-        - "{{ ec2_instance_id_py2 }}"
-      wait: True
-    ignore_errors: true
-    retries: 5
-    register: remove
-    until: remove is successful
+    - name: terminate the instance
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids:
+          - "{{ ec2_instance_id }}"
+          - "{{ ec2_instance_id_py2 }}"
+        wait: true
+      ignore_errors: true
+      retries: 5
+      register: remove
+      until: remove is successful
 
-  - name: remove ssh key
-    ec2_key:
-      name: "{{ ec2_key_name }}"
-      state: absent
-    ignore_errors: true
+    - name: remove ssh key
+      amazon.aws.ec2_key:
+        name: "{{ ec2_key_name }}"
+        state: absent
+      ignore_errors: true
 
-  - name: remove the public route table
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc_id }}"
-      route_table_id: "{{ vpc_route_table_id }}"
-      lookup: id
-      state: absent
-    ignore_errors: true
-    retries: 5
-    register: remove
-    until: remove is successful
+    - name: remove the public route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc_id }}"
+        route_table_id: "{{ vpc_route_table_id }}"
+        lookup: id
+        state: absent
+      ignore_errors: true
+      retries: 5
+      register: remove
+      until: remove is successful
 
-  - name: remove the internet gateway
-    ec2_vpc_igw:
-      vpc_id: "{{ vpc_id }}"
-      state: absent
-    ignore_errors: true
-    retries: 5
-    register: remove
-    until: remove is successful
+    - name: remove the internet gateway
+      amazon.aws.ec2_vpc_igw:
+        vpc_id: "{{ vpc_id }}"
+        state: absent
+      ignore_errors: true
+      retries: 5
+      register: remove
+      until: remove is successful
 
-  - name: remove the security group
-    ec2_security_group:
-      group_id: "{{ vpc_sg_id }}"
-      state: absent
-    ignore_errors: true
-    retries: 5
-    register: remove
-    until: remove is successful
+    - name: remove the security group
+      ec2_security_group:
+        group_id: "{{ vpc_sg_id }}"
+        state: absent
+      ignore_errors: true
+      retries: 5
+      register: remove
+      until: remove is successful
 
-  - name: remove the subnet
-    ec2_vpc_subnet:
-      cidr: "{{ vpc_cidr }}"
-      az: "{{ availability_zone }}"
-      vpc_id: "{{ vpc_id }}"
-      state: absent
-    ignore_errors: true
-    retries: 5
-    register: remove
-    until: remove is successful
+    - name: remove the subnet
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ vpc_cidr }}"
+        az: "{{ availability_zone }}"
+        vpc_id: "{{ vpc_id }}"
+        state: absent
+      ignore_errors: true
+      retries: 5
+      register: remove
+      until: remove is successful
 
-  - name: remove the VPC
-    ec2_vpc_net:
-      name: "{{ resource_prefix }}-vpc"
-      cidr_block: "{{ vpc_cidr }}"
-      state: absent
-    ignore_errors: true
-    retries: 5
-    register: remove
-    until: remove is successful
+    - name: remove the VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: "{{ vpc_cidr }}"
+        state: absent
+      ignore_errors: true
+      retries: 5
+      register: remove
+      until: remove is successful

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
@@ -1,18 +1,17 @@
 ---
 - hosts: testhost
   tasks:
+    - name: Wait for EC2 to be available
+      ansible.builtin.wait_for_connection:
 
-  - name: Wait for EC2 to be available
-    wait_for_connection:
+    - amazon.aws.ec2_metadata_facts:
 
-  - amazon.aws.ec2_metadata_facts:
-
-  - name: Assert initial metadata for the instance
-    assert:
-      that:
-        - ansible_ec2_ami_id == image_id
-        - ansible_ec2_placement_availability_zone == availability_zone
-        - ansible_ec2_security_groups == resource_prefix+"-sg"
-        - ansible_ec2_user_data == "None"
-        - ansible_ec2_instance_tags_keys is defined
-        - ansible_ec2_instance_tags_keys | length == 3
+    - name: Assert initial metadata for the instance
+      ansible.builtin.assert:
+        that:
+          - ansible_ec2_ami_id == image_id
+          - ansible_ec2_placement_availability_zone == availability_zone
+          - ansible_ec2_security_groups == resource_prefix+"-sg"
+          - ansible_ec2_user_data == "None"
+          - ansible_ec2_instance_tags_keys is defined
+          - ansible_ec2_instance_tags_keys | length == 3

--- a/tests/integration/targets/ec2_security_group/defaults/main.yml
+++ b/tests/integration/targets/ec2_security_group/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for test_ec2_group
-ec2_group_name: '{{resource_prefix}}'
-ec2_group_description: 'Created by ansible integration tests'
+ec2_group_name: "{{resource_prefix}}"
+ec2_group_description: Created by ansible integration tests
 
-vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'
-subnet_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.1.0/24'
+vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/16
+subnet_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.1.0/24

--- a/tests/integration/targets/ec2_security_group/meta/main.yml
+++ b/tests/integration/targets/ec2_security_group/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/ec2_security_group/tasks/data_validation.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/data_validation.yml
@@ -2,32 +2,32 @@
 - block:
     - name: Create a group with only the default rule
       ec2_security_group:
-        name: '{{ec2_group_name}}-input-tests'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-input-tests"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
 
     - name: Run through some common weird port specs
       ec2_security_group:
-        name: '{{ec2_group_name}}-input-tests'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-input-tests"
+        description: "{{ec2_group_description}}"
         rules:
           - "{{ item }}"
       with_items:
         - proto: tcp
           from_port: "8182"
           to_port: 8182
-          cidr_ipv6: "fc00:ff9b::/96"
+          cidr_ipv6: fc00:ff9b::/96
           rule_desc: Mixed string and non-string ports
         - proto: tcp
           ports:
-          - "9000"
-          - 9001
-          - 9002-9005
-          cidr_ip: "10.2.3.0/24"
+            - "9000"
+            - 9001
+            - 9002-9005
+          cidr_ip: 10.2.3.0/24
   always:
     - name: tidy up input testing group
       ec2_security_group:
-        name: '{{ec2_group_name}}-input-tests'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}-input-tests"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/ec2_security_group/tasks/diff_mode.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/diff_mode.yml
@@ -1,59 +1,59 @@
 ---
-  # ============================================================
+# ============================================================
 
-  - name: create a group with a rule (CHECK MODE + DIFF)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
+- name: create a group with a rule (CHECK MODE + DIFF)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
       - proto: tcp
         from_port: 80
         to_port: 80
-        cidr_ip: 0.0.0.0/0
-      rules_egress:
+        cidr_ip: "0.0.0.0/0"
+    rules_egress:
       - proto: all
-        cidr_ip: 0.0.0.0/0
-    register: check_mode_result
-    check_mode: true
-    diff: true
+        cidr_ip: "0.0.0.0/0"
+  register: check_mode_result
+  check_mode: true
+  diff: true
 
-  - assert:
-      that:
-        - check_mode_result.changed
+- ansible.builtin.assert:
+    that:
+      - check_mode_result.changed
 
-  - name: create a group with a rule (DIFF)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
+- name: create a group with a rule (DIFF)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
       - proto: tcp
         from_port: 80
         to_port: 80
-        cidr_ip: 0.0.0.0/0
-      rules_egress:
+        cidr_ip: "0.0.0.0/0"
+    rules_egress:
       - proto: all
-        cidr_ip: 0.0.0.0/0
-    register: result
-    diff: true
+        cidr_ip: "0.0.0.0/0"
+  register: result
+  diff: true
 
-  - assert:
-      that:
-        - result.changed
-        - result.diff.0.after.ip_permissions == check_mode_result.diff.0.after.ip_permissions
-        - result.diff.0.after.ip_permissions_egress == check_mode_result.diff.0.after.ip_permissions_egress
+- ansible.builtin.assert:
+    that:
+      - result.changed
+      - result.diff.0.after.ip_permissions == check_mode_result.diff.0.after.ip_permissions
+      - result.diff.0.after.ip_permissions_egress == check_mode_result.diff.0.after.ip_permissions_egress
 
-  - name: add rules to make sorting occur (CHECK MODE + DIFF)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
+- name: add rules to make sorting occur (CHECK MODE + DIFF)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
       - proto: tcp
         from_port: 80
         to_port: 80
-        cidr_ip: 0.0.0.0/0
+        cidr_ip: "0.0.0.0/0"
       - proto: tcp
         from_port: 22
         to_port: 22
@@ -62,23 +62,23 @@
         from_port: 22
         to_port: 22
         cidr_ip: 10.0.0.0/8
-      rules_egress:
+    rules_egress:
       - proto: all
-        cidr_ip: 0.0.0.0/0
-    register: check_mode_result
-    check_mode: true
-    diff: true
+        cidr_ip: "0.0.0.0/0"
+  register: check_mode_result
+  check_mode: true
+  diff: true
 
-  - assert:
-      that:
-        - check_mode_result.changed
+- ansible.builtin.assert:
+    that:
+      - check_mode_result.changed
 
-  - name: add rules in a different order to test sorting consistency (DIFF)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
+- name: add rules in a different order to test sorting consistency (DIFF)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
       - proto: tcp
         from_port: 22
         to_port: 22
@@ -86,82 +86,82 @@
       - proto: tcp
         from_port: 80
         to_port: 80
-        cidr_ip: 0.0.0.0/0
+        cidr_ip: "0.0.0.0/0"
       - proto: tcp
         from_port: 22
         to_port: 22
         cidr_ip: 10.0.0.0/8
-      rules_egress:
+    rules_egress:
       - proto: all
-        cidr_ip: 0.0.0.0/0
-    register: result
-    diff: true
+        cidr_ip: "0.0.0.0/0"
+  register: result
+  diff: true
 
-  - assert:
-      that:
-        - result.changed
-        - result.diff.0.after.ip_permissions == check_mode_result.diff.0.after.ip_permissions
-        - result.diff.0.after.ip_permissions_egress == check_mode_result.diff.0.after.ip_permissions_egress
+- ansible.builtin.assert:
+    that:
+      - result.changed
+      - result.diff.0.after.ip_permissions == check_mode_result.diff.0.after.ip_permissions
+      - result.diff.0.after.ip_permissions_egress == check_mode_result.diff.0.after.ip_permissions_egress
 
-  - name: purge rules (CHECK MODE + DIFF)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
+- name: purge rules (CHECK MODE + DIFF)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
       - proto: tcp
         from_port: 80
         to_port: 80
-        cidr_ip: 0.0.0.0/0
-      rules_egress: []
-    register: check_mode_result
-    check_mode: true
-    diff: true
+        cidr_ip: "0.0.0.0/0"
+    rules_egress: []
+  register: check_mode_result
+  check_mode: true
+  diff: true
 
-  - assert:
-      that:
-        - check_mode_result.changed
+- ansible.builtin.assert:
+    that:
+      - check_mode_result.changed
 
-  - name: purge rules (DIFF)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
+- name: purge rules (DIFF)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
       - proto: tcp
         from_port: 80
         to_port: 80
-        cidr_ip: 0.0.0.0/0
-      rules_egress: []
-    register: result
-    diff: true
+        cidr_ip: "0.0.0.0/0"
+    rules_egress: []
+  register: result
+  diff: true
 
-  - assert:
-      that:
-        - result.changed
-        - result.diff.0.after.ip_permissions == check_mode_result.diff.0.after.ip_permissions
-        - result.diff.0.after.ip_permissions_egress == check_mode_result.diff.0.after.ip_permissions_egress
+- ansible.builtin.assert:
+    that:
+      - result.changed
+      - result.diff.0.after.ip_permissions == check_mode_result.diff.0.after.ip_permissions
+      - result.diff.0.after.ip_permissions_egress == check_mode_result.diff.0.after.ip_permissions_egress
 
-  - name: delete the security group (CHECK MODE + DIFF)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      state: absent
-    register: check_mode_result
-    diff: true
-    check_mode: true
+- name: delete the security group (CHECK MODE + DIFF)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    state: absent
+  register: check_mode_result
+  diff: true
+  check_mode: true
 
-  - assert:
-      that:
-        - check_mode_result.changed
+- ansible.builtin.assert:
+    that:
+      - check_mode_result.changed
 
-  - name: delete the security group (DIFF)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      state: absent
-    register: result
-    diff: true
+- name: delete the security group (DIFF)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    state: absent
+  register: result
+  diff: true
 
-  - assert:
-      that:
-        - result.changed
-        - not result.diff.0.after and not check_mode_result.diff.0.after
+- ansible.builtin.assert:
+    that:
+      - result.changed
+      - not result.diff.0.after and not check_mode_result.diff.0.after

--- a/tests/integration/targets/ec2_security_group/tasks/egress_tests.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/egress_tests.yml
@@ -2,14 +2,14 @@
 - block:
     - name: Create a group with only the default rule
       ec2_security_group:
-        name: '{{ec2_group_name}}-egress-tests'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-egress-tests"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         state: present
       register: result
 
     - name: assert default rule is in place (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - result.ip_permissions|length == 0
@@ -18,15 +18,15 @@
 
     - name: Create a group with only the default rule
       ec2_security_group:
-        name: '{{ec2_group_name}}-egress-tests'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-egress-tests"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         purge_rules_egress: false
         state: present
       register: result
 
     - name: assert default rule is not purged (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
           - result.ip_permissions|length == 0
@@ -35,16 +35,16 @@
 
     - name: Pass empty egress rules without purging, should leave default rule in place
       ec2_security_group:
-        name: '{{ec2_group_name}}-egress-tests'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}-egress-tests"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         purge_rules_egress: false
         rules_egress: []
         state: present
       register: result
 
     - name: assert default rule is not purged (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
           - result.ip_permissions|length == 0
@@ -53,16 +53,16 @@
 
     - name: Purge rules, including the default
       ec2_security_group:
-        name: '{{ec2_group_name}}-egress-tests'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}-egress-tests"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         purge_rules_egress: true
         rules_egress: []
         state: present
       register: result
 
     - name: assert default rule is not purged (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - result.ip_permissions|length == 0
@@ -70,58 +70,58 @@
 
     - name: Add a custom egress rule
       ec2_security_group:
-        name: '{{ec2_group_name}}-egress-tests'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}-egress-tests"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         rules_egress:
-        - proto: tcp
-          ports:
-          - 1212
-          cidr_ip: 10.2.1.2/32
+          - proto: tcp
+            ports:
+              - 1212
+            cidr_ip: 10.2.1.2/32
         state: present
       register: result
 
     - name: assert first rule is here
-      assert:
+      ansible.builtin.assert:
         that:
           - result.ip_permissions_egress|length == 1
 
     - name: Add a second custom egress rule
       ec2_security_group:
-        name: '{{ec2_group_name}}-egress-tests'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-egress-tests"
+        description: "{{ec2_group_description}}"
         purge_rules_egress: false
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        vpc_id: "{{ vpc_result.vpc.id }}"
         rules_egress:
-        - proto: tcp
-          ports:
-          - 2323
-          cidr_ip: 10.3.2.3/32
+          - proto: tcp
+            ports:
+              - 2323
+            cidr_ip: 10.3.2.3/32
         state: present
       register: result
 
     - name: assert the first rule is not purged
-      assert:
+      ansible.builtin.assert:
         that:
           - result.ip_permissions_egress|length == 2
 
     - name: Purge the second rule (CHECK MODE) (DIFF MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}-egress-tests'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}-egress-tests"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         rules_egress:
-        - proto: tcp
-          ports:
-          - 1212
-          cidr_ip: 10.2.1.2/32
+          - proto: tcp
+            ports:
+              - 1212
+            cidr_ip: 10.2.1.2/32
         state: present
       register: result
-      check_mode: True
-      diff: True
+      check_mode: true
+      diff: true
 
     - name: assert first rule will be left
-      assert:
+      ansible.builtin.assert:
         that:
           - result.changed
           - result.diff.0.after.ip_permissions_egress|length == 1
@@ -129,49 +129,49 @@
 
     - name: Purge the second rule
       ec2_security_group:
-        name: '{{ec2_group_name}}-egress-tests'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}-egress-tests"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         rules_egress:
-        - proto: tcp
-          ports:
-          - 1212
-          cidr_ip: 10.2.1.2/32
+          - proto: tcp
+            ports:
+              - 1212
+            cidr_ip: 10.2.1.2/32
         state: present
       register: result
 
     - name: assert first rule is here
-      assert:
+      ansible.builtin.assert:
         that:
           - result.ip_permissions_egress|length == 1
           - result.ip_permissions_egress[0].ip_ranges[0].cidr_ip == '10.2.1.2/32'
 
     - name: add a rule for all TCP ports
       ec2_security_group:
-        name: '{{ec2_group_name}}-egress-tests'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-egress-tests"
+        description: "{{ec2_group_description}}"
         rules_egress:
-        - proto: tcp
-          ports: 0-65535
-          cidr_ip: 0.0.0.0/0
+          - proto: tcp
+            ports: "0-65535"
+            cidr_ip: "0.0.0.0/0"
         state: present
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        vpc_id: "{{ vpc_result.vpc.id }}"
       register: result
 
     - name: Re-add the default rule
       ec2_security_group:
-        name: '{{ec2_group_name}}-egress-tests'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-egress-tests"
+        description: "{{ec2_group_description}}"
         rules_egress:
-        - proto: -1
-          cidr_ip: 0.0.0.0/0
+          - proto: -1
+            cidr_ip: "0.0.0.0/0"
         state: present
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        vpc_id: "{{ vpc_result.vpc.id }}"
       register: result
   always:
     - name: tidy up egress rule test security group
       ec2_security_group:
-        name: '{{ec2_group_name}}-egress-tests'
+        name: "{{ec2_group_name}}-egress-tests"
         state: absent
-        vpc_id: '{{ vpc_result.vpc.id }}'
-      ignore_errors: yes
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      ignore_errors: true

--- a/tests/integration/targets/ec2_security_group/tasks/group_info.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/group_info.yml
@@ -1,25 +1,24 @@
 ---
-
 # file for testing the ec2_group_info module
 
 - block:
     # ======================== Setup =====================================
     - name: Create a group for testing group info retrieval below
       ec2_security_group:
-        name: '{{ ec2_group_name }}-info-1'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ ec2_group_description }}'
+        name: "{{ ec2_group_name }}-info-1"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ ec2_group_description }}"
         rules:
           - proto: tcp
             ports:
               - 90
             cidr_ip: 10.2.2.2/32
         tags:
-          test: '{{ resource_prefix }}_ec2_group_info_module'
+          test: "{{ resource_prefix }}_ec2_group_info_module"
       register: group_info_test_setup
 
     - name: Ensure tags were added without the additional CreateTags/RemoveTags calls
-      assert:
+      ansible.builtin.assert:
         that:
           - group_info_test_setup.tags | length == 1
           - "'test' in group_info_test_setup.tags"
@@ -29,9 +28,9 @@
 
     - name: Create another group for testing group info retrieval below
       ec2_security_group:
-        name: '{{ ec2_group_name }}-info-2'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ ec2_group_description }}'
+        name: "{{ ec2_group_name }}-info-2"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ ec2_group_description }}"
         rules:
           - proto: tcp
             ports:
@@ -43,11 +42,11 @@
     - name: Retrieve security group info based on SG name
       ec2_security_group_info:
         filters:
-          group-name: '{{ ec2_group_name }}-info-2'
+          group-name: "{{ ec2_group_name }}-info-2"
       register: result_1
 
     - name: Assert results found
-      assert:
+      ansible.builtin.assert:
         that:
           - result_1.security_groups is defined
           - (result_1.security_groups|first).group_name == '{{ ec2_group_name }}-info-2'
@@ -55,11 +54,11 @@
     - name: Retrieve security group info based on SG VPC
       ec2_security_group_info:
         filters:
-          vpc-id: '{{ vpc_result.vpc.id }}'
+          vpc-id: "{{ vpc_result.vpc.id }}"
       register: result_2
 
     - name: Assert results found
-      assert:
+      ansible.builtin.assert:
         that:
           - result_2.security_groups is defined
           - (result_2.security_groups|first).vpc_id == vpc_result.vpc.id
@@ -68,11 +67,11 @@
     - name: Retrieve security group info based on SG tags
       ec2_security_group_info:
         filters:
-          "tag:test": "{{ resource_prefix }}_ec2_group_info_module"
+          tag:test: "{{ resource_prefix }}_ec2_group_info_module"
       register: result_3
 
     - name: Assert results found
-      assert:
+      ansible.builtin.assert:
         that:
           - result_3.security_groups is defined
           - (result_3.security_groups|first).group_id == group_info_test_setup.group_id
@@ -80,11 +79,11 @@
     - name: Retrieve security group info based on SG ID
       ec2_security_group_info:
         filters:
-          group-id: '{{ group_info_test_setup.group_id }}'
+          group-id: "{{ group_info_test_setup.group_id }}"
       register: result_4
 
     - name: Assert correct result found
-      assert:
+      ansible.builtin.assert:
         that:
           - result_4.security_groups is defined
           - (result_4.security_groups|first).group_id == group_info_test_setup.group_id
@@ -94,12 +93,12 @@
     # ========================= Cleanup =================================
     - name: tidy up test security group 1
       ec2_security_group:
-        name: '{{ ec2_group_name }}-info-1'
+        name: "{{ ec2_group_name }}-info-1"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: tidy up test security group 2
       ec2_security_group:
-        name: '{{ ec2_group_name }}-info-2'
+        name: "{{ ec2_group_name }}-info-2"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/ec2_security_group/tasks/icmp_verbs.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/icmp_verbs.yml
@@ -3,11 +3,11 @@
     # ============================================================
     - name: Create simple rule using icmp verbs
       ec2_security_group:
-        name: '{{ec2_group_name}}-icmp-1'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-icmp-1"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         rules:
-          - proto: "icmp"
+          - proto: icmp
             icmp_type: 3
             icmp_code: 8
             cidr_ip:
@@ -19,10 +19,10 @@
     - name: Retrieve security group info
       ec2_security_group_info:
         filters:
-          group-name: '{{ ec2_group_name }}-icmp-1'
+          group-name: "{{ ec2_group_name }}-icmp-1"
       register: result_1
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result_1.security_groups is defined
@@ -31,61 +31,60 @@
 
     - name: Create ipv6 rule using icmp verbs
       ec2_security_group:
-        name: '{{ec2_group_name}}-icmp-2'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-icmp-2"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         rules:
-          - proto: "icmpv6"
+          - proto: icmpv6
             icmp_type: 1
             icmp_code: 4
-            cidr_ipv6: "64:ff9b::/96"
+            cidr_ipv6: 64:ff9b::/96
         state: present
       register: result
 
     - name: Retrieve security group info
       ec2_security_group_info:
         filters:
-          group-name: '{{ ec2_group_name }}-icmp-2'
+          group-name: "{{ ec2_group_name }}-icmp-2"
       register: result_1
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result_1.security_groups is defined
           - (result_1.security_groups|first).group_name == '{{ ec2_group_name }}-icmp-2'
           - (result_1.security_groups|first).ip_permissions[0].ip_protocol == "icmpv6"
 
-
     - name: Create rule using security group referencing
       ec2_security_group:
-        name: '{{ec2_group_name}}-icmp-3'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-icmp-3"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         rules:
-          - proto: "icmp"
+          - proto: icmp
             icmp_type: 5
             icmp_code: 1
-            group_name: '{{ec2_group_name}}-auto-create-2'
-            group_desc: "sg-group-referencing"
+            group_name: "{{ec2_group_name}}-auto-create-2"
+            group_desc: sg-group-referencing
         state: present
       register: result
 
     - name: Retrieve security group info
       ec2_security_group_info:
         filters:
-          group-name: '{{ ec2_group_name }}-icmp-3'
+          group-name: "{{ ec2_group_name }}-icmp-3"
       register: result_1
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - (result_1.security_groups | first).ip_permissions[0].user_id_group_pairs is defined
 
     - name: Create list rule using 0 as icmp_type
       ec2_security_group:
-        name: '{{ec2_group_name}}-icmp-4'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-icmp-4"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         rules:
           - proto: icmp
             icmp_type: 0
@@ -93,7 +92,7 @@
             cidr_ip:
               - 10.0.0.0/8
               - 172.16.40.10/32
-          - proto: "tcp"
+          - proto: tcp
             from_port: 80
             to_port: 80
             cidr_ip: 172.16.40.10/32
@@ -103,10 +102,10 @@
     - name: Retrieve security group info
       ec2_security_group_info:
         filters:
-          group-name: '{{ ec2_group_name }}-icmp-4'
+          group-name: "{{ ec2_group_name }}-icmp-4"
       register: result_1
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - (result_1.security_groups | first).ip_permissions | length == 2
@@ -115,30 +114,30 @@
     # ============================================================
     - name: Create a group with non-ICMP protocol
       ec2_security_group:
-        name: '{{ec2_group_name}}-icmp-4'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-icmp-4"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         rules:
-        - proto: "tcp"
-          icmp_type: 0
-          icmp_code: 1
-          cidr_ip:
-            - 10.0.0.0/8
-            - 172.16.40.10/32
+          - proto: tcp
+            icmp_type: 0
+            icmp_code: 1
+            cidr_ip:
+              - 10.0.0.0/8
+              - 172.16.40.10/32
         state: present
       register: result
       ignore_errors: true
 
     - name: assert that group creation fails when proto != icmp with icmp parameters
-      assert:
+      ansible.builtin.assert:
         that:
           - result is failed
 
     - name: Create a group with conflicting parameters
       ec2_security_group:
-        name: '{{ec2_group_name}}-icmp-4'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-icmp-4"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         rules:
           - proto: icmp
             from_port: 5
@@ -153,48 +152,48 @@
       ignore_errors: true
 
     - name: assert that group creation fails when using conflicting parameters
-      assert:
+      ansible.builtin.assert:
         that:
           - result is failed
 
     - name: Create a group with missing icmp parameters
       ec2_security_group:
-        name: '{{ec2_group_name}}-icmp-4'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-icmp-4"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         rules:
-        - proto: "tcp"
-          icmp_type: 0
-          cidr_ip:
-            - 10.0.0.0/8
-            - 172.16.40.10/32
+          - proto: tcp
+            icmp_type: 0
+            cidr_ip:
+              - 10.0.0.0/8
+              - 172.16.40.10/32
         state: present
       register: result
       ignore_errors: true
 
     - name: assert that group creation fails when missing icmp parameters
-      assert:
+      ansible.builtin.assert:
         that:
           - result is failed
 
   always:
     - name: tidy up egress rule test security group rules
       ec2_security_group:
-        name: '{{ec2_group_name}}-auto-create-2'
-        description: 'sg-group-referencing'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}-auto-create-2"
+        description: sg-group-referencing
+        vpc_id: "{{ vpc_result.vpc.id }}"
         rules: []
         rules_egress: []
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: tidy up egress rule test security group rules
       ec2_security_group:
-        name: '{{ec2_group_name}}-icmp-{{ item }}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}-icmp-{{ item }}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         rules: []
         rules_egress: []
-      ignore_errors: yes
+      ignore_errors: true
       with_items:
         - 1
         - 2
@@ -203,17 +202,17 @@
 
     - name: tidy up egress rule test security group rules
       ec2_security_group:
-        name: '{{ec2_group_name}}-auto-create-2'
+        name: "{{ec2_group_name}}-auto-create-2"
         state: absent
-        vpc_id: '{{ vpc_result.vpc.id }}'
-      ignore_errors: yes
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      ignore_errors: true
 
     - name: tidy up egress rule test security group
       ec2_security_group:
-        name: '{{ec2_group_name}}-icmp-{{ item }}'
+        name: "{{ec2_group_name}}-icmp-{{ item }}"
         state: absent
-        vpc_id: '{{ vpc_result.vpc.id }}'
-      ignore_errors: yes
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      ignore_errors: true
       with_items:
         - 1
         - 2

--- a/tests/integration/targets/ec2_security_group/tasks/ipv6_default_tests.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/ipv6_default_tests.yml
@@ -2,89 +2,89 @@
 # ============================================================
 - name: test state=present for ipv6 (expected changed=true) (CHECK MODE)
   ec2_security_group:
-    name: '{{ec2_group_name}}'
-    description: '{{ec2_group_description}}'
+    name: "{{ec2_group_name}}"
+    description: "{{ec2_group_description}}"
     state: present
     rules:
-    - proto: "tcp"
-      from_port: 8182
-      to_port: 8182
-      cidr_ipv6: "64:ff9b::/96"
+      - proto: tcp
+        from_port: 8182
+        to_port: 8182
+        cidr_ipv6: 64:ff9b::/96
   check_mode: true
   register: result
 
 - name: assert state=present (expected changed=true)
-  assert:
+  ansible.builtin.assert:
     that:
-       - 'result.changed'
+      - result.changed
 
 # ============================================================
 - name: test state=present for ipv6 (expected changed=true)
   ec2_security_group:
-    name: '{{ec2_group_name}}'
-    description: '{{ec2_group_description}}'
+    name: "{{ec2_group_name}}"
+    description: "{{ec2_group_description}}"
     state: present
     rules:
-    - proto: "tcp"
-      from_port: 8182
-      to_port: 8182
-      cidr_ipv6: "64:ff9b::/96"
+      - proto: tcp
+        from_port: 8182
+        to_port: 8182
+        cidr_ipv6: 64:ff9b::/96
   register: result
 
 - name: assert state=present (expected changed=true)
-  assert:
+  ansible.builtin.assert:
     that:
-       - 'result.changed'
-       - 'result.group_id.startswith("sg-")'
+      - result.changed
+      - result.group_id.startswith("sg-")
 
 # ============================================================
 - name: test rules_egress state=present for ipv6 (expected changed=true) (CHECK MODE)
   ec2_security_group:
-    name: '{{ec2_group_name}}'
-    description: '{{ec2_group_description}}'
+    name: "{{ec2_group_name}}"
+    description: "{{ec2_group_description}}"
     state: present
     rules:
-    - proto: "tcp"
-      from_port: 8182
-      to_port: 8182
-      cidr_ipv6: "64:ff9b::/96"
+      - proto: tcp
+        from_port: 8182
+        to_port: 8182
+        cidr_ipv6: 64:ff9b::/96
     rules_egress:
-    - proto: "tcp"
-      from_port: 8181
-      to_port: 8181
-      cidr_ipv6: "64:ff9b::/96"
+      - proto: tcp
+        from_port: 8181
+        to_port: 8181
+        cidr_ipv6: 64:ff9b::/96
   check_mode: true
   register: result
 
 - name: assert state=present (expected changed=true)
-  assert:
+  ansible.builtin.assert:
     that:
-       - 'result.changed'
+      - result.changed
 
 # ============================================================
 - name: test rules_egress state=present for ipv6 (expected changed=true)
   ec2_security_group:
-    name: '{{ec2_group_name}}'
-    description: '{{ec2_group_description}}'
+    name: "{{ec2_group_name}}"
+    description: "{{ec2_group_description}}"
     state: present
     rules:
-    - proto: "tcp"
-      from_port: 8182
-      to_port: 8182
-      cidr_ipv6: "64:ff9b::/96"
+      - proto: tcp
+        from_port: 8182
+        to_port: 8182
+        cidr_ipv6: 64:ff9b::/96
     rules_egress:
-    - proto: "tcp"
-      from_port: 8181
-      to_port: 8181
-      cidr_ipv6: "64:ff9b::/96"
+      - proto: tcp
+        from_port: 8181
+        to_port: 8181
+        cidr_ipv6: 64:ff9b::/96
   register: result
 
 - name: assert state=present (expected changed=true)
-  assert:
+  ansible.builtin.assert:
     that:
-       - 'result.changed'
-       - 'result.group_id.startswith("sg-")'
+      - result.changed
+      - result.group_id.startswith("sg-")
 - name: delete it
   ec2_security_group:
-    name: '{{ec2_group_name}}'
+    name: "{{ec2_group_name}}"
     state: absent

--- a/tests/integration/targets/ec2_security_group/tasks/main.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/main.yml
@@ -1,395 +1,392 @@
 ---
-- set_fact:
+- ansible.builtin.set_fact:
     # lookup plugins don't have access to module_defaults
     connection_args:
-        region: "{{ aws_region }}"
-        access_key: "{{ aws_access_key }}"
-        secret_key: "{{ aws_secret_key }}"
-        session_token: "{{ security_token | default(omit) }}"
-  no_log: True
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+  no_log: true
 
 # ============================================================
 - name: Run all tests
   module_defaults:
-      group/aws:
-        access_key: "{{ aws_access_key }}"
-        secret_key: "{{ aws_secret_key }}"
-        session_token: "{{ security_token | default(omit)}}"
-        region: "{{ aws_region }}"
+    group/aws:
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit)}}"
+      region: "{{ aws_region }}"
   block:
     - name: determine if there is a default VPC
-      set_fact:
+      ansible.builtin.set_fact:
         defaultvpc: "{{ lookup('amazon.aws.aws_account_attribute', attribute='default-vpc', **connection_args) }}"
       register: default_vpc
 
     - name: create a VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         name: "{{ resource_prefix }}-vpc"
         state: present
         cidr_block: "{{ vpc_cidr }}"
         tags:
           Name: "{{ resource_prefix }}-vpc"
-          Description: "Created by ansible-test"
+          Description: Created by ansible-test
       register: vpc_result
     #TODO(ryansb): Update CI for VPC peering permissions
     #- include_tasks: ./multi_account.yml
-    - include_tasks: ./diff_mode.yml
-    - include_tasks: ./numeric_protos.yml
-    - include_tasks: ./rule_group_create.yml
-    - include_tasks: ./egress_tests.yml
-    - include_tasks: ./icmp_verbs.yml
-    - include_tasks: ./data_validation.yml
-    - include_tasks: ./multi_nested_target.yml
-    - include_tasks: ./group_info.yml
-
-    # ============================================================
+    - ansible.builtin.include_tasks: ./diff_mode.yml
+    - ansible.builtin.include_tasks: ./numeric_protos.yml
+    - ansible.builtin.include_tasks: ./rule_group_create.yml
+    - ansible.builtin.include_tasks: ./egress_tests.yml
+    - ansible.builtin.include_tasks: ./icmp_verbs.yml
+    - ansible.builtin.include_tasks: ./data_validation.yml
+    - ansible.builtin.include_tasks: ./multi_nested_target.yml
+    - ansible.builtin.include_tasks: ./group_info.yml
     - name: test state=absent (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: absent
       check_mode: true
       register: result
 
     - name: assert no changes would be made
-      assert:
+      ansible.builtin.assert:
         that:
           - not result.changed
 
     # ===========================================================
     - name: test state=absent
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: absent
       register: result
 
     # ============================================================
     - name: test state=present (expected changed=true) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
       check_mode: true
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.changed'
+          - result.changed
 
     # ============================================================
     - name: test state=present (expected changed=true)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.changed'
-           - 'result.group_id.startswith("sg-")'
+          - result.changed
+          - result.group_id.startswith("sg-")
 
     # ============================================================
     - name: test state=present different description (expected changed=false) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}CHANGED'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}CHANGED"
         state: present
       check_mode: true
       register: result
 
     - name: assert state=present (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'not result.changed'
+          - not result.changed
 
     # ============================================================
     - name: test state=present different description (expected changed=false)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}CHANGED'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}CHANGED"
         state: present
       ignore_errors: true
       register: result
 
     - name: assert state=present (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'not result.changed'
-           - 'result.group_id.startswith("sg-")'
+          - not result.changed
+          - result.group_id.startswith("sg-")
 
     # ============================================================
     - name: test state=present (expected changed=false)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
       register: result
 
     - name: assert state=present (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'not result.changed'
-           - 'result.group_id.startswith("sg-")'
+          - not result.changed
+          - result.group_id.startswith("sg-")
 
     # ============================================================
     - name: tests IPv6 with the default VPC
-      include_tasks: ./ipv6_default_tests.yml
+      ansible.builtin.include_tasks: ./ipv6_default_tests.yml
       when: default_vpc
 
     - name: test IPv6 with a specified VPC
       block:
-
         # ============================================================
         - name: test state=present (expected changed=true) (CHECK MODE)
           ec2_security_group:
-            name: '{{ ec2_group_name }}-2'
-            description: '{{ ec2_group_description }}-2'
+            name: "{{ ec2_group_name }}-2"
+            description: "{{ ec2_group_description }}-2"
             state: present
-            vpc_id: '{{ vpc_result.vpc.id }}'
+            vpc_id: "{{ vpc_result.vpc.id }}"
           check_mode: true
           register: result
 
         - name: assert state=present (expected changed=true)
-          assert:
+          ansible.builtin.assert:
             that:
-               - 'result.changed'
+              - result.changed
 
         # ============================================================
         - name: test state=present (expected changed=true)
           ec2_security_group:
-            name: '{{ ec2_group_name }}-2'
-            description: '{{ ec2_group_description }}-2'
+            name: "{{ ec2_group_name }}-2"
+            description: "{{ ec2_group_description }}-2"
             state: present
-            vpc_id: '{{ vpc_result.vpc.id }}'
+            vpc_id: "{{ vpc_result.vpc.id }}"
           register: result
 
         - name: assert state=present (expected changed=true)
-          assert:
+          ansible.builtin.assert:
             that:
-               - 'result.changed'
-               - 'result.group_id.startswith("sg-")'
+              - result.changed
+              - result.group_id.startswith("sg-")
 
         # ============================================================
         - name: test state=present for ipv6 (expected changed=true) (CHECK MODE)
           ec2_security_group:
-            name: '{{ ec2_group_name }}-2'
-            description: '{{ ec2_group_description }}-2'
+            name: "{{ ec2_group_name }}-2"
+            description: "{{ ec2_group_description }}-2"
             state: present
-            vpc_id: '{{ vpc_result.vpc.id }}'
+            vpc_id: "{{ vpc_result.vpc.id }}"
             rules:
-            - proto: "tcp"
-              from_port: 8182
-              to_port: 8182
-              cidr_ipv6: "64:ff9b::/96"
+              - proto: tcp
+                from_port: 8182
+                to_port: 8182
+                cidr_ipv6: 64:ff9b::/96
           check_mode: true
           register: result
 
         - name: assert state=present (expected changed=true)
-          assert:
+          ansible.builtin.assert:
             that:
-               - 'result.changed'
+              - result.changed
 
         # ============================================================
         - name: test state=present for ipv6 (expected changed=true)
           ec2_security_group:
-            name: '{{ ec2_group_name }}-2'
-            description: '{{ ec2_group_description }}-2'
+            name: "{{ ec2_group_name }}-2"
+            description: "{{ ec2_group_description }}-2"
             state: present
-            vpc_id: '{{ vpc_result.vpc.id }}'
+            vpc_id: "{{ vpc_result.vpc.id }}"
             rules:
-            - proto: "tcp"
-              from_port: 8182
-              to_port: 8182
-              cidr_ipv6: "64:ff9b::/96"
+              - proto: tcp
+                from_port: 8182
+                to_port: 8182
+                cidr_ipv6: 64:ff9b::/96
           register: result
 
         - name: assert state=present (expected changed=true)
-          assert:
+          ansible.builtin.assert:
             that:
-               - 'result.changed'
-               - 'result.group_id.startswith("sg-")'
+              - result.changed
+              - result.group_id.startswith("sg-")
 
         # ============================================================
         - name: test state=present for ipv6 (expected changed=false) (CHECK MODE)
           ec2_security_group:
-            name: '{{ ec2_group_name }}-2'
-            description: '{{ ec2_group_description }}-2'
+            name: "{{ ec2_group_name }}-2"
+            description: "{{ ec2_group_description }}-2"
             state: present
-            vpc_id: '{{ vpc_result.vpc.id }}'
+            vpc_id: "{{ vpc_result.vpc.id }}"
             rules:
-            - proto: "tcp"
-              from_port: 8182
-              to_port: 8182
-              cidr_ipv6: "64:ff9b::/96"
+              - proto: tcp
+                from_port: 8182
+                to_port: 8182
+                cidr_ipv6: 64:ff9b::/96
           check_mode: true
           register: result
 
         - name: assert nothing changed
-          assert:
+          ansible.builtin.assert:
             that:
-              - 'not result.changed'
+              - not result.changed
 
         # ============================================================
         - name: test state=present for ipv6 (expected changed=false)
           ec2_security_group:
-            name: '{{ ec2_group_name }}-2'
-            description: '{{ ec2_group_description }}-2'
+            name: "{{ ec2_group_name }}-2"
+            description: "{{ ec2_group_description }}-2"
             state: present
-            vpc_id: '{{ vpc_result.vpc.id }}'
+            vpc_id: "{{ vpc_result.vpc.id }}"
             rules:
-            - proto: "tcp"
-              from_port: 8182
-              to_port: 8182
-              cidr_ipv6: "64:ff9b::/96"
+              - proto: tcp
+                from_port: 8182
+                to_port: 8182
+                cidr_ipv6: 64:ff9b::/96
           register: result
 
         - name: assert nothing changed
-          assert:
+          ansible.builtin.assert:
             that:
-              - 'not result.changed'
+              - not result.changed
 
         # ============================================================
         - name: test rules_egress state=present for ipv6 (expected changed=true) (CHECK MODE)
           ec2_security_group:
-            name: '{{ ec2_group_name }}-2'
-            description: '{{ ec2_group_description }}-2'
+            name: "{{ ec2_group_name }}-2"
+            description: "{{ ec2_group_description }}-2"
             state: present
-            vpc_id: '{{ vpc_result.vpc.id }}'
+            vpc_id: "{{ vpc_result.vpc.id }}"
             rules:
-            - proto: "tcp"
-              from_port: 8182
-              to_port: 8182
-              cidr_ipv6: "64:ff9b::/96"
+              - proto: tcp
+                from_port: 8182
+                to_port: 8182
+                cidr_ipv6: 64:ff9b::/96
             rules_egress:
-            - proto: "tcp"
-              from_port: 8181
-              to_port: 8181
-              cidr_ipv6: "64:ff9b::/96"
+              - proto: tcp
+                from_port: 8181
+                to_port: 8181
+                cidr_ipv6: 64:ff9b::/96
           check_mode: true
           diff: true
           register: result
 
         - name: assert state=present (expected changed=true)
-          assert:
+          ansible.builtin.assert:
             that:
-               - 'result.changed'
-               - 'result.diff.0.before.ip_permissions == result.diff.0.after.ip_permissions'
-               - 'result.diff.0.before.ip_permissions_egress != result.diff.0.after.ip_permissions_egress'
+              - result.changed
+              - result.diff.0.before.ip_permissions == result.diff.0.after.ip_permissions
+              - result.diff.0.before.ip_permissions_egress != result.diff.0.after.ip_permissions_egress
 
         # ============================================================
         - name: test rules_egress state=present for ipv6 (expected changed=true)
           ec2_security_group:
-            name: '{{ ec2_group_name }}-2'
-            description: '{{ ec2_group_description }}-2'
+            name: "{{ ec2_group_name }}-2"
+            description: "{{ ec2_group_description }}-2"
             state: present
-            vpc_id: '{{ vpc_result.vpc.id }}'
+            vpc_id: "{{ vpc_result.vpc.id }}"
             rules:
-            - proto: "tcp"
-              from_port: 8182
-              to_port: 8182
-              cidr_ipv6: "64:ff9b::/96"
+              - proto: tcp
+                from_port: 8182
+                to_port: 8182
+                cidr_ipv6: 64:ff9b::/96
             rules_egress:
-            - proto: "tcp"
-              from_port: 8181
-              to_port: 8181
-              cidr_ipv6: "64:ff9b::/96"
+              - proto: tcp
+                from_port: 8181
+                to_port: 8181
+                cidr_ipv6: 64:ff9b::/96
           register: result
 
         - name: assert state=present (expected changed=true)
-          assert:
+          ansible.builtin.assert:
             that:
-               - 'result.changed'
-               - 'result.group_id.startswith("sg-")'
+              - result.changed
+              - result.group_id.startswith("sg-")
 
         # ============================================================
         - name: test state=absent (expected changed=true) (CHECK MODE)
           ec2_security_group:
-            name: '{{ ec2_group_name }}-2'
-            description: '{{ ec2_group_description }}-2'
+            name: "{{ ec2_group_name }}-2"
+            description: "{{ ec2_group_description }}-2"
             state: absent
-            vpc_id: '{{ vpc_result.vpc.id }}'
+            vpc_id: "{{ vpc_result.vpc.id }}"
           check_mode: true
           diff: true
           register: result
 
         - name: assert group was removed
-          assert:
+          ansible.builtin.assert:
             that:
-              - 'result.changed'
-              - 'not result.diff.0.after'
+              - result.changed
+              - not result.diff.0.after
 
         # ============================================================
         - name: test state=absent (expected changed=true)
           ec2_security_group:
-            name: '{{ ec2_group_name }}-2'
-            description: '{{ ec2_group_description }}-2'
+            name: "{{ ec2_group_name }}-2"
+            description: "{{ ec2_group_description }}-2"
             state: absent
-            vpc_id: '{{ vpc_result.vpc.id }}'
+            vpc_id: "{{ vpc_result.vpc.id }}"
           register: result
 
         - name: assert group was removed
-          assert:
+          ansible.builtin.assert:
             that:
-              - 'result.changed'
+              - result.changed
 
     # ============================================================
     - name: test state=present for ipv4 (expected changed=true) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
       check_mode: true
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-        - 'result.changed'
+          - result.changed
 
     # ============================================================
     - name: test state=present for ipv4 (expected changed=true)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-        - 'result.changed'
-        - 'result.group_id.startswith("sg-")'
-        - 'result.ip_permissions|length == 1'
-        - 'result.ip_permissions_egress|length == 1'
+          - result.changed
+          - result.group_id.startswith("sg-")
+          - result.ip_permissions|length == 1
+          - result.ip_permissions_egress|length == 1
 
     # ============================================================
     - name: add same rule to the existing group  (expected changed=false) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
       check_mode: true
       diff: true
       register: check_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not check_result.changed
           - check_result.diff.0.before.ip_permissions.0 == check_result.diff.0.after.ip_permissions.0
@@ -397,449 +394,446 @@
     # ============================================================
     - name: add same rule to the existing group  (expected changed=false)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
       register: result
 
     - name: assert state=present (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'not result.changed'
-          - 'result.group_id.startswith("sg-")'
+          - not result.changed
+          - result.group_id.startswith("sg-")
 
     - name: assert state=present (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'not check_result.changed'
+          - not check_result.changed
 
     # ============================================================
     - name: add a rule that auto creates another security group (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
-        purge_rules: no
+        purge_rules: false
         rules:
-        - proto: "tcp"
-          group_name: "{{ resource_prefix }} - Another security group"
-          group_desc: Another security group
-          ports: 7171
+          - proto: tcp
+            group_name: "{{ resource_prefix }} - Another security group"
+            group_desc: Another security group
+            ports: 7171
       check_mode: true
       register: result
 
     - name: check that there are now two rules
-      assert:
+      ansible.builtin.assert:
         that:
           - result.changed
 
     # ============================================================
     - name: add a rule that auto creates another security group
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
-        purge_rules: no
+        purge_rules: false
         rules:
-        - proto: "tcp"
-          group_name: "{{ resource_prefix }} - Another security group"
-          group_desc: Another security group
-          ports: 7171
+          - proto: tcp
+            group_name: "{{ resource_prefix }} - Another security group"
+            group_desc: Another security group
+            ports: 7171
       register: result
 
     - name: check that there are now two rules
-      assert:
+      ansible.builtin.assert:
         that:
           - result.changed
           - result.warning is not defined
           - result.ip_permissions|length == 2
-          - result.ip_permissions[0].user_id_group_pairs or
-            result.ip_permissions[1].user_id_group_pairs
-          - 'result.ip_permissions_egress[0].ip_protocol == "-1"'
+          - result.ip_permissions[0].user_id_group_pairs or result.ip_permissions[1].user_id_group_pairs
+          - result.ip_permissions_egress[0].ip_protocol == "-1"
 
     # ============================================================
     - name: test ip rules convert port numbers from string to int (expected changed=true) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: "8183"
-          to_port: "8183"
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: "8183"
+            to_port: "8183"
+            cidr_ip: 10.1.1.1/32
         rules_egress:
-        - proto: "tcp"
-          from_port: "8184"
-          to_port: "8184"
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: "8184"
+            to_port: "8184"
+            cidr_ip: 10.1.1.1/32
       check_mode: true
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.changed'
+          - result.changed
 
     # ============================================================
     - name: test ip rules convert port numbers from string to int (expected changed=true)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: "8183"
-          to_port: "8183"
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: "8183"
+            to_port: "8183"
+            cidr_ip: 10.1.1.1/32
         rules_egress:
-        - proto: "tcp"
-          from_port: "8184"
-          to_port: "8184"
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: "8184"
+            to_port: "8184"
+            cidr_ip: 10.1.1.1/32
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.changed'
-           - 'result.group_id.startswith("sg-")'
-           - 'result.ip_permissions|length == 1'
-           - 'result.ip_permissions_egress[0].ip_protocol == "tcp"'
-
+          - result.changed
+          - result.group_id.startswith("sg-")
+          - result.ip_permissions|length == 1
+          - result.ip_permissions_egress[0].ip_protocol == "tcp"
 
     # ============================================================
     - name: test group rules convert port numbers from string to int (expected changed=true) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: "8185"
-          to_port: "8185"
-          group_id: "{{result.group_id}}"
+          - proto: tcp
+            from_port: "8185"
+            to_port: "8185"
+            group_id: "{{result.group_id}}"
         rules_egress:
-        - proto: "tcp"
-          from_port: "8186"
-          to_port: "8186"
-          group_id: "{{result.group_id}}"
+          - proto: tcp
+            from_port: "8186"
+            to_port: "8186"
+            group_id: "{{result.group_id}}"
       check_mode: true
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.changed'
+          - result.changed
 
     # ============================================================
     - name: test group rules convert port numbers from string to int (expected changed=true)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: "8185"
-          to_port: "8185"
-          group_id: "{{result.group_id}}"
+          - proto: tcp
+            from_port: "8185"
+            to_port: "8185"
+            group_id: "{{result.group_id}}"
         rules_egress:
-        - proto: "tcp"
-          from_port: "8186"
-          to_port: "8186"
-          group_id: "{{result.group_id}}"
+          - proto: tcp
+            from_port: "8186"
+            to_port: "8186"
+            group_id: "{{result.group_id}}"
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.changed'
-           - 'result.group_id.startswith("sg-")'
-           - result.warning is not defined
+          - result.changed
+          - result.group_id.startswith("sg-")
+          - result.warning is not defined
 
     # ============================================================
     - name: test adding a range of ports and ports given as strings (expected changed=true) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
         # set purge_rules to false so we don't get a false positive from previously added rules
         purge_rules: false
         rules:
-        - proto: "tcp"
-          ports:
-            - 8183-8190
-            - '8192'
-          cidr_ip: 10.1.1.1/32
+          - proto: tcp
+            ports:
+              - 8183-8190
+              - "8192"
+            cidr_ip: 10.1.1.1/32
       check_mode: true
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
+          - result.changed
 
     # ============================================================
     - name: test adding a range of ports and ports given as strings (expected changed=true)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
         # set purge_rules to false so we don't get a false positive from previously added rules
         purge_rules: false
         rules:
-        - proto: "tcp"
-          ports:
-            - 8183-8190
-            - '8192'
-          cidr_ip: 10.1.1.1/32
+          - proto: tcp
+            ports:
+              - 8183-8190
+              - "8192"
+            cidr_ip: 10.1.1.1/32
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
-          - 'result.group_id.startswith("sg-")'
+          - result.changed
+          - result.group_id.startswith("sg-")
 
     # ============================================================
     - name: test adding a rule with a IPv4 CIDR with host bits set (expected changed=true) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
         # set purge_rules to false so we don't get a false positive from previously added rules
         purge_rules: false
         rules:
-        - proto: "tcp"
-          ports:
-            - 8195
-          cidr_ip: 10.0.0.1/8
+          - proto: tcp
+            ports:
+              - 8195
+            cidr_ip: 10.0.0.1/8
       check_mode: true
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
+          - result.changed
 
     # ============================================================
     - name: test adding a rule with a IPv4 CIDR with host bits set (expected changed=true)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
         # set purge_rules to false so we don't get a false positive from previously added rules
         purge_rules: false
         rules:
-        - proto: "tcp"
-          ports:
-            - 8195
-          cidr_ip: 10.0.0.1/8
+          - proto: tcp
+            ports:
+              - 8195
+            cidr_ip: 10.0.0.1/8
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
-          - 'result.group_id.startswith("sg-")'
+          - result.changed
+          - result.group_id.startswith("sg-")
 
     # ============================================================
     - name: test adding the same rule with a IPv4 CIDR with host bits set (expected changed=false) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
         # set purge_rules to false so we don't get a false positive from previously added rules
         purge_rules: false
         rules:
-        - proto: "tcp"
-          ports:
-            - 8195
-          cidr_ip: 10.0.0.1/8
+          - proto: tcp
+            ports:
+              - 8195
+            cidr_ip: 10.0.0.1/8
       check_mode: true
       register: check_result
 
     # ============================================================
     - name: test adding the same rule with a IPv4 CIDR with host bits set (expected changed=false and a warning)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
         state: present
         # set purge_rules to false so we don't get a false positive from previously added rules
         purge_rules: false
         rules:
-        - proto: "tcp"
-          ports:
-            - 8195
-          cidr_ip: 10.0.0.1/8
+          - proto: tcp
+            ports:
+              - 8195
+            cidr_ip: 10.0.0.1/8
       register: result
 
     - name: assert state=present (expected changed=false and a warning)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'not check_result.changed'
+          - not check_result.changed
 
     - name: assert state=present (expected changed=false and a warning)
-      assert:
+      ansible.builtin.assert:
         that:
           # No way to assert for warnings?
-          - 'not result.changed'
-          - 'result.group_id.startswith("sg-")'
+          - not result.changed
+          - result.group_id.startswith("sg-")
 
     # ============================================================
     - name: test using the default VPC
       block:
-
         - name: test adding a rule with a IPv6 CIDR with host bits set (expected changed=true) (CHECK MODE)
           ec2_security_group:
-            name: '{{ec2_group_name}}'
-            description: '{{ec2_group_description}}'
+            name: "{{ec2_group_name}}"
+            description: "{{ec2_group_description}}"
             state: present
             # set purge_rules to false so we don't get a false positive from previously added rules
             purge_rules: false
             rules:
-            - proto: "tcp"
-              ports:
-                - 8196
-              cidr_ipv6: '2001:db00::1/24'
+              - proto: tcp
+                ports:
+                  - 8196
+                cidr_ipv6: 2001:db00::1/24
           check_mode: true
           register: result
 
         - name: assert state=present (expected changed=true)
-          assert:
+          ansible.builtin.assert:
             that:
-              - 'result.changed'
+              - result.changed
 
         # ============================================================
         - name: test adding a rule with a IPv6 CIDR with host bits set (expected changed=true)
           ec2_security_group:
-            name: '{{ec2_group_name}}'
-            description: '{{ec2_group_description}}'
+            name: "{{ec2_group_name}}"
+            description: "{{ec2_group_description}}"
             state: present
             # set purge_rules to false so we don't get a false positive from previously added rules
             purge_rules: false
             rules:
-            - proto: "tcp"
-              ports:
-                - 8196
-              cidr_ipv6: '2001:db00::1/24'
+              - proto: tcp
+                ports:
+                  - 8196
+                cidr_ipv6: 2001:db00::1/24
           register: result
 
         - name: assert state=present (expected changed=true)
-          assert:
+          ansible.builtin.assert:
             that:
-              - 'result.changed'
-              - 'result.group_id.startswith("sg-")'
+              - result.changed
+              - result.group_id.startswith("sg-")
 
         # ============================================================
 
         - name: test adding a rule again with a IPv6 CIDR with host bits set (expected changed=false and a warning)
           ec2_security_group:
-            name: '{{ec2_group_name}}'
-            description: '{{ec2_group_description}}'
+            name: "{{ec2_group_name}}"
+            description: "{{ec2_group_description}}"
             state: present
             # set purge_rules to false so we don't get a false positive from previously added rules
             purge_rules: false
             rules:
-            - proto: "tcp"
-              ports:
-                - 8196
-              cidr_ipv6: '2001:db00::1/24'
+              - proto: tcp
+                ports:
+                  - 8196
+                cidr_ipv6: 2001:db00::1/24
           register: result
 
         - name: assert state=present (expected changed=false and a warning)
-          assert:
+          ansible.builtin.assert:
             that:
               # No way to assert for warnings?
-              - 'not result.changed'
-              - 'result.group_id.startswith("sg-")'
+              - not result.changed
+              - result.group_id.startswith("sg-")
 
       when: default_vpc
 
     # ============================================================
     - name: test state=absent (expected changed=true) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
+        name: "{{ec2_group_name}}"
         state: absent
       check_mode: true
       register: result
 
     - name: assert state=absent (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.changed'
+          - result.changed
 
     # ============================================================
     - name: test state=absent (expected changed=true)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
+        name: "{{ec2_group_name}}"
         state: absent
       register: result
 
     - name: assert state=absent (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.changed'
-           - 'not result.group_id'
+          - result.changed
+          - not result.group_id
 
     # ============================================================
     - name: create security group in the VPC (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
       check_mode: true
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
+          - result.changed
 
     # ============================================================
     - name: create security group in the VPC
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
       register: result
 
     - name: assert state=present (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
-          - 'result.vpc_id == vpc_result.vpc.id'
-          - 'result.group_id.startswith("sg-")'
+          - result.changed
+          - result.vpc_id == vpc_result.vpc.id
+          - result.group_id.startswith("sg-")
 
     # ============================================================
     - name: test adding tags (expected changed=true) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
         tags:
           tag1: test1
           tag2: test2
@@ -848,49 +842,49 @@
       register: result
 
     - name: assert that tags were added (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
-          - 'not result.diff.0.before.tags'
-          - 'result.diff.0.after.tags.tag1 == "test1"'
-          - 'result.diff.0.after.tags.tag2 == "test2"'
+          - result.changed
+          - not result.diff.0.before.tags
+          - result.diff.0.after.tags.tag1 == "test1"
+          - result.diff.0.after.tags.tag2 == "test2"
 
     # ============================================================
     - name: test adding tags (expected changed=true)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
         tags:
           tag1: test1
           tag2: test2
       register: result
 
     - name: assert that tags were added (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
+          - result.changed
           - 'result.tags == {"tag1": "test1", "tag2": "test2"}'
 
     # ============================================================
     - name: test that tags are present (expected changed=False) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
         purge_rules_egress: false
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
         tags:
           tag1: test1
           tag2: test2
@@ -898,444 +892,443 @@
       register: result
 
     - name: assert that tags were not changed (expected changed=False)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'not result.changed'
+          - not result.changed
 
     # ============================================================
     - name: test that tags are present (expected changed=False)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
         purge_rules_egress: false
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
         tags:
           tag1: test1
           tag2: test2
       register: result
 
     - name: assert that tags were not changed (expected changed=False)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'not result.changed'
+          - not result.changed
           - 'result.tags == {"tag1": "test1", "tag2": "test2"}'
 
     # ============================================================
     - name: test purging tags (expected changed=True) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
         tags:
           tag1: test1
       check_mode: true
       register: result
 
     - name: assert that tag2 was removed (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
+          - result.changed
 
     # ============================================================
     - name: test purging tags (expected changed=True)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
         tags:
           tag1: test1
       register: result
 
     - name: assert that tag2 was removed (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
+          - result.changed
           - 'result.tags == {"tag1": "test1"}'
 
     # ============================================================
 
     - name: assert that tags are left as-is if not specified (expected changed=False)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
       register: result
 
     - name: assert that the tags stayed the same (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'not result.changed'
+          - not result.changed
           - 'result.tags == {"tag1": "test1"}'
 
     # ============================================================
 
     - name: test purging all tags (expected changed=True)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          cidr_ip: "10.1.1.1/32"
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            cidr_ip: 10.1.1.1/32
         tags: {}
       register: result
 
     - name: assert that tag1 was removed (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
-          - 'not result.tags'
+          - result.changed
+          - not result.tags
 
     # ============================================================
     - name: test adding a rule and egress rule descriptions (expected changed=true) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         # purge the other rules so assertions work for the subsequent tests for rule descriptions
         purge_rules_egress: true
         purge_rules: true
         state: present
         rules:
-        - proto: "tcp"
-          ports:
-          - 8281
-          cidr_ipv6: 1001:d00::/24
-          rule_desc: ipv6 rule desc 1
+          - proto: tcp
+            ports:
+              - 8281
+            cidr_ipv6: 1001:d00::/24
+            rule_desc: ipv6 rule desc 1
         rules_egress:
-        - proto: "tcp"
-          ports:
-          - 8282
-          cidr_ip: 10.2.2.2/32
-          rule_desc: egress rule desc 1
+          - proto: tcp
+            ports:
+              - 8282
+            cidr_ip: 10.2.2.2/32
+            rule_desc: egress rule desc 1
       check_mode: true
       register: result
 
     - name: assert that rule descriptions are created (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
+          - result.changed
 
     # =========================================================================================
     - name: add rules without descriptions ready for adding descriptions to existing rules
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         # purge the other rules so assertions work for the subsequent tests for rule descriptions
         purge_rules_egress: true
         purge_rules: true
         state: present
         rules:
-        - proto: "tcp"
-          ports:
-          - 8281
-          cidr_ipv6: 1001:d00::/24
+          - proto: tcp
+            ports:
+              - 8281
+            cidr_ipv6: 1001:d00::/24
         rules_egress:
-        - proto: "tcp"
-          ports:
-          - 8282
-          cidr_ip: 10.2.2.2/32
+          - proto: tcp
+            ports:
+              - 8282
+            cidr_ip: 10.2.2.2/32
       register: result
 
     # ============================================================
     - name: test adding a rule and egress rule descriptions (expected changed=true)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         # purge the other rules so assertions work for the subsequent tests for rule descriptions
         purge_rules_egress: true
         purge_rules: true
         state: present
         rules:
-        - proto: "tcp"
-          ports:
-          - 8281
-          cidr_ipv6: 1001:d00::/24
-          rule_desc: ipv6 rule desc 1
+          - proto: tcp
+            ports:
+              - 8281
+            cidr_ipv6: 1001:d00::/24
+            rule_desc: ipv6 rule desc 1
         rules_egress:
-        - proto: "tcp"
-          ports:
-          - 8282
-          cidr_ip: 10.2.2.2/32
-          rule_desc: egress rule desc 1
+          - proto: tcp
+            ports:
+              - 8282
+            cidr_ip: 10.2.2.2/32
+            rule_desc: egress rule desc 1
       register: result
 
     - name: assert that rule descriptions are created (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
-          - 'result.ip_permissions[0].ipv6_ranges[0].description == "ipv6 rule desc 1"'
-          - 'result.ip_permissions_egress[0].ip_ranges[0].description == "egress rule desc 1"'
+          - result.changed
+          - result.ip_permissions[0].ipv6_ranges[0].description == "ipv6 rule desc 1"
+          - result.ip_permissions_egress[0].ip_ranges[0].description == "egress rule desc 1"
 
     # ============================================================
     - name: test modifying rule and egress rule descriptions (expected changed=true) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         purge_rules_egress: false
         purge_rules: false
         state: present
         rules:
-        - proto: "tcp"
-          ports:
-          - 8281
-          cidr_ipv6: 1001:d00::/24
-          rule_desc: ipv6 rule desc 2
+          - proto: tcp
+            ports:
+              - 8281
+            cidr_ipv6: 1001:d00::/24
+            rule_desc: ipv6 rule desc 2
         rules_egress:
-        - proto: "tcp"
-          ports:
-          - 8282
-          cidr_ip: 10.2.2.2/32
-          rule_desc: egress rule desc 2
+          - proto: tcp
+            ports:
+              - 8282
+            cidr_ip: 10.2.2.2/32
+            rule_desc: egress rule desc 2
       check_mode: true
       register: result
 
     - name: assert that rule descriptions were modified (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.ip_permissions | length > 0'
-          - 'result.changed'
+          - result.ip_permissions | length > 0
+          - result.changed
 
     # ============================================================
     - name: test modifying rule and egress rule descriptions (expected changed=true)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         purge_rules_egress: false
         purge_rules: false
         state: present
         rules:
-        - proto: "tcp"
-          ports:
-          - 8281
-          cidr_ipv6: 1001:d00::/24
-          rule_desc: ipv6 rule desc 2
+          - proto: tcp
+            ports:
+              - 8281
+            cidr_ipv6: 1001:d00::/24
+            rule_desc: ipv6 rule desc 2
         rules_egress:
-        - proto: "tcp"
-          ports:
-          - 8282
-          cidr_ip: 10.2.2.2/32
-          rule_desc: egress rule desc 2
+          - proto: tcp
+            ports:
+              - 8282
+            cidr_ip: 10.2.2.2/32
+            rule_desc: egress rule desc 2
       register: result
 
     - name: assert that rule descriptions were modified (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
-          - 'result.ip_permissions[0].ipv6_ranges[0].description == "ipv6 rule desc 2"'
-          - 'result.ip_permissions_egress[0].ip_ranges[0].description == "egress rule desc 2"'
+          - result.changed
+          - result.ip_permissions[0].ipv6_ranges[0].description == "ipv6 rule desc 2"
+          - result.ip_permissions_egress[0].ip_ranges[0].description == "egress rule desc 2"
 
     # ============================================================
 
     - name: test creating rule in default vpc with egress rule (expected changed=true)
       ec2_security_group:
-        name: '{{ec2_group_name}}-default-vpc'
-        description: '{{ec2_group_description}} default VPC'
+        name: "{{ec2_group_name}}-default-vpc"
+        description: "{{ec2_group_description}} default VPC"
         purge_rules_egress: true
         state: present
         rules:
-        - proto: "tcp"
-          ports:
-          - 8281
-          cidr_ip: 10.1.1.1/24
-          rule_desc: ipv4 rule desc
+          - proto: tcp
+            ports:
+              - 8281
+            cidr_ip: 10.1.1.1/24
+            rule_desc: ipv4 rule desc
         rules_egress:
-        - proto: "tcp"
-          ports:
-          - 8282
-          cidr_ip: 10.2.2.2/32
-          rule_desc: egress rule desc 2
+          - proto: tcp
+            ports:
+              - 8282
+            cidr_ip: 10.2.2.2/32
+            rule_desc: egress rule desc 2
       register: result
 
     - name: assert that rule descriptions were modified (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
-          - 'result.ip_permissions_egress|length == 1'
+          - result.changed
+          - result.ip_permissions_egress|length == 1
 
     # ============================================================
     - name: test that keeping the same rule descriptions (expected changed=false) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         purge_rules_egress: false
         purge_rules: false
         state: present
         rules:
-        - proto: "tcp"
-          ports:
-          - 8281
-          cidr_ipv6: 1001:d00::/24
-          rule_desc: ipv6 rule desc 2
+          - proto: tcp
+            ports:
+              - 8281
+            cidr_ipv6: 1001:d00::/24
+            rule_desc: ipv6 rule desc 2
         rules_egress:
-        - proto: "tcp"
-          ports:
-          - 8282
-          cidr_ip: 10.2.2.2/32
-          rule_desc: egress rule desc 2
+          - proto: tcp
+            ports:
+              - 8282
+            cidr_ip: 10.2.2.2/32
+            rule_desc: egress rule desc 2
       check_mode: true
       register: result
 
     - name: assert that rule descriptions stayed the same (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'not result.changed'
+          - not result.changed
 
     # ============================================================
     - name: test that keeping the same rule descriptions (expected changed=false)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         purge_rules_egress: false
         purge_rules: false
         state: present
         rules:
-        - proto: "tcp"
-          ports:
-          - 8281
-          cidr_ipv6: 1001:d00::/24
-          rule_desc: ipv6 rule desc 2
+          - proto: tcp
+            ports:
+              - 8281
+            cidr_ipv6: 1001:d00::/24
+            rule_desc: ipv6 rule desc 2
         rules_egress:
-        - proto: "tcp"
-          ports:
-          - 8282
-          cidr_ip: 10.2.2.2/32
-          rule_desc: egress rule desc 2
+          - proto: tcp
+            ports:
+              - 8282
+            cidr_ip: 10.2.2.2/32
+            rule_desc: egress rule desc 2
       register: result
 
     - name: assert that rule descriptions stayed the same (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'not result.changed'
-          - 'result.ip_permissions[0].ipv6_ranges[0].description == "ipv6 rule desc 2"'
-          - 'result.ip_permissions_egress[0].ip_ranges[0].description == "egress rule desc 2"'
+          - not result.changed
+          - result.ip_permissions[0].ipv6_ranges[0].description == "ipv6 rule desc 2"
+          - result.ip_permissions_egress[0].ip_ranges[0].description == "egress rule desc 2"
 
     # ============================================================
     - name: test removing rule descriptions (expected changed=true) (CHECK MODE)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         purge_rules_egress: false
         purge_rules: false
         state: present
         rules:
-        - proto: "tcp"
-          ports:
-          - 8281
-          cidr_ipv6: 1001:d00::/24
-          rule_desc:
+          - proto: tcp
+            ports:
+              - 8281
+            cidr_ipv6: 1001:d00::/24
+            rule_desc:
         rules_egress:
-        - proto: "tcp"
-          ports:
-          - 8282
-          cidr_ip: 10.2.2.2/32
-          rule_desc:
+          - proto: tcp
+            ports:
+              - 8282
+            cidr_ip: 10.2.2.2/32
+            rule_desc:
       check_mode: true
       register: result
 
     - name: assert that rule descriptions were removed (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.changed'
+          - result.changed
 
     # ============================================================
     - name: test removing rule descriptions (expected changed=true)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
-        description: '{{ec2_group_description}}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ec2_group_name}}"
+        description: "{{ec2_group_description}}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         purge_rules_egress: false
         purge_rules: false
         state: present
         rules:
-        - proto: "tcp"
-          ports:
-          - 8281
-          cidr_ipv6: 1001:d00::/24
-          rule_desc:
+          - proto: tcp
+            ports:
+              - 8281
+            cidr_ipv6: 1001:d00::/24
+            rule_desc:
         rules_egress:
-        - proto: "tcp"
-          ports:
-          - 8282
-          cidr_ip: 10.2.2.2/32
-          rule_desc:
+          - proto: tcp
+            ports:
+              - 8282
+            cidr_ip: 10.2.2.2/32
+            rule_desc:
       register: result
       ignore_errors: true
 
     - name: assert that rule descriptions were removed
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.ip_permissions[0].ipv6_ranges[0].description is undefined'
-          - 'result.ip_permissions_egress[0].ip_ranges[0].description is undefined'
+          - result.ip_permissions[0].ipv6_ranges[0].description is undefined
+          - result.ip_permissions_egress[0].ip_ranges[0].description is undefined
 
     # ============================================================
 
     - name: test state=absent (expected changed=true)
       ec2_security_group:
-        name: '{{ec2_group_name}}'
+        name: "{{ec2_group_name}}"
         state: absent
       register: result
 
     - name: assert state=absent (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.changed'
-           - 'not result.group_id'
+          - result.changed
+          - not result.group_id
   always:
-
     # ============================================================
     # Describe state of remaining resources
 
     - name: Retrieve security group info based on SG VPC
       ec2_security_group_info:
         filters:
-          vpc-id: '{{ vpc_result.vpc.id }}'
+          vpc-id: "{{ vpc_result.vpc.id }}"
       register: remaining_groups
 
     - name: Retrieve subnet info based on SG VPC
-      ec2_vpc_subnet_info:
+      amazon.aws.ec2_vpc_subnet_info:
         filters:
-          vpc-id: '{{ vpc_result.vpc.id }}'
+          vpc-id: "{{ vpc_result.vpc.id }}"
       register: remaining_subnets
 
     - name: Retrieve VPC info based on SG VPC
-      ec2_vpc_net_info:
+      amazon.aws.ec2_vpc_net_info:
         vpc_ids:
-          - '{{ vpc_result.vpc.id }}'
+          - "{{ vpc_result.vpc.id }}"
       register: remaining_vpc
 
     # ============================================================
@@ -1343,28 +1336,28 @@
 
     - name: Delete rules from remaining SGs
       ec2_security_group:
-        name: '{{ item.group_name }}'
-        group_id: '{{ item.group_id }}'
-        description: '{{ item.description }}'
+        name: "{{ item.group_name }}"
+        group_id: "{{ item.group_id }}"
+        description: "{{ item.description }}"
         rules: []
         rules_egress: []
-      loop: '{{ remaining_groups.security_groups }}'
-      ignore_errors: yes
+      loop: "{{ remaining_groups.security_groups }}"
+      ignore_errors: true
 
     - name: Delete remaining SGs
       ec2_security_group:
         state: absent
-        group_id: '{{ item.group_id }}'
-      loop: '{{ remaining_groups.security_groups }}'
+        group_id: "{{ item.group_id }}"
+      loop: "{{ remaining_groups.security_groups }}"
       when:
-      - item.group_name != 'default'
-      ignore_errors: yes
+        - item.group_name != 'default'
+      ignore_errors: true
 
     # ============================================================
 
     - name: tidy up VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         name: "{{ resource_prefix }}-vpc"
         state: absent
         cidr_block: "{{ vpc_cidr }}"
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/ec2_security_group/tasks/multi_account.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/multi_account.yml
@@ -1,124 +1,125 @@
+---
 - block:
-    - aws_caller_info:
+    - amazon.aws.aws_caller_info:
       register: caller_facts
     - name: create a VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         name: "{{ resource_prefix }}-vpc-2"
         state: present
         cidr_block: "{{ vpc_cidr }}"
         tags:
-          Description: "Created by ansible-test"
+          Description: Created by ansible-test
       register: vpc_result_2
     - name: Peer the secondary-VPC to the main VPC
-      ec2_vpc_peer:
-        vpc_id: '{{ vpc_result_2.vpc.id }}'
-        peer_vpc_id: '{{ vpc_result.vpc.id }}'
-        peer_owner_id: '{{ caller_facts.account }}'
-        peer_region: '{{ aws_region }}'
+      community.aws.ec2_vpc_peer:
+        vpc_id: "{{ vpc_result_2.vpc.id }}"
+        peer_vpc_id: "{{ vpc_result.vpc.id }}"
+        peer_owner_id: "{{ caller_facts.account }}"
+        peer_region: "{{ aws_region }}"
       register: peer_origin
     - name: Accept the secondary-VPC peering connection in the main VPC
-      ec2_vpc_peer:
-        peer_vpc_id: '{{ vpc_result_2.vpc.id }}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+      community.aws.ec2_vpc_peer:
+        peer_vpc_id: "{{ vpc_result_2.vpc.id }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: accept
-        peering_id: '{{ peer_origin.peering_id }}'
-        peer_owner_id: '{{ caller_facts.account }}'
-        peer_region: '{{ aws_region }}'
+        peering_id: "{{ peer_origin.peering_id }}"
+        peer_owner_id: "{{ caller_facts.account }}"
+        peer_region: "{{ aws_region }}"
     - name: Create group in second VPC
       ec2_security_group:
-        name: '{{ ec2_group_name }}-external'
-        description: '{{ ec2_group_description }}'
-        vpc_id: '{{ vpc_result_2.vpc.id }}'
+        name: "{{ ec2_group_name }}-external"
+        description: "{{ ec2_group_description }}"
+        vpc_id: "{{ vpc_result_2.vpc.id }}"
         state: present
         rules:
-        - proto: "tcp"
-          cidr_ip: 0.0.0.0/0
-          ports:
-          - 80
-          rule_desc: 'http whoo'
+          - proto: tcp
+            cidr_ip: "0.0.0.0/0"
+            ports:
+              - 80
+            rule_desc: http whoo
       register: external
     - name: Create group in internal VPC
       ec2_security_group:
-        name: '{{ ec2_group_name }}-internal'
-        description: '{{ ec2_group_description }}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ ec2_group_name }}-internal"
+        description: "{{ ec2_group_description }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
         rules:
-        - proto: "tcp"
-          group_id: '{{ caller_facts.account }}/{{ external.group_id }}/{{ ec2_group_name }}-external'
-          ports:
-          - 80
+          - proto: tcp
+            group_id: "{{ caller_facts.account }}/{{ external.group_id }}/{{ ec2_group_name }}-external"
+            ports:
+              - 80
     - name: Re-make same rule, expecting changed=false in internal VPC
       ec2_security_group:
-        name: '{{ ec2_group_name }}-internal'
-        description: '{{ ec2_group_description }}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ ec2_group_name }}-internal"
+        description: "{{ ec2_group_description }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
         rules:
-        - proto: "tcp"
-          group_id: '{{ caller_facts.account }}/{{ external.group_id }}/{{ ec2_group_name }}-external'
-          ports:
-          - 80
+          - proto: tcp
+            group_id: "{{ caller_facts.account }}/{{ external.group_id }}/{{ ec2_group_name }}-external"
+            ports:
+              - 80
       register: out
-    - assert:
+    - ansible.builtin.assert:
         that:
           - out is not changed
     - name: Try again with a bad group_id group in internal VPC
       ec2_security_group:
-        name: '{{ ec2_group_name }}-internal'
-        description: '{{ ec2_group_description }}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+        name: "{{ ec2_group_name }}-internal"
+        description: "{{ ec2_group_description }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
         rules:
-        - proto: "tcp"
-          group_id: '{{ external.group_id }}/{{ caller_facts.account }}/{{ ec2_group_name }}-external'
-          ports:
-          - 80
+          - proto: tcp
+            group_id: "{{ external.group_id }}/{{ caller_facts.account }}/{{ ec2_group_name }}-external"
+            ports:
+              - 80
       register: out
       ignore_errors: true
-    - assert:
+    - ansible.builtin.assert:
         that:
           - out is failed
   always:
-    - pause: seconds=5
+    - ansible.builtin.pause: seconds=5
     - name: Delete secondary-VPC side of peer
-      ec2_vpc_peer:
-        vpc_id: '{{ vpc_result_2.vpc.id }}'
-        peer_vpc_id: '{{ vpc_result.vpc.id }}'
-        peering_id: '{{ peer_origin.peering_id }}'
+      community.aws.ec2_vpc_peer:
+        vpc_id: "{{ vpc_result_2.vpc.id }}"
+        peer_vpc_id: "{{ vpc_result.vpc.id }}"
+        peering_id: "{{ peer_origin.peering_id }}"
         state: absent
-        peer_owner_id: '{{ caller_facts.account }}'
-        peer_region: '{{ aws_region }}'
-      ignore_errors: yes
+        peer_owner_id: "{{ caller_facts.account }}"
+        peer_region: "{{ aws_region }}"
+      ignore_errors: true
     - name: Delete main-VPC side of peer
-      ec2_vpc_peer:
-        peer_vpc_id: '{{ vpc_result_2.vpc.id }}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
+      community.aws.ec2_vpc_peer:
+        peer_vpc_id: "{{ vpc_result_2.vpc.id }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
-        peering_id: '{{ peer_origin.peering_id }}'
-        peer_owner_id: '{{ caller_facts.account }}'
-        peer_region: '{{ aws_region }}'
-      ignore_errors: yes
+        peering_id: "{{ peer_origin.peering_id }}"
+        peer_owner_id: "{{ caller_facts.account }}"
+        peer_region: "{{ aws_region }}"
+      ignore_errors: true
     - name: Clean up group in second VPC
       ec2_security_group:
-        name: '{{ ec2_group_name }}-external'
-        description: '{{ ec2_group_description }}'
+        name: "{{ ec2_group_name }}-external"
+        description: "{{ ec2_group_description }}"
         state: absent
-        vpc_id: '{{ vpc_result_2.vpc.id }}'
-      ignore_errors: yes
+        vpc_id: "{{ vpc_result_2.vpc.id }}"
+      ignore_errors: true
     - name: Clean up group in second VPC
       ec2_security_group:
-        name: '{{ ec2_group_name }}-internal'
-        description: '{{ ec2_group_description }}'
+        name: "{{ ec2_group_name }}-internal"
+        description: "{{ ec2_group_description }}"
         state: absent
-        vpc_id: '{{ vpc_result.vpc.id }}'
-      ignore_errors: yes
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      ignore_errors: true
     - name: tidy up VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         name: "{{ resource_prefix }}-vpc-2"
         state: absent
         cidr_block: "{{ vpc_cidr }}"
-      ignore_errors: yes
+      ignore_errors: true
       register: removed
       retries: 10
       until: removed is not failed

--- a/tests/integration/targets/ec2_security_group/tasks/multi_nested_target.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/multi_nested_target.yml
@@ -1,213 +1,213 @@
 ---
-  # ============================================================
+# ============================================================
 
-  - name: test state=present for multiple ipv6 and ipv4 targets (expected changed=true) (CHECK MODE)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
-      - proto: "tcp"
+- name: test state=present for multiple ipv6 and ipv4 targets (expected changed=true) (CHECK MODE)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
+      - proto: tcp
         from_port: 8182
         to_port: 8182
         cidr_ipv6:
-          - "64:ff9b::/96"
-          - ["2620::/32"]
-      - proto: "tcp"
+          - 64:ff9b::/96
+          - [2620::/32]
+      - proto: tcp
         ports: 5665
         cidr_ip:
           - 172.16.1.0/24
           - 172.16.17.0/24
-          - ["10.0.0.0/24", "10.20.0.0/24"]
-    check_mode: true
-    register: result
+          - [10.0.0.0/24, 10.20.0.0/24]
+  check_mode: true
+  register: result
 
-  - name: assert state=present (expected changed=true)
-    assert:
-      that:
-        - 'result.changed'
+- name: assert state=present (expected changed=true)
+  ansible.builtin.assert:
+    that:
+      - result.changed
 
-  - name: test state=present for multiple ipv6 and ipv4 targets (expected changed=true)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
-      - proto: "tcp"
+- name: test state=present for multiple ipv6 and ipv4 targets (expected changed=true)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
+      - proto: tcp
         from_port: 8182
         to_port: 8182
         cidr_ipv6:
-          - "64:ff9b::/96"
-          - ["2620::/32"]
-      - proto: "tcp"
+          - 64:ff9b::/96
+          - [2620::/32]
+      - proto: tcp
         ports: 5665
         cidr_ip:
           - 172.16.1.0/24
           - 172.16.17.0/24
-          - ["10.0.0.0/24", "10.20.0.0/24"]
-    register: result
+          - [10.0.0.0/24, 10.20.0.0/24]
+  register: result
 
-  - name: assert state=present (expected changed=true)
-    assert:
-      that:
-        - 'result.changed'
-        - 'result.ip_permissions | length == 2'
-        - 'result.ip_permissions[0].ip_ranges | length == 4 or result.ip_permissions[1].ip_ranges | length == 4'
-        - 'result.ip_permissions[0].ipv6_ranges | length == 2 or result.ip_permissions[1].ipv6_ranges | length == 2'
+- name: assert state=present (expected changed=true)
+  ansible.builtin.assert:
+    that:
+      - result.changed
+      - result.ip_permissions | length == 2
+      - result.ip_permissions[0].ip_ranges | length == 4 or result.ip_permissions[1].ip_ranges | length == 4
+      - result.ip_permissions[0].ipv6_ranges | length == 2 or result.ip_permissions[1].ipv6_ranges | length == 2
 
-  - name: test state=present for multiple ipv6 and ipv4 targets (expected changed=false) (CHECK MODE)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
-      - proto: "tcp"
+- name: test state=present for multiple ipv6 and ipv4 targets (expected changed=false) (CHECK MODE)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
+      - proto: tcp
         from_port: 8182
         to_port: 8182
         cidr_ipv6:
-          - "64:ff9b::/96"
-          - ["2620::/32"]
-      - proto: "tcp"
+          - 64:ff9b::/96
+          - [2620::/32]
+      - proto: tcp
         ports: 5665
         cidr_ip:
           - 172.16.1.0/24
           - 172.16.17.0/24
-          - ["10.0.0.0/24", "10.20.0.0/24"]
-    check_mode: true
-    register: result
+          - [10.0.0.0/24, 10.20.0.0/24]
+  check_mode: true
+  register: result
 
-  - name: assert state=present (expected changed=true)
-    assert:
-      that:
-        - 'not result.changed'
+- name: assert state=present (expected changed=true)
+  ansible.builtin.assert:
+    that:
+      - not result.changed
 
-  - name: test state=present for multiple ipv6 and ipv4 targets (expected changed=false)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
-      - proto: "tcp"
+- name: test state=present for multiple ipv6 and ipv4 targets (expected changed=false)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
+      - proto: tcp
         from_port: 8182
         to_port: 8182
         cidr_ipv6:
-          - "64:ff9b::/96"
-          - ["2620::/32"]
-      - proto: "tcp"
+          - 64:ff9b::/96
+          - [2620::/32]
+      - proto: tcp
         ports: 5665
         cidr_ip:
           - 172.16.1.0/24
           - 172.16.17.0/24
-          - ["10.0.0.0/24", "10.20.0.0/24"]
-    register: result
+          - [10.0.0.0/24, 10.20.0.0/24]
+  register: result
 
-  - name: assert state=present (expected changed=true)
-    assert:
-      that:
-        - 'not result.changed'
+- name: assert state=present (expected changed=true)
+  ansible.builtin.assert:
+    that:
+      - not result.changed
 
-  - name: test state=present purging a nested ipv4 target (expected changed=true) (CHECK MODE)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
-      - proto: "tcp"
+- name: test state=present purging a nested ipv4 target (expected changed=true) (CHECK MODE)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
+      - proto: tcp
         from_port: 8182
         to_port: 8182
         cidr_ipv6:
-          - "64:ff9b::/96"
-          - ["2620::/32"]
-      - proto: "tcp"
+          - 64:ff9b::/96
+          - [2620::/32]
+      - proto: tcp
         ports: 5665
         cidr_ip:
           - 172.16.1.0/24
           - 172.16.17.0/24
-          - ["10.0.0.0/24"]
-    check_mode: true
-    register: result
+          - [10.0.0.0/24]
+  check_mode: true
+  register: result
 
-  - assert:
-      that:
-        - result.changed
+- ansible.builtin.assert:
+    that:
+      - result.changed
 
-  - name: test state=present purging a nested ipv4 target (expected changed=true)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
-      - proto: "tcp"
+- name: test state=present purging a nested ipv4 target (expected changed=true)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
+      - proto: tcp
         from_port: 8182
         to_port: 8182
         cidr_ipv6:
-          - "64:ff9b::/96"
-          - ["2620::/32"]
-      - proto: "tcp"
+          - 64:ff9b::/96
+          - [2620::/32]
+      - proto: tcp
         ports: 5665
         cidr_ip:
           - 172.16.1.0/24
           - 172.16.17.0/24
-          - ["10.0.0.0/24"]
-    register: result
+          - [10.0.0.0/24]
+  register: result
 
-  - assert:
-      that:
-        - result.changed
-        - 'result.ip_permissions[0].ip_ranges | length == 3 or result.ip_permissions[1].ip_ranges | length == 3'
-        - 'result.ip_permissions[0].ipv6_ranges | length == 2 or result.ip_permissions[1].ipv6_ranges | length == 2'
+- ansible.builtin.assert:
+    that:
+      - result.changed
+      - result.ip_permissions[0].ip_ranges | length == 3 or result.ip_permissions[1].ip_ranges | length == 3
+      - result.ip_permissions[0].ipv6_ranges | length == 2 or result.ip_permissions[1].ipv6_ranges | length == 2
 
-  - name: test state=present with both associated ipv6 targets nested (expected changed=false)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
-      - proto: "tcp"
+- name: test state=present with both associated ipv6 targets nested (expected changed=false)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
+      - proto: tcp
         from_port: 8182
         to_port: 8182
         cidr_ipv6:
-          - ["2620::/32", "64:ff9b::/96"]
-      - proto: "tcp"
+          - [2620::/32, 64:ff9b::/96]
+      - proto: tcp
         ports: 5665
         cidr_ip:
           - 172.16.1.0/24
           - 172.16.17.0/24
-          - ["10.0.0.0/24"]
-    register: result
+          - [10.0.0.0/24]
+  register: result
 
-  - assert:
-      that:
-        - not result.changed
+- ansible.builtin.assert:
+    that:
+      - not result.changed
 
-  - name: test state=present add another nested ipv6 target (expected changed=true)
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      description: '{{ ec2_group_description }}'
-      state: present
-      rules:
-      - proto: "tcp"
+- name: test state=present add another nested ipv6 target (expected changed=true)
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    description: "{{ ec2_group_description }}"
+    state: present
+    rules:
+      - proto: tcp
         from_port: 8182
         to_port: 8182
         cidr_ipv6:
-          - ["2620::/32", "64:ff9b::/96"]
-          - ["2001:DB8:A0B:12F0::1/64"]
-      - proto: "tcp"
+          - [2620::/32, 64:ff9b::/96]
+          - [2001:DB8:A0B:12F0::1/64]
+      - proto: tcp
         ports: 5665
         cidr_ip:
           - 172.16.1.0/24
           - 172.16.17.0/24
-          - ["10.0.0.0/24"]
-    register: result
+          - [10.0.0.0/24]
+  register: result
 
-  - assert:
-      that:
-        - result.changed
-        - result.warning is not defined
-        - 'result.ip_permissions[0].ip_ranges | length == 3 or result.ip_permissions[1].ip_ranges | length == 3'
-        - 'result.ip_permissions[0].ipv6_ranges | length == 3 or result.ip_permissions[1].ipv6_ranges | length == 3'
+- ansible.builtin.assert:
+    that:
+      - result.changed
+      - result.warning is not defined
+      - result.ip_permissions[0].ip_ranges | length == 3 or result.ip_permissions[1].ip_ranges | length == 3
+      - result.ip_permissions[0].ipv6_ranges | length == 3 or result.ip_permissions[1].ipv6_ranges | length == 3
 
-  - name: delete it
-    ec2_security_group:
-      name: '{{ ec2_group_name }}'
-      state: absent
+- name: delete it
+  ec2_security_group:
+    name: "{{ ec2_group_name }}"
+    state: absent

--- a/tests/integration/targets/ec2_security_group/tasks/numeric_protos.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/numeric_protos.yml
@@ -1,66 +1,66 @@
 ---
 - block:
     - name: set up temporary group name for tests
-      set_fact:
-        group_tmp_name: '{{ec2_group_name}}-numbered-protos'
+      ansible.builtin.set_fact:
+        group_tmp_name: "{{ec2_group_name}}-numbered-protos"
 
     - name: Create a group with numbered protocol (GRE)
       ec2_security_group:
-        name: '{{ group_tmp_name }}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ ec2_group_description }}'
+        name: "{{ group_tmp_name }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ ec2_group_description }}"
         rules:
-        - proto: 47
-          to_port: -1
-          from_port: -1
-          cidr_ip: 0.0.0.0/0
-        - proto: -1
-          ports: -1
-          cidr_ip: 0.0.0.0/0
+          - proto: 47
+            to_port: -1
+            from_port: -1
+            cidr_ip: "0.0.0.0/0"
+          - proto: -1
+            ports: -1
+            cidr_ip: "0.0.0.0/0"
         state: present
       register: result
 
     - name: Create a group with a quoted proto
       ec2_security_group:
-        name: '{{ group_tmp_name }}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ ec2_group_description }}'
+        name: "{{ group_tmp_name }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ ec2_group_description }}"
         rules:
-        - proto: '47'
-          to_port: -1
-          from_port: -1
-          cidr_ip: 0.0.0.0/0
-        - proto: -1
-          ports: -1
-          cidr_ip: 0.0.0.0/0
+          - proto: "47"
+            to_port: -1
+            from_port: -1
+            cidr_ip: "0.0.0.0/0"
+          - proto: -1
+            ports: -1
+            cidr_ip: "0.0.0.0/0"
         state: present
       register: result
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
     - name: Add a tag with a numeric value
       ec2_security_group:
-        name: '{{ group_tmp_name }}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ ec2_group_description }}'
+        name: "{{ group_tmp_name }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ ec2_group_description }}"
         tags:
           foo: 1
     - name: Read a tag with a numeric value
       ec2_security_group:
-        name: '{{ group_tmp_name }}'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ ec2_group_description }}'
+        name: "{{ group_tmp_name }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ ec2_group_description }}"
         tags:
           foo: 1
       register: result
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
   always:
     - name: tidy up egress rule test security group
       ec2_security_group:
-        name: '{{group_tmp_name}}'
+        name: "{{group_tmp_name}}"
         state: absent
-        vpc_id: '{{ vpc_result.vpc.id }}'
-      ignore_errors: yes
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      ignore_errors: true

--- a/tests/integration/targets/ec2_security_group/tasks/rule_group_create.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/rule_group_create.yml
@@ -2,35 +2,35 @@
 - block:
     - name: Create a group with self-referring rule
       ec2_security_group:
-        name: '{{ec2_group_name}}-auto-create-1'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-auto-create-1"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         rules:
-        - proto: "tcp"
-          from_port: 8000
-          to_port: 8100
-          group_name: '{{ec2_group_name}}-auto-create-1'
+          - proto: tcp
+            from_port: 8000
+            to_port: 8100
+            group_name: "{{ec2_group_name}}-auto-create-1"
         state: present
       register: result
 
     - name: Create a second group rule
       ec2_security_group:
-        name: '{{ec2_group_name}}-auto-create-2'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-auto-create-2"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         state: present
 
     - name: Create a series of rules with a recently created group as target
       ec2_security_group:
-        name: '{{ec2_group_name}}-auto-create-1'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-auto-create-1"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         purge_rules: false
         rules:
-        - proto: "tcp"
-          from_port: "{{ item }}"
-          to_port: "{{ item }}"
-          group_name: '{{ec2_group_name}}-auto-create-2'
+          - proto: tcp
+            from_port: "{{ item }}"
+            to_port: "{{ item }}"
+            group_name: "{{ec2_group_name}}-auto-create-2"
         state: present
       register: result
       with_items:
@@ -39,89 +39,89 @@
         - 60
         - 80
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result.warning is not defined
 
     - name: Create a group with only the default rule
       ec2_security_group:
-        name: '{{ec2_group_name}}-auto-create-1'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-auto-create-1"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         rules:
-        - proto: "tcp"
-          from_port: 8182
-          to_port: 8182
-          group_name: '{{ec2_group_name}}-auto-create-3'
+          - proto: tcp
+            from_port: 8182
+            to_port: 8182
+            group_name: "{{ec2_group_name}}-auto-create-3"
         state: present
       register: result
       ignore_errors: true
 
     - name: assert you can't create a new group from a rule target with no description
-      assert:
+      ansible.builtin.assert:
         that:
           - result is failed
 
     - name: Create a group with a target of a separate group
       ec2_security_group:
-        name: '{{ec2_group_name}}-auto-create-1'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-auto-create-1"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         rules:
-        - proto: tcp
-          ports:
-            - 22
-            - 80
-          group_name: '{{ec2_group_name}}-auto-create-3'
-          group_desc: '{{ec2_group_description}}'
+          - proto: tcp
+            ports:
+              - 22
+              - 80
+            group_name: "{{ec2_group_name}}-auto-create-3"
+            group_desc: "{{ec2_group_description}}"
         state: present
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result.warning is not defined
 
     - name: Create a 4th group
       ec2_security_group:
-        name: '{{ec2_group_name}}-auto-create-4'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-auto-create-4"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         state: present
         rules:
-        - proto: tcp
-          ports:
-            - 22
-          cidr_ip: 0.0.0.0/0
+          - proto: tcp
+            ports:
+              - 22
+            cidr_ip: "0.0.0.0/0"
 
     - name: use recently created group in a rule
       ec2_security_group:
-        name: '{{ec2_group_name}}-auto-create-5'
-        vpc_id: '{{ vpc_result.vpc.id }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-auto-create-5"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        description: "{{ec2_group_description}}"
         rules:
-        - proto: tcp
-          ports:
-            - 443
-          group_name: '{{ec2_group_name}}-auto-create-4'
+          - proto: tcp
+            ports:
+              - 443
+            group_name: "{{ec2_group_name}}-auto-create-4"
         state: present
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result.warning is not defined
 
   always:
     - name: tidy up egress rule test security group rules
       ec2_security_group:
-        name: '{{ec2_group_name}}-auto-create-{{ item }}'
-        description: '{{ec2_group_description}}'
+        name: "{{ec2_group_name}}-auto-create-{{ item }}"
+        description: "{{ec2_group_description}}"
         rules: []
         rules_egress: []
-      ignore_errors: yes
+      ignore_errors: true
       with_items: [5, 4, 3, 2, 1]
     - name: tidy up egress rule test security group
       ec2_security_group:
-        name: '{{ec2_group_name}}-auto-create-{{ item }}'
+        name: "{{ec2_group_name}}-auto-create-{{ item }}"
         state: absent
-        vpc_id: '{{ vpc_result.vpc.id }}'
-      ignore_errors: yes
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      ignore_errors: true
       with_items: [1, 2, 3, 4, 5]

--- a/tests/integration/targets/ec2_snapshot/meta/main.yml
+++ b/tests/integration/targets/ec2_snapshot/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
-- role: setup_ec2_facts
+  - role: setup_ec2_facts

--- a/tests/integration/targets/ec2_snapshot/tasks/main.yml
+++ b/tests/integration/targets/ec2_snapshot/tasks/main.yml
@@ -23,36 +23,34 @@
 
   block:
     - name: Gather availability zones
-      aws_az_info:
+      amazon.aws.aws_az_info:
       register: azs
 
     - name: Run tasks for testing snapshot createVolumePermissions modifications
-      import_tasks: test_modify_create_volume_permissions.yml
-
-    # Create a new volume in detached mode without tags
+      ansible.builtin.import_tasks: test_modify_create_volume_permissions.yml
     - name: Create a detached volume without tags
-      ec2_vol:
+      amazon.aws.ec2_vol:
         volume_size: 1
-        zone: '{{ azs.availability_zones[0].zone_name }}'
+        zone: "{{ azs.availability_zones[0].zone_name }}"
       register: volume_detached
 
     # Capture snapshot of this detached volume and assert the results
     - name: Create a snapshot of detached volume without tags and store results
-      ec2_snapshot:
-        volume_id: '{{ volume_detached.volume_id }}'
+      amazon.aws.ec2_snapshot:
+        volume_id: "{{ volume_detached.volume_id }}"
       register: untagged_snapshot
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - untagged_snapshot is changed
           - untagged_snapshot.snapshots| length == 1
           - untagged_snapshot.snapshots[0].volume_id == volume_detached.volume_id
 
     - name: Setup an instance for testing, make sure volumes are attached before next task
-      ec2_instance:
-        name: '{{ resource_prefix }}'
+      amazon.aws.ec2_instance:
+        name: "{{ resource_prefix }}"
         instance_type: t2.nano
-        image_id: '{{ ec2_ami_id }}'
+        image_id: "{{ ec2_ami_id }}"
         volumes:
           - device_name: /dev/xvda
             ebs:
@@ -62,37 +60,37 @@
         wait: true
       register: instance
 
-    - set_fact:
-        volume_id: '{{ instance.instances[0].block_device_mappings[0].ebs.volume_id }}'
-        instance_id: '{{ instance.instances[0].instance_id }}'
-        device_name: '{{ instance.instances[0].block_device_mappings[0].device_name }}'
+    - ansible.builtin.set_fact:
+        volume_id: "{{ instance.instances[0].block_device_mappings[0].ebs.volume_id }}"
+        instance_id: "{{ instance.instances[0].instance_id }}"
+        device_name: "{{ instance.instances[0].block_device_mappings[0].device_name }}"
 
     - name: Take snapshot (check mode)
-      ec2_snapshot:
-        instance_id: '{{ instance_id }}'
-        device_name: '{{ device_name }}'
+      amazon.aws.ec2_snapshot:
+        instance_id: "{{ instance_id }}"
+        device_name: "{{ device_name }}"
         snapshot_tags:
-          Test: '{{ resource_prefix }}'
+          Test: "{{ resource_prefix }}"
       check_mode: true
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
     - name: Take snapshot of volume
-      ec2_snapshot:
-        volume_id: '{{ volume_id }}'
+      amazon.aws.ec2_snapshot:
+        volume_id: "{{ volume_id }}"
       register: result
 
     # The Name tag is created automatically as the instance_name; ie the resource_prefix
     - name: Get info about snapshots
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         filters:
-          "tag:Name": '{{ resource_prefix }}'
+          tag:Name: "{{ resource_prefix }}"
       register: info_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - info_result is not changed
@@ -103,13 +101,13 @@
           - info_result.snapshots[0].tags == result.tags
 
     - name: Get info about snapshots (check_mode)
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         filters:
-          "tag:Name": '{{ resource_prefix }}'
+          tag:Name: "{{ resource_prefix }}"
       register: info_check
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - info_check is not changed
           - info_check.snapshots| length == 1
@@ -119,96 +117,96 @@
           - info_check.snapshots[0].tags == result.tags
 
     - name: Take snapshot if most recent >1hr (False) (check mode)
-      ec2_snapshot:
-        volume_id: '{{ volume_id }}'
+      amazon.aws.ec2_snapshot:
+        volume_id: "{{ volume_id }}"
         snapshot_tags:
-          Name: '{{ resource_prefix }}'
+          Name: "{{ resource_prefix }}"
         last_snapshot_min_age: 60
       check_mode: true
       register: result
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
     - name: Take snapshot if most recent >1hr (False)
-      ec2_snapshot:
-        volume_id: '{{ volume_id }}'
+      amazon.aws.ec2_snapshot:
+        volume_id: "{{ volume_id }}"
         last_snapshot_min_age: 60
       register: result
 
     - name: Get info about snapshots
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         filters:
-          "tag:Name": '{{ resource_prefix }}'
+          tag:Name: "{{ resource_prefix }}"
       register: info_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
           - info_result.snapshots| length == 1
 
     - name: Pause so we can do a last_snapshot_min_age test
-      pause:
+      ansible.builtin.pause:
         minutes: 1
 
     - name: Take snapshot if most recent >1min (True) (check mode)
-      ec2_snapshot:
-        volume_id: '{{ volume_id }}'
+      amazon.aws.ec2_snapshot:
+        volume_id: "{{ volume_id }}"
         snapshot_tags:
-          Name: '{{ resource_prefix }}'
+          Name: "{{ resource_prefix }}"
         last_snapshot_min_age: 1
       check_mode: true
       register: result
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
     - name: Take snapshot if most recent >1min (True)
-      ec2_snapshot:
-        volume_id: '{{ volume_id }}'
+      amazon.aws.ec2_snapshot:
+        volume_id: "{{ volume_id }}"
         last_snapshot_min_age: 1
       register: result
 
     - name: Get info about snapshots
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         filters:
-          "tag:Name": '{{ resource_prefix }}'
+          tag:Name: "{{ resource_prefix }}"
       register: info_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - info_result.snapshots| length == 2
           - result.snapshot_id in ( info_result.snapshots | map(attribute='snapshot_id') | list )
 
     - name: Take snapshot with a tag (check mode)
-      ec2_snapshot:
-        volume_id: '{{ volume_id }}'
+      amazon.aws.ec2_snapshot:
+        volume_id: "{{ volume_id }}"
         snapshot_tags:
-          MyTag: '{{ resource_prefix }}'
+          MyTag: "{{ resource_prefix }}"
       check_mode: true
       register: result
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
     - name: Take snapshot and tag it
-      ec2_snapshot:
-        volume_id: '{{ volume_id }}'
+      amazon.aws.ec2_snapshot:
+        volume_id: "{{ volume_id }}"
         snapshot_tags:
-          MyTag: '{{ resource_prefix }}'
+          MyTag: "{{ resource_prefix }}"
       register: tagged_result
 
     - name: Get info about snapshots by tag
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         filters:
-          "tag:MyTag": '{{ resource_prefix }}'
+          tag:MyTag: "{{ resource_prefix }}"
       register: tag_info_result
 
-    - set_fact:
-        tagged_snapshot_id: '{{ tag_info_result.snapshots[0].snapshot_id }}'
+    - ansible.builtin.set_fact:
+        tagged_snapshot_id: "{{ tag_info_result.snapshots[0].snapshot_id }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - tagged_result is changed
           - tagged_result.tags| length == 2
@@ -217,52 +215,52 @@
           - tagged_result.snapshot_id == tagged_snapshot_id
 
     - name: Get info about all snapshots for this test
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         filters:
-          "tag:Name": '{{ resource_prefix }}'
+          tag:Name: "{{ resource_prefix }}"
       register: info_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - info_result.snapshots | length == 3
 
     - name: Generate extra snapshots
-      ec2_snapshot:
-        volume_id: '{{ volume_id }}'
+      amazon.aws.ec2_snapshot:
+        volume_id: "{{ volume_id }}"
         snapshot_tags:
-          ResourcePrefix: '{{ resource_prefix }}'
-      loop: '{{ range(1, 6, 1) | list }}'
+          ResourcePrefix: "{{ resource_prefix }}"
+      loop: "{{ range(1, 6, 1) | list }}"
       loop_control:
         # Anything under 15 will trigger SnapshotCreationPerVolumeRateExceeded,
         # this should now be automatically handled, but pause a little anyway to
         # avoid being aggressive
         pause: 15
-        label: "Generate extra snapshots - {{ item }}"
+        label: Generate extra snapshots - {{ item }}
 
     # Retrieve snapshots in paginated mode
     - name: Get snapshots in paginated mode using max_results option
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         filters:
-          "tag:Name": '{{ resource_prefix }}'
+          tag:Name: "{{ resource_prefix }}"
         max_results: 5
       register: info_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - info_result.next_token_id is defined
 
     # Pagination : 2nd request
     - name: Get snapshots for a second paginated request
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         filters:
-          "tag:Name": '{{ resource_prefix }}'
+          tag:Name: "{{ resource_prefix }}"
         next_token_id: "{{ info_result.next_token_id }}"
         max_results: 5
       register: info_result_2
 
     # note: *MAX* 5 results, sometimes they'll throw us fewer...
     # 8 is the absolute max it should find
-    - assert:
+    - ansible.builtin.assert:
         that:
           - (length_1 | int ) + (length_2 | int) <= 8
       vars:
@@ -271,134 +269,133 @@
 
     # delete the tagged snapshot - check mode
     - name: Delete the tagged snapshot (check mode)
-      ec2_snapshot:
+      amazon.aws.ec2_snapshot:
         state: absent
-        snapshot_id: '{{ tagged_snapshot_id }}'
+        snapshot_id: "{{ tagged_snapshot_id }}"
       register: delete_result_check_mode
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - delete_result_check_mode is changed
 
     # check that snapshot_ids and max_results are mutually exclusive
     - name: Check that max_results and snapshot_ids are mutually exclusive
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
-          - '{{ tagged_snapshot_id }}'
+          - "{{ tagged_snapshot_id }}"
         max_results: 5
       ignore_errors: true
       register: info_result
 
     - name: assert that operation failed
-      assert:
+      ansible.builtin.assert:
         that:
           - info_result is failed
 
     # check that snapshot_ids and next_token_id are mutually exclusive
     - name: Check that snapshot_ids and next_token_id are mutually exclusive
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
-          - '{{ tagged_snapshot_id }}'
-        next_token_id: 'random_value_token'
+          - "{{ tagged_snapshot_id }}"
+        next_token_id: random_value_token
       ignore_errors: true
       register: info_result
 
     - name: assert that operation failed
-      assert:
+      ansible.builtin.assert:
         that:
           - info_result is failed
 
     # delete the tagged snapshot
     - name: Delete the tagged snapshot
-      ec2_snapshot:
+      amazon.aws.ec2_snapshot:
         state: absent
-        snapshot_id: '{{ tagged_snapshot_id }}'
+        snapshot_id: "{{ tagged_snapshot_id }}"
 
     # delete the tagged snapshot again (results in InvalidSnapshot.NotFound)
     - name: Delete already removed snapshot (check mode)
-      ec2_snapshot:
+      amazon.aws.ec2_snapshot:
         state: absent
-        snapshot_id: '{{ tagged_snapshot_id }}'
+        snapshot_id: "{{ tagged_snapshot_id }}"
       register: delete_result_second_check_mode
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - delete_result_second_check_mode is not changed
 
     - name: Delete already removed snapshot (idempotent)
-      ec2_snapshot:
+      amazon.aws.ec2_snapshot:
         state: absent
-        snapshot_id: '{{ tagged_snapshot_id }}'
+        snapshot_id: "{{ tagged_snapshot_id }}"
       register: delete_result_second_idempotent
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - delete_result_second_idempotent is not changed
 
     - name: Get info about all snapshots for this test
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         filters:
-          "tag:Name": '{{ resource_prefix }}'
+          tag:Name: "{{ resource_prefix }}"
       register: info_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - info_result.snapshots| length == 7
           - tagged_snapshot_id not in ( info_result.snapshots | map(attribute='snapshot_id') | list )
 
     - name: Delete snapshots
-      ec2_snapshot:
+      amazon.aws.ec2_snapshot:
         state: absent
-        snapshot_id: '{{ item.snapshot_id }}'
-      with_items: '{{ info_result.snapshots }}'
+        snapshot_id: "{{ item.snapshot_id }}"
+      with_items: "{{ info_result.snapshots }}"
 
     - name: Get info about all snapshots for this test
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         filters:
-          "tag:Name": '{{ resource_prefix }}'
+          tag:Name: "{{ resource_prefix }}"
       register: info_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - info_result.snapshots| length == 0
 
   always:
-
     - name: Snapshots to delete
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         filters:
-          "tag:Name": '{{ resource_prefix }}'
+          tag:Name: "{{ resource_prefix }}"
       register: tagged_snapshots
 
     - name: Delete tagged snapshots
-      ec2_snapshot:
+      amazon.aws.ec2_snapshot:
         state: absent
-        snapshot_id: '{{ item.snapshot_id }}'
-      with_items: '{{ tagged_snapshots.snapshots }}'
+        snapshot_id: "{{ item.snapshot_id }}"
+      with_items: "{{ tagged_snapshots.snapshots }}"
       ignore_errors: true
 
     - name: Delete instance
-      ec2_instance:
-        instance_ids: '{{ instance_id }}'
+      amazon.aws.ec2_instance:
+        instance_ids: "{{ instance_id }}"
         state: absent
       ignore_errors: true
 
     - name: Delete volume
-      ec2_vol:
-        id: '{{ volume_id }}'
+      amazon.aws.ec2_vol:
+        id: "{{ volume_id }}"
         state: absent
       ignore_errors: true
 
     - name: Delete detached and untagged volume
-      ec2_vol:
-        id: '{{ volume_detached.volume_id}}'
+      amazon.aws.ec2_vol:
+        id: "{{ volume_detached.volume_id}}"
         state: absent
       ignore_errors: true
 
     - name: Delete untagged snapshot
-      ec2_snapshot:
+      amazon.aws.ec2_snapshot:
         state: absent
-        snapshot_id: '{{ untagged_snapshot.snapshot_id }}'
+        snapshot_id: "{{ untagged_snapshot.snapshot_id }}"
       ignore_errors: true

--- a/tests/integration/targets/ec2_snapshot/tasks/test_modify_create_volume_permissions.yml
+++ b/tests/integration/targets/ec2_snapshot/tasks/test_modify_create_volume_permissions.yml
@@ -3,57 +3,56 @@
 - name: Tests relating to createVolumePermission
   block:
     - name: Create a volume
-      ec2_vol:
+      amazon.aws.ec2_vol:
         volume_size: 1
-        zone: '{{ azs.availability_zones[0].zone_name }}'
+        zone: "{{ azs.availability_zones[0].zone_name }}"
       register: create_vol_result
 
-    - set_fact:
+    - ansible.builtin.set_fact:
         volume_id: "{{ create_vol_result.volume_id }}"
 
     - name: Take snapshot of volume
-      ec2_snapshot:
-        volume_id: '{{ volume_id }}'
+      amazon.aws.ec2_snapshot:
+        volume_id: "{{ volume_id }}"
         snapshot_tags:
-          Name: 'mandkulk-test-modify-test-snap'
+          Name: mandkulk-test-modify-test-snap
       register: create_snapshot_result
 
-    - set_fact:
+    - ansible.builtin.set_fact:
         snapshot_id: "{{ create_snapshot_result.snapshot_id }}"
 
-
-  # Run Tests ============================================
+    # Run Tests ============================================
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
 
     - name: assert that createVolumePermission are "Private"
-      assert:
+      ansible.builtin.assert:
         that:
           - info_result.snapshots[0].create_volume_permissions | length == 0
 
-  # Update Permissions to add user_ids --------------------------------------------------------
+    # Update Permissions to add user_ids --------------------------------------------------------
     - name: Modify snapshot createVolmePermission - ADD new user_ids - check_mode
       amazon.aws.ec2_snapshot:
         snapshot_id: "{{ snapshot_id }}"
         modify_create_vol_permission: true
         user_ids:
-          - '111111111111'
-          - '222222222222'
+          - "111111111111"
+          - "222222222222"
         wait: true
       register: update_permission_result
       check_mode: true
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is changed
           - update_permission_result is not failed
@@ -64,20 +63,20 @@
         snapshot_id: "{{ snapshot_id }}"
         modify_create_vol_permission: true
         user_ids:
-          - '111111111111'
-          - '222222222222'
+          - "111111111111"
+          - "222222222222"
         wait: true
       register: update_permission_result
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is changed
           - update_permission_result is not failed
@@ -90,20 +89,20 @@
         snapshot_id: "{{ snapshot_id }}"
         modify_create_vol_permission: true
         user_ids:
-          - '111111111111'
-          - '222222222222'
+          - "111111111111"
+          - "222222222222"
         wait: true
       register: update_permission_result
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is not changed
           - update_permission_result is not failed
@@ -114,45 +113,45 @@
         snapshot_id: "{{ snapshot_id }}"
         modify_create_vol_permission: true
         user_ids:
-          - '111111111111'
-          - '222222222222'
+          - "111111111111"
+          - "222222222222"
         wait: true
       register: update_permission_result
       check_mode: true
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is not changed
           - update_permission_result is not failed
           - permissions_list | length == 2
 
-  # Update Permissions to remove user_id --------------------------------------------------------
+    # Update Permissions to remove user_id --------------------------------------------------------
     - name: Modify snapshot createVolmePermission - remove user_id - check_mode
       amazon.aws.ec2_snapshot:
         snapshot_id: "{{ snapshot_id }}"
         modify_create_vol_permission: true
         purge_create_vol_permission: true
         user_ids:
-          - '111111111111'
+          - "111111111111"
         wait: true
       register: update_permission_result
       check_mode: true
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is changed
           - update_permission_result is not failed
@@ -164,19 +163,19 @@
         modify_create_vol_permission: true
         purge_create_vol_permission: true
         user_ids:
-          - '222222222222'
+          - "222222222222"
         wait: true
       register: update_permission_result
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is changed
           - update_permission_result is not failed
@@ -190,19 +189,19 @@
         modify_create_vol_permission: true
         purge_create_vol_permission: true
         user_ids:
-          - '222222222222'
+          - "222222222222"
         wait: true
       register: update_permission_result
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is not changed
           - update_permission_result is not failed
@@ -214,46 +213,46 @@
         modify_create_vol_permission: true
         purge_create_vol_permission: true
         user_ids:
-          - '222222222222'
+          - "222222222222"
         wait: true
       register: update_permission_result
       check_mode: true
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is not changed
           - update_permission_result is not failed
           - permissions_list | length == 1
 
-  # Update Permissions to Public --------------------------------------------------------
+    # Update Permissions to Public --------------------------------------------------------
     - name: Modify snapshot createVolmePermission - add group_names 'all' - check_mode
       amazon.aws.ec2_snapshot:
         snapshot_id: "{{ snapshot_id }}"
         modify_create_vol_permission: true
         purge_create_vol_permission: true
         group_names:
-          - 'all'
+          - all
         wait: true
       register: update_permission_result
       check_mode: true
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='user_id') | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is changed
           - update_permission_result is not failed
@@ -266,19 +265,19 @@
         modify_create_vol_permission: true
         purge_create_vol_permission: true
         group_names:
-          - 'all'
+          - all
         wait: true
       register: update_permission_result
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='group') | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is changed
           - update_permission_result is not failed
@@ -292,19 +291,19 @@
         modify_create_vol_permission: true
         purge_create_vol_permission: true
         group_names:
-          - 'all'
+          - all
         wait: true
       register: update_permission_result
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='group') | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is not changed
           - update_permission_result is not failed
@@ -318,20 +317,20 @@
         modify_create_vol_permission: true
         purge_create_vol_permission: true
         group_names:
-          - 'all'
+          - all
         wait: true
       register: update_permission_result
       check_mode: true
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='group') | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is not changed
           - update_permission_result is not failed
@@ -339,7 +338,7 @@
           - '"222222222222" not in permissions_list'
           - '"all" in permissions_list'
 
-  # Reset Permissions to Private --------------------------------------------------------
+    # Reset Permissions to Private --------------------------------------------------------
     - name: Modify snapshot createVolmePermission - RESET to 'private' - check_mode
       amazon.aws.ec2_snapshot:
         snapshot_id: "{{ snapshot_id }}"
@@ -350,14 +349,14 @@
       check_mode: true
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | map(attribute='group') | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is changed
           - update_permission_result is not failed
@@ -374,14 +373,14 @@
       register: update_permission_result
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is changed
           - update_permission_result is not failed
@@ -398,14 +397,14 @@
       register: update_permission_result
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is not changed
           - update_permission_result is not failed
@@ -423,14 +422,14 @@
       check_mode: true
 
     - name: Get current createVolumePermission
-      ec2_snapshot_info:
+      amazon.aws.ec2_snapshot_info:
         snapshot_ids:
           - "{{ snapshot_id }}"
       register: info_result
-    - set_fact:
+    - ansible.builtin.set_fact:
         permissions_list: "{{ info_result.snapshots[0].create_volume_permissions | list }}"
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - update_permission_result is not changed
           - update_permission_result is not failed
@@ -438,17 +437,16 @@
           - '"222222222222" not in permissions_list'
           - '"all" not in permissions_list'
 
-# Teardown for this task ===============================
+  # Teardown for this task ===============================
   always:
+    - name: Delete snapshot
+      amazon.aws.ec2_snapshot:
+        snapshot_id: "{{ snapshot_id }}"
+        state: absent
+      ignore_errors: true
 
-  - name: Delete snapshot
-    ec2_snapshot:
-      snapshot_id: "{{ snapshot_id }}"
-      state: absent
-    ignore_errors: true
-
-  - name: Delete volume
-    ec2_vol:
-      id: "{{ volume_id }}"
-      state: absent
-    ignore_errors: true
+    - name: Delete volume
+      amazon.aws.ec2_vol:
+        id: "{{ volume_id }}"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/ec2_spot_instance/defaults/main.yml
+++ b/tests/integration/targets/ec2_spot_instance/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
-vpc_seed_a: '{{ resource_prefix }}'
-vpc_seed_b: '{{ resource_prefix }}-ec2_eni'
-vpc_prefix: '10.{{ 256 | random(seed=vpc_seed_a) }}.{{ 256 | random(seed=vpc_seed_b ) }}'
-vpc_cidr: '{{ vpc_prefix}}.128/26'
+vpc_seed_a: "{{ resource_prefix }}"
+vpc_seed_b: "{{ resource_prefix }}-ec2_eni"
+vpc_prefix: 10.{{ 256 | random(seed=vpc_seed_a) }}.{{ 256 | random(seed=vpc_seed_b ) }}
+vpc_cidr: "{{ vpc_prefix}}.128/26"
 ip_1: "{{ vpc_prefix }}.132"
 ip_2: "{{ vpc_prefix }}.133"
 ip_3: "{{ vpc_prefix }}.134"
@@ -10,5 +10,5 @@ ip_4: "{{ vpc_prefix }}.135"
 ip_5: "{{ vpc_prefix }}.136"
 
 ec2_ips:
-- "{{ vpc_prefix }}.137"
-- "{{ vpc_prefix }}.138"
+  - "{{ vpc_prefix }}.137"
+  - "{{ vpc_prefix }}.138"

--- a/tests/integration/targets/ec2_spot_instance/meta/main.yml
+++ b/tests/integration/targets/ec2_spot_instance/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
   - setup_ec2_facts

--- a/tests/integration/targets/ec2_spot_instance/tasks/main.yaml
+++ b/tests/integration/targets/ec2_spot_instance/tasks/main.yaml
@@ -7,309 +7,306 @@
       region: "{{ aws_region }}"
 
   collections:
-  - amazon.aws
-  - community.aws
+    - amazon.aws
+    - community.aws
 
   block:
-  - name: Get available AZs
-    aws_az_info:
-      filters:
-        region-name: "{{ aws_region }}"
-    register: az_info
+    - name: Get available AZs
+      amazon.aws.aws_az_info:
+        filters:
+          region-name: "{{ aws_region }}"
+      register: az_info
 
-  - name: Pick an AZ
-    set_fact:
-      availability_zone: "{{ az_info['availability_zones'][0]['zone_name'] }}"
-
-  # ============================================================
-  - name: create a VPC
-    ec2_vpc_net:
-      name: "{{ resource_prefix }}-vpc"
-      state: present
-      cidr_block: "{{ vpc_cidr }}"
-      tags:
-        Name: "{{ resource_prefix }}-vpc"
-        Description: "Created by ansible-test"
-    register: vpc_result
-
-  - name: create a subnet
-    ec2_vpc_subnet:
-      cidr: "{{ vpc_cidr }}"
-      az: "{{ availability_zone }}"
-      vpc_id: "{{ vpc_result.vpc.id }}"
-      tags:
-        Name: "{{ resource_prefix }}-vpc"
-        Description: "Created by ansible-test"
-      state: present
-    register: vpc_subnet_result
-
-  - name: create a security group
-    ec2_security_group:
-      name: "{{ resource_prefix }}-sg"
-      description: "Created by {{ resource_prefix }}"
-      rules: []
-      state: present
-      vpc_id: "{{ vpc_result.vpc.id }}"
-    register: vpc_sg_result
-
-  - name: create a new ec2 key pair
-    ec2_key:
-      name: "{{ resource_prefix }}-keypair"
-
-  - name: Set facts to simplify use of extra resources
-    set_fact:
-      vpc_id: "{{ vpc_result.vpc.id }}"
-      vpc_subnet_id: "{{ vpc_subnet_result.subnet.id }}"
-      vpc_sg_id: "{{ vpc_sg_result.group_id }}"
-
-  # ============================================================
-
-  - name: Run tests for termianting associated instances
-    import_tasks: terminate_associated_instances.yml
-
-  # Assert that spot instance request is created
-  - name: Create simple spot instance request
-    ec2_spot_instance:
-      launch_specification:
-        image_id: "{{ ec2_ami_id }}"
-        key_name: "{{ resource_prefix }}-keypair"
-        instance_type: "t2.medium"
-        subnet_id: "{{ vpc_subnet_result.subnet.id }}"
-      tags:
-        ansible-test: "{{ resource_prefix }}"
-    register: create_result
-
-  - name: Assert that result has changed and request has been created
-    assert:
-      that:
-        - create_result is changed
-        - create_result.spot_request is defined
-        - create_result.spot_request.spot_instance_request_id is defined
-        - create_result.spot_request.launch_specification.subnet_id == vpc_subnet_result.subnet.id
-
-  - name: Get info about the spot instance request created
-    ec2_spot_instance_info:
-      spot_instance_request_ids:
-        - "{{ create_result.spot_request.spot_instance_request_id }}"
-    register: spot_instance_info_result
-
-  - name: Assert that the spot request created is open or active
-    assert:
-      that:
-        - spot_instance_info_result.spot_request[0].state in ['open', 'active']
-
-  - name: Create spot request with more complex options
-    ec2_spot_instance:
-      launch_specification:
-        image_id: "{{ ec2_ami_id }}"
-        key_name: "{{ resource_prefix }}-keypair"
-        instance_type: "t2.medium"
-        block_device_mappings:
-          - device_name: /dev/sdb
-            ebs:
-              delete_on_termination: True
-              volume_type: gp3
-              volume_size: 5
-        network_interfaces:
-          - associate_public_ip_address: False
-            subnet_id: "{{ vpc_subnet_result.subnet.id }}"
-            delete_on_termination: True
-            device_index: 0
-        placement:
-          availability_zone: '{{ availability_zone }}'
-        monitoring:
-          enabled: False
-      spot_price: 0.002
-      tags:
-        camelCase: "helloWorld"
-        PascalCase: "HelloWorld"
-        snake_case: "hello_world"
-        "Title Case": "Hello World"
-        "lowercase spaced": "hello world"
-        ansible-test: "{{ resource_prefix }}"
-    register: complex_create_result
-
-  - assert:
-      that:
-        - complex_create_result is changed
-        - complex_create_result.spot_request is defined
-        - complex_create_result.spot_request.spot_instance_request_id is defined
-        - complex_create_result.spot_request.type == 'one-time'
-        - '"0.002" in complex_create_result.spot_request.spot_price'  ## AWS pads trailing zeros on the spot price
-        - launch_spec.placement.availability_zone == availability_zone
-        - launch_spec.block_device_mappings|length == 1
-        - launch_spec.block_device_mappings.0.ebs.delete_on_termination == true
-        - launch_spec.block_device_mappings.0.ebs.volume_type == 'gp3'
-        - launch_spec.block_device_mappings.0.ebs.volume_size == 5
-        - launch_spec.network_interfaces|length == 1
-        - launch_spec.network_interfaces.0.device_index == 0
-        - launch_spec.network_interfaces.0.associate_public_ip_address == false
-        - launch_spec.network_interfaces.0.delete_on_termination == true
-        - spot_request_tags|length == 6
-        - spot_request_tags['camelCase'] == 'helloWorld'
-        - spot_request_tags['PascalCase'] == 'HelloWorld'
-        - spot_request_tags['snake_case'] == 'hello_world'
-        - spot_request_tags['Title Case'] == 'Hello World'
-        - spot_request_tags['lowercase spaced'] == 'hello world'
-    vars:
-      launch_spec: '{{ complex_create_result.spot_request.launch_specification }}'
-      spot_request_tags: '{{ complex_create_result.spot_request.tags }}'
-
-  - name: Get info about the complex spot instance request created
-    ec2_spot_instance_info:
-      spot_instance_request_ids:
-        - "{{ complex_create_result.spot_request.spot_instance_request_id }}"
-    register: complex_info_result
-
-  - name: Assert that the complex spot request created is open/active and correct keys are set
-    assert:
-      that:
-        - complex_info_result.spot_request[0].state in ['open', 'active']
-        - complex_create_result.spot_request.spot_price == complex_info_result.spot_request[0].spot_price
-        - create_launch_spec.block_device_mappings[0].ebs.volume_size == info_launch_spec.block_device_mappings[0].ebs.volume_size
-        - create_launch_spec.block_device_mappings[0].ebs.volume_type == info_launch_spec.block_device_mappings[0].ebs.volume_type
-        - create_launch_spec.network_interfaces[0].delete_on_termination == info_launch_spec.network_interfaces[0].delete_on_termination
-    vars:
-      create_launch_spec: "{{ complex_create_result.spot_request.launch_specification }}"
-      info_launch_spec: "{{ complex_info_result.spot_request[0].launch_specification }}"
-
-  - name: Get info about the created spot instance requests and filter result based on provided filters
-    ec2_spot_instance_info:
-      spot_instance_request_ids:
-        - '{{ create_result.spot_request.spot_instance_request_id }}'
-        - '{{ complex_create_result.spot_request.spot_instance_request_id }}'
-      filters:
-        tag:ansible-test: "{{ resource_prefix }}"
-        launch.block-device-mapping.device-name: /dev/sdb
-    register: spot_instance_info_filter_result
-
-  - name: Assert that the correct spot request was returned in the filtered result
-    assert:
-      that:
-        - spot_instance_info_filter_result.spot_request[0].spot_instance_request_id == complex_create_result.spot_request.spot_instance_request_id
-
-  # Assert check mode
-  - name: Create spot instance request (check_mode)
-    ec2_spot_instance:
-      launch_specification:
-        image_id: "{{ ec2_ami_id }}"
-        key_name: "{{ resource_prefix }}-keypair"
-        instance_type: "t2.medium"
-        subnet_id: "{{ vpc_subnet_result.subnet.id }}"
-      tags:
-        ansible-test: "{{ resource_prefix }}"
-    check_mode: True
-    register: check_create_result
-
-  - assert:
-      that:
-        - check_create_result is changed
-
-  - name: Remove spot instance request (check_mode)
-    ec2_spot_instance:
-      spot_instance_request_ids: '{{ create_result.spot_request.spot_instance_request_id }}'
-      state: absent
-    check_mode: True
-    register: check_cancel_result
-
-  - assert:
-      that:
-        - check_cancel_result is changed
-
-  - name: Remove spot instance requests
-    ec2_spot_instance:
-      spot_instance_request_ids:
-        - '{{ create_result.spot_request.spot_instance_request_id }}'
-        - '{{ complex_create_result.spot_request.spot_instance_request_id }}'
-      state: absent
-    register: cancel_result
-
-  - assert:
-      that:
-        - cancel_result is changed
-        - '"Cancelled Spot request" in cancel_result.msg'
-
-  - name: Sometimes we run the next test before the EC2 API is fully updated from the previous task
-    pause:
-      seconds: 3
-
-  - name: Check no change if request is already cancelled (idempotency)
-    ec2_spot_instance:
-      spot_instance_request_ids: '{{ create_result.spot_request.spot_instance_request_id }}'
-      state: absent
-    register: cancel_request_again
-
-  - assert:
-      that:
-        - cancel_request_again is not changed
-        - '"Spot request not found or already cancelled" in cancel_request_again.msg'
-
-  - name: Gracefully try to remove non-existent request (NotFound)
-    ec2_spot_instance:
-      spot_instance_request_ids:
-        - sir-12345678
-      state: absent
-    register: fake_cancel_result
-
-  - assert:
-      that:
-        - fake_cancel_result is not changed
-        - '"Spot request not found or already cancelled" in fake_cancel_result.msg'
-
-  always:
+    - name: Pick an AZ
+      ansible.builtin.set_fact:
+        availability_zone: "{{ az_info['availability_zones'][0]['zone_name'] }}"
 
     # ============================================================
-      - name: Delete spot instances
-        ec2_instance:
-          state: absent
-          filters:
-            vpc-id: "{{ vpc_result.vpc.id }}"
+    - name: create a VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        state: present
+        cidr_block: "{{ vpc_cidr }}"
+        tags:
+          Name: "{{ resource_prefix }}-vpc"
+          Description: Created by ansible-test
+      register: vpc_result
 
-      - name: get all spot requests created during test
-        ec2_spot_instance_info:
-          filters:
-            tag:ansible-test: "{{ resource_prefix }}"
-        register: spot_request_list
+    - name: create a subnet
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ vpc_cidr }}"
+        az: "{{ availability_zone }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          Name: "{{ resource_prefix }}-vpc"
+          Description: Created by ansible-test
+        state: present
+      register: vpc_subnet_result
 
-      - name: remove spot instance requests
-        ec2_spot_instance:
-          spot_instance_request_ids:
-            - '{{ item.spot_instance_request_id }}'
-          state: 'absent'
-        ignore_errors: true
-        retries: 5
-        with_items: "{{ spot_request_list.spot_request }}"
+    - name: create a security group
+      ec2_security_group:
+        name: "{{ resource_prefix }}-sg"
+        description: Created by {{ resource_prefix }}
+        rules: []
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      register: vpc_sg_result
 
-      - name: remove the security group
-        ec2_security_group:
-          name: "{{ resource_prefix }}-sg"
-          description: "{{ resource_prefix }}"
-          rules: []
-          state: absent
-          vpc_id: "{{ vpc_result.vpc.id }}"
-        ignore_errors: true
-        retries: 5
+    - name: create a new ec2 key pair
+      amazon.aws.ec2_key:
+        name: "{{ resource_prefix }}-keypair"
 
-      - name: remove the subnet
-        ec2_vpc_subnet:
-          cidr: "{{ vpc_cidr }}"
-          az: "{{ availability_zone }}"
-          vpc_id: "{{ vpc_result.vpc.id }}"
-          state: absent
-        ignore_errors: true
-        retries: 5
-        when: vpc_subnet_result is defined
+    - name: Set facts to simplify use of extra resources
+      ansible.builtin.set_fact:
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        vpc_subnet_id: "{{ vpc_subnet_result.subnet.id }}"
+        vpc_sg_id: "{{ vpc_sg_result.group_id }}"
 
-      - name: remove the VPC
-        ec2_vpc_net:
-          name: "{{ resource_prefix }}-vpc"
-          cidr_block: "{{ vpc_cidr }}"
-          state: absent
-        ignore_errors: true
-        retries: 5
+    # ============================================================
 
-      - name: remove key pair by name
-        ec2_key:
-          name: "{{ resource_prefix }}-keypair"
-          state: absent
-        ignore_errors: true
+    - name: Run tests for termianting associated instances
+      ansible.builtin.import_tasks: terminate_associated_instances.yml
+    - name: Create simple spot instance request
+      ec2_spot_instance:
+        launch_specification:
+          image_id: "{{ ec2_ami_id }}"
+          key_name: "{{ resource_prefix }}-keypair"
+          instance_type: t2.medium
+          subnet_id: "{{ vpc_subnet_result.subnet.id }}"
+        tags:
+          ansible-test: "{{ resource_prefix }}"
+      register: create_result
+
+    - name: Assert that result has changed and request has been created
+      ansible.builtin.assert:
+        that:
+          - create_result is changed
+          - create_result.spot_request is defined
+          - create_result.spot_request.spot_instance_request_id is defined
+          - create_result.spot_request.launch_specification.subnet_id == vpc_subnet_result.subnet.id
+
+    - name: Get info about the spot instance request created
+      ec2_spot_instance_info:
+        spot_instance_request_ids:
+          - "{{ create_result.spot_request.spot_instance_request_id }}"
+      register: spot_instance_info_result
+
+    - name: Assert that the spot request created is open or active
+      ansible.builtin.assert:
+        that:
+          - spot_instance_info_result.spot_request[0].state in ['open', 'active']
+
+    - name: Create spot request with more complex options
+      ec2_spot_instance:
+        launch_specification:
+          image_id: "{{ ec2_ami_id }}"
+          key_name: "{{ resource_prefix }}-keypair"
+          instance_type: t2.medium
+          block_device_mappings:
+            - device_name: /dev/sdb
+              ebs:
+                delete_on_termination: true
+                volume_type: gp3
+                volume_size: 5
+          network_interfaces:
+            - associate_public_ip_address: false
+              subnet_id: "{{ vpc_subnet_result.subnet.id }}"
+              delete_on_termination: true
+              device_index: 0
+          placement:
+            availability_zone: "{{ availability_zone }}"
+          monitoring:
+            enabled: false
+        spot_price: !!float "0.002"
+        tags:
+          camelCase: helloWorld
+          PascalCase: HelloWorld
+          snake_case: hello_world
+          Title Case: Hello World
+          lowercase spaced: hello world
+          ansible-test: "{{ resource_prefix }}"
+      register: complex_create_result
+
+    - ansible.builtin.assert:
+        that:
+          - complex_create_result is changed
+          - complex_create_result.spot_request is defined
+          - complex_create_result.spot_request.spot_instance_request_id is defined
+          - complex_create_result.spot_request.type == 'one-time'
+          - '"0.002" in complex_create_result.spot_request.spot_price' ## AWS pads trailing zeros on the spot price
+          - launch_spec.placement.availability_zone == availability_zone
+          - launch_spec.block_device_mappings|length == 1
+          - launch_spec.block_device_mappings.0.ebs.delete_on_termination == true
+          - launch_spec.block_device_mappings.0.ebs.volume_type == 'gp3'
+          - launch_spec.block_device_mappings.0.ebs.volume_size == 5
+          - launch_spec.network_interfaces|length == 1
+          - launch_spec.network_interfaces.0.device_index == 0
+          - launch_spec.network_interfaces.0.associate_public_ip_address == false
+          - launch_spec.network_interfaces.0.delete_on_termination == true
+          - spot_request_tags|length == 6
+          - spot_request_tags['camelCase'] == 'helloWorld'
+          - spot_request_tags['PascalCase'] == 'HelloWorld'
+          - spot_request_tags['snake_case'] == 'hello_world'
+          - spot_request_tags['Title Case'] == 'Hello World'
+          - spot_request_tags['lowercase spaced'] == 'hello world'
+      vars:
+        launch_spec: "{{ complex_create_result.spot_request.launch_specification }}"
+        spot_request_tags: "{{ complex_create_result.spot_request.tags }}"
+
+    - name: Get info about the complex spot instance request created
+      ec2_spot_instance_info:
+        spot_instance_request_ids:
+          - "{{ complex_create_result.spot_request.spot_instance_request_id }}"
+      register: complex_info_result
+
+    - name: Assert that the complex spot request created is open/active and correct keys are set
+      ansible.builtin.assert:
+        that:
+          - complex_info_result.spot_request[0].state in ['open', 'active']
+          - complex_create_result.spot_request.spot_price == complex_info_result.spot_request[0].spot_price
+          - create_launch_spec.block_device_mappings[0].ebs.volume_size == info_launch_spec.block_device_mappings[0].ebs.volume_size
+          - create_launch_spec.block_device_mappings[0].ebs.volume_type == info_launch_spec.block_device_mappings[0].ebs.volume_type
+          - create_launch_spec.network_interfaces[0].delete_on_termination == info_launch_spec.network_interfaces[0].delete_on_termination
+      vars:
+        create_launch_spec: "{{ complex_create_result.spot_request.launch_specification }}"
+        info_launch_spec: "{{ complex_info_result.spot_request[0].launch_specification }}"
+
+    - name: Get info about the created spot instance requests and filter result based on provided filters
+      ec2_spot_instance_info:
+        spot_instance_request_ids:
+          - "{{ create_result.spot_request.spot_instance_request_id }}"
+          - "{{ complex_create_result.spot_request.spot_instance_request_id }}"
+        filters:
+          tag:ansible-test: "{{ resource_prefix }}"
+          launch.block-device-mapping.device-name: /dev/sdb
+      register: spot_instance_info_filter_result
+
+    - name: Assert that the correct spot request was returned in the filtered result
+      ansible.builtin.assert:
+        that:
+          - spot_instance_info_filter_result.spot_request[0].spot_instance_request_id == complex_create_result.spot_request.spot_instance_request_id
+
+    # Assert check mode
+    - name: Create spot instance request (check_mode)
+      ec2_spot_instance:
+        launch_specification:
+          image_id: "{{ ec2_ami_id }}"
+          key_name: "{{ resource_prefix }}-keypair"
+          instance_type: t2.medium
+          subnet_id: "{{ vpc_subnet_result.subnet.id }}"
+        tags:
+          ansible-test: "{{ resource_prefix }}"
+      check_mode: true
+      register: check_create_result
+
+    - ansible.builtin.assert:
+        that:
+          - check_create_result is changed
+
+    - name: Remove spot instance request (check_mode)
+      ec2_spot_instance:
+        spot_instance_request_ids: "{{ create_result.spot_request.spot_instance_request_id }}"
+        state: absent
+      check_mode: true
+      register: check_cancel_result
+
+    - ansible.builtin.assert:
+        that:
+          - check_cancel_result is changed
+
+    - name: Remove spot instance requests
+      ec2_spot_instance:
+        spot_instance_request_ids:
+          - "{{ create_result.spot_request.spot_instance_request_id }}"
+          - "{{ complex_create_result.spot_request.spot_instance_request_id }}"
+        state: absent
+      register: cancel_result
+
+    - ansible.builtin.assert:
+        that:
+          - cancel_result is changed
+          - '"Cancelled Spot request" in cancel_result.msg'
+
+    - name: Sometimes we run the next test before the EC2 API is fully updated from the previous task
+      ansible.builtin.pause:
+        seconds: 3
+
+    - name: Check no change if request is already cancelled (idempotency)
+      ec2_spot_instance:
+        spot_instance_request_ids: "{{ create_result.spot_request.spot_instance_request_id }}"
+        state: absent
+      register: cancel_request_again
+
+    - ansible.builtin.assert:
+        that:
+          - cancel_request_again is not changed
+          - '"Spot request not found or already cancelled" in cancel_request_again.msg'
+
+    - name: Gracefully try to remove non-existent request (NotFound)
+      ec2_spot_instance:
+        spot_instance_request_ids:
+          - sir-12345678
+        state: absent
+      register: fake_cancel_result
+
+    - ansible.builtin.assert:
+        that:
+          - fake_cancel_result is not changed
+          - '"Spot request not found or already cancelled" in fake_cancel_result.msg'
+
+  always:
+    # ============================================================
+    - name: Delete spot instances
+      amazon.aws.ec2_instance:
+        state: absent
+        filters:
+          vpc-id: "{{ vpc_result.vpc.id }}"
+
+    - name: get all spot requests created during test
+      ec2_spot_instance_info:
+        filters:
+          tag:ansible-test: "{{ resource_prefix }}"
+      register: spot_request_list
+
+    - name: remove spot instance requests
+      ec2_spot_instance:
+        spot_instance_request_ids:
+          - "{{ item.spot_instance_request_id }}"
+        state: absent
+      ignore_errors: true
+      retries: 5
+      with_items: "{{ spot_request_list.spot_request }}"
+
+    - name: remove the security group
+      ec2_security_group:
+        name: "{{ resource_prefix }}-sg"
+        description: "{{ resource_prefix }}"
+        rules: []
+        state: absent
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      ignore_errors: true
+      retries: 5
+
+    - name: remove the subnet
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ vpc_cidr }}"
+        az: "{{ availability_zone }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        state: absent
+      ignore_errors: true
+      retries: 5
+      when: vpc_subnet_result is defined
+
+    - name: remove the VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        cidr_block: "{{ vpc_cidr }}"
+        state: absent
+      ignore_errors: true
+      retries: 5
+
+    - name: remove key pair by name
+      amazon.aws.ec2_key:
+        name: "{{ resource_prefix }}-keypair"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/ec2_spot_instance/tasks/terminate_associated_instances.yml
+++ b/tests/integration/targets/ec2_spot_instance/tasks/terminate_associated_instances.yml
@@ -1,109 +1,108 @@
 ---
 - block:
+    # Spot instance request creation
+    - name: Simple Spot Request Creation
+      amazon.aws.ec2_spot_instance:
+        launch_specification:
+          image_id: "{{ ec2_ami_id }}"
+          key_name: "{{ resource_prefix }}-keypair"
+          instance_type: t2.micro
+          subnet_id: "{{ vpc_subnet_result.subnet.id }}"
+        tags:
+          ansible-test: "{{ resource_prefix }}"
+      register: create_result
 
-  # Spot instance request creation
-  - name: Simple Spot Request Creation
-    amazon.aws.ec2_spot_instance:
-      launch_specification:
-        image_id: "{{ ec2_ami_id }}"
-        key_name: "{{ resource_prefix }}-keypair"
-        instance_type: "t2.micro"
-        subnet_id: "{{ vpc_subnet_result.subnet.id }}"
-      tags:
-        ansible-test: "{{ resource_prefix }}"
-    register: create_result
+    # Get instance ID of associated spot instance request
+    - name: Get info about the spot instance request created
+      amazon.aws.ec2_spot_instance_info:
+        spot_instance_request_ids:
+          - "{{ create_result.spot_request.spot_instance_request_id }}"
+      register: spot_instance_info_result
+      retries: 5
+      until: spot_instance_info_result.spot_request[0].instance_id is defined
 
-  # Get instance ID of associated spot instance request
-  - name: Get info about the spot instance request created
-    amazon.aws.ec2_spot_instance_info:
-      spot_instance_request_ids:
-        - "{{ create_result.spot_request.spot_instance_request_id }}"
-    register: spot_instance_info_result
-    retries: 5
-    until: spot_instance_info_result.spot_request[0].instance_id is defined
+    - name: Pause to allow instance launch
+      ansible.builtin.pause:
+        seconds: 60
 
-  - name: Pause to allow instance launch
-    pause:
-      seconds: 60
+    - name: Get instance ID of the instance associated with above spot instance request
+      ansible.builtin.set_fact:
+        instance_id_1: "{{ spot_instance_info_result.spot_request[0].instance_id }}"
 
-  - name: Get instance ID of the instance associated with above spot instance request
-    set_fact:
-      instance_id_1: "{{ spot_instance_info_result.spot_request[0].instance_id }}"
+    - name: Check state of instance - BEFORE request cancellation
+      amazon.aws.ec2_instance_info:
+        instance_ids: ["{{ instance_id_1 }}"]
+      register: instance_info_result
 
-  - name: Check state of instance - BEFORE request cancellation
-    amazon.aws.ec2_instance_info:
-      instance_ids: ["{{ instance_id_1 }}"]
-    register: instance_info_result
+    # Cancel spot instance request
+    - name: Spot Request Termination
+      amazon.aws.ec2_spot_instance:
+        spot_instance_request_ids:
+          - "{{ create_result.spot_request.spot_instance_request_id }}"
+        state: absent
 
-  # Cancel spot instance request
-  - name: Spot Request Termination
-    amazon.aws.ec2_spot_instance:
-      spot_instance_request_ids:
-        - '{{ create_result.spot_request.spot_instance_request_id }}'
-      state: absent
+    # Verify that instance is not terminated and still running
+    - name: Check state of instance - AFTER request cancellation
+      amazon.aws.ec2_instance_info:
+        instance_ids: ["{{ instance_id_1 }}"]
+      register: instance_info_result
 
-  # Verify that instance is not terminated and still running
-  - name: Check state of instance - AFTER request cancellation
-    amazon.aws.ec2_instance_info:
-      instance_ids: ["{{ instance_id_1 }}"]
-    register: instance_info_result
+    - ansible.builtin.assert:
+        that: instance_info_result.instances[0].state.name == 'running'
 
-  - assert:
-      that: instance_info_result.instances[0].state.name == 'running'
+    #==========================================================================
 
-#==========================================================================
+    # Spot instance request creation
+    - name: Simple Spot Request Creation
+      amazon.aws.ec2_spot_instance:
+        launch_specification:
+          image_id: "{{ ec2_ami_id }}"
+          key_name: "{{ resource_prefix }}-keypair"
+          instance_type: t2.micro
+          subnet_id: "{{ vpc_subnet_result.subnet.id }}"
+        tags:
+          ansible-test: "{{ resource_prefix }}"
+      register: create_result
 
-  # Spot instance request creation
-  - name: Simple Spot Request Creation
-    amazon.aws.ec2_spot_instance:
-      launch_specification:
-        image_id: "{{ ec2_ami_id }}"
-        key_name: "{{ resource_prefix }}-keypair"
-        instance_type: "t2.micro"
-        subnet_id: "{{ vpc_subnet_result.subnet.id }}"
-      tags:
-        ansible-test: "{{ resource_prefix }}"
-    register: create_result
+    # Get instance ID of associated spot instance request
+    - name: Get info about the spot instance request created
+      amazon.aws.ec2_spot_instance_info:
+        spot_instance_request_ids:
+          - "{{ create_result.spot_request.spot_instance_request_id }}"
+      register: spot_instance_info_result
+      retries: 5
+      until: spot_instance_info_result.spot_request[0].instance_id is defined
 
-  # Get instance ID of associated spot instance request
-  - name: Get info about the spot instance request created
-    amazon.aws.ec2_spot_instance_info:
-      spot_instance_request_ids:
-        - "{{ create_result.spot_request.spot_instance_request_id }}"
-    register: spot_instance_info_result
-    retries: 5
-    until: spot_instance_info_result.spot_request[0].instance_id is defined
+    - name: Pause to allow instance launch
+      ansible.builtin.pause:
+        seconds: 60
 
-  - name: Pause to allow instance launch
-    pause:
-      seconds: 60
+    - name: Get instance ID of the instance associated with above spot instance request
+      ansible.builtin.set_fact:
+        instance_id_2: "{{ spot_instance_info_result.spot_request[0].instance_id }}"
 
-  - name: Get instance ID of the instance associated with above spot instance request
-    set_fact:
-      instance_id_2: "{{ spot_instance_info_result.spot_request[0].instance_id }}"
+    - name: Check state of instance - BEFORE request cancellation
+      amazon.aws.ec2_instance_info:
+        instance_ids: ["{{ instance_id_2 }}"]
+      register: instance_info_result
 
-  - name: Check state of instance - BEFORE request cancellation
-    amazon.aws.ec2_instance_info:
-      instance_ids: ["{{ instance_id_2 }}"]
-    register: instance_info_result
+    # Cancel spot instance request
+    - name: Spot Request Termination
+      amazon.aws.ec2_spot_instance:
+        spot_instance_request_ids:
+          - "{{ create_result.spot_request.spot_instance_request_id }}"
+        state: absent
+        terminate_instances: true
 
-  # Cancel spot instance request
-  - name: Spot Request Termination
-    amazon.aws.ec2_spot_instance:
-      spot_instance_request_ids:
-        - '{{ create_result.spot_request.spot_instance_request_id }}'
-      state: absent
-      terminate_instances: true
+    - name: wait for instance to terminate
+      ansible.builtin.pause:
+        seconds: 60
 
-  - name: wait for instance to terminate
-    pause:
-      seconds: 60
+    # Verify that instance is terminated or shutting-down
+    - name: Check state of instance - AFTER request cancellation
+      amazon.aws.ec2_instance_info:
+        instance_ids: ["{{ instance_id_2 }}"]
+      register: instance_info_result
 
-  # Verify that instance is terminated or shutting-down
-  - name: Check state of instance - AFTER request cancellation
-    amazon.aws.ec2_instance_info:
-      instance_ids: ["{{ instance_id_2 }}"]
-    register: instance_info_result
-
-  - assert:
-      that: instance_info_result.instances[0].state.name in ['terminated', 'shutting-down']
+    - ansible.builtin.assert:
+        that: instance_info_result.instances[0].state.name in ['terminated', 'shutting-down']

--- a/tests/integration/targets/ec2_tag/meta/main.yml
+++ b/tests/integration/targets/ec2_tag/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/ec2_tag/tasks/main.yml
+++ b/tests/integration/targets/ec2_tag/tasks/main.yml
@@ -8,7 +8,7 @@
       region: "{{ aws_region }}"
   block:
     - name: Create an EC2 volume so we have something to tag
-      ec2_vol:
+      amazon.aws.ec2_vol:
         name: "{{ resource_prefix }} ec2_tag volume"
         volume_size: 1
         state: present
@@ -16,17 +16,17 @@
       register: volume
 
     - name: List the tags on the volume (ec2_tag_info)
-      ec2_tag_info:
+      amazon.aws.ec2_tag_info:
         resource: "{{ volume.volume_id }}"
       register: result_info
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result_info.tags | length == 1
           - result_info.tags.Name == '{{ resource_prefix }} ec2_tag volume'
 
     - name: Set some new tags on the volume
-      ec2_tag:
+      amazon.aws.ec2_tag:
         resource: "{{ volume.volume_id }}"
         state: present
         tags:
@@ -35,11 +35,11 @@
           baz: also baz
       register: result
     - name: List the new tags on the volume
-      ec2_tag_info:
+      amazon.aws.ec2_tag_info:
         resource: "{{ volume.volume_id }}"
       register: result_info
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.tags | length == 4
@@ -55,40 +55,40 @@
           - result_info.tags.baz == 'also baz'
 
     - name: Remove a tag by name
-      ec2_tag:
+      amazon.aws.ec2_tag:
         resource: "{{ volume.volume_id }}"
         state: absent
         tags:
           baz:
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.removed_tags | length == 1
           - "'baz' in result.removed_tags"
 
     - name: Don't remove a tag
-      ec2_tag:
+      amazon.aws.ec2_tag:
         resource: "{{ volume.volume_id }}"
         state: absent
         tags:
           foo: baz
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
     - name: Remove a tag
-      ec2_tag:
+      amazon.aws.ec2_tag:
         resource: "{{ volume.volume_id }}"
         state: absent
         tags:
           foo: foo
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.tags | length == 2
@@ -98,14 +98,14 @@
           - result.tags.bar == 'baz'
 
     - name: Set an exclusive tag
-      ec2_tag:
+      amazon.aws.ec2_tag:
         resource: "{{ volume.volume_id }}"
         purge_tags: true
         tags:
           baz: quux
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.tags | length == 1
@@ -114,23 +114,23 @@
           - result.tags.baz == 'quux'
 
     - name: Remove all tags
-      ec2_tag:
+      amazon.aws.ec2_tag:
         resource: "{{ volume.volume_id }}"
         purge_tags: true
         tags: {}
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.tags | length == 0
 
   always:
     - name: Remove the volume
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ volume.volume_id }}"
         state: absent
       register: result
       until: result is not failed
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10

--- a/tests/integration/targets/ec2_vol/defaults/main.yml
+++ b/tests/integration/targets/ec2_vol/defaults/main.yml
@@ -1,8 +1,9 @@
-availability_zone: '{{ ec2_availability_zone_names[0] }}'
+---
+availability_zone: "{{ ec2_availability_zone_names[0] }}"
 
-vpc_name: '{{ resource_prefix }}-vpc'
-vpc_seed: '{{ resource_prefix }}'
-vpc_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.0.0/16'
-subnet_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.32.0/24'
+vpc_name: "{{ resource_prefix }}-vpc"
+vpc_seed: "{{ resource_prefix }}"
+vpc_cidr: 10.{{ 256 | random(seed=vpc_seed) }}.0.0/16
+subnet_cidr: 10.{{ 256 | random(seed=vpc_seed) }}.32.0/24
 
-instance_name: '{{ resource_prefix }}-instance'
+instance_name: "{{ resource_prefix }}-instance"

--- a/tests/integration/targets/ec2_vol/meta/main.yml
+++ b/tests/integration/targets/ec2_vol/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
-- role: setup_ec2_facts
+  - role: setup_ec2_facts

--- a/tests/integration/targets/ec2_vol/tasks/main.yml
+++ b/tests/integration/targets/ec2_vol/tasks/main.yml
@@ -1,19 +1,18 @@
 ---
 - module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
   collections:
     - amazon.aws
     - community.aws
 
   block:
-
     - name: Create a test VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         name: "{{ vpc_name }}"
         cidr_block: "{{ vpc_cidr }}"
         tags:
@@ -22,17 +21,17 @@
       register: testing_vpc
 
     - name: Create a test subnet
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         cidr: "{{ subnet_cidr }}"
         tags:
           Name: ec2_vol testing
           ResourcePrefix: "{{ resource_prefix }}"
-        az: '{{ availability_zone }}'
+        az: "{{ availability_zone }}"
       register: testing_subnet
 
     - name: create an ec2 instance
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ instance_name }}"
         vpc_subnet_id: "{{ testing_subnet.subnet.id }}"
         instance_type: t3.nano
@@ -42,12 +41,12 @@
       register: test_instance
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - test_instance.changed
 
     - name: create another ec2 instance
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ instance_name }}-2"
         vpc_subnet_id: "{{ testing_subnet.subnet.id }}"
         instance_type: t3.nano
@@ -57,12 +56,12 @@
       register: test_instance_2
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - test_instance_2.changed
 
     - name: create another ec2 instance
-      ec2_instance:
+      amazon.aws.ec2_instance:
         name: "{{ instance_name }}-3"
         vpc_subnet_id: "{{ testing_subnet.subnet.id }}"
         instance_type: t3.nano
@@ -72,14 +71,14 @@
       register: test_instance_3
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - test_instance_3.changed
 
     # # ==== ec2_vol tests ===============================================
 
     - name: create a volume (validate module defaults - check_mode)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         volume_size: 1
         zone: "{{ availability_zone }}"
         tags:
@@ -87,13 +86,12 @@
       check_mode: true
       register: volume1_check_mode
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - volume1_check_mode is changed
 
-
     - name: create a volume (validate module defaults)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         volume_size: 1
         zone: "{{ availability_zone }}"
         tags:
@@ -101,7 +99,7 @@
       register: volume1
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - volume1.changed
           - "'volume' in volume1"
@@ -119,8 +117,8 @@
     # no idempotency check needed here
 
     - name: create another volume (override module defaults)
-      ec2_vol:
-        encrypted: yes
+      amazon.aws.ec2_vol:
+        encrypted: true
         volume_size: 4
         volume_type: io1
         iops: 101
@@ -131,7 +129,7 @@
       register: volume2
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - volume2.changed
           - "'volume' in volume2"
@@ -147,8 +145,8 @@
           - volume2.volume.tags.ResourcePrefix == resource_prefix
 
     - name: create another volume (override module defaults) (idempotent)
-      ec2_vol:
-        encrypted: yes
+      amazon.aws.ec2_vol:
+        encrypted: true
         volume_size: 4
         volume_type: io1
         iops: 101
@@ -159,27 +157,27 @@
       register: volume2_idem
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - not volume2_idem.changed
 
     - name: create snapshot from volume
-      ec2_snapshot:
+      amazon.aws.ec2_snapshot:
         volume_id: "{{ volume1.volume_id }}"
-        description: "Resource Prefix - {{ resource_prefix }}"
+        description: Resource Prefix - {{ resource_prefix }}
         snapshot_tags:
           ResourcePrefix: "{{ resource_prefix }}"
       register: vol1_snapshot
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - vol1_snapshot.changed
 
     - name: create a volume from a snapshot (check_mode)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         snapshot: "{{ vol1_snapshot.snapshot_id }}"
-        encrypted: yes
+        encrypted: true
         volume_type: gp2
         volume_size: 1
         zone: "{{ availability_zone }}"
@@ -189,14 +187,14 @@
       register: volume3_check_mode
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - volume3_check_mode.changed
 
     - name: create a volume from a snapshot
-      ec2_vol:
+      amazon.aws.ec2_vol:
         snapshot: "{{ vol1_snapshot.snapshot_id }}"
-        encrypted: yes
+        encrypted: true
         volume_type: gp2
         volume_size: 1
         zone: "{{ availability_zone }}"
@@ -205,40 +203,40 @@
       register: volume3
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - volume3.changed
-          - "volume3.volume.snapshot_id ==  vol1_snapshot.snapshot_id"
+          - volume3.volume.snapshot_id ==  vol1_snapshot.snapshot_id
 
     - name: Wait for instance to start
-      ec2_instance:
+      amazon.aws.ec2_instance:
         state: running
         instance_ids: "{{ test_instance.instance_ids }}"
-        wait: True
+        wait: true
 
     - name: attach existing volume to an instance (check_mode)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ volume1.volume_id }}"
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdg
-        delete_on_termination: no
+        delete_on_termination: false
       check_mode: true
       register: vol_attach_result_check_mode
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - vol_attach_result_check_mode is changed
 
     - name: attach existing volume to an instance
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ volume1.volume_id }}"
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdg
-        delete_on_termination: no
+        delete_on_termination: false
       register: vol_attach_result
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - vol_attach_result.changed
           - "'device' in vol_attach_result and vol_attach_result.device == '/dev/sdg'"
@@ -247,16 +245,16 @@
     # There's a delay between the volume being "In Use", and the attachment being reported.  This
     # can result in a race condition on the results.  (There's no clean waiter to use either)
     - name: wait for volume to report attached/attaching
-      ec2_vol_info:
+      amazon.aws.ec2_vol_info:
         filters:
-          volume-id: '{{ volume1.volume_id }}'
+          volume-id: "{{ volume1.volume_id }}"
       register: vol_attach_info
       until:
         - vol_attach_info.volumes[0].attachment_set | length >=1
       retries: 5
       delay: 2
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - vol_attach_info.volumes[0].attachment_set[0].status in ['attached', 'attaching']
           - vol_attach_info.volumes[0].attachment_set[0].instance_id == test_instance.instance_ids[0]
@@ -264,69 +262,69 @@
           - not vol_attach_info.volumes[0].attachment_set[0].delete_on_termination
 
     - name: attach existing volume to an instance (idempotent - check_mode)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ volume1.volume_id }}"
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdg
-        delete_on_termination: no
+        delete_on_termination: false
       check_mode: true
       register: vol_attach_result_check_mode
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - vol_attach_result_check_mode is not changed
 
     - name: attach existing volume to an instance (idempotent)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ volume1.volume_id }}"
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdg
-        delete_on_termination: no
+        delete_on_termination: false
       register: vol_attach_result
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
-          - "not vol_attach_result.changed"
+          - not vol_attach_result.changed
           - vol_attach_result.volume.attachment_set[0].status in ['attached', 'attaching']
 
     - name: attach a new volume to an instance (check_mode)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdh
         volume_size: 1
         volume_type: gp2
-        name: '{{ resource_prefix }} - sdh'
+        name: "{{ resource_prefix }} - sdh"
         tags:
-          "lowercase spaced": 'hello cruel world'
-          "Title Case": 'Hello Cruel World'
-          CamelCase: 'SimpleCamelCase'
-          snake_case: 'simple_snake_case'
+          lowercase spaced: hello cruel world
+          Title Case: Hello Cruel World
+          CamelCase: SimpleCamelCase
+          snake_case: simple_snake_case
           ResourcePrefix: "{{ resource_prefix }}"
       check_mode: true
       register: new_vol_attach_result_check_mode
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - new_vol_attach_result_check_mode is changed
 
     - name: attach a new volume to an instance
-      ec2_vol:
+      amazon.aws.ec2_vol:
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdh
         volume_size: 1
         volume_type: standard
-        name: '{{ resource_prefix }} - sdh'
+        name: "{{ resource_prefix }} - sdh"
         tags:
-          "lowercase spaced": 'hello cruel world'
-          "Title Case": 'Hello Cruel World'
-          CamelCase: 'SimpleCamelCase'
-          snake_case: 'simple_snake_case'
+          lowercase spaced: hello cruel world
+          Title Case: Hello Cruel World
+          CamelCase: SimpleCamelCase
+          snake_case: simple_snake_case
           ResourcePrefix: "{{ resource_prefix }}"
       register: new_vol_attach_result
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - new_vol_attach_result.changed
           - "'device' in new_vol_attach_result and new_vol_attach_result.device == '/dev/sdh'"
@@ -341,7 +339,7 @@
           - new_vol_attach_result.volume.tags["Name"] == '{{ resource_prefix }} - sdh'
 
     - name: attach a new volume to an instance (idempotent - check_mode)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdh
         volume_size: 1
@@ -352,12 +350,12 @@
       register: new_vol_attach_result_idem_check_mode
       ignore_errors: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - new_vol_attach_result_idem_check_mode is not changed
 
     - name: attach a new volume to an instance (idempotent)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdh
         volume_size: 1
@@ -368,28 +366,28 @@
       ignore_errors: true
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
-          - "not new_vol_attach_result_idem.changed"
+          - not new_vol_attach_result_idem.changed
           - "'Volume mapping for /dev/sdh already exists' in new_vol_attach_result_idem.msg"
 
     - name: change some tag values
-      ec2_vol:
+      amazon.aws.ec2_vol:
         instance: "{{ test_instance.instance_ids[0] }}"
         id: "{{ new_vol_attach_result.volume.id }}"
         device_name: /dev/sdh
         volume_size: 1
         volume_type: standard
         tags:
-          "lowercase spaced": 'hello cruel world ❤️'
-          "Title Case": 'Hello Cruel World ❤️'
-          CamelCase: 'SimpleCamelCase ❤️'
-          snake_case: 'simple_snake_case ❤️'
+          lowercase spaced: hello cruel world ❤️
+          Title Case: Hello Cruel World ❤️
+          CamelCase: SimpleCamelCase ❤️
+          snake_case: simple_snake_case ❤️
         purge_tags: false
       register: new_vol_attach_result
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - new_vol_attach_result.changed
           - "'volume_id' in new_vol_attach_result"
@@ -411,22 +409,22 @@
           - new_vol_attach_result.volume.tags["Name"] == '{{ resource_prefix }} - sdh'
 
     - name: change some tag values
-      ec2_vol:
+      amazon.aws.ec2_vol:
         instance: "{{ test_instance.instance_ids[0] }}"
         id: "{{ new_vol_attach_result.volume.id }}"
         device_name: /dev/sdh
         volume_size: 1
         volume_type: standard
         tags:
-          "lowercase spaced": 'hello cruel world ❤️'
-          "Title Case": 'Hello Cruel World ❤️'
-          snake_case: 'simple_snake_case ❤️'
+          lowercase spaced: hello cruel world ❤️
+          Title Case: Hello Cruel World ❤️
+          snake_case: simple_snake_case ❤️
           ResourcePrefix: "{{ resource_prefix }}"
         purge_tags: true
       register: new_vol_attach_result
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - new_vol_attach_result.changed
           - "'volume_id' in new_vol_attach_result"
@@ -446,7 +444,7 @@
           - new_vol_attach_result.volume.tags["ResourcePrefix"] == resource_prefix
 
     - name: create a volume from a snapshot and attach to the instance (check_mode)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdi
         snapshot: "{{ vol1_snapshot.snapshot_id }}"
@@ -455,13 +453,12 @@
       check_mode: true
       register: attach_new_vol_from_snapshot_result_check_mode
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - attach_new_vol_from_snapshot_result_check_mode is changed
 
-
     - name: create a volume from a snapshot and attach to the instance
-      ec2_vol:
+      amazon.aws.ec2_vol:
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdi
         snapshot: "{{ vol1_snapshot.snapshot_id }}"
@@ -470,7 +467,7 @@
       register: attach_new_vol_from_snapshot_result
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - attach_new_vol_from_snapshot_result.changed
           - "'device' in attach_new_vol_from_snapshot_result and attach_new_vol_from_snapshot_result.device == '/dev/sdi'"
@@ -479,60 +476,60 @@
           - attach_new_vol_from_snapshot_result.volume.attachment_set[0].instance_id == test_instance.instance_ids[0]
 
     - name: get info on ebs volumes
-      ec2_vol_info:
+      amazon.aws.ec2_vol_info:
       register: ec2_vol_info
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - not ec2_vol_info.failed
 
     - name: get info on ebs volumes
-      ec2_vol_info:
+      amazon.aws.ec2_vol_info:
         filters:
           attachment.instance-id: "{{ test_instance.instance_ids[0] }}"
       register: ec2_vol_info
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - ec2_vol_info.volumes | length == 4
 
     - name: must not change because of missing parameter modify_volume
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ new_vol_attach_result.volume_id }}"
         zone: "{{ availability_zone }}"
         volume_type: gp3
       register: changed_gp3_volume
 
     - name: volume must not changed
-      assert:
+      ansible.builtin.assert:
         that:
           - not changed_gp3_volume.changed
 
     - name: change existing volume to gp3 (check_mode)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ new_vol_attach_result.volume_id }}"
         zone: "{{ availability_zone }}"
         volume_type: gp3
-        modify_volume: yes
+        modify_volume: true
       check_mode: true
       register: changed_gp3_volume_check_mode
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - changed_gp3_volume_check_mode is changed
 
     - name: change existing volume to gp3
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ new_vol_attach_result.volume_id }}"
         zone: "{{ availability_zone }}"
         volume_type: gp3
-        modify_volume: yes
+        modify_volume: true
       register: changed_gp3_volume
 
     - name: check that volume_type has changed
-      assert:
+      ansible.builtin.assert:
         that:
           - changed_gp3_volume.changed
           - "'volume_id' in changed_gp3_volume"
@@ -554,11 +551,11 @@
           - new_vol_attach_result.volume.tags["ResourcePrefix"] == resource_prefix
 
     - name: volume must be from type gp3 (idempotent)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ new_vol_attach_result.volume_id }}"
         zone: "{{ availability_zone }}"
         volume_type: gp3
-        modify_volume: yes
+        modify_volume: true
       register: changed_gp3_volume
       retries: 10
       delay: 3
@@ -566,7 +563,7 @@
       # retry because ebs change is to slow
 
     - name: must not changed (idempotent)
-      assert:
+      ansible.builtin.assert:
         that:
           - not changed_gp3_volume.changed
           - "'volume_id' in changed_gp3_volume"
@@ -588,104 +585,104 @@
           - new_vol_attach_result.volume.tags["ResourcePrefix"] == resource_prefix
 
     - name: re-read volume information to validate new volume_type
-      ec2_vol_info:
+      amazon.aws.ec2_vol_info:
         filters:
           volume-id: "{{ changed_gp3_volume.volume_id }}"
       register: verify_gp3_change
 
     - name: volume type must be gp3
-      assert:
+      ansible.builtin.assert:
         that:
           - v.type == 'gp3'
       vars:
         v: "{{ verify_gp3_change.volumes[0] }}"
 
     - name: detach volume from the instance (check_mode)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ new_vol_attach_result.volume_id }}"
         instance: ""
       check_mode: true
       register: new_vol_attach_result_check_mode
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - new_vol_attach_result_check_mode is changed
 
     - name: detach volume from the instance
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ new_vol_attach_result.volume_id }}"
         instance: ""
       register: new_vol_attach_result
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - new_vol_attach_result.changed
           - new_vol_attach_result.volume.status == 'available'
 
     - name: detach volume from the instance (idempotent - check_mode)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ new_vol_attach_result.volume_id }}"
         instance: ""
       register: new_vol_attach_result_idem_check_mode
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - not new_vol_attach_result_idem_check_mode.changed
 
     - name: detach volume from the instance (idempotent)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ new_vol_attach_result.volume_id }}"
         instance: ""
       register: new_vol_attach_result_idem
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - not new_vol_attach_result_idem.changed
 
     - name: delete volume (check_mode)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ volume2.volume_id }}"
         state: absent
       check_mode: true
       register: delete_volume_result_check_mode
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - delete_volume_result_check_mode is changed
 
     - name: delete volume
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ volume2.volume_id }}"
         state: absent
       register: delete_volume_result
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
-          - "delete_volume_result.changed"
+          - delete_volume_result.changed
 
     - name: delete volume (idempotent - check_mode)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ volume2.volume_id }}"
         state: absent
       check_mode: true
       register: delete_volume_result_check_mode
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - delete_volume_result_check_mode is not changed
 
     - name: delete volume (idempotent)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ volume2.volume_id }}"
         state: absent
       register: delete_volume_result_idem
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - not delete_volume_result_idem.changed
           - '"Volume {{ volume2.volume_id }} does not exist" in delete_volume_result_idem.msg'
@@ -693,7 +690,7 @@
     # Originally from ec2_vol_info
 
     - name: Create test volume with Destroy on Terminate
-      ec2_vol:
+      amazon.aws.ec2_vol:
         instance: "{{ test_instance.instance_ids[0] }}"
         volume_size: 4
         name: "{{ resource_prefix }}_delete_on_terminate"
@@ -701,12 +698,12 @@
         volume_type: io1
         iops: 100
         tags:
-            Tag Name with Space-and-dash: Tag Value with Space-and-dash
-        delete_on_termination: yes
+          Tag Name with Space-and-dash: Tag Value with Space-and-dash
+        delete_on_termination: true
       register: dot_volume
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - dot_volume.changed
           - "'attachment_set' in dot_volume.volume"
@@ -725,67 +722,67 @@
           - dot_volume.volume.tags["Tag Name with Space-and-dash"] == 'Tag Value with Space-and-dash'
 
     - name: Gather volume info without any filters
-      ec2_vol_info:
+      amazon.aws.ec2_vol_info:
       register: volume_info_wo_filters
-      check_mode: no
+      check_mode: false
 
     - name: Check if info are returned without filters
-      assert:
+      ansible.builtin.assert:
         that:
-          - "volume_info_wo_filters.volumes is defined"
+          - volume_info_wo_filters.volumes is defined
 
     - name: Gather volume info
-      ec2_vol_info:
-          filters:
-            "tag:Name": "{{ resource_prefix }}_delete_on_terminate"
+      amazon.aws.ec2_vol_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}_delete_on_terminate"
       register: volume_info
-      check_mode: no
+      check_mode: false
 
     - name: Format check
-      assert:
+      ansible.builtin.assert:
         that:
-            - "volume_info.volumes|length == 1"
-            - "v.attachment_set[0].attach_time is defined"
-            - "v.attachment_set[0].device      is defined and v.attachment_set[0].device      == dot_volume.device"
-            - "v.attachment_set[0].instance_id is defined and v.attachment_set[0].instance_id == test_instance.instance_ids[0]"
-            - "v.attachment_set[0].status      is defined and v.attachment_set[0].status      == 'attached'"
-            - "v.create_time                is defined"
-            - "v.encrypted                  is defined and v.encrypted                  == false"
-            - "v.id                         is defined and v.id                         == dot_volume.volume_id"
-            - "v.iops                       is defined and v.iops                       == 100"
-            - "v.region                     is defined and v.region                     == aws_region"
-            - "v.size                       is defined and v.size                       == 4"
-            - "v.snapshot_id                is defined and v.snapshot_id                == ''"
-            - "v.status                     is defined and v.status                     == 'in-use'"
-            - "v.tags.Name                  is defined and v.tags.Name                  == resource_prefix + '_delete_on_terminate'"
-            - "v.tags['Tag Name with Space-and-dash']                                   == 'Tag Value with Space-and-dash'"
-            - "v.type                       is defined and v.type                       == 'io1'"
-            - "v.zone                       is defined and v.zone                       == test_instance.instances[0].placement.availability_zone"
+          - volume_info.volumes|length == 1
+          - v.attachment_set[0].attach_time is defined
+          - v.attachment_set[0].device      is defined and v.attachment_set[0].device      == dot_volume.device
+          - v.attachment_set[0].instance_id is defined and v.attachment_set[0].instance_id == test_instance.instance_ids[0]
+          - v.attachment_set[0].status      is defined and v.attachment_set[0].status      == 'attached'
+          - v.create_time                is defined
+          - v.encrypted                  is defined and v.encrypted                  == false
+          - v.id                         is defined and v.id                         == dot_volume.volume_id
+          - v.iops                       is defined and v.iops                       == 100
+          - v.region                     is defined and v.region                     == aws_region
+          - v.size                       is defined and v.size                       == 4
+          - v.snapshot_id                is defined and v.snapshot_id                == ''
+          - v.status                     is defined and v.status                     == 'in-use'
+          - v.tags.Name                  is defined and v.tags.Name                  == resource_prefix + '_delete_on_terminate'
+          - v.tags['Tag Name with Space-and-dash']                                   == 'Tag Value with Space-and-dash'
+          - v.type                       is defined and v.type                       == 'io1'
+          - v.zone                       is defined and v.zone                       == test_instance.instances[0].placement.availability_zone
       vars:
-          v: "{{ volume_info.volumes[0] }}"
+        v: "{{ volume_info.volumes[0] }}"
 
     - name: New format check
-      assert:
+      ansible.builtin.assert:
         that:
-            - "v.attachment_set[0].delete_on_termination is defined"
+          - v.attachment_set[0].delete_on_termination is defined
       vars:
-          v: "{{ volume_info.volumes[0] }}"
+        v: "{{ volume_info.volumes[0] }}"
       when: ansible_version.full is version('2.7', '>=')
 
     - name: test create a new gp3 volume
-      ec2_vol:
+      amazon.aws.ec2_vol:
         volume_size: 70
         zone: "{{ availability_zone }}"
         volume_type: gp3
         throughput: 130
         iops: 3001
-        name: "GP3-TEST-{{ resource_prefix }}"
+        name: GP3-TEST-{{ resource_prefix }}
         tags:
           ResourcePrefix: "{{ resource_prefix }}"
       register: gp3_volume
 
     - name: check that volume_type is gp3
-      assert:
+      ansible.builtin.assert:
         that:
           - gp3_volume.changed
           - "'attachment_set' in gp3_volume.volume"
@@ -804,53 +801,53 @@
           - gp3_volume.volume.tags["ResourcePrefix"] == resource_prefix
 
     - name: Read volume information to validate throughput
-      ec2_vol_info:
+      amazon.aws.ec2_vol_info:
         filters:
           volume-id: "{{ gp3_volume.volume_id }}"
       register: verify_throughput
 
     - name: throughput must be equal to 130
-      assert:
+      ansible.builtin.assert:
         that:
           - v.throughput == 130
       vars:
         v: "{{ verify_throughput.volumes[0] }}"
 
     - name: print out facts
-      debug:
+      ansible.builtin.debug:
         var: vol_facts
 
     - name: Read volume information to validate throughput
-      ec2_vol_info:
+      amazon.aws.ec2_vol_info:
         filters:
           volume-id: "{{ gp3_volume.volume_id }}"
       register: verify_throughput
 
     - name: throughput must be equal to 130
-      assert:
+      ansible.builtin.assert:
         that:
           - v.throughput == 130
       vars:
         v: "{{ verify_throughput.volumes[0] }}"
 
     - name: print out facts
-      debug:
+      ansible.builtin.debug:
         var: vol_facts
 
     - name: increase throughput
-      ec2_vol:
+      amazon.aws.ec2_vol:
         volume_size: 70
         zone: "{{ availability_zone }}"
         volume_type: gp3
         throughput: 131
-        modify_volume: yes
-        name: "GP3-TEST-{{ resource_prefix }}"
+        modify_volume: true
+        name: GP3-TEST-{{ resource_prefix }}
         tags:
           ResourcePrefix: "{{ resource_prefix }}"
       register: gp3_volume
 
     - name: check that throughput has changed
-      assert:
+      ansible.builtin.assert:
         that:
           - gp3_volume.changed
           - "'create_time' in gp3_volume.volume"
@@ -866,110 +863,110 @@
 
     # Multi-Attach disk
     - name: create disk with multi-attach enabled
-      ec2_vol:
+      amazon.aws.ec2_vol:
         volume_size: 4
         volume_type: io1
         iops: 102
         zone: "{{ availability_zone }}"
-        multi_attach: yes
+        multi_attach: true
         tags:
           ResourcePrefix: "{{ resource_prefix }}"
       register: multi_attach_disk
 
     - name: check volume creation
-      assert:
+      ansible.builtin.assert:
         that:
           - multi_attach_disk.changed
           - "'volume' in multi_attach_disk"
           - multi_attach_disk.volume.multi_attach_enabled
 
     - name: attach existing volume to an instance
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ multi_attach_disk.volume_id }}"
         instance: "{{ test_instance.instance_ids[0] }}"
         device_name: /dev/sdk
-        delete_on_termination: no
+        delete_on_termination: false
       register: vol_attach_result
 
     - name: Wait for instance to start
-      ec2_instance:
+      amazon.aws.ec2_instance:
         state: running
         instance_ids: "{{ test_instance_2.instance_ids }}"
-        wait: True
+        wait: true
 
     - name: attach existing volume to second instance
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ multi_attach_disk.volume_id }}"
         instance: "{{ test_instance_2.instance_ids[0] }}"
         device_name: /dev/sdg
-        delete_on_termination: no
+        delete_on_termination: false
       register: vol_attach_result
 
     - name: check task return attributes
-      assert:
+      ansible.builtin.assert:
         that:
           - vol_attach_result.changed
           - "'volume' in vol_attach_result"
           - vol_attach_result.volume.attachment_set | length == 2
-          - 'test_instance.instance_ids[0] in vol_attach_result.volume.attachment_set | map(attribute="instance_id") | list'
-          - 'test_instance_2.instance_ids[0] in vol_attach_result.volume.attachment_set | map(attribute="instance_id") | list'
+          - test_instance.instance_ids[0] in vol_attach_result.volume.attachment_set | map(attribute="instance_id") | list
+          - test_instance_2.instance_ids[0] in vol_attach_result.volume.attachment_set | map(attribute="instance_id") | list
 
     - name: create a volume without tags
-      ec2_vol:
+      amazon.aws.ec2_vol:
         volume_size: 5
         zone: "{{ availability_zone }}"
         instance: "{{ test_instance_3.instance_ids[0] }}"
       register: volume_without_tag
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - volume_without_tag.changed
 
     # idempotency check without tags
     - name: create a volume without tags (idempotency check)
-      ec2_vol:
+      amazon.aws.ec2_vol:
         volume_size: 5
         zone: "{{ availability_zone }}"
         instance: "{{ test_instance_3.instance_ids[0] }}"
       register: volume_without_tag
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not volume_without_tag.changed
-    # ==== Cleanup ============================================================
+  # ==== Cleanup ============================================================
 
   always:
     - name: Describe the instance before we delete it
-      ec2_instance_info:
+      amazon.aws.ec2_instance_info:
         instance_ids:
           - "{{ item }}"
-      ignore_errors: yes
+      ignore_errors: true
       with_items:
         - "{{ test_instance.instance_ids[0] }}"
         - "{{ test_instance_2.instance_ids[0] }}"
         - "{{ test_instance_3.instance_ids[0] }}"
       register: pre_delete
 
-    - debug:
+    - ansible.builtin.debug:
         var: pre_delete
 
     - name: delete test instance
-      ec2_instance:
+      amazon.aws.ec2_instance:
         instance_ids:
           - "{{ item }}"
         state: terminated
-        wait: True
+        wait: true
       with_items:
         - "{{ test_instance.instance_ids[0] }}"
         - "{{ test_instance_2.instance_ids[0] }}"
         - "{{ test_instance_3.instance_ids[0] }}"
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: delete volumes
-      ec2_vol:
+      amazon.aws.ec2_vol:
         id: "{{ item.volume_id }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
       with_items:
         - "{{ volume1 }}"
         - "{{ volume2 }}"
@@ -982,21 +979,21 @@
         - "{{ volume_without_tag }}"
 
     - name: delete snapshot
-      ec2_snapshot:
+      amazon.aws.ec2_snapshot:
         snapshot_id: "{{ vol1_snapshot.snapshot_id }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: delete test subnet
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         cidr: "{{ subnet_cidr }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: delete test VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         name: "{{ vpc_name }}"
         cidr_block: "{{ vpc_cidr }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/ec2_vpc_dhcp_option/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_dhcp_option/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
 # defaults file for ec2_dhcp_option_info tests
-vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/24'
+vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/24
 # default option sets get an AWS domain_name, which is different in us-east-1
 aws_domain_name: "{{ (aws_region == 'us-east-1') | ternary('ec2.internal', aws_region + '.compute.internal') }}"

--- a/tests/integration/targets/ec2_vpc_dhcp_option/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_dhcp_option/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_dhcp_option/tasks/main.yml
@@ -14,926 +14,923 @@
       region: "{{ aws_region }}"
 
   block:
-
   # DHCP option set can be attached to multiple VPCs, we don't want to use any that
   # don't belong to this test run
-  - name: find all DHCP option sets that already exist before running tests
-    ec2_vpc_dhcp_option_info:
-    register: result
+    - name: find all DHCP option sets that already exist before running tests
+      amazon.aws.ec2_vpc_dhcp_option_info:
+      register: result
 
-  - set_fact:
-      preexisting_option_sets: "{{ result.dhcp_options | map(attribute='dhcp_options_id') | list }}"
+    - ansible.builtin.set_fact:
+        preexisting_option_sets: "{{ result.dhcp_options | map(attribute='dhcp_options_id') | list }}"
 
-  - name: create a VPC with a default DHCP option set to test inheritance and delete_old
-    ec2_vpc_net:
-      name: "{{ resource_prefix }}"
-      cidr_block: "{{ vpc_cidr }}"
-      state: present
-    register: vpc
+    - name: create a VPC with a default DHCP option set to test inheritance and delete_old
+      amazon.aws.ec2_vpc_net:
+        name: "{{ resource_prefix }}"
+        cidr_block: "{{ vpc_cidr }}"
+        state: present
+      register: vpc
 
-  - name: ensure a DHCP option set is attached to the VPC
-    assert:
-      that:
-        - vpc.vpc.dhcp_options_id is defined
+    - name: ensure a DHCP option set is attached to the VPC
+      ansible.builtin.assert:
+        that:
+          - vpc.vpc.dhcp_options_id is defined
 
-  - set_fact:
-      vpc_id: "{{ vpc.vpc.id }}"
-      default_options_id: "{{ vpc.vpc.dhcp_options_id }}"
+    - ansible.builtin.set_fact:
+        vpc_id: "{{ vpc.vpc.id }}"
+        default_options_id: "{{ vpc.vpc.dhcp_options_id }}"
 
-## ============================================
-  - name: Option Sets can be attached to multiple VPCs, create a new one if the test VPC is reusing a pre-existing one
-    when: vpc.vpc.dhcp_options_id in preexisting_option_sets
-    block:
-      - name: Create the new option set
-        ec2_vpc_dhcp_option:
-          state: present
-          domain_name: "{{ aws_domain_name }}"
-          dns_servers:
-            - AmazonProvidedDNS
-          delete_old: True
-          tags:
-            Name: "{{ resource_prefix }}"
-        register: new_dhcp_options
+    ## ============================================
+    - name: Option Sets can be attached to multiple VPCs, create a new one if the test VPC is reusing a pre-existing one
+      when: vpc.vpc.dhcp_options_id in preexisting_option_sets
+      block:
+        - name: Create the new option set
+          amazon.aws.ec2_vpc_dhcp_option:
+            state: present
+            domain_name: "{{ aws_domain_name }}"
+            dns_servers:
+              - AmazonProvidedDNS
+            delete_old: true
+            tags:
+              Name: "{{ resource_prefix }}"
+          register: new_dhcp_options
 
-      - assert:
-          that:
-            - new_dhcp_options.dhcp_options_id not in preexisting_option_sets
+        - ansible.builtin.assert:
+            that:
+              - new_dhcp_options.dhcp_options_id not in preexisting_option_sets
 
-      - name: Attach the new option set to the VPC
-        ec2_vpc_dhcp_option:
-          state: present
-          vpc_id: "{{ vpc_id }}"
-          purge_tags: False
-          dhcp_options_id: "{{ new_dhcp_options.dhcp_options_id }}"
-## ============================================
+        - name: Attach the new option set to the VPC
+          amazon.aws.ec2_vpc_dhcp_option:
+            state: present
+            vpc_id: "{{ vpc_id }}"
+            purge_tags: false
+            dhcp_options_id: "{{ new_dhcp_options.dhcp_options_id }}"
+    ## ============================================
 
-  - name: find the VPC's associated option set
-    ec2_vpc_net_info:
-      vpc_ids: "{{ vpc_id }}"
-    register: vpc_info
+    - name: find the VPC's associated option set
+      amazon.aws.ec2_vpc_net_info:
+        vpc_ids: "{{ vpc_id }}"
+      register: vpc_info
 
-  - set_fact:
-      original_dhcp_options_id: "{{ vpc_info.vpcs[0].dhcp_options_id }}"
+    - ansible.builtin.set_fact:
+        original_dhcp_options_id: "{{ vpc_info.vpcs[0].dhcp_options_id }}"
 
-  - name: get information about the DHCP option
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ original_dhcp_options_id }}"]
-    register: original_dhcp_options_info
+    - name: get information about the DHCP option
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ original_dhcp_options_id }}"]
+      register: original_dhcp_options_info
 
-  - set_fact:
-      original_config: "{{ original_dhcp_options_info.dhcp_options[0].dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
+    - ansible.builtin.set_fact:
+        original_config: "{{ original_dhcp_options_info.dhcp_options[0].dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
 
-  - assert:
-      that:
-        - original_dhcp_options_info.dhcp_options | length == 1
-        - original_config.keys() | list | sort == ['domain-name', 'domain-name-servers']
-        - original_config['domain-name'][0]['value'] == '{{ aws_domain_name }}'
-        - original_config['domain-name-servers'][0]['value'] == 'AmazonProvidedDNS'
-        - original_dhcp_options_id not in preexisting_option_sets
+    - ansible.builtin.assert:
+        that:
+          - original_dhcp_options_info.dhcp_options | length == 1
+          - original_config.keys() | list | sort == ['domain-name', 'domain-name-servers']
+          - original_config['domain-name'][0]['value'] == '{{ aws_domain_name }}'
+          - original_config['domain-name-servers'][0]['value'] == 'AmazonProvidedDNS'
+          - original_dhcp_options_id not in preexisting_option_sets
 
-## ============================================
+    ## ============================================
 
-  # FIXME: always reassociated to lowest alphanum dhcp_options_id when vpc_id is provided without options,
-  # This task will return an unpredictable dhcp_option_id so we can't assert anything about the option's values
-  - name: test a DHCP option exists (check mode)
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      domain_name: "{{ aws_domain_name }}"
-      dns_servers:
-        - AmazonProvidedDNS
-      tags:
-        Name: "{{ resource_prefix }}"
-    register: found_dhcp_options
-    check_mode: true
+    # FIXME: always reassociated to lowest alphanum dhcp_options_id when vpc_id is provided without options,
+    # This task will return an unpredictable dhcp_option_id so we can't assert anything about the option's values
+    - name: test a DHCP option exists (check mode)
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        domain_name: "{{ aws_domain_name }}"
+        dns_servers:
+          - AmazonProvidedDNS
+        tags:
+          Name: "{{ resource_prefix }}"
+      register: found_dhcp_options
+      check_mode: true
 
-  - assert:
-      that:
-        - not found_dhcp_options.changed
+    - ansible.builtin.assert:
+        that:
+          - not found_dhcp_options.changed
 
-  # FIXME: always reassociated when vpc_id is provided without options, so here we provide the default options
-  - name: test a DHCP option exists
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      domain_name: "{{ aws_domain_name }}"
-      dns_servers:
-        - AmazonProvidedDNS
-      tags:
-        Name: "{{ resource_prefix }}"
-    register: found_dhcp_options
+    # FIXME: always reassociated when vpc_id is provided without options, so here we provide the default options
+    - name: test a DHCP option exists
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        domain_name: "{{ aws_domain_name }}"
+        dns_servers:
+          - AmazonProvidedDNS
+        tags:
+          Name: "{{ resource_prefix }}"
+      register: found_dhcp_options
 
-  - assert:
-      that:
-        - found_dhcp_options is not changed
-        - found_dhcp_options.dhcp_options_id is defined
-        - original_dhcp_options_id == found_dhcp_options.dhcp_options_id
+    - ansible.builtin.assert:
+        that:
+          - found_dhcp_options is not changed
+          - found_dhcp_options.dhcp_options_id is defined
+          - original_dhcp_options_id == found_dhcp_options.dhcp_options_id
 
-  # Create a DHCP option set that inherits from the default set and does not delete the old set
-  - name: create a DHCP option set that inherits from the default set (check mode)
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: True
-      ntp_servers:
+    # Create a DHCP option set that inherits from the default set and does not delete the old set
+    - name: create a DHCP option set that inherits from the default set (check mode)
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      netbios_node_type: 2
-      delete_old: False
-    register: dhcp_options
-    check_mode: true
+        netbios_node_type: 2
+        delete_old: false
+      register: dhcp_options
+      check_mode: true
 
-  - assert:
-      that:
-        - dhcp_options.changed
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
 
-  - name: create a DHCP option set that inherits from the default set
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: True
-      ntp_servers:
+    - name: create a DHCP option set that inherits from the default set
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      netbios_node_type: 2
-      delete_old: False
-    register: dhcp_options
+        netbios_node_type: 2
+        delete_old: false
+      register: dhcp_options
 
-  - set_fact:
-      dhcp_options_config: "{{ dhcp_options.dhcp_options.dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
+    - ansible.builtin.set_fact:
+        dhcp_options_config: "{{ dhcp_options.dhcp_options.dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
 
-  - assert:
-      that:
-        - dhcp_options.changed
-        - dhcp_options.dhcp_config
-        - dhcp_options.dhcp_config.keys() | list | sort == ['domain-name', 'domain-name-servers', 'netbios-name-servers', 'netbios-node-type', 'ntp-servers']
-        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
-        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.dhcp_config['netbios-node-type'] == '2'
-        - dhcp_options.dhcp_config['domain-name'] == ['{{ aws_domain_name }}']
-        - dhcp_options.dhcp_config['domain-name-servers'] == ['AmazonProvidedDNS']
-        # We return the list of dicts that boto gives us, in addition to the user-friendly config dict
-        - dhcp_options_config['ntp-servers'] | map(attribute='value') | list | sort == ['10.0.0.2', '10.0.1.2']
-        - dhcp_options_config['netbios-name-servers'] | map(attribute='value') | list | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options_config['netbios-node-type'][0]['value'] == '2'
-        - dhcp_options_config['domain-name'][0]['value'] == '{{ aws_domain_name }}'
-        - dhcp_options_config['domain-name-servers'][0]['value'] == 'AmazonProvidedDNS'
-        - original_dhcp_options_id != dhcp_options.dhcp_options_id
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
+          - dhcp_options.dhcp_config
+          - dhcp_options.dhcp_config.keys() | list | sort == ['domain-name', 'domain-name-servers', 'netbios-name-servers', 'netbios-node-type', 'ntp-servers']
+          - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+          - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+          - dhcp_options.dhcp_config['netbios-node-type'] == '2'
+          - dhcp_options.dhcp_config['domain-name'] == ['{{ aws_domain_name }}']
+          - dhcp_options.dhcp_config['domain-name-servers'] == ['AmazonProvidedDNS']
+          # We return the list of dicts that boto gives us, in addition to the user-friendly config dict
+          - dhcp_options_config['ntp-servers'] | map(attribute='value') | list | sort == ['10.0.0.2', '10.0.1.2']
+          - dhcp_options_config['netbios-name-servers'] | map(attribute='value') | list | sort == ['10.0.0.1', '10.0.1.1']
+          - dhcp_options_config['netbios-node-type'][0]['value'] == '2'
+          - dhcp_options_config['domain-name'][0]['value'] == '{{ aws_domain_name }}'
+          - dhcp_options_config['domain-name-servers'][0]['value'] == 'AmazonProvidedDNS'
+          - original_dhcp_options_id != dhcp_options.dhcp_options_id
 
-  - set_fact:
-      new_dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
+    - ansible.builtin.set_fact:
+        new_dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
 
-  - name: get information about the new DHCP option
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ new_dhcp_options_id }}"]
-    register: new_dhcp_options
+    - name: get information about the new DHCP option
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ new_dhcp_options_id }}"]
+      register: new_dhcp_options
 
-  - set_fact:
-      new_config: "{{ new_dhcp_options.dhcp_options[0].dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
+    - ansible.builtin.set_fact:
+        new_config: "{{ new_dhcp_options.dhcp_options[0].dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
 
-  - assert:
-      that:
-        - new_config.keys() | list | sort == ['domain-name', 'domain-name-servers', 'netbios-name-servers', 'netbios-node-type', 'ntp-servers']
-        - new_config['domain-name'][0]['value'] == '{{ aws_domain_name }}'
-        - new_config['domain-name-servers'][0]['value'] == 'AmazonProvidedDNS'
-        - new_config['ntp-servers'] | map(attribute='value') | list | sort == ['10.0.0.2', '10.0.1.2']
-        - new_config['netbios-name-servers'] | map(attribute='value') | list | sort == ['10.0.0.1', '10.0.1.1']
-        - new_config['netbios-node-type'][0]['value'] == '2'
-        # We return the list of dicts that boto gives us, in addition to the user-friendly config dict
-        - new_dhcp_options.dhcp_config[0]['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
-        - new_dhcp_options.dhcp_config[0]['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - new_dhcp_options.dhcp_config[0]['netbios-node-type'] == '2'
-        - new_dhcp_options.dhcp_config[0]['domain-name'] == ['{{ aws_domain_name }}']
-        - new_dhcp_options.dhcp_config[0]['domain-name-servers'] == ['AmazonProvidedDNS']
+    - ansible.builtin.assert:
+        that:
+          - new_config.keys() | list | sort == ['domain-name', 'domain-name-servers', 'netbios-name-servers', 'netbios-node-type', 'ntp-servers']
+          - new_config['domain-name'][0]['value'] == '{{ aws_domain_name }}'
+          - new_config['domain-name-servers'][0]['value'] == 'AmazonProvidedDNS'
+          - new_config['ntp-servers'] | map(attribute='value') | list | sort == ['10.0.0.2', '10.0.1.2']
+          - new_config['netbios-name-servers'] | map(attribute='value') | list | sort == ['10.0.0.1', '10.0.1.1']
+          - new_config['netbios-node-type'][0]['value'] == '2'
+          # We return the list of dicts that boto gives us, in addition to the user-friendly config dict
+          - new_dhcp_options.dhcp_config[0]['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+          - new_dhcp_options.dhcp_config[0]['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+          - new_dhcp_options.dhcp_config[0]['netbios-node-type'] == '2'
+          - new_dhcp_options.dhcp_config[0]['domain-name'] == ['{{ aws_domain_name }}']
+          - new_dhcp_options.dhcp_config[0]['domain-name-servers'] == ['AmazonProvidedDNS']
 
+    # FIXME: no way to associate `default` in the module
+    - name: Re-associate the default DHCP options set so that the new one can be deleted
+      amazon.aws.ec2_vpc_dhcp_option:
+        vpc_id: "{{ vpc_id }}"
+        dhcp_options_id: "{{ default_options_id }}"
+        state: present
+      register: result
 
-  # FIXME: no way to associate `default` in the module
-  - name: Re-associate the default DHCP options set so that the new one can be deleted
-    ec2_vpc_dhcp_option:
-      vpc_id: '{{ vpc_id }}'
-      dhcp_options_id: '{{ default_options_id }}'
-      state: present
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result is success
+          - result.dhcp_options_id == '{{ default_options_id }}'
 
-  - assert:
-      that:
-        - result.changed
-        - result is success
-        - result.dhcp_options_id == '{{ default_options_id }}'
+    - name: delete it for the next test
+      amazon.aws.ec2_vpc_dhcp_option:
+        dhcp_options_id: "{{ new_dhcp_options_id }}"
+        state: absent
 
-  - name: delete it for the next test
-    ec2_vpc_dhcp_option:
-      dhcp_options_id: "{{ new_dhcp_options_id }}"
-      state: absent
+    # Create a DHCP option set that does not inherit from the old set and doesn't delete the old set
 
-  # Create a DHCP option set that does not inherit from the old set and doesn't delete the old set
-
-  - name: create a DHCP option set that does not inherit from the default set (check mode)
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      ntp_servers:
+    - name: create a DHCP option set that does not inherit from the default set (check mode)
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      netbios_node_type: 2
-      delete_old: False
-    register: dhcp_options
-    check_mode: true
+        netbios_node_type: 2
+        delete_old: false
+      register: dhcp_options
+      check_mode: true
 
-  - assert:
-      that:
-        - dhcp_options.changed
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
 
-  - name: create a DHCP option set that does not inherit from the default set
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      ntp_servers:
+    - name: create a DHCP option set that does not inherit from the default set
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      netbios_node_type: 2
-      delete_old: False
-    register: dhcp_options
+        netbios_node_type: 2
+        delete_old: false
+      register: dhcp_options
 
-  - set_fact:
-      dhcp_options_config: "{{ dhcp_options.dhcp_options.dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
+    - ansible.builtin.set_fact:
+        dhcp_options_config: "{{ dhcp_options.dhcp_options.dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
 
-  - assert:
-      that:
-        - dhcp_options.changed
-        - dhcp_options.dhcp_config
-        - dhcp_options.dhcp_config.keys() | list | sort == ['netbios-name-servers', 'netbios-node-type', 'ntp-servers']
-        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
-        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.dhcp_config['netbios-node-type'] == '2'
-        - original_dhcp_options_id != dhcp_options.dhcp_options_id
-        # We return the list of dicts that boto gives us, in addition to the user-friendly config dict
-        - new_dhcp_options.dhcp_config[0]['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
-        - new_dhcp_options.dhcp_config[0]['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - new_dhcp_options.dhcp_config[0]['netbios-node-type'] == '2'
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
+          - dhcp_options.dhcp_config
+          - dhcp_options.dhcp_config.keys() | list | sort == ['netbios-name-servers', 'netbios-node-type', 'ntp-servers']
+          - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+          - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+          - dhcp_options.dhcp_config['netbios-node-type'] == '2'
+          - original_dhcp_options_id != dhcp_options.dhcp_options_id
+          # We return the list of dicts that boto gives us, in addition to the user-friendly config dict
+          - new_dhcp_options.dhcp_config[0]['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+          - new_dhcp_options.dhcp_config[0]['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+          - new_dhcp_options.dhcp_config[0]['netbios-node-type'] == '2'
 
-  - set_fact:
-      new_dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
+    - ansible.builtin.set_fact:
+        new_dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
 
-  - name: get information about the new DHCP option
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ new_dhcp_options_id }}"]
-    register: new_dhcp_options
+    - name: get information about the new DHCP option
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ new_dhcp_options_id }}"]
+      register: new_dhcp_options
 
-  - set_fact:
-      new_config: "{{ new_dhcp_options.dhcp_options[0].dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
+    - ansible.builtin.set_fact:
+        new_config: "{{ new_dhcp_options.dhcp_options[0].dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
 
-  - assert:
-      that:
-        - new_config.keys() | list | sort == ['netbios-name-servers', 'netbios-node-type', 'ntp-servers']
-        - new_config['ntp-servers'] | map(attribute='value') | list | sort == ['10.0.0.2', '10.0.1.2']
-        - new_config['netbios-name-servers'] | map(attribute='value') | list | sort == ['10.0.0.1', '10.0.1.1']
-        - new_config['netbios-node-type'][0]['value'] == '2'
+    - ansible.builtin.assert:
+        that:
+          - new_config.keys() | list | sort == ['netbios-name-servers', 'netbios-node-type', 'ntp-servers']
+          - new_config['ntp-servers'] | map(attribute='value') | list | sort == ['10.0.0.2', '10.0.1.2']
+          - new_config['netbios-name-servers'] | map(attribute='value') | list | sort == ['10.0.0.1', '10.0.1.1']
+          - new_config['netbios-node-type'][0]['value'] == '2'
 
-  - name: disassociate the new DHCP option set so it can be deleted
-    ec2_vpc_dhcp_option:
-      dhcp_options_id: "{{ original_dhcp_options_id }}"
-      vpc_id: "{{ vpc_id }}"
-      state: present
+    - name: disassociate the new DHCP option set so it can be deleted
+      amazon.aws.ec2_vpc_dhcp_option:
+        dhcp_options_id: "{{ original_dhcp_options_id }}"
+        vpc_id: "{{ vpc_id }}"
+        state: present
 
-  - name: delete it for the next test
-    ec2_vpc_dhcp_option:
-      dhcp_options_id: "{{ new_dhcp_options_id }}"
-      state: absent
+    - name: delete it for the next test
+      amazon.aws.ec2_vpc_dhcp_option:
+        dhcp_options_id: "{{ new_dhcp_options_id }}"
+        state: absent
 
-  # Create a DHCP option set that inherits from the default set overwrites a default and deletes the old set
-  - name: create a DHCP option set that inherits from the default set and deletes the original set (check mode)
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: True
-      domain_name: us-west-2.compute.internal
-      ntp_servers:
+    # Create a DHCP option set that inherits from the default set overwrites a default and deletes the old set
+    - name: create a DHCP option set that inherits from the default set and deletes the original set (check mode)
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: true
+        domain_name: us-west-2.compute.internal
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      netbios_node_type: 2
-      delete_old: True
-    register: dhcp_options
-    check_mode: true
+        netbios_node_type: 2
+        delete_old: true
+      register: dhcp_options
+      check_mode: true
 
-  - assert:
-      that:
-        - dhcp_options.changed
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
 
-  - name: create a DHCP option set that inherits from the default set and deletes the original set
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: True
-      domain_name: '{{ aws_domain_name }}'
-      ntp_servers:
+    - name: create a DHCP option set that inherits from the default set and deletes the original set
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: true
+        domain_name: "{{ aws_domain_name }}"
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      netbios_node_type: 1
-      delete_old: True
-    register: dhcp_options
+        netbios_node_type: 1
+        delete_old: true
+      register: dhcp_options
 
-  - assert:
-      that:
-        - dhcp_options.changed
-        - dhcp_options.dhcp_config
-        - dhcp_options.dhcp_config.keys() | list | sort == ['domain-name', 'domain-name-servers', 'netbios-name-servers', 'netbios-node-type', 'ntp-servers']
-        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
-        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.dhcp_config['netbios-node-type'] == '1'
-        - dhcp_options.dhcp_config['domain-name'] == ['{{ aws_domain_name }}']
-        - original_dhcp_options_id != dhcp_options.dhcp_options_id
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
+          - dhcp_options.dhcp_config
+          - dhcp_options.dhcp_config.keys() | list | sort == ['domain-name', 'domain-name-servers', 'netbios-name-servers', 'netbios-node-type', 'ntp-servers']
+          - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+          - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+          - dhcp_options.dhcp_config['netbios-node-type'] == '1'
+          - dhcp_options.dhcp_config['domain-name'] == ['{{ aws_domain_name }}']
+          - original_dhcp_options_id != dhcp_options.dhcp_options_id
 
-  - set_fact:
-      new_dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
+    - ansible.builtin.set_fact:
+        new_dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
 
-  - name: get information about the new DHCP option
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ new_dhcp_options_id }}"]
-    register: new_dhcp_options
+    - name: get information about the new DHCP option
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ new_dhcp_options_id }}"]
+      register: new_dhcp_options
 
-  - set_fact:
-      new_config: "{{ new_dhcp_options.dhcp_options[0].dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
+    - ansible.builtin.set_fact:
+        new_config: "{{ new_dhcp_options.dhcp_options[0].dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
 
-  - assert:
-      that:
-        - new_config.keys() | list | sort == ['domain-name', 'domain-name-servers', 'netbios-name-servers', 'netbios-node-type', 'ntp-servers']
-        - new_config['domain-name'][0]['value'] == '{{ aws_domain_name }}'
-        - new_config['ntp-servers'] | map(attribute='value') | list | sort == ['10.0.0.2', '10.0.1.2']
-        - new_config['netbios-name-servers'] | map(attribute='value') | list | sort == ['10.0.0.1', '10.0.1.1']
-        - new_config['netbios-node-type'][0]['value'] == '1'
+    - ansible.builtin.assert:
+        that:
+          - new_config.keys() | list | sort == ['domain-name', 'domain-name-servers', 'netbios-name-servers', 'netbios-node-type', 'ntp-servers']
+          - new_config['domain-name'][0]['value'] == '{{ aws_domain_name }}'
+          - new_config['ntp-servers'] | map(attribute='value') | list | sort == ['10.0.0.2', '10.0.1.2']
+          - new_config['netbios-name-servers'] | map(attribute='value') | list | sort == ['10.0.0.1', '10.0.1.1']
+          - new_config['netbios-node-type'][0]['value'] == '1'
 
-  - name: verify the original set was deleted
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ original_dhcp_options_id }}"]
-    register: dhcp_options
-    ignore_errors: yes
-    retries: 5
-    until: dhcp_options is failed
-    delay: 5
+    - name: verify the original set was deleted
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ original_dhcp_options_id }}"]
+      register: dhcp_options
+      ignore_errors: true
+      retries: 5
+      until: dhcp_options is failed
+      delay: 5
 
-  - assert:
-      that:
-        - dhcp_options.failed
-        - '"does not exist" in dhcp_options.error.message'
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.failed
+          - '"does not exist" in dhcp_options.error.message'
 
-  - set_fact:
-      original_dhcp_options_id: "{{ new_dhcp_options_id }}"
+    - ansible.builtin.set_fact:
+        original_dhcp_options_id: "{{ new_dhcp_options_id }}"
 
-  # Create a DHCP option set that does not inherit from the old set and deletes the old set
+    # Create a DHCP option set that does not inherit from the old set and deletes the old set
 
-  - name: create a DHCP option set that does not inherit from the default set and deletes the original set (check mode)
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      domain_name: '{{ aws_domain_name }}'
-      dns_servers:
-        - AmazonProvidedDNS
-      delete_old: True
-    register: dhcp_options
-    check_mode: true
+    - name: create a DHCP option set that does not inherit from the default set and deletes the original set (check mode)
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        domain_name: "{{ aws_domain_name }}"
+        dns_servers:
+          - AmazonProvidedDNS
+        delete_old: true
+      register: dhcp_options
+      check_mode: true
 
-  - assert:
-      that:
-        - dhcp_options.changed
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
 
-  - name: create a DHCP option set that does not inherit from the default set and deletes the original set
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      domain_name: "{{ aws_domain_name }}"
-      dns_servers:
-        - AmazonProvidedDNS
-      delete_old: True
-    register: dhcp_options
+    - name: create a DHCP option set that does not inherit from the default set and deletes the original set
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        domain_name: "{{ aws_domain_name }}"
+        dns_servers:
+          - AmazonProvidedDNS
+        delete_old: true
+      register: dhcp_options
 
-  - assert:
-      that:
-        - dhcp_options.dhcp_config
-        - dhcp_options.dhcp_config.keys() | list | sort is superset(['domain-name', 'domain-name-servers'])
-        - dhcp_options.dhcp_config['domain-name'] == ['{{ aws_domain_name }}']
-        - dhcp_options.dhcp_config['domain-name-servers'] == ['AmazonProvidedDNS']
-        - original_dhcp_options_id != dhcp_options.dhcp_options_id
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.dhcp_config
+          - dhcp_options.dhcp_config.keys() | list | sort is superset(['domain-name', 'domain-name-servers'])
+          - dhcp_options.dhcp_config['domain-name'] == ['{{ aws_domain_name }}']
+          - dhcp_options.dhcp_config['domain-name-servers'] == ['AmazonProvidedDNS']
+          - original_dhcp_options_id != dhcp_options.dhcp_options_id
 
-  - set_fact:
-      new_dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
+    - ansible.builtin.set_fact:
+        new_dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
 
-  - name: get information about the new DHCP option
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ new_dhcp_options_id }}"]
-    register: new_dhcp_options
+    - name: get information about the new DHCP option
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ new_dhcp_options_id }}"]
+      register: new_dhcp_options
 
-  - set_fact:
-      new_config: "{{ new_dhcp_options.dhcp_options[0].dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
+    - ansible.builtin.set_fact:
+        new_config: "{{ new_dhcp_options.dhcp_options[0].dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
 
-  - assert:
-      that:
-        - new_config.keys() | list | sort == ['domain-name', 'domain-name-servers']
-        - new_config['domain-name'][0]['value'] == '{{ aws_domain_name }}'
-        - new_config['domain-name-servers'][0]['value'] == 'AmazonProvidedDNS'
+    - ansible.builtin.assert:
+        that:
+          - new_config.keys() | list | sort == ['domain-name', 'domain-name-servers']
+          - new_config['domain-name'][0]['value'] == '{{ aws_domain_name }}'
+          - new_config['domain-name-servers'][0]['value'] == 'AmazonProvidedDNS'
 
-  - name: verify the original set was deleted
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ original_dhcp_options_id }}"]
-    register: dhcp_options
-    ignore_errors: yes
+    - name: verify the original set was deleted
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ original_dhcp_options_id }}"]
+      register: dhcp_options
+      ignore_errors: true
 
-  - assert:
-      that:
-        - dhcp_options.failed
-        - '"does not exist" in dhcp_options.error.message'
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.failed
+          - '"does not exist" in dhcp_options.error.message'
 
-  - set_fact:
-      original_dhcp_options_id: "{{ new_dhcp_options_id }}"
+    - ansible.builtin.set_fact:
+        original_dhcp_options_id: "{{ new_dhcp_options_id }}"
 
-  # Create a DHCP option set with tags
+    # Create a DHCP option set with tags
 
-  - name: create a DHCP option set with tags (check mode)
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      delete_old: True
-      ntp_servers:
+    - name: create a DHCP option set with tags (check mode)
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        delete_old: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      tags:
-        CreatedBy: ansible-test
-        Collection: amazon.aws
-    register: dhcp_options
-    check_mode: true
-    ignore_errors: true
+        tags:
+          CreatedBy: ansible-test
+          Collection: amazon.aws
+      register: dhcp_options
+      check_mode: true
+      ignore_errors: true
 
-  - assert:
-      that:
-        - dhcp_options.changed
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
 
-  - name: create a DHCP option set with tags
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      delete_old: True
-      ntp_servers:
+    - name: create a DHCP option set with tags
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        delete_old: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      tags:
-        CreatedBy: ansible-test
-        Collection: amazon.aws
-    register: dhcp_options
+        tags:
+          CreatedBy: ansible-test
+          Collection: amazon.aws
+      register: dhcp_options
 
-  - set_fact:
-      dhcp_options_config: "{{ dhcp_options.dhcp_options.dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
+    - ansible.builtin.set_fact:
+        dhcp_options_config: "{{ dhcp_options.dhcp_options.dhcp_configurations | items2dict(key_name='key', value_name='values') }}"
 
-  - assert:
-      that:
-        - dhcp_options.changed
-        - dhcp_options.dhcp_config.keys() | list | sort is superset(['ntp-servers', 'netbios-name-servers'])
-        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
-        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - original_dhcp_options_id != dhcp_options.dhcp_options_id
-        # We return the list of dicts that boto gives us, in addition to the user-friendly config dict
-        - dhcp_options_config['ntp-servers'] | map(attribute='value') | list | sort == ['10.0.0.2', '10.0.1.2']
-        - dhcp_options_config['netbios-name-servers'] | map(attribute='value') | list | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.dhcp_options.tags.keys() | length == 2
-        - dhcp_options.dhcp_options.tags['CreatedBy'] == 'ansible-test'
-        - dhcp_options.dhcp_options.tags['Collection'] == 'amazon.aws'
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
+          - dhcp_options.dhcp_config.keys() | list | sort is superset(['ntp-servers', 'netbios-name-servers'])
+          - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+          - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+          - original_dhcp_options_id != dhcp_options.dhcp_options_id
+          # We return the list of dicts that boto gives us, in addition to the user-friendly config dict
+          - dhcp_options_config['ntp-servers'] | map(attribute='value') | list | sort == ['10.0.0.2', '10.0.1.2']
+          - dhcp_options_config['netbios-name-servers'] | map(attribute='value') | list | sort == ['10.0.0.1', '10.0.1.1']
+          - dhcp_options.dhcp_options.tags.keys() | length == 2
+          - dhcp_options.dhcp_options.tags['CreatedBy'] == 'ansible-test'
+          - dhcp_options.dhcp_options.tags['Collection'] == 'amazon.aws'
 
-  - set_fact:
-      new_dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
+    - ansible.builtin.set_fact:
+        new_dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
 
-  - name: check if the expected tags are associated
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ new_dhcp_options_id }}"]
-    register: dhcp_options_info
+    - name: check if the expected tags are associated
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ new_dhcp_options_id }}"]
+      register: dhcp_options_info
 
-  - assert:
-      that:
-        - dhcp_options_info.dhcp_options[0].tags is defined
-        - dhcp_options_info.dhcp_options[0].tags | length == 2
-        - dhcp_options_info.dhcp_options[0].tags['Collection'] == 'amazon.aws'
-        - dhcp_options_info.dhcp_options[0].tags['CreatedBy'] == 'ansible-test'
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options_info.dhcp_options[0].tags is defined
+          - dhcp_options_info.dhcp_options[0].tags | length == 2
+          - dhcp_options_info.dhcp_options[0].tags['Collection'] == 'amazon.aws'
+          - dhcp_options_info.dhcp_options[0].tags['CreatedBy'] == 'ansible-test'
 
-  - name: test no changes with the same tags (check mode)
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      delete_old: True
-      ntp_servers:
+    - name: test no changes with the same tags (check mode)
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        delete_old: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      tags:
-        CreatedBy: ansible-test
-        Collection: amazon.aws
-    register: dhcp_options
-    check_mode: true
+        tags:
+          CreatedBy: ansible-test
+          Collection: amazon.aws
+      register: dhcp_options
+      check_mode: true
 
-  - assert:
-      that:
-        - not dhcp_options.changed
-        - dhcp_options.dhcp_config.keys() | list | sort == ['netbios-name-servers', 'ntp-servers']
-        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+    - ansible.builtin.assert:
+        that:
+          - not dhcp_options.changed
+          - dhcp_options.dhcp_config.keys() | list | sort == ['netbios-name-servers', 'ntp-servers']
+          - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+          - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
 
-  - name: test no changes with the same tags
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      delete_old: True
-      ntp_servers:
+    - name: test no changes with the same tags
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        delete_old: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      tags:
-        CreatedBy: ansible-test
-        Collection: amazon.aws
-    register: dhcp_options
+        tags:
+          CreatedBy: ansible-test
+          Collection: amazon.aws
+      register: dhcp_options
 
-  - name: check if the expected tags are associated
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
-    register: dhcp_options_info
+    - name: check if the expected tags are associated
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
+      register: dhcp_options_info
 
-  - assert:
-      that:
-        - not dhcp_options.changed
-        - dhcp_options.dhcp_config.keys() | list | sort == ['netbios-name-servers', 'ntp-servers']
-        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
-        - new_dhcp_options_id == dhcp_options.dhcp_options_id
-        - dhcp_options.dhcp_options.tags.keys() | length == 2
-        - dhcp_options.dhcp_options.tags['CreatedBy'] == 'ansible-test'
-        - dhcp_options.dhcp_options.tags['Collection'] == 'amazon.aws'
-        - dhcp_options_info.dhcp_options[0].tags is defined
-        - dhcp_options_info.dhcp_options[0].tags.keys() | length == 2
-        - dhcp_options_info.dhcp_options[0].tags['Collection'] == 'amazon.aws'
-        - dhcp_options_info.dhcp_options[0].tags['CreatedBy'] == 'ansible-test'
+    - ansible.builtin.assert:
+        that:
+          - not dhcp_options.changed
+          - dhcp_options.dhcp_config.keys() | list | sort == ['netbios-name-servers', 'ntp-servers']
+          - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+          - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+          - new_dhcp_options_id == dhcp_options.dhcp_options_id
+          - dhcp_options.dhcp_options.tags.keys() | length == 2
+          - dhcp_options.dhcp_options.tags['CreatedBy'] == 'ansible-test'
+          - dhcp_options.dhcp_options.tags['Collection'] == 'amazon.aws'
+          - dhcp_options_info.dhcp_options[0].tags is defined
+          - dhcp_options_info.dhcp_options[0].tags.keys() | length == 2
+          - dhcp_options_info.dhcp_options[0].tags['Collection'] == 'amazon.aws'
+          - dhcp_options_info.dhcp_options[0].tags['CreatedBy'] == 'ansible-test'
 
-  - name: test no changes without specifying tags (check mode)
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      delete_old: True
-      ntp_servers:
+    - name: test no changes without specifying tags (check mode)
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        delete_old: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      purge_tags: False
-    register: dhcp_options
-    check_mode: true
+        purge_tags: false
+      register: dhcp_options
+      check_mode: true
 
-  - assert:
-      that:
-        - not dhcp_options.changed
-        - dhcp_options.dhcp_config.keys() | list | sort is superset(['netbios-name-servers', 'ntp-servers'])
-        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+    - ansible.builtin.assert:
+        that:
+          - not dhcp_options.changed
+          - dhcp_options.dhcp_config.keys() | list | sort is superset(['netbios-name-servers', 'ntp-servers'])
+          - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+          - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
 
-  - name: test no changes without specifying tags
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      delete_old: True
-      ntp_servers:
+    - name: test no changes without specifying tags
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        delete_old: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      purge_tags: False
-    register: dhcp_options
+        purge_tags: false
+      register: dhcp_options
 
-  - name: check if the expected tags are associated
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
-    register: dhcp_options_info
+    - name: check if the expected tags are associated
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
+      register: dhcp_options_info
 
-  - assert:
-      that:
-        - not dhcp_options.changed
-        - dhcp_options.dhcp_config.keys() | list | sort is superset(['netbios-name-servers', 'ntp-servers'])
-        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
-        - new_dhcp_options_id == dhcp_options.dhcp_options_id
-        - dhcp_options_info.dhcp_options[0].tags is defined
-        - dhcp_options_info.dhcp_options[0].tags.keys() | length == 2
-        - dhcp_options_info.dhcp_options[0].tags['Collection'] == 'amazon.aws'
-        - dhcp_options_info.dhcp_options[0].tags['CreatedBy'] == 'ansible-test'
+    - ansible.builtin.assert:
+        that:
+          - not dhcp_options.changed
+          - dhcp_options.dhcp_config.keys() | list | sort is superset(['netbios-name-servers', 'ntp-servers'])
+          - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+          - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+          - new_dhcp_options_id == dhcp_options.dhcp_options_id
+          - dhcp_options_info.dhcp_options[0].tags is defined
+          - dhcp_options_info.dhcp_options[0].tags.keys() | length == 2
+          - dhcp_options_info.dhcp_options[0].tags['Collection'] == 'amazon.aws'
+          - dhcp_options_info.dhcp_options[0].tags['CreatedBy'] == 'ansible-test'
 
-  - name: add a tag without using dhcp_options_id
-    ec2_vpc_dhcp_option:
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      delete_old: True
-      ntp_servers:
+    - name: add a tag without using dhcp_options_id
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        delete_old: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      tags:
-        CreatedBy: ansible-test
-        Collection: amazon.aws
-        another: tag
-    register: dhcp_options
+        tags:
+          CreatedBy: ansible-test
+          Collection: amazon.aws
+          another: tag
+      register: dhcp_options
 
-  - name: check if the expected tags are associated
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
-    register: dhcp_options_info
+    - name: check if the expected tags are associated
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
+      register: dhcp_options_info
 
-  - assert:
-      that:
-        - dhcp_options.changed
-        - dhcp_options.dhcp_config.keys() | list | sort is superset(['netbios-name-servers', 'ntp-servers'])
-        - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
-        - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
-        - new_dhcp_options_id == dhcp_options.dhcp_options_id
-        - dhcp_options.dhcp_options.tags.keys() | length == 3
-        - dhcp_options.dhcp_options.tags['another'] == 'tag'
-        - dhcp_options.dhcp_options.tags['CreatedBy'] == 'ansible-test'
-        - dhcp_options.dhcp_options.tags['Collection'] == 'amazon.aws'
-        - dhcp_options_info.dhcp_options[0].tags is defined
-        - dhcp_options_info.dhcp_options[0].tags.keys() | length == 3
-        - dhcp_options_info.dhcp_options[0].tags['another'] == 'tag'
-        - dhcp_options_info.dhcp_options[0].tags['Collection'] == 'amazon.aws'
-        - dhcp_options_info.dhcp_options[0].tags['CreatedBy'] == 'ansible-test'
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
+          - dhcp_options.dhcp_config.keys() | list | sort is superset(['netbios-name-servers', 'ntp-servers'])
+          - dhcp_options.dhcp_config['netbios-name-servers'] | sort == ['10.0.0.1', '10.0.1.1']
+          - dhcp_options.dhcp_config['ntp-servers'] | sort == ['10.0.0.2', '10.0.1.2']
+          - new_dhcp_options_id == dhcp_options.dhcp_options_id
+          - dhcp_options.dhcp_options.tags.keys() | length == 3
+          - dhcp_options.dhcp_options.tags['another'] == 'tag'
+          - dhcp_options.dhcp_options.tags['CreatedBy'] == 'ansible-test'
+          - dhcp_options.dhcp_options.tags['Collection'] == 'amazon.aws'
+          - dhcp_options_info.dhcp_options[0].tags is defined
+          - dhcp_options_info.dhcp_options[0].tags.keys() | length == 3
+          - dhcp_options_info.dhcp_options[0].tags['another'] == 'tag'
+          - dhcp_options_info.dhcp_options[0].tags['Collection'] == 'amazon.aws'
+          - dhcp_options_info.dhcp_options[0].tags['CreatedBy'] == 'ansible-test'
 
-  - name: add and removing tags (check mode)
-    ec2_vpc_dhcp_option:
-      dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      delete_old: True
-      ntp_servers:
+    - name: add and removing tags (check mode)
+      amazon.aws.ec2_vpc_dhcp_option:
+        dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        delete_old: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      tags:
-        AnsibleTest: integration
-        Collection: amazon.aws
-    register: dhcp_options
-    check_mode: true
+        tags:
+          AnsibleTest: integration
+          Collection: amazon.aws
+      register: dhcp_options
+      check_mode: true
 
-  - assert:
-      that:
-        - dhcp_options.changed
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
 
-  - name: add and remove tags
-    ec2_vpc_dhcp_option:
-      dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      delete_old: True
-      ntp_servers:
+    - name: add and remove tags
+      amazon.aws.ec2_vpc_dhcp_option:
+        dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        delete_old: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      tags:
-        AnsibleTest: integration
-        Collection: amazon.aws
-    register: dhcp_options
+        tags:
+          AnsibleTest: integration
+          Collection: amazon.aws
+      register: dhcp_options
 
-  - name: check if the expected tags are associated
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
-    register: dhcp_options_info
+    - name: check if the expected tags are associated
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
+      register: dhcp_options_info
 
-  - assert:
-      that:
-        - dhcp_options.changed
-        - dhcp_options.dhcp_options.tags.keys() | length == 2
-        - dhcp_options.dhcp_options.tags['AnsibleTest'] == 'integration'
-        - dhcp_options.dhcp_options.tags['Collection'] == 'amazon.aws'
-        - new_dhcp_options_id == dhcp_options.dhcp_options_id
-        - dhcp_options_info.dhcp_options[0].tags is defined
-        - dhcp_options_info.dhcp_options[0].tags.keys() | length == 2
-        - dhcp_options_info.dhcp_options[0].tags['Collection'] == 'amazon.aws'
-        - dhcp_options_info.dhcp_options[0].tags['AnsibleTest'] == 'integration'
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
+          - dhcp_options.dhcp_options.tags.keys() | length == 2
+          - dhcp_options.dhcp_options.tags['AnsibleTest'] == 'integration'
+          - dhcp_options.dhcp_options.tags['Collection'] == 'amazon.aws'
+          - new_dhcp_options_id == dhcp_options.dhcp_options_id
+          - dhcp_options_info.dhcp_options[0].tags is defined
+          - dhcp_options_info.dhcp_options[0].tags.keys() | length == 2
+          - dhcp_options_info.dhcp_options[0].tags['Collection'] == 'amazon.aws'
+          - dhcp_options_info.dhcp_options[0].tags['AnsibleTest'] == 'integration'
 
-  - name: add tags with different cases
-    ec2_vpc_dhcp_option:
-      dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      delete_old: True
-      ntp_servers:
+    - name: add tags with different cases
+      amazon.aws.ec2_vpc_dhcp_option:
+        dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        delete_old: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      tags:
-        "lowercase spaced": 'hello cruel world'
-        "Title Case": 'Hello Cruel World'
-        CamelCase: 'SimpleCamelCase'
-        snake_case: 'simple_snake_case'
-    register: dhcp_options
+        tags:
+          lowercase spaced: hello cruel world
+          Title Case: Hello Cruel World
+          CamelCase: SimpleCamelCase
+          snake_case: simple_snake_case
+      register: dhcp_options
 
-  - name: check if the expected tags are associated
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
-    register: dhcp_options_info
+    - name: check if the expected tags are associated
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
+      register: dhcp_options_info
 
-  - assert:
-      that:
-        - dhcp_options.changed
-        - new_dhcp_options_id == dhcp_options.dhcp_options_id
-        - dhcp_options.dhcp_options.tags.keys() | length == 4
-        - dhcp_options.dhcp_options.tags['lowercase spaced'] == 'hello cruel world'
-        - dhcp_options.dhcp_options.tags['Title Case'] == 'Hello Cruel World'
-        - dhcp_options.dhcp_options.tags['CamelCase'] == 'SimpleCamelCase'
-        - dhcp_options.dhcp_options.tags['snake_case'] == 'simple_snake_case'
-        - dhcp_options_info.dhcp_options[0].tags is defined
-        - dhcp_options_info.dhcp_options[0].tags.keys() | length == 4
-        - dhcp_options_info.dhcp_options[0].tags['lowercase spaced'] == 'hello cruel world'
-        - dhcp_options_info.dhcp_options[0].tags['Title Case'] == 'Hello Cruel World'
-        - dhcp_options_info.dhcp_options[0].tags['CamelCase'] == 'SimpleCamelCase'
-        - dhcp_options_info.dhcp_options[0].tags['snake_case'] == 'simple_snake_case'
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
+          - new_dhcp_options_id == dhcp_options.dhcp_options_id
+          - dhcp_options.dhcp_options.tags.keys() | length == 4
+          - dhcp_options.dhcp_options.tags['lowercase spaced'] == 'hello cruel world'
+          - dhcp_options.dhcp_options.tags['Title Case'] == 'Hello Cruel World'
+          - dhcp_options.dhcp_options.tags['CamelCase'] == 'SimpleCamelCase'
+          - dhcp_options.dhcp_options.tags['snake_case'] == 'simple_snake_case'
+          - dhcp_options_info.dhcp_options[0].tags is defined
+          - dhcp_options_info.dhcp_options[0].tags.keys() | length == 4
+          - dhcp_options_info.dhcp_options[0].tags['lowercase spaced'] == 'hello cruel world'
+          - dhcp_options_info.dhcp_options[0].tags['Title Case'] == 'Hello Cruel World'
+          - dhcp_options_info.dhcp_options[0].tags['CamelCase'] == 'SimpleCamelCase'
+          - dhcp_options_info.dhcp_options[0].tags['snake_case'] == 'simple_snake_case'
 
-  - name: test purging all tags
-    ec2_vpc_dhcp_option:
-      dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      delete_old: True
-      ntp_servers:
+    - name: test purging all tags
+      amazon.aws.ec2_vpc_dhcp_option:
+        dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        delete_old: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      tags: {}
-    register: dhcp_options
+        tags: {}
+      register: dhcp_options
 
-  - name: check if the expected tags are associated
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
-    register: dhcp_options_info
+    - name: check if the expected tags are associated
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
+      register: dhcp_options_info
 
-  - assert:
-      that:
-        - dhcp_options.changed
-        - new_dhcp_options_id == dhcp_options.dhcp_options_id
-        - not dhcp_options_info.dhcp_options[0].tags
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
+          - new_dhcp_options_id == dhcp_options.dhcp_options_id
+          - not dhcp_options_info.dhcp_options[0].tags
 
-  - name: test removing all tags
-    ec2_vpc_dhcp_option:
-      dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      inherit_existing: False
-      delete_old: True
-      ntp_servers:
+    - name: test removing all tags
+      amazon.aws.ec2_vpc_dhcp_option:
+        dhcp_options_id: "{{ dhcp_options.dhcp_options_id }}"
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        inherit_existing: false
+        delete_old: true
+        ntp_servers:
           - 10.0.0.2
           - 10.0.1.2
-      netbios_name_servers:
+        netbios_name_servers:
           - 10.0.0.1
           - 10.0.1.1
-      tags: {}
-    register: dhcp_options
+        tags: {}
+      register: dhcp_options
 
-  - name: check if the expected tags are associated
-    ec2_vpc_dhcp_option_info:
-      dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
-    register: dhcp_options_info
+    - name: check if the expected tags are associated
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        dhcp_options_ids: ["{{ dhcp_options.dhcp_options_id }}"]
+      register: dhcp_options_info
 
-  - assert:
-      that:
-        - dhcp_options.changed
-        - new_dhcp_options_id == dhcp_options.dhcp_options_id
-        - not dhcp_options_info.dhcp_options[0].tags
+    - ansible.builtin.assert:
+        that:
+          - dhcp_options.changed
+          - new_dhcp_options_id == dhcp_options.dhcp_options_id
+          - not dhcp_options_info.dhcp_options[0].tags
 
-  - name: remove the DHCP option set (check mode)
-    ec2_vpc_dhcp_option:
-      state: absent
-      vpc_id: "{{ vpc_id }}"
-      dhcp_options_id: "{{ new_dhcp_options_id }}"
-    register: dhcp_options
-    check_mode: true
+    - name: remove the DHCP option set (check mode)
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: absent
+        vpc_id: "{{ vpc_id }}"
+        dhcp_options_id: "{{ new_dhcp_options_id }}"
+      register: dhcp_options
+      check_mode: true
 
-#  - assert:
-#      that:
-#        - dhcp_options.changed
+    #  - assert:
+    #      that:
+    #        - dhcp_options.changed
 
-  # FIXME: does nothing - the module should associate "default" with the VPC provided but currently does not
-  - name: removing the DHCP option set
-    ec2_vpc_dhcp_option:
-      state: absent
-      vpc_id: "{{ vpc_id }}"
-      dhcp_options_id: "{{ new_dhcp_options_id }}"
-    register: dhcp_options
+    # FIXME: does nothing - the module should associate "default" with the VPC provided but currently does not
+    - name: removing the DHCP option set
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: absent
+        vpc_id: "{{ vpc_id }}"
+        dhcp_options_id: "{{ new_dhcp_options_id }}"
+      register: dhcp_options
 
-#  - assert:
-#      that:
-#        - dhcp_options.changed
+    #  - assert:
+    #      that:
+    #        - dhcp_options.changed
 
-  - name: remove the DHCP option set again (check mode)
-    ec2_vpc_dhcp_option:
-      state: absent
-      vpc_id: "{{ vpc_id }}"
-      dhcp_options_id: "{{ new_dhcp_options_id }}"
-    register: dhcp_options
-    check_mode: true
+    - name: remove the DHCP option set again (check mode)
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: absent
+        vpc_id: "{{ vpc_id }}"
+        dhcp_options_id: "{{ new_dhcp_options_id }}"
+      register: dhcp_options
+      check_mode: true
 
-  - assert:
-      that:
-        - not dhcp_options.changed
+    - ansible.builtin.assert:
+        that:
+          - not dhcp_options.changed
 
-  - name: remove the DHCP option set again
-    ec2_vpc_dhcp_option:
-      state: absent
-      vpc_id: "{{ vpc_id }}"
-      dhcp_options_id: "{{ new_dhcp_options_id }}"
-    register: dhcp_options
+    - name: remove the DHCP option set again
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: absent
+        vpc_id: "{{ vpc_id }}"
+        dhcp_options_id: "{{ new_dhcp_options_id }}"
+      register: dhcp_options
 
-  - assert:
-      that:
-        - not dhcp_options.changed
+    - ansible.builtin.assert:
+        that:
+          - not dhcp_options.changed
 
   always:
+    - name: Re-associate the default DHCP options set so that the new one(s) can be deleted
+      amazon.aws.ec2_vpc_dhcp_option:
+        vpc_id: "{{ vpc_id }}"
+        dhcp_options_id: "{{ default_options_id }}"
+        state: present
+      register: result
+      when: vpc_id is defined
+      ignore_errors: true
 
-  - name: Re-associate the default DHCP options set so that the new one(s) can be deleted
-    ec2_vpc_dhcp_option:
-      vpc_id: '{{ vpc_id }}'
-      dhcp_options_id: '{{ default_options_id }}'
-      state: present
-    register: result
-    when: vpc_id is defined
-    ignore_errors: yes
+    - name: Query all option sets created by the test
+      amazon.aws.ec2_vpc_dhcp_option_info:
+        filters:
+          tag:Name: "*'{{ resource_prefix }}*"
+      register: option_sets
 
-  - name: Query all option sets created by the test
-    ec2_vpc_dhcp_option_info:
-      filters:
-        "tag:Name": "*'{{ resource_prefix }}*"
-    register: option_sets
+    - name: clean up DHCP option sets
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: absent
+        dhcp_options_id: "{{ original_dhcp_options_id }}"
+        vpc_id: "{{ vpc_id }}"
+      when: original_dhcp_options_id is defined
+      ignore_errors: true
 
-  - name: clean up DHCP option sets
-    ec2_vpc_dhcp_option:
-      state: absent
-      dhcp_options_id: "{{ original_dhcp_options_id }}"
-      vpc_id: "{{ vpc_id }}"
-    when: original_dhcp_options_id is defined
-    ignore_errors: yes
+    - name: clean up DHCP option sets
+      amazon.aws.ec2_vpc_dhcp_option:
+        state: absent
+        dhcp_options_id: "{{ new_dhcp_options_id }}"
+        vpc_id: "{{ vpc_id }}"
+      when: new_dhcp_options_id is defined
+      ignore_errors: true
 
-  - name: clean up DHCP option sets
-    ec2_vpc_dhcp_option:
-      state: absent
-      dhcp_options_id: "{{ new_dhcp_options_id }}"
-      vpc_id: "{{ vpc_id }}"
-    when: new_dhcp_options_id is defined
-    ignore_errors: yes
-
-  - name: Delete the VPC
-    ec2_vpc_net:
-      name: "{{ resource_prefix }}"
-      cidr_block: "{{ vpc_cidr }}"
-      state: absent
+    - name: Delete the VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ resource_prefix }}"
+        cidr_block: "{{ vpc_cidr }}"
+        state: absent

--- a/tests/integration/targets/ec2_vpc_endpoint/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint/defaults/main.yml
@@ -1,5 +1,6 @@
-vpc_name: '{{ resource_prefix }}-vpc'
-vpc_seed: '{{ resource_prefix }}'
+---
+vpc_name: "{{ resource_prefix }}-vpc"
+vpc_seed: "{{ resource_prefix }}"
 vpc_cidr: 10.{{ 256 | random(seed=vpc_seed) }}.22.0/24
 
 # S3, Cloud Trail and EC2 should generally be available...

--- a/tests/integration/targets/ec2_vpc_endpoint/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
-- role: setup_ec2_vpc
+  - role: setup_ec2_vpc

--- a/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint/tasks/main.yml
@@ -1,795 +1,790 @@
+---
 - name: ec2_vpc_endpoint tests
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
   # ============================================================
   # BEGIN PRE-TEST SETUP
-  - name: create a VPC
-    ec2_vpc_net:
-      state: present
-      name: '{{ vpc_name }}'
-      cidr_block: '{{ vpc_cidr }}'
-      tags:
-        AnsibleTest: ec2_vpc_endpoint
-        AnsibleRun: '{{ resource_prefix }}'
-    register: vpc_creation
-  - name: Assert success
-    assert:
-      that:
-      - vpc_creation is successful
+    - name: create a VPC
+      amazon.aws.ec2_vpc_net:
+        state: present
+        name: "{{ vpc_name }}"
+        cidr_block: "{{ vpc_cidr }}"
+        tags:
+          AnsibleTest: ec2_vpc_endpoint
+          AnsibleRun: "{{ resource_prefix }}"
+      register: vpc_creation
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - vpc_creation is successful
 
-  - name: Create an IGW
-    ec2_vpc_igw:
-      vpc_id: '{{ vpc_creation.vpc.id }}'
-      state: present
-      tags:
-        Name: '{{ resource_prefix }}'
-        AnsibleTest: ec2_vpc_endpoint
-        AnsibleRun: '{{ resource_prefix }}'
-    register: igw_creation
-  - name: Assert success
-    assert:
-      that:
-      - igw_creation is successful
+    - name: Create an IGW
+      amazon.aws.ec2_vpc_igw:
+        vpc_id: "{{ vpc_creation.vpc.id }}"
+        state: present
+        tags:
+          Name: "{{ resource_prefix }}"
+          AnsibleTest: ec2_vpc_endpoint
+          AnsibleRun: "{{ resource_prefix }}"
+      register: igw_creation
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - igw_creation is successful
 
-  - name: Create a minimal route table (no routes)
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc_creation.vpc.id }}'
-      tags:
-        AnsibleTest: ec2_vpc_endpoint
-        AnsibleRun: '{{ resource_prefix }}'
-        Name: '{{ resource_prefix }}-empty'
-      subnets: []
-      routes: []
-    register: rtb_creation_empty
+    - name: Create a minimal route table (no routes)
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc_creation.vpc.id }}"
+        tags:
+          AnsibleTest: ec2_vpc_endpoint
+          AnsibleRun: "{{ resource_prefix }}"
+          Name: "{{ resource_prefix }}-empty"
+        subnets: []
+        routes: []
+      register: rtb_creation_empty
 
-  - name: Create a minimal route table (with IGW)
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc_creation.vpc.id }}'
-      tags:
-        AnsibleTest: ec2_vpc_endpoint
-        AnsibleRun: '{{ resource_prefix }}'
-        Name: '{{ resource_prefix }}-igw'
-      subnets: []
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: '{{ igw_creation.gateway_id }}'
-    register: rtb_creation_igw
+    - name: Create a minimal route table (with IGW)
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc_creation.vpc.id }}"
+        tags:
+          AnsibleTest: ec2_vpc_endpoint
+          AnsibleRun: "{{ resource_prefix }}"
+          Name: "{{ resource_prefix }}-igw"
+        subnets: []
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: "{{ igw_creation.gateway_id }}"
+      register: rtb_creation_igw
 
-  - name: Save VPC info in a fact
-    set_fact:
-      vpc_id: '{{ vpc_creation.vpc.id }}'
-      rtb_empty_id: '{{ rtb_creation_empty.route_table.id }}'
-      rtb_igw_id: '{{ rtb_creation_igw.route_table.id }}'
+    - name: Save VPC info in a fact
+      ansible.builtin.set_fact:
+        vpc_id: "{{ vpc_creation.vpc.id }}"
+        rtb_empty_id: "{{ rtb_creation_empty.route_table.id }}"
+        rtb_igw_id: "{{ rtb_creation_igw.route_table.id }}"
 
-  # ============================================================
-  # BEGIN TESTS
+    # ============================================================
+    # BEGIN TESTS
 
-  # Minimal check_mode with _info
-  - name: Fetch Endpoints in check_mode
-    ec2_vpc_endpoint_info:
-    register: endpoint_info
-    check_mode: true
-  - name: Assert success
-    assert:
-      that:
+    # Minimal check_mode with _info
+    - name: Fetch Endpoints in check_mode
+      amazon.aws.ec2_vpc_endpoint_info:
+      register: endpoint_info
+      check_mode: true
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
         # May be run in parallel, the only thing we can guarantee is
         # - we shouldn't error
         # - we should return 'vpc_endpoints' (even if it's empty)
-      - endpoint_info is successful
-      - '"vpc_endpoints" in endpoint_info'
+          - endpoint_info is successful
+          - '"vpc_endpoints" in endpoint_info'
 
-  # Attempt to create an endpoint
-  - name: Create minimal endpoint (check mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-    register: create_endpoint_check
-    check_mode: true
-  - name: Assert changed
-    assert:
-      that:
-      - create_endpoint_check is changed
+    # Attempt to create an endpoint
+    - name: Create minimal endpoint (check mode)
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        service: "{{ endpoint_service_a }}"
+      register: create_endpoint_check
+      check_mode: true
+    - name: Assert changed
+      ansible.builtin.assert:
+        that:
+          - create_endpoint_check is changed
 
-  - name: Create minimal endpoint
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-      wait: true
-    register: create_endpoint
-  - name: Check standard return values
-    assert:
-      that:
-      - create_endpoint is changed
-      - '"result" in create_endpoint'
-      - '"creation_timestamp" in create_endpoint.result'
-      - '"dns_entries" in create_endpoint.result'
-      - '"groups" in create_endpoint.result'
-      - '"network_interface_ids" in create_endpoint.result'
-      - '"owner_id" in create_endpoint.result'
-      - '"policy_document" in create_endpoint.result'
-      - '"private_dns_enabled" in create_endpoint.result'
-      - create_endpoint.result.private_dns_enabled == False
-      - '"requester_managed" in create_endpoint.result'
-      - create_endpoint.result.requester_managed == False
-      - '"service_name" in create_endpoint.result'
-      - create_endpoint.result.service_name == endpoint_service_a
-      - '"state" in create_endpoint.result'
-      - create_endpoint.result.state == "available"
-      - '"vpc_endpoint_id" in create_endpoint.result'
-      - create_endpoint.result.vpc_endpoint_id.startswith("vpce-")
-      - '"vpc_endpoint_type" in create_endpoint.result'
-      - create_endpoint.result.vpc_endpoint_type == "Gateway"
-      - '"vpc_id" in create_endpoint.result'
-      - create_endpoint.result.vpc_id == vpc_id
+    - name: Create minimal endpoint
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        service: "{{ endpoint_service_a }}"
+        wait: true
+      register: create_endpoint
+    - name: Check standard return values
+      ansible.builtin.assert:
+        that:
+          - create_endpoint is changed
+          - '"result" in create_endpoint'
+          - '"creation_timestamp" in create_endpoint.result'
+          - '"dns_entries" in create_endpoint.result'
+          - '"groups" in create_endpoint.result'
+          - '"network_interface_ids" in create_endpoint.result'
+          - '"owner_id" in create_endpoint.result'
+          - '"policy_document" in create_endpoint.result'
+          - '"private_dns_enabled" in create_endpoint.result'
+          - create_endpoint.result.private_dns_enabled == False
+          - '"requester_managed" in create_endpoint.result'
+          - create_endpoint.result.requester_managed == False
+          - '"service_name" in create_endpoint.result'
+          - create_endpoint.result.service_name == endpoint_service_a
+          - '"state" in create_endpoint.result'
+          - create_endpoint.result.state == "available"
+          - '"vpc_endpoint_id" in create_endpoint.result'
+          - create_endpoint.result.vpc_endpoint_id.startswith("vpce-")
+          - '"vpc_endpoint_type" in create_endpoint.result'
+          - create_endpoint.result.vpc_endpoint_type == "Gateway"
+          - '"vpc_id" in create_endpoint.result'
+          - create_endpoint.result.vpc_id == vpc_id
 
-  - name: Save Endpoint info in a fact
-    set_fact:
-      endpoint_id: '{{ create_endpoint.result.vpc_endpoint_id }}'
+    - name: Save Endpoint info in a fact
+      ansible.builtin.set_fact:
+        endpoint_id: "{{ create_endpoint.result.vpc_endpoint_id }}"
 
-  # Pull info about the endpoints
-  - name: Fetch Endpoints (all)
-    ec2_vpc_endpoint_info:
-    register: endpoint_info
-  - name: Assert success
-    assert:
-      that:
+    # Pull info about the endpoints
+    - name: Fetch Endpoints (all)
+      amazon.aws.ec2_vpc_endpoint_info:
+      register: endpoint_info
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
         # We're fetching all endpoints, there's no guarantee what the values
         # will be
-      - endpoint_info is successful
-      - '"vpc_endpoints" in endpoint_info'
-      - '"creation_timestamp" in first_endpoint'
-      - '"policy_document" in first_endpoint'
-      - '"route_table_ids" in first_endpoint'
-      - '"service_name" in first_endpoint'
-      - '"state" in first_endpoint'
-      - '"vpc_endpoint_id" in first_endpoint'
-      - '"vpc_id" in first_endpoint'
-        # Not yet documented, but returned
-      - '"dns_entries" in first_endpoint'
-      - '"groups" in first_endpoint'
-      - '"network_interface_ids" in first_endpoint'
-      - '"owner_id" in first_endpoint'
-      - '"private_dns_enabled" in first_endpoint'
-      - '"requester_managed" in first_endpoint'
-      - '"subnet_ids" in first_endpoint'
-      - '"tags" in first_endpoint'
-      - '"vpc_endpoint_type" in first_endpoint'
-        # Make sure our endpoint is included
-      - endpoint_id in ( endpoint_info | community.general.json_query("vpc_endpoints[*].vpc_endpoint_id")
-        | list | flatten )
-    vars:
-      first_endpoint: '{{ endpoint_info.vpc_endpoints[0] }}'
+          - endpoint_info is successful
+          - '"vpc_endpoints" in endpoint_info'
+          - '"creation_timestamp" in first_endpoint'
+          - '"policy_document" in first_endpoint'
+          - '"route_table_ids" in first_endpoint'
+          - '"service_name" in first_endpoint'
+          - '"state" in first_endpoint'
+          - '"vpc_endpoint_id" in first_endpoint'
+          - '"vpc_id" in first_endpoint'
+          # Not yet documented, but returned
+          - '"dns_entries" in first_endpoint'
+          - '"groups" in first_endpoint'
+          - '"network_interface_ids" in first_endpoint'
+          - '"owner_id" in first_endpoint'
+          - '"private_dns_enabled" in first_endpoint'
+          - '"requester_managed" in first_endpoint'
+          - '"subnet_ids" in first_endpoint'
+          - '"tags" in first_endpoint'
+          - '"vpc_endpoint_type" in first_endpoint'
+          # Make sure our endpoint is included
+          - endpoint_id in ( endpoint_info | community.general.json_query("vpc_endpoints[*].vpc_endpoint_id") | list | flatten )
+      vars:
+        first_endpoint: "{{ endpoint_info.vpc_endpoints[0] }}"
 
-  - name: Fetch Endpoints (targetted by ID)
-    ec2_vpc_endpoint_info:
-      vpc_endpoint_ids: '{{ endpoint_id }}'
-    register: endpoint_info
-  - name: Assert success
-    assert:
-      that:
-      - endpoint_info is successful
-      - '"vpc_endpoints" in endpoint_info'
-      - '"creation_timestamp" in first_endpoint'
-      - '"policy_document" in first_endpoint'
-      - '"route_table_ids" in first_endpoint'
-      - first_endpoint.route_table_ids | length == 0
-      - '"service_name" in first_endpoint'
-      - first_endpoint.service_name == endpoint_service_a
-      - '"state" in first_endpoint'
-      - first_endpoint.state == "available"
-      - '"vpc_endpoint_id" in first_endpoint'
-      - first_endpoint.vpc_endpoint_id == endpoint_id
-      - '"vpc_id" in first_endpoint'
-      - first_endpoint.vpc_id == vpc_id
-        # Not yet documented, but returned
-      - '"dns_entries" in first_endpoint'
-      - '"groups" in first_endpoint'
-      - '"network_interface_ids" in first_endpoint'
-      - '"owner_id" in first_endpoint'
-      - '"private_dns_enabled" in first_endpoint'
-      - first_endpoint.private_dns_enabled == False
-      - '"requester_managed" in first_endpoint'
-      - first_endpoint.requester_managed == False
-      - '"subnet_ids" in first_endpoint'
-      - '"tags" in first_endpoint'
-      - '"vpc_endpoint_type" in first_endpoint'
-    vars:
-      first_endpoint: '{{ endpoint_info.vpc_endpoints[0] }}'
+    - name: Fetch Endpoints (targetted by ID)
+      amazon.aws.ec2_vpc_endpoint_info:
+        vpc_endpoint_ids: "{{ endpoint_id }}"
+      register: endpoint_info
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - endpoint_info is successful
+          - '"vpc_endpoints" in endpoint_info'
+          - '"creation_timestamp" in first_endpoint'
+          - '"policy_document" in first_endpoint'
+          - '"route_table_ids" in first_endpoint'
+          - first_endpoint.route_table_ids | length == 0
+          - '"service_name" in first_endpoint'
+          - first_endpoint.service_name == endpoint_service_a
+          - '"state" in first_endpoint'
+          - first_endpoint.state == "available"
+          - '"vpc_endpoint_id" in first_endpoint'
+          - first_endpoint.vpc_endpoint_id == endpoint_id
+          - '"vpc_id" in first_endpoint'
+          - first_endpoint.vpc_id == vpc_id
+          # Not yet documented, but returned
+          - '"dns_entries" in first_endpoint'
+          - '"groups" in first_endpoint'
+          - '"network_interface_ids" in first_endpoint'
+          - '"owner_id" in first_endpoint'
+          - '"private_dns_enabled" in first_endpoint'
+          - first_endpoint.private_dns_enabled == False
+          - '"requester_managed" in first_endpoint'
+          - first_endpoint.requester_managed == False
+          - '"subnet_ids" in first_endpoint'
+          - '"tags" in first_endpoint'
+          - '"vpc_endpoint_type" in first_endpoint'
+      vars:
+        first_endpoint: "{{ endpoint_info.vpc_endpoints[0] }}"
 
-  - name: Fetch Endpoints (targetted by VPC)
-    ec2_vpc_endpoint_info:
-      filters:
-        vpc-id:
-        - '{{ vpc_id }}'
-    register: endpoint_info
-  - name: Assert success
-    assert:
-      that:
-      - endpoint_info is successful
-      - '"vpc_endpoints" in endpoint_info'
-      - '"creation_timestamp" in first_endpoint'
-      - '"policy_document" in first_endpoint'
-      - '"route_table_ids" in first_endpoint'
-      - '"service_name" in first_endpoint'
-      - first_endpoint.service_name == endpoint_service_a
-      - '"state" in first_endpoint'
-      - first_endpoint.state == "available"
-      - '"vpc_endpoint_id" in first_endpoint'
-      - first_endpoint.vpc_endpoint_id == endpoint_id
-      - '"vpc_id" in first_endpoint'
-      - first_endpoint.vpc_id == vpc_id
-        # Not yet documented, but returned
-      - '"dns_entries" in first_endpoint'
-      - '"groups" in first_endpoint'
-      - '"network_interface_ids" in first_endpoint'
-      - '"owner_id" in first_endpoint'
-      - '"private_dns_enabled" in first_endpoint'
-      - first_endpoint.private_dns_enabled == False
-      - '"requester_managed" in first_endpoint'
-      - first_endpoint.requester_managed == False
-      - '"subnet_ids" in first_endpoint'
-      - '"tags" in first_endpoint'
-      - '"vpc_endpoint_type" in first_endpoint'
-    vars:
-      first_endpoint: '{{ endpoint_info.vpc_endpoints[0] }}'
+    - name: Fetch Endpoints (targetted by VPC)
+      amazon.aws.ec2_vpc_endpoint_info:
+        filters:
+          vpc-id:
+            - "{{ vpc_id }}"
+      register: endpoint_info
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - endpoint_info is successful
+          - '"vpc_endpoints" in endpoint_info'
+          - '"creation_timestamp" in first_endpoint'
+          - '"policy_document" in first_endpoint'
+          - '"route_table_ids" in first_endpoint'
+          - '"service_name" in first_endpoint'
+          - first_endpoint.service_name == endpoint_service_a
+          - '"state" in first_endpoint'
+          - first_endpoint.state == "available"
+          - '"vpc_endpoint_id" in first_endpoint'
+          - first_endpoint.vpc_endpoint_id == endpoint_id
+          - '"vpc_id" in first_endpoint'
+          - first_endpoint.vpc_id == vpc_id
+          # Not yet documented, but returned
+          - '"dns_entries" in first_endpoint'
+          - '"groups" in first_endpoint'
+          - '"network_interface_ids" in first_endpoint'
+          - '"owner_id" in first_endpoint'
+          - '"private_dns_enabled" in first_endpoint'
+          - first_endpoint.private_dns_enabled == False
+          - '"requester_managed" in first_endpoint'
+          - first_endpoint.requester_managed == False
+          - '"subnet_ids" in first_endpoint'
+          - '"tags" in first_endpoint'
+          - '"vpc_endpoint_type" in first_endpoint'
+      vars:
+        first_endpoint: "{{ endpoint_info.vpc_endpoints[0] }}"
 
+    # matches on parameters without explicitly passing the endpoint ID
+    - name: Create minimal endpoint - idempotency (check mode)
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        service: "{{ endpoint_service_a }}"
+      register: create_endpoint_idem_check
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - create_endpoint_idem_check is not changed
 
-  # matches on parameters without explicitly passing the endpoint ID
-  - name: Create minimal endpoint - idempotency (check mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-    register: create_endpoint_idem_check
-    check_mode: true
-  - assert:
-      that:
-      - create_endpoint_idem_check is not changed
+    - name: Create minimal endpoint - idempotency
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        service: "{{ endpoint_service_a }}"
+      register: create_endpoint_idem
+    - ansible.builtin.assert:
+        that:
+          - create_endpoint_idem is not changed
 
-  - name: Create minimal endpoint - idempotency
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-    register: create_endpoint_idem
-  - assert:
-      that:
-      - create_endpoint_idem is not changed
+    - name: Delete minimal endpoint by ID (check_mode)
+      amazon.aws.ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ endpoint_id }}"
+      check_mode: true
+      register: endpoint_delete_check
+    - ansible.builtin.assert:
+        that:
+          - endpoint_delete_check is changed
 
-  - name: Delete minimal endpoint by ID (check_mode)
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ endpoint_id }}'
-    check_mode: true
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is changed
+    - name: Delete minimal endpoint by ID
+      amazon.aws.ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ endpoint_id }}"
+      register: endpoint_delete_check
+    - ansible.builtin.assert:
+        that:
+          - endpoint_delete_check is changed
 
+    - name: Delete minimal endpoint by ID - idempotency (check_mode)
+      amazon.aws.ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ endpoint_id }}"
+      check_mode: true
+      register: endpoint_delete_check
+    - ansible.builtin.assert:
+        that:
+          - endpoint_delete_check is not changed
 
-  - name: Delete minimal endpoint by ID
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ endpoint_id }}'
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is changed
+    - name: Delete minimal endpoint by ID - idempotency
+      amazon.aws.ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ endpoint_id }}"
+      register: endpoint_delete_check
+    - ansible.builtin.assert:
+        that:
+          - endpoint_delete_check is not changed
 
-  - name: Delete minimal endpoint by ID - idempotency (check_mode)
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ endpoint_id }}'
-    check_mode: true
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is not changed
+    - name: Fetch Endpoints by ID (expect failed)
+      amazon.aws.ec2_vpc_endpoint_info:
+        vpc_endpoint_ids: "{{ endpoint_id }}"
+      ignore_errors: true
+      register: endpoint_info
+    - name: Assert endpoint does not exist
+      ansible.builtin.assert:
+        that:
+          - endpoint_info is successful
+          - '"does not exist" in endpoint_info.msg'
+          - endpoint_info.vpc_endpoints | length == 0
 
-  - name: Delete minimal endpoint by ID - idempotency
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ endpoint_id }}'
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is not changed
+    # Attempt to create an endpoint with a route table
+    - name: Create an endpoint with route table (check mode)
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        service: "{{ endpoint_service_a }}"
+        route_table_ids:
+          - "{{ rtb_empty_id }}"
+      register: create_endpoint_check
+      check_mode: true
+    - name: Assert changed
+      ansible.builtin.assert:
+        that:
+          - create_endpoint_check is changed
 
-  - name: Fetch Endpoints by ID (expect failed)
-    ec2_vpc_endpoint_info:
-      vpc_endpoint_ids: '{{ endpoint_id }}'
-    ignore_errors: true
-    register: endpoint_info
-  - name: Assert endpoint does not exist
-    assert:
-      that:
-      - endpoint_info is successful
-      - '"does not exist" in endpoint_info.msg'
-      - endpoint_info.vpc_endpoints | length == 0
+    - name: Create an endpoint with route table
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        service: "{{ endpoint_service_a }}"
+        route_table_ids:
+          - "{{ rtb_empty_id }}"
+        wait: true
+      register: create_rtb_endpoint
+    - name: Check standard return values
+      ansible.builtin.assert:
+        that:
+          - create_rtb_endpoint is changed
+          - '"result" in create_rtb_endpoint'
+          - '"creation_timestamp" in create_rtb_endpoint.result'
+          - '"dns_entries" in create_rtb_endpoint.result'
+          - '"groups" in create_rtb_endpoint.result'
+          - '"network_interface_ids" in create_rtb_endpoint.result'
+          - '"owner_id" in create_rtb_endpoint.result'
+          - '"policy_document" in create_rtb_endpoint.result'
+          - '"private_dns_enabled" in create_rtb_endpoint.result'
+          - '"route_table_ids" in create_rtb_endpoint.result'
+          - create_rtb_endpoint.result.route_table_ids | length == 1
+          - create_rtb_endpoint.result.route_table_ids[0] == '{{ rtb_empty_id }}'
+          - create_rtb_endpoint.result.private_dns_enabled == False
+          - '"requester_managed" in create_rtb_endpoint.result'
+          - create_rtb_endpoint.result.requester_managed == False
+          - '"service_name" in create_rtb_endpoint.result'
+          - create_rtb_endpoint.result.service_name == endpoint_service_a
+          - '"state" in create_endpoint.result'
+          - create_rtb_endpoint.result.state == "available"
+          - '"vpc_endpoint_id" in create_rtb_endpoint.result'
+          - create_rtb_endpoint.result.vpc_endpoint_id.startswith("vpce-")
+          - '"vpc_endpoint_type" in create_rtb_endpoint.result'
+          - create_rtb_endpoint.result.vpc_endpoint_type == "Gateway"
+          - '"vpc_id" in create_rtb_endpoint.result'
+          - create_rtb_endpoint.result.vpc_id == vpc_id
 
-  # Attempt to create an endpoint with a route table
-  - name: Create an endpoint with route table (check mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_empty_id }}'
-    register: create_endpoint_check
-    check_mode: true
-  - name: Assert changed
-    assert:
-      that:
-      - create_endpoint_check is changed
+    - name: Save Endpoint info in a fact
+      ansible.builtin.set_fact:
+        rtb_endpoint_id: "{{ create_rtb_endpoint.result.vpc_endpoint_id }}"
 
-  - name: Create an endpoint with route table
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_empty_id }}'
-      wait: true
-    register: create_rtb_endpoint
-  - name: Check standard return values
-    assert:
-      that:
-      - create_rtb_endpoint is changed
-      - '"result" in create_rtb_endpoint'
-      - '"creation_timestamp" in create_rtb_endpoint.result'
-      - '"dns_entries" in create_rtb_endpoint.result'
-      - '"groups" in create_rtb_endpoint.result'
-      - '"network_interface_ids" in create_rtb_endpoint.result'
-      - '"owner_id" in create_rtb_endpoint.result'
-      - '"policy_document" in create_rtb_endpoint.result'
-      - '"private_dns_enabled" in create_rtb_endpoint.result'
-      - '"route_table_ids" in create_rtb_endpoint.result'
-      - create_rtb_endpoint.result.route_table_ids | length == 1
-      - create_rtb_endpoint.result.route_table_ids[0] == '{{ rtb_empty_id }}'
-      - create_rtb_endpoint.result.private_dns_enabled == False
-      - '"requester_managed" in create_rtb_endpoint.result'
-      - create_rtb_endpoint.result.requester_managed == False
-      - '"service_name" in create_rtb_endpoint.result'
-      - create_rtb_endpoint.result.service_name == endpoint_service_a
-      - '"state" in create_endpoint.result'
-      - create_rtb_endpoint.result.state == "available"
-      - '"vpc_endpoint_id" in create_rtb_endpoint.result'
-      - create_rtb_endpoint.result.vpc_endpoint_id.startswith("vpce-")
-      - '"vpc_endpoint_type" in create_rtb_endpoint.result'
-      - create_rtb_endpoint.result.vpc_endpoint_type == "Gateway"
-      - '"vpc_id" in create_rtb_endpoint.result'
-      - create_rtb_endpoint.result.vpc_id == vpc_id
+    - name: Create an endpoint with route table - idempotency (check mode)
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        service: "{{ endpoint_service_a }}"
+        route_table_ids:
+          - "{{ rtb_empty_id }}"
+      register: create_endpoint_check
+      check_mode: true
+    - name: Assert changed
+      ansible.builtin.assert:
+        that:
+          - create_endpoint_check is not changed
 
-  - name: Save Endpoint info in a fact
-    set_fact:
-      rtb_endpoint_id: '{{ create_rtb_endpoint.result.vpc_endpoint_id }}'
+    - name: Create an endpoint with route table - idempotency
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        service: "{{ endpoint_service_a }}"
+        route_table_ids:
+          - "{{ rtb_empty_id }}"
+      register: create_endpoint_check
+      check_mode: true
+    - name: Assert changed
+      ansible.builtin.assert:
+        that:
+          - create_endpoint_check is not changed
 
-  - name: Create an endpoint with route table - idempotency (check mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_empty_id }}'
-    register: create_endpoint_check
-    check_mode: true
-  - name: Assert changed
-    assert:
-      that:
-      - create_endpoint_check is not changed
+    # # Endpoint modifications are not yet supported by the module
+    #  # A Change the route table for the endpoint
+    #  - name: Change the route table for the endpoint (check_mode)
+    #    ec2_vpc_endpoint:
+    #      state: present
+    #      vpc_id: '{{ vpc_id }}'
+    #      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+    #      service: '{{ endpoint_service_a }}'
+    #      route_table_ids:
+    #        - '{{ rtb_igw_id }}'
+    #    check_mode: True
+    #    register: check_two_rtbs_endpoint
+    #
+    #  - name: Assert second route table would be added
+    #    assert:
+    #      that:
+    #        - check_two_rtbs_endpoint.changed
+    #
+    #  - name: Change the route table for the endpoint
+    #    ec2_vpc_endpoint:
+    #      state: present
+    #      vpc_id: '{{ vpc_id }}'
+    #      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+    #      service: '{{ endpoint_service_a }}'
+    #      route_table_ids:
+    #        - '{{ rtb_igw_id }}'
+    #    register: two_rtbs_endpoint
+    #
+    #  - name: Assert second route table would be added
+    #    assert:
+    #      that:
+    #        - check_two_rtbs_endpoint.changed
+    #        - two_rtbs_endpoint.result.route_table_ids | length == 1
+    #        - two_rtbs_endpoint.result.route_table_ids[0] == '{{ rtb_igw_id }}'
+    #
+    #  - name: Change the route table for the endpoint - idempotency (check_mode)
+    #    ec2_vpc_endpoint:
+    #      state: present
+    #      vpc_id: '{{ vpc_id }}'
+    #      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+    #      service: '{{ endpoint_service_a }}'
+    #      route_table_ids:
+    #        - '{{ rtb_igw_id }}'
+    #    check_mode: True
+    #    register: check_two_rtbs_endpoint
+    #
+    #  - name: Assert route table would not change
+    #    assert:
+    #      that:
+    #        - not check_two_rtbs_endpoint.changed
+    #
+    #  - name: Change the route table for the endpoint - idempotency
+    #    ec2_vpc_endpoint:
+    #      state: present
+    #      vpc_id: '{{ vpc_id }}'
+    #      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+    #      service: '{{ endpoint_service_a }}'
+    #      route_table_ids:
+    #        - '{{ rtb_igw_id }}'
+    #    register: two_rtbs_endpoint
+    #
+    #  - name: Assert route table would not change
+    #    assert:
+    #      that:
+    #        - not check_two_rtbs_endpoint.changed
 
-  - name: Create an endpoint with route table - idempotency
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_empty_id }}'
-    register: create_endpoint_check
-    check_mode: true
-  - name: Assert changed
-    assert:
-      that:
-      - create_endpoint_check is not changed
+    - name: Tag the endpoint (check_mode)
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+        service: "{{ endpoint_service_a }}"
+        route_table_ids:
+          - "{{ rtb_empty_id }}"
+        tags:
+          camelCase: helloWorld
+          PascalCase: HelloWorld
+          snake_case: hello_world
+          Title Case: Hello World
+          lowercase spaced: hello world
+      check_mode: true
+      register: check_tag_vpc_endpoint
 
-# # Endpoint modifications are not yet supported by the module
-#  # A Change the route table for the endpoint
-#  - name: Change the route table for the endpoint (check_mode)
-#    ec2_vpc_endpoint:
-#      state: present
-#      vpc_id: '{{ vpc_id }}'
-#      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
-#      service: '{{ endpoint_service_a }}'
-#      route_table_ids:
-#        - '{{ rtb_igw_id }}'
-#    check_mode: True
-#    register: check_two_rtbs_endpoint
-#
-#  - name: Assert second route table would be added
-#    assert:
-#      that:
-#        - check_two_rtbs_endpoint.changed
-#
-#  - name: Change the route table for the endpoint
-#    ec2_vpc_endpoint:
-#      state: present
-#      vpc_id: '{{ vpc_id }}'
-#      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
-#      service: '{{ endpoint_service_a }}'
-#      route_table_ids:
-#        - '{{ rtb_igw_id }}'
-#    register: two_rtbs_endpoint
-#
-#  - name: Assert second route table would be added
-#    assert:
-#      that:
-#        - check_two_rtbs_endpoint.changed
-#        - two_rtbs_endpoint.result.route_table_ids | length == 1
-#        - two_rtbs_endpoint.result.route_table_ids[0] == '{{ rtb_igw_id }}'
-#
-#  - name: Change the route table for the endpoint - idempotency (check_mode)
-#    ec2_vpc_endpoint:
-#      state: present
-#      vpc_id: '{{ vpc_id }}'
-#      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
-#      service: '{{ endpoint_service_a }}'
-#      route_table_ids:
-#        - '{{ rtb_igw_id }}'
-#    check_mode: True
-#    register: check_two_rtbs_endpoint
-#
-#  - name: Assert route table would not change
-#    assert:
-#      that:
-#        - not check_two_rtbs_endpoint.changed
-#
-#  - name: Change the route table for the endpoint - idempotency
-#    ec2_vpc_endpoint:
-#      state: present
-#      vpc_id: '{{ vpc_id }}'
-#      vpc_endpoint_id: "{{ rtb_endpoint_id }}"
-#      service: '{{ endpoint_service_a }}'
-#      route_table_ids:
-#        - '{{ rtb_igw_id }}'
-#    register: two_rtbs_endpoint
-#
-#  - name: Assert route table would not change
-#    assert:
-#      that:
-#        - not check_two_rtbs_endpoint.changed
+    - name: Assert tags would have changed
+      ansible.builtin.assert:
+        that:
+          - check_tag_vpc_endpoint.changed
 
-  - name: Tag the endpoint (check_mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_empty_id }}'
-      tags:
-        camelCase: helloWorld
-        PascalCase: HelloWorld
-        snake_case: hello_world
-        Title Case: Hello World
-        lowercase spaced: hello world
-    check_mode: true
-    register: check_tag_vpc_endpoint
+    - name: Tag the endpoint
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+        service: "{{ endpoint_service_a }}"
+        route_table_ids:
+          - "{{ rtb_igw_id }}"
+        tags:
+          testPrefix: "{{ resource_prefix }}"
+          camelCase: helloWorld
+          PascalCase: HelloWorld
+          snake_case: hello_world
+          Title Case: Hello World
+          lowercase spaced: hello world
+      register: tag_vpc_endpoint
 
-  - name: Assert tags would have changed
-    assert:
-      that:
-      - check_tag_vpc_endpoint.changed
+    - name: Assert tags are successful
+      ansible.builtin.assert:
+        that:
+          - tag_vpc_endpoint.changed
+          - tag_vpc_endpoint.result.tags | length == 6
+          - endpoint_tags["testPrefix"] == resource_prefix
+          - endpoint_tags["camelCase"] == "helloWorld"
+          - endpoint_tags["PascalCase"] == "HelloWorld"
+          - endpoint_tags["snake_case"] == "hello_world"
+          - endpoint_tags["Title Case"] == "Hello World"
+          - endpoint_tags["lowercase spaced"] == "hello world"
+      vars:
+        endpoint_tags: "{{ tag_vpc_endpoint.result.tags | items2dict(key_name='Key', value_name='Value') }}"
 
-  - name: Tag the endpoint
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_igw_id }}'
-      tags:
-        testPrefix: '{{ resource_prefix }}'
-        camelCase: helloWorld
-        PascalCase: HelloWorld
-        snake_case: hello_world
-        Title Case: Hello World
-        lowercase spaced: hello world
-    register: tag_vpc_endpoint
+    - name: Query by tag
+      amazon.aws.ec2_vpc_endpoint_info:
+        filters:
+          tag:testPrefix:
+            - "{{ resource_prefix }}"
+      register: tag_result
 
-  - name: Assert tags are successful
-    assert:
-      that:
-      - tag_vpc_endpoint.changed
-      - tag_vpc_endpoint.result.tags | length == 6
-      - endpoint_tags["testPrefix"] == resource_prefix
-      - endpoint_tags["camelCase"] == "helloWorld"
-      - endpoint_tags["PascalCase"] == "HelloWorld"
-      - endpoint_tags["snake_case"] == "hello_world"
-      - endpoint_tags["Title Case"] == "Hello World"
-      - endpoint_tags["lowercase spaced"] == "hello world"
-    vars:
-      endpoint_tags: "{{ tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
-        \ value_name='Value') }}"
+    - name: Assert tag lookup found endpoint
+      ansible.builtin.assert:
+        that:
+          - tag_result is successful
+          - '"vpc_endpoints" in tag_result'
+          - first_endpoint.vpc_endpoint_id == rtb_endpoint_id
+      vars:
+        first_endpoint: "{{ tag_result.vpc_endpoints[0] }}"
 
-  - name: Query by tag
-    ec2_vpc_endpoint_info:
-      filters:
-        tag:testPrefix:
-        - '{{ resource_prefix }}'
-    register: tag_result
+    - name: Tag the endpoint - idempotency (check_mode)
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+        service: "{{ endpoint_service_a }}"
+        route_table_ids:
+          - "{{ rtb_igw_id }}"
+        tags:
+          testPrefix: "{{ resource_prefix }}"
+          camelCase: helloWorld
+          PascalCase: HelloWorld
+          snake_case: hello_world
+          Title Case: Hello World
+          lowercase spaced: hello world
+      register: tag_vpc_endpoint_again
 
-  - name: Assert tag lookup found endpoint
-    assert:
-      that:
-      - tag_result is successful
-      - '"vpc_endpoints" in tag_result'
-      - first_endpoint.vpc_endpoint_id == rtb_endpoint_id
-    vars:
-      first_endpoint: '{{ tag_result.vpc_endpoints[0] }}'
+    - name: Assert tags would not change
+      ansible.builtin.assert:
+        that:
+          - not tag_vpc_endpoint_again.changed
 
-  - name: Tag the endpoint - idempotency (check_mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_igw_id }}'
-      tags:
-        testPrefix: '{{ resource_prefix }}'
-        camelCase: helloWorld
-        PascalCase: HelloWorld
-        snake_case: hello_world
-        Title Case: Hello World
-        lowercase spaced: hello world
-    register: tag_vpc_endpoint_again
+    - name: Tag the endpoint - idempotency
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+        service: "{{ endpoint_service_a }}"
+        route_table_ids:
+          - "{{ rtb_igw_id }}"
+        tags:
+          testPrefix: "{{ resource_prefix }}"
+          camelCase: helloWorld
+          PascalCase: HelloWorld
+          snake_case: hello_world
+          Title Case: Hello World
+          lowercase spaced: hello world
+      register: tag_vpc_endpoint_again
 
-  - name: Assert tags would not change
-    assert:
-      that:
-      - not tag_vpc_endpoint_again.changed
+    - name: Assert tags would not change
+      ansible.builtin.assert:
+        that:
+          - not tag_vpc_endpoint_again.changed
 
-  - name: Tag the endpoint - idempotency
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_igw_id }}'
-      tags:
-        testPrefix: '{{ resource_prefix }}'
-        camelCase: helloWorld
-        PascalCase: HelloWorld
-        snake_case: hello_world
-        Title Case: Hello World
-        lowercase spaced: hello world
-    register: tag_vpc_endpoint_again
+    - name: Add a tag (check_mode)
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+        service: "{{ endpoint_service_a }}"
+        route_table_ids:
+          - "{{ rtb_igw_id }}"
+        tags:
+          new_tag: ANewTag
+      check_mode: true
+      register: check_tag_vpc_endpoint
 
-  - name: Assert tags would not change
-    assert:
-      that:
-      - not tag_vpc_endpoint_again.changed
+    - name: Assert tags would have changed
+      ansible.builtin.assert:
+        that:
+          - check_tag_vpc_endpoint.changed
 
-  - name: Add a tag (check_mode)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_igw_id }}'
-      tags:
-        new_tag: ANewTag
-    check_mode: true
-    register: check_tag_vpc_endpoint
+    - name: Add a tag (purge_tags=False)
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+        service: "{{ endpoint_service_a }}"
+        route_table_ids:
+          - "{{ rtb_igw_id }}"
+        purge_tags: false
+        tags:
+          new_tag: ANewTag
+      register: add_tag_vpc_endpoint
 
-  - name: Assert tags would have changed
-    assert:
-      that:
-      - check_tag_vpc_endpoint.changed
+    - name: Assert tags changed
+      ansible.builtin.assert:
+        that:
+          - add_tag_vpc_endpoint.changed
+          - add_tag_vpc_endpoint.result.tags | length == 7
+          - endpoint_tags["testPrefix"] == resource_prefix
+          - endpoint_tags["camelCase"] == "helloWorld"
+          - endpoint_tags["PascalCase"] == "HelloWorld"
+          - endpoint_tags["snake_case"] == "hello_world"
+          - endpoint_tags["Title Case"] == "Hello World"
+          - endpoint_tags["lowercase spaced"] == "hello world"
+          - endpoint_tags["new_tag"] == "ANewTag"
+      vars:
+        endpoint_tags: "{{ add_tag_vpc_endpoint.result.tags | items2dict(key_name='Key', value_name='Value') }}"
 
-  - name: Add a tag (purge_tags=False)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_igw_id }}'
-      purge_tags: false
-      tags:
-        new_tag: ANewTag
-    register: add_tag_vpc_endpoint
+    - name: Add a tag (purge_tags=True)
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+        service: "{{ endpoint_service_a }}"
+        route_table_ids:
+          - "{{ rtb_igw_id }}"
+        tags:
+          another_new_tag: AnotherNewTag
+        purge_tags: true
+      register: purge_tag_vpc_endpoint
 
-  - name: Assert tags changed
-    assert:
-      that:
-      - add_tag_vpc_endpoint.changed
-      - add_tag_vpc_endpoint.result.tags | length == 7
-      - endpoint_tags["testPrefix"] == resource_prefix
-      - endpoint_tags["camelCase"] == "helloWorld"
-      - endpoint_tags["PascalCase"] == "HelloWorld"
-      - endpoint_tags["snake_case"] == "hello_world"
-      - endpoint_tags["Title Case"] == "Hello World"
-      - endpoint_tags["lowercase spaced"] == "hello world"
-      - endpoint_tags["new_tag"] == "ANewTag"
-    vars:
-      endpoint_tags: "{{ add_tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
-        \ value_name='Value') }}"
+    - name: Assert tags changed
+      ansible.builtin.assert:
+        that:
+          - purge_tag_vpc_endpoint.changed
+          - purge_tag_vpc_endpoint.result.tags | length == 1
+          - endpoint_tags["another_new_tag"] == "AnotherNewTag"
+      vars:
+        endpoint_tags: "{{ purge_tag_vpc_endpoint.result.tags | items2dict(key_name='Key', value_name='Value') }}"
 
-  - name: Add a tag (purge_tags=True)
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-      service: '{{ endpoint_service_a }}'
-      route_table_ids:
-      - '{{ rtb_igw_id }}'
-      tags:
-        another_new_tag: AnotherNewTag
-      purge_tags: true
-    register: purge_tag_vpc_endpoint
+    - name: Delete minimal route table (no routes)
+      amazon.aws.ec2_vpc_route_table:
+        state: absent
+        lookup: id
+        route_table_id: "{{ rtb_empty_id }}"
+      register: rtb_delete
+    - ansible.builtin.assert:
+        that:
+          - rtb_delete is changed
 
-  - name: Assert tags changed
-    assert:
-      that:
-      - purge_tag_vpc_endpoint.changed
-      - purge_tag_vpc_endpoint.result.tags | length == 1
-      - endpoint_tags["another_new_tag"] == "AnotherNewTag"
-    vars:
-      endpoint_tags: "{{ purge_tag_vpc_endpoint.result.tags | items2dict(key_name='Key',\
-        \ value_name='Value') }}"
+    - name: Delete minimal route table (IGW route)
+      amazon.aws.ec2_vpc_route_table:
+        state: absent
+        lookup: id
+        route_table_id: "{{ rtb_igw_id }}"
+    - ansible.builtin.assert:
+        that:
+          - rtb_delete is changed
 
-  - name: Delete minimal route table (no routes)
-    ec2_vpc_route_table:
-      state: absent
-      lookup: id
-      route_table_id: '{{ rtb_empty_id }}'
-    register: rtb_delete
-  - assert:
-      that:
-      - rtb_delete is changed
+    - name: Delete route table endpoint by ID
+      amazon.aws.ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+      register: endpoint_delete_check
+    - ansible.builtin.assert:
+        that:
+          - endpoint_delete_check is changed
 
-  - name: Delete minimal route table (IGW route)
-    ec2_vpc_route_table:
-      state: absent
-      lookup: id
-      route_table_id: '{{ rtb_igw_id }}'
-  - assert:
-      that:
-      - rtb_delete is changed
+    - name: Delete minimal endpoint by ID - idempotency (check_mode)
+      amazon.aws.ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ rtb_endpoint_id }}"
+      check_mode: true
+      register: endpoint_delete_check
+    - ansible.builtin.assert:
+        that:
+          - endpoint_delete_check is not changed
 
-  - name: Delete route table endpoint by ID
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is changed
+    - name: Delete endpoint by ID - idempotency
+      amazon.aws.ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ endpoint_id }}"
+      register: endpoint_delete_check
+    - ansible.builtin.assert:
+        that:
+          - endpoint_delete_check is not changed
 
-  - name: Delete minimal endpoint by ID - idempotency (check_mode)
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ rtb_endpoint_id }}'
-    check_mode: true
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is not changed
+    - name: Create interface endpoint
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        service: "{{ endpoint_service_a }}"
+        vpc_endpoint_type: Interface
+      register: create_interface_endpoint
+    - name: Check that the interface endpoint was created properly
+      ansible.builtin.assert:
+        that:
+          - create_interface_endpoint is changed
+          - create_interface_endpoint.result.vpc_endpoint_type == "Interface"
+    - name: Delete interface endpoint
+      amazon.aws.ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ create_interface_endpoint.result.vpc_endpoint_id }}"
+      register: interface_endpoint_delete_check
+    - ansible.builtin.assert:
+        that:
+          - interface_endpoint_delete_check is changed
 
-  - name: Delete endpoint by ID - idempotency
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ endpoint_id }}'
-    register: endpoint_delete_check
-  - assert:
-      that:
-      - endpoint_delete_check is not changed
+    - name: Create a subnet
+      amazon.aws.ec2_vpc_subnet:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        az: "{{ aws_region}}a"
+        cidr: "{{ vpc_cidr }}"
+      register: interface_endpoint_create_subnet_check
 
-  - name: Create interface endpoint
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_a }}'
-      vpc_endpoint_type: Interface
-    register: create_interface_endpoint
-  - name: Check that the interface endpoint was created properly
-    assert:
-      that:
-      - create_interface_endpoint is changed
-      - create_interface_endpoint.result.vpc_endpoint_type == "Interface"
-  - name: Delete interface endpoint
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ create_interface_endpoint.result.vpc_endpoint_id }}'
-    register: interface_endpoint_delete_check
-  - assert:
-      that:
-      - interface_endpoint_delete_check is changed
+    - name: Create a security group
+      ec2_security_group:
+        name: securitygroup-prodext
+        description: security group for Ansible interface endpoint
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        rules:
+          - proto: tcp
+            from_port: 1
+            to_port: 65535
+            cidr_ip: "0.0.0.0/0"
+      register: interface_endpoint_create_sg_check
 
-  - name: Create a subnet
-    ec2_vpc_subnet:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      az: "{{ aws_region}}a"
-      cidr: "{{ vpc_cidr }}"
-    register: interface_endpoint_create_subnet_check
+    - name: Create interface endpoint attached to a subnet
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        service: "{{ endpoint_service_c }}"
+        vpc_endpoint_type: Interface
+        vpc_endpoint_subnets: "{{ interface_endpoint_create_subnet_check.subnet.id }}"
+        vpc_endpoint_security_groups: "{{ interface_endpoint_create_sg_check.group_id }}"
+        wait: true
+      register: create_interface_endpoint_with_sg_subnets
+    - name: Check that the interface endpoint was created properly
+      ansible.builtin.assert:
+        that:
+          - create_interface_endpoint_with_sg_subnets is changed
+          - create_interface_endpoint_with_sg_subnets.result.vpc_endpoint_type == "Interface"
 
-  - name: Create a security group
-    ec2_security_group:
-      name: securitygroup-prodext
-      description: "security group for Ansible interface endpoint"
-      state: present
-      vpc_id: "{{ vpc_id }}"
-      rules:
-        - proto: tcp
-          from_port: 1
-          to_port: 65535
-          cidr_ip: 0.0.0.0/0
-    register: interface_endpoint_create_sg_check
-
-  - name: Create interface endpoint attached to a subnet
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      service: '{{ endpoint_service_c }}'
-      vpc_endpoint_type: Interface
-      vpc_endpoint_subnets: "{{ interface_endpoint_create_subnet_check.subnet.id }}"
-      vpc_endpoint_security_groups: "{{ interface_endpoint_create_sg_check.group_id }}"
-      wait: true
-    register: create_interface_endpoint_with_sg_subnets
-  - name: Check that the interface endpoint was created properly
-    assert:
-      that:
-        - create_interface_endpoint_with_sg_subnets is changed
-        - create_interface_endpoint_with_sg_subnets.result.vpc_endpoint_type == "Interface"
-
-  - name: Delete interface endpoint
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: "{{ create_interface_endpoint_with_sg_subnets.result.vpc_endpoint_id }}"
-      wait: true
-    register: create_interface_endpoint_with_sg_subnets_delete_check
-  - assert:
-      that:
-        - create_interface_endpoint_with_sg_subnets_delete_check is changed
+    - name: Delete interface endpoint
+      amazon.aws.ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ create_interface_endpoint_with_sg_subnets.result.vpc_endpoint_id }}"
+        wait: true
+      register: create_interface_endpoint_with_sg_subnets_delete_check
+    - ansible.builtin.assert:
+        that:
+          - create_interface_endpoint_with_sg_subnets_delete_check is changed
 
   # ============================================================
   # BEGIN POST-TEST CLEANUP
   always:
-  - name: Query any remain endpoints we created
-    ec2_vpc_endpoint_info:
-      filters:
-        vpc-id:
-        - '{{ vpc_id }}'
-    register: remaining_endpoints
+    - name: Query any remain endpoints we created
+      amazon.aws.ec2_vpc_endpoint_info:
+        filters:
+          vpc-id:
+            - "{{ vpc_id }}"
+      register: remaining_endpoints
 
-  - name: Delete all endpoints
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ item.vpc_endpoint_id }}'
-      wait: true
-    loop: '{{ remaining_endpoints.vpc_endpoints }}'
-    ignore_errors: true
-    register: endpoints_removed
-    until:
-      - endpoints_removed is not failed
-      - endpoints_removed is not changed
-    retries: 20
-    delay: 10
+    - name: Delete all endpoints
+      amazon.aws.ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ item.vpc_endpoint_id }}"
+        wait: true
+      loop: "{{ remaining_endpoints.vpc_endpoints }}"
+      ignore_errors: true
+      register: endpoints_removed
+      until:
+        - endpoints_removed is not failed
+        - endpoints_removed is not changed
+      retries: 20
+      delay: 10
 
-  - include_role:
-      name: 'setup_ec2_vpc'
-      tasks_from: 'cleanup.yml'
-    vars:
-      vpc_id: '{{ vpc_creation.vpc.id }}'
+    - ansible.builtin.include_role:
+        name: setup_ec2_vpc
+        tasks_from: cleanup.yml
+      vars:
+        vpc_id: "{{ vpc_creation.vpc.id }}"

--- a/tests/integration/targets/ec2_vpc_endpoint_service_info/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint_service_info/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 search_service_names:
-  - 'com.amazonaws.{{ aws_region }}.s3'
-  - 'com.amazonaws.{{ aws_region }}.ec2'
+  - com.amazonaws.{{ aws_region }}.s3
+  - com.amazonaws.{{ aws_region }}.ec2

--- a/tests/integration/targets/ec2_vpc_endpoint_service_info/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint_service_info/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/ec2_vpc_endpoint_service_info/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_endpoint_service_info/tasks/main.yml
@@ -10,12 +10,12 @@
     - amazon.aws
     - community.aws
   block:
-    - name: "List all available services (Check Mode)"
+    - name: List all available services (Check Mode)
       ec2_vpc_endpoint_service_info:
       check_mode: true
       register: services_check
 
-    - name: "Verify services (Check Mode)"
+    - name: Verify services (Check Mode)
       vars:
         first_service: "{{ services_check.service_details[0] }}"
       ansible.builtin.assert:
@@ -37,11 +37,11 @@
           - '"tags" in first_service'
           - '"vpc_endpoint_policy_supported" in first_service'
 
-    - name: "List all available services"
+    - name: List all available services
       ec2_vpc_endpoint_service_info:
       register: services_info
 
-    - name: "Verify services"
+    - name: Verify services
       vars:
         first_service: "{{ services_info.service_details[0] }}"
       ansible.builtin.assert:
@@ -63,12 +63,12 @@
           - '"tags" in first_service'
           - '"vpc_endpoint_policy_supported" in first_service'
 
-    - name: "Limit services by name"
+    - name: Limit services by name
       ec2_vpc_endpoint_service_info:
         service_names: "{{ search_service_names }}"
       register: services_info
 
-    - name: "Verify services"
+    - name: Verify services
       vars:
         first_service: "{{ services_info.service_details[0] }}"
         # The same service sometimes pop up twice. s3 for example has
@@ -100,17 +100,17 @@
           - '"tags" in first_service'
           - '"vpc_endpoint_policy_supported" in first_service'
 
-    - name: "Grab single service details to test filters"
+    - name: Grab single service details to test filters
       ansible.builtin.set_fact:
         example_service: "{{ services_info.service_details[0] }}"
 
-    - name: "Limit services by filter"
+    - name: Limit services by filter
       ec2_vpc_endpoint_service_info:
         filters:
           service-name: "{{ example_service.service_name }}"
       register: filtered_service
 
-    - name: "Verify services"
+    - name: Verify services
       vars:
         first_service: "{{ filtered_service.service_details[0] }}"
       ansible.builtin.assert:

--- a/tests/integration/targets/ec2_vpc_igw/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_igw/defaults/main.yml
@@ -1,6 +1,7 @@
-vpc_name: '{{ resource_prefix }}-vpc'
-vpc_seed: '{{ resource_prefix }}'
+---
+vpc_name: "{{ resource_prefix }}-vpc"
+vpc_seed: "{{ resource_prefix }}"
 vpc_cidr: 10.{{ 256 | random(seed=vpc_seed) }}.0.0/16
-vpc_name_2: '{{ tiny_prefix }}-vpc-2'
-vpc_seed_2: '{{ tiny_prefix }}'
+vpc_name_2: "{{ tiny_prefix }}-vpc-2"
+vpc_seed_2: "{{ tiny_prefix }}"
 vpc_cidr_2: 10.{{ 256 | random(seed=vpc_seed_2) }}.0.0/16

--- a/tests/integration/targets/ec2_vpc_igw/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_igw/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/ec2_vpc_igw/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_igw/tasks/main.yml
@@ -1,850 +1,848 @@
+---
 - name: ec2_vpc_igw tests
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
   # ============================================================
-  - name: Fetch IGWs in check_mode
-    ec2_vpc_igw_info:
-    register: igw_info
-    check_mode: true
-  - name: Assert success
-    assert:
-      that:
-      - igw_info is successful
-      - '"internet_gateways" in igw_info'
+    - name: Fetch IGWs in check_mode
+      amazon.aws.ec2_vpc_igw_info:
+      register: igw_info
+      check_mode: true
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - igw_info is successful
+          - '"internet_gateways" in igw_info'
 
-  # ============================================================
-  - name: Create a VPC
-    ec2_vpc_net:
-      name: '{{ vpc_name }}'
-      state: present
-      cidr_block: '{{ vpc_cidr }}'
-      tags:
-        Name: '{{ resource_prefix }}-vpc'
-        Description: Created by ansible-test
-    register: vpc_result
-  - name: Assert success
-    assert:
-      that:
-      - vpc_result is successful
-      - '"vpc" in vpc_result'
-      - '"id" in vpc_result.vpc'
-      - vpc_result.vpc.state == 'available'
-      - '"tags" in vpc_result.vpc'
-      - vpc_result.vpc.tags | length == 2
-      - vpc_result.vpc.tags["Name"] == resource_prefix+"-vpc"
-      - vpc_result.vpc.tags["Description"] == "Created by ansible-test"
+    # ============================================================
+    - name: Create a VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ vpc_name }}"
+        state: present
+        cidr_block: "{{ vpc_cidr }}"
+        tags:
+          Name: "{{ resource_prefix }}-vpc"
+          Description: Created by ansible-test
+      register: vpc_result
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - vpc_result is successful
+          - '"vpc" in vpc_result'
+          - '"id" in vpc_result.vpc'
+          - vpc_result.vpc.state == 'available'
+          - '"tags" in vpc_result.vpc'
+          - vpc_result.vpc.tags | length == 2
+          - vpc_result.vpc.tags["Name"] == resource_prefix+"-vpc"
+          - vpc_result.vpc.tags["Description"] == "Created by ansible-test"
 
-  # ============================================================
-  - name: Create a second VPC
-    ec2_vpc_net:
-      name: '{{ vpc_name_2 }}'
-      state: present
-      cidr_block: '{{ vpc_cidr_2 }}'
-      tags:
-        Description: Created by ansible-test
-    register: vpc_2_result
+    # ============================================================
+    - name: Create a second VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ vpc_name_2 }}"
+        state: present
+        cidr_block: "{{ vpc_cidr_2 }}"
+        tags:
+          Description: Created by ansible-test
+      register: vpc_2_result
 
-  # ============================================================
-  - name: Search for internet gateway by VPC - no matches
-    ec2_vpc_igw_info:
-      filters:
-        attachment.vpc-id: '{{ vpc_result.vpc.id }}'
-    register: igw_info
+    # ============================================================
+    - name: Search for internet gateway by VPC - no matches
+      amazon.aws.ec2_vpc_igw_info:
+        filters:
+          attachment.vpc-id: "{{ vpc_result.vpc.id }}"
+      register: igw_info
 
-  - name: Assert success
-    assert:
-      that:
-      - igw_info is successful
-      - '"internet_gateways" in igw_info'
-      - (igw_info.internet_gateways | length) == 0
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - igw_info is successful
+          - '"internet_gateways" in igw_info'
+          - (igw_info.internet_gateways | length) == 0
 
-  # ============================================================
-  - name: Create internet gateway (expected changed=true) - CHECK_MODE
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      tags:
-        tag_one: '{{ resource_prefix }} One'
-        Tag Two: two {{ resource_prefix }}
-    register: vpc_igw_create
-    check_mode: yes
+    # ============================================================
+    - name: Create internet gateway (expected changed=true) - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          tag_one: "{{ resource_prefix }} One"
+          Tag Two: two {{ resource_prefix }}
+      register: vpc_igw_create
+      check_mode: true
 
-  - name: Assert creation would happen (expected changed=true) - CHECK_MODE
-    assert:
-      that:
-      - vpc_igw_create is changed
+    - name: Assert creation would happen (expected changed=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_create is changed
 
-  - name: Create internet gateway (expected changed=true)
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      tags:
-        tag_one: '{{ resource_prefix }} One'
-        Tag Two: two {{ resource_prefix }}
-    register: vpc_igw_create
+    - name: Create internet gateway (expected changed=true)
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          tag_one: "{{ resource_prefix }} One"
+          Tag Two: two {{ resource_prefix }}
+      register: vpc_igw_create
 
-  - name: Assert creation happened (expected changed=true)
-    assert:
-      that:
-      - "'ec2:CreateTags' not in vpc_igw_create.resource_actions"
-      - "'ec2:DeleteTags' not in vpc_igw_create.resource_actions"
-      - vpc_igw_create is changed
-      - vpc_igw_create.gateway_id.startswith("igw-")
-      - vpc_igw_create.vpc_id == vpc_result.vpc.id
-      - '"tags" in vpc_igw_create'
-      - vpc_igw_create.tags | length == 2
-      - vpc_igw_create.tags["tag_one"] == '{{ resource_prefix }} One'
-      - vpc_igw_create.tags["Tag Two"] == 'two {{ resource_prefix }}'
-      - '"gateway_id" in vpc_igw_create'
+    - name: Assert creation happened (expected changed=true)
+      ansible.builtin.assert:
+        that:
+          - "'ec2:CreateTags' not in vpc_igw_create.resource_actions"
+          - "'ec2:DeleteTags' not in vpc_igw_create.resource_actions"
+          - vpc_igw_create is changed
+          - vpc_igw_create.gateway_id.startswith("igw-")
+          - vpc_igw_create.vpc_id == vpc_result.vpc.id
+          - '"tags" in vpc_igw_create'
+          - vpc_igw_create.tags | length == 2
+          - vpc_igw_create.tags["tag_one"] == '{{ resource_prefix }} One'
+          - vpc_igw_create.tags["Tag Two"] == 'two {{ resource_prefix }}'
+          - '"gateway_id" in vpc_igw_create'
 
-  # ============================================================
-  - name: Save IDs for later
-    set_fact:
-      igw_id: '{{ vpc_igw_create.gateway_id }}'
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      vpc_2_id: '{{ vpc_2_result.vpc.id }}'
+    # ============================================================
+    - name: Save IDs for later
+      ansible.builtin.set_fact:
+        igw_id: "{{ vpc_igw_create.gateway_id }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        vpc_2_id: "{{ vpc_2_result.vpc.id }}"
 
-  - name: Search for internet gateway by VPC
-    ec2_vpc_igw_info:
-      filters:
-        attachment.vpc-id: '{{ vpc_id }}'
-      convert_tags: false
-    register: igw_info
+    - name: Search for internet gateway by VPC
+      amazon.aws.ec2_vpc_igw_info:
+        filters:
+          attachment.vpc-id: "{{ vpc_id }}"
+        convert_tags: false
+      register: igw_info
 
-  - name: Check standard IGW details
-    assert:
-      that:
-      - '"internet_gateways" in igw_info'
-      - igw_info.internet_gateways | length == 1
-      - '"attachments" in current_igw'
-      - current_igw.attachments | length == 1
-      - '"state" in current_igw.attachments[0]'
-      - current_igw.attachments[0].state == "available"
-      - '"vpc_id" in current_igw.attachments[0]'
-      - current_igw.attachments[0].vpc_id == vpc_id
-      - '"internet_gateway_id" in current_igw'
-      - current_igw.internet_gateway_id == igw_id
-      - '"tags" in current_igw'
-      - current_igw.tags | length == 2
-      - '"key" in current_igw.tags[0]'
-      - '"value" in current_igw.tags[0]'
-      - '"key" in current_igw.tags[1]'
-      - '"value" in current_igw.tags[1]'
+    - name: Check standard IGW details
+      ansible.builtin.assert:
+        that:
+          - '"internet_gateways" in igw_info'
+          - igw_info.internet_gateways | length == 1
+          - '"attachments" in current_igw'
+          - current_igw.attachments | length == 1
+          - '"state" in current_igw.attachments[0]'
+          - current_igw.attachments[0].state == "available"
+          - '"vpc_id" in current_igw.attachments[0]'
+          - current_igw.attachments[0].vpc_id == vpc_id
+          - '"internet_gateway_id" in current_igw'
+          - current_igw.internet_gateway_id == igw_id
+          - '"tags" in current_igw'
+          - current_igw.tags | length == 2
+          - '"key" in current_igw.tags[0]'
+          - '"value" in current_igw.tags[0]'
+          - '"key" in current_igw.tags[1]'
+          - '"value" in current_igw.tags[1]'
           # Order isn't guaranteed in boto3 style, so just check the keys and
           # values we expect are in there.
-      - current_igw.tags[0].key in ["tag_one", "Tag Two"]
-      - current_igw.tags[1].key in ["tag_one", "Tag Two"]
-      - current_igw.tags[0].value in [resource_prefix + " One", "two " + resource_prefix]
-      - current_igw.tags[1].value in [resource_prefix + " One", "two " + resource_prefix]
-    vars:
-      current_igw: '{{ igw_info.internet_gateways[0] }}'
+          - current_igw.tags[0].key in ["tag_one", "Tag Two"]
+          - current_igw.tags[1].key in ["tag_one", "Tag Two"]
+          - current_igw.tags[0].value in [resource_prefix + " One", "two " + resource_prefix]
+          - current_igw.tags[1].value in [resource_prefix + " One", "two " + resource_prefix]
+      vars:
+        current_igw: "{{ igw_info.internet_gateways[0] }}"
 
-  - name: Fetch IGW by ID
-    ec2_vpc_igw_info:
-      internet_gateway_ids: '{{ igw_id }}'
-    register: igw_info
+    - name: Fetch IGW by ID
+      amazon.aws.ec2_vpc_igw_info:
+        internet_gateway_ids: "{{ igw_id }}"
+      register: igw_info
 
-  - name: Check standard IGW details
-    assert:
-      that:
-      - '"internet_gateways" in igw_info'
-      - igw_info.internet_gateways | length == 1
-      - '"attachments" in current_igw'
-      - current_igw.attachments | length == 1
-      - '"state" in current_igw.attachments[0]'
-      - current_igw.attachments[0].state == "available"
-      - '"vpc_id" in current_igw.attachments[0]'
-      - current_igw.attachments[0].vpc_id == vpc_id
-      - '"internet_gateway_id" in current_igw'
-      - current_igw.internet_gateway_id == igw_id
-      - '"tags" in current_igw'
-      - current_igw.tags | length == 2
-      - '"tag_one" in current_igw.tags'
-      - '"Tag Two" in current_igw.tags'
-      - current_igw.tags["tag_one"] == '{{ resource_prefix }} One'
-      - current_igw.tags["Tag Two"] == 'two {{ resource_prefix }}'
-    vars:
-      current_igw: '{{ igw_info.internet_gateways[0] }}'
+    - name: Check standard IGW details
+      ansible.builtin.assert:
+        that:
+          - '"internet_gateways" in igw_info'
+          - igw_info.internet_gateways | length == 1
+          - '"attachments" in current_igw'
+          - current_igw.attachments | length == 1
+          - '"state" in current_igw.attachments[0]'
+          - current_igw.attachments[0].state == "available"
+          - '"vpc_id" in current_igw.attachments[0]'
+          - current_igw.attachments[0].vpc_id == vpc_id
+          - '"internet_gateway_id" in current_igw'
+          - current_igw.internet_gateway_id == igw_id
+          - '"tags" in current_igw'
+          - current_igw.tags | length == 2
+          - '"tag_one" in current_igw.tags'
+          - '"Tag Two" in current_igw.tags'
+          - current_igw.tags["tag_one"] == '{{ resource_prefix }} One'
+          - current_igw.tags["Tag Two"] == 'two {{ resource_prefix }}'
+      vars:
+        current_igw: "{{ igw_info.internet_gateways[0] }}"
 
-  - name: Fetch IGW by ID (list)
-    ec2_vpc_igw_info:
-      internet_gateway_ids:
-      - '{{ igw_id }}'
-    register: igw_info
+    - name: Fetch IGW by ID (list)
+      amazon.aws.ec2_vpc_igw_info:
+        internet_gateway_ids:
+          - "{{ igw_id }}"
+      register: igw_info
 
-  - name: Check standard IGW details
-    assert:
-      that:
-      - '"internet_gateways" in igw_info'
-      - igw_info.internet_gateways | length == 1
-      - '"attachments" in current_igw'
-      - current_igw.attachments | length == 1
-      - '"state" in current_igw.attachments[0]'
-      - current_igw.attachments[0].state == "available"
-      - '"vpc_id" in current_igw.attachments[0]'
-      - current_igw.attachments[0].vpc_id == vpc_id
-      - '"internet_gateway_id" in current_igw'
-      - current_igw.internet_gateway_id == igw_id
-      - '"tags" in current_igw'
-    vars:
-      current_igw: '{{ igw_info.internet_gateways[0] }}'
+    - name: Check standard IGW details
+      ansible.builtin.assert:
+        that:
+          - '"internet_gateways" in igw_info'
+          - igw_info.internet_gateways | length == 1
+          - '"attachments" in current_igw'
+          - current_igw.attachments | length == 1
+          - '"state" in current_igw.attachments[0]'
+          - current_igw.attachments[0].state == "available"
+          - '"vpc_id" in current_igw.attachments[0]'
+          - current_igw.attachments[0].vpc_id == vpc_id
+          - '"internet_gateway_id" in current_igw'
+          - current_igw.internet_gateway_id == igw_id
+          - '"tags" in current_igw'
+      vars:
+        current_igw: "{{ igw_info.internet_gateways[0] }}"
 
-  - name: Attempt to recreate internet gateway on VPC (expected changed=false) - CHECK_MODE
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-    register: vpc_igw_recreate
-    check_mode: yes
+    - name: Attempt to recreate internet gateway on VPC (expected changed=false) - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      register: vpc_igw_recreate
+      check_mode: true
 
-  - name: Assert recreation would do nothing (expected changed=false) - CHECK_MODE
-    assert:
-      that:
-      - vpc_igw_recreate is not changed
-      - vpc_igw_recreate.gateway_id == igw_id
-      - vpc_igw_recreate.vpc_id == vpc_id
-      - '"tags" in vpc_igw_create'
-      - vpc_igw_create.tags | length == 2
-      - vpc_igw_create.tags["tag_one"] == '{{ resource_prefix }} One'
-      - vpc_igw_create.tags["Tag Two"] == 'two {{ resource_prefix }}'
+    - name: Assert recreation would do nothing (expected changed=false) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_recreate is not changed
+          - vpc_igw_recreate.gateway_id == igw_id
+          - vpc_igw_recreate.vpc_id == vpc_id
+          - '"tags" in vpc_igw_create'
+          - vpc_igw_create.tags | length == 2
+          - vpc_igw_create.tags["tag_one"] == '{{ resource_prefix }} One'
+          - vpc_igw_create.tags["Tag Two"] == 'two {{ resource_prefix }}'
 
-  - name: Attempt to recreate internet gateway on VPC (expected changed=false)
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-    register: vpc_igw_recreate
+    - name: Attempt to recreate internet gateway on VPC (expected changed=false)
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      register: vpc_igw_recreate
 
-  - name: Assert recreation did nothing (expected changed=false)
-    assert:
-      that:
-      - vpc_igw_recreate is not changed
-      - vpc_igw_recreate.gateway_id == igw_id
-      - vpc_igw_recreate.vpc_id == vpc_id
-      - '"tags" in vpc_igw_create'
-      - vpc_igw_create.tags | length == 2
-      - vpc_igw_create.tags["tag_one"] == '{{ resource_prefix }} One'
-      - vpc_igw_create.tags["Tag Two"] == 'two {{ resource_prefix }}'
+    - name: Assert recreation did nothing (expected changed=false)
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_recreate is not changed
+          - vpc_igw_recreate.gateway_id == igw_id
+          - vpc_igw_recreate.vpc_id == vpc_id
+          - '"tags" in vpc_igw_create'
+          - vpc_igw_create.tags | length == 2
+          - vpc_igw_create.tags["tag_one"] == '{{ resource_prefix }} One'
+          - vpc_igw_create.tags["Tag Two"] == 'two {{ resource_prefix }}'
 
-  # ============================================================
-  - name: Update the tags (no change) - CHECK_MODE
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      tags:
-        tag_one: '{{ resource_prefix }} One'
-        Tag Two: two {{ resource_prefix }}
-    register: vpc_igw_recreate
-    check_mode: yes
+    # ============================================================
+    - name: Update the tags (no change) - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          tag_one: "{{ resource_prefix }} One"
+          Tag Two: two {{ resource_prefix }}
+      register: vpc_igw_recreate
+      check_mode: true
 
-  - name: Assert tag update would do nothing (expected changed=false) - CHECK_MODE
-    assert:
-      that:
-      - vpc_igw_recreate is not changed
-      - vpc_igw_recreate.gateway_id == igw_id
-      - vpc_igw_recreate.vpc_id == vpc_id
-      - '"tags" in vpc_igw_recreate'
-      - vpc_igw_recreate.tags | length == 2
-      - vpc_igw_recreate.tags["tag_one"] == '{{ resource_prefix }} One'
-      - vpc_igw_recreate.tags["Tag Two"] == 'two {{ resource_prefix }}'
+    - name: Assert tag update would do nothing (expected changed=false) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_recreate is not changed
+          - vpc_igw_recreate.gateway_id == igw_id
+          - vpc_igw_recreate.vpc_id == vpc_id
+          - '"tags" in vpc_igw_recreate'
+          - vpc_igw_recreate.tags | length == 2
+          - vpc_igw_recreate.tags["tag_one"] == '{{ resource_prefix }} One'
+          - vpc_igw_recreate.tags["Tag Two"] == 'two {{ resource_prefix }}'
 
-  - name: Update the tags (no change)
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      tags:
-        tag_one: '{{ resource_prefix }} One'
-        Tag Two: two {{ resource_prefix }}
-    register: vpc_igw_recreate
+    - name: Update the tags (no change)
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          tag_one: "{{ resource_prefix }} One"
+          Tag Two: two {{ resource_prefix }}
+      register: vpc_igw_recreate
 
-  - name: Assert tag update did nothing (expected changed=false)
-    assert:
-      that:
-      - vpc_igw_recreate is not changed
-      - vpc_igw_recreate.gateway_id == igw_id
-      - vpc_igw_recreate.vpc_id == vpc_id
-      - '"tags" in vpc_igw_recreate'
-      - vpc_igw_recreate.tags | length == 2
-      - vpc_igw_recreate.tags["tag_one"] == '{{ resource_prefix }} One'
-      - vpc_igw_recreate.tags["Tag Two"] == 'two {{ resource_prefix }}'
+    - name: Assert tag update did nothing (expected changed=false)
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_recreate is not changed
+          - vpc_igw_recreate.gateway_id == igw_id
+          - vpc_igw_recreate.vpc_id == vpc_id
+          - '"tags" in vpc_igw_recreate'
+          - vpc_igw_recreate.tags | length == 2
+          - vpc_igw_recreate.tags["tag_one"] == '{{ resource_prefix }} One'
+          - vpc_igw_recreate.tags["Tag Two"] == 'two {{ resource_prefix }}'
 
-  # ============================================================
-  - name: Update the tags (remove and add) - CHECK_MODE
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      tags:
-        tag_three: '{{ resource_prefix }} Three'
-        Tag Two: two {{ resource_prefix }}
-    register: vpc_igw_update
-    check_mode: yes
+    # ============================================================
+    - name: Update the tags (remove and add) - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          tag_three: "{{ resource_prefix }} Three"
+          Tag Two: two {{ resource_prefix }}
+      register: vpc_igw_update
+      check_mode: true
 
-  - name: Assert tag update would happen (expected changed=true) - CHECK_MODE
-    assert:
-      that:
-      - vpc_igw_update is changed
-      - vpc_igw_update.gateway_id == igw_id
-      - vpc_igw_update.vpc_id == vpc_id
-      - '"tags" in vpc_igw_update'
-      - vpc_igw_update.tags | length == 2
+    - name: Assert tag update would happen (expected changed=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_update is changed
+          - vpc_igw_update.gateway_id == igw_id
+          - vpc_igw_update.vpc_id == vpc_id
+          - '"tags" in vpc_igw_update'
+          - vpc_igw_update.tags | length == 2
 
-  - name: Update the tags (remove and add)
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      tags:
-        tag_three: '{{ resource_prefix }} Three'
-        Tag Two: two {{ resource_prefix }}
-    register: vpc_igw_update
+    - name: Update the tags (remove and add)
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          tag_three: "{{ resource_prefix }} Three"
+          Tag Two: two {{ resource_prefix }}
+      register: vpc_igw_update
 
-  - name: Assert tags are updated (expected changed=true)
-    assert:
-      that:
-      - vpc_igw_update is changed
-      - vpc_igw_update.gateway_id == igw_id
-      - vpc_igw_update.vpc_id == vpc_id
-      - '"tags" in vpc_igw_update'
-      - vpc_igw_update.tags | length == 2
-      - vpc_igw_update.tags["tag_three"] == '{{ resource_prefix }} Three'
-      - vpc_igw_update.tags["Tag Two"] == 'two {{ resource_prefix }}'
+    - name: Assert tags are updated (expected changed=true)
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_update is changed
+          - vpc_igw_update.gateway_id == igw_id
+          - vpc_igw_update.vpc_id == vpc_id
+          - '"tags" in vpc_igw_update'
+          - vpc_igw_update.tags | length == 2
+          - vpc_igw_update.tags["tag_three"] == '{{ resource_prefix }} Three'
+          - vpc_igw_update.tags["Tag Two"] == 'two {{ resource_prefix }}'
 
-  # ============================================================
-  - name: Update the tags add without purge - CHECK_MODE
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      purge_tags: no
-      tags:
-        tag_one: '{{ resource_prefix }} One'
-    register: vpc_igw_update
-    check_mode: yes
+    # ============================================================
+    - name: Update the tags add without purge - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        purge_tags: false
+        tags:
+          tag_one: "{{ resource_prefix }} One"
+      register: vpc_igw_update
+      check_mode: true
 
-  - name: Assert tags would be added - CHECK_MODE
-    assert:
-      that:
-      - vpc_igw_update is changed
-      - vpc_igw_update.gateway_id == igw_id
-      - vpc_igw_update.vpc_id == vpc_id
-      - '"tags" in vpc_igw_update'
+    - name: Assert tags would be added - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_update is changed
+          - vpc_igw_update.gateway_id == igw_id
+          - vpc_igw_update.vpc_id == vpc_id
+          - '"tags" in vpc_igw_update'
 
-  - name: Update the tags add without purge
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      purge_tags: no
-      tags:
-        tag_one: '{{ resource_prefix }} One'
-    register: vpc_igw_update
+    - name: Update the tags add without purge
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        purge_tags: false
+        tags:
+          tag_one: "{{ resource_prefix }} One"
+      register: vpc_igw_update
 
-  - name: Assert tags added
-    assert:
-      that:
-      - vpc_igw_update is changed
-      - vpc_igw_update.gateway_id == igw_id
-      - vpc_igw_update.vpc_id == vpc_id
-      - '"tags" in vpc_igw_update'
-      - vpc_igw_update.tags | length == 3
-      - vpc_igw_update.tags["tag_one"] == '{{ resource_prefix }} One'
-      - vpc_igw_update.tags["tag_three"] == '{{ resource_prefix }} Three'
-      - vpc_igw_update.tags["Tag Two"] == 'two {{ resource_prefix }}'
+    - name: Assert tags added
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_update is changed
+          - vpc_igw_update.gateway_id == igw_id
+          - vpc_igw_update.vpc_id == vpc_id
+          - '"tags" in vpc_igw_update'
+          - vpc_igw_update.tags | length == 3
+          - vpc_igw_update.tags["tag_one"] == '{{ resource_prefix }} One'
+          - vpc_igw_update.tags["tag_three"] == '{{ resource_prefix }} Three'
+          - vpc_igw_update.tags["Tag Two"] == 'two {{ resource_prefix }}'
 
+    # ============================================================
+    - name: Update with CamelCase tags - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          lowercase spaced: hello cruel world
+          Title Case: Hello Cruel World
+          CamelCase: SimpleCamelCase
+          snake_case: simple_snake_case
+      register: vpc_igw_update
+      check_mode: true
 
-  # ============================================================
-  - name: Update with CamelCase tags - CHECK_MODE
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      tags:
-        lowercase spaced: "hello cruel world"
-        Title Case: "Hello Cruel World"
-        CamelCase: "SimpleCamelCase"
-        snake_case: "simple_snake_case"
-    register: vpc_igw_update
-    check_mode: yes
+    - name: Assert tag update would happen (expected changed=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_update is changed
+          - vpc_igw_update.gateway_id == igw_id
+          - vpc_igw_update.vpc_id == vpc_id
+          - '"tags" in vpc_igw_update'
 
-  - name: Assert tag update would happen (expected changed=true) - CHECK_MODE
-    assert:
-      that:
-      - vpc_igw_update is changed
-      - vpc_igw_update.gateway_id == igw_id
-      - vpc_igw_update.vpc_id == vpc_id
-      - '"tags" in vpc_igw_update'
+    - name: Update the tags - remove and add
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          lowercase spaced: hello cruel world
+          Title Case: Hello Cruel World
+          CamelCase: SimpleCamelCase
+          snake_case: simple_snake_case
+      register: vpc_igw_update
 
-  - name: Update the tags - remove and add
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      tags:
-        lowercase spaced: "hello cruel world"
-        Title Case: "Hello Cruel World"
-        CamelCase: "SimpleCamelCase"
-        snake_case: "simple_snake_case"
-    register: vpc_igw_update
+    - name: assert tags are updated (expected changed=true)
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_update is changed
+          - vpc_igw_update.gateway_id == igw_id
+          - vpc_igw_update.vpc_id == vpc_id
+          - '"tags" in vpc_igw_update'
+          - vpc_igw_update.tags | length == 4
+          - vpc_igw_update.tags["lowercase spaced"] == 'hello cruel world'
+          - vpc_igw_update.tags["Title Case"] == 'Hello Cruel World'
+          - vpc_igw_update.tags["CamelCase"] == 'SimpleCamelCase'
+          - vpc_igw_update.tags["snake_case"] == 'simple_snake_case'
 
-  - name: assert tags are updated (expected changed=true)
-    assert:
-      that:
-      - vpc_igw_update is changed
-      - vpc_igw_update.gateway_id == igw_id
-      - vpc_igw_update.vpc_id == vpc_id
-      - '"tags" in vpc_igw_update'
-      - vpc_igw_update.tags | length == 4
-      - vpc_igw_update.tags["lowercase spaced"] == 'hello cruel world'
-      - vpc_igw_update.tags["Title Case"] == 'Hello Cruel World'
-      - vpc_igw_update.tags["CamelCase"] == 'SimpleCamelCase'
-      - vpc_igw_update.tags["snake_case"] == 'simple_snake_case'
+    # ============================================================
+    - name: Gather information about a filtered list of Internet Gateways using tags
+      amazon.aws.ec2_vpc_igw_info:
+        filters:
+          tag:Title Case: Hello Cruel World
+      register: igw_info
 
-  # ============================================================
-  - name: Gather information about a filtered list of Internet Gateways using tags
-    ec2_vpc_igw_info:
-      filters:
-        tag:Title Case: "Hello Cruel World"
-    register: igw_info
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - igw_info is successful
+          - '"internet_gateways" in igw_info'
+          - igw_info.internet_gateways | selectattr("internet_gateway_id",'equalto',"{{ igw_id }}")
 
-  - name: Assert success
-    assert:
-      that:
-      - igw_info is successful
-      - '"internet_gateways" in igw_info'
-      - igw_info.internet_gateways | selectattr("internet_gateway_id",'equalto',"{{
-        igw_id }}")
+    - name: Gather information about a filtered list of Internet Gateways using tags - CHECK_MODE
+      amazon.aws.ec2_vpc_igw_info:
+        filters:
+          tag:Title Case: Hello Cruel World
+      register: igw_info
+      check_mode: true
 
-  - name: Gather information about a filtered list of Internet Gateways using tags - CHECK_MODE
-    ec2_vpc_igw_info:
-      filters:
-        tag:Title Case: "Hello Cruel World"
-    register: igw_info
-    check_mode: yes
+    - name: Assert success - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - igw_info is successful
+          - '"internet_gateways" in igw_info'
+          - igw_info.internet_gateways | selectattr("internet_gateway_id",'equalto',"{{ igw_id }}")
 
-  - name: Assert success - CHECK_MODE
-    assert:
-      that:
-      - igw_info is successful
-      - '"internet_gateways" in igw_info'
-      - igw_info.internet_gateways | selectattr("internet_gateway_id",'equalto',"{{
-        igw_id }}")
+    # ============================================================
+    - name: Gather information about a filtered list of Internet Gateways using tags (no match)
+      amazon.aws.ec2_vpc_igw_info:
+        filters:
+          tag:tag_one: "{{ resource_prefix }} One"
+      register: igw_info
 
-  # ============================================================
-  - name: Gather information about a filtered list of Internet Gateways using tags (no match)
-    ec2_vpc_igw_info:
-      filters:
-        tag:tag_one: '{{ resource_prefix }} One'
-    register: igw_info
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - igw_info is successful
+          - '"internet_gateways" in igw_info'
+          - igw_info.internet_gateways | length == 0
 
-  - name: Assert success
-    assert:
-      that:
-      - igw_info is successful
-      - '"internet_gateways" in igw_info'
-      - igw_info.internet_gateways | length == 0
+    - name: Gather information about a filtered list of Internet Gateways using tags (no match) - CHECK_MODE
+      amazon.aws.ec2_vpc_igw_info:
+        filters:
+          tag:tag_one: "{{ resource_prefix }} One"
+      register: igw_info
+      check_mode: true
 
-  - name: Gather information about a filtered list of Internet Gateways using tags (no match) - CHECK_MODE
-    ec2_vpc_igw_info:
-      filters:
-        tag:tag_one: '{{ resource_prefix }} One'
-    register: igw_info
-    check_mode: yes
+    - name: Assert success - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - igw_info is successful
+          - '"internet_gateways" in igw_info'
+          - igw_info.internet_gateways | length == 0
 
-  - name: Assert success - CHECK_MODE
-    assert:
-      that:
-      - igw_info is successful
-      - '"internet_gateways" in igw_info'
-      - igw_info.internet_gateways | length == 0
+    # ============================================================
+    - name: Remove all tags - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags: {}
+      register: vpc_igw_update
+      check_mode: true
 
-  # ============================================================
-  - name: Remove all tags - CHECK_MODE
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      tags: {}
-    register: vpc_igw_update
-    check_mode: yes
+    - name: Assert tags would be removed - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_update is changed
 
-  - name: Assert tags would be removed - CHECK_MODE
-    assert:
-      that:
-      - vpc_igw_update is changed
+    - name: Remove all tags
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags: {}
+      register: vpc_igw_update
 
-  - name: Remove all tags
-    ec2_vpc_igw:
-      state: present
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      tags: {}
-    register: vpc_igw_update
+    - name: Assert tags removed
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_update is changed
+          - vpc_igw_update.gateway_id == igw_id
+          - vpc_igw_update.vpc_id == vpc_id
+          - '"tags" in vpc_igw_update'
+          - vpc_igw_update.tags | length == 0
 
-  - name: Assert tags removed
-    assert:
-      that:
-      - vpc_igw_update is changed
-      - vpc_igw_update.gateway_id == igw_id
-      - vpc_igw_update.vpc_id == vpc_id
-      - '"tags" in vpc_igw_update'
-      - vpc_igw_update.tags | length == 0
+    # ============================================================
+    - name: Test state=absent (expected changed=true) - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      register: vpc_igw_delete
+      check_mode: true
 
-  # ============================================================
-  - name: Test state=absent (expected changed=true) - CHECK_MODE
-    ec2_vpc_igw:
-      state: absent
-      vpc_id: '{{ vpc_result.vpc.id }}'
-    register: vpc_igw_delete
-    check_mode: yes
+    - name: Assert state=absent (expected changed=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_delete is changed
 
-  - name: Assert state=absent (expected changed=true) - CHECK_MODE
-    assert:
-      that:
-      - vpc_igw_delete is changed
+    - name: Test state=absent (expected changed=true)
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      register: vpc_igw_delete
 
-  - name: Test state=absent (expected changed=true)
-    ec2_vpc_igw:
-      state: absent
-      vpc_id: '{{ vpc_result.vpc.id }}'
-    register: vpc_igw_delete
+    - name: Assert state=absent (expected changed=true)
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_delete is changed
 
-  - name: Assert state=absent (expected changed=true)
-    assert:
-      that:
-      - vpc_igw_delete is changed
+    # ============================================================
+    - name: Fetch IGW by ID (list)
+      amazon.aws.ec2_vpc_igw_info:
+        internet_gateway_ids:
+          - "{{ igw_id }}"
+      register: igw_info
+      ignore_errors: true
 
-  # ============================================================
-  - name: Fetch IGW by ID (list)
-    ec2_vpc_igw_info:
-      internet_gateway_ids:
-      - '{{ igw_id }}'
-    register: igw_info
-    ignore_errors: true
-
-  - name: Check IGW does not exist
-    assert:
-      that:
+    - name: Check IGW does not exist
+      ansible.builtin.assert:
+        that:
         # Deliberate choice not to change bevahiour when searching by ID
-      - igw_info is failed
+          - igw_info is failed
 
-  # ============================================================
-  - name: Test state=absent when already deleted (expected changed=false) - CHECK_MODE
-    ec2_vpc_igw:
-      state: absent
-      vpc_id: '{{ vpc_result.vpc.id }}'
-    register: vpc_igw_delete
-    check_mode: yes
+    # ============================================================
+    - name: Test state=absent when already deleted (expected changed=false) - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      register: vpc_igw_delete
+      check_mode: true
 
-  - name: Assert state=absent (expected changed=false) - CHECK_MODE
-    assert:
-      that:
-      - vpc_igw_delete is not changed
+    - name: Assert state=absent (expected changed=false) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_delete is not changed
 
-  - name: Test state=absent when already deleted (expected changed=false)
-    ec2_vpc_igw:
-      state: absent
-      vpc_id: '{{ vpc_result.vpc.id }}'
-    register: vpc_igw_delete
+    - name: Test state=absent when already deleted (expected changed=false)
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      register: vpc_igw_delete
 
-  - name: Assert state=absent (expected changed=false)
-    assert:
-      that:
-      - vpc_igw_delete is not changed
+    - name: Assert state=absent (expected changed=false)
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_delete is not changed
 
-  # ============================================================
-  - name: Create new detached internet gateway - CHECK_MODE
-    ec2_vpc_igw:
-      state: present
-    register: detached_igw_result
-    check_mode: true
+    # ============================================================
+    - name: Create new detached internet gateway - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: present
+      register: detached_igw_result
+      check_mode: true
 
-  - name: Assert creation would happen (expected changed=true) - CHECK_MODE
-    assert:
-      that:
-      - detached_igw_result is changed
+    - name: Assert creation would happen (expected changed=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - detached_igw_result is changed
 
-  - name: Create new detached internet gateway (expected changed=true)
-    ec2_vpc_igw:
-      state: present
-    register: detached_igw_result
+    - name: Create new detached internet gateway (expected changed=true)
+      amazon.aws.ec2_vpc_igw:
+        state: present
+      register: detached_igw_result
 
-  - name: Assert creation happened (expected changed=true)
-    assert:
-      that:
-      - detached_igw_result is changed
-      - '"gateway_id" in detached_igw_result'
-      - detached_igw_result.gateway_id.startswith("igw-")
-      - not detached_igw_result.vpc_id
-      
-  # ============================================================
-  - name: Test state=absent when supplying only a gateway id (expected chaged=true) - CHECK_MODE
-    ec2_vpc_igw:
-      state: absent
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-    register: vpc_igw_delete
-    check_mode: true
+    - name: Assert creation happened (expected changed=true)
+      ansible.builtin.assert:
+        that:
+          - detached_igw_result is changed
+          - '"gateway_id" in detached_igw_result'
+          - detached_igw_result.gateway_id.startswith("igw-")
+          - not detached_igw_result.vpc_id
 
-  - name: Assert state=absent when supplying only a gateway id (expected chaged=true) - CHECK_MODE
-    assert:
-      that:
-        - vpc_igw_delete is changed
+    # ============================================================
+    - name: Test state=absent when supplying only a gateway id (expected chaged=true) - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+      register: vpc_igw_delete
+      check_mode: true
 
-  - name: Search for IGW by ID
-    ec2_vpc_igw_info:
-      internet_gateway_ids: '{{ detached_igw_result.gateway_id }}'
-    register: igw_info
+    - name: Assert state=absent when supplying only a gateway id (expected chaged=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_delete is changed
 
-  - name: Check that IGW was not deleted in check mode
-    assert:
-      that:
-        - '"internet_gateways" in igw_info'
-        - igw_info.internet_gateways | length == 1
+    - name: Search for IGW by ID
+      amazon.aws.ec2_vpc_igw_info:
+        internet_gateway_ids: "{{ detached_igw_result.gateway_id }}"
+      register: igw_info
 
-  - name: Test state=absent when supplying only a gateway id (expected chaged=true)
-    ec2_vpc_igw:
-      state: absent
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-    register: vpc_igw_delete
+    - name: Check that IGW was not deleted in check mode
+      ansible.builtin.assert:
+        that:
+          - '"internet_gateways" in igw_info'
+          - igw_info.internet_gateways | length == 1
 
-  - name: Assert state=absent when supplying only a gateway id (expected chaged=true)
-    assert:
-      that:
-        - vpc_igw_delete is changed
+    - name: Test state=absent when supplying only a gateway id (expected chaged=true)
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+      register: vpc_igw_delete
 
-  - name: Fetch removed IGW by ID
-    ec2_vpc_igw_info:
-      internet_gateway_ids: '{{ detached_igw_result.gateway_id }}'
-    register: igw_info
-    ignore_errors: true
+    - name: Assert state=absent when supplying only a gateway id (expected chaged=true)
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_delete is changed
 
-  - name: Check IGW does not exist
-    assert:
-      that:
+    - name: Fetch removed IGW by ID
+      amazon.aws.ec2_vpc_igw_info:
+        internet_gateway_ids: "{{ detached_igw_result.gateway_id }}"
+      register: igw_info
+      ignore_errors: true
+
+    - name: Check IGW does not exist
+      ansible.builtin.assert:
+        that:
         # Deliberate choice not to change bevahiour when searching by ID
-      - igw_info is failed
+          - igw_info is failed
 
-  # ============================================================
-  - name: Create new internet gateway for vpc tests
-    ec2_vpc_igw:
-      state: present
-    register: detached_igw_result
-      
-  # ============================================================
-  - name: Test attaching VPC to gateway - CHECK_MODE
-    ec2_vpc_igw:
-      state: present
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-      vpc_id: '{{ vpc_id }}'
-    register: attach_vpc_result
-    check_mode: true
+    # ============================================================
+    - name: Create new internet gateway for vpc tests
+      amazon.aws.ec2_vpc_igw:
+        state: present
+      register: detached_igw_result
 
-  - name: Assert that VPC was attached - CHECK_MODE
-    assert:
-      that:
-        - attach_vpc_result is changed
+    # ============================================================
+    - name: Test attaching VPC to gateway - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+        vpc_id: "{{ vpc_id }}"
+      register: attach_vpc_result
+      check_mode: true
 
-  - name: Test attaching VPC to gateway
-    ec2_vpc_igw:
-      state: present
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-      vpc_id: '{{ vpc_id }}'
-    register: attach_vpc_result
+    - name: Assert that VPC was attached - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - attach_vpc_result is changed
 
-  - name: Assert that VPC was attached
-    assert:
-      that:
-        - attach_vpc_result is changed
-        - attach_vpc_result.vpc_id == vpc_id
-        - attach_vpc_result.gateway_id == detached_igw_result.gateway_id
+    - name: Test attaching VPC to gateway
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+        vpc_id: "{{ vpc_id }}"
+      register: attach_vpc_result
 
-  # ============================================================
-  - name: Test detaching VPC from gateway - CHECK_MODE
-    ec2_vpc_igw:
-      state: present
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-      detach_vpc: true
-    register: detach_vpc_result
-    check_mode: true
+    - name: Assert that VPC was attached
+      ansible.builtin.assert:
+        that:
+          - attach_vpc_result is changed
+          - attach_vpc_result.vpc_id == vpc_id
+          - attach_vpc_result.gateway_id == detached_igw_result.gateway_id
 
-  - name: Assert that VPC was detached - CHECK_MODE
-    assert:
-      that:
-        - detach_vpc_result is changed
+    # ============================================================
+    - name: Test detaching VPC from gateway - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+        detach_vpc: true
+      register: detach_vpc_result
+      check_mode: true
 
-  - name: Test detaching VPC from gateway
-    ec2_vpc_igw:
-      state: present
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-      detach_vpc: true
-    register: detach_vpc_result
+    - name: Assert that VPC was detached - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - detach_vpc_result is changed
 
-  - name: Assert that VPC was detached
-    assert:
-      that:
-        - detach_vpc_result is changed
-        - not detach_vpc_result.vpc_id
-        - detach_vpc_result.gateway_id == detached_igw_result.gateway_id
+    - name: Test detaching VPC from gateway
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+        detach_vpc: true
+      register: detach_vpc_result
 
-  # ============================================================
-  - name: Attach VPC to gateway for VPC change tests
-    ec2_vpc_igw:
-      state: present
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-      vpc_id: '{{ vpc_id }}'
+    - name: Assert that VPC was detached
+      ansible.builtin.assert:
+        that:
+          - detach_vpc_result is changed
+          - not detach_vpc_result.vpc_id
+          - detach_vpc_result.gateway_id == detached_igw_result.gateway_id
 
-  # ============================================================
-  - name: Attempt change attached VPC with force_attach=false (default) - CHECK_MODE
-    ec2_vpc_igw:
-      state: present
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-      vpc_id: '{{ vpc_2_result.vpc.id }}'
-    register: igw_vpc_changed_result
-    check_mode: true
+    # ============================================================
+    - name: Attach VPC to gateway for VPC change tests
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+        vpc_id: "{{ vpc_id }}"
 
-  - name: Assert VPC changed with force_attach=false (default) - CHECK_MODE
-    assert:
-      that:
-        - igw_vpc_changed_result is changed
-        - vpc_id not in igw_vpc_changed_result
-      
-  - name: Attempt change with force_attach=false (default) (expected failure)
-    ec2_vpc_igw:
-      state: present
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-      vpc_id: '{{ vpc_2_result.vpc.id }}'
-    register: igw_vpc_changed_result
-    ignore_errors: true
+    # ============================================================
+    - name: Attempt change attached VPC with force_attach=false (default) - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+        vpc_id: "{{ vpc_2_result.vpc.id }}"
+      register: igw_vpc_changed_result
+      check_mode: true
 
-  - name: Assert VPC changed with force_attach=false (default)
-    assert:
-      that:
-        - igw_vpc_changed_result is failed
-        - igw_vpc_changed_result.msg is search('VPC already attached, but does not match requested VPC.')
+    - name: Assert VPC changed with force_attach=false (default) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - igw_vpc_changed_result is changed
+          - vpc_id not in igw_vpc_changed_result
 
-  # ============================================================
-  - name: Attempt change attached VPC with force_attach=true - CHECK_MODE
-    ec2_vpc_igw:
-      state: present
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-      vpc_id: '{{ vpc_2_result.vpc.id }}'
-      force_attach: true
-    register: igw_vpc_changed_result
-    check_mode: true
+    - name: Attempt change with force_attach=false (default) (expected failure)
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+        vpc_id: "{{ vpc_2_result.vpc.id }}"
+      register: igw_vpc_changed_result
+      ignore_errors: true
 
-  - name: Assert VPC changed with force_attach=true - CHECK_MODE
-    assert:
-      that:
-        - igw_vpc_changed_result is changed
-        - vpc_id not in igw_vpc_changed_result
-      
-  - name: Attempt change with force_attach=true
-    ec2_vpc_igw:
-      state: present
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-      vpc_id: '{{ vpc_2_result.vpc.id }}'
-      force_attach: true
-    register: igw_vpc_changed_result
+    - name: Assert VPC changed with force_attach=false (default)
+      ansible.builtin.assert:
+        that:
+          - igw_vpc_changed_result is failed
+          - igw_vpc_changed_result.msg is search('VPC already attached, but does not match requested VPC.')
 
-  - name: Assert VPC changed with force_attach=true
-    assert:
-      that:
-        - igw_vpc_changed_result is changed
-        - igw_vpc_changed_result.vpc_id == vpc_2_id
+    # ============================================================
+    - name: Attempt change attached VPC with force_attach=true - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+        vpc_id: "{{ vpc_2_result.vpc.id }}"
+        force_attach: true
+      register: igw_vpc_changed_result
+      check_mode: true
 
-  # ============================================================
-  - name: Test state=absent when supplying a gateway id and wrong vpc id (expected failure) - CHECK_MODE
-    ec2_vpc_igw:
-      state: absent
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-      vpc_id: 'vpc-xxxxxxxxx'
-    register: vpc_igw_delete
-    check_mode: true
-    ignore_errors: true
+    - name: Assert VPC changed with force_attach=true - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - igw_vpc_changed_result is changed
+          - vpc_id not in igw_vpc_changed_result
 
-  - name: Assert state=absent when supplying a gateway id and wrong vpc id (expected failure) - CHECK_MODE
-    assert:
-      that:
-        - vpc_igw_delete is failed
-        - vpc_igw_delete.msg is search('Supplied VPC.*does not match found VPC.*')
+    - name: Attempt change with force_attach=true
+      amazon.aws.ec2_vpc_igw:
+        state: present
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+        vpc_id: "{{ vpc_2_result.vpc.id }}"
+        force_attach: true
+      register: igw_vpc_changed_result
 
-  - name: Test state=absent when supplying a gateway id and wrong vpc id (expected failure)
-    ec2_vpc_igw:
-      state: absent
-      internet_gateway_id: '{{ detached_igw_result.gateway_id}}'
-      vpc_id: 'vpc-xxxxxxxxx'
-    register: vpc_igw_delete
-    ignore_errors: true
+    - name: Assert VPC changed with force_attach=true
+      ansible.builtin.assert:
+        that:
+          - igw_vpc_changed_result is changed
+          - igw_vpc_changed_result.vpc_id == vpc_2_id
 
-  - name: Assert state=absent when supplying a gateway id and wrong vpc id (expected failure)
-    assert:
-      that:
-        - vpc_igw_delete is failed
-        - vpc_igw_delete.msg is search('Supplied VPC.*does not match found VPC.*')
+    # ============================================================
+    - name: Test state=absent when supplying a gateway id and wrong vpc id (expected failure) - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+        vpc_id: vpc-xxxxxxxxx
+      register: vpc_igw_delete
+      check_mode: true
+      ignore_errors: true
 
-  # ============================================================
-  - name: Test state=absent when supplying a gateway id and vpc id (expected chaged=true) - CHECK_MODE
-    ec2_vpc_igw:
-      state: absent
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-      vpc_id: '{{ vpc_2_id }}'
-    register: vpc_igw_delete
-    check_mode: true
+    - name: Assert state=absent when supplying a gateway id and wrong vpc id (expected failure) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_delete is failed
+          - vpc_igw_delete.msg is search('Supplied VPC.*does not match found VPC.*')
 
-  - name: Assert state=absent when supplying a gateway id and vpc id (expected chaged=true) - CHECK_MODE
-    assert:
-      that:
-        - vpc_igw_delete is changed
+    - name: Test state=absent when supplying a gateway id and wrong vpc id (expected failure)
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        internet_gateway_id: "{{ detached_igw_result.gateway_id}}"
+        vpc_id: vpc-xxxxxxxxx
+      register: vpc_igw_delete
+      ignore_errors: true
 
-  - name: Test state=absent when supplying a gateway id and vpc id (expected chaged=true)
-    ec2_vpc_igw:
-      state: absent
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-      vpc_id: '{{ vpc_2_id }}'
-    register: vpc_igw_delete
+    - name: Assert state=absent when supplying a gateway id and wrong vpc id (expected failure)
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_delete is failed
+          - vpc_igw_delete.msg is search('Supplied VPC.*does not match found VPC.*')
 
-  - name: Assert state=absent when supplying a gateway id and vpc id (expected chaged=true)
-    assert:
-      that:
-        - vpc_igw_delete is changed
+    # ============================================================
+    - name: Test state=absent when supplying a gateway id and vpc id (expected chaged=true) - CHECK_MODE
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+        vpc_id: "{{ vpc_2_id }}"
+      register: vpc_igw_delete
+      check_mode: true
 
-  - name: Fetch removed IGW by ID
-    ec2_vpc_igw_info:
-      internet_gateway_ids: '{{ detached_igw_result.gateway_id }}'
-    register: igw_info
-    ignore_errors: true
+    - name: Assert state=absent when supplying a gateway id and vpc id (expected chaged=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_delete is changed
 
-  - name: Check IGW does not exist
-    assert:
-      that:
+    - name: Test state=absent when supplying a gateway id and vpc id (expected chaged=true)
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+        vpc_id: "{{ vpc_2_id }}"
+      register: vpc_igw_delete
+
+    - name: Assert state=absent when supplying a gateway id and vpc id (expected chaged=true)
+      ansible.builtin.assert:
+        that:
+          - vpc_igw_delete is changed
+
+    - name: Fetch removed IGW by ID
+      amazon.aws.ec2_vpc_igw_info:
+        internet_gateway_ids: "{{ detached_igw_result.gateway_id }}"
+      register: igw_info
+      ignore_errors: true
+
+    - name: Check IGW does not exist
+      ansible.builtin.assert:
+        that:
         # Deliberate choice not to change bevahiour when searching by ID
-      - igw_info is failed
+          - igw_info is failed
 
   always:
     # ============================================================
-  - name: Tidy up IGW
-    ec2_vpc_igw:
-      state: absent
-      vpc_id: '{{ vpc_result.vpc.id }}'
-    ignore_errors: true
+    - name: Tidy up IGW
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        vpc_id: "{{ vpc_result.vpc.id }}"
+      ignore_errors: true
 
-  - name: Tidy up IGW on second VPC
-    ec2_vpc_igw:
-      state: absent
-      vpc_id: '{{ vpc_2_result.vpc.id }}'
-    ignore_errors: true
+    - name: Tidy up IGW on second VPC
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        vpc_id: "{{ vpc_2_result.vpc.id }}"
+      ignore_errors: true
 
-  - name: Tidy up detached IGW
-    ec2_vpc_igw:
-      state: absent
-      internet_gateway_id: '{{ detached_igw_result.gateway_id }}'
-    ignore_errors: true
+    - name: Tidy up detached IGW
+      amazon.aws.ec2_vpc_igw:
+        state: absent
+        internet_gateway_id: "{{ detached_igw_result.gateway_id }}"
+      ignore_errors: true
 
-  - name: Tidy up VPC
-    ec2_vpc_net:
-      name: '{{ vpc_name }}'
-      state: absent
-      cidr_block: '{{ vpc_cidr }}'
-    ignore_errors: true
+    - name: Tidy up VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ vpc_name }}"
+        state: absent
+        cidr_block: "{{ vpc_cidr }}"
+      ignore_errors: true
 
-  - name: Tidy up second VPC
-    ec2_vpc_net:
-      name: '{{ vpc_name_2 }}'
-      state: absent
-      cidr_block: '{{ vpc_cidr_2 }}'
-    ignore_errors: true
+    - name: Tidy up second VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ vpc_name_2 }}"
+        state: absent
+        cidr_block: "{{ vpc_cidr_2 }}"
+      ignore_errors: true

--- a/tests/integration/targets/ec2_vpc_nat_gateway/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_nat_gateway/defaults/main.yml
@@ -1,4 +1,5 @@
-vpc_name: '{{ resource_prefix }}-vpc'
-vpc_seed: '{{ resource_prefix }}'
+---
+vpc_name: "{{ resource_prefix }}-vpc"
+vpc_seed: "{{ resource_prefix }}"
 vpc_cidr: 10.0.0.0/16
 subnet_cidr: 10.0.{{ 256 | random(seed=vpc_seed) }}.0/24

--- a/tests/integration/targets/ec2_vpc_nat_gateway/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_nat_gateway/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/ec2_vpc_nat_gateway/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_nat_gateway/tasks/main.yml
@@ -1,1020 +1,995 @@
+---
 - name: ec2_vpc_nat_gateway tests
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
   # ============================================================
-  - name: Create a VPC
-    ec2_vpc_net:
-      name: '{{ vpc_name }}'
-      state: present
-      cidr_block: '{{ vpc_cidr }}'
-    register: vpc_result
+    - name: Create a VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ vpc_name }}"
+        state: present
+        cidr_block: "{{ vpc_cidr }}"
+      register: vpc_result
 
-  - name: Assert success
-    assert:
-      that:
-      - vpc_result is successful
-      - '"vpc" in vpc_result'
-      - '"cidr_block" in vpc_result.vpc'
-      - vpc_result.vpc.cidr_block == vpc_cidr
-      - '"id" in vpc_result.vpc'
-      - vpc_result.vpc.id.startswith("vpc-")
-      - '"state" in vpc_result.vpc'
-      - vpc_result.vpc.state == 'available'
-      - '"tags" in vpc_result.vpc'
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - vpc_result is successful
+          - '"vpc" in vpc_result'
+          - '"cidr_block" in vpc_result.vpc'
+          - vpc_result.vpc.cidr_block == vpc_cidr
+          - '"id" in vpc_result.vpc'
+          - vpc_result.vpc.id.startswith("vpc-")
+          - '"state" in vpc_result.vpc'
+          - vpc_result.vpc.state == 'available'
+          - '"tags" in vpc_result.vpc'
 
-  - name: 'Set fact: VPC ID'
-    set_fact:
-      vpc_id: '{{ vpc_result.vpc.id }}'
+    - name: "Set fact: VPC ID"
+      ansible.builtin.set_fact:
+        vpc_id: "{{ vpc_result.vpc.id }}"
 
+    # ============================================================
+    - name: Allocate a new EIP
+      amazon.aws.ec2_eip:
+        in_vpc: true
+        reuse_existing_ip_allowed: true
+        tag_name: FREE
+      register: eip_result
+
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - eip_result is successful
+          - '"allocation_id" in eip_result'
+          - eip_result.allocation_id.startswith("eipalloc-")
+          - '"public_ip" in eip_result'
+
+    - name: "set fact: EIP allocation ID and EIP public IP"
+      ansible.builtin.set_fact:
+        eip_address: "{{ eip_result.public_ip }}"
+        allocation_id: "{{ eip_result.allocation_id }}"
+
+    # ============================================================
+    - name: Create subnet and associate to the VPC
+      amazon.aws.ec2_vpc_subnet:
+        state: present
+        vpc_id: "{{ vpc_id }}"
+        cidr: "{{ subnet_cidr }}"
+      register: subnet_result
+
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - subnet_result is successful
+          - '"subnet" in subnet_result'
+          - '"cidr_block" in subnet_result.subnet'
+          - subnet_result.subnet.cidr_block == subnet_cidr
+          - '"id" in subnet_result.subnet'
+          - subnet_result.subnet.id.startswith("subnet-")
+          - '"state" in subnet_result.subnet'
+          - subnet_result.subnet.state == 'available'
+          - '"tags" in subnet_result.subnet'
+          - subnet_result.subnet.vpc_id == vpc_id
+
+    - name: "set fact: VPC subnet ID"
+      ansible.builtin.set_fact:
+        subnet_id: "{{ subnet_result.subnet.id }}"
+
+    # ============================================================
+    - name: Search for NAT gateways by subnet (no matches) - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway_info:
+        filters:
+          subnet-id: "{{ subnet_id }}"
+          state: [available]
+      register: existing_ngws
+      check_mode: true
+
+    - name: Assert no NAT gateway found - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - existing_ngws is successful
+          - (existing_ngws.result|length) == 0
+
+    - name: Search for NAT gateways by subnet - no matches
+      amazon.aws.ec2_vpc_nat_gateway_info:
+        filters:
+          subnet-id: "{{ subnet_id }}"
+          state: [available]
+      register: existing_ngws
+
+    - name: Assert no NAT gateway found
+      ansible.builtin.assert:
+        that:
+          - existing_ngws is successful
+          - (existing_ngws.result|length) == 0
+
+    # ============================================================
+    - name: Create IGW
+      amazon.aws.ec2_vpc_igw:
+        vpc_id: "{{ vpc_id }}"
+      register: create_igw
+
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - create_igw is successful
+          - create_igw.gateway_id.startswith("igw-")
+          - create_igw.vpc_id == vpc_id
+          - '"gateway_id" in create_igw'
+
+    # ============================================================
+    - name: Create new NAT gateway with eip allocation-id - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        wait: true
+      register: create_ngw
+      check_mode: true
+
+    - name: Assert creation happened (expected changed=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - create_ngw.changed
+
+    - name: Create new NAT gateway with eip allocation-id
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        wait: true
+      register: create_ngw
+
+    - name: Assert creation happened (expected changed=true)
+      ansible.builtin.assert:
+        that:
+          - create_ngw.changed
+          - '"create_time" in create_ngw'
+          - '"nat_gateway_addresses" in create_ngw'
+          - '"nat_gateway_id" in create_ngw'
+          - create_ngw.nat_gateway_addresses[0].allocation_id == allocation_id
+          - create_ngw.nat_gateway_id.startswith("nat-")
+          - '"state" in create_ngw'
+          - create_ngw.state == 'available'
+          - '"subnet_id" in create_ngw'
+          - create_ngw.subnet_id == subnet_id
+          - '"tags" in create_ngw'
+          - '"vpc_id" in create_ngw'
+          - create_ngw.vpc_id == vpc_id
+
+    - name: "set facts: NAT gateway ID"
+      ansible.builtin.set_fact:
+        nat_gateway_id: "{{ create_ngw.nat_gateway_id }}"
+        network_interface_id: "{{ create_ngw.nat_gateway_addresses[0].network_interface_id }}"
+
+    # ============================================================
+    - name: Get NAT gateway with specific filters (state and subnet)
+      amazon.aws.ec2_vpc_nat_gateway_info:
+        filters:
+          subnet-id: "{{ subnet_id }}"
+          state: [available]
+      register: avalaible_ngws
+
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - avalaible_ngws is successful
+          - avalaible_ngws.result | length == 1
+          - '"create_time" in first_ngw'
+          - '"nat_gateway_addresses" in first_ngw'
+          - '"nat_gateway_id" in first_ngw'
+          - first_ngw.nat_gateway_id == nat_gateway_id
+          - '"state" in first_ngw'
+          - first_ngw.state == 'available'
+          - '"subnet_id" in first_ngw'
+          - first_ngw.subnet_id == subnet_id
+          - '"tags" in first_ngw'
+          - '"vpc_id" in first_ngw'
+          - first_ngw.vpc_id == vpc_id
+      vars:
+        first_ngw: "{{ avalaible_ngws.result[0] }}"
+
+    # ============================================================
+    - name: Trying this again for idempotency - create new NAT gateway with eip allocation-id - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        wait: true
+      register: create_ngw
+      check_mode: true
+
+    - name: Assert recreation would do nothing (expected changed=false) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - not create_ngw.changed
+          - '"create_time" in create_ngw'
+          - '"nat_gateway_addresses" in create_ngw'
+          - '"nat_gateway_id" in create_ngw'
+          - create_ngw.nat_gateway_addresses[0].allocation_id == allocation_id
+          - create_ngw.nat_gateway_id.startswith("nat-")
+          - '"state" in create_ngw'
+          - create_ngw.state == 'available'
+          - '"subnet_id" in create_ngw'
+          - create_ngw.subnet_id == subnet_id
+          - '"tags" in create_ngw'
+          - '"vpc_id" in create_ngw'
+          - create_ngw.vpc_id == vpc_id
+
+    - name: Trying this again for idempotency - create new NAT gateway with eip allocation-id
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        wait: true
+      register: create_ngw
+
+    - name: Assert recreation would do nothing (expected changed=false)
+      ansible.builtin.assert:
+        that:
+          - not create_ngw.changed
+          - '"create_time" in create_ngw'
+          - '"nat_gateway_addresses" in create_ngw'
+          - '"nat_gateway_id" in create_ngw'
+          - create_ngw.nat_gateway_addresses[0].allocation_id == allocation_id
+          - create_ngw.nat_gateway_id.startswith("nat-")
+          - '"state" in create_ngw'
+          - create_ngw.state == 'available'
+          - '"subnet_id" in create_ngw'
+          - create_ngw.subnet_id == subnet_id
+          - '"tags" in create_ngw'
+          - '"vpc_id" in create_ngw'
+          - create_ngw.vpc_id == vpc_id
+
+    # ============================================================
+    - name: Create new NAT gateway only if one does not exist already - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway:
+        if_exist_do_not_create: true
+        subnet_id: "{{ subnet_id }}"
+        wait: true
+      register: create_ngw
+      check_mode: true
+
+    - name: Assert recreation would do nothing (expected changed=false) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - not create_ngw.changed
+          - '"create_time" in create_ngw'
+          - '"nat_gateway_addresses" in create_ngw'
+          - '"nat_gateway_id" in create_ngw'
+          - create_ngw.nat_gateway_addresses[0].allocation_id == allocation_id
+          - create_ngw.nat_gateway_id.startswith("nat-")
+          - '"state" in create_ngw'
+          - create_ngw.state == 'available'
+          - '"subnet_id" in create_ngw'
+          - create_ngw.subnet_id == subnet_id
+          - '"tags" in create_ngw'
+          - '"vpc_id" in create_ngw'
+          - create_ngw.vpc_id == vpc_id
+
+    - name: Create new NAT gateway only if one does not exist already
+      amazon.aws.ec2_vpc_nat_gateway:
+        if_exist_do_not_create: true
+        subnet_id: "{{ subnet_id }}"
+        wait: true
+      register: create_ngw
+
+    - name: Assert recreation would do nothing (expected changed=false)
+      ansible.builtin.assert:
+        that:
+          - not create_ngw.changed
+          - '"create_time" in create_ngw'
+          - '"nat_gateway_addresses" in create_ngw'
+          - '"nat_gateway_id" in create_ngw'
+          - create_ngw.nat_gateway_addresses[0].allocation_id == allocation_id
+          - create_ngw.nat_gateway_id.startswith("nat-")
+          - '"state" in create_ngw'
+          - create_ngw.state == 'available'
+          - '"subnet_id" in create_ngw'
+          - create_ngw.subnet_id == subnet_id
+          - '"tags" in create_ngw'
+          - '"vpc_id" in create_ngw'
+          - create_ngw.vpc_id == vpc_id
+
+    # ============================================================
+    - name: Allocate a new EIP
+      amazon.aws.ec2_eip:
+        in_vpc: true
+        reuse_existing_ip_allowed: true
+        tag_name: FREE
+      register: eip_result
+
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - eip_result is successful
+          - '"allocation_id" in eip_result'
+          - eip_result.allocation_id.startswith("eipalloc-")
+          - '"public_ip" in eip_result'
+
+    - name: "Set fact: EIP allocation ID and EIP public IP"
+      ansible.builtin.set_fact:
+        second_eip_address: "{{ eip_result.public_ip }}"
+        second_allocation_id: "{{ eip_result.allocation_id }}"
+
+    # ============================================================
+    - name: Create new nat gateway with eip address - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        eip_address: "{{ second_eip_address }}"
+        wait: true
+      register: create_ngw
+      check_mode: true
+
+    - name: Assert creation happened (expected changed=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - create_ngw.changed
+
+    - name: Create new NAT gateway with eip address
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        eip_address: "{{ second_eip_address }}"
+        wait: true
+      register: create_ngw
+
+    - name: Assert creation happened (expected changed=true)
+      ansible.builtin.assert:
+        that:
+          - create_ngw.changed
+          - '"create_time" in create_ngw'
+          - '"nat_gateway_addresses" in create_ngw'
+          - '"nat_gateway_id" in create_ngw'
+          - create_ngw.nat_gateway_addresses[0].allocation_id == second_allocation_id
+          - create_ngw.nat_gateway_id.startswith("nat-")
+          - '"state" in create_ngw'
+          - create_ngw.state == 'available'
+          - '"subnet_id" in create_ngw'
+          - create_ngw.subnet_id == subnet_id
+          - '"tags" in create_ngw'
+          - '"vpc_id" in create_ngw'
+          - create_ngw.vpc_id == vpc_id
+
+    # ============================================================
+    - name: Trying this again for idempotency - create new NAT gateway with eip address - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        eip_address: "{{ second_eip_address }}"
+        wait: true
+      register: create_ngw
+      check_mode: true
+
+    - name: Assert recreation would do nothing (expected changed=false) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - not create_ngw.changed
+          - '"create_time" in create_ngw'
+          - '"nat_gateway_addresses" in create_ngw'
+          - '"nat_gateway_id" in create_ngw'
+          - create_ngw.nat_gateway_addresses[0].allocation_id == second_allocation_id
+          - create_ngw.nat_gateway_id.startswith("nat-")
+          - '"state" in create_ngw'
+          - create_ngw.state == 'available'
+          - '"subnet_id" in create_ngw'
+          - create_ngw.subnet_id == subnet_id
+          - '"tags" in create_ngw'
+          - '"vpc_id" in create_ngw'
+          - create_ngw.vpc_id == vpc_id
+
+    - name: Trying this again for idempotency -  create new NAT gateway with eip address
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        eip_address: "{{ second_eip_address }}"
+        wait: true
+      register: create_ngw
+
+    - name: Assert recreation would do nothing (expected changed=false)
+      ansible.builtin.assert:
+        that:
+          - not create_ngw.changed
+          - '"create_time" in create_ngw'
+          - '"nat_gateway_addresses" in create_ngw'
+          - '"nat_gateway_id" in create_ngw'
+          - create_ngw.nat_gateway_addresses[0].allocation_id == second_allocation_id
+          - create_ngw.nat_gateway_id.startswith("nat-")
+          - '"state" in create_ngw'
+          - create_ngw.state == 'available'
+          - '"subnet_id" in create_ngw'
+          - create_ngw.subnet_id == subnet_id
+          - '"tags" in create_ngw'
+          - '"vpc_id" in create_ngw'
+          - create_ngw.vpc_id == vpc_id
+
+    # ============================================================
+    - name: Create new NAT gateway when eip_address is invalid and create_default is true
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        eip_address: 192.0.2.1
+        state: present
+        wait: true
+        default_create: true
+      register: _nat_gateway
+
+    - name:
+      ansible.builtin.assert:
+        that:
+          - _nat_gateway.changed
+          - '"create_time" in _nat_gateway'
+          - '"nat_gateway_addresses" in _nat_gateway'
+          - '"nat_gateway_id" in _nat_gateway'
+          - _nat_gateway.nat_gateway_id.startswith("nat-")
+          - '"state" in _nat_gateway'
+          - _nat_gateway.state == 'available'
+          - '"subnet_id" in _nat_gateway'
+          - _nat_gateway.subnet_id == subnet_id
+          - '"tags" in _nat_gateway'
+          - '"vpc_id" in _nat_gateway'
+          - _nat_gateway.vpc_id == vpc_id
+
+    - name: Fail when eip_address is invalid and create_default is false
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        eip_address: 192.0.2.1
+        state: present
+        wait: true
+      register: _fail_nat_gateway
+      ignore_errors: true
+
+    - name: Assert fail because eip_address is invalid
+      ansible.builtin.assert:
+        that: _fail_nat_gateway.msg == "EIP 192.0.2.1 does not exist"
+
+    # ============================================================
+    - name: Fetch NAT gateway by ID (list)
+      amazon.aws.ec2_vpc_nat_gateway_info:
+        nat_gateway_ids:
+          - "{{ nat_gateway_id }}"
+      register: ngw_info
+
+    - name: Check NAT gateway exists
+      ansible.builtin.assert:
+        that:
+          - ngw_info is successful
+          - ngw_info.result | length == 1
+          - '"create_time" in first_ngw'
+          - '"nat_gateway_addresses" in first_ngw'
+          - '"nat_gateway_id" in first_ngw'
+          - first_ngw.nat_gateway_id == nat_gateway_id
+          - '"state" in first_ngw'
+          - first_ngw.state == 'available'
+          - '"subnet_id" in first_ngw'
+          - first_ngw.subnet_id == subnet_id
+          - '"tags" in first_ngw'
+          - '"vpc_id" in first_ngw'
+          - first_ngw.vpc_id == vpc_id
+      vars:
+        first_ngw: "{{ ngw_info.result[0] }}"
+
+    # ============================================================
+    - name: Delete NAT gateway - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway:
+        nat_gateway_id: "{{ nat_gateway_id }}"
+        state: absent
+        wait: true
+      register: delete_nat_gateway
+      check_mode: true
+
+    - name: Assert state=absent (expected changed=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - delete_nat_gateway.changed
+
+    - name: Delete NAT gateway
+      amazon.aws.ec2_vpc_nat_gateway:
+        nat_gateway_id: "{{ nat_gateway_id }}"
+        state: absent
+        wait: true
+      register: delete_nat_gateway
+
+    - name: Assert state=absent (expected changed=true)
+      ansible.builtin.assert:
+        that:
+          - delete_nat_gateway.changed
+          - '"delete_time" in delete_nat_gateway'
+          - '"nat_gateway_addresses" in delete_nat_gateway'
+          - '"nat_gateway_id" in delete_nat_gateway'
+          - delete_nat_gateway.nat_gateway_id == nat_gateway_id
+          - '"state" in delete_nat_gateway'
+          - delete_nat_gateway.state in ['deleted', 'deleting']
+          - '"subnet_id" in delete_nat_gateway'
+          - delete_nat_gateway.subnet_id == subnet_id
+          - '"tags" in delete_nat_gateway'
+          - '"vpc_id" in delete_nat_gateway'
+          - delete_nat_gateway.vpc_id == vpc_id
+
+    # ============================================================
+    - name: Create new NAT gateway with eip allocation-id and tags - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        tags:
+          tag_one: "{{ resource_prefix }} One"
+          Tag Two: two {{ resource_prefix }}
+        wait: true
+      register: create_ngw
+      check_mode: true
+
+    - name: Assert creation happened (expected changed=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - create_ngw.changed
+
+    - name: Create new NAT gateway with eip allocation-id and tags
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        tags:
+          tag_one: "{{ resource_prefix }} One"
+          Tag Two: two {{ resource_prefix }}
+        wait: true
+      register: create_ngw
+
+    - name: Assert creation happened (expected changed=true)
+      ansible.builtin.assert:
+        that:
+          - create_ngw.changed
+          - '"create_time" in create_ngw'
+          - create_ngw.nat_gateway_addresses[0].allocation_id == allocation_id
+          - '"nat_gateway_id" in create_ngw'
+          - create_ngw.nat_gateway_id.startswith("nat-")
+          - '"state" in create_ngw'
+          - create_ngw.state == 'available'
+          - '"subnet_id" in create_ngw'
+          - create_ngw.subnet_id == subnet_id
+          - '"tags" in create_ngw'
+          - create_ngw.tags | length == 2
+          - create_ngw.tags["tag_one"] == '{{ resource_prefix }} One'
+          - create_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
+          - '"vpc_id" in create_ngw'
+          - create_ngw.vpc_id == vpc_id
+          - create_ngw.connectivity_type == 'public'
+
+    - name: "Set facts: NAT gateway ID"
+      ansible.builtin.set_fact:
+        ngw_id: "{{ create_ngw.nat_gateway_id }}"
+
+    # ============================================================
+    - name: Update the tags (no change) - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        tags:
+          tag_one: "{{ resource_prefix }} One"
+          Tag Two: two {{ resource_prefix }}
+        wait: true
+      register: update_tags_ngw
+      check_mode: true
+
+    - name: Assert tag update would do nothing (expected changed=false) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - not update_tags_ngw.changed
+          - '"nat_gateway_id" in update_tags_ngw'
+          - update_tags_ngw.nat_gateway_id == ngw_id
+          - '"subnet_id" in update_tags_ngw'
+          - update_tags_ngw.subnet_id == subnet_id
+          - '"tags" in update_tags_ngw'
+          - update_tags_ngw.tags | length == 2
+          - update_tags_ngw.tags["tag_one"] == '{{ resource_prefix }} One'
+          - update_tags_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
+          - '"vpc_id" in update_tags_ngw'
+          - update_tags_ngw.vpc_id == vpc_id
+
+    - name: Update the tags (no change)
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        tags:
+          tag_one: "{{ resource_prefix }} One"
+          Tag Two: two {{ resource_prefix }}
+        wait: true
+      register: update_tags_ngw
+
+    - name: Assert tag update would do nothing (expected changed=false)
+      ansible.builtin.assert:
+        that:
+          - not update_tags_ngw.changed
+          - '"nat_gateway_id" in update_tags_ngw'
+          - update_tags_ngw.nat_gateway_id == ngw_id
+          - '"subnet_id" in update_tags_ngw'
+          - update_tags_ngw.subnet_id == subnet_id
+          - '"tags" in update_tags_ngw'
+          - update_tags_ngw.tags | length == 2
+          - update_tags_ngw.tags["tag_one"] == '{{ resource_prefix }} One'
+          - update_tags_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
+          - '"vpc_id" in update_tags_ngw'
+          - update_tags_ngw.vpc_id == vpc_id
+
+    # ============================================================
+    - name: Gather information about a filtered list of NAT Gateways using tags and state - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway_info:
+        filters:
+          tag:Tag Two: two {{ resource_prefix }}
+          state: [available]
+      register: ngw_info
+      check_mode: true
+
+    - name: Assert success - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - ngw_info is successful
+          - ngw_info.result | length == 1
+          - '"create_time" in second_ngw'
+          - '"nat_gateway_addresses" in second_ngw'
+          - '"nat_gateway_id" in second_ngw'
+          - second_ngw.nat_gateway_id == ngw_id
+          - '"state" in second_ngw'
+          - second_ngw.state == 'available'
+          - '"subnet_id" in second_ngw'
+          - second_ngw.subnet_id == subnet_id
+          - '"tags" in second_ngw'
+          - second_ngw.tags | length == 2
+          - '"tag_one" in second_ngw.tags'
+          - '"Tag Two" in second_ngw.tags'
+          - second_ngw.tags["tag_one"] == '{{ resource_prefix }} One'
+          - second_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
+          - '"vpc_id" in second_ngw'
+          - second_ngw.vpc_id == vpc_id
+      vars:
+        second_ngw: "{{ ngw_info.result[0] }}"
+
+    - name: Gather information about a filtered list of NAT Gateways using tags and state
+      amazon.aws.ec2_vpc_nat_gateway_info:
+        filters:
+          tag:Tag Two: two {{ resource_prefix }}
+          state: [available]
+      register: ngw_info
+
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - ngw_info is successful
+          - ngw_info.result | length == 1
+          - '"create_time" in second_ngw'
+          - '"nat_gateway_addresses" in second_ngw'
+          - '"nat_gateway_id" in second_ngw'
+          - second_ngw.nat_gateway_id == ngw_id
+          - '"state" in second_ngw'
+          - second_ngw.state == 'available'
+          - '"subnet_id" in second_ngw'
+          - second_ngw.subnet_id == subnet_id
+          - '"tags" in second_ngw'
+          - second_ngw.tags | length == 2
+          - '"tag_one" in second_ngw.tags'
+          - '"Tag Two" in second_ngw.tags'
+          - second_ngw.tags["tag_one"] == '{{ resource_prefix }} One'
+          - second_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
+          - '"vpc_id" in second_ngw'
+          - second_ngw.vpc_id == vpc_id
+      vars:
+        second_ngw: "{{ ngw_info.result[0] }}"
+
+    # ============================================================
+    - name: Update the tags (remove and add) - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        tags:
+          tag_three: "{{ resource_prefix }} Three"
+          Tag Two: two {{ resource_prefix }}
+        wait: true
+      register: update_tags_ngw
+      check_mode: true
+
+    - name: Assert tag update would happen (expected changed=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - update_tags_ngw.changed
+          - '"nat_gateway_id" in update_tags_ngw'
+          - update_tags_ngw.nat_gateway_id == ngw_id
+          - '"subnet_id" in update_tags_ngw'
+          - update_tags_ngw.subnet_id == subnet_id
+          - '"tags" in update_tags_ngw'
+          - '"vpc_id" in update_tags_ngw'
+          - update_tags_ngw.vpc_id == vpc_id
+
+    - name: Update the tags (remove and add)
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        tags:
+          tag_three: "{{ resource_prefix }} Three"
+          Tag Two: two {{ resource_prefix }}
+        wait: true
+      register: update_tags_ngw
+
+    - name: Assert tag update would happen (expected changed=true)
+      ansible.builtin.assert:
+        that:
+          - update_tags_ngw.changed
+          - '"nat_gateway_id" in update_tags_ngw'
+          - update_tags_ngw.nat_gateway_id == ngw_id
+          - '"subnet_id" in update_tags_ngw'
+          - update_tags_ngw.subnet_id == subnet_id
+          - '"tags" in update_tags_ngw'
+          - update_tags_ngw.tags | length == 2
+          - update_tags_ngw.tags["tag_three"] == '{{ resource_prefix }} Three'
+          - update_tags_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
+          - '"vpc_id" in update_tags_ngw'
+          - update_tags_ngw.vpc_id == vpc_id
+
+    # ============================================================
+    - name: Gather information about a filtered list of NAT Gateways using tags and state (no match) - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway_info:
+        filters:
+          tag:tag_one: "{{ resource_prefix }} One"
+          state: [available]
+      register: ngw_info
+      check_mode: true
+
+    - name: Assert success - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - ngw_info is successful
+          - ngw_info.result | length == 0
+
+    - name: Gather information about a filtered list of NAT Gateways using tags and state (no match)
+      amazon.aws.ec2_vpc_nat_gateway_info:
+        filters:
+          tag:tag_one: "{{ resource_prefix }} One"
+          state: [available]
+      register: ngw_info
+
+    - name: Assert success
+      ansible.builtin.assert:
+        that:
+          - ngw_info is successful
+          - ngw_info.result | length == 0
+
+    # ============================================================
+    - name: Update the tags add without purge - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway:
+        if_exist_do_not_create: true
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        purge_tags: false
+        tags:
+          tag_one: "{{ resource_prefix }} One"
+        wait: true
+      register: update_tags_ngw
+      check_mode: true
+
+    - name: Assert tags would be added - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - update_tags_ngw.changed
+          - '"nat_gateway_id" in update_tags_ngw'
+          - update_tags_ngw.nat_gateway_id == ngw_id
+          - '"subnet_id" in update_tags_ngw'
+          - update_tags_ngw.subnet_id == subnet_id
+          - '"tags" in update_tags_ngw'
+          - '"vpc_id" in update_tags_ngw'
+          - update_tags_ngw.vpc_id == vpc_id
+
+    - name: Update the tags add without purge
+      amazon.aws.ec2_vpc_nat_gateway:
+        if_exist_do_not_create: true
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        purge_tags: false
+        tags:
+          tag_one: "{{ resource_prefix }} One"
+        wait: true
+      register: update_tags_ngw
+
+    - name: Assert tags would be added
+      ansible.builtin.assert:
+        that:
+          - update_tags_ngw.changed
+          - '"nat_gateway_id" in update_tags_ngw'
+          - update_tags_ngw.nat_gateway_id == ngw_id
+          - '"subnet_id" in update_tags_ngw'
+          - update_tags_ngw.subnet_id == subnet_id
+          - '"tags" in update_tags_ngw'
+          - update_tags_ngw.tags | length == 3
+          - update_tags_ngw.tags["tag_one"] == '{{ resource_prefix }} One'
+          - update_tags_ngw.tags["tag_three"] == '{{ resource_prefix }} Three'
+          - update_tags_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
+          - '"vpc_id" in update_tags_ngw'
+          - update_tags_ngw.vpc_id == vpc_id
+
+    # ============================================================
+    - name: Remove all tags - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        tags: {}
+      register: delete_tags_ngw
+      check_mode: true
+
+    - name: assert tags would be removed - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - delete_tags_ngw.changed
+          - '"nat_gateway_id" in delete_tags_ngw'
+          - delete_tags_ngw.nat_gateway_id == ngw_id
+          - '"subnet_id" in delete_tags_ngw'
+          - delete_tags_ngw.subnet_id == subnet_id
+          - '"tags" in delete_tags_ngw'
+          - '"vpc_id" in delete_tags_ngw'
+          - delete_tags_ngw.vpc_id == vpc_id
+
+    - name: Remove all tags
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        tags: {}
+      register: delete_tags_ngw
+
+    - name: Assert tags would be removed
+      ansible.builtin.assert:
+        that:
+          - delete_tags_ngw.changed
+          - '"nat_gateway_id" in delete_tags_ngw'
+          - delete_tags_ngw.nat_gateway_id == ngw_id
+          - '"subnet_id" in delete_tags_ngw'
+          - delete_tags_ngw.subnet_id == subnet_id
+          - '"tags" in delete_tags_ngw'
+          - delete_tags_ngw.tags | length == 0
+          - '"vpc_id" in delete_tags_ngw'
+          - delete_tags_ngw.vpc_id == vpc_id
+
+    # ============================================================
+    - name: Update with CamelCase tags - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway:
+        if_exist_do_not_create: true
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        purge_tags: false
+        tags:
+          lowercase spaced: hello cruel world
+          Title Case: Hello Cruel World
+          CamelCase: SimpleCamelCase
+          snake_case: simple_snake_case
+        wait: true
+      register: update_tags_ngw
+      check_mode: true
+
+    - name: Assert tags would be added - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - update_tags_ngw.changed
+          - '"nat_gateway_id" in update_tags_ngw'
+          - update_tags_ngw.nat_gateway_id == ngw_id
+          - '"subnet_id" in update_tags_ngw'
+          - update_tags_ngw.subnet_id == subnet_id
+          - '"tags" in update_tags_ngw'
+          - '"vpc_id" in update_tags_ngw'
+          - update_tags_ngw.vpc_id == vpc_id
+
+    - name: Update with CamelCase tags
+      amazon.aws.ec2_vpc_nat_gateway:
+        if_exist_do_not_create: true
+        subnet_id: "{{ subnet_id }}"
+        allocation_id: "{{ allocation_id }}"
+        purge_tags: false
+        tags:
+          lowercase spaced: hello cruel world
+          Title Case: Hello Cruel World
+          CamelCase: SimpleCamelCase
+          snake_case: simple_snake_case
+        wait: true
+      register: update_tags_ngw
+
+    - name: Assert tags would be added
+      ansible.builtin.assert:
+        that:
+          - update_tags_ngw.changed
+          - '"nat_gateway_id" in update_tags_ngw'
+          - update_tags_ngw.nat_gateway_id == ngw_id
+          - '"subnet_id" in update_tags_ngw'
+          - update_tags_ngw.subnet_id == subnet_id
+          - '"tags" in update_tags_ngw'
+          - update_tags_ngw.tags | length == 4
+          - update_tags_ngw.tags["lowercase spaced"] == 'hello cruel world'
+          - update_tags_ngw.tags["Title Case"] == 'Hello Cruel World'
+          - update_tags_ngw.tags["CamelCase"] == 'SimpleCamelCase'
+          - update_tags_ngw.tags["snake_case"] == 'simple_snake_case'
+          - '"vpc_id" in update_tags_ngw'
+          - update_tags_ngw.vpc_id == vpc_id
+
+    # ============================================================
+
+    - name: Delete NAT gateway
+      amazon.aws.ec2_vpc_nat_gateway:
+        nat_gateway_id: "{{ nat_gateway_id }}"
+        state: absent
+        wait: true
+      register: delete_nat_gateway
+
+    # ============================================================
+
+    - name: Create new NAT gateway with connectivity_type = private - CHECK_MODE
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        connectivity_type: private
+        wait: true
+      register: create_ngw
+      check_mode: true
+
+    - name: Assert creation happened (expected changed=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - create_ngw.changed
+          - '"ec2:CreateNatGateway" not in create_ngw.resource_actions'
+
+    - name: Create new NAT gateway with eip connectivity_type = private
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ subnet_id }}"
+        connectivity_type: private
+        wait: true
+      register: create_ngw
+
+    - name: Assert creation happened (expected changed=true)
+      ansible.builtin.assert:
+        that:
+          - create_ngw.changed
+          - create_ngw.connectivity_type == 'private'
+          - '"create_time" in create_ngw'
+          - '"allocation_id" not in create_ngw.nat_gateway_addresses[0]'
+
+    - name: "set facts: NAT gateway ID"
+      ansible.builtin.set_fact:
+        nat_gateway_id: "{{ create_ngw.nat_gateway_id }}"
+        network_interface_id: "{{ create_ngw.nat_gateway_addresses[0].network_interface_id }}"
 
   # ============================================================
-  - name: Allocate a new EIP
-    ec2_eip:
-      in_vpc: true
-      reuse_existing_ip_allowed: true
-      tag_name: FREE
-    register: eip_result
-
-  - name: Assert success
-    assert:
-      that:
-      - eip_result is successful
-      - '"allocation_id" in eip_result'
-      - eip_result.allocation_id.startswith("eipalloc-")
-      - '"public_ip" in eip_result'
-
-  - name: 'set fact: EIP allocation ID and EIP public IP'
-    set_fact:
-      eip_address: '{{ eip_result.public_ip }}'
-      allocation_id: '{{ eip_result.allocation_id }}'
-
-
-  # ============================================================
-  - name: Create subnet and associate to the VPC
-    ec2_vpc_subnet:
-      state: present
-      vpc_id: '{{ vpc_id }}'
-      cidr: '{{ subnet_cidr }}'
-    register: subnet_result
-
-  - name: Assert success
-    assert:
-      that:
-      - subnet_result is successful
-      - '"subnet" in subnet_result'
-      - '"cidr_block" in subnet_result.subnet'
-      - subnet_result.subnet.cidr_block == subnet_cidr
-      - '"id" in subnet_result.subnet'
-      - subnet_result.subnet.id.startswith("subnet-")
-      - '"state" in subnet_result.subnet'
-      - subnet_result.subnet.state == 'available'
-      - '"tags" in subnet_result.subnet'
-      - subnet_result.subnet.vpc_id == vpc_id
-
-  - name: 'set fact: VPC subnet ID'
-    set_fact:
-      subnet_id: '{{ subnet_result.subnet.id }}'
-
-
-  # ============================================================
-  - name: Search for NAT gateways by subnet (no matches) - CHECK_MODE
-    ec2_vpc_nat_gateway_info:
-      filters:
-        subnet-id: '{{ subnet_id }}'
-        state: [available]
-    register: existing_ngws
-    check_mode: yes
-
-  - name: Assert no NAT gateway found - CHECK_MODE
-    assert:
-      that:
-      - existing_ngws is successful
-      - (existing_ngws.result|length) == 0
-
-  - name: Search for NAT gateways by subnet - no matches
-    ec2_vpc_nat_gateway_info:
-      filters:
-        subnet-id: '{{ subnet_id }}'
-        state: [available]
-    register: existing_ngws
-
-  - name: Assert no NAT gateway found
-    assert:
-      that:
-      - existing_ngws is successful
-      - (existing_ngws.result|length) == 0
-
-
-  # ============================================================
-  - name: Create IGW
-    ec2_vpc_igw:
-      vpc_id: '{{ vpc_id }}'
-    register: create_igw
-
-  - name: Assert success
-    assert:
-      that:
-      - create_igw is successful
-      - create_igw.gateway_id.startswith("igw-")
-      - create_igw.vpc_id == vpc_id
-      - '"gateway_id" in create_igw'
-
-
-  # ============================================================
-  - name: Create new NAT gateway with eip allocation-id - CHECK_MODE
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      wait: yes
-    register: create_ngw
-    check_mode: yes
-
-  - name: Assert creation happened (expected changed=true) - CHECK_MODE
-    assert:
-      that:
-      - create_ngw.changed
-
-  - name: Create new NAT gateway with eip allocation-id
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      wait: yes
-    register: create_ngw
-
-  - name: Assert creation happened (expected changed=true)
-    assert:
-      that:
-      - create_ngw.changed
-      - '"create_time" in create_ngw'
-      - '"nat_gateway_addresses" in create_ngw'
-      - '"nat_gateway_id" in create_ngw'
-      - create_ngw.nat_gateway_addresses[0].allocation_id == allocation_id
-      - create_ngw.nat_gateway_id.startswith("nat-")
-      - '"state" in create_ngw'
-      - create_ngw.state == 'available'
-      - '"subnet_id" in create_ngw'
-      - create_ngw.subnet_id == subnet_id
-      - '"tags" in create_ngw'
-      - '"vpc_id" in create_ngw'
-      - create_ngw.vpc_id == vpc_id
-
-  - name: 'set facts: NAT gateway ID'
-    set_fact:
-      nat_gateway_id: '{{ create_ngw.nat_gateway_id }}'
-      network_interface_id: '{{ create_ngw.nat_gateway_addresses[0].network_interface_id }}'
-
-
-  # ============================================================
-  - name: Get NAT gateway with specific filters (state and subnet)
-    ec2_vpc_nat_gateway_info:
-      filters:
-        subnet-id: '{{ subnet_id }}'
-        state: [available]
-    register: avalaible_ngws
-
-  - name: Assert success
-    assert:
-      that:
-      - avalaible_ngws is successful
-      - avalaible_ngws.result | length == 1
-      - '"create_time" in first_ngw'
-      - '"nat_gateway_addresses" in first_ngw'
-      - '"nat_gateway_id" in first_ngw'
-      - first_ngw.nat_gateway_id == nat_gateway_id
-      - '"state" in first_ngw'
-      - first_ngw.state == 'available'
-      - '"subnet_id" in first_ngw'
-      - first_ngw.subnet_id == subnet_id
-      - '"tags" in first_ngw'
-      - '"vpc_id" in first_ngw'
-      - first_ngw.vpc_id == vpc_id
-    vars:
-      first_ngw: '{{ avalaible_ngws.result[0] }}'
-
-  # ============================================================
-  - name: Trying this again for idempotency - create new NAT gateway with eip allocation-id
-      - CHECK_MODE
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      wait: yes
-    register: create_ngw
-    check_mode: yes
-
-  - name: Assert recreation would do nothing (expected changed=false) - CHECK_MODE
-    assert:
-      that:
-      - not create_ngw.changed
-      - '"create_time" in create_ngw'
-      - '"nat_gateway_addresses" in create_ngw'
-      - '"nat_gateway_id" in create_ngw'
-      - create_ngw.nat_gateway_addresses[0].allocation_id == allocation_id
-      - create_ngw.nat_gateway_id.startswith("nat-")
-      - '"state" in create_ngw'
-      - create_ngw.state == 'available'
-      - '"subnet_id" in create_ngw'
-      - create_ngw.subnet_id == subnet_id
-      - '"tags" in create_ngw'
-      - '"vpc_id" in create_ngw'
-      - create_ngw.vpc_id == vpc_id
-
-  - name: Trying this again for idempotency - create new NAT gateway with eip allocation-id
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      wait: yes
-    register: create_ngw
-
-  - name: Assert recreation would do nothing (expected changed=false)
-    assert:
-      that:
-      - not create_ngw.changed
-      - '"create_time" in create_ngw'
-      - '"nat_gateway_addresses" in create_ngw'
-      - '"nat_gateway_id" in create_ngw'
-      - create_ngw.nat_gateway_addresses[0].allocation_id == allocation_id
-      - create_ngw.nat_gateway_id.startswith("nat-")
-      - '"state" in create_ngw'
-      - create_ngw.state == 'available'
-      - '"subnet_id" in create_ngw'
-      - create_ngw.subnet_id == subnet_id
-      - '"tags" in create_ngw'
-      - '"vpc_id" in create_ngw'
-      - create_ngw.vpc_id == vpc_id
-
-
-  # ============================================================
-  - name: Create new NAT gateway only if one does not exist already - CHECK_MODE
-    ec2_vpc_nat_gateway:
-      if_exist_do_not_create: yes
-      subnet_id: '{{ subnet_id }}'
-      wait: yes
-    register: create_ngw
-    check_mode: yes
-
-  - name: Assert recreation would do nothing (expected changed=false) - CHECK_MODE
-    assert:
-      that:
-      - not create_ngw.changed
-      - '"create_time" in create_ngw'
-      - '"nat_gateway_addresses" in create_ngw'
-      - '"nat_gateway_id" in create_ngw'
-      - create_ngw.nat_gateway_addresses[0].allocation_id == allocation_id
-      - create_ngw.nat_gateway_id.startswith("nat-")
-      - '"state" in create_ngw'
-      - create_ngw.state == 'available'
-      - '"subnet_id" in create_ngw'
-      - create_ngw.subnet_id == subnet_id
-      - '"tags" in create_ngw'
-      - '"vpc_id" in create_ngw'
-      - create_ngw.vpc_id == vpc_id
-
-  - name: Create new NAT gateway only if one does not exist already
-    ec2_vpc_nat_gateway:
-      if_exist_do_not_create: yes
-      subnet_id: '{{ subnet_id }}'
-      wait: yes
-    register: create_ngw
-
-  - name: Assert recreation would do nothing (expected changed=false)
-    assert:
-      that:
-      - not create_ngw.changed
-      - '"create_time" in create_ngw'
-      - '"nat_gateway_addresses" in create_ngw'
-      - '"nat_gateway_id" in create_ngw'
-      - create_ngw.nat_gateway_addresses[0].allocation_id == allocation_id
-      - create_ngw.nat_gateway_id.startswith("nat-")
-      - '"state" in create_ngw'
-      - create_ngw.state == 'available'
-      - '"subnet_id" in create_ngw'
-      - create_ngw.subnet_id == subnet_id
-      - '"tags" in create_ngw'
-      - '"vpc_id" in create_ngw'
-      - create_ngw.vpc_id == vpc_id
-
-
-  # ============================================================
-  - name: Allocate a new EIP
-    ec2_eip:
-      in_vpc: true
-      reuse_existing_ip_allowed: true
-      tag_name: FREE
-    register: eip_result
-
-  - name: Assert success
-    assert:
-      that:
-      - eip_result is successful
-      - '"allocation_id" in eip_result'
-      - eip_result.allocation_id.startswith("eipalloc-")
-      - '"public_ip" in eip_result'
-  
-  - name: 'Set fact: EIP allocation ID and EIP public IP'
-    set_fact:
-      second_eip_address: '{{ eip_result.public_ip }}'
-      second_allocation_id: '{{ eip_result.allocation_id }}'
-
-  
-  # ============================================================
-  - name: Create new nat gateway with eip address - CHECK_MODE
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      eip_address: '{{ second_eip_address }}'
-      wait: yes
-    register: create_ngw
-    check_mode: yes
-
-  - name: Assert creation happened (expected changed=true) - CHECK_MODE
-    assert:
-      that:
-      - create_ngw.changed
-
-  - name: Create new NAT gateway with eip address
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      eip_address: '{{ second_eip_address }}'
-      wait: yes
-    register: create_ngw
-
-  - name: Assert creation happened (expected changed=true)
-    assert:
-      that:
-      - create_ngw.changed
-      - '"create_time" in create_ngw'
-      - '"nat_gateway_addresses" in create_ngw'
-      - '"nat_gateway_id" in create_ngw'
-      - create_ngw.nat_gateway_addresses[0].allocation_id == second_allocation_id
-      - create_ngw.nat_gateway_id.startswith("nat-")
-      - '"state" in create_ngw'
-      - create_ngw.state == 'available'
-      - '"subnet_id" in create_ngw'
-      - create_ngw.subnet_id == subnet_id
-      - '"tags" in create_ngw'
-      - '"vpc_id" in create_ngw'
-      - create_ngw.vpc_id == vpc_id
-
-
-  # ============================================================
-  - name: Trying this again for idempotency - create new NAT gateway with eip address - CHECK_MODE
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      eip_address: '{{ second_eip_address }}'
-      wait: yes
-    register: create_ngw
-    check_mode: yes
-
-  - name: Assert recreation would do nothing (expected changed=false) - CHECK_MODE
-    assert:
-      that:
-      - not create_ngw.changed
-      - '"create_time" in create_ngw'
-      - '"nat_gateway_addresses" in create_ngw'
-      - '"nat_gateway_id" in create_ngw'
-      - create_ngw.nat_gateway_addresses[0].allocation_id == second_allocation_id
-      - create_ngw.nat_gateway_id.startswith("nat-")
-      - '"state" in create_ngw'
-      - create_ngw.state == 'available'
-      - '"subnet_id" in create_ngw'
-      - create_ngw.subnet_id == subnet_id
-      - '"tags" in create_ngw'
-      - '"vpc_id" in create_ngw'
-      - create_ngw.vpc_id == vpc_id
-
-  - name: Trying this again for idempotency -  create new NAT gateway with eip address
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      eip_address: '{{ second_eip_address }}'
-      wait: yes
-    register: create_ngw
-
-  - name: Assert recreation would do nothing (expected changed=false)
-    assert:
-      that:
-      - not create_ngw.changed
-      - '"create_time" in create_ngw'
-      - '"nat_gateway_addresses" in create_ngw'
-      - '"nat_gateway_id" in create_ngw'
-      - create_ngw.nat_gateway_addresses[0].allocation_id == second_allocation_id
-      - create_ngw.nat_gateway_id.startswith("nat-")
-      - '"state" in create_ngw'
-      - create_ngw.state == 'available'
-      - '"subnet_id" in create_ngw'
-      - create_ngw.subnet_id == subnet_id
-      - '"tags" in create_ngw'
-      - '"vpc_id" in create_ngw'
-      - create_ngw.vpc_id == vpc_id
-
-
-  # ============================================================
-  - name: Create new NAT gateway when eip_address is invalid and create_default is true
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      eip_address:  "192.0.2.1"
-      state: present
-      wait: yes
-      default_create: true
-    register: _nat_gateway
-
-  - name: 
-    assert:
-      that:
-        - _nat_gateway.changed
-        - '"create_time" in _nat_gateway'
-        - '"nat_gateway_addresses" in _nat_gateway'
-        - '"nat_gateway_id" in _nat_gateway'
-        - _nat_gateway.nat_gateway_id.startswith("nat-")
-        - '"state" in _nat_gateway'
-        - _nat_gateway.state == 'available'
-        - '"subnet_id" in _nat_gateway'
-        - _nat_gateway.subnet_id == subnet_id
-        - '"tags" in _nat_gateway'
-        - '"vpc_id" in _nat_gateway'
-        - _nat_gateway.vpc_id == vpc_id
-  
-  - name: Fail when eip_address is invalid and create_default is false
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      eip_address:  "192.0.2.1"
-      state: present
-      wait: yes
-    register: _fail_nat_gateway
-    ignore_errors: true
-
-  - name: Assert fail because eip_address is invalid
-    assert:
-      that:
-        _fail_nat_gateway.msg == "EIP 192.0.2.1 does not exist"
-
-
-  # ============================================================
-  - name: Fetch NAT gateway by ID (list)
-    ec2_vpc_nat_gateway_info:
-      nat_gateway_ids:
-      - '{{ nat_gateway_id }}'
-    register: ngw_info
-
-  - name: Check NAT gateway exists
-    assert:
-      that:
-      - ngw_info is successful
-      - ngw_info.result | length == 1
-      - '"create_time" in first_ngw'
-      - '"nat_gateway_addresses" in first_ngw'
-      - '"nat_gateway_id" in first_ngw'
-      - first_ngw.nat_gateway_id == nat_gateway_id
-      - '"state" in first_ngw'
-      - first_ngw.state == 'available'
-      - '"subnet_id" in first_ngw'
-      - first_ngw.subnet_id == subnet_id
-      - '"tags" in first_ngw'
-      - '"vpc_id" in first_ngw'
-      - first_ngw.vpc_id == vpc_id
-    vars:
-      first_ngw: '{{ ngw_info.result[0] }}'
-
-
-  # ============================================================
-  - name: Delete NAT gateway - CHECK_MODE
-    ec2_vpc_nat_gateway:
-      nat_gateway_id: '{{ nat_gateway_id }}'
-      state: absent
-      wait: yes
-    register: delete_nat_gateway
-    check_mode: yes
-
-  - name: Assert state=absent (expected changed=true) - CHECK_MODE
-    assert:
-      that:
-      - delete_nat_gateway.changed
-
-  - name: Delete NAT gateway
-    ec2_vpc_nat_gateway:
-      nat_gateway_id: '{{ nat_gateway_id }}'
-      state: absent
-      wait: yes
-    register: delete_nat_gateway
-
-  - name: Assert state=absent (expected changed=true)
-    assert:
-      that:
-      - delete_nat_gateway.changed
-      - '"delete_time" in delete_nat_gateway'
-      - '"nat_gateway_addresses" in delete_nat_gateway'
-      - '"nat_gateway_id" in delete_nat_gateway'
-      - delete_nat_gateway.nat_gateway_id == nat_gateway_id
-      - '"state" in delete_nat_gateway'
-      - delete_nat_gateway.state in ['deleted', 'deleting']
-      - '"subnet_id" in delete_nat_gateway'
-      - delete_nat_gateway.subnet_id == subnet_id
-      - '"tags" in delete_nat_gateway'
-      - '"vpc_id" in delete_nat_gateway'
-      - delete_nat_gateway.vpc_id == vpc_id
-
-
-  # ============================================================
-  - name: Create new NAT gateway with eip allocation-id and tags - CHECK_MODE
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      tags:
-        tag_one: '{{ resource_prefix }} One'
-        Tag Two: two {{ resource_prefix }}
-      wait: yes
-    register: create_ngw
-    check_mode: yes
-
-  - name: Assert creation happened (expected changed=true) - CHECK_MODE
-    assert:
-      that:
-      - create_ngw.changed
-
-  - name: Create new NAT gateway with eip allocation-id and tags
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      tags:
-        tag_one: '{{ resource_prefix }} One'
-        Tag Two: two {{ resource_prefix }}
-      wait: yes
-    register: create_ngw
-
-  - name: Assert creation happened (expected changed=true)
-    assert:
-      that:
-      - create_ngw.changed
-      - '"create_time" in create_ngw'
-      - create_ngw.nat_gateway_addresses[0].allocation_id == allocation_id
-      - '"nat_gateway_id" in create_ngw'
-      - create_ngw.nat_gateway_id.startswith("nat-")
-      - '"state" in create_ngw'
-      - create_ngw.state == 'available'
-      - '"subnet_id" in create_ngw'
-      - create_ngw.subnet_id == subnet_id
-      - '"tags" in create_ngw'
-      - create_ngw.tags | length == 2
-      - create_ngw.tags["tag_one"] == '{{ resource_prefix }} One'
-      - create_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
-      - '"vpc_id" in create_ngw'
-      - create_ngw.vpc_id == vpc_id
-      - create_ngw.connectivity_type == 'public'
-
-  - name: 'Set facts: NAT gateway ID'
-    set_fact:
-      ngw_id: '{{ create_ngw.nat_gateway_id }}'
-
-
-  # ============================================================
-  - name: Update the tags (no change) - CHECK_MODE
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      tags:
-        tag_one: '{{ resource_prefix }} One'
-        Tag Two: two {{ resource_prefix }}
-      wait: yes
-    register: update_tags_ngw
-    check_mode: yes
-
-  - name: Assert tag update would do nothing (expected changed=false) - CHECK_MODE
-    assert:
-      that:
-      - not update_tags_ngw.changed
-      - '"nat_gateway_id" in update_tags_ngw'
-      - update_tags_ngw.nat_gateway_id == ngw_id
-      - '"subnet_id" in update_tags_ngw'
-      - update_tags_ngw.subnet_id == subnet_id
-      - '"tags" in update_tags_ngw'
-      - update_tags_ngw.tags | length == 2
-      - update_tags_ngw.tags["tag_one"] == '{{ resource_prefix }} One'
-      - update_tags_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
-      - '"vpc_id" in update_tags_ngw'
-      - update_tags_ngw.vpc_id == vpc_id
-
-  - name: Update the tags (no change)
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      tags:
-        tag_one: '{{ resource_prefix }} One'
-        Tag Two: two {{ resource_prefix }}
-      wait: yes
-    register: update_tags_ngw
-
-  - name: Assert tag update would do nothing (expected changed=false)
-    assert:
-      that:
-      - not update_tags_ngw.changed
-      - '"nat_gateway_id" in update_tags_ngw'
-      - update_tags_ngw.nat_gateway_id == ngw_id
-      - '"subnet_id" in update_tags_ngw'
-      - update_tags_ngw.subnet_id == subnet_id
-      - '"tags" in update_tags_ngw'
-      - update_tags_ngw.tags | length == 2
-      - update_tags_ngw.tags["tag_one"] == '{{ resource_prefix }} One'
-      - update_tags_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
-      - '"vpc_id" in update_tags_ngw'
-      - update_tags_ngw.vpc_id == vpc_id
-
-
-  # ============================================================
-  - name: Gather information about a filtered list of NAT Gateways using tags and state - CHECK_MODE
-    ec2_vpc_nat_gateway_info:
-      filters:
-        tag:Tag Two: two {{ resource_prefix }}
-        state: [available]
-    register: ngw_info
-    check_mode: yes
-
-  - name: Assert success - CHECK_MODE
-    assert:
-      that:
-      - ngw_info is successful
-      - ngw_info.result | length == 1
-      - '"create_time" in second_ngw'
-      - '"nat_gateway_addresses" in second_ngw'
-      - '"nat_gateway_id" in second_ngw'
-      - second_ngw.nat_gateway_id == ngw_id
-      - '"state" in second_ngw'
-      - second_ngw.state == 'available'
-      - '"subnet_id" in second_ngw'
-      - second_ngw.subnet_id == subnet_id
-      - '"tags" in second_ngw'
-      - second_ngw.tags | length == 2
-      - '"tag_one" in second_ngw.tags'
-      - '"Tag Two" in second_ngw.tags'
-      - second_ngw.tags["tag_one"] == '{{ resource_prefix }} One'
-      - second_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
-      - '"vpc_id" in second_ngw'
-      - second_ngw.vpc_id == vpc_id
-    vars:
-      second_ngw: '{{ ngw_info.result[0] }}'
-
-  - name: Gather information about a filtered list of NAT Gateways using tags and state
-    ec2_vpc_nat_gateway_info:
-      filters:
-        tag:Tag Two: two {{ resource_prefix }}
-        state: [available]
-    register: ngw_info
-
-  - name: Assert success
-    assert:
-      that:
-      - ngw_info is successful
-      - ngw_info.result | length == 1
-      - '"create_time" in second_ngw'
-      - '"nat_gateway_addresses" in second_ngw'
-      - '"nat_gateway_id" in second_ngw'
-      - second_ngw.nat_gateway_id == ngw_id
-      - '"state" in second_ngw'
-      - second_ngw.state == 'available'
-      - '"subnet_id" in second_ngw'
-      - second_ngw.subnet_id == subnet_id
-      - '"tags" in second_ngw'
-      - second_ngw.tags | length == 2
-      - '"tag_one" in second_ngw.tags'
-      - '"Tag Two" in second_ngw.tags'
-      - second_ngw.tags["tag_one"] == '{{ resource_prefix }} One'
-      - second_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
-      - '"vpc_id" in second_ngw'
-      - second_ngw.vpc_id == vpc_id
-    vars:
-      second_ngw: '{{ ngw_info.result[0] }}'
-
-
-  # ============================================================
-  - name: Update the tags (remove and add) - CHECK_MODE
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      tags:
-        tag_three: '{{ resource_prefix }} Three'
-        Tag Two: two {{ resource_prefix }}
-      wait: yes
-    register: update_tags_ngw
-    check_mode: yes
-
-  - name: Assert tag update would happen (expected changed=true) - CHECK_MODE
-    assert:
-      that:
-      - update_tags_ngw.changed
-      - '"nat_gateway_id" in update_tags_ngw'
-      - update_tags_ngw.nat_gateway_id == ngw_id
-      - '"subnet_id" in update_tags_ngw'
-      - update_tags_ngw.subnet_id == subnet_id
-      - '"tags" in update_tags_ngw'
-      - '"vpc_id" in update_tags_ngw'
-      - update_tags_ngw.vpc_id == vpc_id
-
-  - name: Update the tags (remove and add)
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      tags:
-        tag_three: '{{ resource_prefix }} Three'
-        Tag Two: two {{ resource_prefix }}
-      wait: yes
-    register: update_tags_ngw
-
-  - name: Assert tag update would happen (expected changed=true)
-    assert:
-      that:
-      - update_tags_ngw.changed
-      - '"nat_gateway_id" in update_tags_ngw'
-      - update_tags_ngw.nat_gateway_id == ngw_id
-      - '"subnet_id" in update_tags_ngw'
-      - update_tags_ngw.subnet_id == subnet_id
-      - '"tags" in update_tags_ngw'
-      - update_tags_ngw.tags | length == 2
-      - update_tags_ngw.tags["tag_three"] == '{{ resource_prefix }} Three'
-      - update_tags_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
-      - '"vpc_id" in update_tags_ngw'
-      - update_tags_ngw.vpc_id == vpc_id
-
-
-  # ============================================================
-  - name: Gather information about a filtered list of NAT Gateways using tags and state (no match) - CHECK_MODE
-    ec2_vpc_nat_gateway_info:
-      filters:
-        tag:tag_one: '{{ resource_prefix }} One'
-        state: [available]
-    register: ngw_info
-    check_mode: yes
-
-  - name: Assert success - CHECK_MODE
-    assert:
-      that:
-      - ngw_info is successful
-      - ngw_info.result | length == 0
-
-  - name: Gather information about a filtered list of NAT Gateways using tags and
-      state (no match)
-    ec2_vpc_nat_gateway_info:
-      filters:
-        tag:tag_one: '{{ resource_prefix }} One'
-        state: [available]
-    register: ngw_info
-
-  - name: Assert success
-    assert:
-      that:
-      - ngw_info is successful
-      - ngw_info.result | length == 0
-
-
-  # ============================================================
-  - name: Update the tags add without purge - CHECK_MODE
-    ec2_vpc_nat_gateway:
-      if_exist_do_not_create: yes
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      purge_tags: no
-      tags:
-        tag_one: '{{ resource_prefix }} One'
-      wait: yes
-    register: update_tags_ngw
-    check_mode: yes
-
-  - name: Assert tags would be added - CHECK_MODE
-    assert:
-      that:
-      - update_tags_ngw.changed
-      - '"nat_gateway_id" in update_tags_ngw'
-      - update_tags_ngw.nat_gateway_id == ngw_id
-      - '"subnet_id" in update_tags_ngw'
-      - update_tags_ngw.subnet_id == subnet_id
-      - '"tags" in update_tags_ngw'
-      - '"vpc_id" in update_tags_ngw'
-      - update_tags_ngw.vpc_id == vpc_id
-
-  - name: Update the tags add without purge
-    ec2_vpc_nat_gateway:
-      if_exist_do_not_create: yes
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      purge_tags: no
-      tags:
-        tag_one: '{{ resource_prefix }} One'
-      wait: yes
-    register: update_tags_ngw
-
-  - name: Assert tags would be added
-    assert:
-      that:
-      - update_tags_ngw.changed
-      - '"nat_gateway_id" in update_tags_ngw'
-      - update_tags_ngw.nat_gateway_id == ngw_id
-      - '"subnet_id" in update_tags_ngw'
-      - update_tags_ngw.subnet_id == subnet_id
-      - '"tags" in update_tags_ngw'
-      - update_tags_ngw.tags | length == 3
-      - update_tags_ngw.tags["tag_one"] == '{{ resource_prefix }} One'
-      - update_tags_ngw.tags["tag_three"] == '{{ resource_prefix }} Three'
-      - update_tags_ngw.tags["Tag Two"] == 'two {{ resource_prefix }}'
-      - '"vpc_id" in update_tags_ngw'
-      - update_tags_ngw.vpc_id == vpc_id
-
-
-  # ============================================================
-  - name: Remove all tags - CHECK_MODE
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      tags: {}
-    register: delete_tags_ngw
-    check_mode: yes
-
-  - name: assert tags would be removed - CHECK_MODE
-    assert:
-      that:
-      - delete_tags_ngw.changed
-      - '"nat_gateway_id" in delete_tags_ngw'
-      - delete_tags_ngw.nat_gateway_id == ngw_id
-      - '"subnet_id" in delete_tags_ngw'
-      - delete_tags_ngw.subnet_id == subnet_id
-      - '"tags" in delete_tags_ngw'
-      - '"vpc_id" in delete_tags_ngw'
-      - delete_tags_ngw.vpc_id == vpc_id
-
-  - name: Remove all tags
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      tags: {}
-    register: delete_tags_ngw
-
-  - name: Assert tags would be removed
-    assert:
-      that:
-      - delete_tags_ngw.changed
-      - '"nat_gateway_id" in delete_tags_ngw'
-      - delete_tags_ngw.nat_gateway_id == ngw_id
-      - '"subnet_id" in delete_tags_ngw'
-      - delete_tags_ngw.subnet_id == subnet_id
-      - '"tags" in delete_tags_ngw'
-      - delete_tags_ngw.tags | length == 0
-      - '"vpc_id" in delete_tags_ngw'
-      - delete_tags_ngw.vpc_id == vpc_id
-
-
-  # ============================================================
-  - name: Update with CamelCase tags - CHECK_MODE
-    ec2_vpc_nat_gateway:
-      if_exist_do_not_create: yes
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      purge_tags: no
-      tags:
-        lowercase spaced: "hello cruel world"
-        Title Case: "Hello Cruel World"
-        CamelCase: "SimpleCamelCase"
-        snake_case: "simple_snake_case"
-      wait: yes
-    register: update_tags_ngw
-    check_mode: yes
-
-  - name: Assert tags would be added - CHECK_MODE
-    assert:
-      that:
-      - update_tags_ngw.changed
-      - '"nat_gateway_id" in update_tags_ngw'
-      - update_tags_ngw.nat_gateway_id == ngw_id
-      - '"subnet_id" in update_tags_ngw'
-      - update_tags_ngw.subnet_id == subnet_id
-      - '"tags" in update_tags_ngw'
-      - '"vpc_id" in update_tags_ngw'
-      - update_tags_ngw.vpc_id == vpc_id
-
-  - name: Update with CamelCase tags
-    ec2_vpc_nat_gateway:
-      if_exist_do_not_create: yes
-      subnet_id: '{{ subnet_id }}'
-      allocation_id: '{{ allocation_id }}'
-      purge_tags: no
-      tags:
-        lowercase spaced: "hello cruel world"
-        Title Case: "Hello Cruel World"
-        CamelCase: "SimpleCamelCase"
-        snake_case: "simple_snake_case"
-      wait: yes
-    register: update_tags_ngw
-
-  - name: Assert tags would be added
-    assert:
-      that:
-      - update_tags_ngw.changed
-      - '"nat_gateway_id" in update_tags_ngw'
-      - update_tags_ngw.nat_gateway_id == ngw_id
-      - '"subnet_id" in update_tags_ngw'
-      - update_tags_ngw.subnet_id == subnet_id
-      - '"tags" in update_tags_ngw'
-      - update_tags_ngw.tags | length == 4
-      - update_tags_ngw.tags["lowercase spaced"] == 'hello cruel world'
-      - update_tags_ngw.tags["Title Case"] == 'Hello Cruel World'
-      - update_tags_ngw.tags["CamelCase"] == 'SimpleCamelCase'
-      - update_tags_ngw.tags["snake_case"] == 'simple_snake_case'
-      - '"vpc_id" in update_tags_ngw'
-      - update_tags_ngw.vpc_id == vpc_id
-
-
-  # ============================================================
-
-  - name: Delete NAT gateway
-    ec2_vpc_nat_gateway:
-      nat_gateway_id: '{{ nat_gateway_id }}'
-      state: absent
-      wait: yes
-    register: delete_nat_gateway
-
-  # ============================================================
-
-  - name: Create new NAT gateway with connectivity_type = private - CHECK_MODE
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      connectivity_type: 'private'
-      wait: yes
-    register: create_ngw
-    check_mode: yes
-
-  - name: Assert creation happened (expected changed=true) - CHECK_MODE
-    assert:
-      that:
-      - create_ngw.changed
-      - '"ec2:CreateNatGateway" not in create_ngw.resource_actions'
-
-  - name: Create new NAT gateway with eip connectivity_type = private
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ subnet_id }}'
-      connectivity_type: 'private'
-      wait: yes
-    register: create_ngw
-
-  - name: Assert creation happened (expected changed=true)
-    assert:
-      that:
-      - create_ngw.changed
-      - create_ngw.connectivity_type == 'private'
-      - '"create_time" in create_ngw'
-      - '"allocation_id" not in create_ngw.nat_gateway_addresses[0]'
-
-  - name: 'set facts: NAT gateway ID'
-    set_fact:
-      nat_gateway_id: '{{ create_ngw.nat_gateway_id }}'
-      network_interface_id: '{{ create_ngw.nat_gateway_addresses[0].network_interface_id }}'
- 
-  # ============================================================
-
 
   always:
-  - name: Get NAT gateways
-    ec2_vpc_nat_gateway_info:
-      filters:
-        vpc-id: '{{ vpc_id }}'
-        state: [available]
-    register: existing_ngws
-    ignore_errors: true
+    - name: Get NAT gateways
+      amazon.aws.ec2_vpc_nat_gateway_info:
+        filters:
+          vpc-id: "{{ vpc_id }}"
+          state: [available]
+      register: existing_ngws
+      ignore_errors: true
 
-  - name: Tidy up NAT gateway
-    ec2_vpc_nat_gateway:
-      subnet_id: '{{ item.subnet_id }}'
-      nat_gateway_id: '{{ item.nat_gateway_id }}'
-      connectivity_type: '{{ item.connectivity_type }}'
-      release_eip: yes
-      state: absent
-      wait: yes
-    with_items: '{{ existing_ngws.result }}'
-    ignore_errors: true
+    - name: Tidy up NAT gateway
+      amazon.aws.ec2_vpc_nat_gateway:
+        subnet_id: "{{ item.subnet_id }}"
+        nat_gateway_id: "{{ item.nat_gateway_id }}"
+        connectivity_type: "{{ item.connectivity_type }}"
+        release_eip: true
+        state: absent
+        wait: true
+      with_items: "{{ existing_ngws.result }}"
+      ignore_errors: true
 
-  - name: Delete IGW
-    ec2_vpc_igw:
-      vpc_id: '{{ vpc_id }}'
-      state: absent
-    ignore_errors: true
+    - name: Delete IGW
+      amazon.aws.ec2_vpc_igw:
+        vpc_id: "{{ vpc_id }}"
+        state: absent
+      ignore_errors: true
 
-  - name: Remove subnet
-    ec2_vpc_subnet:
-      state: absent
-      cidr: '{{ subnet_cidr }}'
-      vpc_id: '{{ vpc_id }}'
-    ignore_errors: true
+    - name: Remove subnet
+      amazon.aws.ec2_vpc_subnet:
+        state: absent
+        cidr: "{{ subnet_cidr }}"
+        vpc_id: "{{ vpc_id }}"
+      ignore_errors: true
 
-  - name: Ensure EIP is actually released
-    ec2_eip:
-      state: absent
-      device_id: '{{ item.nat_gateway_addresses[0].network_interface_id }}'
-      in_vpc: yes
-    with_items: '{{ existing_ngws.result }}'
-    ignore_errors: yes
+    - name: Ensure EIP is actually released
+      amazon.aws.ec2_eip:
+        state: absent
+        device_id: "{{ item.nat_gateway_addresses[0].network_interface_id }}"
+        in_vpc: true
+      with_items: "{{ existing_ngws.result }}"
+      ignore_errors: true
 
-  - name: Delete VPC
-    ec2_vpc_net:
-      name: '{{ vpc_name }}'
-      cidr_block: '{{ vpc_cidr }}'
-      state: absent
-      purge_cidrs: yes
-    ignore_errors: yes
+    - name: Delete VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ vpc_name }}"
+        cidr_block: "{{ vpc_cidr }}"
+        state: absent
+        purge_cidrs: true
+      ignore_errors: true

--- a/tests/integration/targets/ec2_vpc_net/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_net/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # defaults file for ec2_vpc_net
-vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/24'
-vpc_cidr_a: '10.{{ 256 | random(seed=resource_prefix) }}.1.0/24'
-vpc_cidr_b: '10.{{ 256 | random(seed=resource_prefix) }}.2.0/24'
+vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/24
+vpc_cidr_a: 10.{{ 256 | random(seed=resource_prefix) }}.1.0/24
+vpc_cidr_b: 10.{{ 256 | random(seed=resource_prefix) }}.2.0/24
 
-vpc_name: '{{ resource_prefix }}-vpc-net'
-vpc_name_updated: '{{ resource_prefix }}-updated-vpc-net'
+vpc_name: "{{ resource_prefix }}-vpc-net"
+vpc_name_updated: "{{ resource_prefix }}-updated-vpc-net"

--- a/tests/integration/targets/ec2_vpc_net/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_net/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/ec2_vpc_net/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_net/tasks/main.yml
@@ -8,47 +8,46 @@
       region: "{{ aws_region }}"
   vars:
     first_tags:
-      'Key with Spaces': Value with spaces
+      Key with Spaces: Value with spaces
       CamelCaseKey: CamelCaseValue
       pascalCaseKey: pascalCaseValue
       snake_case_key: snake_case_value
     second_tags:
-      'New Key with Spaces': Value with spaces
+      New Key with Spaces: Value with spaces
       NewCamelCaseKey: CamelCaseValue
       newPascalCaseKey: pascalCaseValue
       new_snake_case_key: snake_case_value
     third_tags:
-      'Key with Spaces': Value with spaces
+      Key with Spaces: Value with spaces
       CamelCaseKey: CamelCaseValue
       pascalCaseKey: pascalCaseValue
       snake_case_key: snake_case_value
-      'New Key with Spaces': Updated Value with spaces
+      New Key with Spaces: Updated Value with spaces
     final_tags:
-      'Key with Spaces': Value with spaces
+      Key with Spaces: Value with spaces
       CamelCaseKey: CamelCaseValue
       pascalCaseKey: pascalCaseValue
       snake_case_key: snake_case_value
-      'New Key with Spaces': Updated Value with spaces
+      New Key with Spaces: Updated Value with spaces
       NewCamelCaseKey: CamelCaseValue
       newPascalCaseKey: pascalCaseValue
       new_snake_case_key: snake_case_value
     name_tags:
       Name: "{{ vpc_name }}"
   block:
-
     # ============================================================
 
     - name: Get the current caller identity facts
-      aws_caller_info:
+      amazon.aws.aws_caller_info:
       register: caller_facts
 
     - name: run the module without parameters
-      ec2_vpc_net:
-      ignore_errors: yes
+      amazon.aws.ec2_vpc_net:
+      ignore_errors: true
       register: result
 
     - name: assert failure
-      assert:
+      ansible.builtin.assert:
         that:
           - result is failed
           #- result.msg.startswith("missing required arguments")
@@ -57,29 +56,29 @@
     # ============================================================
 
     - name: Fetch existing VPC info
-      ec2_vpc_net_info:
+      amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
     - name: Check no-one is using the Prefix before we start
-      assert:
+      ansible.builtin.assert:
         that:
           - vpc_info.vpcs | length == 0
 
     - name: test check mode creating a VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
       check_mode: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: check for a change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - vpc_info.vpcs | length == 0
@@ -87,26 +86,26 @@
     # ============================================================
 
     - name: create a VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        ipv6_cidr: True
+        ipv6_cidr: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the VPC was created successfully
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
           - vpc_info.vpcs | length == 1
 
     - name: assert the output
-      assert:
+      ansible.builtin.assert:
         that:
           - '"cidr_block" in result.vpc'
           - result.vpc.cidr_block == vpc_cidr
@@ -127,26 +126,26 @@
           - result.vpc.tags.Name == vpc_name
 
     - name: set the first VPC's details as facts for comparison and cleanup
-      set_fact:
+      ansible.builtin.set_fact:
         vpc_1_result: "{{ result }}"
         vpc_1: "{{ result.vpc.id }}"
         vpc_1_ipv6_cidr: "{{ result.vpc.ipv6_cidr_block_association_set.0.ipv6_cidr_block }}"
         default_dhcp_options_id: "{{ result.vpc.dhcp_options_id }}"
 
     - name: create a VPC (retry)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        ipv6_cidr: True
+        ipv6_cidr: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert nothing changed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -171,7 +170,7 @@
           - result.vpc.id == vpc_1
 
     - name: No-op VPC configuration, missing ipv6_cidr property
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
@@ -181,7 +180,7 @@
         #ipv6_cidr: True
       register: result
     - name: assert configuration did not change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -189,25 +188,25 @@
     # ============================================================
 
     - name: VPC info (no filters)
-      ec2_vpc_net_info:
+      amazon.aws.ec2_vpc_net_info:
       register: vpc_info
       retries: 3
       delay: 3
       until: '"InvalidVpcID.NotFound" not in ( vpc_info.msg | default("") )'
 
     - name: Test that our new VPC shows up in the results
-      assert:
+      ansible.builtin.assert:
         that:
           - vpc_1 in ( vpc_info.vpcs | map(attribute="vpc_id") | list )
 
     - name: VPC info (Simple tag filter)
-      ec2_vpc_net_info:
+      amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: Test vpc_info results
-      assert:
+      ansible.builtin.assert:
         that:
           - vpc_info.vpcs[0].cidr_block == vpc_cidr
           - vpc_info.vpcs[0].cidr_block_association_set | length == 1
@@ -231,19 +230,19 @@
     # ============================================================
 
     - name: Try to add IPv6 CIDR when one already exists
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        ipv6_cidr: True
+        ipv6_cidr: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: Assert no changes made
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
           - vpc_info.vpcs | length == 1
@@ -251,46 +250,46 @@
     # ============================================================
 
     - name: test check mode creating an identical VPC (multi_ok)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        ipv6_cidr: True
-        multi_ok: yes
+        ipv6_cidr: true
+        multi_ok: true
       check_mode: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert a change would be made
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
     - name: assert a change was not actually made
-      assert:
+      ansible.builtin.assert:
         that:
           - vpc_info.vpcs | length == 1
 
     # ============================================================
 
     - name: create a VPC with a dedicated tenancy using the same CIDR and name
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        ipv6_cidr: True
+        ipv6_cidr: true
         tenancy: dedicated
-        multi_ok: yes
+        multi_ok: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert a new VPC was created
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -299,20 +298,20 @@
           - vpc_info.vpcs | length == 2
 
     - name: set the second VPC's details as facts for comparison and cleanup
-      set_fact:
+      ansible.builtin.set_fact:
         vpc_2_result: "{{ result }}"
         vpc_2: "{{ result.vpc.id }}"
 
     # ============================================================
 
     - name: VPC info (Simple VPC-ID filter)
-      ec2_vpc_net_info:
+      amazon.aws.ec2_vpc_net_info:
         filters:
-          "vpc-id": "{{ vpc_2 }}"
+          vpc-id: "{{ vpc_2 }}"
       register: vpc_info
 
     - name: Test vpc_info results
-      assert:
+      ansible.builtin.assert:
         that:
           - vpc_info.vpcs[0].cidr_block == vpc_cidr
           - vpc_info.vpcs[0].cidr_block_association_set | length == 1
@@ -338,22 +337,22 @@
     # This will only fail if there are already *2* vpcs otherwise ec2_vpc_net
     # assumes you want to update your existing VPC...
     - name: attempt to create another VPC with the same CIDR and name without multi_ok
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        ipv6_cidr: True
+        ipv6_cidr: true
         tenancy: dedicated
-        multi_ok: no
+        multi_ok: false
       register: new_result
-      ignore_errors: yes
-    - ec2_vpc_net_info:
+      ignore_errors: true
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert failure
-      assert:
+      ansible.builtin.assert:
         that:
           - new_result is failed
           - '"If you would like to create the VPC anyway please pass True to the multi_ok param" in new_result.msg'
@@ -362,7 +361,7 @@
     # ============================================================
 
     - name: Set new name for second VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         vpc_id: "{{ vpc_2 }}"
         name: "{{ vpc_name_updated }}"
@@ -370,7 +369,7 @@
       register: result
 
     - name: assert name changed
-      assert:
+      ansible.builtin.assert:
         that:
           - '"cidr_block" in result.vpc'
           - result.vpc.cidr_block == vpc_cidr
@@ -390,32 +389,32 @@
           - result.vpc.tags.Name == vpc_name_updated
           - result.vpc.id == vpc_2
 
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert success
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - vpc_info.vpcs | length == 1
           - vpc_info.vpcs[0].vpc_id == vpc_1
 
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name_updated }}"
+          tag:Name: "{{ vpc_name_updated }}"
       register: vpc_info
 
     - name: assert success
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - vpc_info.vpcs | length == 1
           - vpc_info.vpcs[0].vpc_id == vpc_2
 
     - name: delete second VPC (by id)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         vpc_id: "{{ vpc_2 }}"
         state: absent
         cidr_block: "{{ vpc_cidr }}"
@@ -424,14 +423,14 @@
     # ============================================================
 
     - name: attempt to delete a VPC that doesn't exist
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: absent
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}-does-not-exist"
       register: result
 
     - name: assert no changes were made
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
           - not result.vpc
@@ -439,7 +438,7 @@
     # ============================================================
 
     - name: create a DHCP option set to use in next test
-      ec2_vpc_dhcp_option:
+      amazon.aws.ec2_vpc_dhcp_option:
         dns_servers:
           - 8.8.4.4
           - 8.8.8.8
@@ -447,25 +446,25 @@
           Name: "{{ vpc_name }}"
       register: new_dhcp
     - name: assert the DHCP option set was successfully created
-      assert:
+      ansible.builtin.assert:
         that:
           - new_dhcp is successful
 
     - name: modify the DHCP options set for a VPC (check_mode)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
         dhcp_opts_id: "{{ new_dhcp.dhcp_options_id }}"
       register: result
-      check_mode: True
-    - ec2_vpc_net_info:
+      check_mode: true
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the DHCP option set changed but didn't update
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - result.vpc.id == vpc_1
@@ -473,19 +472,19 @@
           - vpc_info.vpcs[0].dhcp_options_id == default_dhcp_options_id
 
     - name: modify the DHCP options set for a VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
         dhcp_opts_id: "{{ new_dhcp.dhcp_options_id }}"
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the DHCP option set changed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - result.vpc.id == vpc_1
@@ -495,19 +494,19 @@
           - vpc_info.vpcs[0].dhcp_options_id == new_dhcp.dhcp_options_id
 
     - name: modify the DHCP options set for a VPC (retry)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
         dhcp_opts_id: "{{ new_dhcp.dhcp_options_id }}"
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the DHCP option set changed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
           - result.vpc.id == vpc_1
@@ -518,20 +517,20 @@
     # ============================================================
 
     - name: disable dns_hostnames (check mode)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        dns_hostnames: False
+        dns_hostnames: false
       register: result
-      check_mode: True
-    - ec2_vpc_net_info:
+      check_mode: true
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert changed was set but not made
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -540,19 +539,19 @@
           - vpc_info.vpcs[0].enable_dns_support | bool == True
 
     - name: disable dns_hostnames
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        dns_hostnames: False
+        dns_hostnames: false
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert a change was made
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -562,19 +561,19 @@
           - vpc_info.vpcs[0].enable_dns_support | bool == True
 
     - name: disable dns_hostnames (retry)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        dns_hostnames: False
+        dns_hostnames: false
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert a change was made
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -584,21 +583,21 @@
           - vpc_info.vpcs[0].enable_dns_support | bool == True
 
     - name: disable dns_support (check mode)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        dns_hostnames: False
-        dns_support: False
-      check_mode: True
+        dns_hostnames: false
+        dns_support: false
+      check_mode: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert changed was set but not made
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -608,20 +607,20 @@
           - vpc_info.vpcs[0].enable_dns_support | bool == True
 
     - name: disable dns_support
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        dns_hostnames: False
-        dns_support: False
+        dns_hostnames: false
+        dns_support: false
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert a change was made
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -631,20 +630,20 @@
           - vpc_info.vpcs[0].enable_dns_support | bool == False
 
     - name: disable dns_support (retry)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        dns_hostnames: False
-        dns_support: False
+        dns_hostnames: false
+        dns_support: false
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert a change was not made
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -654,21 +653,21 @@
           - vpc_info.vpcs[0].enable_dns_support | bool == False
 
     - name: re-enable dns_support (check mode)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        dns_hostnames: True
-        dns_support: True
+        dns_hostnames: true
+        dns_support: true
       register: result
-      check_mode: True
-    - ec2_vpc_net_info:
+      check_mode: true
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert a change would be made but has not been
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -678,20 +677,20 @@
           - vpc_info.vpcs[0].enable_dns_support | bool == False
 
     - name: re-enable dns_support
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        dns_hostnames: True
-        dns_support: True
+        dns_hostnames: true
+        dns_support: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert a change was made
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -701,20 +700,20 @@
           - vpc_info.vpcs[0].enable_dns_support | bool == True
 
     - name: re-enable dns_support (retry)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        dns_hostnames: True
-        dns_support: True
+        dns_hostnames: true
+        dns_support: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert a change was not made
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -726,20 +725,20 @@
     # ============================================================
 
     - name: add tags (check mode)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
         tags: "{{ first_tags }}"
       check_mode: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the VPC has Name but not Ansible tag
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -750,19 +749,19 @@
           - vpc_info.vpcs[0].tags == name_tags
 
     - name: add tags
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
         tags: "{{ first_tags }}"
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the VPC has Name and Ansible tags
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -772,19 +771,19 @@
           - vpc_info.vpcs[0].tags == (first_tags | combine(name_tags))
 
     - name: add tags (no change)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
         tags: "{{ first_tags }}"
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the VPC has Name and Ansible tags
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -796,7 +795,7 @@
     # ============================================================
 
     - name: modify tags with purge (check mode)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
@@ -804,13 +803,13 @@
         purge_tags: true
       check_mode: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the VPC has Name but not Ansible tag
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -820,20 +819,20 @@
           - vpc_info.vpcs[0].tags == (first_tags | combine(name_tags))
 
     - name: modify tags with purge
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
         tags: "{{ second_tags }}"
         purge_tags: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the VPC has Name and Ansible tags
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -843,20 +842,20 @@
           - vpc_info.vpcs[0].tags == (second_tags | combine(name_tags))
 
     - name: modify tags with purge (no change)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
         tags: "{{ second_tags }}"
         purge_tags: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the VPC has Name and Ansible tags
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -868,7 +867,7 @@
     # ============================================================
 
     - name: modify tags without purge (check mode)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
@@ -876,13 +875,13 @@
         purge_tags: false
       check_mode: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the VPC has Name but not Ansible tag
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -892,20 +891,20 @@
           - vpc_info.vpcs[0].tags == (second_tags | combine(name_tags))
 
     - name: modify tags with purge
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
         tags: "{{ third_tags }}"
         purge_tags: false
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the VPC has Name and Ansible tags
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -915,20 +914,20 @@
           - vpc_info.vpcs[0].tags == (final_tags | combine(name_tags))
 
     - name: modify tags with purge (no change)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
         tags: "{{ third_tags }}"
         purge_tags: false
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the VPC has Name and Ansible tags
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -940,21 +939,21 @@
     # ============================================================
 
     - name: modify CIDR (check mode)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block:
-        - "{{ vpc_cidr }}"
-        - "{{ vpc_cidr_a }}"
+          - "{{ vpc_cidr }}"
+          - "{{ vpc_cidr_a }}"
         name: "{{ vpc_name }}"
       check_mode: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: Check the CIDRs weren't changed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -972,20 +971,20 @@
           - vpc_cidr_b not in (result.vpc.cidr_block_association_set | map(attribute="cidr_block") | list)
 
     - name: modify CIDR
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block:
-        - "{{ vpc_cidr }}"
-        - "{{ vpc_cidr_a }}"
+          - "{{ vpc_cidr }}"
+          - "{{ vpc_cidr_a }}"
         name: "{{ vpc_name }}"
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the CIDRs changed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -1011,20 +1010,20 @@
           - vpc_cidr_b not in (vpc_info.vpcs[0].cidr_block_association_set | map(attribute="cidr_block") | list)
 
     - name: modify CIDR (no change)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block:
-        - "{{ vpc_cidr }}"
-        - "{{ vpc_cidr_a }}"
+          - "{{ vpc_cidr }}"
+          - "{{ vpc_cidr_a }}"
         name: "{{ vpc_name }}"
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the CIDRs didn't change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -1050,21 +1049,21 @@
           - vpc_cidr_b not in (vpc_info.vpcs[0].cidr_block_association_set | map(attribute="cidr_block") | list)
 
     - name: modify CIDR - no purge (check mode)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block:
-        - "{{ vpc_cidr }}"
-        - "{{ vpc_cidr_b }}"
+          - "{{ vpc_cidr }}"
+          - "{{ vpc_cidr_b }}"
         name: "{{ vpc_name }}"
       check_mode: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: Check the CIDRs weren't changed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -1083,20 +1082,20 @@
           - vpc_cidr_b not in (vpc_info.vpcs[0].cidr_block_association_set | map(attribute="cidr_block") | list)
 
     - name: modify CIDR - no purge
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block:
-        - "{{ vpc_cidr }}"
-        - "{{ vpc_cidr_b }}"
+          - "{{ vpc_cidr }}"
+          - "{{ vpc_cidr_b }}"
         name: "{{ vpc_name }}"
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the CIDRs changed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -1126,20 +1125,20 @@
           - vpc_cidr_b in (vpc_info.vpcs[0].cidr_block_association_set | map(attribute="cidr_block") | list)
 
     - name: modify CIDR - no purge (no change)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block:
-        - "{{ vpc_cidr }}"
-        - "{{ vpc_cidr_b }}"
+          - "{{ vpc_cidr }}"
+          - "{{ vpc_cidr_b }}"
         name: "{{ vpc_name }}"
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the CIDRs didn't change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -1168,21 +1167,21 @@
           - vpc_cidr_b in (vpc_info.vpcs[0].cidr_block_association_set | map(attribute="cidr_block") | list)
 
     - name: modify CIDR - no purge (no change - list all - check mode)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block:
-        - "{{ vpc_cidr }}"
-        - "{{ vpc_cidr_a }}"
-        - "{{ vpc_cidr_b }}"
+          - "{{ vpc_cidr }}"
+          - "{{ vpc_cidr_a }}"
+          - "{{ vpc_cidr_b }}"
         name: "{{ vpc_name }}"
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the CIDRs didn't change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -1211,21 +1210,21 @@
           - vpc_cidr_b in (vpc_info.vpcs[0].cidr_block_association_set | map(attribute="cidr_block") | list)
 
     - name: modify CIDR - no purge (no change - list all)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block:
-        - "{{ vpc_cidr }}"
-        - "{{ vpc_cidr_a }}"
-        - "{{ vpc_cidr_b }}"
+          - "{{ vpc_cidr }}"
+          - "{{ vpc_cidr_a }}"
+          - "{{ vpc_cidr_b }}"
         name: "{{ vpc_name }}"
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the CIDRs didn't change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -1254,21 +1253,21 @@
           - vpc_cidr_b in (vpc_info.vpcs[0].cidr_block_association_set | map(attribute="cidr_block") | list)
 
     - name: modify CIDR - no purge (no change - different order - check mode)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block:
-        - "{{ vpc_cidr }}"
-        - "{{ vpc_cidr_b }}"
-        - "{{ vpc_cidr_a }}"
+          - "{{ vpc_cidr }}"
+          - "{{ vpc_cidr_b }}"
+          - "{{ vpc_cidr_a }}"
         name: "{{ vpc_name }}"
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the CIDRs didn't change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -1297,21 +1296,21 @@
           - vpc_cidr_b in (vpc_info.vpcs[0].cidr_block_association_set | map(attribute="cidr_block") | list)
 
     - name: modify CIDR - no purge (no change - different order)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block:
-        - "{{ vpc_cidr }}"
-        - "{{ vpc_cidr_b }}"
-        - "{{ vpc_cidr_a }}"
+          - "{{ vpc_cidr }}"
+          - "{{ vpc_cidr_b }}"
+          - "{{ vpc_cidr_a }}"
         name: "{{ vpc_name }}"
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the CIDRs didn't change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -1340,22 +1339,22 @@
           - vpc_cidr_b in (vpc_info.vpcs[0].cidr_block_association_set | map(attribute="cidr_block") | list)
 
     - name: modify CIDR - purge (check mode)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block:
-        - "{{ vpc_cidr }}"
-        - "{{ vpc_cidr_b }}"
+          - "{{ vpc_cidr }}"
+          - "{{ vpc_cidr_b }}"
         name: "{{ vpc_name }}"
-        purge_cidrs: yes
+        purge_cidrs: true
       check_mode: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: Check the CIDRs weren't changed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -1373,21 +1372,21 @@
           - vpc_cidr_b in (vpc_info.vpcs[0].cidr_block_association_set | map(attribute="cidr_block") | list)
 
     - name: modify CIDR - purge
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block:
-        - "{{ vpc_cidr }}"
-        - "{{ vpc_cidr_b }}"
+          - "{{ vpc_cidr }}"
+          - "{{ vpc_cidr_b }}"
         name: "{{ vpc_name }}"
-        purge_cidrs: yes
+        purge_cidrs: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the CIDRs changed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -1395,31 +1394,36 @@
           - vpc_info.vpcs | length == 1
           - result.vpc.cidr_block == vpc_cidr
           - vpc_info.vpcs[0].cidr_block == vpc_cidr
-          - result.vpc.cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list | length == 2
+          - result.vpc.cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list | length ==
+            2
           - vpc_cidr in (result.vpc.cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list)
           - vpc_cidr_a not in (result.vpc.cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block'))
           - vpc_cidr_b in (result.vpc.cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block'))
-          - vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list | length == 2
-          - vpc_cidr in (vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list)
-          - vpc_cidr_a not in (vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list)
-          - vpc_cidr_b in (vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list)
+          - vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list | length
+            == 2
+          - vpc_cidr in (vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block')
+            | list)
+          - vpc_cidr_a not in (vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block')
+            | list)
+          - vpc_cidr_b in (vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block')
+            | list)
 
     - name: modify CIDR - purge (no change)
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block:
-        - "{{ vpc_cidr }}"
-        - "{{ vpc_cidr_b }}"
+          - "{{ vpc_cidr }}"
+          - "{{ vpc_cidr_b }}"
         name: "{{ vpc_name }}"
-        purge_cidrs: yes
+        purge_cidrs: true
       register: result
-    - ec2_vpc_net_info:
+    - amazon.aws.ec2_vpc_net_info:
         filters:
-          "tag:Name": "{{ vpc_name }}"
+          tag:Name: "{{ vpc_name }}"
       register: vpc_info
 
     - name: assert the CIDRs didn't change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
@@ -1427,27 +1431,33 @@
           - vpc_info.vpcs | length == 1
           - result.vpc.cidr_block == vpc_cidr
           - vpc_info.vpcs[0].cidr_block == vpc_cidr
-          - result.vpc.cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list | length == 2
+          - result.vpc.cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list | length ==
+            2
           - vpc_cidr in (result.vpc.cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list)
-          - vpc_cidr_a not in (result.vpc.cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list)
+          - vpc_cidr_a not in (result.vpc.cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block')
+            | list)
           - vpc_cidr_b in (result.vpc.cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list)
-          - vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list | length == 2
-          - vpc_cidr in (vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list)
-          - vpc_cidr_a not in (vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list)
-          - vpc_cidr_b in (vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list)
+          - vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block') | list | length
+            == 2
+          - vpc_cidr in (vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block')
+            | list)
+          - vpc_cidr_a not in (vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block')
+            | list)
+          - vpc_cidr_b in (vpc_info.vpcs[0].cidr_block_association_set | selectattr('cidr_block_state.state', 'equalto', 'associated') | map(attribute='cidr_block')
+            | list)
 
     # ============================================================
 
     - name: Remove IPv6 CIDR association from VPC in check mode
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        ipv6_cidr: False
+        ipv6_cidr: false
       check_mode: true
       register: result
     - name: assert configuration would change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -1455,27 +1465,27 @@
     - name: Set IPv6 CIDR association to VPC, no change expected
       # I.e. assert the previous ec2_vpc_net task in check_mode did not
       # mistakenly modify the VPC configuration.
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        ipv6_cidr: True
+        ipv6_cidr: true
       register: result
     - name: assert configuration did not change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is not changed
 
     - name: Remove IPv6 CIDR association from VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        ipv6_cidr: False
+        ipv6_cidr: false
       register: result
     - name: assert IPv6 CIDR association removed from VPC
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -1485,14 +1495,14 @@
           - result.vpc.ipv6_cidr_block_association_set[0].ipv6_cidr_block_state.state in ["disassociated"]
 
     - name: Add IPv6 CIDR association to VPC again
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
-        ipv6_cidr: True
+        ipv6_cidr: true
       register: result
     - name: assert configuration change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is successful
           - result is changed
@@ -1506,11 +1516,10 @@
           - result.vpc.ipv6_cidr_block_association_set[1].ipv6_cidr_block | ansible.netcommon.ipv6
           - result.vpc.ipv6_cidr_block_association_set[1].ipv6_cidr_block_state.state in ["associated", "associating"]
 
-
     # ============================================================
 
     - name: test check mode to delete a VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
         state: absent
@@ -1518,35 +1527,34 @@
       register: result
 
     - name: assert that a change would have been made
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
 
-    # ============================================================
+  # ============================================================
 
   always:
-
     - name: Describe VPCs before deleting them (for debugging)
-      ec2_vpc_net_info:
+      amazon.aws.ec2_vpc_net_info:
       ignore_errors: true
 
     - name: replace the DHCP options set so the new one can be deleted
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
         state: present
-        multi_ok: no
+        multi_ok: false
         dhcp_opts_id: "{{ default_dhcp_options_id }}"
       ignore_errors: true
 
     - name: remove the DHCP option set
-      ec2_vpc_dhcp_option:
+      amazon.aws.ec2_vpc_dhcp_option:
         dhcp_options_id: "{{ new_dhcp.dhcp_options_id }}"
         state: absent
       ignore_errors: true
 
     - name: remove the VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         cidr_block: "{{ vpc_cidr }}"
         name: "{{ vpc_name }}"
         state: absent

--- a/tests/integration/targets/ec2_vpc_route_table/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
-availability_zone_a: '{{ ec2_availability_zone_names[0] }}'
-availability_zone_b: '{{ ec2_availability_zone_names[1] }}'
+availability_zone_a: "{{ ec2_availability_zone_names[0] }}"
+availability_zone_b: "{{ ec2_availability_zone_names[1] }}"
 vpc_cidr: 10.228.224.0/21

--- a/tests/integration/targets/ec2_vpc_route_table/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
-- setup_ec2_facts
+  - setup_ec2_facts

--- a/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_route_table/tasks/main.yml
@@ -1,1500 +1,1497 @@
+---
 - name: ec2_vpc_route_table integration tests
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-
-  - name: create VPC
-    ec2_vpc_net:
-      cidr_block: '{{ vpc_cidr }}'
-      name: '{{ resource_prefix }}_vpc'
-      state: present
-    register: vpc
-  - name: assert that VPC has an id
-    assert:
-      that:
-      - vpc.vpc.id is defined
-      - vpc.changed
-  - name: Assign IPv6 CIDR block to existing VPC, check mode
-    ec2_vpc_net:
-      cidr_block: '{{ vpc_cidr }}'
-      name: '{{ resource_prefix }}_vpc'
-      ipv6_cidr: true
-    check_mode: true
-    register: vpc_update
-  - name: assert that VPC would changed
-    assert:
-      that:
-      - vpc_update.changed
-  - name: Assign Amazon-provided IPv6 CIDR block to existing VPC
-    ec2_vpc_net:
-      cidr_block: '{{ vpc_cidr }}'
-      name: '{{ resource_prefix }}_vpc'
-      ipv6_cidr: true
-    register: vpc_update
-  - name: assert that VPC was changed, IPv6 CIDR is configured
-    assert:
-      that:
-      - vpc_update.vpc.id == vpc.vpc.id
-      - vpc_update.changed
-      - vpc_update.vpc.ipv6_cidr_block_association_set | length == 1
-  - name: Fetch existing VPC info
-    ec2_vpc_net_info:
-      filters:
-        "tag:Name": "{{ resource_prefix }}_vpc"
-    register: vpc_info
-  - name: assert vpc net info after configuring IPv6 CIDR
-    assert:
-      that:
-        - vpc_info.vpcs | length == 1
-        - vpc_info.vpcs[0].id == vpc.vpc.id
-        - vpc_info.vpcs[0].ipv6_cidr_block_association_set | length == 1
-        - vpc_info.vpcs[0].ipv6_cidr_block_association_set[0].ipv6_cidr_block_state.state == "associated"
-  - name: get Amazon-provided IPv6 CIDR associated with the VPC
-    set_fact:
+    - name: create VPC
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ vpc_cidr }}"
+        name: "{{ resource_prefix }}_vpc"
+        state: present
+      register: vpc
+    - name: assert that VPC has an id
+      ansible.builtin.assert:
+        that:
+          - vpc.vpc.id is defined
+          - vpc.changed
+    - name: Assign IPv6 CIDR block to existing VPC, check mode
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ vpc_cidr }}"
+        name: "{{ resource_prefix }}_vpc"
+        ipv6_cidr: true
+      check_mode: true
+      register: vpc_update
+    - name: assert that VPC would changed
+      ansible.builtin.assert:
+        that:
+          - vpc_update.changed
+    - name: Assign Amazon-provided IPv6 CIDR block to existing VPC
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ vpc_cidr }}"
+        name: "{{ resource_prefix }}_vpc"
+        ipv6_cidr: true
+      register: vpc_update
+    - name: assert that VPC was changed, IPv6 CIDR is configured
+      ansible.builtin.assert:
+        that:
+          - vpc_update.vpc.id == vpc.vpc.id
+          - vpc_update.changed
+          - vpc_update.vpc.ipv6_cidr_block_association_set | length == 1
+    - name: Fetch existing VPC info
+      amazon.aws.ec2_vpc_net_info:
+        filters:
+          tag:Name: "{{ resource_prefix }}_vpc"
+      register: vpc_info
+    - name: assert vpc net info after configuring IPv6 CIDR
+      ansible.builtin.assert:
+        that:
+          - vpc_info.vpcs | length == 1
+          - vpc_info.vpcs[0].id == vpc.vpc.id
+          - vpc_info.vpcs[0].ipv6_cidr_block_association_set | length == 1
+          - vpc_info.vpcs[0].ipv6_cidr_block_association_set[0].ipv6_cidr_block_state.state == "associated"
+    - name: get Amazon-provided IPv6 CIDR associated with the VPC
+      ansible.builtin.set_fact:
       # Example value: 2600:1f1c:1b3:8f00::/56
-      vpc_ipv6_cidr_block: '{{ vpc_info.vpcs[0].ipv6_cidr_block_association_set[0].ipv6_cidr_block }}'
-  - name: create subnets
-    ec2_vpc_subnet:
-      cidr: '{{ item.cidr }}'
-      az: '{{ item.zone }}'
-      assign_instances_ipv6: '{{ item.assign_instances_ipv6 }}'
-      ipv6_cidr: '{{ item.ipv6_cidr  }}'
-      vpc_id: '{{ vpc.vpc.id }}'
-      state: present
-      tags:
-        Public: '{{ item.public | string }}'
-        Name: "{{ (item.public | bool) | ternary('public', 'private') }}-{{ item.zone }}"
-    with_items:
-    - cidr: 10.228.224.0/24
-      zone: '{{ availability_zone_a }}'
-      public: 'True'
-      assign_instances_ipv6: false
-      ipv6_cidr: null
-    - cidr: 10.228.225.0/24
-      zone: '{{ availability_zone_b }}'
-      public: 'True'
-      assign_instances_ipv6: false
-      ipv6_cidr: null
-    - cidr: 10.228.226.0/24
-      zone: '{{ availability_zone_a }}'
-      public: 'False'
-      assign_instances_ipv6: false
-      ipv6_cidr: null
-    - cidr: 10.228.227.0/24
-      zone: '{{ availability_zone_b }}'
-      public: 'False'
-      assign_instances_ipv6: false
-      ipv6_cidr: null
-    - cidr: 10.228.228.0/24
-      zone: '{{ availability_zone_a }}'
-      public: 'False'
-      assign_instances_ipv6: true
-      # Carve first /64 subnet of the Amazon-provided CIDR for the VPC.
-      ipv6_cidr: "{{ vpc_ipv6_cidr_block | ansible.netcommon.ipsubnet(64, 1) }}"
-    - cidr: 10.228.229.0/24
-      zone: '{{ availability_zone_a }}'
-      public: 'True'
-      assign_instances_ipv6: true
-      ipv6_cidr: "{{ vpc_ipv6_cidr_block | ansible.netcommon.ipsubnet(64, 2) }}"
-    - cidr: 10.228.230.0/24
-      zone: '{{ availability_zone_b }}'
-      public: 'False'
-      assign_instances_ipv6: true
-      ipv6_cidr: "{{ vpc_ipv6_cidr_block | ansible.netcommon.ipsubnet(64, 3) }}"
-    register: subnets
-  - ec2_vpc_subnet_info:
-      filters:
-        vpc-id: '{{ vpc.vpc.id }}'
-    register: vpc_subnets
-  - set_fact:
-      public_subnets: "{{ (vpc_subnets.subnets | selectattr('tags.Public', 'equalto',\
-        \ 'True') | map(attribute='id') | list) }}"
-      public_cidrs: "{{ (vpc_subnets.subnets | selectattr('tags.Public', 'equalto',\
-        \ 'True') | map(attribute='cidr_block') | list) }}"
-      private_subnets: "{{ (vpc_subnets.subnets | selectattr('tags.Public', 'equalto',\
-        \ 'False') | map(attribute='id') | list) }}"
-  - name: create IGW
-    ec2_vpc_igw:
-      vpc_id: '{{ vpc.vpc.id }}'
-    register: vpc_igw
-  - name: create NAT GW
-    ec2_vpc_nat_gateway:
-      if_exist_do_not_create: yes
-      wait: yes
-      subnet_id: '{{ subnets.results[0].subnet.id }}'
-    register: nat_gateway
-  - name: CHECK MODE - route table should be created
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-    check_mode: true
-    register: check_mode_results
-  - name: assert that the public route table would be created
-    assert:
-      that:
-      - check_mode_results.changed
-
-  - name: create public route table
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-    register: create_public_table
-  - name: assert that public route table has an id
-    assert:
-      that:
-      - create_public_table.changed
-      - "'ec2:CreateTags' not in create_public_table.resource_actions"
-      - "'ec2:DeleteTags' not in create_public_table.resource_actions"
-      - create_public_table.route_table.id.startswith('rtb-')
-      - "'Public' in create_public_table.route_table.tags"
-      - create_public_table.route_table.tags['Public'] == 'true'
-      - create_public_table.route_table.associations | length == 0
-      - create_public_table.route_table.vpc_id == vpc.vpc.id
-      - create_public_table.route_table.propagating_vgws | length == 0
-      # One route for IPv4, one route for IPv6
-      - create_public_table.route_table.routes | length == 2
-
-  - name: CHECK MODE - route table should already exist
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-    check_mode: true
-    register: check_mode_results
-  - name: assert the table already exists
-    assert:
-      that:
-      - not check_mode_results.changed
-
-  - name: recreate public route table
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-    register: recreate_public_route_table
-  - name: assert that public route table did not change
-    assert:
-      that:
-      - not recreate_public_route_table.changed
-      - create_public_table.route_table.id.startswith('rtb-')
-      - "'Public' in create_public_table.route_table.tags"
-      - create_public_table.route_table.tags['Public'] == 'true'
-      - create_public_table.route_table.associations | length == 0
-      - create_public_table.route_table.vpc_id == vpc.vpc.id
-      - create_public_table.route_table.propagating_vgws | length == 0
-      - create_public_table.route_table.routes | length == 2
-
-  - name: CHECK MODE - add route to public route table
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-      - dest: ::/0
-        gateway_id: igw
-    check_mode: true
-    register: check_mode_results
-  - name: assert a route would be added
-    assert:
-      that:
-      - check_mode_results.changed
-
-  - name: add a route to public route table
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-      - dest: ::/0
-        gateway_id: igw
-    register: add_routes
-  - name: assert route table contains new route
-    assert:
-      that:
-      - add_routes.changed
-      - add_routes.route_table.id.startswith('rtb-')
-      - "'Public' in add_routes.route_table.tags"
-      - add_routes.route_table.tags['Public'] == 'true'
-      # 10.228.224.0/21
-      # 0.0.0.0/0
-      # ::/0
-      # Amazon-provide IPv6 block
-      - add_routes.route_table.routes | length == 4
-      - add_routes.route_table.associations | length == 0
-      - add_routes.route_table.vpc_id == vpc.vpc.id
-      - add_routes.route_table.propagating_vgws | length == 0
-
-  - name: CHECK MODE - re-add route to public route table
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-    check_mode: true
-    register: check_mode_results
-  - name: assert a route would not be added
-    assert:
-      that:
-      - check_mode_results is not changed
-
-  - name: re-add a route to public route table
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-    register: add_routes
-  - name: assert route table contains route
-    assert:
-      that:
-      - add_routes is not changed
-      - add_routes.route_table.routes | length == 4
-
-  - name: CHECK MODE - add subnets to public route table
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-      subnets: '{{ public_subnets }}'
-    check_mode: true
-    register: check_mode_results
-  - name: assert the subnets would be added to the route table
-    assert:
-      that:
-      - check_mode_results.changed
-
-  - name: add subnets to public route table
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-      subnets: '{{ public_subnets }}'
-    register: add_subnets
-  - name: assert route table contains subnets
-    assert:
-      that:
-      - add_subnets.changed
-      - add_subnets.route_table.associations | length == 3
-
-  - name: CHECK MODE - no routes but purge_routes set to false
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-      purge_routes: no
-      subnets: '{{ public_subnets }}'
-    check_mode: true
-    register: check_mode_results
-  - name: assert no routes would be removed
-    assert:
-      that:
-      - not check_mode_results.changed
-
-  - name: rerun with purge_routes set to false
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-      purge_routes: no
-      subnets: '{{ public_subnets }}'
-    register: no_purge_routes
-  - name: assert route table still has routes
-    assert:
-      that:
-      - not no_purge_routes.changed
-      - no_purge_routes.route_table.routes | length == 4
-      - no_purge_routes.route_table.associations | length == 3
-
-  - name: rerun with purge_subnets set to false
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-      purge_subnets: no
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-    register: no_purge_subnets
-  - name: assert route table still has subnets
-    assert:
-      that:
-      - not no_purge_subnets.changed
-      - no_purge_subnets.route_table.routes | length == 4
-      - no_purge_subnets.route_table.associations | length == 3
-
-  - name: rerun with purge_tags not set (implicitly false)
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-      lookup: id
-      route_table_id: '{{ create_public_table.route_table.id }}'
-      subnets: '{{ public_subnets }}'
-    register: no_purge_tags
-  - name: assert route table still has tags
-    assert:
-      that:
-      - not no_purge_tags.changed
-      - "'Public' in no_purge_tags.route_table.tags"
-      - no_purge_tags.route_table.tags['Public'] == 'true'
-
-  - name: CHECK MODE - purge subnets
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-      subnets: []
-      tags:
-        Public: 'true'
-        Name: Public route table
-    check_mode: true
-    register: check_mode_results
-  - name: assert subnets would be removed
-    assert:
-      that:
-      - check_mode_results.changed
-
-  - name: purge subnets
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-      subnets: []
-      tags:
-        Public: 'true'
-        Name: Public route table
-    register: purge_subnets
-  - name: assert purge subnets worked
-    assert:
-      that:
-      - purge_subnets.changed
-      - purge_subnets.route_table.associations | length == 0
-      - purge_subnets.route_table.id == create_public_table.route_table.id
-
-  - name: CHECK MODE - purge routes
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-      routes: []
-    check_mode: true
-    register: check_mode_results
-  - name: assert routes would be removed
-    assert:
-      that:
-      - check_mode_results.changed
-
-  - name: add subnets by cidr to public route table
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-      subnets: '{{ public_cidrs }}'
-      lookup: id
-      route_table_id: '{{ create_public_table.route_table.id }}'
-    register: add_subnets_cidr
-  - name: assert route table contains subnets added by cidr
-    assert:
-      that:
-      - add_subnets_cidr.changed
-      - add_subnets_cidr.route_table.associations | length == 3
-
-  - name: purge subnets added by cidr
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-      subnets: []
-      lookup: id
-      route_table_id: '{{ create_public_table.route_table.id }}'
-    register: purge_subnets_cidr
-  - name: assert purge subnets added by cidr worked
-    assert:
-      that:
-      - purge_subnets_cidr.changed
-      - purge_subnets_cidr.route_table.associations | length == 0
-
-  - name: add subnets by name to public route table
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-      subnets: '{{ public_subnets }}'
-      lookup: id
-      route_table_id: '{{ create_public_table.route_table.id }}'
-    register: add_subnets_name
-  - name: assert route table contains subnets added by name
-    assert:
-      that:
-      - add_subnets_name.changed
-      - add_subnets_name.route_table.associations | length == 3
-
-  - name: purge subnets added by name
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      routes:
-      - dest: 0.0.0.0/0
-        gateway_id: igw
-      subnets: []
-      lookup: id
-      route_table_id: '{{ create_public_table.route_table.id }}'
-    register: purge_subnets_name
-  - name: assert purge subnets added by name worked
-    assert:
-      that:
-      - purge_subnets_name.changed
-      - purge_subnets_name.route_table.associations | length == 0
-
-  - name: purge routes
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'true'
-        Name: Public route table
-      routes: []
-    register: purge_routes
-  - name: assert purge routes worked
-    assert:
-      that:
-      - purge_routes.changed
-      - purge_routes.route_table.routes | length == 3
-      - purge_routes.route_table.id == create_public_table.route_table.id
-
-  - name: CHECK MODE - update tags
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      route_table_id: '{{ create_public_table.route_table.id }}'
-      lookup: id
-      purge_tags: yes
-      tags:
-        Name: Public route table
-        Updated: new_tag
-    check_mode: true
-    register: check_mode_results
-  - name: assert tags would be changed
-    assert:
-      that:
-      - check_mode_results.changed
-
-  - name: update tags
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      route_table_id: '{{ create_public_table.route_table.id }}'
-      lookup: id
-      purge_tags: yes
-      tags:
-        Name: Public route table
-        Updated: new_tag
-    register: update_tags
-  - name: assert update tags worked
-    assert:
-      that:
-      - update_tags.changed
-      - "'Updated' in update_tags.route_table.tags"
-      - update_tags.route_table.tags['Updated'] == 'new_tag'
-      - "'Public' not in update_tags.route_table.tags"
-
-  - name: create NAT GW
-    ec2_vpc_nat_gateway:
-      if_exist_do_not_create: yes
-      wait: yes
-      subnet_id: '{{ subnets.results[0].subnet.id }}'
-    register: nat_gateway
-  - name: CHECK MODE - create private route table
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'false'
-        Name: Private route table
-      routes:
-      - gateway_id: '{{ nat_gateway.nat_gateway_id }}'
-        dest: 0.0.0.0/0
-      subnets: '{{ private_subnets }}'
-    check_mode: true
-    register: check_mode_results
-  - name: assert the route table would be created
-    assert:
-      that:
-      - check_mode_results.changed
-
-  - name: create private route table
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'false'
-        Name: Private route table
-      routes:
-      - gateway_id: '{{ nat_gateway.nat_gateway_id }}'
-        dest: 0.0.0.0/0
-      subnets: '{{ private_subnets }}'
-    register: create_private_table
-  - name: assert creating private route table worked
-    assert:
-      that:
-      - create_private_table.changed
-      - create_private_table.route_table.id != create_public_table.route_table.id
-      - "'Public' in create_private_table.route_table.tags"
-
-  - name: CHECK MODE - destroy public route table by tags
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      state: absent
-      tags:
-        Updated: new_tag
-        Name: Public route table
-    check_mode: true
-    register: check_mode_results
-  - name: assert the route table would be deleted
-    assert:
-      that: check_mode_results.changed
-  - name: destroy public route table by tags
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      state: absent
-      tags:
-        Updated: new_tag
-        Name: Public route table
-    register: destroy_table
-  - name: assert destroy table worked
-    assert:
-      that:
-      - destroy_table.changed
-
-  - name: CHECK MODE - redestroy public route table
-    ec2_vpc_route_table:
-      route_table_id: '{{ create_public_table.route_table.id }}'
-      lookup: id
-      state: absent
-    check_mode: true
-    register: check_mode_results
-  - name: assert the public route table does not exist
-    assert:
-      that:
-      - not check_mode_results.changed
-
-  - name: redestroy public route table
-    ec2_vpc_route_table:
-      route_table_id: '{{ create_public_table.route_table.id }}'
-      lookup: id
-      state: absent
-    register: redestroy_table
-  - name: assert redestroy table worked
-    assert:
-      that:
-      - not redestroy_table.changed
-
-  - name: destroy NAT GW
-    ec2_vpc_nat_gateway:
-      state: absent
-      wait: yes
-      release_eip: yes
-      subnet_id: '{{ subnets.results[0].subnet.id }}'
-      nat_gateway_id: '{{ nat_gateway.nat_gateway_id }}'
-    register: nat_gateway
-  - name: show route table info, get table using route-table-id
-    ec2_vpc_route_table_info:
-      filters:
-        route-table-id: '{{ create_private_table.route_table.id }}'
-    register: route_table_info
-  - name: assert route_table_info has correct attributes
-    assert:
-      that:
-      - '"route_tables" in route_table_info'
-      - route_table_info.route_tables | length == 1
-      - '"id" in route_table_info.route_tables[0]'
-      - '"routes" in route_table_info.route_tables[0]'
-      - '"associations" in route_table_info.route_tables[0]'
-      - '"tags" in route_table_info.route_tables[0]'
-      - '"vpc_id" in route_table_info.route_tables[0]'
-      - route_table_info.route_tables[0].id == create_private_table.route_table.id
-      - '"propagating_vgws" in route_table_info.route_tables[0]'
-
-  - name: show route table info, get table using tags
-    ec2_vpc_route_table_info:
-      filters:
-        tag:Public: 'false'
-        tag:Name: Private route table
-        vpc-id: '{{ vpc.vpc.id }}'
-    register: route_table_info
-  - name: assert route_table_info has correct tags
-    assert:
-      that:
-      - route_table_info.route_tables | length == 1
-      - '"tags" in route_table_info.route_tables[0]'
-      - '"Public" in route_table_info.route_tables[0].tags'
-      - route_table_info.route_tables[0].tags["Public"] == "false"
-      - '"Name" in route_table_info.route_tables[0].tags'
-      - route_table_info.route_tables[0].tags["Name"] == "Private route table"
-
-  - name: create NAT GW
-    ec2_vpc_nat_gateway:
-      if_exist_do_not_create: yes
-      wait: yes
-      subnet_id: '{{ subnets.results[0].subnet.id }}'
-    register: nat_gateway
-  - name: show route table info
-    ec2_vpc_route_table_info:
-      filters:
-        route-table-id: '{{ create_private_table.route_table.id }}'
-  - name: recreate private route table with new NAT GW
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'false'
-        Name: Private route table
-      routes:
-      - nat_gateway_id: '{{ nat_gateway.nat_gateway_id }}'
-        dest: 0.0.0.0/0
-      subnets: '{{ private_subnets }}'
-    register: recreate_private_table
-  - name: assert creating private route table worked
-    assert:
-      that:
-      - recreate_private_table.changed
-      - recreate_private_table.route_table.id != create_public_table.route_table.id
-
-  - name: create a VPC endpoint to test ec2_vpc_route_table ignores it
-    ec2_vpc_endpoint:
-      state: present
-      vpc_id: '{{ vpc.vpc.id }}'
-      service: com.amazonaws.{{ aws_region }}.s3
-      route_table_ids:
-      - '{{ recreate_private_table.route_table.route_table_id }}'
-      wait: True
-    register: vpc_endpoint
-  - name: purge routes
-    ec2_vpc_route_table:
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Public: 'false'
-        Name: Private route table
-      routes:
-      - nat_gateway_id: '{{ nat_gateway.nat_gateway_id }}'
-        dest: 0.0.0.0/0
-      subnets: '{{ private_subnets }}'
-      purge_routes: true
-    register: result
-  - name: Get endpoint infos to verify that it wasn't purged from the route table
-    ec2_vpc_endpoint_info:
-      vpc_endpoint_ids:
-      - '{{ vpc_endpoint.result.vpc_endpoint_id }}'
-    register: endpoint_details
-  - name: assert the route table is associated with the VPC endpoint
-    assert:
-      that:
-      - endpoint_details.vpc_endpoints[0].route_table_ids[0] == recreate_private_table.route_table.route_table_id
-
-  # ------------------------------------------------------------------------------------------
-
-  - name: Create gateway route table - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-
-  - name: Create gateway route table
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
-        - create_gateway_table.route_table.associations | length == 1
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-
-  - name: Create gateway route table (idempotence) - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-
-  - name: Create gateway route table (idempotence)
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
-        - create_gateway_table.route_table.associations | length == 1
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-
-  # ------------------------------------------------------------------------------------------
-
-  - name: Create ENI for gateway route table
-    ec2_eni:
-      subnet_id: '{{ public_subnets[0] }}'
-    register: eni
-
-  - name: Replace route to gateway route table - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-      routes:
-      - dest: "{{ vpc_cidr }}"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-
-  - name: Replace route to gateway route table
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-      routes:
-      - dest: "{{ vpc_cidr }}"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
-        - create_gateway_table.route_table.associations | length == 1
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-        - create_gateway_table.route_table.routes[0].destination_cidr_block == vpc_cidr
-        - create_gateway_table.route_table.routes[0].network_interface_id == eni.interface.id
-
-  - name: Replace route to gateway route table (idempotence) - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-      routes:
-      - dest: "{{ vpc_cidr }}"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-
-  - name: Replace route to gateway route table (idempotence)
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-      routes:
-      - dest: "{{ vpc_cidr }}"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 2
-        - create_gateway_table.route_table.associations | length == 1
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-        - create_gateway_table.route_table.routes[0].destination_cidr_block == vpc_cidr
-        - create_gateway_table.route_table.routes[0].network_interface_id == eni.interface.id
-
-  # ------------------------------------------------------------------------------------------
-
-  - name: Add route to gateway route table - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-
-  - name: Add route to gateway route table
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 3
-        - create_gateway_table.route_table.associations | length == 1
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-
-  - name: Add route to gateway route table (idempotence) - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-
-  - name: Add route to gateway route table (idempotence)
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 3
-        - create_gateway_table.route_table.associations | length == 1
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-
-  # ------------------------------------------------------------------------------------------
-
-  - name: Ensure gateway doesn't disassociate when not passed in - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-
-  - name: Ensure gateway doesn't disassociate when not passed in
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 3
-        - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-
-  # ------------------------------------------------------------------------------------------
-
-  - name: Disassociate gateway when gateway_id is 'None' - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: None
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-
-  - name: Disassociate gateway when gateway_id is 'None'
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: None
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 3
-        - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-
-  - name: Disassociate gateway when gateway_id is 'None' (idempotence) - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: None
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-
-  - name: Disassociate gateway when gateway_id is 'None' (idempotence)
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: None
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 3
-        - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-
-  # ------------------------------------------------------------------------------------------
-
-  - name: Associate gateway with route table - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-
-  - name: Associate gateway with route table
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-      purge_routes: no
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 3
-        - create_gateway_table.route_table.associations | length == 1
-        - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-
-  - name: Associate gateway with route table (idempotence) - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-
-  - name: Associate gateway with route table (idempotence)
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vpc_igw.gateway_id }}"
-      purge_routes: no
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 3
-        - create_gateway_table.route_table.associations | length == 1
-        - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-
-  # ------------------------------------------------------------------------------------------
-
-  - name: Disassociate gateway when gateway_id is '' - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: ''
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-
-  - name: Disassociate gateway when gateway_id is ''
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: ''
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 3
-        - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-
-  - name: Disassociate gateway when gateway_id is '' (idempotence) - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: ''
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-
-  - name: Disassociate gateway when gateway_id is '' (idempotence)
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: ''
-      routes:
-      - dest: "10.228.228.0/24"
-        network_interface_id: "{{ eni.interface.id }}"
-      purge_routes: no
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 3
-        - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-
-  # ------------------------------------------------------------------------------------------
-
-  - name: Create vgw for gateway route table
-    ec2_vpc_vgw:
-      state: present
-      vpc_id: "{{ vpc.vpc.id }}"
-      type: ipsec.1
-      name: '{{ resource_prefix }}_vpc'
-    register: vgw
-
-  - name: Associate vgw with route table - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vgw.vgw.id }}"
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-
-  - name: Associate vgw with route table
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vgw.vgw.id }}"
-      purge_routes: no
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 3
-        - create_gateway_table.route_table.associations | length == 2
-        - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-
-  - name: Associate vgw with route table (idempotence) - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vgw.vgw.id }}"
-      purge_routes: no
-    register: create_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-
-  - name: Associate vgw with route table (idempotence)
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      gateway_id: "{{ vgw.vgw.id }}"
-      purge_routes: no
-    register: create_gateway_table
-
-  - assert:
-      that:
-        - create_gateway_table is not changed
-        - create_gateway_table.route_table.id.startswith('rtb-')
-        - "'Public' in create_gateway_table.route_table.tags"
-        - create_gateway_table.route_table.tags['Public'] == 'true'
-        - create_gateway_table.route_table.routes | length == 3
-        - create_gateway_table.route_table.associations | length == 2
-        - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1
-        - create_gateway_table.route_table.vpc_id == vpc.vpc.id
-        - create_gateway_table.route_table.propagating_vgws | length == 0
-
-  # ------------------------------------------------------------------------------------------
-
-  - name: Get route table info
-    ec2_vpc_route_table_info:
-      filters:
-        route-table-id: "{{ create_gateway_table.route_table.id }}"
-    register: rt_info
-
-  - name: Assert route table exists prior to deletion
-    assert:
-      that:
-        - rt_info.route_tables | length == 1
-
-  - name: Delete gateway route table - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      state: absent
-    register: delete_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - delete_gateway_table is changed
-
-  - name: Delete gateway route table
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      state: absent
-    register: delete_gateway_table
-
-  - name: Get route table info
-    ec2_vpc_route_table_info:
-      filters:
-        route-table-id: "{{ create_gateway_table.route_table.id }}"
-    register: rt_info
-
-  - name: Assert route table was deleted
-    assert:
-      that:
-        - delete_gateway_table is changed
-        - rt_info.route_tables | length == 0
-
-  - name: Delete gateway route table (idempotence) - check_mode
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      state: absent
-    register: delete_gateway_table
-    check_mode: yes
-
-  - assert:
-      that:
-        - delete_gateway_table is not changed
-
-  - name: Delete gateway route table (idempotence)
-    ec2_vpc_route_table:
-      vpc_id: "{{ vpc.vpc.id }}"
-      tags:
-        Public: 'true'
-        Name: Gateway route table
-      state: absent
-    register: delete_gateway_table
-
-  - name: Get route table info
-    ec2_vpc_route_table_info:
-      filters:
-        route-table-id: "{{ create_gateway_table.route_table.id }}"
-    register: rt_info
-
-  - name: Assert route table was deleted
-    assert:
-      that:
-        - delete_gateway_table is not changed
-        - rt_info.route_tables | length == 0
+        vpc_ipv6_cidr_block: "{{ vpc_info.vpcs[0].ipv6_cidr_block_association_set[0].ipv6_cidr_block }}"
+    - name: create subnets
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ item.cidr }}"
+        az: "{{ item.zone }}"
+        assign_instances_ipv6: "{{ item.assign_instances_ipv6 }}"
+        ipv6_cidr: "{{ item.ipv6_cidr  }}"
+        vpc_id: "{{ vpc.vpc.id }}"
+        state: present
+        tags:
+          Public: "{{ item.public | string }}"
+          Name: "{{ (item.public | bool) | ternary('public', 'private') }}-{{ item.zone }}"
+      with_items:
+        - cidr: 10.228.224.0/24
+          zone: "{{ availability_zone_a }}"
+          public: "True"
+          assign_instances_ipv6: false
+          ipv6_cidr:
+        - cidr: 10.228.225.0/24
+          zone: "{{ availability_zone_b }}"
+          public: "True"
+          assign_instances_ipv6: false
+          ipv6_cidr:
+        - cidr: 10.228.226.0/24
+          zone: "{{ availability_zone_a }}"
+          public: "False"
+          assign_instances_ipv6: false
+          ipv6_cidr:
+        - cidr: 10.228.227.0/24
+          zone: "{{ availability_zone_b }}"
+          public: "False"
+          assign_instances_ipv6: false
+          ipv6_cidr:
+        - cidr: 10.228.228.0/24
+          zone: "{{ availability_zone_a }}"
+          public: "False"
+          assign_instances_ipv6: true
+          # Carve first /64 subnet of the Amazon-provided CIDR for the VPC.
+          ipv6_cidr: "{{ vpc_ipv6_cidr_block | ansible.netcommon.ipsubnet(64, 1) }}"
+        - cidr: 10.228.229.0/24
+          zone: "{{ availability_zone_a }}"
+          public: "True"
+          assign_instances_ipv6: true
+          ipv6_cidr: "{{ vpc_ipv6_cidr_block | ansible.netcommon.ipsubnet(64, 2) }}"
+        - cidr: 10.228.230.0/24
+          zone: "{{ availability_zone_b }}"
+          public: "False"
+          assign_instances_ipv6: true
+          ipv6_cidr: "{{ vpc_ipv6_cidr_block | ansible.netcommon.ipsubnet(64, 3) }}"
+      register: subnets
+    - amazon.aws.ec2_vpc_subnet_info:
+        filters:
+          vpc-id: "{{ vpc.vpc.id }}"
+      register: vpc_subnets
+    - ansible.builtin.set_fact:
+        public_subnets: "{{ (vpc_subnets.subnets | selectattr('tags.Public', 'equalto', 'True') | map(attribute='id') | list) }}"
+        public_cidrs: "{{ (vpc_subnets.subnets | selectattr('tags.Public', 'equalto', 'True') | map(attribute='cidr_block') | list) }}"
+        private_subnets: "{{ (vpc_subnets.subnets | selectattr('tags.Public', 'equalto', 'False') | map(attribute='id') | list) }}"
+    - name: create IGW
+      amazon.aws.ec2_vpc_igw:
+        vpc_id: "{{ vpc.vpc.id }}"
+      register: vpc_igw
+    - name: create NAT GW
+      amazon.aws.ec2_vpc_nat_gateway:
+        if_exist_do_not_create: true
+        wait: true
+        subnet_id: "{{ subnets.results[0].subnet.id }}"
+      register: nat_gateway
+    - name: CHECK MODE - route table should be created
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+      check_mode: true
+      register: check_mode_results
+    - name: assert that the public route table would be created
+      ansible.builtin.assert:
+        that:
+          - check_mode_results.changed
+
+    - name: create public route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+      register: create_public_table
+    - name: assert that public route table has an id
+      ansible.builtin.assert:
+        that:
+          - create_public_table.changed
+          - "'ec2:CreateTags' not in create_public_table.resource_actions"
+          - "'ec2:DeleteTags' not in create_public_table.resource_actions"
+          - create_public_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_public_table.route_table.tags"
+          - create_public_table.route_table.tags['Public'] == 'true'
+          - create_public_table.route_table.associations | length == 0
+          - create_public_table.route_table.vpc_id == vpc.vpc.id
+          - create_public_table.route_table.propagating_vgws | length == 0
+          # One route for IPv4, one route for IPv6
+          - create_public_table.route_table.routes | length == 2
+
+    - name: CHECK MODE - route table should already exist
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+      check_mode: true
+      register: check_mode_results
+    - name: assert the table already exists
+      ansible.builtin.assert:
+        that:
+          - not check_mode_results.changed
+
+    - name: recreate public route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+      register: recreate_public_route_table
+    - name: assert that public route table did not change
+      ansible.builtin.assert:
+        that:
+          - not recreate_public_route_table.changed
+          - create_public_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_public_table.route_table.tags"
+          - create_public_table.route_table.tags['Public'] == 'true'
+          - create_public_table.route_table.associations | length == 0
+          - create_public_table.route_table.vpc_id == vpc.vpc.id
+          - create_public_table.route_table.propagating_vgws | length == 0
+          - create_public_table.route_table.routes | length == 2
+
+    - name: CHECK MODE - add route to public route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+          - dest: ::/0
+            gateway_id: igw
+      check_mode: true
+      register: check_mode_results
+    - name: assert a route would be added
+      ansible.builtin.assert:
+        that:
+          - check_mode_results.changed
+
+    - name: add a route to public route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+          - dest: ::/0
+            gateway_id: igw
+      register: add_routes
+    - name: assert route table contains new route
+      ansible.builtin.assert:
+        that:
+          - add_routes.changed
+          - add_routes.route_table.id.startswith('rtb-')
+          - "'Public' in add_routes.route_table.tags"
+          - add_routes.route_table.tags['Public'] == 'true'
+          # 10.228.224.0/21
+          # 0.0.0.0/0
+          # ::/0
+          # Amazon-provide IPv6 block
+          - add_routes.route_table.routes | length == 4
+          - add_routes.route_table.associations | length == 0
+          - add_routes.route_table.vpc_id == vpc.vpc.id
+          - add_routes.route_table.propagating_vgws | length == 0
+
+    - name: CHECK MODE - re-add route to public route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+      check_mode: true
+      register: check_mode_results
+    - name: assert a route would not be added
+      ansible.builtin.assert:
+        that:
+          - check_mode_results is not changed
+
+    - name: re-add a route to public route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+      register: add_routes
+    - name: assert route table contains route
+      ansible.builtin.assert:
+        that:
+          - add_routes is not changed
+          - add_routes.route_table.routes | length == 4
+
+    - name: CHECK MODE - add subnets to public route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+        subnets: "{{ public_subnets }}"
+      check_mode: true
+      register: check_mode_results
+    - name: assert the subnets would be added to the route table
+      ansible.builtin.assert:
+        that:
+          - check_mode_results.changed
+
+    - name: add subnets to public route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+        subnets: "{{ public_subnets }}"
+      register: add_subnets
+    - name: assert route table contains subnets
+      ansible.builtin.assert:
+        that:
+          - add_subnets.changed
+          - add_subnets.route_table.associations | length == 3
+
+    - name: CHECK MODE - no routes but purge_routes set to false
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+        purge_routes: false
+        subnets: "{{ public_subnets }}"
+      check_mode: true
+      register: check_mode_results
+    - name: assert no routes would be removed
+      ansible.builtin.assert:
+        that:
+          - not check_mode_results.changed
+
+    - name: rerun with purge_routes set to false
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+        purge_routes: false
+        subnets: "{{ public_subnets }}"
+      register: no_purge_routes
+    - name: assert route table still has routes
+      ansible.builtin.assert:
+        that:
+          - not no_purge_routes.changed
+          - no_purge_routes.route_table.routes | length == 4
+          - no_purge_routes.route_table.associations | length == 3
+
+    - name: rerun with purge_subnets set to false
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+        purge_subnets: false
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+      register: no_purge_subnets
+    - name: assert route table still has subnets
+      ansible.builtin.assert:
+        that:
+          - not no_purge_subnets.changed
+          - no_purge_subnets.route_table.routes | length == 4
+          - no_purge_subnets.route_table.associations | length == 3
+
+    - name: rerun with purge_tags not set (implicitly false)
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+        lookup: id
+        route_table_id: "{{ create_public_table.route_table.id }}"
+        subnets: "{{ public_subnets }}"
+      register: no_purge_tags
+    - name: assert route table still has tags
+      ansible.builtin.assert:
+        that:
+          - not no_purge_tags.changed
+          - "'Public' in no_purge_tags.route_table.tags"
+          - no_purge_tags.route_table.tags['Public'] == 'true'
+
+    - name: CHECK MODE - purge subnets
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+        subnets: []
+        tags:
+          Public: "true"
+          Name: Public route table
+      check_mode: true
+      register: check_mode_results
+    - name: assert subnets would be removed
+      ansible.builtin.assert:
+        that:
+          - check_mode_results.changed
+
+    - name: purge subnets
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+        subnets: []
+        tags:
+          Public: "true"
+          Name: Public route table
+      register: purge_subnets
+    - name: assert purge subnets worked
+      ansible.builtin.assert:
+        that:
+          - purge_subnets.changed
+          - purge_subnets.route_table.associations | length == 0
+          - purge_subnets.route_table.id == create_public_table.route_table.id
+
+    - name: CHECK MODE - purge routes
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+        routes: []
+      check_mode: true
+      register: check_mode_results
+    - name: assert routes would be removed
+      ansible.builtin.assert:
+        that:
+          - check_mode_results.changed
+
+    - name: add subnets by cidr to public route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+        subnets: "{{ public_cidrs }}"
+        lookup: id
+        route_table_id: "{{ create_public_table.route_table.id }}"
+      register: add_subnets_cidr
+    - name: assert route table contains subnets added by cidr
+      ansible.builtin.assert:
+        that:
+          - add_subnets_cidr.changed
+          - add_subnets_cidr.route_table.associations | length == 3
+
+    - name: purge subnets added by cidr
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+        subnets: []
+        lookup: id
+        route_table_id: "{{ create_public_table.route_table.id }}"
+      register: purge_subnets_cidr
+    - name: assert purge subnets added by cidr worked
+      ansible.builtin.assert:
+        that:
+          - purge_subnets_cidr.changed
+          - purge_subnets_cidr.route_table.associations | length == 0
+
+    - name: add subnets by name to public route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+        subnets: "{{ public_subnets }}"
+        lookup: id
+        route_table_id: "{{ create_public_table.route_table.id }}"
+      register: add_subnets_name
+    - name: assert route table contains subnets added by name
+      ansible.builtin.assert:
+        that:
+          - add_subnets_name.changed
+          - add_subnets_name.route_table.associations | length == 3
+
+    - name: purge subnets added by name
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        routes:
+          - dest: "0.0.0.0/0"
+            gateway_id: igw
+        subnets: []
+        lookup: id
+        route_table_id: "{{ create_public_table.route_table.id }}"
+      register: purge_subnets_name
+    - name: assert purge subnets added by name worked
+      ansible.builtin.assert:
+        that:
+          - purge_subnets_name.changed
+          - purge_subnets_name.route_table.associations | length == 0
+
+    - name: purge routes
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Public route table
+        routes: []
+      register: purge_routes
+    - name: assert purge routes worked
+      ansible.builtin.assert:
+        that:
+          - purge_routes.changed
+          - purge_routes.route_table.routes | length == 3
+          - purge_routes.route_table.id == create_public_table.route_table.id
+
+    - name: CHECK MODE - update tags
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        route_table_id: "{{ create_public_table.route_table.id }}"
+        lookup: id
+        purge_tags: true
+        tags:
+          Name: Public route table
+          Updated: new_tag
+      check_mode: true
+      register: check_mode_results
+    - name: assert tags would be changed
+      ansible.builtin.assert:
+        that:
+          - check_mode_results.changed
+
+    - name: update tags
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        route_table_id: "{{ create_public_table.route_table.id }}"
+        lookup: id
+        purge_tags: true
+        tags:
+          Name: Public route table
+          Updated: new_tag
+      register: update_tags
+    - name: assert update tags worked
+      ansible.builtin.assert:
+        that:
+          - update_tags.changed
+          - "'Updated' in update_tags.route_table.tags"
+          - update_tags.route_table.tags['Updated'] == 'new_tag'
+          - "'Public' not in update_tags.route_table.tags"
+
+    - name: create NAT GW
+      amazon.aws.ec2_vpc_nat_gateway:
+        if_exist_do_not_create: true
+        wait: true
+        subnet_id: "{{ subnets.results[0].subnet.id }}"
+      register: nat_gateway
+    - name: CHECK MODE - create private route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "false"
+          Name: Private route table
+        routes:
+          - gateway_id: "{{ nat_gateway.nat_gateway_id }}"
+            dest: "0.0.0.0/0"
+        subnets: "{{ private_subnets }}"
+      check_mode: true
+      register: check_mode_results
+    - name: assert the route table would be created
+      ansible.builtin.assert:
+        that:
+          - check_mode_results.changed
+
+    - name: create private route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "false"
+          Name: Private route table
+        routes:
+          - gateway_id: "{{ nat_gateway.nat_gateway_id }}"
+            dest: "0.0.0.0/0"
+        subnets: "{{ private_subnets }}"
+      register: create_private_table
+    - name: assert creating private route table worked
+      ansible.builtin.assert:
+        that:
+          - create_private_table.changed
+          - create_private_table.route_table.id != create_public_table.route_table.id
+          - "'Public' in create_private_table.route_table.tags"
+
+    - name: CHECK MODE - destroy public route table by tags
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        state: absent
+        tags:
+          Updated: new_tag
+          Name: Public route table
+      check_mode: true
+      register: check_mode_results
+    - name: assert the route table would be deleted
+      ansible.builtin.assert:
+        that: check_mode_results.changed
+    - name: destroy public route table by tags
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        state: absent
+        tags:
+          Updated: new_tag
+          Name: Public route table
+      register: destroy_table
+    - name: assert destroy table worked
+      ansible.builtin.assert:
+        that:
+          - destroy_table.changed
+
+    - name: CHECK MODE - redestroy public route table
+      amazon.aws.ec2_vpc_route_table:
+        route_table_id: "{{ create_public_table.route_table.id }}"
+        lookup: id
+        state: absent
+      check_mode: true
+      register: check_mode_results
+    - name: assert the public route table does not exist
+      ansible.builtin.assert:
+        that:
+          - not check_mode_results.changed
+
+    - name: redestroy public route table
+      amazon.aws.ec2_vpc_route_table:
+        route_table_id: "{{ create_public_table.route_table.id }}"
+        lookup: id
+        state: absent
+      register: redestroy_table
+    - name: assert redestroy table worked
+      ansible.builtin.assert:
+        that:
+          - not redestroy_table.changed
+
+    - name: destroy NAT GW
+      amazon.aws.ec2_vpc_nat_gateway:
+        state: absent
+        wait: true
+        release_eip: true
+        subnet_id: "{{ subnets.results[0].subnet.id }}"
+        nat_gateway_id: "{{ nat_gateway.nat_gateway_id }}"
+      register: nat_gateway
+    - name: show route table info, get table using route-table-id
+      amazon.aws.ec2_vpc_route_table_info:
+        filters:
+          route-table-id: "{{ create_private_table.route_table.id }}"
+      register: route_table_info
+    - name: assert route_table_info has correct attributes
+      ansible.builtin.assert:
+        that:
+          - '"route_tables" in route_table_info'
+          - route_table_info.route_tables | length == 1
+          - '"id" in route_table_info.route_tables[0]'
+          - '"routes" in route_table_info.route_tables[0]'
+          - '"associations" in route_table_info.route_tables[0]'
+          - '"tags" in route_table_info.route_tables[0]'
+          - '"vpc_id" in route_table_info.route_tables[0]'
+          - route_table_info.route_tables[0].id == create_private_table.route_table.id
+          - '"propagating_vgws" in route_table_info.route_tables[0]'
+
+    - name: show route table info, get table using tags
+      amazon.aws.ec2_vpc_route_table_info:
+        filters:
+          tag:Public: "false"
+          tag:Name: Private route table
+          vpc-id: "{{ vpc.vpc.id }}"
+      register: route_table_info
+    - name: assert route_table_info has correct tags
+      ansible.builtin.assert:
+        that:
+          - route_table_info.route_tables | length == 1
+          - '"tags" in route_table_info.route_tables[0]'
+          - '"Public" in route_table_info.route_tables[0].tags'
+          - route_table_info.route_tables[0].tags["Public"] == "false"
+          - '"Name" in route_table_info.route_tables[0].tags'
+          - route_table_info.route_tables[0].tags["Name"] == "Private route table"
+
+    - name: create NAT GW
+      amazon.aws.ec2_vpc_nat_gateway:
+        if_exist_do_not_create: true
+        wait: true
+        subnet_id: "{{ subnets.results[0].subnet.id }}"
+      register: nat_gateway
+    - name: show route table info
+      amazon.aws.ec2_vpc_route_table_info:
+        filters:
+          route-table-id: "{{ create_private_table.route_table.id }}"
+    - name: recreate private route table with new NAT GW
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "false"
+          Name: Private route table
+        routes:
+          - nat_gateway_id: "{{ nat_gateway.nat_gateway_id }}"
+            dest: "0.0.0.0/0"
+        subnets: "{{ private_subnets }}"
+      register: recreate_private_table
+    - name: assert creating private route table worked
+      ansible.builtin.assert:
+        that:
+          - recreate_private_table.changed
+          - recreate_private_table.route_table.id != create_public_table.route_table.id
+
+    - name: create a VPC endpoint to test ec2_vpc_route_table ignores it
+      amazon.aws.ec2_vpc_endpoint:
+        state: present
+        vpc_id: "{{ vpc.vpc.id }}"
+        service: com.amazonaws.{{ aws_region }}.s3
+        route_table_ids:
+          - "{{ recreate_private_table.route_table.route_table_id }}"
+        wait: true
+      register: vpc_endpoint
+    - name: purge routes
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "false"
+          Name: Private route table
+        routes:
+          - nat_gateway_id: "{{ nat_gateway.nat_gateway_id }}"
+            dest: "0.0.0.0/0"
+        subnets: "{{ private_subnets }}"
+        purge_routes: true
+      register: result
+    - name: Get endpoint infos to verify that it wasn't purged from the route table
+      amazon.aws.ec2_vpc_endpoint_info:
+        vpc_endpoint_ids:
+          - "{{ vpc_endpoint.result.vpc_endpoint_id }}"
+      register: endpoint_details
+    - name: assert the route table is associated with the VPC endpoint
+      ansible.builtin.assert:
+        that:
+          - endpoint_details.vpc_endpoints[0].route_table_ids[0] == recreate_private_table.route_table.route_table_id
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Create gateway route table - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+
+    - name: Create gateway route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 2
+          - create_gateway_table.route_table.associations | length == 1
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+
+    - name: Create gateway route table (idempotence) - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+
+    - name: Create gateway route table (idempotence)
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 2
+          - create_gateway_table.route_table.associations | length == 1
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Create ENI for gateway route table
+      amazon.aws.ec2_eni:
+        subnet_id: "{{ public_subnets[0] }}"
+      register: eni
+
+    - name: Replace route to gateway route table - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+        routes:
+          - dest: "{{ vpc_cidr }}"
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+
+    - name: Replace route to gateway route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+        routes:
+          - dest: "{{ vpc_cidr }}"
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 2
+          - create_gateway_table.route_table.associations | length == 1
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+          - create_gateway_table.route_table.routes[0].destination_cidr_block == vpc_cidr
+          - create_gateway_table.route_table.routes[0].network_interface_id == eni.interface.id
+
+    - name: Replace route to gateway route table (idempotence) - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+        routes:
+          - dest: "{{ vpc_cidr }}"
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+
+    - name: Replace route to gateway route table (idempotence)
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+        routes:
+          - dest: "{{ vpc_cidr }}"
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 2
+          - create_gateway_table.route_table.associations | length == 1
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+          - create_gateway_table.route_table.routes[0].destination_cidr_block == vpc_cidr
+          - create_gateway_table.route_table.routes[0].network_interface_id == eni.interface.id
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Add route to gateway route table - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+
+    - name: Add route to gateway route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 3
+          - create_gateway_table.route_table.associations | length == 1
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+
+    - name: Add route to gateway route table (idempotence) - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+
+    - name: Add route to gateway route table (idempotence)
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 3
+          - create_gateway_table.route_table.associations | length == 1
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Ensure gateway doesn't disassociate when not passed in - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+
+    - name: Ensure gateway doesn't disassociate when not passed in
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 3
+          - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Disassociate gateway when gateway_id is 'None' - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: None
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+
+    - name: Disassociate gateway when gateway_id is 'None'
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: None
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 3
+          - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+
+    - name: Disassociate gateway when gateway_id is 'None' (idempotence) - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: None
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+
+    - name: Disassociate gateway when gateway_id is 'None' (idempotence)
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: None
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 3
+          - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Associate gateway with route table - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+        purge_routes: false
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+
+    - name: Associate gateway with route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+        purge_routes: false
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 3
+          - create_gateway_table.route_table.associations | length == 1
+          - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+
+    - name: Associate gateway with route table (idempotence) - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+        purge_routes: false
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+
+    - name: Associate gateway with route table (idempotence)
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vpc_igw.gateway_id }}"
+        purge_routes: false
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 3
+          - create_gateway_table.route_table.associations | length == 1
+          - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Disassociate gateway when gateway_id is '' - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: ""
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+
+    - name: Disassociate gateway when gateway_id is ''
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: ""
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 3
+          - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+
+    - name: Disassociate gateway when gateway_id is '' (idempotence) - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: ""
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+
+    - name: Disassociate gateway when gateway_id is '' (idempotence)
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: ""
+        routes:
+          - dest: 10.228.228.0/24
+            network_interface_id: "{{ eni.interface.id }}"
+        purge_routes: false
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 3
+          - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 0
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Create vgw for gateway route table
+      community.aws.ec2_vpc_vgw:
+        state: present
+        vpc_id: "{{ vpc.vpc.id }}"
+        type: ipsec.1
+        name: "{{ resource_prefix }}_vpc"
+      register: vgw
+
+    - name: Associate vgw with route table - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vgw.vgw.id }}"
+        purge_routes: false
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+
+    - name: Associate vgw with route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vgw.vgw.id }}"
+        purge_routes: false
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 3
+          - create_gateway_table.route_table.associations | length == 2
+          - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+
+    - name: Associate vgw with route table (idempotence) - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vgw.vgw.id }}"
+        purge_routes: false
+      register: create_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+
+    - name: Associate vgw with route table (idempotence)
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        gateway_id: "{{ vgw.vgw.id }}"
+        purge_routes: false
+      register: create_gateway_table
+
+    - ansible.builtin.assert:
+        that:
+          - create_gateway_table is not changed
+          - create_gateway_table.route_table.id.startswith('rtb-')
+          - "'Public' in create_gateway_table.route_table.tags"
+          - create_gateway_table.route_table.tags['Public'] == 'true'
+          - create_gateway_table.route_table.routes | length == 3
+          - create_gateway_table.route_table.associations | length == 2
+          - create_gateway_table.route_table.associations | map(attribute='association_state') | selectattr('state', '==', 'associated') | length == 1
+          - create_gateway_table.route_table.vpc_id == vpc.vpc.id
+          - create_gateway_table.route_table.propagating_vgws | length == 0
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Get route table info
+      amazon.aws.ec2_vpc_route_table_info:
+        filters:
+          route-table-id: "{{ create_gateway_table.route_table.id }}"
+      register: rt_info
+
+    - name: Assert route table exists prior to deletion
+      ansible.builtin.assert:
+        that:
+          - rt_info.route_tables | length == 1
+
+    - name: Delete gateway route table - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        state: absent
+      register: delete_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - delete_gateway_table is changed
+
+    - name: Delete gateway route table
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        state: absent
+      register: delete_gateway_table
+
+    - name: Get route table info
+      amazon.aws.ec2_vpc_route_table_info:
+        filters:
+          route-table-id: "{{ create_gateway_table.route_table.id }}"
+      register: rt_info
+
+    - name: Assert route table was deleted
+      ansible.builtin.assert:
+        that:
+          - delete_gateway_table is changed
+          - rt_info.route_tables | length == 0
+
+    - name: Delete gateway route table (idempotence) - check_mode
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        state: absent
+      register: delete_gateway_table
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - delete_gateway_table is not changed
+
+    - name: Delete gateway route table (idempotence)
+      amazon.aws.ec2_vpc_route_table:
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Public: "true"
+          Name: Gateway route table
+        state: absent
+      register: delete_gateway_table
+
+    - name: Get route table info
+      amazon.aws.ec2_vpc_route_table_info:
+        filters:
+          route-table-id: "{{ create_gateway_table.route_table.id }}"
+      register: rt_info
+
+    - name: Assert route table was deleted
+      ansible.builtin.assert:
+        that:
+          - delete_gateway_table is not changed
+          - rt_info.route_tables | length == 0
 
   always:
   #############################################################################
   # TEAR DOWN STARTS HERE
   #############################################################################
-  - name: remove the VPC endpoint
-    ec2_vpc_endpoint:
-      state: absent
-      vpc_endpoint_id: '{{ vpc_endpoint.result.vpc_endpoint_id }}'
-    when: vpc_endpoint is defined
-    ignore_errors: yes
-  - name: destroy route tables
-    ec2_vpc_route_table:
-      route_table_id: '{{ item.route_table.id }}'
-      lookup: id
-      state: absent
-    with_items:
-    - '{{ create_public_table | default() }}'
-    - '{{ create_private_table | default() }}'
-    - '{{ create_gateway_table | default() }}'
-    when: item and not item.failed
-    ignore_errors: yes
-  - name: destroy NAT GW
-    ec2_vpc_nat_gateway:
-      state: absent
-      wait: yes
-      release_eip: yes
-      subnet_id: '{{ subnets.results[0].subnet.id }}'
-      nat_gateway_id: '{{ nat_gateway.nat_gateway_id }}'
-    ignore_errors: yes
-  - name: destroy IGW
-    ec2_vpc_igw:
-      vpc_id: '{{ vpc.vpc.id }}'
-      state: absent
-    ignore_errors: yes
-  - name: destroy VGW
-    ec2_vpc_vgw:
-      state: absent
-      type: ipsec.1
-      name: '{{ resource_prefix }}_vpc'
-      vpc_id: "{{ vpc.vpc.id }}"
-    ignore_errors: yes
-  - name: destroy ENI
-    ec2_eni:
-      state: absent
-      eni_id: '{{ eni.interface.id }}'
-    ignore_errors: yes
-  - name: destroy subnets
-    ec2_vpc_subnet:
-      cidr: '{{ item.cidr }}'
-      vpc_id: '{{ vpc.vpc.id }}'
-      state: absent
-    with_items:
-    - cidr: 10.228.224.0/24
-    - cidr: 10.228.225.0/24
-    - cidr: 10.228.226.0/24
-    - cidr: 10.228.227.0/24
-    - cidr: 10.228.228.0/24
-    - cidr: 10.228.229.0/24
-    - cidr: 10.228.230.0/24
-    ignore_errors: yes
-  - name: destroy VPC
-    ec2_vpc_net:
-      cidr_block: 10.228.224.0/21
-      name: '{{ resource_prefix }}_vpc'
-      state: absent
-    ignore_errors: yes
+    - name: remove the VPC endpoint
+      amazon.aws.ec2_vpc_endpoint:
+        state: absent
+        vpc_endpoint_id: "{{ vpc_endpoint.result.vpc_endpoint_id }}"
+      when: vpc_endpoint is defined
+      ignore_errors: true
+    - name: destroy route tables
+      amazon.aws.ec2_vpc_route_table:
+        route_table_id: "{{ item.route_table.id }}"
+        lookup: id
+        state: absent
+      with_items:
+        - "{{ create_public_table | default() }}"
+        - "{{ create_private_table | default() }}"
+        - "{{ create_gateway_table | default() }}"
+      when: item and not item.failed
+      ignore_errors: true
+    - name: destroy NAT GW
+      amazon.aws.ec2_vpc_nat_gateway:
+        state: absent
+        wait: true
+        release_eip: true
+        subnet_id: "{{ subnets.results[0].subnet.id }}"
+        nat_gateway_id: "{{ nat_gateway.nat_gateway_id }}"
+      ignore_errors: true
+    - name: destroy IGW
+      amazon.aws.ec2_vpc_igw:
+        vpc_id: "{{ vpc.vpc.id }}"
+        state: absent
+      ignore_errors: true
+    - name: destroy VGW
+      community.aws.ec2_vpc_vgw:
+        state: absent
+        type: ipsec.1
+        name: "{{ resource_prefix }}_vpc"
+        vpc_id: "{{ vpc.vpc.id }}"
+      ignore_errors: true
+    - name: destroy ENI
+      amazon.aws.ec2_eni:
+        state: absent
+        eni_id: "{{ eni.interface.id }}"
+      ignore_errors: true
+    - name: destroy subnets
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ item.cidr }}"
+        vpc_id: "{{ vpc.vpc.id }}"
+        state: absent
+      with_items:
+        - cidr: 10.228.224.0/24
+        - cidr: 10.228.225.0/24
+        - cidr: 10.228.226.0/24
+        - cidr: 10.228.227.0/24
+        - cidr: 10.228.228.0/24
+        - cidr: 10.228.229.0/24
+        - cidr: 10.228.230.0/24
+      ignore_errors: true
+    - name: destroy VPC
+      amazon.aws.ec2_vpc_net:
+        cidr_block: 10.228.224.0/21
+        name: "{{ resource_prefix }}_vpc"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/ec2_vpc_subnet/defaults/main.yml
+++ b/tests/integration/targets/ec2_vpc_subnet/defaults/main.yml
@@ -1,9 +1,9 @@
 ---
-availability_zone: '{{ ec2_availability_zone_names[0] }}'
+availability_zone: "{{ ec2_availability_zone_names[0] }}"
 
 # defaults file for ec2_vpc_subnet
-ec2_vpc_subnet_name: '{{resource_prefix}}'
-ec2_vpc_subnet_description: 'Created by ansible integration tests'
-vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'
-subnet_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.1.0/24'
-subnet_cidr_b: '10.{{ 256 | random(seed=resource_prefix) }}.2.0/24'
+ec2_vpc_subnet_name: "{{resource_prefix}}"
+ec2_vpc_subnet_description: Created by ansible integration tests
+vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/16
+subnet_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.1.0/24
+subnet_cidr_b: 10.{{ 256 | random(seed=resource_prefix) }}.2.0/24

--- a/tests/integration/targets/ec2_vpc_subnet/meta/main.yml
+++ b/tests/integration/targets/ec2_vpc_subnet/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
   - setup_ec2_facts

--- a/tests/integration/targets/ec2_vpc_subnet/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_subnet/tasks/main.yml
@@ -8,252 +8,252 @@
   block:
     # ============================================================
     - name: create a VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         name: "{{ resource_prefix }}-vpc"
         state: present
         cidr_block: "{{ vpc_cidr }}"
-        ipv6_cidr: True
+        ipv6_cidr: true
         tags:
           Name: "{{ resource_prefix }}-vpc"
-          Description: "Created by ansible-test"
+          Description: Created by ansible-test
       register: vpc_result
 
-    - set_fact:
+    - ansible.builtin.set_fact:
         vpc_ipv6_cidr: "{{ vpc_result.vpc.ipv6_cidr_block_association_set[0].ipv6_cidr_block }}"
 
-    - set_fact:
+    - ansible.builtin.set_fact:
         subnet_ipv6_cidr: "{{ vpc_ipv6_cidr | regex_replace('::/.*', '::/64') }}"
 
     # ============================================================
     - name: check subnet does not exist
-      ec2_vpc_subnet_info:
+      amazon.aws.ec2_vpc_subnet_info:
         filters:
-          "tag:Name": '{{ec2_vpc_subnet_name}}'
+          tag:Name: "{{ec2_vpc_subnet_name}}"
       register: vpc_subnet_info
 
     - name: Assert info result is zero
-      assert:
+      ansible.builtin.assert:
         that:
           - (vpc_subnet_info.subnets|length) == 0
 
     - name: create subnet (expected changed=true) (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
         state: present
       check_mode: true
       register: vpc_subnet_create
 
     - name: assert creation would happen
-      assert:
+      ansible.builtin.assert:
         that:
           - vpc_subnet_create is changed
 
     - name: create subnet (expected changed=true)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
         state: present
       register: vpc_subnet_create
 
     - name: assert creation happened (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'vpc_subnet_create'
-           - "'ec2:CreateTags' not in vpc_subnet_create.resource_actions"
-           - "'ec2:DeleteTags' not in vpc_subnet_create.resource_actions"
-           - 'vpc_subnet_create.subnet.id.startswith("subnet-")'
-           - '"Name" in vpc_subnet_create.subnet.tags and vpc_subnet_create.subnet.tags["Name"] == ec2_vpc_subnet_name'
-           - '"Description" in vpc_subnet_create.subnet.tags and vpc_subnet_create.subnet.tags["Description"] == ec2_vpc_subnet_description'
+          - vpc_subnet_create
+          - "'ec2:CreateTags' not in vpc_subnet_create.resource_actions"
+          - "'ec2:DeleteTags' not in vpc_subnet_create.resource_actions"
+          - vpc_subnet_create.subnet.id.startswith("subnet-")
+          - '"Name" in vpc_subnet_create.subnet.tags and vpc_subnet_create.subnet.tags["Name"] == ec2_vpc_subnet_name'
+          - '"Description" in vpc_subnet_create.subnet.tags and vpc_subnet_create.subnet.tags["Description"] == ec2_vpc_subnet_description'
 
     - name: get info about the subnet
-      ec2_vpc_subnet_info:
-        subnet_ids: '{{ vpc_subnet_create.subnet.id }}'
+      amazon.aws.ec2_vpc_subnet_info:
+        subnet_ids: "{{ vpc_subnet_create.subnet.id }}"
       register: vpc_subnet_info
 
     - name: Assert info result matches create result
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'vpc_subnet_info.subnets | length == 1'
+          - vpc_subnet_info.subnets | length == 1
           - '"assign_ipv6_address_on_creation" in subnet_info'
-          - 'subnet_info.assign_ipv6_address_on_creation == False'
+          - subnet_info.assign_ipv6_address_on_creation == False
           - '"availability_zone" in subnet_info'
-          - 'subnet_info.availability_zone == availability_zone'
+          - subnet_info.availability_zone == availability_zone
           - '"available_ip_address_count" in subnet_info'
           - '"cidr_block" in subnet_info'
-          - 'subnet_info.cidr_block == subnet_cidr'
+          - subnet_info.cidr_block == subnet_cidr
           - '"default_for_az" in subnet_info'
           - '"id" in subnet_info'
-          - 'subnet_info.id == vpc_subnet_create.subnet.id'
+          - subnet_info.id == vpc_subnet_create.subnet.id
           - '"map_public_ip_on_launch" in subnet_info'
-          - 'subnet_info.map_public_ip_on_launch == False'
+          - subnet_info.map_public_ip_on_launch == False
           - '"state" in subnet_info'
           - '"subnet_id" in subnet_info'
-          - 'subnet_info.subnet_id == vpc_subnet_create.subnet.id'
+          - subnet_info.subnet_id == vpc_subnet_create.subnet.id
           - '"tags" in subnet_info'
-          - 'subnet_info.tags["Description"] == ec2_vpc_subnet_description'
-          - 'subnet_info.tags["Name"] == vpc_subnet_create.subnet.tags["Name"]'
+          - subnet_info.tags["Description"] == ec2_vpc_subnet_description
+          - subnet_info.tags["Name"] == vpc_subnet_create.subnet.tags["Name"]
           - '"vpc_id" in subnet_info'
-          - 'subnet_info.vpc_id == vpc_result.vpc.id'
+          - subnet_info.vpc_id == vpc_result.vpc.id
       vars:
-        subnet_info: '{{ vpc_subnet_info.subnets[0] }}'
+        subnet_info: "{{ vpc_subnet_info.subnets[0] }}"
 
     # ============================================================
     - name: recreate subnet (expected changed=false) (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
         state: present
       check_mode: true
       register: vpc_subnet_recreate
 
     - name: assert recreation changed nothing (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_subnet_recreate is not changed
+          - vpc_subnet_recreate is not changed
 
     - name: recreate subnet (expected changed=false)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
         state: present
       register: vpc_subnet_recreate
 
     - name: assert recreation changed nothing (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_subnet_recreate is not changed
-           - 'vpc_subnet_recreate.subnet == vpc_subnet_create.subnet'
+          - vpc_subnet_recreate is not changed
+          - vpc_subnet_recreate.subnet == vpc_subnet_create.subnet
 
     # ============================================================
     - name: update subnet so instances launched in it are assigned an IP (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
         state: present
         map_public: true
       check_mode: true
       register: vpc_subnet_modify
 
     - name: assert subnet changed
-      assert:
+      ansible.builtin.assert:
         that:
           - vpc_subnet_modify is changed
 
     - name: update subnet so instances launched in it are assigned an IP
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
         state: present
         map_public: true
       register: vpc_subnet_modify
 
     - name: assert subnet changed
-      assert:
+      ansible.builtin.assert:
         that:
           - vpc_subnet_modify is changed
           - vpc_subnet_modify.subnet.map_public_ip_on_launch
 
     # ============================================================
     - name: add invalid ipv6 block to subnet (expected failed)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: 2001:db8::/64
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
         state: present
       register: vpc_subnet_ipv6_failed
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: assert failure happened (expected failed)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_subnet_ipv6_failed is failed
-           - "'Couldn\\'t associate ipv6 cidr' in vpc_subnet_ipv6_failed.msg"
+          - vpc_subnet_ipv6_failed is failed
+          - "'Couldn\\'t associate ipv6 cidr' in vpc_subnet_ipv6_failed.msg"
 
     # ============================================================
     - name: add a tag (expected changed=true) (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
           AnotherTag: SomeValue
         state: present
       check_mode: true
       register: vpc_subnet_add_a_tag
 
     - name: assert tag addition happened (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_subnet_add_a_tag is changed
+          - vpc_subnet_add_a_tag is changed
 
     - name: add a tag (expected changed=true)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
           AnotherTag: SomeValue
         state: present
       register: vpc_subnet_add_a_tag
 
     - name: assert tag addition happened (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_subnet_add_a_tag is changed
-           - '"Name" in vpc_subnet_add_a_tag.subnet.tags and vpc_subnet_add_a_tag.subnet.tags["Name"] == ec2_vpc_subnet_name'
-           - '"Description" in vpc_subnet_add_a_tag.subnet.tags and vpc_subnet_add_a_tag.subnet.tags["Description"] == ec2_vpc_subnet_description'
-           - '"AnotherTag" in vpc_subnet_add_a_tag.subnet.tags and vpc_subnet_add_a_tag.subnet.tags["AnotherTag"] == "SomeValue"'
+          - vpc_subnet_add_a_tag is changed
+          - '"Name" in vpc_subnet_add_a_tag.subnet.tags and vpc_subnet_add_a_tag.subnet.tags["Name"] == ec2_vpc_subnet_name'
+          - '"Description" in vpc_subnet_add_a_tag.subnet.tags and vpc_subnet_add_a_tag.subnet.tags["Description"] == ec2_vpc_subnet_description'
+          - '"AnotherTag" in vpc_subnet_add_a_tag.subnet.tags and vpc_subnet_add_a_tag.subnet.tags["AnotherTag"] == "SomeValue"'
 
     - name: Get info by tag
-      ec2_vpc_subnet_info:
+      amazon.aws.ec2_vpc_subnet_info:
         filters:
-          "tag:Name": '{{ec2_vpc_subnet_name}}'
+          tag:Name: "{{ec2_vpc_subnet_name}}"
       register: vpc_subnet_info_by_tag
 
     - name: assert info matches expected output
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'vpc_subnet_info_by_tag.subnets[0].id == vpc_subnet_add_a_tag.subnet.id'
+          - vpc_subnet_info_by_tag.subnets[0].id == vpc_subnet_add_a_tag.subnet.id
           - (vpc_subnet_info_by_tag.subnets[0].tags|length) == 3
           - '"Description" in vpc_subnet_info_by_tag.subnets[0].tags and vpc_subnet_info_by_tag.subnets[0].tags["Description"] == ec2_vpc_subnet_description'
           - '"AnotherTag" in vpc_subnet_info_by_tag.subnets[0].tags and vpc_subnet_info_by_tag.subnets[0].tags["AnotherTag"] == "SomeValue"'
 
     # ============================================================
     - name: remove tags with default purge_tags=true (expected changed=true) (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
@@ -264,12 +264,12 @@
       register: vpc_subnet_remove_tags
 
     - name: assert tag removal happened (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_subnet_remove_tags is changed
+          - vpc_subnet_remove_tags is changed
 
     - name: remove tags with default purge_tags=true (expected changed=true)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
@@ -279,68 +279,67 @@
       register: vpc_subnet_remove_tags
 
     - name: assert tag removal happened (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_subnet_remove_tags is changed
-           - '"Name" not in vpc_subnet_remove_tags.subnet.tags'
-           - '"Description" not in vpc_subnet_remove_tags.subnet.tags'
-           - '"AnotherTag" in vpc_subnet_remove_tags.subnet.tags and vpc_subnet_remove_tags.subnet.tags["AnotherTag"] == "SomeValue"'
+          - vpc_subnet_remove_tags is changed
+          - '"Name" not in vpc_subnet_remove_tags.subnet.tags'
+          - '"Description" not in vpc_subnet_remove_tags.subnet.tags'
+          - '"AnotherTag" in vpc_subnet_remove_tags.subnet.tags and vpc_subnet_remove_tags.subnet.tags["AnotherTag"] == "SomeValue"'
 
     - name: Check tags by info
-      ec2_vpc_subnet_info:
-        subnet_id: '{{ vpc_subnet_remove_tags.subnet.id }}'
+      amazon.aws.ec2_vpc_subnet_info:
+        subnet_id: "{{ vpc_subnet_remove_tags.subnet.id }}"
       register: vpc_subnet_info_removed_tags
 
     - name: assert info matches expected output
-      assert:
+      ansible.builtin.assert:
         that:
           - '"Name" not in vpc_subnet_info_removed_tags.subnets[0].tags'
           - '"Description" not in vpc_subnet_info_removed_tags.subnets[0].tags'
           - '"AnotherTag" in vpc_subnet_info_removed_tags.subnets[0].tags and vpc_subnet_info_removed_tags.subnets[0].tags["AnotherTag"] == "SomeValue"'
 
-
     # ============================================================
     - name: change tags with purge_tags=false (expected changed=true) (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
         state: present
         purge_tags: false
       check_mode: true
       register: vpc_subnet_change_tags
 
     - name: assert tag addition happened (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_subnet_change_tags is changed
+          - vpc_subnet_change_tags is changed
 
     - name: change tags with purge_tags=false (expected changed=true)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         az: "{{ availability_zone }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
         state: present
         purge_tags: false
       register: vpc_subnet_change_tags
 
     - name: assert tag addition happened (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_subnet_change_tags is changed
-           - '"Name" in vpc_subnet_change_tags.subnet.tags and vpc_subnet_change_tags.subnet.tags["Name"] == ec2_vpc_subnet_name'
-           - '"Description" in vpc_subnet_change_tags.subnet.tags and vpc_subnet_change_tags.subnet.tags["Description"] == ec2_vpc_subnet_description'
-           - '"AnotherTag" in vpc_subnet_change_tags.subnet.tags and vpc_subnet_change_tags.subnet.tags["AnotherTag"] == "SomeValue"'
+          - vpc_subnet_change_tags is changed
+          - '"Name" in vpc_subnet_change_tags.subnet.tags and vpc_subnet_change_tags.subnet.tags["Name"] == ec2_vpc_subnet_name'
+          - '"Description" in vpc_subnet_change_tags.subnet.tags and vpc_subnet_change_tags.subnet.tags["Description"] == ec2_vpc_subnet_description'
+          - '"AnotherTag" in vpc_subnet_change_tags.subnet.tags and vpc_subnet_change_tags.subnet.tags["AnotherTag"] == "SomeValue"'
 
     # ============================================================
     - name: test state=absent (expected changed=true) (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
@@ -348,25 +347,25 @@
       register: result
 
     - name: assert state=absent (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is changed
+          - result is changed
 
     - name: test state=absent (expected changed=true)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
       register: result
 
     - name: assert state=absent (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is changed
+          - result is changed
 
     # ============================================================
     - name: test state=absent (expected changed=false) (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
@@ -374,25 +373,25 @@
       register: result
 
     - name: assert state=absent (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is not changed
+          - result is not changed
 
     - name: test state=absent (expected changed=false)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
       register: result
 
     - name: assert state=absent (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is not changed
+          - result is not changed
 
     # ============================================================
     - name: create subnet without AZ (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
@@ -400,25 +399,25 @@
       register: subnet_without_az
 
     - name: check that subnet without AZ works fine
-      assert:
+      ansible.builtin.assert:
         that:
-           - subnet_without_az is changed
+          - subnet_without_az is changed
 
     - name: create subnet without AZ
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
       register: subnet_without_az
 
     - name: check that subnet without AZ works fine
-      assert:
+      ansible.builtin.assert:
         that:
-           - subnet_without_az is changed
+          - subnet_without_az is changed
 
     # ============================================================
     - name: remove subnet without AZ (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
@@ -426,104 +425,103 @@
       register: result
 
     - name: assert state=absent (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is changed
+          - result is changed
 
     - name: remove subnet without AZ
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
       register: result
 
     - name: assert state=absent (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - result is changed
-
+          - result is changed
 
     # ============================================================
     - name: create subnet with IPv6 (expected changed=true) (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: "{{ subnet_ipv6_cidr }}"
         assign_instances_ipv6: true
         state: present
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
       check_mode: true
       register: vpc_subnet_ipv6_create
 
     - name: assert creation with IPv6 happened (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_subnet_ipv6_create is changed
+          - vpc_subnet_ipv6_create is changed
 
     - name: create subnet with IPv6 (expected changed=true)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: "{{ subnet_ipv6_cidr }}"
         assign_instances_ipv6: true
         state: present
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
       register: vpc_subnet_ipv6_create
 
     - name: assert creation with IPv6 happened (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_subnet_ipv6_create is changed
-           - 'vpc_subnet_ipv6_create.subnet.id.startswith("subnet-")'
-           - "vpc_subnet_ipv6_create.subnet.ipv6_cidr_block == subnet_ipv6_cidr"
-           - '"Name" in vpc_subnet_ipv6_create.subnet.tags and vpc_subnet_ipv6_create.subnet.tags["Name"] == ec2_vpc_subnet_name'
-           - '"Description" in vpc_subnet_ipv6_create.subnet.tags and vpc_subnet_ipv6_create.subnet.tags["Description"] == ec2_vpc_subnet_description'
-           - 'vpc_subnet_ipv6_create.subnet.assign_ipv6_address_on_creation'
+          - vpc_subnet_ipv6_create is changed
+          - vpc_subnet_ipv6_create.subnet.id.startswith("subnet-")
+          - vpc_subnet_ipv6_create.subnet.ipv6_cidr_block == subnet_ipv6_cidr
+          - '"Name" in vpc_subnet_ipv6_create.subnet.tags and vpc_subnet_ipv6_create.subnet.tags["Name"] == ec2_vpc_subnet_name'
+          - '"Description" in vpc_subnet_ipv6_create.subnet.tags and vpc_subnet_ipv6_create.subnet.tags["Description"] == ec2_vpc_subnet_description'
+          - vpc_subnet_ipv6_create.subnet.assign_ipv6_address_on_creation
 
     # ============================================================
     - name: recreate subnet (expected changed=false) (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: "{{ subnet_ipv6_cidr }}"
         assign_instances_ipv6: true
         state: present
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
       check_mode: true
       register: vpc_subnet_ipv6_recreate
 
     - name: assert recreation changed nothing (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_subnet_ipv6_recreate is not changed
+          - vpc_subnet_ipv6_recreate is not changed
 
     - name: recreate subnet (expected changed=false)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: "{{ subnet_ipv6_cidr }}"
         assign_instances_ipv6: true
         state: present
         tags:
-          Name: '{{ec2_vpc_subnet_name}}'
-          Description: '{{ec2_vpc_subnet_description}}'
+          Name: "{{ec2_vpc_subnet_name}}"
+          Description: "{{ec2_vpc_subnet_description}}"
       register: vpc_subnet_ipv6_recreate
 
     - name: assert recreation changed nothing (expected changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_subnet_ipv6_recreate is not changed
-           - 'vpc_subnet_ipv6_recreate.subnet == vpc_subnet_ipv6_create.subnet'
+          - vpc_subnet_ipv6_recreate is not changed
+          - vpc_subnet_ipv6_recreate.subnet == vpc_subnet_ipv6_create.subnet
 
     # ============================================================
     - name: change subnet assign_instances_ipv6 attribute (expected changed=true) (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: "{{ subnet_ipv6_cidr }}"
@@ -534,12 +532,12 @@
       register: vpc_change_attribute
 
     - name: assert assign_instances_ipv6 attribute changed (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_change_attribute is changed
+          - vpc_change_attribute is changed
 
     - name: change subnet assign_instances_ipv6 attribute (expected changed=true)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: "{{ subnet_ipv6_cidr }}"
@@ -549,14 +547,14 @@
       register: vpc_change_attribute
 
     - name: assert assign_instances_ipv6 attribute changed (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_change_attribute is changed
-           - 'not vpc_change_attribute.subnet.assign_ipv6_address_on_creation'
+          - vpc_change_attribute is changed
+          - not vpc_change_attribute.subnet.assign_ipv6_address_on_creation
 
     # ============================================================
     - name: add second subnet with duplicate ipv6 cidr (expected failure)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr_b }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         ipv6_cidr: "{{ subnet_ipv6_cidr }}"
@@ -566,14 +564,14 @@
       ignore_errors: true
 
     - name: assert graceful failure (expected failed)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_add_duplicate_ipv6 is failed
-           - "'The IPv6 CIDR \\'{{ subnet_ipv6_cidr }}\\' conflicts with another subnet' in vpc_add_duplicate_ipv6.msg"
+          - vpc_add_duplicate_ipv6 is failed
+          - "'The IPv6 CIDR \\'{{ subnet_ipv6_cidr }}\\' conflicts with another subnet' in vpc_add_duplicate_ipv6.msg"
 
     # ============================================================
     - name: remove subnet ipv6 cidr (expected changed=true) (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
@@ -582,12 +580,12 @@
       register: vpc_remove_ipv6_cidr
 
     - name: assert subnet ipv6 cidr removed (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_remove_ipv6_cidr is changed
+          - vpc_remove_ipv6_cidr is changed
 
     - name: remove subnet ipv6 cidr (expected changed=true)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
@@ -595,15 +593,15 @@
       register: vpc_remove_ipv6_cidr
 
     - name: assert subnet ipv6 cidr removed (expected changed=true)
-      assert:
+      ansible.builtin.assert:
         that:
-           - vpc_remove_ipv6_cidr is changed
-           - "vpc_remove_ipv6_cidr.subnet.ipv6_cidr_block == ''"
-           - 'not vpc_remove_ipv6_cidr.subnet.assign_ipv6_address_on_creation'
+          - vpc_remove_ipv6_cidr is changed
+          - vpc_remove_ipv6_cidr.subnet.ipv6_cidr_block == ''
+          - not vpc_remove_ipv6_cidr.subnet.assign_ipv6_address_on_creation
 
     # ============================================================
     - name: test adding a tag that looks like a boolean to the subnet (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
@@ -614,12 +612,12 @@
       register: vpc_subnet_info
 
     - name: assert a tag was added
-      assert:
+      ansible.builtin.assert:
         that:
           - vpc_subnet_info is changed
 
     - name: test adding a tag that looks like a boolean to the subnet
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
@@ -629,14 +627,14 @@
       register: vpc_subnet_info
 
     - name: assert a tag was added
-      assert:
+      ansible.builtin.assert:
         that:
           - vpc_subnet_info is changed
-          - 'vpc_subnet_info.subnet.tags.looks_like_boolean == "True"'
+          - vpc_subnet_info.subnet.tags.looks_like_boolean == "True"
 
     # ============================================================
     - name: test idempotence adding a tag that looks like a boolean (CHECK MODE)
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
@@ -647,12 +645,12 @@
       register: vpc_subnet_info
 
     - name: assert tags haven't changed
-      assert:
+      ansible.builtin.assert:
         that:
           - vpc_subnet_info is not changed
 
     - name: test idempotence adding a tag that looks like a boolean
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: present
@@ -662,24 +660,23 @@
       register: vpc_subnet_info
 
     - name: assert tags haven't changed
-      assert:
+      ansible.builtin.assert:
         that:
           - vpc_subnet_info is not changed
 
   always:
-
     ################################################
     # TEARDOWN STARTS HERE
     ################################################
 
     - name: tidy up subnet
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_result.vpc.id }}"
         state: absent
 
     - name: tidy up VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         name: "{{ resource_prefix }}-vpc"
         state: absent
         cidr_block: "{{ vpc_cidr }}"

--- a/tests/integration/targets/elb_application_lb/tasks/main.yml
+++ b/tests/integration/targets/elb_application_lb/tasks/main.yml
@@ -145,7 +145,7 @@
             DefaultActions:
               - Type: forward
                 TargetGroupName: "{{ tg_name }}"
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
       register: alb
     - ansible.builtin.assert:
         that:
@@ -160,7 +160,7 @@
         state: present
         listeners:
           - Port: 80
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
       register: alb
     - ansible.builtin.assert:
         that:
@@ -179,7 +179,7 @@
             DefaultActions:
               - Type: forward
                 TargetGroupName: "{{ tg_name }}"
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
       register: alb
     - ansible.builtin.assert:
         that:
@@ -199,7 +199,7 @@
               - Type: forward
                 TargetGroupName: "{{ tg_name }}"
         ip_address_type: ip_addr_v4_v6
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
       register: alb
     - ansible.builtin.assert:
         that:
@@ -1552,14 +1552,14 @@
         state: absent
         wait: true
         wait_timeout: 600
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
     - name: Destroy ALB 2
       amazon.aws.elb_application_lb:
         name: "{{ alb_2_name }}"
         state: absent
         wait: true
         wait_timeout: 600
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
     - name: Destroy target group if it was created
       community.aws.elb_target_group:
         name: "{{ tg_name }}"
@@ -1574,7 +1574,7 @@
       delay: 3
       until: remove_tg is success
       when: tg is defined
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
     - name: Destroy target group 2 if it was created
       community.aws.elb_target_group:
         name: "{{ tg_2_name }}"
@@ -1589,7 +1589,7 @@
       delay: 3
       until: remove_tg_2 is success
       when: tg_2 is defined
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
     - name: Destroy sec groups
       amazon.aws.ec2_security_group:
         name: "{{ item }}"
@@ -1600,7 +1600,7 @@
       retries: 10
       delay: 5
       until: remove_sg is success
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
       with_items:
         - "{{ resource_prefix }}"
         - "{{ resource_prefix }}-2"
@@ -1615,7 +1615,7 @@
       retries: 10
       delay: 5
       until: remove_rt is success
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
     - name: Destroy subnets
       amazon.aws.ec2_vpc_subnet:
         cidr: "{{ item }}"
@@ -1630,7 +1630,7 @@
         - "{{ private_subnet_cidr_2 }}"
         - "{{ public_subnet_cidr_1 }}"
         - "{{ public_subnet_cidr_2 }}"
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
     - name: Destroy internet gateway
       amazon.aws.ec2_vpc_igw:
         vpc_id: "{{ vpc_id }}"
@@ -1641,7 +1641,7 @@
       retries: 10
       delay: 5
       until: remove_igw is success
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
     - name: Destroy VPC
       amazon.aws.ec2_vpc_net:
         cidr_block: "{{ vpc_cidr }}"
@@ -1651,7 +1651,7 @@
       retries: 10
       delay: 5
       until: remove_vpc is success
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
     - name: Destroy ELB acccess log test file
       amazon.aws.s3_object:
         bucket: "{{ s3_bucket_name }}"

--- a/tests/integration/targets/elb_classic_lb/defaults/main.yml
+++ b/tests/integration/targets/elb_classic_lb/defaults/main.yml
@@ -1,19 +1,19 @@
 ---
 # defaults file for elb_classic_lb
-elb_name: 'ansible-test-{{ tiny_prefix }}'
+elb_name: ansible-test-{{ tiny_prefix }}
 
-vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'
-subnet_cidr_1: '10.{{ 256 | random(seed=resource_prefix) }}.1.0/24'
-subnet_cidr_2: '10.{{ 256 | random(seed=resource_prefix) }}.2.0/24'
-subnet_cidr_3: '10.{{ 256 | random(seed=resource_prefix) }}.3.0/24'
-subnet_cidr_4: '10.{{ 256 | random(seed=resource_prefix) }}.4.0/24'
+vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/16
+subnet_cidr_1: 10.{{ 256 | random(seed=resource_prefix) }}.1.0/24
+subnet_cidr_2: 10.{{ 256 | random(seed=resource_prefix) }}.2.0/24
+subnet_cidr_3: 10.{{ 256 | random(seed=resource_prefix) }}.3.0/24
+subnet_cidr_4: 10.{{ 256 | random(seed=resource_prefix) }}.4.0/24
 
 default_tags:
   snake_case_key: snake_case_value
   camelCaseKey: camelCaseValue
   PascalCaseKey: PascalCaseValue
-  "key with spaces": value with spaces
-  "Upper With Spaces": Upper With Spaces
+  key with spaces: value with spaces
+  Upper With Spaces: Upper With Spaces
 
 partial_tags:
   snake_case_key: snake_case_value
@@ -23,8 +23,8 @@ updated_tags:
   updated_snake_case_key: updated_snake_case_value
   updatedCamelCaseKey: updatedCamelCaseValue
   UpdatedPascalCaseKey: UpdatedPascalCaseValue
-  "updated key with spaces": updated value with spaces
-  "updated Upper With Spaces": Updated Upper With Spaces
+  updated key with spaces: updated value with spaces
+  updated Upper With Spaces: Updated Upper With Spaces
 
 default_listeners:
   - protocol: http
@@ -35,8 +35,8 @@ default_listeners:
     instance_port: 8080
     instance_protocol: http
 default_listener_tuples:
-  - [80, 80, "HTTP", "HTTP"]
-  - [8080, 8080, "HTTP", "HTTP"]
+  - [80, 80, HTTP, HTTP]
+  - [8080, 8080, HTTP, HTTP]
 
 purged_listeners:
   - protocol: http
@@ -44,7 +44,7 @@ purged_listeners:
     instance_port: 8080
     instance_protocol: http
 purged_listener_tuples:
-  - [8080, 8080, "HTTP", "HTTP"]
+  - [8080, 8080, HTTP, HTTP]
 
 updated_listeners:
   - protocol: http
@@ -55,24 +55,24 @@ updated_listeners:
     instance_port: 8080
     instance_protocol: http
 updated_listener_tuples:
-  - [80, 8181, "HTTP", "HTTP"]
-  - [8080, 8080, "HTTP", "HTTP"]
+  - [80, 8181, HTTP, HTTP]
+  - [8080, 8080, HTTP, HTTP]
 
 unproxied_listener:
   - protocol: http
     load_balancer_port: 80
     instance_port: 8181
-    proxy_protocol: False
+    proxy_protocol: false
 unproxied_listener_tuples:
-  - [80, 8181, "HTTP", "HTTP"]
+  - [80, 8181, HTTP, HTTP]
 
 proxied_listener:
   - protocol: http
     load_balancer_port: 80
     instance_port: 8181
-    proxy_protocol: True
+    proxy_protocol: true
 proxied_listener_tuples:
-  - [80, 8181, "HTTP", "HTTP"]
+  - [80, 8181, HTTP, HTTP]
 
 ssh_listeners:
   - protocol: tcp
@@ -80,45 +80,45 @@ ssh_listeners:
     instance_port: 22
     instance_protocol: tcp
 ssh_listener_tuples:
-  - [22, 22, "TCP", "TCP"]
+  - [22, 22, TCP, TCP]
 
 default_health_check:
-    ping_protocol: http
-    ping_port: 80
-    ping_path: "/index.html"
-    response_timeout: 5
-    interval: 30
-    unhealthy_threshold: 2
-    healthy_threshold: 10
-default_health_check_target: "HTTP:80/index.html"
+  ping_protocol: http
+  ping_port: 80
+  ping_path: /index.html
+  response_timeout: 5
+  interval: 30
+  unhealthy_threshold: 2
+  healthy_threshold: 10
+default_health_check_target: HTTP:80/index.html
 
 updated_health_check:
-    ping_protocol: http
-    ping_port: 8181
-    ping_path: "/healthz"
-    response_timeout: 15
-    interval: 42
-    unhealthy_threshold: 7
-    healthy_threshold: 6
-updated_health_check_target: "HTTP:8181/healthz"
+  ping_protocol: http
+  ping_port: 8181
+  ping_path: /healthz
+  response_timeout: 15
+  interval: 42
+  unhealthy_threshold: 7
+  healthy_threshold: 6
+updated_health_check_target: HTTP:8181/healthz
 
 nonhttp_health_check:
-    ping_protocol: tcp
-    ping_port: 8282
-    response_timeout: 16
-    interval: 43
-    unhealthy_threshold: 8
-    healthy_threshold: 2
-nonhttp_health_check_target: "TCP:8282"
+  ping_protocol: tcp
+  ping_port: 8282
+  response_timeout: 16
+  interval: 43
+  unhealthy_threshold: 8
+  healthy_threshold: 2
+nonhttp_health_check_target: TCP:8282
 
 ssh_health_check:
-    ping_protocol: tcp
-    ping_port: 22
-    response_timeout: 5
-    interval: 10
-    unhealthy_threshold: 2
-    healthy_threshold: 2
-ssh_health_check_target: "TCP:22"
+  ping_protocol: tcp
+  ping_port: 22
+  response_timeout: 5
+  interval: 10
+  unhealthy_threshold: 2
+  healthy_threshold: 2
+ssh_health_check_target: TCP:22
 
 default_idle_timeout: 25
 updated_idle_timeout: 50
@@ -126,39 +126,39 @@ default_drain_timeout: 15
 updated_drain_timeout: 25
 
 app_stickiness:
-    type: application
-    cookie: MyCookie
-    enabled: true
+  type: application
+  cookie: MyCookie
+  enabled: true
 
 updated_app_stickiness:
-    type: application
-    cookie: AnotherCookie
+  type: application
+  cookie: AnotherCookie
 
 lb_stickiness:
-    type: loadbalancer
+  type: loadbalancer
 
 updated_lb_stickiness:
-    type: loadbalancer
-    expiration: 600
+  type: loadbalancer
+  expiration: 600
 
 # Amazon's SDKs don't provide the list of account ID's.  Amazon only provide a
 # web page.  If you want to run the tests outside the US regions you'll need to
 # update this.
 # https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html
 access_log_account_id_map:
-    us-east-1: '127311923021'
-    us-east-2: '033677994240'
-    us-west-1: '027434742980'
-    us-west-2: '797873946194'
-    us-gov-west-1: '048591011584'
-    us-gov-east-1: '190560391635'
+  us-east-1: "127311923021"
+  us-east-2: "033677994240"
+  us-west-1: "027434742980"
+  us-west-2: "797873946194"
+  us-gov-west-1: "048591011584"
+  us-gov-east-1: "190560391635"
 
-access_log_account_id: '{{ access_log_account_id_map[aws_region] }}'
+access_log_account_id: "{{ access_log_account_id_map[aws_region] }}"
 
-s3_logging_bucket_a: 'ansible-test-{{ tiny_prefix }}-a'
-s3_logging_bucket_b: 'ansible-test-{{ tiny_prefix }}-b'
-default_logging_prefix: 'logs'
-updated_logging_prefix: 'mylogs'
+s3_logging_bucket_a: ansible-test-{{ tiny_prefix }}-a
+s3_logging_bucket_b: ansible-test-{{ tiny_prefix }}-b
+default_logging_prefix: logs
+updated_logging_prefix: mylogs
 default_logging_interval: 5
 updated_logging_interval: 60
 
@@ -166,5 +166,5 @@ local_certs:
   - priv_key: "{{ remote_tmp_dir }}/private-1.pem"
     cert: "{{ remote_tmp_dir }}/public-1.pem"
     csr: "{{ remote_tmp_dir }}/csr-1.csr"
-    domain: "elb-classic.{{ tiny_prefix }}.ansible.test"
+    domain: elb-classic.{{ tiny_prefix }}.ansible.test
     name: "{{ resource_prefix }}_{{ resource_prefix }}_1"

--- a/tests/integration/targets/elb_classic_lb/meta/main.yml
+++ b/tests/integration/targets/elb_classic_lb/meta/main.yml
@@ -1,3 +1,4 @@
+---
 dependencies:
   - setup_ec2_facts
   - setup_remote_tmp_dir

--- a/tests/integration/targets/elb_classic_lb/tasks/basic_internal.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/basic_internal.yml
@@ -4,33 +4,33 @@
     - module_defaults:
         elb_classic_lb:
           # zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-          listeners: '{{ default_listeners }}'
+          listeners: "{{ default_listeners }}"
           wait: true
-          scheme: 'internal'
-          subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
+          scheme: internal
+          subnets: ["{{ subnet_a }}", "{{ subnet_b }}"]
       block:
         # ============================================================
         # create test elb with listeners, certificate, and health check
 
         - name: Create internal ELB (check_mode)
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
           check_mode: true
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is changed
               - result.elb.status == "created"
 
         - name: Create ELB
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is changed
               - result.elb.status == "created"
@@ -40,24 +40,24 @@
               - subnet_b in result.elb.subnets
 
         - name: Create internal ELB idempotency (check_mode)
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
           check_mode: true
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is not changed
               - result.elb.status == "exists"
 
         - name: Create internal ELB idempotency
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is not changed
               - result.elb.status == "exists"
@@ -66,20 +66,20 @@
               - subnet_a in result.elb.subnets
               - subnet_b in result.elb.subnets
 
-        - ec2_eni_info:
+        - amazon.aws.ec2_eni_info:
             filters:
-              description: 'ELB {{ elb_name }}'
+              description: ELB {{ elb_name }}
           register: info
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - info.network_interfaces | length > 0
 
-        - elb_classic_lb_info:
-            names: ['{{ elb_name }}']
+        - community.aws.elb_classic_lb_info:
+            names: ["{{ elb_name }}"]
           register: info
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - info.elbs | length > 0
 
@@ -88,26 +88,26 @@
     # ============================================================
 
     - name: Add a subnet - no purge (check_mode)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        subnets: ['{{ subnet_c }}']
+        subnets: ["{{ subnet_c }}"]
       register: result
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.elb.status == "exists"
 
     - name: Add a subnet - no purge
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        subnets: ['{{ subnet_c }}']
+        subnets: ["{{ subnet_c }}"]
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.elb.status == "exists"
@@ -119,26 +119,26 @@
           - subnet_c in result.elb.subnets
 
     - name: Add a subnet - no purge - idempotency (check_mode)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        subnets: ['{{ subnet_c }}']
+        subnets: ["{{ subnet_c }}"]
       register: result
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
           - result.elb.status == "exists"
 
     - name: Add a subnet - no purge - idempotency
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        subnets: ['{{ subnet_c }}']
+        subnets: ["{{ subnet_c }}"]
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
           - result.elb.status == "exists"
@@ -153,28 +153,28 @@
     # This is important because you can't add 2 AZs to an LB from the same AZ at
     # the same time.
     - name: Add a subnet - purge (check_mode)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        subnets: ['{{ subnet_c }}', '{{ subnet_a2 }}']
+        subnets: ["{{ subnet_c }}", "{{ subnet_a2 }}"]
         purge_subnets: true
       register: result
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.elb.status == "exists"
 
     - name: Add a subnet - purge
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        subnets: ['{{ subnet_c }}', '{{ subnet_a2 }}']
+        subnets: ["{{ subnet_c }}", "{{ subnet_a2 }}"]
         purge_subnets: true
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.elb.status == "exists"
@@ -187,28 +187,28 @@
           - subnet_a2 in result.elb.subnets
 
     - name: Add a subnet - purge - idempotency (check_mode)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        subnets: ['{{ subnet_c }}', '{{ subnet_a2 }}']
+        subnets: ["{{ subnet_c }}", "{{ subnet_a2 }}"]
         purge_subnets: true
       register: result
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
           - result.elb.status == "exists"
 
     - name: Add a subnet - purge - idempotency
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        subnets: ['{{ subnet_c }}', '{{ subnet_a2 }}']
+        subnets: ["{{ subnet_c }}", "{{ subnet_a2 }}"]
         purge_subnets: true
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
           - result.elb.status == "exists"
@@ -223,7 +223,7 @@
     # ============================================================
 
     - name: remove the test load balancer completely (check_mode)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true
@@ -231,28 +231,28 @@
       check_mode: true
 
     - name: assert the load balancer would be removed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
-          - 'result.elb.name == elb_name'
-          - 'result.elb.status == "deleted"'
+          - result.elb.name == elb_name
+          - result.elb.status == "deleted"
 
     - name: remove the test load balancer completely
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true
       register: result
 
     - name: assert the load balancer was removed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
-          - 'result.elb.name == elb_name'
-          - 'result.elb.status == "deleted"'
+          - result.elb.name == elb_name
+          - result.elb.status == "deleted"
 
     - name: remove the test load balancer completely (idempotency) (check_mode)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true
@@ -260,31 +260,30 @@
       check_mode: true
 
     - name: assert the load balancer is gone
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
-          - 'result.elb.name == elb_name'
-          - 'result.elb.status == "gone"'
+          - result.elb.name == elb_name
+          - result.elb.status == "gone"
 
     - name: remove the test load balancer completely (idempotency)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true
       register: result
 
     - name: assert the load balancer is gone
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
-          - 'result.elb.name == elb_name'
-          - 'result.elb.status == "gone"'
+          - result.elb.name == elb_name
+          - result.elb.status == "gone"
 
   always:
-
     # ============================================================
     - name: remove the test load balancer
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true

--- a/tests/integration/targets/elb_classic_lb/tasks/basic_public.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/basic_public.yml
@@ -3,34 +3,34 @@
     # For creation test some basic behaviour
     - module_defaults:
         elb_classic_lb:
-          zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-          listeners: '{{ default_listeners }}'
+          zones: ["{{ availability_zone_a }}", "{{ availability_zone_b }}"]
+          listeners: "{{ default_listeners }}"
           wait: true
-          scheme: 'internet-facing'
+          scheme: internet-facing
           # subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
       block:
         # ============================================================
         # create test elb with listeners, certificate, and health check
 
         - name: Create public ELB (check_mode)
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
           check_mode: true
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is changed
               - result.elb.status == "created"
 
         - name: Create public ELB
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is changed
               - result.elb.status == "created"
@@ -38,44 +38,44 @@
               - availability_zone_b in result.elb.zones
 
         - name: Create public ELB idempotency (check_mode)
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
           check_mode: true
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is not changed
               - result.elb.status == "exists"
 
         - name: Create public ELB idempotency
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is not changed
               - result.elb.status == "exists"
               - availability_zone_a in result.elb.zones
               - availability_zone_b in result.elb.zones
 
-        - ec2_eni_info:
+        - amazon.aws.ec2_eni_info:
             filters:
-              description: 'ELB {{ elb_name }}'
+              description: ELB {{ elb_name }}
           register: info
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - info.network_interfaces | length > 0
 
-        - elb_classic_lb_info:
-            names: ['{{ elb_name }}']
+        - community.aws.elb_classic_lb_info:
+            names: ["{{ elb_name }}"]
           register: info
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - info.elbs | length > 0
 
@@ -84,26 +84,26 @@
     # ============================================================
 
     - name: Add a zone - no purge (check_mode)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        zones: ['{{ availability_zone_c }}']
+        zones: ["{{ availability_zone_c }}"]
       register: result
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.elb.status == "exists"
 
     - name: Add a zone - no purge
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        zones: ['{{ availability_zone_c }}']
+        zones: ["{{ availability_zone_c }}"]
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.elb.status == "exists"
@@ -112,26 +112,26 @@
           - availability_zone_c in result.elb.zones
 
     - name: Add a zone - no purge - idempotency (check_mode)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        zones: ['{{ availability_zone_c }}']
+        zones: ["{{ availability_zone_c }}"]
       register: result
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
           - result.elb.status == "exists"
 
     - name: Add a zone - no purge - idempotency
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        zones: ['{{ availability_zone_c }}']
+        zones: ["{{ availability_zone_c }}"]
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
           - result.elb.status == "exists"
@@ -142,28 +142,28 @@
     # ============================================================
 
     - name: Remove a zone - purge (check_mode)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        zones: ['{{ availability_zone_c }}']
+        zones: ["{{ availability_zone_c }}"]
         purge_zones: true
       register: result
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.elb.status == "exists"
 
     - name: Remove a zone - purge
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        zones: ['{{ availability_zone_c }}']
+        zones: ["{{ availability_zone_c }}"]
         purge_zones: true
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.elb.status == "exists"
@@ -172,28 +172,28 @@
           - availability_zone_c in result.elb.zones
 
     - name: Remove a zone - purge - idempotency (check_mode)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        zones: ['{{ availability_zone_c }}']
+        zones: ["{{ availability_zone_c }}"]
         purge_zones: true
       register: result
       check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
           - result.elb.status == "exists"
 
     - name: Remove a zone - purge - idempotency
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        zones: ['{{ availability_zone_c }}']
+        zones: ["{{ availability_zone_c }}"]
         purge_zones: true
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
           - result.elb.status == "exists"
@@ -204,7 +204,7 @@
     # ============================================================
 
     - name: remove the test load balancer completely (check_mode)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true
@@ -212,28 +212,28 @@
       check_mode: true
 
     - name: assert the load balancer would be removed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
-          - 'result.elb.name == elb_name'
-          - 'result.elb.status == "deleted"'
+          - result.elb.name == elb_name
+          - result.elb.status == "deleted"
 
     - name: remove the test load balancer completely
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true
       register: result
 
     - name: assert the load balancer was removed
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
-          - 'result.elb.name == elb_name'
-          - 'result.elb.status == "deleted"'
+          - result.elb.name == elb_name
+          - result.elb.status == "deleted"
 
     - name: remove the test load balancer completely (idempotency) (check_mode)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true
@@ -241,31 +241,30 @@
       check_mode: true
 
     - name: assert the load balancer is gone
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
-          - 'result.elb.name == elb_name'
-          - 'result.elb.status == "gone"'
+          - result.elb.name == elb_name
+          - result.elb.status == "gone"
 
     - name: remove the test load balancer completely (idempotency)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true
       register: result
 
     - name: assert the load balancer is gone
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
-          - 'result.elb.name == elb_name'
-          - 'result.elb.status == "gone"'
+          - result.elb.name == elb_name
+          - result.elb.status == "gone"
 
   always:
-
     # ============================================================
     - name: remove the test load balancer
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true

--- a/tests/integration/targets/elb_classic_lb/tasks/cleanup_instances.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/cleanup_instances.yml
@@ -1,9 +1,9 @@
 ---
 - name: Delete instance
-  ec2_instance:
+  amazon.aws.ec2_instance:
     instance_ids:
-    - '{{ instance_a }}'
-    - '{{ instance_b }}'
+      - "{{ instance_a }}"
+      - "{{ instance_b }}"
     state: absent
     wait: true
   ignore_errors: true

--- a/tests/integration/targets/elb_classic_lb/tasks/cleanup_s3.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/cleanup_s3.yml
@@ -1,32 +1,32 @@
 ---
 - name: Create empty temporary directory
-  tempfile:
+  ansible.builtin.tempfile:
     state: directory
   register: tmpdir
   ignore_errors: true
 
 - name: Empty S3 buckets before deletion
-  s3_sync:
-    bucket: '{{ item }}'
+  community.aws.s3_sync:
+    bucket: "{{ item }}"
     delete: true
-    file_root: '{{ tmpdir.path }}'
+    file_root: "{{ tmpdir.path }}"
   ignore_errors: true
   loop:
-    - '{{ s3_logging_bucket_a }}'
-    - '{{ s3_logging_bucket_b }}'
+    - "{{ s3_logging_bucket_a }}"
+    - "{{ s3_logging_bucket_b }}"
 
 - name: Delete S3 bucket for access logs
-  s3_bucket:
-    name: '{{ item }}'
+  amazon.aws.s3_bucket:
+    name: "{{ item }}"
     state: absent
   register: logging_bucket
   ignore_errors: true
   loop:
-    - '{{ s3_logging_bucket_a }}'
-    - '{{ s3_logging_bucket_b }}'
+    - "{{ s3_logging_bucket_a }}"
+    - "{{ s3_logging_bucket_b }}"
 
 - name: Remove temporary directory
-  file:
+  ansible.builtin.file:
     state: absent
     path: "{{ tmpdir.path }}"
-  ignore_errors: yes
+  ignore_errors: true

--- a/tests/integration/targets/elb_classic_lb/tasks/cleanup_vpc.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/cleanup_vpc.yml
@@ -1,29 +1,29 @@
 ---
 - name: delete security groups
   ec2_security_group:
-    name: '{{ item }}'
+    name: "{{ item }}"
     state: absent
   ignore_errors: true
   loop:
-    - '{{ resource_prefix }}-a'
-    - '{{ resource_prefix }}-b'
-    - '{{ resource_prefix }}-c'
+    - "{{ resource_prefix }}-a"
+    - "{{ resource_prefix }}-b"
+    - "{{ resource_prefix }}-c"
 
 - name: delete subnets
-  ec2_vpc_subnet:
-    vpc_id: '{{ setup_vpc.vpc.id }}'
-    cidr: '{{ item }}'
+  amazon.aws.ec2_vpc_subnet:
+    vpc_id: "{{ setup_vpc.vpc.id }}"
+    cidr: "{{ item }}"
     state: absent
   ignore_errors: true
   loop:
-    - '{{ subnet_cidr_1 }}'
-    - '{{ subnet_cidr_2 }}'
-    - '{{ subnet_cidr_3 }}'
-    - '{{ subnet_cidr_4 }}'
+    - "{{ subnet_cidr_1 }}"
+    - "{{ subnet_cidr_2 }}"
+    - "{{ subnet_cidr_3 }}"
+    - "{{ subnet_cidr_4 }}"
 
 - name: delete VPC
-  ec2_vpc_net:
-    cidr_block: '{{ vpc_cidr }}'
+  amazon.aws.ec2_vpc_net:
+    cidr_block: "{{ vpc_cidr }}"
     state: absent
-    name: '{{ resource_prefix }}'
+    name: "{{ resource_prefix }}"
   ignore_errors: true

--- a/tests/integration/targets/elb_classic_lb/tasks/complex_changes.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/complex_changes.yml
@@ -1,57 +1,57 @@
 ---
 - block:
     - name: Create ELB for testing complex updates (CHECK)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
         # zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-        listeners: '{{ default_listeners }}'
-        health_check: '{{ default_health_check }}'
+        listeners: "{{ default_listeners }}"
+        health_check: "{{ default_health_check }}"
         wait: true
-        scheme: 'internal'
-        subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
-        security_group_names: ['{{ resource_prefix }}-a', '{{ resource_prefix }}-b']
-        tags: '{{ default_tags }}'
-        cross_az_load_balancing: True
-        idle_timeout: '{{ default_idle_timeout }}'
-        connection_draining_timeout: '{{ default_drain_timeout }}'
+        scheme: internal
+        subnets: ["{{ subnet_a }}", "{{ subnet_b }}"]
+        security_group_names: ["{{ resource_prefix }}-a", "{{ resource_prefix }}-b"]
+        tags: "{{ default_tags }}"
+        cross_az_load_balancing: true
+        idle_timeout: "{{ default_idle_timeout }}"
+        connection_draining_timeout: "{{ default_drain_timeout }}"
         access_logs:
-          interval: '{{ default_logging_interval }}'
-          s3_location: '{{ s3_logging_bucket_a }}'
-          s3_prefix: '{{ default_logging_prefix }}'
+          interval: "{{ default_logging_interval }}"
+          s3_location: "{{ s3_logging_bucket_a }}"
+          s3_prefix: "{{ default_logging_prefix }}"
           enabled: true
       register: result
-      check_mode: True
+      check_mode: true
 
     - name: Verify that we expect to change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
 
     - name: Create ELB for testing complex updates
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
         # zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-        listeners: '{{ default_listeners }}'
-        health_check: '{{ default_health_check }}'
+        listeners: "{{ default_listeners }}"
+        health_check: "{{ default_health_check }}"
         wait: true
-        scheme: 'internal'
-        subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
-        security_group_names: ['{{ resource_prefix }}-a', '{{ resource_prefix }}-b']
-        tags: '{{ default_tags }}'
-        cross_az_load_balancing: True
-        idle_timeout: '{{ default_idle_timeout }}'
-        connection_draining_timeout: '{{ default_drain_timeout }}'
+        scheme: internal
+        subnets: ["{{ subnet_a }}", "{{ subnet_b }}"]
+        security_group_names: ["{{ resource_prefix }}-a", "{{ resource_prefix }}-b"]
+        tags: "{{ default_tags }}"
+        cross_az_load_balancing: true
+        idle_timeout: "{{ default_idle_timeout }}"
+        connection_draining_timeout: "{{ default_drain_timeout }}"
         access_logs:
-          interval: '{{ default_logging_interval }}'
-          s3_location: '{{ s3_logging_bucket_a }}'
-          s3_prefix: '{{ default_logging_prefix }}'
+          interval: "{{ default_logging_interval }}"
+          s3_location: "{{ s3_logging_bucket_a }}"
+          s3_prefix: "{{ default_logging_prefix }}"
           enabled: true
       register: result
 
     - name: Verify that simple parameters were set
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - result.elb.status == "created"
@@ -80,57 +80,57 @@
           - result.load_balancer.load_balancer_attributes.access_log.enabled == True
 
     - name: Create ELB for testing complex updates - idempotency (CHECK)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
         # zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-        listeners: '{{ default_listeners }}'
-        health_check: '{{ default_health_check }}'
+        listeners: "{{ default_listeners }}"
+        health_check: "{{ default_health_check }}"
         wait: true
-        scheme: 'internal'
-        subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
-        security_group_names: ['{{ resource_prefix }}-a', '{{ resource_prefix }}-b']
-        tags: '{{ default_tags }}'
-        cross_az_load_balancing: True
-        idle_timeout: '{{ default_idle_timeout }}'
-        connection_draining_timeout: '{{ default_drain_timeout }}'
+        scheme: internal
+        subnets: ["{{ subnet_a }}", "{{ subnet_b }}"]
+        security_group_names: ["{{ resource_prefix }}-a", "{{ resource_prefix }}-b"]
+        tags: "{{ default_tags }}"
+        cross_az_load_balancing: true
+        idle_timeout: "{{ default_idle_timeout }}"
+        connection_draining_timeout: "{{ default_drain_timeout }}"
         access_logs:
-          interval: '{{ default_logging_interval }}'
-          s3_location: '{{ s3_logging_bucket_a }}'
-          s3_prefix: '{{ default_logging_prefix }}'
+          interval: "{{ default_logging_interval }}"
+          s3_location: "{{ s3_logging_bucket_a }}"
+          s3_prefix: "{{ default_logging_prefix }}"
           enabled: true
       register: result
-      check_mode: True
+      check_mode: true
 
     - name: Verify that we expect to not change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
 
     - name: Create ELB for testing complex updates - idempotency
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
         # zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-        listeners: '{{ default_listeners }}'
-        health_check: '{{ default_health_check }}'
+        listeners: "{{ default_listeners }}"
+        health_check: "{{ default_health_check }}"
         wait: true
-        scheme: 'internal'
-        subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
-        security_group_names: ['{{ resource_prefix }}-a', '{{ resource_prefix }}-b']
-        tags: '{{ default_tags }}'
-        cross_az_load_balancing: True
-        idle_timeout: '{{ default_idle_timeout }}'
-        connection_draining_timeout: '{{ default_drain_timeout }}'
+        scheme: internal
+        subnets: ["{{ subnet_a }}", "{{ subnet_b }}"]
+        security_group_names: ["{{ resource_prefix }}-a", "{{ resource_prefix }}-b"]
+        tags: "{{ default_tags }}"
+        cross_az_load_balancing: true
+        idle_timeout: "{{ default_idle_timeout }}"
+        connection_draining_timeout: "{{ default_drain_timeout }}"
         access_logs:
-          interval: '{{ default_logging_interval }}'
-          s3_location: '{{ s3_logging_bucket_a }}'
-          s3_prefix: '{{ default_logging_prefix }}'
+          interval: "{{ default_logging_interval }}"
+          s3_location: "{{ s3_logging_bucket_a }}"
+          s3_prefix: "{{ default_logging_prefix }}"
           enabled: true
       register: result
 
     - name: Verify that simple parameters were set
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
           - result.elb.status == "exists"
@@ -161,57 +161,57 @@
     ###
 
     - name: Perform complex update (CHECK)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
         # zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-        listeners: '{{ updated_listeners }}'
-        health_check: '{{ updated_health_check }}'
+        listeners: "{{ updated_listeners }}"
+        health_check: "{{ updated_health_check }}"
         wait: true
-        scheme: 'internal'
-        subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
-        security_group_names: ['{{ resource_prefix }}-c', '{{ resource_prefix }}-b']
-        tags: '{{ updated_tags }}'
-        cross_az_load_balancing: False
-        idle_timeout: '{{ updated_idle_timeout }}'
-        connection_draining_timeout: '{{ default_drain_timeout }}'
+        scheme: internal
+        subnets: ["{{ subnet_a }}", "{{ subnet_b }}"]
+        security_group_names: ["{{ resource_prefix }}-c", "{{ resource_prefix }}-b"]
+        tags: "{{ updated_tags }}"
+        cross_az_load_balancing: false
+        idle_timeout: "{{ updated_idle_timeout }}"
+        connection_draining_timeout: "{{ default_drain_timeout }}"
         access_logs:
-          interval: '{{ updated_logging_interval }}'
-          s3_location: '{{ s3_logging_bucket_a }}'
-          s3_prefix: '{{ default_logging_prefix }}'
+          interval: "{{ updated_logging_interval }}"
+          s3_location: "{{ s3_logging_bucket_a }}"
+          s3_prefix: "{{ default_logging_prefix }}"
           enabled: true
       register: result
-      check_mode: True
+      check_mode: true
 
     - name: Verify that we expect to change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
 
     - name: Perform complex update
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
         # zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-        listeners: '{{ updated_listeners }}'
-        health_check: '{{ updated_health_check }}'
+        listeners: "{{ updated_listeners }}"
+        health_check: "{{ updated_health_check }}"
         wait: true
-        scheme: 'internal'
-        subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
-        security_group_names: ['{{ resource_prefix }}-c', '{{ resource_prefix }}-b']
-        tags: '{{ updated_tags }}'
-        cross_az_load_balancing: False
-        idle_timeout: '{{ updated_idle_timeout }}'
-        connection_draining_timeout: '{{ default_drain_timeout }}'
+        scheme: internal
+        subnets: ["{{ subnet_a }}", "{{ subnet_b }}"]
+        security_group_names: ["{{ resource_prefix }}-c", "{{ resource_prefix }}-b"]
+        tags: "{{ updated_tags }}"
+        cross_az_load_balancing: false
+        idle_timeout: "{{ updated_idle_timeout }}"
+        connection_draining_timeout: "{{ default_drain_timeout }}"
         access_logs:
-          interval: '{{ updated_logging_interval }}'
-          s3_location: '{{ s3_logging_bucket_a }}'
-          s3_prefix: '{{ default_logging_prefix }}'
+          interval: "{{ updated_logging_interval }}"
+          s3_location: "{{ s3_logging_bucket_a }}"
+          s3_prefix: "{{ default_logging_prefix }}"
           enabled: true
       register: result
 
     - name: Verify that simple parameters were set
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - result.elb.status == "exists"
@@ -240,57 +240,57 @@
           - result.load_balancer.load_balancer_attributes.access_log.enabled == True
 
     - name: Perform complex update idempotency (CHECK)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
         # zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-        listeners: '{{ updated_listeners }}'
-        health_check: '{{ updated_health_check }}'
+        listeners: "{{ updated_listeners }}"
+        health_check: "{{ updated_health_check }}"
         wait: true
-        scheme: 'internal'
-        subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
-        security_group_names: ['{{ resource_prefix }}-c', '{{ resource_prefix }}-b']
-        tags: '{{ updated_tags }}'
-        cross_az_load_balancing: False
-        idle_timeout: '{{ updated_idle_timeout }}'
-        connection_draining_timeout: '{{ default_drain_timeout }}'
+        scheme: internal
+        subnets: ["{{ subnet_a }}", "{{ subnet_b }}"]
+        security_group_names: ["{{ resource_prefix }}-c", "{{ resource_prefix }}-b"]
+        tags: "{{ updated_tags }}"
+        cross_az_load_balancing: false
+        idle_timeout: "{{ updated_idle_timeout }}"
+        connection_draining_timeout: "{{ default_drain_timeout }}"
         access_logs:
-          interval: '{{ updated_logging_interval }}'
-          s3_location: '{{ s3_logging_bucket_a }}'
-          s3_prefix: '{{ default_logging_prefix }}'
+          interval: "{{ updated_logging_interval }}"
+          s3_location: "{{ s3_logging_bucket_a }}"
+          s3_prefix: "{{ default_logging_prefix }}"
           enabled: true
       register: result
-      check_mode: True
+      check_mode: true
 
     - name: Verify we expect to not change
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
 
     - name: Perform complex update - idempotency
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
         # zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-        listeners: '{{ updated_listeners }}'
-        health_check: '{{ updated_health_check }}'
+        listeners: "{{ updated_listeners }}"
+        health_check: "{{ updated_health_check }}"
         wait: true
-        scheme: 'internal'
-        subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
-        security_group_names: ['{{ resource_prefix }}-c', '{{ resource_prefix }}-b']
-        tags: '{{ updated_tags }}'
-        cross_az_load_balancing: False
-        idle_timeout: '{{ updated_idle_timeout }}'
-        connection_draining_timeout: '{{ default_drain_timeout }}'
+        scheme: internal
+        subnets: ["{{ subnet_a }}", "{{ subnet_b }}"]
+        security_group_names: ["{{ resource_prefix }}-c", "{{ resource_prefix }}-b"]
+        tags: "{{ updated_tags }}"
+        cross_az_load_balancing: false
+        idle_timeout: "{{ updated_idle_timeout }}"
+        connection_draining_timeout: "{{ default_drain_timeout }}"
         access_logs:
-          interval: '{{ updated_logging_interval }}'
-          s3_location: '{{ s3_logging_bucket_a }}'
-          s3_prefix: '{{ default_logging_prefix }}'
+          interval: "{{ updated_logging_interval }}"
+          s3_location: "{{ s3_logging_bucket_a }}"
+          s3_prefix: "{{ default_logging_prefix }}"
           enabled: true
       register: result
 
     - name: Verify that simple parameters were set
-      assert:
+      ansible.builtin.assert:
         that:
           - result is not changed
           - result.elb.status == "exists"
@@ -319,10 +319,9 @@
           - result.load_balancer.load_balancer_attributes.access_log.enabled == True
 
   always:
-
     # ============================================================
     - name: remove the test load balancer
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true

--- a/tests/integration/targets/elb_classic_lb/tasks/describe_region.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/describe_region.yml
@@ -1,10 +1,10 @@
 ---
 - name: list available AZs
-  aws_az_info:
+  amazon.aws.aws_az_info:
   register: region_azs
 
 - name: pick AZs for testing
-  set_fact:
+  ansible.builtin.set_fact:
     availability_zone_a: "{{ region_azs.availability_zones[0].zone_name }}"
     availability_zone_b: "{{ region_azs.availability_zones[1].zone_name }}"
     availability_zone_c: "{{ region_azs.availability_zones[2].zone_name }}"

--- a/tests/integration/targets/elb_classic_lb/tasks/https_listeners.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/https_listeners.yml
@@ -1,52 +1,53 @@
+---
 # Create a SSL Certificate to use in test
 
 - name: Generate private key for local certs
-  with_items: '{{ local_certs }}'
+  with_items: "{{ local_certs }}"
   community.crypto.openssl_privatekey:
-    path: '{{ item.priv_key }}'
+    path: "{{ item.priv_key }}"
     type: RSA
     size: 2048
 
 - name: Generate an OpenSSL Certificate Signing Request for own certs
-  with_items: '{{ local_certs }}'
+  with_items: "{{ local_certs }}"
   community.crypto.openssl_csr:
-    path: '{{ item.csr }}'
-    privatekey_path: '{{ item.priv_key }}'
-    common_name: '{{ item.domain }}'
+    path: "{{ item.csr }}"
+    privatekey_path: "{{ item.priv_key }}"
+    common_name: "{{ item.domain }}"
 
 - name: Generate a Self Signed OpenSSL certificate for own certs
-  with_items: '{{ local_certs }}'
+  with_items: "{{ local_certs }}"
   community.crypto.x509_certificate:
     provider: selfsigned
-    path: '{{ item.cert }}'
-    csr_path: '{{ item.csr }}'
-    privatekey_path: '{{ item.priv_key }}'
+    path: "{{ item.cert }}"
+    csr_path: "{{ item.csr }}"
+    privatekey_path: "{{ item.priv_key }}"
     selfsigned_digest: sha256
   register: cert_create_result
 
 - name: upload certificates first time
   community.aws.acm_certificate:
-    name_tag: '{{ item.name }}'
-    certificate: '{{ lookup(''file'', item.cert ) }}'
-    private_key: '{{ lookup(''file'', item.priv_key ) }}'
+    name_tag: "{{ item.name }}"
+    certificate: "{{ lookup('file', item.cert ) }}"
+    private_key: "{{ lookup('file', item.priv_key ) }}"
     state: present
     tags:
       Application: search
       Environment: development
     purge_tags: false
   register: upload
-  with_items: '{{ local_certs }}'
+  with_items: "{{ local_certs }}"
   until: upload is succeeded
   retries: 5
   delay: 10
 
-- set_fact:
-    cert_arn: '{{ upload.results[0].certificate.arn }}'
+- ansible.builtin.set_fact:
+    cert_arn: "{{ upload.results[0].certificate.arn }}"
 
 # Create ELB definition
 
 - name: Create elb definition
-  set_fact:
+  ansible.builtin.set_fact:
     elb_definition:
       connection_draining_timeout: 5
       listeners:
@@ -55,7 +56,7 @@
           load_balancer_port: 443
           protocol: https
           ssl_certificate_id: "{{ cert_arn }}"
-      zones: ['{{ availability_zone_a }}']
+      zones: ["{{ availability_zone_a }}"]
       name: "{{ tiny_prefix }}-integration-test-lb"
       region: "{{ aws_region }}"
       state: present
@@ -68,7 +69,7 @@
   amazon.aws.elb_classic_lb: "{{ elb_definition }}"
   register: elb_create_result
   check_mode: true
-- assert:
+- ansible.builtin.assert:
     that:
       - elb_create_result is changed
       - elb_create_result.elb.status == "created"
@@ -78,7 +79,7 @@
 - name: Create a classic ELB with https method listeners
   amazon.aws.elb_classic_lb: "{{ elb_definition }}"
   register: elb_create_result
-- assert:
+- ansible.builtin.assert:
     that:
       - elb_create_result is changed
       - elb_create_result.elb.status == "created"
@@ -89,7 +90,7 @@
   amazon.aws.elb_classic_lb: "{{ elb_definition }}"
   register: elb_create_result
   check_mode: true
-- assert:
+- ansible.builtin.assert:
     that:
       - elb_create_result is not changed
       - elb_create_result.elb.status != "created"
@@ -100,7 +101,7 @@
 - name: Create a classic ELB with https method listeners - idempotency
   amazon.aws.elb_classic_lb: "{{ elb_definition }}"
   register: elb_create_result
-- assert:
+- ansible.builtin.assert:
     that:
       - elb_create_result is not changed
       - elb_create_result.elb.status != "created"
@@ -117,16 +118,16 @@
 
 - name: Delete the certificate created in this test
   community.aws.acm_certificate:
-    certificate_arn: '{{ cert_arn }}'
+    certificate_arn: "{{ cert_arn }}"
     state: absent
   # AWS doesn't always cleanup the associations properly
   # https://repost.aws/questions/QU63csgGNEQl2M--xCdy-oxw/cant-delete-certificate-because-there-are-dangling-load-balancer-resources
-  ignore_errors: True
+  ignore_errors: true
   register: delete_result
-- assert:
+- ansible.builtin.assert:
     that:
       - delete_result is changed
       - delete_result is not failed
   # AWS doesn't always cleanup the associations properly
   # https://repost.aws/questions/QU63csgGNEQl2M--xCdy-oxw/cant-delete-certificate-because-there-are-dangling-load-balancer-resources
-  ignore_errors: True
+  ignore_errors: true

--- a/tests/integration/targets/elb_classic_lb/tasks/main.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/main.yml
@@ -24,35 +24,28 @@
     - community.aws
     - community.crypto
   block:
-
-    - include_tasks: missing_params.yml
-
-    - include_tasks: describe_region.yml
-    - include_tasks: setup_vpc.yml
-    - include_tasks: setup_instances.yml
-    - include_tasks: setup_s3.yml
-
-    - include_tasks: basic_public.yml
-    - include_tasks: basic_internal.yml
-    - include_tasks: schema_change.yml
-
-    - include_tasks: https_listeners.yml
-
-    - include_tasks: simple_changes.yml
-    - include_tasks: complex_changes.yml
-
+    - ansible.builtin.include_tasks: missing_params.yml
+    - ansible.builtin.include_tasks: describe_region.yml
+    - ansible.builtin.include_tasks: setup_vpc.yml
+    - ansible.builtin.include_tasks: setup_instances.yml
+    - ansible.builtin.include_tasks: setup_s3.yml
+    - ansible.builtin.include_tasks: basic_public.yml
+    - ansible.builtin.include_tasks: basic_internal.yml
+    - ansible.builtin.include_tasks: schema_change.yml
+    - ansible.builtin.include_tasks: https_listeners.yml
+    - ansible.builtin.include_tasks: simple_changes.yml
+    - ansible.builtin.include_tasks: complex_changes.yml
   always:
-
     # ============================================================
     # ELB should already be gone, but double-check
     - name: remove the test load balancer
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true
       register: result
       ignore_errors: true
 
-    - include_tasks: cleanup_s3.yml
-    - include_tasks: cleanup_instances.yml
-    - include_tasks: cleanup_vpc.yml
+    - ansible.builtin.include_tasks: cleanup_s3.yml
+    - ansible.builtin.include_tasks: cleanup_instances.yml
+    - ansible.builtin.include_tasks: cleanup_vpc.yml

--- a/tests/integration/targets/elb_classic_lb/tasks/missing_params.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/missing_params.yml
@@ -4,111 +4,111 @@
     # ============================================================
 
     - name: test with no name
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         state: present
       register: result
       ignore_errors: true
 
     - name: assert failure when called with no parameters
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - '"missing required arguments" in result.msg'
           - '"name" in result.msg'
 
     - name: test with only name (state missing)
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
       register: result
       ignore_errors: true
 
     - name: assert failure when called with only name
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - '"missing required arguments" in result.msg'
           - '"state" in result.msg'
 
-    - elb_classic_lb:
+    - amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        scheme: 'internal'
+        scheme: internal
         listeners:
-        - load_balancer_port: 80
-          instance_port: 80
-          protocol: http
+          - load_balancer_port: 80
+            instance_port: 80
+            protocol: http
       register: result
       ignore_errors: true
 
     - name: assert failure when neither subnets nor AZs are provided on creation
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - '"subnets" in result.msg'
           - '"zones" in result.msg'
 
-    - elb_classic_lb:
+    - amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        scheme: 'internal'
-        subnets: ['subnet-123456789']
+        scheme: internal
+        subnets: [subnet-123456789]
       register: result
       ignore_errors: true
 
     - name: assert failure when listeners not provided on creation
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - '"listeners" in result.msg'
 
-    - elb_classic_lb:
+    - amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        scheme: 'internal'
-        subnets: ['subnet-123456789']
+        scheme: internal
+        subnets: [subnet-123456789]
         listeners:
-        - load_balancer_port: 80
-          instance_port: 80
-          protocol: junk
+          - load_balancer_port: 80
+            instance_port: 80
+            protocol: junk
       register: result
       ignore_errors: true
 
     - name: assert failure when listeners contains invalid protocol
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - '"protocol" in result.msg'
           - '"junk" in result.msg'
 
-    - elb_classic_lb:
+    - amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        scheme: 'internal'
-        subnets: ['subnet-123456789']
+        scheme: internal
+        subnets: [subnet-123456789]
         listeners:
-        - load_balancer_port: 80
-          instance_port: 80
-          protocol: http
-          instance_protocol: junk
+          - load_balancer_port: 80
+            instance_port: 80
+            protocol: http
+            instance_protocol: junk
       register: result
       ignore_errors: true
 
     - name: assert failure when listeners contains invalid instance_protocol
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - '"protocol" in result.msg'
           - '"junk" in result.msg'
 
-    - elb_classic_lb:
+    - amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        scheme: 'internal'
-        subnets: ['subnet-123456789']
+        scheme: internal
+        subnets: [subnet-123456789]
         listeners:
-        - load_balancer_port: 80
-          instance_port: 80
-          protocol: http
+          - load_balancer_port: 80
+            instance_port: 80
+            protocol: http
         health_check:
           ping_protocol: junk
           ping_port: 80
@@ -120,21 +120,21 @@
       ignore_errors: true
 
     - name: assert failure when healthcheck ping_protocol is invalid
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - '"protocol" in result.msg'
           - '"junk" in result.msg'
 
-    - elb_classic_lb:
+    - amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        scheme: 'internal'
-        subnets: ['subnet-123456789']
+        scheme: internal
+        subnets: [subnet-123456789]
         listeners:
-        - load_balancer_port: 80
-          instance_port: 80
-          protocol: http
+          - load_balancer_port: 80
+            instance_port: 80
+            protocol: http
         health_check:
           ping_protocol: http
           ping_port: 80
@@ -146,56 +146,55 @@
       ignore_errors: true
 
     - name: assert failure when HTTP healthcheck missing a ping_path
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - '"ping_path" in result.msg'
 
-    - elb_classic_lb:
+    - amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        scheme: 'internal'
-        subnets: ['subnet-123456789']
+        scheme: internal
+        subnets: [subnet-123456789]
         listeners:
-        - load_balancer_port: 80
-          instance_port: 80
-          protocol: http
+          - load_balancer_port: 80
+            instance_port: 80
+            protocol: http
         stickiness:
           type: application
       register: result
       ignore_errors: true
 
     - name: assert failure when app stickiness policy missing cookie name
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - '"cookie" in result.msg'
 
-    - elb_classic_lb:
+    - amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
-        scheme: 'internal'
-        subnets: ['subnet-123456789']
+        scheme: internal
+        subnets: [subnet-123456789]
         listeners:
-        - load_balancer_port: 80
-          instance_port: 80
-          protocol: http
+          - load_balancer_port: 80
+            instance_port: 80
+            protocol: http
         access_logs:
           interval: 60
       register: result
       ignore_errors: true
 
     - name: assert failure when access log is missing a bucket
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - '"s3_location" in result.msg'
 
   always:
-
     # ============================================================
     - name: remove the test load balancer
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true

--- a/tests/integration/targets/elb_classic_lb/tasks/schema_change.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/schema_change.yml
@@ -3,19 +3,19 @@
     # For creation test some basic behaviour
     - module_defaults:
         elb_classic_lb:
-          zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-          listeners: '{{ default_listeners }}'
+          zones: ["{{ availability_zone_a }}", "{{ availability_zone_b }}"]
+          listeners: "{{ default_listeners }}"
           wait: true
-          scheme: 'internet-facing'
+          scheme: internet-facing
           # subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
       block:
         - name: Create ELB
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is changed
               - result.elb.status == 'created'
@@ -24,76 +24,75 @@
     - module_defaults:
         elb_classic_lb:
           # zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-          listeners: '{{ default_listeners }}'
+          listeners: "{{ default_listeners }}"
           wait: true
-          scheme: 'internal'
-          subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
+          scheme: internal
+          subnets: ["{{ subnet_a }}", "{{ subnet_b }}"]
       block:
-
         - name: Change Schema to internal (check_mode)
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
           check_mode: true
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is changed
 
         - name: Change Schema to internal
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is changed
               - result.elb.scheme == 'internal'
 
         - name: Change Schema to internal idempotency (check_mode)
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
           check_mode: true
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is not changed
 
         - name: Change Schema to internal idempotency
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is not changed
               - result.elb.scheme == 'internal'
 
         - name: No schema specified (check_mode)
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
-            schema: '{{ omit }}'
+            schema: "{{ omit }}"
           register: result
           check_mode: true
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is not changed
 
         - name: No schema specified
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
-            schema: '{{ omit }}'
+            schema: "{{ omit }}"
           register: result
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is not changed
               - result.elb.scheme == 'internal'
@@ -101,84 +100,82 @@
     # For creation test some basic behaviour
     - module_defaults:
         elb_classic_lb:
-          zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-          listeners: '{{ default_listeners }}'
-          health_check: '{{ default_health_check }}'
+          zones: ["{{ availability_zone_a }}", "{{ availability_zone_b }}"]
+          listeners: "{{ default_listeners }}"
+          health_check: "{{ default_health_check }}"
           wait: true
-          scheme: 'internet-facing'
+          scheme: internet-facing
           # subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
       block:
-
         - name: Change schema to internet-facing (check_mode)
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
           check_mode: true
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is changed
 
         - name: Change schema to internet-facing
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is changed
               - result.elb.scheme == 'internet-facing'
 
         - name: Change schema to internet-facing idempotency (check_mode)
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
           check_mode: true
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is not changed
 
         - name: Change schema to internet-facing idempotency
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
           register: result
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is not changed
               - result.elb.scheme == 'internet-facing'
 
         - name: No schema specified (check_mode)
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
-            schema: '{{ omit }}'
+            schema: "{{ omit }}"
           register: result
           check_mode: true
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is not changed
 
         - name: No schema specified
-          elb_classic_lb:
+          amazon.aws.elb_classic_lb:
             name: "{{ elb_name }}"
             state: present
-            schema: '{{ omit }}'
+            schema: "{{ omit }}"
           register: result
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is not changed
               - result.elb.scheme == 'internet-facing'
 
   always:
-
     # ============================================================
     - name: remove the test load balancer
       elb_classic_lb:

--- a/tests/integration/targets/elb_classic_lb/tasks/setup_instances.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/setup_instances.yml
@@ -1,7 +1,7 @@
 ---
 - name: Create instance a
-  ec2_instance:
-    name: "ansible-test-{{ tiny_prefix }}-elb-a"
+  amazon.aws.ec2_instance:
+    name: ansible-test-{{ tiny_prefix }}-elb-a
     image_id: "{{ ec2_ami_id }}"
     vpc_subnet_id: "{{ subnet_a }}"
     instance_type: t2.micro
@@ -10,8 +10,8 @@
   register: ec2_instance_a
 
 - name: Create instance b
-  ec2_instance:
-    name: "ansible-test-{{ tiny_prefix }}-elb-b"
+  amazon.aws.ec2_instance:
+    name: ansible-test-{{ tiny_prefix }}-elb-b
     image_id: "{{ ec2_ami_id }}"
     vpc_subnet_id: "{{ subnet_b }}"
     instance_type: t2.micro
@@ -20,6 +20,6 @@
   register: ec2_instance_b
 
 - name: store the Instance IDs
-  set_fact:
+  ansible.builtin.set_fact:
     instance_a: "{{ ec2_instance_a.instance_ids[0] }}"
     instance_b: "{{ ec2_instance_b.instance_ids[0] }}"

--- a/tests/integration/targets/elb_classic_lb/tasks/setup_s3.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/setup_s3.yml
@@ -1,26 +1,26 @@
 ---
 - name: Create S3 bucket for access logs
   vars:
-    s3_logging_bucket: '{{ s3_logging_bucket_a }}'
-  s3_bucket:
-    name: '{{ s3_logging_bucket_a }}'
+    s3_logging_bucket: "{{ s3_logging_bucket_a }}"
+  amazon.aws.s3_bucket:
+    name: "{{ s3_logging_bucket_a }}"
     state: present
     policy: "{{ lookup('template','s3_policy.j2') }}"
   register: logging_bucket
 
-- assert:
+- ansible.builtin.assert:
     that:
       - logging_bucket is changed
 
 - name: Create S3 bucket for access logs
   vars:
-    s3_logging_bucket: '{{ s3_logging_bucket_b }}'
-  s3_bucket:
-    name: '{{ s3_logging_bucket_b }}'
+    s3_logging_bucket: "{{ s3_logging_bucket_b }}"
+  amazon.aws.s3_bucket:
+    name: "{{ s3_logging_bucket_b }}"
     state: present
     policy: "{{ lookup('template','s3_policy.j2') }}"
   register: logging_bucket
 
-- assert:
+- ansible.builtin.assert:
     that:
       - logging_bucket is changed

--- a/tests/integration/targets/elb_classic_lb/tasks/setup_vpc.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/setup_vpc.yml
@@ -1,99 +1,99 @@
 ---
 # SETUP: vpc, subnet, security group
 - name: create a VPC to work in
-  ec2_vpc_net:
-    cidr_block: '{{ vpc_cidr }}'
+  amazon.aws.ec2_vpc_net:
+    cidr_block: "{{ vpc_cidr }}"
     state: present
-    name: '{{ resource_prefix }}'
+    name: "{{ resource_prefix }}"
     resource_tags:
-      Name: '{{ resource_prefix }}'
+      Name: "{{ resource_prefix }}"
   register: setup_vpc
 
 - name: create a subnet
-  ec2_vpc_subnet:
-    az: '{{ availability_zone_a }}'
-    tags: '{{ resource_prefix }}'
-    vpc_id: '{{ setup_vpc.vpc.id }}'
-    cidr: '{{ subnet_cidr_1 }}'
+  amazon.aws.ec2_vpc_subnet:
+    az: "{{ availability_zone_a }}"
+    tags: "{{ resource_prefix }}"
+    vpc_id: "{{ setup_vpc.vpc.id }}"
+    cidr: "{{ subnet_cidr_1 }}"
     state: present
     resource_tags:
-      Name: '{{ resource_prefix }}-a'
+      Name: "{{ resource_prefix }}-a"
   register: setup_subnet_1
 
 - name: create a subnet
-  ec2_vpc_subnet:
-    az: '{{ availability_zone_b }}'
-    tags: '{{ resource_prefix }}'
-    vpc_id: '{{ setup_vpc.vpc.id }}'
-    cidr: '{{ subnet_cidr_2 }}'
+  amazon.aws.ec2_vpc_subnet:
+    az: "{{ availability_zone_b }}"
+    tags: "{{ resource_prefix }}"
+    vpc_id: "{{ setup_vpc.vpc.id }}"
+    cidr: "{{ subnet_cidr_2 }}"
     state: present
     resource_tags:
-      Name: '{{ resource_prefix }}-b'
+      Name: "{{ resource_prefix }}-b"
   register: setup_subnet_2
 
 - name: create a subnet
-  ec2_vpc_subnet:
-    az: '{{ availability_zone_c }}'
-    tags: '{{ resource_prefix }}'
-    vpc_id: '{{ setup_vpc.vpc.id }}'
-    cidr: '{{ subnet_cidr_3 }}'
+  amazon.aws.ec2_vpc_subnet:
+    az: "{{ availability_zone_c }}"
+    tags: "{{ resource_prefix }}"
+    vpc_id: "{{ setup_vpc.vpc.id }}"
+    cidr: "{{ subnet_cidr_3 }}"
     state: present
     resource_tags:
-      Name: '{{ resource_prefix }}-c'
+      Name: "{{ resource_prefix }}-c"
   register: setup_subnet_3
 
 - name: create a subnet
-  ec2_vpc_subnet:
-    az: '{{ availability_zone_a }}'
-    tags: '{{ resource_prefix }}'
-    vpc_id: '{{ setup_vpc.vpc.id }}'
-    cidr: '{{ subnet_cidr_4 }}'
+  amazon.aws.ec2_vpc_subnet:
+    az: "{{ availability_zone_a }}"
+    tags: "{{ resource_prefix }}"
+    vpc_id: "{{ setup_vpc.vpc.id }}"
+    cidr: "{{ subnet_cidr_4 }}"
     state: present
     resource_tags:
-      Name: '{{ resource_prefix }}-a2'
+      Name: "{{ resource_prefix }}-a2"
   register: setup_subnet_4
 
 - name: create a security group
   ec2_security_group:
-    name: '{{ resource_prefix }}-a'
-    description: 'created by Ansible integration tests'
+    name: "{{ resource_prefix }}-a"
+    description: created by Ansible integration tests
     state: present
-    vpc_id: '{{ setup_vpc.vpc.id }}'
+    vpc_id: "{{ setup_vpc.vpc.id }}"
     rules:
       - proto: tcp
         from_port: 22
         to_port: 22
-        cidr_ip: '{{ vpc_cidr }}'
+        cidr_ip: "{{ vpc_cidr }}"
   register: setup_sg_1
 
 - name: create a security group
   ec2_security_group:
-    name: '{{ resource_prefix }}-b'
-    description: 'created by Ansible integration tests'
+    name: "{{ resource_prefix }}-b"
+    description: created by Ansible integration tests
     state: present
-    vpc_id: '{{ setup_vpc.vpc.id }}'
+    vpc_id: "{{ setup_vpc.vpc.id }}"
     rules:
       - proto: tcp
         from_port: 22
         to_port: 22
-        cidr_ip: '{{ vpc_cidr }}'
+        cidr_ip: "{{ vpc_cidr }}"
   register: setup_sg_2
 
 - name: create a security group
   ec2_security_group:
-    name: '{{ resource_prefix }}-c'
-    description: 'created by Ansible integration tests'
+    name: "{{ resource_prefix }}-c"
+    description: created by Ansible integration tests
     state: present
-    vpc_id: '{{ setup_vpc.vpc.id }}'
+    vpc_id: "{{ setup_vpc.vpc.id }}"
     rules:
       - proto: tcp
         from_port: 22
         to_port: 22
-        cidr_ip: '{{ vpc_cidr }}'
+        cidr_ip: "{{ vpc_cidr }}"
   register: setup_sg_3
 
 - name: store the IDs
-  set_fact:
+  ansible.builtin.set_fact:
     subnet_a: "{{ setup_subnet_1.subnet.id }}"
     subnet_b: "{{ setup_subnet_2.subnet.id }}"
     subnet_c: "{{ setup_subnet_3.subnet.id }}"

--- a/tests/integration/targets/elb_classic_lb/tasks/simple_changes.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/simple_changes.yml
@@ -2,29 +2,29 @@
 - block:
     ## Setup an ELB for testing changing one thing at a time
     - name: Create ELB
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: present
         # zones: ['{{ availability_zone_a }}', '{{ availability_zone_b }}']
-        listeners: '{{ default_listeners }}'
-        health_check: '{{ default_health_check }}'
+        listeners: "{{ default_listeners }}"
+        health_check: "{{ default_health_check }}"
         wait: true
-        scheme: 'internal'
-        subnets: ['{{ subnet_a }}', '{{ subnet_b }}']
-        security_group_ids: ['{{ sg_a }}']
-        tags: '{{ default_tags }}'
-        cross_az_load_balancing: True
-        idle_timeout: '{{ default_idle_timeout }}'
-        connection_draining_timeout: '{{ default_drain_timeout }}'
+        scheme: internal
+        subnets: ["{{ subnet_a }}", "{{ subnet_b }}"]
+        security_group_ids: ["{{ sg_a }}"]
+        tags: "{{ default_tags }}"
+        cross_az_load_balancing: true
+        idle_timeout: "{{ default_idle_timeout }}"
+        connection_draining_timeout: "{{ default_drain_timeout }}"
         access_logs:
-          interval: '{{ default_logging_interval }}'
-          s3_location: '{{ s3_logging_bucket_a }}'
-          s3_prefix: '{{ default_logging_prefix }}'
+          interval: "{{ default_logging_interval }}"
+          s3_location: "{{ s3_logging_bucket_a }}"
+          s3_prefix: "{{ default_logging_prefix }}"
           enabled: true
       register: result
 
     - name: Verify that simple parameters were set
-      assert:
+      ansible.builtin.assert:
         that:
           - result is changed
           - result.elb.status == "created"
@@ -55,23 +55,21 @@
     ## AZ / Subnet changes are tested in wth the public/internal tests
     ## because they depend on the scheme of the LB
 
-    - include_tasks: 'simple_securitygroups.yml'
-    - include_tasks: 'simple_listeners.yml'
-    - include_tasks: 'simple_healthcheck.yml'
-    - include_tasks: 'simple_tags.yml'
-    - include_tasks: 'simple_cross_az.yml'
-    - include_tasks: 'simple_idle_timeout.yml'
-    - include_tasks: 'simple_draining_timeout.yml'
-    - include_tasks: 'simple_proxy_policy.yml'
-    - include_tasks: 'simple_stickiness.yml'
-    - include_tasks: 'simple_instances.yml'
-    - include_tasks: 'simple_logging.yml'
-
+    - ansible.builtin.include_tasks: simple_securitygroups.yml
+    - ansible.builtin.include_tasks: simple_listeners.yml
+    - ansible.builtin.include_tasks: simple_healthcheck.yml
+    - ansible.builtin.include_tasks: simple_tags.yml
+    - ansible.builtin.include_tasks: simple_cross_az.yml
+    - ansible.builtin.include_tasks: simple_idle_timeout.yml
+    - ansible.builtin.include_tasks: simple_draining_timeout.yml
+    - ansible.builtin.include_tasks: simple_proxy_policy.yml
+    - ansible.builtin.include_tasks: simple_stickiness.yml
+    - ansible.builtin.include_tasks: simple_instances.yml
+    - ansible.builtin.include_tasks: simple_logging.yml
   always:
-
     # ============================================================
     - name: remove the test load balancer
-      elb_classic_lb:
+      amazon.aws.elb_classic_lb:
         name: "{{ elb_name }}"
         state: absent
         wait: true

--- a/tests/integration/targets/elb_classic_lb/tasks/simple_cross_az.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/simple_cross_az.yml
@@ -2,49 +2,49 @@
 # ===========================================================
 
 - name: disable cross-az balancing on ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    cross_az_load_balancing: False
+    cross_az_load_balancing: false
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: disable cross-az balancing on ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    cross_az_load_balancing: False
+    cross_az_load_balancing: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.elb.cross_az_load_balancing == 'no'
 
 - name: disable cross-az balancing on ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    cross_az_load_balancing: False
+    cross_az_load_balancing: false
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: disable cross-az balancing on ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    cross_az_load_balancing: False
+    cross_az_load_balancing: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.elb.cross_az_load_balancing == 'no'
@@ -52,49 +52,49 @@
 # ===========================================================
 
 - name: re-enable cross-az balancing on ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    cross_az_load_balancing: True
+    cross_az_load_balancing: true
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: re-enable cross-az balancing on ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    cross_az_load_balancing: True
+    cross_az_load_balancing: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.elb.cross_az_load_balancing == 'yes'
 
 - name: re-enable cross-az balancing on ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    cross_az_load_balancing: True
+    cross_az_load_balancing: true
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: re-enable cross-az balancing on ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    cross_az_load_balancing: True
+    cross_az_load_balancing: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.elb.cross_az_load_balancing == 'yes'

--- a/tests/integration/targets/elb_classic_lb/tasks/simple_draining_timeout.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/simple_draining_timeout.yml
@@ -2,97 +2,97 @@
 # ===========================================================
 
 - name: disable connection draining on ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     connection_draining_timeout: 0
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: disable connection draining on ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     connection_draining_timeout: 0
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: disable connection draining on ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     connection_draining_timeout: 0
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: disable connection draining on ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     connection_draining_timeout: 0
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 # ===========================================================
 
 - name: re-enable connection draining on ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    connection_draining_timeout: '{{ default_drain_timeout }}'
+    connection_draining_timeout: "{{ default_drain_timeout }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: re-enable connection draining on ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    connection_draining_timeout: '{{ default_drain_timeout }}'
+    connection_draining_timeout: "{{ default_drain_timeout }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.elb.connection_draining_timeout == default_drain_timeout
 
 - name: re-enable connection draining on ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    connection_draining_timeout: '{{ default_drain_timeout }}'
+    connection_draining_timeout: "{{ default_drain_timeout }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: re-enable connection draining on ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    connection_draining_timeout: '{{ default_drain_timeout }}'
+    connection_draining_timeout: "{{ default_drain_timeout }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.elb.connection_draining_timeout == default_drain_timeout
@@ -100,49 +100,49 @@
 # ===========================================================
 
 - name: update connection draining timout on ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    connection_draining_timeout: '{{ updated_drain_timeout }}'
+    connection_draining_timeout: "{{ updated_drain_timeout }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: update connection draining timout on ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    connection_draining_timeout: '{{ updated_drain_timeout }}'
+    connection_draining_timeout: "{{ updated_drain_timeout }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.elb.connection_draining_timeout == updated_drain_timeout
 
 - name: update connection draining timout on ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    connection_draining_timeout: '{{ updated_drain_timeout }}'
+    connection_draining_timeout: "{{ updated_drain_timeout }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: update connection draining timout on ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    connection_draining_timeout: '{{ updated_drain_timeout }}'
+    connection_draining_timeout: "{{ updated_drain_timeout }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.elb.connection_draining_timeout == updated_drain_timeout

--- a/tests/integration/targets/elb_classic_lb/tasks/simple_healthcheck.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/simple_healthcheck.yml
@@ -2,25 +2,25 @@
 # Note: AWS doesn't support disabling health checks
 # ==============================================================
 - name: Non-HTTP Healthcheck (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    health_check: '{{ nonhttp_health_check }}'
+    health_check: "{{ nonhttp_health_check }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Non-HTTP Healthcheck
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    health_check: '{{ nonhttp_health_check }}'
+    health_check: "{{ nonhttp_health_check }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.elb.health_check.healthy_threshold == nonhttp_health_check['healthy_threshold']
@@ -30,25 +30,25 @@
       - result.elb.health_check.unhealthy_threshold == nonhttp_health_check['unhealthy_threshold']
 
 - name: Non-HTTP Healthcheck - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    health_check: '{{ nonhttp_health_check }}'
+    health_check: "{{ nonhttp_health_check }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Non-HTTP Healthcheck - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    health_check: '{{ nonhttp_health_check }}'
+    health_check: "{{ nonhttp_health_check }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.elb.health_check.healthy_threshold == nonhttp_health_check['healthy_threshold']
@@ -60,25 +60,25 @@
 # ==============================================================
 
 - name: Update Healthcheck (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    health_check: '{{ updated_health_check }}'
+    health_check: "{{ updated_health_check }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Update Healthcheck
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    health_check: '{{ updated_health_check }}'
+    health_check: "{{ updated_health_check }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.elb.health_check.healthy_threshold == updated_health_check['healthy_threshold']
@@ -88,25 +88,25 @@
       - result.elb.health_check.unhealthy_threshold == updated_health_check['unhealthy_threshold']
 
 - name: Update Healthcheck - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    health_check: '{{ updated_health_check }}'
+    health_check: "{{ updated_health_check }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Update Healthcheck - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    health_check: '{{ updated_health_check }}'
+    health_check: "{{ updated_health_check }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.elb.health_check.healthy_threshold == updated_health_check['healthy_threshold']

--- a/tests/integration/targets/elb_classic_lb/tasks/simple_idle_timeout.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/simple_idle_timeout.yml
@@ -2,49 +2,49 @@
 # ===========================================================
 
 - name: update idle connection timeout on ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     idle_timeout: "{{ updated_idle_timeout }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: update idle connection timeout on ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     idle_timeout: "{{ updated_idle_timeout }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.elb.idle_timeout == updated_idle_timeout
 
 - name: update idle connection timeout on ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     idle_timeout: "{{ updated_idle_timeout }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: update idle connection timeout on ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     idle_timeout: "{{ updated_idle_timeout }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.elb.idle_timeout == updated_idle_timeout

--- a/tests/integration/targets/elb_classic_lb/tasks/simple_instances.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/simple_instances.yml
@@ -1,6 +1,6 @@
 ---
 - name: Add SSH listener and health check to ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ ssh_listeners }}"
@@ -8,7 +8,7 @@
     purge_listeners: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - ssh_listener_tuples[0] in result.elb.listeners
@@ -16,8 +16,8 @@
 # Make sure that the instances are 'OK'
 
 - name: Wait for instance a
-  ec2_instance:
-    name: "ansible-test-{{ tiny_prefix }}-elb-a"
+  amazon.aws.ec2_instance:
+    name: ansible-test-{{ tiny_prefix }}-elb-a
     instance_ids:
       - "{{ instance_a }}"
     vpc_subnet_id: "{{ subnet_a }}"
@@ -27,8 +27,8 @@
   register: ec2_instance_a
 
 - name: Wait for instance b
-  ec2_instance:
-    name: "ansible-test-{{ tiny_prefix }}-elb-b"
+  amazon.aws.ec2_instance:
+    name: ansible-test-{{ tiny_prefix }}-elb-b
     instance_ids:
       - "{{ instance_b }}"
     vpc_subnet_id: "{{ subnet_b }}"
@@ -37,7 +37,7 @@
     security_group: "{{ sg_b }}"
   register: ec2_instance_b
 
-- assert:
+- ansible.builtin.assert:
     that:
       - ec2_instance_a is successful
       - ec2_instance_b is successful
@@ -45,58 +45,58 @@
 # ==============================================================
 
 - name: Add an instance to the LB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_a }}'
+      - "{{ instance_a }}"
     wait: true
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Add an instance to the LB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_a }}'
+      - "{{ instance_a }}"
     wait: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - instance_a in result.elb.instances
       - instance_b not in result.elb.instances
 
 - name: Add an instance to the LB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_a }}'
+      - "{{ instance_a }}"
     wait: true
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Add an instance to the LB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_a }}'
+      - "{{ instance_a }}"
     wait: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - instance_a in result.elb.instances
@@ -105,58 +105,58 @@
 # ==============================================================
 
 - name: Add second instance to the LB without purge (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
+      - "{{ instance_b }}"
     purge_instance_ids: false
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Add second instance to the LB without purge
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
+      - "{{ instance_b }}"
     purge_instance_ids: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - instance_a in result.elb.instances
       - instance_b in result.elb.instances
 
 - name: Add second instance to the LB without purge - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
+      - "{{ instance_b }}"
     purge_instance_ids: false
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Add second instance to the LB without purge - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
+      - "{{ instance_b }}"
     purge_instance_ids: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - instance_a in result.elb.instances
@@ -165,62 +165,62 @@
 # ==============================================================
 
 - name: Both instances with purge - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_a }}'
-    - '{{ instance_b }}'
+      - "{{ instance_a }}"
+      - "{{ instance_b }}"
     purge_instance_ids: true
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Both instances with purge - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_a }}'
-    - '{{ instance_b }}'
+      - "{{ instance_a }}"
+      - "{{ instance_b }}"
     purge_instance_ids: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - instance_a in result.elb.instances
       - instance_b in result.elb.instances
 
 - name: Both instances with purge - different order - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
-    - '{{ instance_a }}'
+      - "{{ instance_b }}"
+      - "{{ instance_a }}"
     purge_instance_ids: true
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Both instances with purge - different order - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
-    - '{{ instance_a }}'
+      - "{{ instance_b }}"
+      - "{{ instance_a }}"
     purge_instance_ids: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - instance_a in result.elb.instances
@@ -229,62 +229,62 @@
 # ==============================================================
 
 - name: Remove first instance from LB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
+      - "{{ instance_b }}"
     purge_instance_ids: true
     wait: true
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Remove first instance from LB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
+      - "{{ instance_b }}"
     purge_instance_ids: true
     wait: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - instance_a not in result.elb.instances
       - instance_b in result.elb.instances
 
 - name: Remove first instance from LB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
+      - "{{ instance_b }}"
     purge_instance_ids: true
     wait: true
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Remove first instance from LB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
+      - "{{ instance_b }}"
     purge_instance_ids: true
     wait: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - instance_a not in result.elb.instances
@@ -293,62 +293,62 @@
 # ==============================================================
 
 - name: Switch instances in LB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_a }}'
+      - "{{ instance_a }}"
     purge_instance_ids: true
     wait: true
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Switch instances in LB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_a }}'
+      - "{{ instance_a }}"
     purge_instance_ids: true
     wait: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - instance_a in result.elb.instances
       - instance_b not in result.elb.instances
 
 - name: Switch instances in LB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_a }}'
+      - "{{ instance_a }}"
     purge_instance_ids: true
     wait: true
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Switch instances in LB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_a }}'
+      - "{{ instance_a }}"
     purge_instance_ids: true
     wait: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - instance_a in result.elb.instances
@@ -357,58 +357,58 @@
 # ==============================================================
 
 - name: Switch instances in LB - no wait (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
+      - "{{ instance_b }}"
     purge_instance_ids: true
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Switch instances in LB - no wait
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
+      - "{{ instance_b }}"
     purge_instance_ids: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - instance_a not in result.elb.instances
       - instance_b in result.elb.instances
 
 - name: Switch instances in LB - no wait - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
+      - "{{ instance_b }}"
     purge_instance_ids: true
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Switch instances in LB - no wait - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     instance_ids:
-    - '{{ instance_b }}'
+      - "{{ instance_b }}"
     purge_instance_ids: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - instance_a not in result.elb.instances

--- a/tests/integration/targets/elb_classic_lb/tasks/simple_listeners.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/simple_listeners.yml
@@ -8,7 +8,7 @@
 # Test passing only one of the listeners
 # Without purge
 - name: Test partial Listener to ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ purged_listeners }}"
@@ -16,19 +16,19 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Test partial Listener to ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ purged_listeners }}"
     purge_listeners: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - default_listener_tuples[0] in result.elb.listeners
@@ -36,7 +36,7 @@
 
 # With purge
 - name: Test partial Listener with purge to ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ purged_listeners }}"
@@ -44,25 +44,25 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Test partial Listener with purge to ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ purged_listeners }}"
     purge_listeners: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - purged_listener_tuples[0] in result.elb.listeners
 
 - name: Test partial Listener with purge to ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ purged_listeners }}"
@@ -70,19 +70,19 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Test partial Listener with purge to ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ purged_listeners }}"
     purge_listeners: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - purged_listener_tuples[0] in result.elb.listeners
@@ -90,50 +90,50 @@
 # ===========================================================
 # Test re-adding a listener
 - name: Test re-adding listener to ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ default_listeners }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Test re-adding listener to ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ default_listeners }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - default_listener_tuples[0] in result.elb.listeners
       - default_listener_tuples[1] in result.elb.listeners
 
 - name: Test re-adding listener to ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ default_listeners }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Test re-adding listener to ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ default_listeners }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - default_listener_tuples[0] in result.elb.listeners
@@ -142,7 +142,7 @@
 # ===========================================================
 # Test passing an updated listener
 - name: Test updated listener to ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ updated_listeners }}"
@@ -150,26 +150,26 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Test updated listener to ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ updated_listeners }}"
     purge_listeners: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - updated_listener_tuples[0] in result.elb.listeners
       - updated_listener_tuples[1] in result.elb.listeners
 
 - name: Test updated listener to ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ updated_listeners }}"
@@ -177,19 +177,19 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Test updated listener to ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ updated_listeners }}"
     purge_listeners: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - updated_listener_tuples[0] in result.elb.listeners

--- a/tests/integration/targets/elb_classic_lb/tasks/simple_logging.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/simple_logging.yml
@@ -2,31 +2,31 @@
 # ===========================================================
 
 - name: S3 logging for ELB - implied enabled (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
-      interval: '{{ default_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ default_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: S3 logging for ELB - implied enabled
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
-      interval: '{{ default_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ default_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.load_balancer.load_balancer_attributes.access_log.emit_interval == default_logging_interval
@@ -37,65 +37,65 @@
 # ===========================================================
 
 - name: Disable S3 logging for ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: false
-      interval: '{{ default_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ default_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Disable S3 logging for ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: false
-      interval: '{{ default_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ default_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.load_balancer.load_balancer_attributes.access_log.enabled == False
 
 - name: Disable S3 logging for ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: false
-      interval: '{{ default_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ default_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Disable S3 logging for ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: false
-      interval: '{{ default_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ default_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.load_balancer.load_balancer_attributes.access_log.enabled == False
@@ -103,39 +103,39 @@
 # ===========================================================
 
 - name: Disable S3 logging for ELB - ignore extras (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: false
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_b }}'
-      s3_prefix: '{{ updated_logging_prefix }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_b }}"
+      s3_prefix: "{{ updated_logging_prefix }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Disable S3 logging for ELB - ignore extras
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: false
-      interval: '{{ default_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ default_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.load_balancer.load_balancer_attributes.access_log.enabled == False
 
 - name: Disable S3 logging for ELB - no extras (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
@@ -143,19 +143,19 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Disable S3 logging for ELB - no extras
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.load_balancer.load_balancer_attributes.access_log.enabled == False
@@ -163,33 +163,33 @@
 # ===========================================================
 
 - name: Re-enable S3 logging for ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ default_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ default_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Re-enable S3 logging for ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ default_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ default_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.load_balancer.load_balancer_attributes.access_log.emit_interval == default_logging_interval
@@ -198,33 +198,33 @@
       - result.load_balancer.load_balancer_attributes.access_log.enabled == True
 
 - name: Re-enable S3 logging for ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ default_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ default_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Re-enable S3 logging for ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ default_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ default_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.load_balancer.load_balancer_attributes.access_log.emit_interval == default_logging_interval
@@ -235,33 +235,33 @@
 # ===========================================================
 
 - name: Update ELB Log delivery interval for ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Update ELB Log delivery interval for ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.load_balancer.load_balancer_attributes.access_log.emit_interval == updated_logging_interval
@@ -270,33 +270,33 @@
       - result.load_balancer.load_balancer_attributes.access_log.enabled == True
 
 - name: Update ELB Log delivery interval for ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Update ELB Log delivery interval for ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_a }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_a }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.load_balancer.load_balancer_attributes.access_log.emit_interval == updated_logging_interval
@@ -307,33 +307,33 @@
 # ===========================================================
 
 - name: Update S3 Logging Location for ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_b }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_b }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Update S3 Logging Location for ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_b }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_b }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.load_balancer.load_balancer_attributes.access_log.emit_interval == updated_logging_interval
@@ -342,33 +342,33 @@
       - result.load_balancer.load_balancer_attributes.access_log.enabled == True
 
 - name: Update S3 Logging Location for ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_b }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_b }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Update S3 Logging Location for ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_b }}'
-      s3_prefix: '{{ default_logging_prefix }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_b }}"
+      s3_prefix: "{{ default_logging_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.load_balancer.load_balancer_attributes.access_log.emit_interval == updated_logging_interval
@@ -379,33 +379,33 @@
 # ===========================================================
 
 - name: Update S3 Logging Prefix for ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_b }}'
-      s3_prefix: '{{ updated_logging_prefix }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_b }}"
+      s3_prefix: "{{ updated_logging_prefix }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Update S3 Logging Prefix for ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_b }}'
-      s3_prefix: '{{ updated_logging_prefix }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_b }}"
+      s3_prefix: "{{ updated_logging_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.load_balancer.load_balancer_attributes.access_log.emit_interval == updated_logging_interval
@@ -414,33 +414,33 @@
       - result.load_balancer.load_balancer_attributes.access_log.enabled == True
 
 - name: Update S3 Logging Prefix for ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_b }}'
-      s3_prefix: '{{ updated_logging_prefix }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_b }}"
+      s3_prefix: "{{ updated_logging_prefix }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Update S3 Logging Prefix for ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_b }}'
-      s3_prefix: '{{ updated_logging_prefix }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_b }}"
+      s3_prefix: "{{ updated_logging_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.load_balancer.load_balancer_attributes.access_log.emit_interval == updated_logging_interval
@@ -451,31 +451,31 @@
 # ===========================================================
 
 - name: Empty S3 Logging Prefix for ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_b }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_b }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Empty S3 Logging Prefix for ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_b }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_b }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.load_balancer.load_balancer_attributes.access_log.emit_interval == updated_logging_interval
@@ -484,31 +484,31 @@
       - result.load_balancer.load_balancer_attributes.access_log.enabled == True
 
 - name: Empty S3 Logging Prefix for ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_b }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_b }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Empty S3 Logging Prefix for ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_location: '{{ s3_logging_bucket_b }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_location: "{{ s3_logging_bucket_b }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.load_balancer.load_balancer_attributes.access_log.emit_interval == updated_logging_interval
@@ -517,33 +517,33 @@
       - result.load_balancer.load_balancer_attributes.access_log.enabled == True
 
 - name: Empty string S3 Logging Prefix for ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_prefix: ''
-      s3_location: '{{ s3_logging_bucket_b }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_prefix: ""
+      s3_location: "{{ s3_logging_bucket_b }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Empty  stringS3 Logging Prefix for ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      interval: '{{ updated_logging_interval }}'
-      s3_prefix: ''
-      s3_location: '{{ s3_logging_bucket_b }}'
+      interval: "{{ updated_logging_interval }}"
+      s3_prefix: ""
+      s3_location: "{{ s3_logging_bucket_b }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.load_balancer.load_balancer_attributes.access_log.emit_interval == updated_logging_interval
@@ -554,31 +554,31 @@
 # ===========================================================
 
 - name: Update S3 Logging interval for ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      s3_location: '{{ s3_logging_bucket_b }}'
-      s3_prefix: ''
+      s3_location: "{{ s3_logging_bucket_b }}"
+      s3_prefix: ""
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Update S3 Logging interval for ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     access_logs:
       enabled: true
-      s3_location: '{{ s3_logging_bucket_b }}'
-      s3_prefix: ''
+      s3_location: "{{ s3_logging_bucket_b }}"
+      s3_prefix: ""
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.load_balancer.load_balancer_attributes.access_log.emit_interval == 60

--- a/tests/integration/targets/elb_classic_lb/tasks/simple_proxy_policy.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/simple_proxy_policy.yml
@@ -1,7 +1,7 @@
 ---
 # ===========================================================
 - name: Enable proxy protocol on a listener (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ proxied_listener }}"
@@ -9,19 +9,19 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Enable proxy protocol on a listener
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ proxied_listener }}"
     purge_listeners: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.elb.proxy_policy == "ProxyProtocol-policy"
@@ -29,7 +29,7 @@
       - result.load_balancer.backend_server_descriptions[0].policy_names == ["ProxyProtocol-policy"]
 
 - name: Enable proxy protocol on a listener - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ proxied_listener }}"
@@ -37,19 +37,19 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Enable proxy protocol on a listener - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ proxied_listener }}"
     purge_listeners: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.elb.proxy_policy == "ProxyProtocol-policy"
@@ -59,7 +59,7 @@
 # ===========================================================
 
 - name: Disable proxy protocol on a listener (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ unproxied_listener }}"
@@ -67,25 +67,25 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Disable proxy protocol on a listener
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ unproxied_listener }}"
     purge_listeners: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.load_balancer.backend_server_descriptions | length == 0
 
 - name: Disable proxy protocol on a listener - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ unproxied_listener }}"
@@ -93,19 +93,19 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Disable proxy protocol on a listener - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ unproxied_listener }}"
     purge_listeners: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.load_balancer.backend_server_descriptions | length == 0
@@ -113,7 +113,7 @@
 # ===========================================================
 
 - name: Re-enable proxy protocol on a listener (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ proxied_listener }}"
@@ -121,19 +121,19 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Re-enable proxy protocol on a listener
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     listeners: "{{ proxied_listener }}"
     purge_listeners: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.elb.proxy_policy == "ProxyProtocol-policy"

--- a/tests/integration/targets/elb_classic_lb/tasks/simple_securitygroups.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/simple_securitygroups.yml
@@ -1,24 +1,24 @@
 ---
 - name: Assign Security Groups to ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    security_group_ids: ['{{ sg_b }}']
+    security_group_ids: ["{{ sg_b }}"]
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Assign Security Groups to ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    security_group_ids: ['{{ sg_b }}']
+    security_group_ids: ["{{ sg_b }}"]
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - sg_a not in result.elb.security_group_ids
@@ -26,25 +26,25 @@
       - sg_c not in result.elb.security_group_ids
 
 - name: Assign Security Groups to ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    security_group_ids: ['{{ sg_b }}']
+    security_group_ids: ["{{ sg_b }}"]
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Assign Security Groups to ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    security_group_ids: ['{{ sg_b }}']
+    security_group_ids: ["{{ sg_b }}"]
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - sg_a not in result.elb.security_group_ids
@@ -54,25 +54,25 @@
 #=====================================================================
 
 - name: Assign Security Groups to ELB by name (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    security_group_names: ['{{ resource_prefix }}-a', '{{ resource_prefix }}-c']
+    security_group_names: ["{{ resource_prefix }}-a", "{{ resource_prefix }}-c"]
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Assign Security Groups to ELB by name
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    security_group_names: ['{{ resource_prefix }}-a', '{{ resource_prefix }}-c']
+    security_group_names: ["{{ resource_prefix }}-a", "{{ resource_prefix }}-c"]
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - sg_a in result.elb.security_group_ids
@@ -80,25 +80,25 @@
       - sg_c in result.elb.security_group_ids
 
 - name: Assign Security Groups to ELB by name - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    security_group_names: ['{{ resource_prefix }}-a', '{{ resource_prefix }}-c']
+    security_group_names: ["{{ resource_prefix }}-a", "{{ resource_prefix }}-c"]
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Assign Security Groups to ELB by name - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
-    security_group_names: ['{{ resource_prefix }}-a', '{{ resource_prefix }}-c']
+    security_group_names: ["{{ resource_prefix }}-a", "{{ resource_prefix }}-c"]
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - sg_a in result.elb.security_group_ids

--- a/tests/integration/targets/elb_classic_lb/tasks/simple_stickiness.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/simple_stickiness.yml
@@ -1,103 +1,102 @@
 ---
 # ==============================================================
 - name: App Cookie Stickiness (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ app_stickiness }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: App Cookie Stickiness
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ app_stickiness }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: App Cookie Stickiness - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ app_stickiness }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: App Cookie Stickiness - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ app_stickiness }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 # ==============================================================
 - name: Update App Cookie Stickiness (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ updated_app_stickiness }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Update App Cookie Stickiness
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ updated_app_stickiness }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Update App Cookie Stickiness - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ updated_app_stickiness }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Update App Cookie Stickiness - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ updated_app_stickiness }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
-
 
 # ==============================================================
 
 - name: Disable Stickiness (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness:
@@ -105,24 +104,24 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Disable Stickiness
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness:
       enabled: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Disable Stickiness - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness:
@@ -130,169 +129,168 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Disable Stickiness - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness:
       enabled: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 # ==============================================================
 
 - name: Re-enable App Stickiness (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ app_stickiness }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Re-enable App Stickiness
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ app_stickiness }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Re-enable App Stickiness (check_mode) - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ app_stickiness }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Re-enable App Stickiness - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ app_stickiness }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 # ==============================================================
 - name: LB Stickiness (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ lb_stickiness }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: LB Stickiness
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ lb_stickiness }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: LB Stickiness - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ lb_stickiness }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: LB Stickiness - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ lb_stickiness }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 # ==============================================================
 - name: Update LB Stickiness (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ updated_lb_stickiness }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Update LB Stickiness
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ updated_lb_stickiness }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Update LB Stickiness - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ updated_lb_stickiness }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Update LB Stickiness - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ updated_lb_stickiness }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
-
 
 # ==============================================================
 
 - name: Disable Stickiness (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness:
@@ -300,24 +298,24 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Disable Stickiness
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness:
       enabled: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Disable Stickiness - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness:
@@ -325,66 +323,66 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Disable Stickiness - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness:
       enabled: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 # ==============================================================
 
 - name: Re-enable LB Stickiness (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ updated_lb_stickiness }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Re-enable LB Stickiness
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ updated_lb_stickiness }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Re-enable LB Stickiness - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ updated_lb_stickiness }}"
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Re-enable LB Stickiness - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     stickiness: "{{ updated_lb_stickiness }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed

--- a/tests/integration/targets/elb_classic_lb/tasks/simple_tags.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/simple_tags.yml
@@ -5,7 +5,7 @@
 # update tags (with purge)
 # ===========================================================
 - name: Pass partial tags to ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     tags: "{{ partial_tags }}"
@@ -13,19 +13,19 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Pass partial tags to ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     tags: "{{ partial_tags }}"
     purge_tags: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.elb.tags == default_tags
@@ -33,7 +33,7 @@
 # ===========================================================
 
 - name: Add tags to ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     tags: "{{ updated_tags }}"
@@ -41,25 +41,25 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Add tags to ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     tags: "{{ updated_tags }}"
     purge_tags: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.elb.tags == ( default_tags | combine(updated_tags) )
 
 - name: Add tags to ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     tags: "{{ updated_tags }}"
@@ -67,19 +67,19 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Add tags to ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     tags: "{{ updated_tags }}"
     purge_tags: false
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.elb.tags == ( default_tags | combine(updated_tags) )
@@ -87,7 +87,7 @@
 # ===========================================================
 
 - name: Purge tags from ELB (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     tags: "{{ updated_tags }}"
@@ -95,25 +95,25 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
 
 - name: Purge tags from ELB
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     tags: "{{ updated_tags }}"
     purge_tags: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is changed
       - result.elb.tags == updated_tags
 
 - name: Purge tags from ELB - idempotency (check_mode)
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     tags: "{{ updated_tags }}"
@@ -121,19 +121,19 @@
   register: result
   check_mode: true
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
 
 - name: Purge tags from ELB - idempotency
-  elb_classic_lb:
+  amazon.aws.elb_classic_lb:
     name: "{{ elb_name }}"
     state: present
     tags: "{{ updated_tags }}"
     purge_tags: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
       - result is not changed
       - result.elb.tags == updated_tags

--- a/tests/integration/targets/iam_access_key/defaults/main.yml
+++ b/tests/integration/targets/iam_access_key/defaults/main.yml
@@ -1,1 +1,2 @@
-test_user: '{{ resource_prefix }}'
+---
+test_user: "{{ resource_prefix }}"

--- a/tests/integration/targets/iam_access_key/meta/main.yml
+++ b/tests/integration/targets/iam_access_key/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/iam_access_key/tasks/main.yml
+++ b/tests/integration/targets/iam_access_key/tasks/main.yml
@@ -1,12 +1,13 @@
+---
 - name: AWS AuthN details
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   collections:
-  - community.aws
+    - community.aws
   block:
   # ==================================================================================
   # Preparation
@@ -14,716 +15,715 @@
   # We create an IAM user with no attached permissions.  The *only* thing the
   # user will be able to do is call sts.get_caller_identity
   # https://docs.aws.amazon.com/STS/latest/APIReference/API_GetCallerIdentity.html
-  - name: Create test user
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-    register: iam_user
-  - assert:
-      that:
-      - iam_user is successful
-      - iam_user is changed
+    - name: Create test user
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+      register: iam_user
+    - ansible.builtin.assert:
+        that:
+          - iam_user is successful
+          - iam_user is changed
 
-  # ==================================================================================
+    # ==================================================================================
 
-  - name: Fetch IAM key info (no keys)
-    iam_access_key_info:
-      user_name: '{{ test_user }}'
-    register: access_key_info
-  - assert:
-      that:
-      - access_key_info is successful
-      - '"access_keys" in access_key_info'
-      - access_key_info.access_keys | length == 0
+    - name: Fetch IAM key info (no keys)
+      iam_access_key_info:
+        user_name: "{{ test_user }}"
+      register: access_key_info
+    - ansible.builtin.assert:
+        that:
+          - access_key_info is successful
+          - '"access_keys" in access_key_info'
+          - access_key_info.access_keys | length == 0
 
-  # ==================================================================================
+    # ==================================================================================
 
-  - name: Create a key (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      state: present
-    register: create_key_1
-    check_mode: true
-  - assert:
-      that:
-      - create_key_1 is successful
-      - create_key_1 is changed
+    - name: Create a key (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        state: present
+      register: create_key_1
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - create_key_1 is successful
+          - create_key_1 is changed
 
-  - name: Create a key
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      state: present
-      no_log: true
-    register: create_key_1
-  - assert:
-      that:
-      - create_key_1 is successful
-      - create_key_1 is changed
-      - '"access_key" in create_key_1'
-      - '"secret_access_key" in create_key_1'
-      - '"deleted_access_key_id" not in create_key_1'
-      - '"access_key_id" in create_key_1.access_key'
-      - '"create_date" in create_key_1.access_key'
-      - '"user_name" in create_key_1.access_key'
-      - '"status" in create_key_1.access_key'
-      - create_key_1.access_key.user_name == test_user
-      - create_key_1.access_key.status == 'Active'
+    - name: Create a key
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        state: present
+        no_log: true
+      register: create_key_1
+    - ansible.builtin.assert:
+        that:
+          - create_key_1 is successful
+          - create_key_1 is changed
+          - '"access_key" in create_key_1'
+          - '"secret_access_key" in create_key_1'
+          - '"deleted_access_key_id" not in create_key_1'
+          - '"access_key_id" in create_key_1.access_key'
+          - '"create_date" in create_key_1.access_key'
+          - '"user_name" in create_key_1.access_key'
+          - '"status" in create_key_1.access_key'
+          - create_key_1.access_key.user_name == test_user
+          - create_key_1.access_key.status == 'Active'
 
-  - name: Fetch IAM key info (1 key)
-    iam_access_key_info:
-      user_name: '{{ test_user }}'
-    register: access_key_info
-  - assert:
-      that:
-      - access_key_info is successful
-      - '"access_keys" in access_key_info'
-      - access_key_info.access_keys | length == 1
-      - '"access_key_id" in access_key_1'
-      - '"create_date" in access_key_1'
-      - '"user_name" in access_key_1'
-      - '"status" in access_key_1'
-      - access_key_1.user_name == test_user
-      - access_key_1.access_key_id == create_key_1.access_key.access_key_id
-      - access_key_1.create_date == create_key_1.access_key.create_date
-      - access_key_1.status == 'Active'
-    vars:
-      access_key_1: '{{ access_key_info.access_keys[0] }}'
-  - name: Create a second key (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      state: present
-    register: create_key_2
-    check_mode: true
-  - assert:
-      that:
-      - create_key_2 is successful
-      - create_key_2 is changed
+    - name: Fetch IAM key info (1 key)
+      iam_access_key_info:
+        user_name: "{{ test_user }}"
+      register: access_key_info
+    - ansible.builtin.assert:
+        that:
+          - access_key_info is successful
+          - '"access_keys" in access_key_info'
+          - access_key_info.access_keys | length == 1
+          - '"access_key_id" in access_key_1'
+          - '"create_date" in access_key_1'
+          - '"user_name" in access_key_1'
+          - '"status" in access_key_1'
+          - access_key_1.user_name == test_user
+          - access_key_1.access_key_id == create_key_1.access_key.access_key_id
+          - access_key_1.create_date == create_key_1.access_key.create_date
+          - access_key_1.status == 'Active'
+      vars:
+        access_key_1: "{{ access_key_info.access_keys[0] }}"
+    - name: Create a second key (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        state: present
+      register: create_key_2
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - create_key_2 is successful
+          - create_key_2 is changed
 
-  - name: Create a second key
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      state: present
-      no_log: true
-    register: create_key_2
-  - assert:
-      that:
-      - create_key_2 is successful
-      - create_key_2 is changed
-      - '"access_key" in create_key_2'
-      - '"secret_access_key" in create_key_2'
-      - '"deleted_access_key_id" not in create_key_2'
-      - '"access_key_id" in create_key_2.access_key'
-      - '"create_date" in create_key_2.access_key'
-      - '"user_name" in create_key_2.access_key'
-      - '"status" in create_key_2.access_key'
-      - create_key_2.access_key.user_name == test_user
-      - create_key_2.access_key.status == 'Active'
+    - name: Create a second key
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        state: present
+        no_log: true
+      register: create_key_2
+    - ansible.builtin.assert:
+        that:
+          - create_key_2 is successful
+          - create_key_2 is changed
+          - '"access_key" in create_key_2'
+          - '"secret_access_key" in create_key_2'
+          - '"deleted_access_key_id" not in create_key_2'
+          - '"access_key_id" in create_key_2.access_key'
+          - '"create_date" in create_key_2.access_key'
+          - '"user_name" in create_key_2.access_key'
+          - '"status" in create_key_2.access_key'
+          - create_key_2.access_key.user_name == test_user
+          - create_key_2.access_key.status == 'Active'
 
-  - name: Fetch IAM key info (2 keys)
-    iam_access_key_info:
-      user_name: '{{ test_user }}'
-    register: access_key_info
-  - assert:
-      that:
-      - access_key_info is successful
-      - '"access_keys" in access_key_info'
-      - access_key_info.access_keys | length == 2
-      - '"access_key_id" in access_key_1'
-      - '"create_date" in access_key_1'
-      - '"user_name" in access_key_1'
-      - '"status" in access_key_1'
-      - access_key_1.user_name == test_user
-      - access_key_1.access_key_id == create_key_1.access_key.access_key_id
-      - access_key_1.create_date == create_key_1.access_key.create_date
-      - access_key_1.status == 'Active'
-      - '"access_key_id" in access_key_2'
-      - '"create_date" in access_key_2'
-      - '"user_name" in access_key_2'
-      - '"status" in access_key_2'
-      - access_key_2.user_name == test_user
-      - access_key_2.access_key_id == create_key_2.access_key.access_key_id
-      - access_key_2.create_date == create_key_2.access_key.create_date
-      - access_key_2.status == 'Active'
-    vars:
-      access_key_1: '{{ access_key_info.access_keys[0] }}'
-      access_key_2: '{{ access_key_info.access_keys[1] }}'
-  - name: Create a third key without rotation
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      state: present
-      no_log: true
-    register: create_key_3
-    ignore_errors: true
-  - assert:
-      that:
-      # If Amazon update the limits we may need to change the expectation here.
-      - create_key_3 is failed
+    - name: Fetch IAM key info (2 keys)
+      iam_access_key_info:
+        user_name: "{{ test_user }}"
+      register: access_key_info
+    - ansible.builtin.assert:
+        that:
+          - access_key_info is successful
+          - '"access_keys" in access_key_info'
+          - access_key_info.access_keys | length == 2
+          - '"access_key_id" in access_key_1'
+          - '"create_date" in access_key_1'
+          - '"user_name" in access_key_1'
+          - '"status" in access_key_1'
+          - access_key_1.user_name == test_user
+          - access_key_1.access_key_id == create_key_1.access_key.access_key_id
+          - access_key_1.create_date == create_key_1.access_key.create_date
+          - access_key_1.status == 'Active'
+          - '"access_key_id" in access_key_2'
+          - '"create_date" in access_key_2'
+          - '"user_name" in access_key_2'
+          - '"status" in access_key_2'
+          - access_key_2.user_name == test_user
+          - access_key_2.access_key_id == create_key_2.access_key.access_key_id
+          - access_key_2.create_date == create_key_2.access_key.create_date
+          - access_key_2.status == 'Active'
+      vars:
+        access_key_1: "{{ access_key_info.access_keys[0] }}"
+        access_key_2: "{{ access_key_info.access_keys[1] }}"
+    - name: Create a third key without rotation
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        state: present
+        no_log: true
+      register: create_key_3
+      ignore_errors: true
+    - ansible.builtin.assert:
+        that:
+          # If Amazon update the limits we may need to change the expectation here.
+          - create_key_3 is failed
 
-  - name: Fetch IAM key info (2 keys - not changed)
-    iam_access_key_info:
-      user_name: '{{ test_user }}'
-    register: access_key_info
-  - assert:
-      that:
-      - access_key_info is successful
-      - '"access_keys" in access_key_info'
-      - access_key_info.access_keys | length == 2
-      - '"access_key_id" in access_key_1'
-      - '"create_date" in access_key_1'
-      - '"user_name" in access_key_1'
-      - '"status" in access_key_1'
-      - access_key_1.user_name == test_user
-      - access_key_1.access_key_id == create_key_1.access_key.access_key_id
-      - access_key_1.create_date == create_key_1.access_key.create_date
-      - access_key_1.status == 'Active'
-      - '"access_key_id" in access_key_2'
-      - '"create_date" in access_key_2'
-      - '"user_name" in access_key_2'
-      - '"status" in access_key_2'
-      - access_key_2.user_name == test_user
-      - access_key_2.access_key_id == create_key_2.access_key.access_key_id
-      - access_key_2.create_date == create_key_2.access_key.create_date
-      - access_key_2.status == 'Active'
-    vars:
-      access_key_1: '{{ access_key_info.access_keys[0] }}'
-      access_key_2: '{{ access_key_info.access_keys[1] }}'
-  - name: Create a third key - rotation enabled (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      state: present
-      rotate_keys: true
-    register: create_key_3
-    check_mode: true
-  - assert:
-      that:
-      - create_key_3 is successful
-      - create_key_3 is changed
-      - '"deleted_access_key_id" in create_key_3'
-      - create_key_3.deleted_access_key_id == create_key_1.access_key.access_key_id
+    - name: Fetch IAM key info (2 keys - not changed)
+      iam_access_key_info:
+        user_name: "{{ test_user }}"
+      register: access_key_info
+    - ansible.builtin.assert:
+        that:
+          - access_key_info is successful
+          - '"access_keys" in access_key_info'
+          - access_key_info.access_keys | length == 2
+          - '"access_key_id" in access_key_1'
+          - '"create_date" in access_key_1'
+          - '"user_name" in access_key_1'
+          - '"status" in access_key_1'
+          - access_key_1.user_name == test_user
+          - access_key_1.access_key_id == create_key_1.access_key.access_key_id
+          - access_key_1.create_date == create_key_1.access_key.create_date
+          - access_key_1.status == 'Active'
+          - '"access_key_id" in access_key_2'
+          - '"create_date" in access_key_2'
+          - '"user_name" in access_key_2'
+          - '"status" in access_key_2'
+          - access_key_2.user_name == test_user
+          - access_key_2.access_key_id == create_key_2.access_key.access_key_id
+          - access_key_2.create_date == create_key_2.access_key.create_date
+          - access_key_2.status == 'Active'
+      vars:
+        access_key_1: "{{ access_key_info.access_keys[0] }}"
+        access_key_2: "{{ access_key_info.access_keys[1] }}"
+    - name: Create a third key - rotation enabled (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        state: present
+        rotate_keys: true
+      register: create_key_3
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - create_key_3 is successful
+          - create_key_3 is changed
+          - '"deleted_access_key_id" in create_key_3'
+          - create_key_3.deleted_access_key_id == create_key_1.access_key.access_key_id
 
-  - name: Create a second key
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      state: present
-      rotate_keys: true
-      no_log: true
-    register: create_key_3
-  - assert:
-      that:
-      - create_key_3 is successful
-      - create_key_3 is changed
-      - '"access_key" in create_key_3'
-      - '"secret_access_key" in create_key_3'
-      - '"deleted_access_key_id" in create_key_3'
-      - create_key_3.deleted_access_key_id == create_key_1.access_key.access_key_id
-      - '"access_key_id" in create_key_3.access_key'
-      - '"create_date" in create_key_3.access_key'
-      - '"user_name" in create_key_3.access_key'
-      - '"status" in create_key_3.access_key'
-      - create_key_3.access_key.user_name == test_user
-      - create_key_3.access_key.status == 'Active'
+    - name: Create a second key
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        state: present
+        rotate_keys: true
+        no_log: true
+      register: create_key_3
+    - ansible.builtin.assert:
+        that:
+          - create_key_3 is successful
+          - create_key_3 is changed
+          - '"access_key" in create_key_3'
+          - '"secret_access_key" in create_key_3'
+          - '"deleted_access_key_id" in create_key_3'
+          - create_key_3.deleted_access_key_id == create_key_1.access_key.access_key_id
+          - '"access_key_id" in create_key_3.access_key'
+          - '"create_date" in create_key_3.access_key'
+          - '"user_name" in create_key_3.access_key'
+          - '"status" in create_key_3.access_key'
+          - create_key_3.access_key.user_name == test_user
+          - create_key_3.access_key.status == 'Active'
 
-  - name: Fetch IAM key info (2 keys - oldest rotated)
-    iam_access_key_info:
-      user_name: '{{ test_user }}'
-    register: access_key_info
-  - assert:
-      that:
-      - access_key_info is successful
-      - '"access_keys" in access_key_info'
-      - access_key_info.access_keys | length == 2
-      - '"access_key_id" in access_key_1'
-      - '"create_date" in access_key_1'
-      - '"user_name" in access_key_1'
-      - '"status" in access_key_1'
-      - access_key_1.user_name == test_user
-      - access_key_1.access_key_id == create_key_2.access_key.access_key_id
-      - access_key_1.create_date == create_key_2.access_key.create_date
-      - access_key_1.status == 'Active'
-      - '"access_key_id" in access_key_2'
-      - '"create_date" in access_key_2'
-      - '"user_name" in access_key_2'
-      - '"status" in access_key_2'
-      - access_key_2.user_name == test_user
-      - access_key_2.access_key_id == create_key_3.access_key.access_key_id
-      - access_key_2.create_date == create_key_3.access_key.create_date
-      - access_key_2.status == 'Active'
-    vars:
-      access_key_1: '{{ access_key_info.access_keys[0] }}'
-      access_key_2: '{{ access_key_info.access_keys[1] }}'
-  - name: Disable third key (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-      enabled: false
-    register: disable_key
-    check_mode: true
-  - assert:
-      that:
-      - disable_key is successful
-      - disable_key is changed
+    - name: Fetch IAM key info (2 keys - oldest rotated)
+      iam_access_key_info:
+        user_name: "{{ test_user }}"
+      register: access_key_info
+    - ansible.builtin.assert:
+        that:
+          - access_key_info is successful
+          - '"access_keys" in access_key_info'
+          - access_key_info.access_keys | length == 2
+          - '"access_key_id" in access_key_1'
+          - '"create_date" in access_key_1'
+          - '"user_name" in access_key_1'
+          - '"status" in access_key_1'
+          - access_key_1.user_name == test_user
+          - access_key_1.access_key_id == create_key_2.access_key.access_key_id
+          - access_key_1.create_date == create_key_2.access_key.create_date
+          - access_key_1.status == 'Active'
+          - '"access_key_id" in access_key_2'
+          - '"create_date" in access_key_2'
+          - '"user_name" in access_key_2'
+          - '"status" in access_key_2'
+          - access_key_2.user_name == test_user
+          - access_key_2.access_key_id == create_key_3.access_key.access_key_id
+          - access_key_2.create_date == create_key_3.access_key.create_date
+          - access_key_2.status == 'Active'
+      vars:
+        access_key_1: "{{ access_key_info.access_keys[0] }}"
+        access_key_2: "{{ access_key_info.access_keys[1] }}"
+    - name: Disable third key (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+        enabled: false
+      register: disable_key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - disable_key is successful
+          - disable_key is changed
 
-  - name: Disable third key
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-      enabled: false
-    register: disable_key
-  - assert:
-      that:
-      - disable_key is successful
-      - disable_key is changed
-      - '"access_key" in disable_key'
-      - '"secret_access_key" not in disable_key'
-      - '"deleted_access_key_id" not in disable_key'
-      - '"access_key_id" in disable_key.access_key'
-      - '"create_date" in disable_key.access_key'
-      - '"user_name" in disable_key.access_key'
-      - '"status" in disable_key.access_key'
-      - disable_key.access_key.user_name == test_user
-      - disable_key.access_key.status == 'Inactive'
+    - name: Disable third key
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+        enabled: false
+      register: disable_key
+    - ansible.builtin.assert:
+        that:
+          - disable_key is successful
+          - disable_key is changed
+          - '"access_key" in disable_key'
+          - '"secret_access_key" not in disable_key'
+          - '"deleted_access_key_id" not in disable_key'
+          - '"access_key_id" in disable_key.access_key'
+          - '"create_date" in disable_key.access_key'
+          - '"user_name" in disable_key.access_key'
+          - '"status" in disable_key.access_key'
+          - disable_key.access_key.user_name == test_user
+          - disable_key.access_key.status == 'Inactive'
 
-  - name: Disable third key - idempotency (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-      enabled: false
-    register: disable_key
-    check_mode: true
-  - assert:
-      that:
-      - disable_key is successful
-      - disable_key is not changed
+    - name: Disable third key - idempotency (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+        enabled: false
+      register: disable_key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - disable_key is successful
+          - disable_key is not changed
 
-  - name: Disable third key - idempotency
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-      enabled: false
-    register: disable_key
-  - assert:
-      that:
-      - disable_key is successful
-      - disable_key is not changed
-      - '"access_key" in disable_key'
-      - '"secret_access_key" not in disable_key'
-      - '"deleted_access_key_id" not in disable_key'
-      - '"access_key_id" in disable_key.access_key'
-      - '"create_date" in disable_key.access_key'
-      - '"user_name" in disable_key.access_key'
-      - '"status" in disable_key.access_key'
-      - disable_key.access_key.user_name == test_user
-      - disable_key.access_key.status == 'Inactive'
+    - name: Disable third key - idempotency
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+        enabled: false
+      register: disable_key
+    - ansible.builtin.assert:
+        that:
+          - disable_key is successful
+          - disable_key is not changed
+          - '"access_key" in disable_key'
+          - '"secret_access_key" not in disable_key'
+          - '"deleted_access_key_id" not in disable_key'
+          - '"access_key_id" in disable_key.access_key'
+          - '"create_date" in disable_key.access_key'
+          - '"user_name" in disable_key.access_key'
+          - '"status" in disable_key.access_key'
+          - disable_key.access_key.user_name == test_user
+          - disable_key.access_key.status == 'Inactive'
 
-  - name: Fetch IAM key info (2 keys - 1 disabled)
-    iam_access_key_info:
-      user_name: '{{ test_user }}'
-    register: access_key_info
-  - assert:
-      that:
-      - access_key_info is successful
-      - '"access_keys" in access_key_info'
-      - access_key_info.access_keys | length == 2
-      - '"access_key_id" in access_key_1'
-      - '"create_date" in access_key_1'
-      - '"user_name" in access_key_1'
-      - '"status" in access_key_1'
-      - access_key_1.user_name == test_user
-      - access_key_1.access_key_id == create_key_2.access_key.access_key_id
-      - access_key_1.create_date == create_key_2.access_key.create_date
-      - access_key_1.status == 'Active'
-      - '"access_key_id" in access_key_2'
-      - '"create_date" in access_key_2'
-      - '"user_name" in access_key_2'
-      - '"status" in access_key_2'
-      - access_key_2.user_name == test_user
-      - access_key_2.access_key_id == create_key_3.access_key.access_key_id
-      - access_key_2.create_date == create_key_3.access_key.create_date
-      - access_key_2.status == 'Inactive'
-    vars:
-      access_key_1: '{{ access_key_info.access_keys[0] }}'
-      access_key_2: '{{ access_key_info.access_keys[1] }}'
-  - name: Touch third key - no change (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-    register: touch_key
-    check_mode: true
-  - assert:
-      that:
-      - touch_key is successful
-      - touch_key is not changed
+    - name: Fetch IAM key info (2 keys - 1 disabled)
+      iam_access_key_info:
+        user_name: "{{ test_user }}"
+      register: access_key_info
+    - ansible.builtin.assert:
+        that:
+          - access_key_info is successful
+          - '"access_keys" in access_key_info'
+          - access_key_info.access_keys | length == 2
+          - '"access_key_id" in access_key_1'
+          - '"create_date" in access_key_1'
+          - '"user_name" in access_key_1'
+          - '"status" in access_key_1'
+          - access_key_1.user_name == test_user
+          - access_key_1.access_key_id == create_key_2.access_key.access_key_id
+          - access_key_1.create_date == create_key_2.access_key.create_date
+          - access_key_1.status == 'Active'
+          - '"access_key_id" in access_key_2'
+          - '"create_date" in access_key_2'
+          - '"user_name" in access_key_2'
+          - '"status" in access_key_2'
+          - access_key_2.user_name == test_user
+          - access_key_2.access_key_id == create_key_3.access_key.access_key_id
+          - access_key_2.create_date == create_key_3.access_key.create_date
+          - access_key_2.status == 'Inactive'
+      vars:
+        access_key_1: "{{ access_key_info.access_keys[0] }}"
+        access_key_2: "{{ access_key_info.access_keys[1] }}"
+    - name: Touch third key - no change (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+      register: touch_key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - touch_key is successful
+          - touch_key is not changed
 
-  - name: Touch third key - no change
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-    register: touch_key
-  - assert:
-      that:
-      - touch_key is successful
-      - touch_key is not changed
-      - '"access_key" in touch_key'
-      - '"secret_access_key" not in touch_key'
-      - '"deleted_access_key_id" not in touch_key'
-      - '"access_key_id" in touch_key.access_key'
-      - '"create_date" in touch_key.access_key'
-      - '"user_name" in touch_key.access_key'
-      - '"status" in touch_key.access_key'
-      - touch_key.access_key.user_name == test_user
-      - touch_key.access_key.status == 'Inactive'
+    - name: Touch third key - no change
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+      register: touch_key
+    - ansible.builtin.assert:
+        that:
+          - touch_key is successful
+          - touch_key is not changed
+          - '"access_key" in touch_key'
+          - '"secret_access_key" not in touch_key'
+          - '"deleted_access_key_id" not in touch_key'
+          - '"access_key_id" in touch_key.access_key'
+          - '"create_date" in touch_key.access_key'
+          - '"user_name" in touch_key.access_key'
+          - '"status" in touch_key.access_key'
+          - touch_key.access_key.user_name == test_user
+          - touch_key.access_key.status == 'Inactive'
 
-  # ==================================================================================
+    # ==================================================================================
 
-  - name: Enable third key (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-      enabled: true
-    register: enable_key
-    check_mode: true
-  - assert:
-      that:
-      - enable_key is successful
-      - enable_key is changed
+    - name: Enable third key (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+        enabled: true
+      register: enable_key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - enable_key is successful
+          - enable_key is changed
 
-  - name: Enable third key
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-      enabled: true
-    register: enable_key
-  - assert:
-      that:
-      - enable_key is successful
-      - enable_key is changed
-      - '"access_key" in enable_key'
-      - '"secret_access_key" not in enable_key'
-      - '"deleted_access_key_id" not in enable_key'
-      - '"access_key_id" in enable_key.access_key'
-      - '"create_date" in enable_key.access_key'
-      - '"user_name" in enable_key.access_key'
-      - '"status" in enable_key.access_key'
-      - enable_key.access_key.user_name == test_user
-      - enable_key.access_key.status == 'Active'
+    - name: Enable third key
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+        enabled: true
+      register: enable_key
+    - ansible.builtin.assert:
+        that:
+          - enable_key is successful
+          - enable_key is changed
+          - '"access_key" in enable_key'
+          - '"secret_access_key" not in enable_key'
+          - '"deleted_access_key_id" not in enable_key'
+          - '"access_key_id" in enable_key.access_key'
+          - '"create_date" in enable_key.access_key'
+          - '"user_name" in enable_key.access_key'
+          - '"status" in enable_key.access_key'
+          - enable_key.access_key.user_name == test_user
+          - enable_key.access_key.status == 'Active'
 
-  - name: Enable third key - idempotency (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-      enabled: true
-    register: enable_key
-    check_mode: true
-  - assert:
-      that:
-      - enable_key is successful
-      - enable_key is not changed
+    - name: Enable third key - idempotency (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+        enabled: true
+      register: enable_key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - enable_key is successful
+          - enable_key is not changed
 
-  - name: Enable third key - idempotency
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-      enabled: true
-    register: enable_key
-  - assert:
-      that:
-      - enable_key is successful
-      - enable_key is not changed
-      - '"access_key" in enable_key'
-      - '"secret_access_key" not in enable_key'
-      - '"deleted_access_key_id" not in enable_key'
-      - '"access_key_id" in enable_key.access_key'
-      - '"create_date" in enable_key.access_key'
-      - '"user_name" in enable_key.access_key'
-      - '"status" in enable_key.access_key'
-      - enable_key.access_key.user_name == test_user
-      - enable_key.access_key.status == 'Active'
+    - name: Enable third key - idempotency
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+        enabled: true
+      register: enable_key
+    - ansible.builtin.assert:
+        that:
+          - enable_key is successful
+          - enable_key is not changed
+          - '"access_key" in enable_key'
+          - '"secret_access_key" not in enable_key'
+          - '"deleted_access_key_id" not in enable_key'
+          - '"access_key_id" in enable_key.access_key'
+          - '"create_date" in enable_key.access_key'
+          - '"user_name" in enable_key.access_key'
+          - '"status" in enable_key.access_key'
+          - enable_key.access_key.user_name == test_user
+          - enable_key.access_key.status == 'Active'
 
-  # ==================================================================================
+    # ==================================================================================
 
-  - name: Touch third key again - no change (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-    register: touch_key
-    check_mode: true
-  - assert:
-      that:
-      - touch_key is successful
-      - touch_key is not changed
+    - name: Touch third key again - no change (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+      register: touch_key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - touch_key is successful
+          - touch_key is not changed
 
-  - name: Touch third key again - no change
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-    register: touch_key
-  - assert:
-      that:
-      - touch_key is successful
-      - touch_key is not changed
-      - '"access_key" in touch_key'
-      - '"secret_access_key" not in touch_key'
-      - '"deleted_access_key_id" not in touch_key'
-      - '"access_key_id" in touch_key.access_key'
-      - '"create_date" in touch_key.access_key'
-      - '"user_name" in touch_key.access_key'
-      - '"status" in touch_key.access_key'
-      - touch_key.access_key.user_name == test_user
-      - touch_key.access_key.status == 'Active'
+    - name: Touch third key again - no change
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+      register: touch_key
+    - ansible.builtin.assert:
+        that:
+          - touch_key is successful
+          - touch_key is not changed
+          - '"access_key" in touch_key'
+          - '"secret_access_key" not in touch_key'
+          - '"deleted_access_key_id" not in touch_key'
+          - '"access_key_id" in touch_key.access_key'
+          - '"create_date" in touch_key.access_key'
+          - '"user_name" in touch_key.access_key'
+          - '"status" in touch_key.access_key'
+          - touch_key.access_key.user_name == test_user
+          - touch_key.access_key.status == 'Active'
 
-  # ==================================================================================
+    # ==================================================================================
 
-  - name: Re-Disable third key
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-      enabled: false
-    register: redisable_key
-  - assert:
-      that:
-      - redisable_key is successful
-      - redisable_key is changed
-      - redisable_key.access_key.status == 'Inactive'
+    - name: Re-Disable third key
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+        enabled: false
+      register: redisable_key
+    - ansible.builtin.assert:
+        that:
+          - redisable_key is successful
+          - redisable_key is changed
+          - redisable_key.access_key.status == 'Inactive'
 
-  - pause:
-      seconds: 10
-  - name: Test GetCallerIdentity - Key 2
-    aws_caller_info:
-      access_key: '{{ create_key_2.access_key.access_key_id }}'
-      secret_key: '{{ create_key_2.secret_access_key }}'
-      session_token: '{{ omit }}'
-    register: caller_identity_2
-  - assert:
-      that:
-      - caller_identity_2 is successful
-      - caller_identity_2.arn == iam_user.iam_user.user.arn
+    - ansible.builtin.pause:
+        seconds: 10
+    - name: Test GetCallerIdentity - Key 2
+      amazon.aws.aws_caller_info:
+        access_key: "{{ create_key_2.access_key.access_key_id }}"
+        secret_key: "{{ create_key_2.secret_access_key }}"
+        session_token: "{{ omit }}"
+      register: caller_identity_2
+    - ansible.builtin.assert:
+        that:
+          - caller_identity_2 is successful
+          - caller_identity_2.arn == iam_user.iam_user.user.arn
 
-  - name: Test GetCallerIdentity - Key 1 (gone)
-    aws_caller_info:
-      access_key: '{{ create_key_1.access_key.access_key_id }}'
-      secret_key: '{{ create_key_1.secret_access_key }}'
-      session_token: '{{ omit }}'
-    register: caller_identity_1
-    ignore_errors: true
-  - assert:
-      that:
-      - caller_identity_1 is failed
-      - caller_identity_1.error.code == 'InvalidClientTokenId'
+    - name: Test GetCallerIdentity - Key 1 (gone)
+      amazon.aws.aws_caller_info:
+        access_key: "{{ create_key_1.access_key.access_key_id }}"
+        secret_key: "{{ create_key_1.secret_access_key }}"
+        session_token: "{{ omit }}"
+      register: caller_identity_1
+      ignore_errors: true
+    - ansible.builtin.assert:
+        that:
+          - caller_identity_1 is failed
+          - caller_identity_1.error.code == 'InvalidClientTokenId'
 
-  - name: Test GetCallerIdentity - Key 3 (disabled)
-    aws_caller_info:
-      access_key: '{{ create_key_3.access_key.access_key_id }}'
-      secret_key: '{{ create_key_3.secret_access_key }}'
-      session_token: '{{ omit }}'
-    register: caller_identity_3
-    ignore_errors: true
-  - assert:
-      that:
-      - caller_identity_3 is failed
-      - caller_identity_3.error.code == 'InvalidClientTokenId'
+    - name: Test GetCallerIdentity - Key 3 (disabled)
+      amazon.aws.aws_caller_info:
+        access_key: "{{ create_key_3.access_key.access_key_id }}"
+        secret_key: "{{ create_key_3.secret_access_key }}"
+        session_token: "{{ omit }}"
+      register: caller_identity_3
+      ignore_errors: true
+    - ansible.builtin.assert:
+        that:
+          - caller_identity_3 is failed
+          - caller_identity_3.error.code == 'InvalidClientTokenId'
 
-  # ==================================================================================
+    # ==================================================================================
 
-  - name: Delete active key (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_2.access_key.access_key_id }}'
-      state: absent
-    register: delete_active_key
-    check_mode: true
-  - assert:
-      that:
-      - delete_active_key is successful
-      - delete_active_key is changed
+    - name: Delete active key (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_2.access_key.access_key_id }}"
+        state: absent
+      register: delete_active_key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - delete_active_key is successful
+          - delete_active_key is changed
 
-  - name: Delete active key
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_2.access_key.access_key_id }}'
-      state: absent
-    register: delete_active_key
-  - assert:
-      that:
-      - delete_active_key is successful
-      - delete_active_key is changed
+    - name: Delete active key
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_2.access_key.access_key_id }}"
+        state: absent
+      register: delete_active_key
+    - ansible.builtin.assert:
+        that:
+          - delete_active_key is successful
+          - delete_active_key is changed
 
-  - name: Delete active key - idempotency (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_2.access_key.access_key_id }}'
-      state: absent
-    register: delete_active_key
-    check_mode: true
-  - assert:
-      that:
-      - delete_active_key is successful
-      - delete_active_key is not changed
+    - name: Delete active key - idempotency (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_2.access_key.access_key_id }}"
+        state: absent
+      register: delete_active_key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - delete_active_key is successful
+          - delete_active_key is not changed
 
-  - name: Delete active key - idempotency
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_2.access_key.access_key_id }}'
-      state: absent
-    register: delete_active_key
-  - assert:
-      that:
-      - delete_active_key is successful
-      - delete_active_key is not changed
+    - name: Delete active key - idempotency
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_2.access_key.access_key_id }}"
+        state: absent
+      register: delete_active_key
+    - ansible.builtin.assert:
+        that:
+          - delete_active_key is successful
+          - delete_active_key is not changed
 
-  # ==================================================================================
+    # ==================================================================================
 
-  - name: Delete inactive key (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-      state: absent
-    register: delete_inactive_key
-    check_mode: true
-  - assert:
-      that:
-      - delete_inactive_key is successful
-      - delete_inactive_key is changed
+    - name: Delete inactive key (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+        state: absent
+      register: delete_inactive_key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - delete_inactive_key is successful
+          - delete_inactive_key is changed
 
-  - name: Delete inactive key
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-      state: absent
-    register: delete_inactive_key
-  - assert:
-      that:
-      - delete_inactive_key is successful
-      - delete_inactive_key is changed
+    - name: Delete inactive key
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+        state: absent
+      register: delete_inactive_key
+    - ansible.builtin.assert:
+        that:
+          - delete_inactive_key is successful
+          - delete_inactive_key is changed
 
-  - name: Delete inactive key - idempotency (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-      state: absent
-    register: delete_inactive_key
-    check_mode: true
-  - assert:
-      that:
-      - delete_inactive_key is successful
-      - delete_inactive_key is not changed
+    - name: Delete inactive key - idempotency (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+        state: absent
+      register: delete_inactive_key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - delete_inactive_key is successful
+          - delete_inactive_key is not changed
 
-  - name: Delete inactive key - idempotency
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_3.access_key.access_key_id }}'
-      state: absent
-    register: delete_inactive_key
-  - assert:
-      that:
-      - delete_inactive_key is successful
-      - delete_inactive_key is not changed
+    - name: Delete inactive key - idempotency
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_3.access_key.access_key_id }}"
+        state: absent
+      register: delete_inactive_key
+    - ansible.builtin.assert:
+        that:
+          - delete_inactive_key is successful
+          - delete_inactive_key is not changed
 
-  # ==================================================================================
+    # ==================================================================================
 
-  - name: Fetch IAM key info (no keys)
-    iam_access_key_info:
-      user_name: '{{ test_user }}'
-    register: access_key_info
-  - assert:
-      that:
-      - access_key_info is successful
-      - '"access_keys" in access_key_info'
-      - access_key_info.access_keys | length == 0
+    - name: Fetch IAM key info (no keys)
+      iam_access_key_info:
+        user_name: "{{ test_user }}"
+      register: access_key_info
+    - ansible.builtin.assert:
+        that:
+          - access_key_info is successful
+          - '"access_keys" in access_key_info'
+          - access_key_info.access_keys | length == 0
 
-  # ==================================================================================
+    # ==================================================================================
 
-  - name: Create an inactive key (check_mode)
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      state: present
-      enabled: false
-    register: create_key_4
-    check_mode: true
-  - assert:
-      that:
-      - create_key_4 is successful
-      - create_key_4 is changed
+    - name: Create an inactive key (check_mode)
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        state: present
+        enabled: false
+      register: create_key_4
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - create_key_4 is successful
+          - create_key_4 is changed
 
-  - name: Create a key
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      state: present
-      enabled: false
-      no_log: true
-    register: create_key_4
-  - assert:
-      that:
-      - create_key_4 is successful
-      - create_key_4 is changed
-      - '"access_key" in create_key_4'
-      - '"secret_access_key" in create_key_4'
-      - '"deleted_access_key_id" not in create_key_4'
-      - '"access_key_id" in create_key_4.access_key'
-      - '"create_date" in create_key_4.access_key'
-      - '"user_name" in create_key_4.access_key'
-      - '"status" in create_key_4.access_key'
-      - create_key_4.access_key.user_name == test_user
-      - create_key_4.access_key.status == 'Inactive'
+    - name: Create a key
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        state: present
+        enabled: false
+        no_log: true
+      register: create_key_4
+    - ansible.builtin.assert:
+        that:
+          - create_key_4 is successful
+          - create_key_4 is changed
+          - '"access_key" in create_key_4'
+          - '"secret_access_key" in create_key_4'
+          - '"deleted_access_key_id" not in create_key_4'
+          - '"access_key_id" in create_key_4.access_key'
+          - '"create_date" in create_key_4.access_key'
+          - '"user_name" in create_key_4.access_key'
+          - '"status" in create_key_4.access_key'
+          - create_key_4.access_key.user_name == test_user
+          - create_key_4.access_key.status == 'Inactive'
 
-  - name: Fetch IAM key info (1 inactive key)
-    iam_access_key_info:
-      user_name: '{{ test_user }}'
-    register: access_key_info
-  - assert:
-      that:
-      - access_key_info is successful
-      - '"access_keys" in access_key_info'
-      - access_key_info.access_keys | length == 1
-      - '"access_key_id" in access_key_1'
-      - '"create_date" in access_key_1'
-      - '"user_name" in access_key_1'
-      - '"status" in access_key_1'
-      - access_key_1.user_name == test_user
-      - access_key_1.access_key_id == create_key_4.access_key.access_key_id
-      - access_key_1.create_date == create_key_4.access_key.create_date
-      - access_key_1.status == 'Inactive'
-    vars:
-      access_key_1: '{{ access_key_info.access_keys[0] }}'
-  - name: Disable new key
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_4.access_key.access_key_id }}'
-      enabled: false
-    register: disable_new_key
-  - assert:
-      that:
-      - disable_new_key is successful
-      - disable_new_key is not changed
-      - '"access_key" in disable_new_key'
+    - name: Fetch IAM key info (1 inactive key)
+      iam_access_key_info:
+        user_name: "{{ test_user }}"
+      register: access_key_info
+    - ansible.builtin.assert:
+        that:
+          - access_key_info is successful
+          - '"access_keys" in access_key_info'
+          - access_key_info.access_keys | length == 1
+          - '"access_key_id" in access_key_1'
+          - '"create_date" in access_key_1'
+          - '"user_name" in access_key_1'
+          - '"status" in access_key_1'
+          - access_key_1.user_name == test_user
+          - access_key_1.access_key_id == create_key_4.access_key.access_key_id
+          - access_key_1.create_date == create_key_4.access_key.create_date
+          - access_key_1.status == 'Inactive'
+      vars:
+        access_key_1: "{{ access_key_info.access_keys[0] }}"
+    - name: Disable new key
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_4.access_key.access_key_id }}"
+        enabled: false
+      register: disable_new_key
+    - ansible.builtin.assert:
+        that:
+          - disable_new_key is successful
+          - disable_new_key is not changed
+          - '"access_key" in disable_new_key'
 
-  # ==================================================================================
-  # Cleanup
+    # ==================================================================================
+    # Cleanup
 
-  - name: Delete new key
-    iam_access_key:
-      user_name: '{{ test_user }}'
-      id: '{{ create_key_4.access_key.access_key_id }}'
-      state: absent
-    register: delete_new_key
-  - assert:
-      that:
-      - delete_new_key is successful
-      - delete_new_key is changed
+    - name: Delete new key
+      iam_access_key:
+        user_name: "{{ test_user }}"
+        id: "{{ create_key_4.access_key.access_key_id }}"
+        state: absent
+      register: delete_new_key
+    - ansible.builtin.assert:
+        that:
+          - delete_new_key is successful
+          - delete_new_key is changed
 
-  - name: Remove test user
-    iam_user:
-      name: '{{ test_user }}'
-      state: absent
-    register: delete_user
-  - assert:
-      that:
-      - delete_user is successful
-      - delete_user is changed
+    - name: Remove test user
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: absent
+      register: delete_user
+    - ansible.builtin.assert:
+        that:
+          - delete_user is successful
+          - delete_user is changed
 
   always:
-
-  - name: Remove test user
-    iam_user:
-      name: '{{ test_user }}'
-      state: absent
-    ignore_errors: true
+    - name: Remove test user
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/iam_instance_profile/defaults/main.yml
+++ b/tests/integration/targets/iam_instance_profile/defaults/main.yml
@@ -1,12 +1,12 @@
 ---
-test_profile: '{{ resource_prefix }}-iam-ip'
-test_profile_complex: '{{ resource_prefix }}-iam-ip-complex'
-test_role: '{{ resource_prefix }}-iam-ipr'
-test_path: '/{{ resource_prefix }}-ip/'
-safe_managed_policy: 'AWSDenyAll'
+test_profile: "{{ resource_prefix }}-iam-ip"
+test_profile_complex: "{{ resource_prefix }}-iam-ip-complex"
+test_role: "{{ resource_prefix }}-iam-ipr"
+test_path: /{{ resource_prefix }}-ip/
+safe_managed_policy: AWSDenyAll
 
 test_tags:
-  'Key with Spaces': Value with spaces
+  Key with Spaces: Value with spaces
   CamelCaseKey: CamelCaseValue
   pascalCaseKey: pascalCaseValue
   snake_case_key: snake_case_value

--- a/tests/integration/targets/iam_instance_profile/meta/main.yml
+++ b/tests/integration/targets/iam_instance_profile/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/iam_instance_profile/tasks/main.yml
+++ b/tests/integration/targets/iam_instance_profile/tasks/main.yml
@@ -2,7 +2,7 @@
 # Tests for iam_instance_profile and iam_instance_profile_info
 #
 
-- name: "Setup AWS connection info"
+- name: Setup AWS connection info
   module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -16,16 +16,16 @@
     # ===================================================================
     # Prepare
 
-    - name: "Prepare IAM Roles"
-      iam_role:
+    - name: Prepare IAM Roles
+      community.aws.iam_role:
         state: present
         name: "{{ item }}"
         path: "{{ test_path }}"
-        create_instance_profile: True
+        create_instance_profile: true
         assume_role_policy_document: '{{ lookup("file", "deny-assume.json") }}'
         managed_policies:
           - "{{ safe_managed_policy }}"
-        wait: True
+        wait: true
       loop:
         - "{{ test_role }}"
         - "{{ test_role }}-2"
@@ -35,245 +35,242 @@
 
     # ===================================================================
 
-    - name: "Create minimal Instance Profile (CHECK)"
+    - name: Create minimal Instance Profile (CHECK)
       iam_instance_profile:
         name: "{{ test_profile }}"
-      check_mode: True
+      check_mode: true
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is changed
 
-    - name: "Create minimal Instance Profile"
+    - name: Create minimal Instance Profile
       iam_instance_profile:
         name: "{{ test_profile }}"
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is changed
 
-    - name: "Create minimal Instance Profile - Idempotent (CHECK)"
+    - name: Create minimal Instance Profile - Idempotent (CHECK)
       iam_instance_profile:
         name: "{{ test_profile }}"
-      check_mode: True
+      check_mode: true
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is not changed
 
-    - name: "Create minimal Instance Profile - Idempotent"
+    - name: Create minimal Instance Profile - Idempotent
       iam_instance_profile:
         name: "{{ test_profile }}"
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is not changed
 
     # ===================================================================
 
-    - include_tasks: 'tags.yml'
-
-    # ===================================================================
-
-    - name: "Add role to Instance Profile (CHECK)"
+    - ansible.builtin.include_tasks: tags.yml
+    - name: Add role to Instance Profile (CHECK)
       iam_instance_profile:
         name: "{{ test_profile }}"
         role: "{{ test_role }}"
-      check_mode: True
+      check_mode: true
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is changed
 
-    - name: "Add role to Instance Profile"
+    - name: Add role to Instance Profile
       iam_instance_profile:
         name: "{{ test_profile }}"
         role: "{{ test_role }}"
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is changed
 
-    - name: "Add role to Instance Profile - Idempotent (CHECK)"
+    - name: Add role to Instance Profile - Idempotent (CHECK)
       iam_instance_profile:
         name: "{{ test_profile }}"
         role: "{{ test_role }}"
-      check_mode: True
+      check_mode: true
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is not changed
 
-    - name: "Add role to Instance Profile - Idempotent"
+    - name: Add role to Instance Profile - Idempotent
       iam_instance_profile:
         name: "{{ test_profile }}"
         role: "{{ test_role }}"
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is not changed
 
     # =====
 
-    - name: "Replace role on Instance Profile (CHECK)"
+    - name: Replace role on Instance Profile (CHECK)
       iam_instance_profile:
         name: "{{ test_profile }}"
         role: "{{ test_role }}-2"
-      check_mode: True
+      check_mode: true
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is changed
 
-    - name: "Replace role on Instance Profile"
+    - name: Replace role on Instance Profile
       iam_instance_profile:
         name: "{{ test_profile }}"
         role: "{{ test_role }}-2"
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is changed
 
-    - name: "Replace role on Instance Profile - Idempotent (CHECK)"
+    - name: Replace role on Instance Profile - Idempotent (CHECK)
       iam_instance_profile:
         name: "{{ test_profile }}"
         role: "{{ test_role }}-2"
-      check_mode: True
+      check_mode: true
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is not changed
 
-    - name: "Replace role on Instance Profile - Idempotent"
+    - name: Replace role on Instance Profile - Idempotent
       iam_instance_profile:
         name: "{{ test_profile }}"
         role: "{{ test_role }}-2"
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is not changed
 
     # =====
 
-    - name: "Remove role from Instance Profile (CHECK)"
+    - name: Remove role from Instance Profile (CHECK)
       iam_instance_profile:
         name: "{{ test_profile }}"
         role: ""
-      check_mode: True
+      check_mode: true
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is changed
 
-    - name: "Remove role from Instance Profile"
+    - name: Remove role from Instance Profile
       iam_instance_profile:
         name: "{{ test_profile }}"
         role: ""
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is changed
 
-    - name: "Remove role from Instance Profile - Idempotent (CHECK)"
+    - name: Remove role from Instance Profile - Idempotent (CHECK)
       iam_instance_profile:
         name: "{{ test_profile }}"
         role: ""
-      check_mode: True
+      check_mode: true
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is not changed
 
-    - name: "Remove role from Instance Profile - Idempotent"
+    - name: Remove role from Instance Profile - Idempotent
       iam_instance_profile:
         name: "{{ test_profile }}"
         role: ""
       register: profile_result
 
-    - assert:
-        that:
-          - profile_result is not changed
-
-    # ===================================================================
-
-    - name: "Create complex Instance Profile (CHECK)"
-      iam_instance_profile:
-        name: "{{ test_profile_complex }}"
-        role: "{{ test_role }}-2"
-        path: "{{ test_path }}"
-        tags: "{{ test_tags }}"
-      check_mode: True
-      register: profile_result
-
-    - assert:
-        that:
-          - profile_result is changed
-
-    - name: "Create complex Instance Profile"
-      iam_instance_profile:
-        name: "{{ test_profile_complex }}"
-        role: "{{ test_role }}-2"
-        path: "{{ test_path }}"
-        tags: "{{ test_tags }}"
-      register: profile_result
-
-    - assert:
-        that:
-          - profile_result is changed
-
-    - name: "Create complex Instance Profile - Idempotent (CHECK)"
-      iam_instance_profile:
-        name: "{{ test_profile_complex }}"
-        role: "{{ test_role }}-2"
-        path: "{{ test_path }}"
-        tags: "{{ test_tags }}"
-      check_mode: True
-      register: profile_result
-
-    - assert:
-        that:
-          - profile_result is not changed
-
-    - name: "Create complex Instance Profile - Idempotent"
-      iam_instance_profile:
-        name: "{{ test_profile_complex }}"
-        role: "{{ test_role }}-2"
-        path: "{{ test_path }}"
-        tags: "{{ test_tags }}"
-      register: profile_result
-
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is not changed
 
     # ===================================================================
 
-    - name: "List all Instance Profiles (no filter)"
+    - name: Create complex Instance Profile (CHECK)
+      iam_instance_profile:
+        name: "{{ test_profile_complex }}"
+        role: "{{ test_role }}-2"
+        path: "{{ test_path }}"
+        tags: "{{ test_tags }}"
+      check_mode: true
+      register: profile_result
+
+    - ansible.builtin.assert:
+        that:
+          - profile_result is changed
+
+    - name: Create complex Instance Profile
+      iam_instance_profile:
+        name: "{{ test_profile_complex }}"
+        role: "{{ test_role }}-2"
+        path: "{{ test_path }}"
+        tags: "{{ test_tags }}"
+      register: profile_result
+
+    - ansible.builtin.assert:
+        that:
+          - profile_result is changed
+
+    - name: Create complex Instance Profile - Idempotent (CHECK)
+      iam_instance_profile:
+        name: "{{ test_profile_complex }}"
+        role: "{{ test_role }}-2"
+        path: "{{ test_path }}"
+        tags: "{{ test_tags }}"
+      check_mode: true
+      register: profile_result
+
+    - ansible.builtin.assert:
+        that:
+          - profile_result is not changed
+
+    - name: Create complex Instance Profile - Idempotent
+      iam_instance_profile:
+        name: "{{ test_profile_complex }}"
+        role: "{{ test_role }}-2"
+        path: "{{ test_path }}"
+        tags: "{{ test_tags }}"
+      register: profile_result
+
+    - ansible.builtin.assert:
+        that:
+          - profile_result is not changed
+
+    # ===================================================================
+
+    - name: List all Instance Profiles (no filter)
       iam_instance_profile_info:
       register: profile_info
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_info.iam_instance_profiles | length >= 4
-          - 'test_role in profile_names'
-          - 'test_role+"-2" in profile_names'
-          - 'test_profile in profile_names'
-          - 'test_profile_complex in profile_names'
+          - test_role in profile_names
+          - test_role+"-2" in profile_names
+          - test_profile in profile_names
+          - test_profile_complex in profile_names
 
           - '"arn" in complex_profile'
           - '"create_date" in complex_profile'
@@ -296,17 +293,17 @@
         profile_names: '{{ profile_info.iam_instance_profiles | map(attribute="instance_profile_name") }}'
         complex_profile: '{{ profile_info.iam_instance_profiles | selectattr("instance_profile_name", "match", test_profile_complex) | first}}'
 
-    - name: "List all Instance Profiles (filter by path)"
+    - name: List all Instance Profiles (filter by path)
       iam_instance_profile_info:
         path: "{{ test_path }}"
       register: profile_info
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_info.iam_instance_profiles | length == 3
-          - 'test_role in profile_names'
-          - 'test_role+"-2" in profile_names'
-          - 'test_profile_complex in profile_names'
+          - test_role in profile_names
+          - test_role+"-2" in profile_names
+          - test_profile_complex in profile_names
 
           - '"arn" in complex_profile'
           - '"create_date" in complex_profile'
@@ -329,15 +326,15 @@
         profile_names: '{{ profile_info.iam_instance_profiles | map(attribute="instance_profile_name") }}'
         complex_profile: '{{ profile_info.iam_instance_profiles | selectattr("instance_profile_name", "match", test_profile_complex) | first}}'
 
-    - name: "List all Instance Profiles (filter by name - complex)"
+    - name: List all Instance Profiles (filter by name - complex)
       iam_instance_profile_info:
         name: "{{ test_profile_complex }}"
       register: profile_info
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_info.iam_instance_profiles | length == 1
-          - 'test_profile_complex in profile_names'
+          - test_profile_complex in profile_names
 
           - '"arn" in complex_profile'
           - '"create_date" in complex_profile'
@@ -364,12 +361,12 @@
         profile_names: '{{ profile_info.iam_instance_profiles | map(attribute="instance_profile_name") }}'
         complex_profile: '{{ profile_info.iam_instance_profiles | selectattr("instance_profile_name", "match", test_profile_complex) | first}}'
 
-    - name: "List an Instance Profile (filter by name)"
+    - name: List an Instance Profile (filter by name)
       iam_instance_profile_info:
         name: "{{ test_profile }}"
       register: profile_info
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_info.iam_instance_profiles | length == 1
           - '"arn" in simple_profile'
@@ -384,93 +381,93 @@
           - '"roles" in simple_profile'
           - simple_profile.roles | length == 0
       vars:
-        simple_profile: '{{ profile_info.iam_instance_profiles[0] }}'
+        simple_profile: "{{ profile_info.iam_instance_profiles[0] }}"
 
     # ===================================================================
 
-    - name: "Delete minimal Instance Profile (CHECK)"
+    - name: Delete minimal Instance Profile (CHECK)
       iam_instance_profile:
         state: absent
         name: "{{ test_profile }}"
-      check_mode: True
+      check_mode: true
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is changed
 
-    - name: "Delete minimal Instance Profile"
+    - name: Delete minimal Instance Profile
       iam_instance_profile:
         state: absent
         name: "{{ test_profile }}"
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is changed
 
-    - name: "Delete minimal Instance Profile - Idempotent (CHECK)"
+    - name: Delete minimal Instance Profile - Idempotent (CHECK)
       iam_instance_profile:
         state: absent
         name: "{{ test_profile }}"
-      check_mode: True
+      check_mode: true
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is not changed
 
-    - name: "Delete minimal Instance Profile - Idempotent"
+    - name: Delete minimal Instance Profile - Idempotent
       iam_instance_profile:
         state: absent
         name: "{{ test_profile }}"
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is not changed
 
     # ===================================================================
 
-    - name: "Delete complex Instance Profile (CHECK)"
+    - name: Delete complex Instance Profile (CHECK)
       iam_instance_profile:
         state: absent
         name: "{{ test_profile_complex }}"
-      check_mode: True
+      check_mode: true
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is changed
 
-    - name: "Delete complex Instance Profile"
+    - name: Delete complex Instance Profile
       iam_instance_profile:
         state: absent
         name: "{{ test_profile_complex }}"
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is changed
 
-    - name: "Delete complex Instance Profile - Idempotent (CHECK)"
+    - name: Delete complex Instance Profile - Idempotent (CHECK)
       iam_instance_profile:
         state: absent
         name: "{{ test_profile_complex }}"
-      check_mode: True
+      check_mode: true
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is not changed
 
-    - name: "Delete complex Instance Profile - Idempotent"
+    - name: Delete complex Instance Profile - Idempotent
       iam_instance_profile:
         state: absent
         name: "{{ test_profile_complex }}"
       register: profile_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - profile_result is not changed
 
@@ -478,11 +475,11 @@
     # ===================================================================
     # Cleanup
 
-#    - name: "iam_instance_profile_info after Role deletion"
-#      iam_instance_profile_info:
-#      ignore_errors: true
+    #    - name: "iam_instance_profile_info after Role deletion"
+    #      iam_instance_profile_info:
+    #      ignore_errors: true
 
-    - name: "Delete Instance Profiles"
+    - name: Delete Instance Profiles
       iam_instance_profile:
         state: absent
         name: "{{ item }}"
@@ -493,12 +490,12 @@
         - "{{ test_role }}"
         - "{{ test_role }}-2"
 
-    - name: "Remove IAM Roles"
-      iam_role:
+    - name: Remove IAM Roles
+      community.aws.iam_role:
         state: absent
         name: "{{ item }}"
         path: "{{ test_path }}"
-        delete_instance_profile: yes
+        delete_instance_profile: true
       ignore_errors: true
       loop:
         - "{{ test_role }}"

--- a/tests/integration/targets/iam_instance_profile/tasks/tags.yml
+++ b/tests/integration/targets/iam_instance_profile/tasks/tags.yml
@@ -1,298 +1,298 @@
+---
 - vars:
     first_tags:
-      'Key with Spaces': Value with spaces
+      Key with Spaces: Value with spaces
       CamelCaseKey: CamelCaseValue
       pascalCaseKey: pascalCaseValue
       snake_case_key: snake_case_value
     second_tags:
-      'New Key with Spaces': Value with spaces
+      New Key with Spaces: Value with spaces
       NewCamelCaseKey: CamelCaseValue
       newPascalCaseKey: pascalCaseValue
       new_snake_case_key: snake_case_value
     third_tags:
-      'Key with Spaces': Value with spaces
+      Key with Spaces: Value with spaces
       CamelCaseKey: CamelCaseValue
       pascalCaseKey: pascalCaseValue
       snake_case_key: snake_case_value
-      'New Key with Spaces': Updated Value with spaces
+      New Key with Spaces: Updated Value with spaces
     final_tags:
-      'Key with Spaces': Value with spaces
+      Key with Spaces: Value with spaces
       CamelCaseKey: CamelCaseValue
       pascalCaseKey: pascalCaseValue
       snake_case_key: snake_case_value
-      'New Key with Spaces': Updated Value with spaces
+      New Key with Spaces: Updated Value with spaces
       NewCamelCaseKey: CamelCaseValue
       newPascalCaseKey: pascalCaseValue
       new_snake_case_key: snake_case_value
   module_defaults:
     amazon.aws.iam_instance_profile:
-      name: '{{ test_profile }}'
+      name: "{{ test_profile }}"
     amazon.aws.iam_instance_profile_info:
       name: "{{ test_profile }}"
   block:
-
   # ============================================================
   #
 
-  - name: (check) add tags
-    iam_instance_profile:
-      tags: '{{ first_tags }}'
-      state: 'present'
-    register: tag_profile
-    check_mode: True
+    - name: (check) add tags
+      iam_instance_profile:
+        tags: "{{ first_tags }}"
+        state: present
+      register: tag_profile
+      check_mode: true
 
-  - name: assert would change
-    assert:
-      that:
-        - tag_profile is changed
+    - name: assert would change
+      ansible.builtin.assert:
+        that:
+          - tag_profile is changed
 
-  - name: add tags
-    iam_instance_profile:
-      tags: '{{ first_tags }}'
-      state: 'present'
-    register: tag_profile
+    - name: add tags
+      iam_instance_profile:
+        tags: "{{ first_tags }}"
+        state: present
+      register: tag_profile
 
-  - name: get instance profile facts
-    iam_instance_profile_info: {}
-    register: tag_profile_info
+    - name: get instance profile facts
+      iam_instance_profile_info: {}
+      register: tag_profile_info
 
-  - name: verify the tags were added
-    assert:
-      that:
-        - tag_profile is changed
-        - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
-        - tag_profile_info.iam_instance_profiles[0].tags == first_tags
+    - name: verify the tags were added
+      ansible.builtin.assert:
+        that:
+          - tag_profile is changed
+          - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
+          - tag_profile_info.iam_instance_profiles[0].tags == first_tags
 
-  - name: (check) add tags - IDEMPOTENCY
-    iam_instance_profile:
-      tags: '{{ first_tags }}'
-      state: 'present'
-    register: tag_profile
-    check_mode: True
+    - name: (check) add tags - IDEMPOTENCY
+      iam_instance_profile:
+        tags: "{{ first_tags }}"
+        state: present
+      register: tag_profile
+      check_mode: true
 
-  - name: assert would not change
-    assert:
-      that:
-        - tag_profile is not changed
+    - name: assert would not change
+      ansible.builtin.assert:
+        that:
+          - tag_profile is not changed
 
-  - name: add tags - IDEMPOTENCY
-    iam_instance_profile:
-      tags: '{{ first_tags }}'
-      state: 'present'
-    register: tag_profile
-  - name: get instance profile facts
-    iam_instance_profile_info: {}
-    register: tag_profile_info
+    - name: add tags - IDEMPOTENCY
+      iam_instance_profile:
+        tags: "{{ first_tags }}"
+        state: present
+      register: tag_profile
+    - name: get instance profile facts
+      iam_instance_profile_info: {}
+      register: tag_profile_info
 
-  - name: verify no change
-    assert:
-      that:
-        - tag_profile is not changed
-        - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
-        - tag_profile_info.iam_instance_profiles[0].tags == first_tags
+    - name: verify no change
+      ansible.builtin.assert:
+        that:
+          - tag_profile is not changed
+          - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
+          - tag_profile_info.iam_instance_profiles[0].tags == first_tags
 
-  # ============================================================
+    # ============================================================
 
-  - name: (check) modify tags with purge
-    iam_instance_profile:
-      tags: '{{ second_tags }}'
-      state: 'present'
-    register: tag_profile
-    check_mode: True
+    - name: (check) modify tags with purge
+      iam_instance_profile:
+        tags: "{{ second_tags }}"
+        state: present
+      register: tag_profile
+      check_mode: true
 
-  - name: assert would change
-    assert:
-      that:
-        - tag_profile is changed
+    - name: assert would change
+      ansible.builtin.assert:
+        that:
+          - tag_profile is changed
 
-  - name: modify tags with purge
-    iam_instance_profile:
-      tags: '{{ second_tags }}'
-      state: 'present'
-    register: tag_profile
-  - name: get instance profile facts
-    iam_instance_profile_info:
-    register: tag_profile_info
+    - name: modify tags with purge
+      iam_instance_profile:
+        tags: "{{ second_tags }}"
+        state: present
+      register: tag_profile
+    - name: get instance profile facts
+      iam_instance_profile_info:
+      register: tag_profile_info
 
-  - name: verify the tags were added
-    assert:
-      that:
-        - tag_profile is changed
-        - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
-        - tag_profile_info.iam_instance_profiles[0].tags == second_tags
+    - name: verify the tags were added
+      ansible.builtin.assert:
+        that:
+          - tag_profile is changed
+          - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
+          - tag_profile_info.iam_instance_profiles[0].tags == second_tags
 
-  - name: (check) modify tags with purge - IDEMPOTENCY
-    iam_instance_profile:
-      tags: '{{ second_tags }}'
-      state: 'present'
-    register: tag_profile
-    check_mode: True
+    - name: (check) modify tags with purge - IDEMPOTENCY
+      iam_instance_profile:
+        tags: "{{ second_tags }}"
+        state: present
+      register: tag_profile
+      check_mode: true
 
-  - name: assert would not change
-    assert:
-      that:
-        - tag_profile is not changed
+    - name: assert would not change
+      ansible.builtin.assert:
+        that:
+          - tag_profile is not changed
 
-  - name: modify tags with purge - IDEMPOTENCY
-    iam_instance_profile:
-      tags: '{{ second_tags }}'
-      state: 'present'
-    register: tag_profile
-  - name: get instance profile facts
-    iam_instance_profile_info:
-    register: tag_profile_info
+    - name: modify tags with purge - IDEMPOTENCY
+      iam_instance_profile:
+        tags: "{{ second_tags }}"
+        state: present
+      register: tag_profile
+    - name: get instance profile facts
+      iam_instance_profile_info:
+      register: tag_profile_info
 
-  - name: verify no change
-    assert:
-      that:
-        - tag_profile is not changed
-        - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
-        - tag_profile_info.iam_instance_profiles[0].tags == second_tags
+    - name: verify no change
+      ansible.builtin.assert:
+        that:
+          - tag_profile is not changed
+          - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
+          - tag_profile_info.iam_instance_profiles[0].tags == second_tags
 
-  # ============================================================
+    # ============================================================
 
-  - name: (check) modify tags without purge
-    iam_instance_profile:
-      tags: '{{ third_tags }}'
-      state: 'present'
-      purge_tags: False
-    register: tag_profile
-    check_mode: True
+    - name: (check) modify tags without purge
+      iam_instance_profile:
+        tags: "{{ third_tags }}"
+        state: present
+        purge_tags: false
+      register: tag_profile
+      check_mode: true
 
-  - name: assert would change
-    assert:
-      that:
-        - tag_profile is changed
+    - name: assert would change
+      ansible.builtin.assert:
+        that:
+          - tag_profile is changed
 
-  - name: modify tags without purge
-    iam_instance_profile:
-      tags: '{{ third_tags }}'
-      state: 'present'
-      purge_tags: False
-    register: tag_profile
-  - name: get instance profile facts
-    iam_instance_profile_info:
-    register: tag_profile_info
+    - name: modify tags without purge
+      iam_instance_profile:
+        tags: "{{ third_tags }}"
+        state: present
+        purge_tags: false
+      register: tag_profile
+    - name: get instance profile facts
+      iam_instance_profile_info:
+      register: tag_profile_info
 
-  - name: verify the tags were added
-    assert:
-      that:
-        - tag_profile is changed
-        - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
-        - tag_profile_info.iam_instance_profiles[0].tags == final_tags
+    - name: verify the tags were added
+      ansible.builtin.assert:
+        that:
+          - tag_profile is changed
+          - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
+          - tag_profile_info.iam_instance_profiles[0].tags == final_tags
 
-  - name: (check) modify tags without purge - IDEMPOTENCY
-    iam_instance_profile:
-      tags: '{{ third_tags }}'
-      state: 'present'
-      purge_tags: False
-    register: tag_profile
-    check_mode: True
+    - name: (check) modify tags without purge - IDEMPOTENCY
+      iam_instance_profile:
+        tags: "{{ third_tags }}"
+        state: present
+        purge_tags: false
+      register: tag_profile
+      check_mode: true
 
-  - name: assert would not change
-    assert:
-      that:
-        - tag_profile is not changed
+    - name: assert would not change
+      ansible.builtin.assert:
+        that:
+          - tag_profile is not changed
 
-  - name: modify tags without purge - IDEMPOTENCY
-    iam_instance_profile:
-      tags: '{{ third_tags }}'
-      state: 'present'
-      purge_tags: False
-    register: tag_profile
-  - name: get instance profile facts
-    iam_instance_profile_info:
-    register: tag_profile_info
+    - name: modify tags without purge - IDEMPOTENCY
+      iam_instance_profile:
+        tags: "{{ third_tags }}"
+        state: present
+        purge_tags: false
+      register: tag_profile
+    - name: get instance profile facts
+      iam_instance_profile_info:
+      register: tag_profile_info
 
-  - name: verify no change
-    assert:
-      that:
-        - tag_profile is not changed
-        - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
-        - tag_profile_info.iam_instance_profiles[0].tags == final_tags
+    - name: verify no change
+      ansible.builtin.assert:
+        that:
+          - tag_profile is not changed
+          - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
+          - tag_profile_info.iam_instance_profiles[0].tags == final_tags
 
-  # ============================================================
+    # ============================================================
 
-  - name: (check) No change to tags without setting tags
-    iam_instance_profile:
-      state: 'present'
-    register: tag_profile
-    check_mode: True
+    - name: (check) No change to tags without setting tags
+      iam_instance_profile:
+        state: present
+      register: tag_profile
+      check_mode: true
 
-  - name: assert would change
-    assert:
-      that:
-        - tag_profile is not changed
+    - name: assert would change
+      ansible.builtin.assert:
+        that:
+          - tag_profile is not changed
 
-  - name: No change to tags without setting tags
-    iam_instance_profile:
-      state: 'present'
-    register: tag_profile
-  - name: get instance profile facts
-    iam_instance_profile_info:
-    register: tag_profile_info
+    - name: No change to tags without setting tags
+      iam_instance_profile:
+        state: present
+      register: tag_profile
+    - name: get instance profile facts
+      iam_instance_profile_info:
+      register: tag_profile_info
 
-  - name: verify the tags were added
-    assert:
-      that:
-        - tag_profile is not changed
-        - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
-        - tag_profile_info.iam_instance_profiles[0].tags == final_tags
+    - name: verify the tags were added
+      ansible.builtin.assert:
+        that:
+          - tag_profile is not changed
+          - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
+          - tag_profile_info.iam_instance_profiles[0].tags == final_tags
 
-  # ============================================================
+    # ============================================================
 
-  - name: (check) remove all tags
-    iam_instance_profile:
-      tags: {}
-      state: 'present'
-    register: tag_profile
-    check_mode: True
+    - name: (check) remove all tags
+      iam_instance_profile:
+        tags: {}
+        state: present
+      register: tag_profile
+      check_mode: true
 
-  - name: assert would change
-    assert:
-      that:
-        - tag_profile is changed
+    - name: assert would change
+      ansible.builtin.assert:
+        that:
+          - tag_profile is changed
 
-  - name: remove all tags
-    iam_instance_profile:
-      tags: {}
-      state: 'present'
-    register: tag_profile
-  - name: get instance profile facts
-    iam_instance_profile_info:
-    register: tag_profile_info
+    - name: remove all tags
+      iam_instance_profile:
+        tags: {}
+        state: present
+      register: tag_profile
+    - name: get instance profile facts
+      iam_instance_profile_info:
+      register: tag_profile_info
 
-  - name: verify the tags were added
-    assert:
-      that:
-        - tag_profile is changed
-        - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
-        - tag_profile_info.iam_instance_profiles[0].tags == {}
+    - name: verify the tags were added
+      ansible.builtin.assert:
+        that:
+          - tag_profile is changed
+          - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
+          - tag_profile_info.iam_instance_profiles[0].tags == {}
 
-  - name: (check) remove all tags - IDEMPOTENCY
-    iam_instance_profile:
-      tags: {}
-      state: 'present'
-    register: tag_profile
-    check_mode: True
+    - name: (check) remove all tags - IDEMPOTENCY
+      iam_instance_profile:
+        tags: {}
+        state: present
+      register: tag_profile
+      check_mode: true
 
-  - name: assert would not change
-    assert:
-      that:
-        - tag_profile is not changed
+    - name: assert would not change
+      ansible.builtin.assert:
+        that:
+          - tag_profile is not changed
 
-  - name: remove all tags - IDEMPOTENCY
-    iam_instance_profile:
-      tags: {}
-      state: 'present'
-    register: tag_profile
-  - name: get instance profile
-    iam_instance_profile_info:
-    register: tag_profile_info
+    - name: remove all tags - IDEMPOTENCY
+      iam_instance_profile:
+        tags: {}
+        state: present
+      register: tag_profile
+    - name: get instance profile
+      iam_instance_profile_info:
+      register: tag_profile_info
 
-  - name: verify no change
-    assert:
-      that:
-        - tag_profile is not changed
-        - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
-        - tag_profile_info.iam_instance_profiles[0].tags == {}
+    - name: verify no change
+      ansible.builtin.assert:
+        that:
+          - tag_profile is not changed
+          - tag_profile_info.iam_instance_profiles[0].instance_profile_name == test_profile
+          - tag_profile_info.iam_instance_profiles[0].tags == {}

--- a/tests/integration/targets/iam_managed_policy/meta/main.yml
+++ b/tests/integration/targets/iam_managed_policy/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/iam_managed_policy/tasks/main.yml
+++ b/tests/integration/targets/iam_managed_policy/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: "Run integration tests for IAM managed policy"
+- name: Run integration tests for IAM managed policy
   module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -11,150 +11,150 @@
   block:
     ## Test policy creation
     - name: Create IAM managed policy - check mode
-      iam_managed_policy:
+      community.aws.iam_managed_policy:
         policy_name: "{{ policy_name }}"
         policy:
           Version: "2012-10-17"
           Statement:
-            - Effect: "Deny"
-              Action: "logs:CreateLogGroup"
+            - Effect: Deny
+              Action: logs:CreateLogGroup
               Resource: "*"
         state: present
       register: result
-      check_mode: yes
+      check_mode: true
 
     - name: Create IAM managed policy - check mode
-      assert:
+      ansible.builtin.assert:
         that:
           - result.changed
 
     - name: Create IAM managed policy
-      iam_managed_policy:
+      community.aws.iam_managed_policy:
         policy_name: "{{ policy_name }}"
         policy:
           Version: "2012-10-17"
           Statement:
-            - Effect: "Deny"
-              Action: "logs:CreateLogGroup"
+            - Effect: Deny
+              Action: logs:CreateLogGroup
               Resource: "*"
         state: present
       register: result
 
     - name: Create IAM managed policy
-      assert:
+      ansible.builtin.assert:
         that:
           - result.changed
           - result.policy.policy_name == policy_name
 
     - name: Create IAM managed policy - idempotency check
-      iam_managed_policy:
+      community.aws.iam_managed_policy:
         policy_name: "{{ policy_name }}"
         policy:
           Version: "2012-10-17"
           Statement:
-            - Effect: "Deny"
-              Action: "logs:CreateLogGroup"
+            - Effect: Deny
+              Action: logs:CreateLogGroup
               Resource: "*"
         state: present
       register: result
 
     - name: Create IAM managed policy - idempotency check
-      assert:
+      ansible.builtin.assert:
         that:
           - not result.changed
 
     ## Test policy update
     - name: Update IAM managed policy - check mode
-      iam_managed_policy:
+      community.aws.iam_managed_policy:
         policy_name: "{{ policy_name }}"
         policy:
           Version: "2012-10-17"
           Statement:
-            - Effect: "Deny"
-              Action: "logs:Describe*"
+            - Effect: Deny
+              Action: logs:Describe*
               Resource: "*"
         state: present
       register: result
-      check_mode: yes
+      check_mode: true
 
     - name: Update IAM managed policy - check mode
-      assert:
+      ansible.builtin.assert:
         that:
           - result.changed
 
     - name: Update IAM managed policy
-      iam_managed_policy:
+      community.aws.iam_managed_policy:
         policy_name: "{{ policy_name }}"
         policy:
           Version: "2012-10-17"
           Statement:
-            - Effect: "Deny"
-              Action: "logs:Describe*"
+            - Effect: Deny
+              Action: logs:Describe*
               Resource: "*"
         state: present
       register: result
 
     - name: Update IAM managed policy
-      assert:
+      ansible.builtin.assert:
         that:
           - result.changed
           - result.policy.policy_name == policy_name
 
     - name: Update IAM managed policy - idempotency check
-      iam_managed_policy:
+      community.aws.iam_managed_policy:
         policy_name: "{{ policy_name }}"
         policy:
           Version: "2012-10-17"
           Statement:
-            - Effect: "Deny"
-              Action: "logs:Describe*"
+            - Effect: Deny
+              Action: logs:Describe*
               Resource: "*"
         state: present
       register: result
 
     - name: Update IAM managed policy - idempotency check
-      assert:
+      ansible.builtin.assert:
         that:
           - not result.changed
 
     ## Test policy deletion
     - name: Delete IAM managed policy - check mode
-      iam_managed_policy:
+      community.aws.iam_managed_policy:
         policy_name: "{{ policy_name }}"
         state: absent
       register: result
-      check_mode: yes
+      check_mode: true
 
     - name: Delete IAM managed policy - check mode
-      assert:
+      ansible.builtin.assert:
         that:
           - result.changed
 
     - name: Delete IAM managed policy
-      iam_managed_policy:
+      community.aws.iam_managed_policy:
         policy_name: "{{ policy_name }}"
         state: absent
       register: result
 
     - name: Delete IAM managed policy
-      assert:
+      ansible.builtin.assert:
         that:
           - result.changed
 
     - name: Delete IAM managed policy - idempotency check
-      iam_managed_policy:
+      community.aws.iam_managed_policy:
         policy_name: "{{ policy_name }}"
         state: absent
       register: result
 
     - name: Delete IAM managed policy - idempotency check
-      assert:
+      ansible.builtin.assert:
         that:
           - not result.changed
 
   always:
     - name: Delete IAM managed policy
-      iam_managed_policy:
+      community.aws.iam_managed_policy:
         policy_name: "{{ policy_name }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/iam_password_policy/meta/main.yml
+++ b/tests/integration/targets/iam_password_policy/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/iam_password_policy/tasks/main.yaml
+++ b/tests/integration/targets/iam_password_policy/tasks/main.yaml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -7,101 +8,101 @@
   collections:
     - amazon.aws
   block:
-  - name: set iam password policy
-    iam_password_policy:
-      state: present
-      min_pw_length: 8
-      require_symbols: false
-      require_numbers: true
-      require_uppercase: true
-      require_lowercase: true
-      allow_pw_change: true
-      pw_max_age: 60
-      pw_reuse_prevent: 5
-      pw_expire: false
-    register: result
+    - name: set iam password policy
+      community.aws.iam_password_policy:
+        state: present
+        min_pw_length: 8
+        require_symbols: false
+        require_numbers: true
+        require_uppercase: true
+        require_lowercase: true
+        allow_pw_change: true
+        pw_max_age: 60
+        pw_reuse_prevent: 5
+        pw_expire: false
+      register: result
 
-  - name: assert that changes were made
-    assert:
-      that:
-        - result.changed
+    - name: assert that changes were made
+      ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: verify iam password policy has been created
-    iam_password_policy:
-      state: present
-      min_pw_length: 8
-      require_symbols: false
-      require_numbers: true
-      require_uppercase: true
-      require_lowercase: true
-      allow_pw_change: true
-      pw_max_age: 60
-      pw_reuse_prevent: 5
-      pw_expire: false
-    register: result
+    - name: verify iam password policy has been created
+      community.aws.iam_password_policy:
+        state: present
+        min_pw_length: 8
+        require_symbols: false
+        require_numbers: true
+        require_uppercase: true
+        require_lowercase: true
+        allow_pw_change: true
+        pw_max_age: 60
+        pw_reuse_prevent: 5
+        pw_expire: false
+      register: result
 
-  - name: assert that no changes were made
-    assert:
-      that:
-        - not result.changed
+    - name: assert that no changes were made
+      ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: update iam password policy with different settings
-    iam_password_policy:
-      state: present
-      min_pw_length: 15
-      require_symbols: true
-      require_numbers: true
-      require_uppercase: true
-      require_lowercase: true
-      allow_pw_change: true
-      pw_max_age: 30
-      pw_reuse_prevent: 10
-      pw_expire: true
-    register: result
+    - name: update iam password policy with different settings
+      community.aws.iam_password_policy:
+        state: present
+        min_pw_length: 15
+        require_symbols: true
+        require_numbers: true
+        require_uppercase: true
+        require_lowercase: true
+        allow_pw_change: true
+        pw_max_age: 30
+        pw_reuse_prevent: 10
+        pw_expire: true
+      register: result
 
-  - name: assert that updates were made
-    assert:
-      that:
-        - result.changed
+    - name: assert that updates were made
+      ansible.builtin.assert:
+        that:
+          - result.changed
 
-  # Test for regression of #59102
-  - name: update iam password policy without expiry
-    iam_password_policy:
-      state: present
-      min_pw_length: 15
-      require_symbols: true
-      require_numbers: true
-      require_uppercase: true
-      require_lowercase: true
-      allow_pw_change: true
-    register: result
+    # Test for regression of #59102
+    - name: update iam password policy without expiry
+      community.aws.iam_password_policy:
+        state: present
+        min_pw_length: 15
+        require_symbols: true
+        require_numbers: true
+        require_uppercase: true
+        require_lowercase: true
+        allow_pw_change: true
+      register: result
 
-  - name: assert that changes were made
-    assert:
-      that:
-        - result.changed
+    - name: assert that changes were made
+      ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: remove iam password policy
-    iam_password_policy:
-      state: absent
-    register: result
+    - name: remove iam password policy
+      community.aws.iam_password_policy:
+        state: absent
+      register: result
 
-  - name: assert password policy has been removed
-    assert:
-      that:
-        - result.changed
+    - name: assert password policy has been removed
+      ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: verify password policy has been removed
-    iam_password_policy:
-      state: absent
-    register: result
+    - name: verify password policy has been removed
+      community.aws.iam_password_policy:
+        state: absent
+      register: result
 
-  - name: assert no changes were made
-    assert:
-      that:
-        - not result.changed
+    - name: assert no changes were made
+      ansible.builtin.assert:
+        that:
+          - not result.changed
   always:
-  - name: remove iam password policy
-    iam_password_policy:
-      state: absent
-    register: result
+    - name: remove iam password policy
+      community.aws.iam_password_policy:
+        state: absent
+      register: result

--- a/tests/integration/targets/iam_policy/defaults/main.yml
+++ b/tests/integration/targets/iam_policy/defaults/main.yml
@@ -1,5 +1,6 @@
-iam_name: '{{resource_prefix}}'
-iam_policy_name_a: '{{resource_prefix}}-document-a'
-iam_policy_name_b: '{{resource_prefix}}-document-b'
-iam_policy_name_c: '{{resource_prefix}}-json-a'
-iam_policy_name_d: '{{resource_prefix}}-json-b'
+---
+iam_name: "{{resource_prefix}}"
+iam_policy_name_a: "{{resource_prefix}}-document-a"
+iam_policy_name_b: "{{resource_prefix}}-document-b"
+iam_policy_name_c: "{{resource_prefix}}-json-a"
+iam_policy_name_d: "{{resource_prefix}}-json-b"

--- a/tests/integration/targets/iam_policy/meta/main.yml
+++ b/tests/integration/targets/iam_policy/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/iam_policy/tasks/main.yml
+++ b/tests/integration/targets/iam_policy/tasks/main.yml
@@ -1,70 +1,71 @@
+---
 - name: Run integration tests for IAM (inline) Policy management
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
     # ============================================================
-  - name: Create user for tests
-    iam_user:
-      state: present
-      name: '{{ iam_name }}'
-    register: result
-  - name: Ensure user was created
-    assert:
-      that:
-      - result is changed
+    - name: Create user for tests
+      amazon.aws.iam_user:
+        state: present
+        name: "{{ iam_name }}"
+      register: result
+    - name: Ensure user was created
+      ansible.builtin.assert:
+        that:
+          - result is changed
 
-  - name: Create role for tests
-    iam_role:
-      state: present
-      name: '{{ iam_name }}'
-      assume_role_policy_document: "{{ lookup('file','no_trust.json') }}"
-    register: result
-  - name: Ensure role was created
-    assert:
-      that:
-      - result is changed
+    - name: Create role for tests
+      community.aws.iam_role:
+        state: present
+        name: "{{ iam_name }}"
+        assume_role_policy_document: "{{ lookup('file','no_trust.json') }}"
+      register: result
+    - name: Ensure role was created
+      ansible.builtin.assert:
+        that:
+          - result is changed
 
-  - name: Create group for tests
-    iam_group:
-      state: present
-      name: '{{ iam_name }}'
-    register: result
-  - name: Ensure group was created
-    assert:
-      that:
-      - result is changed
-
-    # ============================================================
-
-  - name: Run tests for each type of object
-    include_tasks: object.yml
-    loop_control:
-      loop_var: iam_type
-    with_items:
-    - user
-    - group
-    - role
+    - name: Create group for tests
+      community.aws.iam_group:
+        state: present
+        name: "{{ iam_name }}"
+      register: result
+    - name: Ensure group was created
+      ansible.builtin.assert:
+        that:
+          - result is changed
 
     # ============================================================
+
+    - name: Run tests for each type of object
+      ansible.builtin.include_tasks: object.yml
+      loop_control:
+        loop_var: iam_type
+      with_items:
+        - user
+        - group
+        - role
+
+  # ============================================================
 
   always:
     # ============================================================
-  - name: Remove user
-    iam_user:
-      state: absent
-      name: '{{ iam_name }}'
-    ignore_errors: yes
-  - name: Remove role
-    iam_role:
-      state: absent
-      name: '{{ iam_name }}'
-    ignore_errors: yes
-  - name: Remove group
-    iam_group:
-      state: absent
-      name: '{{ iam_name }}'
-    ignore_errors: yes
+    - name: Remove user
+      amazon.aws.iam_user:
+        state: absent
+        name: "{{ iam_name }}"
+      ignore_errors: true
+    - name: Remove role
+      community.aws.iam_role:
+        state: absent
+        name: "{{ iam_name }}"
+      ignore_errors: true
+    - name: Remove group
+      community.aws.iam_group:
+        state: absent
+        name: "{{ iam_name }}"
+      ignore_errors: true

--- a/tests/integration/targets/iam_policy/tasks/object.yml
+++ b/tests/integration/targets/iam_policy/tasks/object.yml
@@ -1,1169 +1,1154 @@
+---
 - name: Run integration tests for IAM (inline) Policy management on {{ iam_type }}s
   vars:
-    iam_object_key: '{{ iam_type }}_name'
+    iam_object_key: "{{ iam_type }}_name"
   block:
   # ============================================================
-  - name: Fetch policies from {{ iam_type }} before making changes
-    iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-    register: iam_policy_info
-  - name: Assert empty policy list
-    assert:
-      that:
-      - iam_policy_info is succeeded
-      - iam_policy_info.policies | length == 0
-      - iam_policy_info.all_policy_names | length == 0
-      - iam_policy_info.policy_names | length == 0
+    - name: Fetch policies from {{ iam_type }} before making changes
+      amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+      register: iam_policy_info
+    - name: Assert empty policy list
+      ansible.builtin.assert:
+        that:
+          - iam_policy_info is succeeded
+          - iam_policy_info.policies | length == 0
+          - iam_policy_info.all_policy_names | length == 0
+          - iam_policy_info.policy_names | length == 0
 
-  - name: Fetch policies from non-existent {{ iam_type }}
-    iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}-junk'
-    register: iam_policy_info
-  - name: Assert not failed
-    assert:
-      that:
-      - iam_policy_info is succeeded
+    - name: Fetch policies from non-existent {{ iam_type }}
+      amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}-junk"
+      register: iam_policy_info
+    - name: Assert not failed
+      ansible.builtin.assert:
+        that:
+          - iam_policy_info is succeeded
 
-  # ============================================================
-  - name: Invalid creation of policy for {{ iam_type }} - missing required parameters
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-      skip_duplicates: yes
-    register: result
-    ignore_errors: yes
-  - name: Assert task failed with correct error message
-    assert:
-      that:
-      - result.failed
-      - "'state is present but any of the following are missing: policy_json' in result.msg"
+    # ============================================================
+    - name: Invalid creation of policy for {{ iam_type }} - missing required parameters
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+        skip_duplicates: true
+      register: result
+      ignore_errors: true
+    - name: Assert task failed with correct error message
+      ansible.builtin.assert:
+        that:
+          - result.failed
+          - "'state is present but any of the following are missing: policy_json' in result.msg"
 
-  - name: Create policy using document for {{ iam_type }} (check mode)
-    check_mode: yes
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-      skip_duplicates: yes
-    register: result
-  - name: Assert policy would be added for {{ iam_type }}
-    assert:
-      that:
-      - result is changed
+    - name: Create policy using document for {{ iam_type }} (check mode)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+        skip_duplicates: true
+      register: result
+    - name: Assert policy would be added for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is changed
 
-  - name: Create policy using document for {{ iam_type }}
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-      skip_duplicates: yes
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-    register: iam_policy_info
-  - name: Assert policy was added for {{ iam_type }}
-    assert:
-      that:
-      - result is changed
-      - result.policies | length == 1
-      - iam_policy_name_a in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_name_a in iam_policy_info.policy_names
-      - iam_policy_info.policy_names | length == 1
-      - iam_policy_info.policies | length == 1
-      - iam_policy_name_a in iam_policy_info.all_policy_names
-      - iam_policy_info.all_policy_names | length == 1
-      - iam_policy_info.policies[0].policy_name == iam_policy_name_a
-      - '"Id" not in iam_policy_info.policies[0].policy_document'
+    - name: Create policy using document for {{ iam_type }}
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+        skip_duplicates: true
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+      register: iam_policy_info
+    - name: Assert policy was added for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.policies | length == 1
+          - iam_policy_name_a in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_name_a in iam_policy_info.policy_names
+          - iam_policy_info.policy_names | length == 1
+          - iam_policy_info.policies | length == 1
+          - iam_policy_name_a in iam_policy_info.all_policy_names
+          - iam_policy_info.all_policy_names | length == 1
+          - iam_policy_info.policies[0].policy_name == iam_policy_name_a
+          - '"Id" not in iam_policy_info.policies[0].policy_document'
 
-  - name: Create policy using document for {{ iam_type }} (idempotency - check mode)
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-      skip_duplicates: yes
-    register: result
-    check_mode: yes
-  - name: Assert no change would occur
-    assert:
-      that:
-      - result is not changed
+    - name: Create policy using document for {{ iam_type }} (idempotency - check mode)
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+        skip_duplicates: true
+      register: result
+      check_mode: true
+    - name: Assert no change would occur
+      ansible.builtin.assert:
+        that:
+          - result is not changed
 
-  - name: Create policy using document for {{ iam_type }} (idempotency)
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-      skip_duplicates: yes
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-    register: iam_policy_info
-  - name: Assert no change
-    assert:
-      that:
-      - result is not changed
-      - result.policies | length == 1
-      - iam_policy_name_a in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_info.policies | length == 1
-      - iam_policy_info.all_policy_names | length == 1
-      - iam_policy_name_a in iam_policy_info.all_policy_names
-      - iam_policy_info.policies[0].policy_name == iam_policy_name_a
-      - '"Id" not in iam_policy_info.policies[0].policy_document'
+    - name: Create policy using document for {{ iam_type }} (idempotency)
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+        skip_duplicates: true
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+      register: iam_policy_info
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.policies | length == 1
+          - iam_policy_name_a in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_info.policies | length == 1
+          - iam_policy_info.all_policy_names | length == 1
+          - iam_policy_name_a in iam_policy_info.all_policy_names
+          - iam_policy_info.policies[0].policy_name == iam_policy_name_a
+          - '"Id" not in iam_policy_info.policies[0].policy_document'
 
-  # ============================================================
-  - name: Create policy using document for {{ iam_type }} (check mode) (skip_duplicates)
-    check_mode: yes
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-      skip_duplicates: yes
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-    register: iam_policy_info
-  - name: Assert policy would be added for {{ iam_type }}
-    assert:
-      that:
-      - result is not changed
-      - iam_policy_info.all_policy_names | length == 1
-      - '"policies" not in iam_policy_info'
-      - iam_policy_name_b not in iam_policy_info.all_policy_names
+    # ============================================================
+    - name: Create policy using document for {{ iam_type }} (check mode) (skip_duplicates)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+        skip_duplicates: true
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+      register: iam_policy_info
+    - name: Assert policy would be added for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - iam_policy_info.all_policy_names | length == 1
+          - '"policies" not in iam_policy_info'
+          - iam_policy_name_b not in iam_policy_info.all_policy_names
 
-  - name: Create policy using document for {{ iam_type }} (skip_duplicates)
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-      skip_duplicates: yes
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-    register: iam_policy_info
-  - name: Assert policy was not added for {{ iam_type }} (skip_duplicates)
-    assert:
-      that:
-      - result is not changed
-      - result.policies | length == 1
-      - iam_policy_name_b not in result.policies
-      - result[iam_object_key] == iam_name
-      - '"policies" not in iam_policy_info'
-      - '"policy_names" not in iam_policy_info'
-      - iam_policy_info.all_policy_names | length == 1
-      - iam_policy_name_b not in iam_policy_info.all_policy_names
+    - name: Create policy using document for {{ iam_type }} (skip_duplicates)
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+        skip_duplicates: true
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+      register: iam_policy_info
+    - name: Assert policy was not added for {{ iam_type }} (skip_duplicates)
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.policies | length == 1
+          - iam_policy_name_b not in result.policies
+          - result[iam_object_key] == iam_name
+          - '"policies" not in iam_policy_info'
+          - '"policy_names" not in iam_policy_info'
+          - iam_policy_info.all_policy_names | length == 1
+          - iam_policy_name_b not in iam_policy_info.all_policy_names
 
-  - name: Create policy using document for {{ iam_type }} (check mode) (skip_duplicates
-      = no)
-    check_mode: yes
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-      skip_duplicates: no
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-    register: iam_policy_info
-  - name: Assert policy would be added for {{ iam_type }}
-    assert:
-      that:
-      - result.changed == True
-      - '"policies" not in iam_policy_info'
-      - iam_policy_info.all_policy_names | length == 1
-      - iam_policy_name_a in iam_policy_info.all_policy_names
-      - iam_policy_name_b not in iam_policy_info.all_policy_names
+    - name: Create policy using document for {{ iam_type }} (check mode) (skip_duplicates = no)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+        skip_duplicates: false
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+      register: iam_policy_info
+    - name: Assert policy would be added for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result.changed == True
+          - '"policies" not in iam_policy_info'
+          - iam_policy_info.all_policy_names | length == 1
+          - iam_policy_name_a in iam_policy_info.all_policy_names
+          - iam_policy_name_b not in iam_policy_info.all_policy_names
 
-  - name: Create policy using document for {{ iam_type }} (skip_duplicates = no)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-    register: iam_policy_info
-  - name: Assert policy was added for {{ iam_type }}
-    assert:
-      that:
-      - result is changed
-      - result.policies | length == 2
-      - iam_policy_name_b in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_info.policies | length == 1
-      - iam_policy_info.all_policy_names | length == 2
-      - iam_policy_name_a in iam_policy_info.all_policy_names
-      - iam_policy_name_b in iam_policy_info.all_policy_names
-      - iam_policy_info.policies[0].policy_name == iam_policy_name_b
-      - '"Id" not in iam_policy_info.policies[0].policy_document'
+    - name: Create policy using document for {{ iam_type }} (skip_duplicates = no)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+      register: iam_policy_info
+    - name: Assert policy was added for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.policies | length == 2
+          - iam_policy_name_b in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_info.policies | length == 1
+          - iam_policy_info.all_policy_names | length == 2
+          - iam_policy_name_a in iam_policy_info.all_policy_names
+          - iam_policy_name_b in iam_policy_info.all_policy_names
+          - iam_policy_info.policies[0].policy_name == iam_policy_name_b
+          - '"Id" not in iam_policy_info.policies[0].policy_document'
 
-  - name: Create policy using document for {{ iam_type }} (idempotency - check mode)
-      (skip_duplicates = no)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-    register: result
-    check_mode: yes
-  - name: Assert no change would occur
-    assert:
-      that:
-      - result is not changed
+    - name: Create policy using document for {{ iam_type }} (idempotency - check mode) (skip_duplicates = no)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+      register: result
+      check_mode: true
+    - name: Assert no change would occur
+      ansible.builtin.assert:
+        that:
+          - result is not changed
 
-  - name: Create policy using document for {{ iam_type }} (idempotency) (skip_duplicates
-      = no)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-    register: iam_policy_info
-  - name: Assert no change
-    assert:
-      that:
-      - result is not changed
-      - result.policies | length == 2
-      - iam_policy_name_b in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_info.policies | length == 1
-      - iam_policy_name_a in iam_policy_info.all_policy_names
-      - iam_policy_name_b in iam_policy_info.all_policy_names
-      - iam_policy_info.all_policy_names | length == 2
-      - iam_policy_info.policies[0].policy_name == iam_policy_name_b
-      - '"Id" not in iam_policy_info.policies[0].policy_document'
+    - name: Create policy using document for {{ iam_type }} (idempotency) (skip_duplicates = no)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+      register: iam_policy_info
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.policies | length == 2
+          - iam_policy_name_b in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_info.policies | length == 1
+          - iam_policy_name_a in iam_policy_info.all_policy_names
+          - iam_policy_name_b in iam_policy_info.all_policy_names
+          - iam_policy_info.all_policy_names | length == 2
+          - iam_policy_info.policies[0].policy_name == iam_policy_name_b
+          - '"Id" not in iam_policy_info.policies[0].policy_document'
 
-  # ============================================================
-  - name: Create policy using json for {{ iam_type }} (check mode)
-    check_mode: yes
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-      skip_duplicates: yes
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-    register: iam_policy_info
-  - name: Assert policy would be added for {{ iam_type }}
-    assert:
-      that:
-      - result is changed
-      - '"policies" not in iam_policy_info'
-      - iam_policy_info.all_policy_names | length == 2
-      - iam_policy_name_c not in iam_policy_info.all_policy_names
-      - iam_policy_name_a in iam_policy_info.all_policy_names
-      - iam_policy_name_b in iam_policy_info.all_policy_names
+    # ============================================================
+    - name: Create policy using json for {{ iam_type }} (check mode)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+        skip_duplicates: true
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+      register: iam_policy_info
+    - name: Assert policy would be added for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - '"policies" not in iam_policy_info'
+          - iam_policy_info.all_policy_names | length == 2
+          - iam_policy_name_c not in iam_policy_info.all_policy_names
+          - iam_policy_name_a in iam_policy_info.all_policy_names
+          - iam_policy_name_b in iam_policy_info.all_policy_names
 
-  - name: Create policy using json for {{ iam_type }}
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-      skip_duplicates: yes
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-    register: iam_policy_info
-  - name: Assert policy was added for {{ iam_type }}
-    assert:
-      that:
-      - result is changed
-      - result.policies | length == 3
-      - iam_policy_name_c in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_info.policies | length == 1
-      - iam_policy_name_a in iam_policy_info.all_policy_names
-      - iam_policy_name_b in iam_policy_info.all_policy_names
-      - iam_policy_name_c in iam_policy_info.all_policy_names
-      - iam_policy_info.all_policy_names | length == 3
-      - iam_policy_info.policies[0].policy_name == iam_policy_name_c
-      - iam_policy_info.policies[0].policy_document.Id == 'MyId'
+    - name: Create policy using json for {{ iam_type }}
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+        skip_duplicates: true
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+      register: iam_policy_info
+    - name: Assert policy was added for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.policies | length == 3
+          - iam_policy_name_c in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_info.policies | length == 1
+          - iam_policy_name_a in iam_policy_info.all_policy_names
+          - iam_policy_name_b in iam_policy_info.all_policy_names
+          - iam_policy_name_c in iam_policy_info.all_policy_names
+          - iam_policy_info.all_policy_names | length == 3
+          - iam_policy_info.policies[0].policy_name == iam_policy_name_c
+          - iam_policy_info.policies[0].policy_document.Id == 'MyId'
 
-  - name: Create policy using json for {{ iam_type }} (idempotency - check mode)
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-      skip_duplicates: yes
-    register: result
-    check_mode: yes
-  - name: Assert no change would occur
-    assert:
-      that:
-      - result is not changed
+    - name: Create policy using json for {{ iam_type }} (idempotency - check mode)
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+        skip_duplicates: true
+      register: result
+      check_mode: true
+    - name: Assert no change would occur
+      ansible.builtin.assert:
+        that:
+          - result is not changed
 
-  - name: Create policy using json for {{ iam_type }} (idempotency)
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-      skip_duplicates: yes
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-    register: iam_policy_info
-  - name: Assert no change
-    assert:
-      that:
-      - result is not changed
-      - result.policies | length == 3
-      - iam_policy_name_c in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_name_a in iam_policy_info.all_policy_names
-      - iam_policy_name_b in iam_policy_info.all_policy_names
-      - iam_policy_name_c in iam_policy_info.all_policy_names
-      - iam_policy_info.all_policy_names | length == 3
-      - iam_policy_info.policies[0].policy_name == iam_policy_name_c
-      - iam_policy_info.policies[0].policy_document.Id == 'MyId'
+    - name: Create policy using json for {{ iam_type }} (idempotency)
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+        skip_duplicates: true
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+      register: iam_policy_info
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.policies | length == 3
+          - iam_policy_name_c in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_name_a in iam_policy_info.all_policy_names
+          - iam_policy_name_b in iam_policy_info.all_policy_names
+          - iam_policy_name_c in iam_policy_info.all_policy_names
+          - iam_policy_info.all_policy_names | length == 3
+          - iam_policy_info.policies[0].policy_name == iam_policy_name_c
+          - iam_policy_info.policies[0].policy_document.Id == 'MyId'
 
-  # ============================================================
-  - name: Create policy using json for {{ iam_type }} (check mode) (skip_duplicates)
-    check_mode: yes
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-      skip_duplicates: yes
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: iam_policy_info
-  - name: Assert policy would not be added for {{ iam_type }}
-    assert:
-      that:
-      - result is not changed
-      - iam_policy_name_a in iam_policy_info.all_policy_names
-      - iam_policy_name_b in iam_policy_info.all_policy_names
-      - iam_policy_name_c in iam_policy_info.all_policy_names
-      - iam_policy_name_d not in iam_policy_info.all_policy_names
-      - iam_policy_info.all_policy_names | length == 3
-      - '"policies" not in iam_policy_info'
+    # ============================================================
+    - name: Create policy using json for {{ iam_type }} (check mode) (skip_duplicates)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+        skip_duplicates: true
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: iam_policy_info
+    - name: Assert policy would not be added for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - iam_policy_name_a in iam_policy_info.all_policy_names
+          - iam_policy_name_b in iam_policy_info.all_policy_names
+          - iam_policy_name_c in iam_policy_info.all_policy_names
+          - iam_policy_name_d not in iam_policy_info.all_policy_names
+          - iam_policy_info.all_policy_names | length == 3
+          - '"policies" not in iam_policy_info'
 
-  - name: Create policy using json for {{ iam_type }} (skip_duplicates)
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-      skip_duplicates: yes
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: iam_policy_info
-  - name: Assert policy was not added for {{ iam_type }} (skip_duplicates)
-    assert:
-      that:
-      - result is not changed
-      - result.policies | length == 3
-      - iam_policy_name_d not in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_name_a in iam_policy_info.all_policy_names
-      - iam_policy_name_b in iam_policy_info.all_policy_names
-      - iam_policy_name_c in iam_policy_info.all_policy_names
-      - iam_policy_name_d not in iam_policy_info.all_policy_names
-      - iam_policy_info.all_policy_names | length == 3
-      - '"policies" not in iam_policy_info'
+    - name: Create policy using json for {{ iam_type }} (skip_duplicates)
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+        skip_duplicates: true
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: iam_policy_info
+    - name: Assert policy was not added for {{ iam_type }} (skip_duplicates)
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.policies | length == 3
+          - iam_policy_name_d not in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_name_a in iam_policy_info.all_policy_names
+          - iam_policy_name_b in iam_policy_info.all_policy_names
+          - iam_policy_name_c in iam_policy_info.all_policy_names
+          - iam_policy_name_d not in iam_policy_info.all_policy_names
+          - iam_policy_info.all_policy_names | length == 3
+          - '"policies" not in iam_policy_info'
 
-  - name: Create policy using json for {{ iam_type }} (check mode) (skip_duplicates
-      = no)
-    check_mode: yes
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-      skip_duplicates: no
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: iam_policy_info
-  - name: Assert policy would be added for {{ iam_type }}
-    assert:
-      that:
-      - result.changed == True
+    - name: Create policy using json for {{ iam_type }} (check mode) (skip_duplicates = no)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+        skip_duplicates: false
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: iam_policy_info
+    - name: Assert policy would be added for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result.changed == True
 
-  - name: Create policy using json for {{ iam_type }} (skip_duplicates = no)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: iam_policy_info
-  - name: Assert policy was added for {{ iam_type }}
-    assert:
-      that:
-      - result is changed
-      - result.policies | length == 4
-      - iam_policy_name_d in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_name_a in iam_policy_info.all_policy_names
-      - iam_policy_name_b in iam_policy_info.all_policy_names
-      - iam_policy_name_c in iam_policy_info.all_policy_names
-      - iam_policy_name_d in iam_policy_info.all_policy_names
-      - iam_policy_name_a not in iam_policy_info.policy_names
-      - iam_policy_name_b not in iam_policy_info.policy_names
-      - iam_policy_name_c not in iam_policy_info.policy_names
-      - iam_policy_name_d in iam_policy_info.policy_names
-      - iam_policy_info.policy_names | length == 1
-      - iam_policy_info.all_policy_names | length == 4
-      - iam_policy_info.policies[0].policy_name == iam_policy_name_d
-      - iam_policy_info.policies[0].policy_document.Id == 'MyId'
+    - name: Create policy using json for {{ iam_type }} (skip_duplicates = no)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: iam_policy_info
+    - name: Assert policy was added for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.policies | length == 4
+          - iam_policy_name_d in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_name_a in iam_policy_info.all_policy_names
+          - iam_policy_name_b in iam_policy_info.all_policy_names
+          - iam_policy_name_c in iam_policy_info.all_policy_names
+          - iam_policy_name_d in iam_policy_info.all_policy_names
+          - iam_policy_name_a not in iam_policy_info.policy_names
+          - iam_policy_name_b not in iam_policy_info.policy_names
+          - iam_policy_name_c not in iam_policy_info.policy_names
+          - iam_policy_name_d in iam_policy_info.policy_names
+          - iam_policy_info.policy_names | length == 1
+          - iam_policy_info.all_policy_names | length == 4
+          - iam_policy_info.policies[0].policy_name == iam_policy_name_d
+          - iam_policy_info.policies[0].policy_document.Id == 'MyId'
 
-  - name: Create policy using json for {{ iam_type }} (idempotency - check mode) (skip_duplicates
-      = no)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-    register: result
-    check_mode: yes
-  - name: Assert no change would occur
-    assert:
-      that:
-      - result is not changed
+    - name: Create policy using json for {{ iam_type }} (idempotency - check mode) (skip_duplicates = no)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+      register: result
+      check_mode: true
+    - name: Assert no change would occur
+      ansible.builtin.assert:
+        that:
+          - result is not changed
 
-  - name: Create policy using json for {{ iam_type }} (idempotency) (skip_duplicates
-      = no)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: iam_policy_info
-  - name: Assert no change
-    assert:
-      that:
-      - result is not changed
-      - result.policies | length == 4
-      - iam_policy_name_d in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_name_a in iam_policy_info.all_policy_names
-      - iam_policy_name_b in iam_policy_info.all_policy_names
-      - iam_policy_name_c in iam_policy_info.all_policy_names
-      - iam_policy_name_d in iam_policy_info.all_policy_names
-      - iam_policy_info.all_policy_names | length == 4
-      - iam_policy_info.policies[0].policy_name == iam_policy_name_d
-      - iam_policy_info.policies[0].policy_document.Id == 'MyId'
+    - name: Create policy using json for {{ iam_type }} (idempotency) (skip_duplicates = no)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: iam_policy_info
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.policies | length == 4
+          - iam_policy_name_d in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_name_a in iam_policy_info.all_policy_names
+          - iam_policy_name_b in iam_policy_info.all_policy_names
+          - iam_policy_name_c in iam_policy_info.all_policy_names
+          - iam_policy_name_d in iam_policy_info.all_policy_names
+          - iam_policy_info.all_policy_names | length == 4
+          - iam_policy_info.policies[0].policy_name == iam_policy_name_d
+          - iam_policy_info.policies[0].policy_document.Id == 'MyId'
 
-  # ============================================================
-  - name: Test fetching multiple policies from {{ iam_type }}
-    iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-    register: iam_policy_info
-  - name: Assert all policies returned
-    assert:
-      that:
-      - iam_policy_info is succeeded
-      - iam_policy_info.policies | length == 4
-      - iam_policy_info.all_policy_names | length == 4
-      - iam_policy_name_a in iam_policy_info.all_policy_names
-      - iam_policy_name_b in iam_policy_info.all_policy_names
-      - iam_policy_name_c in iam_policy_info.all_policy_names
-      - iam_policy_name_d in iam_policy_info.all_policy_names
-      # Quick test that the policies are the ones we expect
-      - iam_policy_info.policies | community.general.json_query('[*].policy_name')
-        | length == 4
-      - iam_policy_info.policies | community.general.json_query('[?policy_document.Id
-        == `MyId`].policy_name') | length == 2
-      - iam_policy_name_c in (iam_policy_info.policies | community.general.json_query('[?policy_document.Id
-        == `MyId`].policy_name') | list)
-      - iam_policy_name_d in (iam_policy_info.policies | community.general.json_query('[?policy_document.Id
-        == `MyId`].policy_name') | list)
+    # ============================================================
+    - name: Test fetching multiple policies from {{ iam_type }}
+      amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+      register: iam_policy_info
+    - name: Assert all policies returned
+      ansible.builtin.assert:
+        that:
+          - iam_policy_info is succeeded
+          - iam_policy_info.policies | length == 4
+          - iam_policy_info.all_policy_names | length == 4
+          - iam_policy_name_a in iam_policy_info.all_policy_names
+          - iam_policy_name_b in iam_policy_info.all_policy_names
+          - iam_policy_name_c in iam_policy_info.all_policy_names
+          - iam_policy_name_d in iam_policy_info.all_policy_names
+          # Quick test that the policies are the ones we expect
+          - iam_policy_info.policies | community.general.json_query('[*].policy_name') | length == 4
+          - iam_policy_info.policies | community.general.json_query('[?policy_document.Id == `MyId`].policy_name') | length == 2
+          - iam_policy_name_c in (iam_policy_info.policies | community.general.json_query('[?policy_document.Id == `MyId`].policy_name') | list)
+          - iam_policy_name_d in (iam_policy_info.policies | community.general.json_query('[?policy_document.Id == `MyId`].policy_name') | list)
 
-  # ============================================================
-  - name: Update policy using document for {{ iam_type }} (check mode) (skip_duplicates)
-    check_mode: yes
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-      skip_duplicates: yes
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-    register: iam_policy_info
-  - name: Assert policy would not be added for {{ iam_type }}
-    assert:
-      that:
-      - result is not changed
-      - iam_policy_info.policies[0].policy_name == iam_policy_name_a
-      - '"Id" not in iam_policy_info.policies[0].policy_document'
+    # ============================================================
+    - name: Update policy using document for {{ iam_type }} (check mode) (skip_duplicates)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+        skip_duplicates: true
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+      register: iam_policy_info
+    - name: Assert policy would not be added for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - iam_policy_info.policies[0].policy_name == iam_policy_name_a
+          - '"Id" not in iam_policy_info.policies[0].policy_document'
 
-  - name: Update policy using document for {{ iam_type }} (skip_duplicates)
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-      skip_duplicates: yes
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-    register: iam_policy_info
-  - name: Assert policy was not updated for {{ iam_type }} (skip_duplicates)
-    assert:
-      that:
-      - result is not changed
-      - result.policies | length == 4
-      - iam_policy_name_a in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_info.all_policy_names | length == 4
-      - iam_policy_info.policies[0].policy_name == iam_policy_name_a
-      - '"Id" not in iam_policy_info.policies[0].policy_document'
+    - name: Update policy using document for {{ iam_type }} (skip_duplicates)
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+        skip_duplicates: true
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+      register: iam_policy_info
+    - name: Assert policy was not updated for {{ iam_type }} (skip_duplicates)
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.policies | length == 4
+          - iam_policy_name_a in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_info.all_policy_names | length == 4
+          - iam_policy_info.policies[0].policy_name == iam_policy_name_a
+          - '"Id" not in iam_policy_info.policies[0].policy_document'
 
-  - name: Update policy using document for {{ iam_type }} (check mode) (skip_duplicates
-      = no)
-    check_mode: yes
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-      skip_duplicates: no
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-    register: iam_policy_info
-  - name: Assert policy would be updated for {{ iam_type }}
-    assert:
-      that:
-      - result.changed == True
-      - iam_policy_info.all_policy_names | length == 4
-      - iam_policy_info.policies[0].policy_name == iam_policy_name_a
-      - '"Id" not in iam_policy_info.policies[0].policy_document'
+    - name: Update policy using document for {{ iam_type }} (check mode) (skip_duplicates = no)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+        skip_duplicates: false
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+      register: iam_policy_info
+    - name: Assert policy would be updated for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result.changed == True
+          - iam_policy_info.all_policy_names | length == 4
+          - iam_policy_info.policies[0].policy_name == iam_policy_name_a
+          - '"Id" not in iam_policy_info.policies[0].policy_document'
 
-  - name: Update policy using document for {{ iam_type }} (skip_duplicates = no)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-    register: iam_policy_info
-  - name: Assert policy was updated for {{ iam_type }}
-    assert:
-      that:
-      - result is changed
-      - result.policies | length == 4
-      - iam_policy_name_a in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_info.policies[0].policy_document.Id == 'MyId'
+    - name: Update policy using document for {{ iam_type }} (skip_duplicates = no)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+      register: iam_policy_info
+    - name: Assert policy was updated for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.policies | length == 4
+          - iam_policy_name_a in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_info.policies[0].policy_document.Id == 'MyId'
 
-  - name: Update policy using document for {{ iam_type }} (idempotency - check mode)
-      (skip_duplicates = no)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-    register: result
-    check_mode: yes
-  - name: Assert no change would occur
-    assert:
-      that:
-      - result is not changed
+    - name: Update policy using document for {{ iam_type }} (idempotency - check mode) (skip_duplicates = no)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+      register: result
+      check_mode: true
+    - name: Assert no change would occur
+      ansible.builtin.assert:
+        that:
+          - result is not changed
 
-  - name: Update policy using document for {{ iam_type }} (idempotency) (skip_duplicates
-      = no)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-      policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-    register: iam_policy_info
-  - name: Assert no change
-    assert:
-      that:
-      - result is not changed
-      - result.policies | length == 4
-      - iam_policy_name_a in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_info.policies[0].policy_document.Id == 'MyId'
+    - name: Update policy using document for {{ iam_type }} (idempotency) (skip_duplicates = no)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+        policy_json: '{{ lookup("file", "no_access_with_id.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+      register: iam_policy_info
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.policies | length == 4
+          - iam_policy_name_a in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_info.policies[0].policy_document.Id == 'MyId'
 
-  - name: Delete policy A
-    iam_policy:
-      state: absent
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-    register: iam_policy_info
-  - name: Assert deleted
-    assert:
-      that:
-      - result is changed
-      - result.policies | length == 3
-      - iam_policy_name_a not in result.policies
-      - result[iam_object_key] == iam_name
-      - '"policies" not in iam_policy_info'
-      - iam_policy_info.all_policy_names | length == 3
-      - iam_policy_name_a not in iam_policy_info.all_policy_names
+    - name: Delete policy A
+      amazon.aws.iam_policy:
+        state: absent
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+      register: iam_policy_info
+    - name: Assert deleted
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.policies | length == 3
+          - iam_policy_name_a not in result.policies
+          - result[iam_object_key] == iam_name
+          - '"policies" not in iam_policy_info'
+          - iam_policy_info.all_policy_names | length == 3
+          - iam_policy_name_a not in iam_policy_info.all_policy_names
 
-  # ============================================================
-  # Update C with no_access.json
-  # Delete C
+    # ============================================================
+    # Update C with no_access.json
+    # Delete C
 
-  - name: Update policy using json for {{ iam_type }} (check mode) (skip_duplicates)
-    check_mode: yes
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-      skip_duplicates: yes
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-    register: iam_policy_info
-  - name: Assert policy would not be added for {{ iam_type }}
-    assert:
-      that:
-      - result is not changed
-      - iam_policy_info.policies[0].policy_document.Id == 'MyId'
+    - name: Update policy using json for {{ iam_type }} (check mode) (skip_duplicates)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+        skip_duplicates: true
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+      register: iam_policy_info
+    - name: Assert policy would not be added for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - iam_policy_info.policies[0].policy_document.Id == 'MyId'
 
-  - name: Update policy using json for {{ iam_type }} (skip_duplicates)
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-      skip_duplicates: yes
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-    register: iam_policy_info
-  - name: Assert policy was not updated for {{ iam_type }} (skip_duplicates)
-    assert:
-      that:
-      - result is not changed
-      - result.policies | length == 3
-      - iam_policy_name_c in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_info.policies[0].policy_document.Id == 'MyId'
+    - name: Update policy using json for {{ iam_type }} (skip_duplicates)
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+        skip_duplicates: true
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+      register: iam_policy_info
+    - name: Assert policy was not updated for {{ iam_type }} (skip_duplicates)
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.policies | length == 3
+          - iam_policy_name_c in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_info.policies[0].policy_document.Id == 'MyId'
 
-  - name: Update policy using json for {{ iam_type }} (check mode) (skip_duplicates
-      = no)
-    check_mode: yes
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-      skip_duplicates: no
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-    register: iam_policy_info
-  - name: Assert policy would be updated for {{ iam_type }}
-    assert:
-      that:
-      - result.changed == True
-      - iam_policy_info.policies[0].policy_document.Id == 'MyId'
+    - name: Update policy using json for {{ iam_type }} (check mode) (skip_duplicates = no)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+        skip_duplicates: false
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+      register: iam_policy_info
+    - name: Assert policy would be updated for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result.changed == True
+          - iam_policy_info.policies[0].policy_document.Id == 'MyId'
 
-  - name: Update policy using json for {{ iam_type }} (skip_duplicates = no)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-    register: iam_policy_info
-  - name: Assert policy was updated for {{ iam_type }}
-    assert:
-      that:
-      - result is changed
-      - result.policies | length == 3
-      - iam_policy_name_c in result.policies
-      - result[iam_object_key] == iam_name
-      - '"Id" not in iam_policy_info.policies[0].policy_document'
+    - name: Update policy using json for {{ iam_type }} (skip_duplicates = no)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+      register: iam_policy_info
+    - name: Assert policy was updated for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.policies | length == 3
+          - iam_policy_name_c in result.policies
+          - result[iam_object_key] == iam_name
+          - '"Id" not in iam_policy_info.policies[0].policy_document'
 
-  - name: Update policy using json for {{ iam_type }} (idempotency - check mode) (skip_duplicates
-      = no)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-    register: result
-    check_mode: yes
-  - name: Assert no change would occur
-    assert:
-      that:
-      - result is not changed
+    - name: Update policy using json for {{ iam_type }} (idempotency - check mode) (skip_duplicates = no)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+      register: result
+      check_mode: true
+    - name: Assert no change would occur
+      ansible.builtin.assert:
+        that:
+          - result is not changed
 
-  - name: Update policy using json for {{ iam_type }} (idempotency) (skip_duplicates
-      = no)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-      policy_json: '{{ lookup("file", "no_access.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-    register: iam_policy_info
-  - name: Assert no change
-    assert:
-      that:
-      - result is not changed
-      - result.policies | length == 3
-      - iam_policy_name_c in result.policies
-      - result[iam_object_key] == iam_name
-      - '"Id" not in iam_policy_info.policies[0].policy_document'
+    - name: Update policy using json for {{ iam_type }} (idempotency) (skip_duplicates = no)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+        policy_json: '{{ lookup("file", "no_access.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+      register: iam_policy_info
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.policies | length == 3
+          - iam_policy_name_c in result.policies
+          - result[iam_object_key] == iam_name
+          - '"Id" not in iam_policy_info.policies[0].policy_document'
 
-  - name: Delete policy C
-    iam_policy:
-      state: absent
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-    register: iam_policy_info
-  - name: Assert deleted
-    assert:
-      that:
-      - result is changed
-      - result.policies | length == 2
-      - iam_policy_name_c not in result.policies
-      - result[iam_object_key] == iam_name
-      - '"policies" not in iam_policy_info'
-      - iam_policy_info.all_policy_names | length == 2
-      - iam_policy_name_c not in iam_policy_info.all_policy_names
+    - name: Delete policy C
+      amazon.aws.iam_policy:
+        state: absent
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+      register: iam_policy_info
+    - name: Assert deleted
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.policies | length == 2
+          - iam_policy_name_c not in result.policies
+          - result[iam_object_key] == iam_name
+          - '"policies" not in iam_policy_info'
+          - iam_policy_info.all_policy_names | length == 2
+          - iam_policy_name_c not in iam_policy_info.all_policy_names
 
-  # ============================================================
-  - name: Update policy using document for {{ iam_type }} (check mode)
-    check_mode: yes
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-      policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-    register: iam_policy_info
-  - name: Assert policy would be updated for {{ iam_type }}
-    assert:
-      that:
-      - result.changed == True
-      - '"Id" not in iam_policy_info.policies[0].policy_document'
+    # ============================================================
+    - name: Update policy using document for {{ iam_type }} (check mode)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+        policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+      register: iam_policy_info
+    - name: Assert policy would be updated for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result.changed == True
+          - '"Id" not in iam_policy_info.policies[0].policy_document'
 
-  - name: Update policy using document for {{ iam_type }}
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-      policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-    register: iam_policy_info
-  - name: Assert policy was updated for {{ iam_type }}
-    assert:
-      that:
-      - result is changed
-      - result.policies | length == 2
-      - iam_policy_name_b in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_info.policies[0].policy_document.Id == 'MyOtherId'
+    - name: Update policy using document for {{ iam_type }}
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+        policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+      register: iam_policy_info
+    - name: Assert policy was updated for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.policies | length == 2
+          - iam_policy_name_b in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_info.policies[0].policy_document.Id == 'MyOtherId'
 
-  - name: Update policy using document for {{ iam_type }} (idempotency - check mode)
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-      policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
-    register: result
-    check_mode: yes
-  - name: Assert no change would occur
-    assert:
-      that:
-      - result is not changed
+    - name: Update policy using document for {{ iam_type }} (idempotency - check mode)
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+        policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
+      register: result
+      check_mode: true
+    - name: Assert no change would occur
+      ansible.builtin.assert:
+        that:
+          - result is not changed
 
-  - name: Update policy using document for {{ iam_type }} (idempotency)
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-      policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-    register: iam_policy_info
-  - name: Assert no change
-    assert:
-      that:
-      - result is not changed
-      - result.policies | length == 2
-      - iam_policy_name_b in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_info.policies[0].policy_document.Id == 'MyOtherId'
+    - name: Update policy using document for {{ iam_type }} (idempotency)
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+        policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+      register: iam_policy_info
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.policies | length == 2
+          - iam_policy_name_b in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_info.policies[0].policy_document.Id == 'MyOtherId'
 
-  - name: Delete policy B
-    iam_policy:
-      state: absent
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-    register: iam_policy_info
-  - name: Assert deleted
-    assert:
-      that:
-      - result is changed
-      - result.policies | length == 1
-      - iam_policy_name_b not in result.policies
-      - result[iam_object_key] == iam_name
-      - '"policies" not in iam_policy_info'
-      - iam_policy_info.all_policy_names | length == 1
-      - iam_policy_name_b not in iam_policy_info.all_policy_names
+    - name: Delete policy B
+      amazon.aws.iam_policy:
+        state: absent
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+      register: iam_policy_info
+    - name: Assert deleted
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.policies | length == 1
+          - iam_policy_name_b not in result.policies
+          - result[iam_object_key] == iam_name
+          - '"policies" not in iam_policy_info'
+          - iam_policy_info.all_policy_names | length == 1
+          - iam_policy_name_b not in iam_policy_info.all_policy_names
 
-  # ============================================================
-  - name: Update policy using json for {{ iam_type }} (check mode)
-    check_mode: yes
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-      policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: iam_policy_info
-  - name: Assert policy would be updated for {{ iam_type }}
-    assert:
-      that:
-      - result.changed == True
-      - iam_policy_info.policies[0].policy_document.Id == 'MyId'
+    # ============================================================
+    - name: Update policy using json for {{ iam_type }} (check mode)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+        policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: iam_policy_info
+    - name: Assert policy would be updated for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result.changed == True
+          - iam_policy_info.policies[0].policy_document.Id == 'MyId'
 
-  - name: Update policy using json for {{ iam_type }}
-    iam_policy:
-      state: present
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-      policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: iam_policy_info
-  - name: Assert policy was updated for {{ iam_type }}
-    assert:
-      that:
-      - result is changed
-      - result.policies | length == 1
-      - iam_policy_name_d in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_info.policies[0].policy_document.Id == 'MyOtherId'
+    - name: Update policy using json for {{ iam_type }}
+      amazon.aws.iam_policy:
+        state: present
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+        policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: iam_policy_info
+    - name: Assert policy was updated for {{ iam_type }}
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.policies | length == 1
+          - iam_policy_name_d in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_info.policies[0].policy_document.Id == 'MyOtherId'
 
-  - name: Update policy using json for {{ iam_type }} (idempotency - check mode)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-      policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
-    register: result
-    check_mode: yes
-  - name: Assert no change would occur
-    assert:
-      that:
-      - result is not changed
+    - name: Update policy using json for {{ iam_type }} (idempotency - check mode)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+        policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
+      register: result
+      check_mode: true
+    - name: Assert no change would occur
+      ansible.builtin.assert:
+        that:
+          - result is not changed
 
-  - name: Update policy using json for {{ iam_type }} (idempotency)
-    iam_policy:
-      state: present
-      skip_duplicates: no
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-      policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: iam_policy_info
-  - name: Assert no change
-    assert:
-      that:
-      - result is not changed
-      - result.policies | length == 1
-      - iam_policy_name_d in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_info.policies[0].policy_document.Id == 'MyOtherId'
+    - name: Update policy using json for {{ iam_type }} (idempotency)
+      amazon.aws.iam_policy:
+        state: present
+        skip_duplicates: false
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+        policy_json: '{{ lookup("file", "no_access_with_second_id.json") }}'
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: iam_policy_info
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.policies | length == 1
+          - iam_policy_name_d in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_info.policies[0].policy_document.Id == 'MyOtherId'
 
-  # ============================================================
-  - name: Delete policy D (check_mode)
-    check_mode: yes
-    iam_policy:
-      state: absent
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: iam_policy_info
-  - name: Assert not deleted
-    assert:
-      that:
-      - result is changed
-      - result.policies | length == 1
-      - iam_policy_name_d in result.policies
-      - result[iam_object_key] == iam_name
-      - iam_policy_info.all_policy_names | length == 1
-      - iam_policy_name_d in iam_policy_info.all_policy_names
-      - iam_policy_info.policies[0].policy_document.Id == 'MyOtherId'
+    # ============================================================
+    - name: Delete policy D (check_mode)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: absent
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: iam_policy_info
+    - name: Assert not deleted
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.policies | length == 1
+          - iam_policy_name_d in result.policies
+          - result[iam_object_key] == iam_name
+          - iam_policy_info.all_policy_names | length == 1
+          - iam_policy_name_d in iam_policy_info.all_policy_names
+          - iam_policy_info.policies[0].policy_document.Id == 'MyOtherId'
 
-  - name: Delete policy D
-    iam_policy:
-      state: absent
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: iam_policy_info
-  - name: Assert deleted
-    assert:
-      that:
-      - result is changed
-      - '"policies" not in iam_policy_info'
-      - iam_policy_name_d not in result.policies
-      - result[iam_object_key] == iam_name
-      - '"policies" not in iam_policy_info'
-      - iam_policy_info.all_policy_names | length == 0
+    - name: Delete policy D
+      amazon.aws.iam_policy:
+        state: absent
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: iam_policy_info
+    - name: Assert deleted
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - '"policies" not in iam_policy_info'
+          - iam_policy_name_d not in result.policies
+          - result[iam_object_key] == iam_name
+          - '"policies" not in iam_policy_info'
+          - iam_policy_info.all_policy_names | length == 0
 
-  - name: Delete policy D (test idempotency)
-    iam_policy:
-      state: absent
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: iam_policy_info
-  - name: Assert deleted
-    assert:
-      that:
-      - result is not changed
-      - '"policies" not in iam_policy_info'
-      - iam_policy_info.all_policy_names | length == 0
+    - name: Delete policy D (test idempotency)
+      amazon.aws.iam_policy:
+        state: absent
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: iam_policy_info
+    - name: Assert deleted
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - '"policies" not in iam_policy_info'
+          - iam_policy_info.all_policy_names | length == 0
 
-  - name: Delete policy D (check_mode) (test idempotency)
-    check_mode: yes
-    iam_policy:
-      state: absent
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: result
-  - iam_policy_info:
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    register: iam_policy_info
-  - name: Assert deleted
-    assert:
-      that:
-      - result is not changed
-      - '"policies" not in iam_policy_info'
-      - iam_policy_info.all_policy_names | length == 0
+    - name: Delete policy D (check_mode) (test idempotency)
+      check_mode: true
+      amazon.aws.iam_policy:
+        state: absent
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: result
+    - amazon.aws.iam_policy_info:
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      register: iam_policy_info
+    - name: Assert deleted
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - '"policies" not in iam_policy_info'
+          - iam_policy_info.all_policy_names | length == 0
 
   always:
   # ============================================================
-  - name: Delete policy A for {{ iam_type }}
-    iam_policy:
-      state: absent
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_a }}'
-    ignore_errors: yes
-  - name: Delete policy B for {{ iam_type }}
-    iam_policy:
-      state: absent
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_b }}'
-    ignore_errors: yes
-  - name: Delete policy C for {{ iam_type }}
-    iam_policy:
-      state: absent
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_c }}'
-    ignore_errors: yes
-  - name: Delete policy D for {{ iam_type }}
-    iam_policy:
-      state: absent
-      iam_type: '{{ iam_type }}'
-      iam_name: '{{ iam_name }}'
-      policy_name: '{{ iam_policy_name_d }}'
-    ignore_errors: yes
+    - name: Delete policy A for {{ iam_type }}
+      amazon.aws.iam_policy:
+        state: absent
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_a }}"
+      ignore_errors: true
+    - name: Delete policy B for {{ iam_type }}
+      amazon.aws.iam_policy:
+        state: absent
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_b }}"
+      ignore_errors: true
+    - name: Delete policy C for {{ iam_type }}
+      amazon.aws.iam_policy:
+        state: absent
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_c }}"
+      ignore_errors: true
+    - name: Delete policy D for {{ iam_type }}
+      amazon.aws.iam_policy:
+        state: absent
+        iam_type: "{{ iam_type }}"
+        iam_name: "{{ iam_name }}"
+        policy_name: "{{ iam_policy_name_d }}"
+      ignore_errors: true

--- a/tests/integration/targets/iam_role/defaults/main.yml
+++ b/tests/integration/targets/iam_role/defaults/main.yml
@@ -1,5 +1,6 @@
-test_role: '{{ resource_prefix }}-role'
+---
+test_role: "{{ resource_prefix }}-role"
 test_path: /{{ resource_prefix }}/
 safe_managed_policy: AWSDenyAll
-custom_policy_name: '{{ resource_prefix }}-denyall'
+custom_policy_name: "{{ resource_prefix }}-denyall"
 boundary_policy: arn:aws:iam::aws:policy/AWSDenyAll

--- a/tests/integration/targets/iam_role/meta/main.yml
+++ b/tests/integration/targets/iam_role/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/iam_role/tasks/boundary_policy.yml
+++ b/tests/integration/targets/iam_role/tasks/boundary_policy.yml
@@ -1,86 +1,87 @@
+---
 - name: Create minimal role with no boundary policy
-  iam_role:
-    name: '{{ test_role }}'
-    create_instance_profile: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    create_instance_profile: false
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
 
 - name: Configure Boundary Policy (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
-    create_instance_profile: no
-    boundary: '{{ boundary_policy }}'
-  check_mode: yes
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    create_instance_profile: false
+    boundary: "{{ boundary_policy }}"
+  check_mode: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: Configure Boundary Policy
-  iam_role:
-    name: '{{ test_role }}'
-    create_instance_profile: no
-    boundary: '{{ boundary_policy }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    create_instance_profile: false
+    boundary: "{{ boundary_policy }}"
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
 
 - name: Configure Boundary Policy (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
-    create_instance_profile: no
-    boundary: '{{ boundary_policy }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    create_instance_profile: false
+    boundary: "{{ boundary_policy }}"
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Configure Boundary Policy (no change)
-  iam_role:
-    name: '{{ test_role }}'
-    create_instance_profile: no
-    boundary: '{{ boundary_policy }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    create_instance_profile: false
+    boundary: "{{ boundary_policy }}"
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
 
 - name: iam_role_info after adding boundary policy
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - '"description" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 0
-    - role_info.iam_roles[0].managed_policies | length == 0
-    - role_info.iam_roles[0].max_session_duration == 3600
-    - role_info.iam_roles[0].path == '/'
-    - role_info.iam_roles[0].permissions_boundary.permissions_boundary_arn == boundary_policy
-    - role_info.iam_roles[0].permissions_boundary.permissions_boundary_type == 'Policy'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - '"description" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 0
+      - role_info.iam_roles[0].managed_policies | length == 0
+      - role_info.iam_roles[0].max_session_duration == 3600
+      - role_info.iam_roles[0].path == '/'
+      - role_info.iam_roles[0].permissions_boundary.permissions_boundary_arn == boundary_policy
+      - role_info.iam_roles[0].permissions_boundary.permissions_boundary_type == 'Policy'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
 
 - name: Remove IAM Role
-  iam_role:
+  community.aws.iam_role:
     state: absent
-    name: '{{ test_role }}'
-    delete_instance_profile: yes
+    name: "{{ test_role }}"
+    delete_instance_profile: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed

--- a/tests/integration/targets/iam_role/tasks/complex_role_creation.yml
+++ b/tests/integration/targets/iam_role/tasks/complex_role_creation.yml
@@ -1,128 +1,126 @@
+---
 - name: Complex IAM Role (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     assume_role_policy_document: '{{ lookup("file", "deny-assume.json") }}'
-    boundary: '{{ boundary_policy }}'
-    create_instance_profile: no
+    boundary: "{{ boundary_policy }}"
+    create_instance_profile: false
     description: Ansible Test Role {{ resource_prefix }}
     managed_policy:
-    - '{{ safe_managed_policy }}'
-    - '{{ custom_policy_name }}'
+      - "{{ safe_managed_policy }}"
+      - "{{ custom_policy_name }}"
     max_session_duration: 43200
-    path: '{{ test_path }}'
+    path: "{{ test_path }}"
     tags:
       TagA: ValueA
-  check_mode: yes
+  check_mode: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: iam_role_info after Complex Role creation in check_mode
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 0
+      - role_info is succeeded
+      - role_info.iam_roles | length == 0
 
 - name: Complex IAM Role
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     assume_role_policy_document: '{{ lookup("file", "deny-assume.json") }}'
-    boundary: '{{ boundary_policy }}'
-    create_instance_profile: no
+    boundary: "{{ boundary_policy }}"
+    create_instance_profile: false
     description: Ansible Test Role {{ resource_prefix }}
     managed_policy:
-    - '{{ safe_managed_policy }}'
-    - '{{ custom_policy_name }}'
+      - "{{ safe_managed_policy }}"
+      - "{{ custom_policy_name }}"
     max_session_duration: 43200
-    path: '{{ test_path }}'
+    path: "{{ test_path }}"
     tags:
       TagA: ValueA
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
-    - iam_role.iam_role.arn.startswith("arn")
-    - iam_role.iam_role.arn.endswith("role" + test_path + test_role )
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
+      - iam_role.iam_role.arn.startswith("arn")
+      - iam_role.iam_role.arn.endswith("role" + test_path + test_role )
       # Would be nice to test the contents...
-    - '"assume_role_policy_document" in iam_role.iam_role'
-    - iam_role.iam_role.attached_policies | length == 2
-    - iam_role.iam_role.max_session_duration == 43200
-    - iam_role.iam_role.path == test_path
-    - iam_role.iam_role.role_name == test_role
-    - '"create_date" in iam_role.iam_role'
-    - '"role_id" in iam_role.iam_role'
+      - '"assume_role_policy_document" in iam_role.iam_role'
+      - iam_role.iam_role.attached_policies | length == 2
+      - iam_role.iam_role.max_session_duration == 43200
+      - iam_role.iam_role.path == test_path
+      - iam_role.iam_role.role_name == test_role
+      - '"create_date" in iam_role.iam_role'
+      - '"role_id" in iam_role.iam_role'
 
 - name: Complex IAM role (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     assume_role_policy_document: '{{ lookup("file", "deny-assume.json") }}'
-    boundary: '{{ boundary_policy }}'
-    create_instance_profile: no
+    boundary: "{{ boundary_policy }}"
+    create_instance_profile: false
     description: Ansible Test Role {{ resource_prefix }}
     managed_policy:
-    - '{{ safe_managed_policy }}'
-    - '{{ custom_policy_name }}'
+      - "{{ safe_managed_policy }}"
+      - "{{ custom_policy_name }}"
     max_session_duration: 43200
-    path: '{{ test_path }}'
+    path: "{{ test_path }}"
     tags:
       TagA: ValueA
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Complex IAM role (no change)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     assume_role_policy_document: '{{ lookup("file", "deny-assume.json") }}'
-    boundary: '{{ boundary_policy }}'
-    create_instance_profile: no
+    boundary: "{{ boundary_policy }}"
+    create_instance_profile: false
     description: Ansible Test Role {{ resource_prefix }}
     managed_policy:
-    - '{{ safe_managed_policy }}'
-    - '{{ custom_policy_name }}'
+      - "{{ safe_managed_policy }}"
+      - "{{ custom_policy_name }}"
     max_session_duration: 43200
-    path: '{{ test_path }}'
+    path: "{{ test_path }}"
     tags:
       TagA: ValueA
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
 
 - name: iam_role_info after Role creation
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role" + test_path + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].description == "Ansible Test Role {{ resource_prefix
-      }}"
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 0
-    - role_info.iam_roles[0].managed_policies | length == 2
-    - safe_managed_policy in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name")
-      | list | flatten )
-    - custom_policy_name in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name")
-      | list | flatten )
-    - role_info.iam_roles[0].max_session_duration == 43200
-    - role_info.iam_roles[0].path == test_path
-    - role_info.iam_roles[0].permissions_boundary.permissions_boundary_arn == boundary_policy
-    - role_info.iam_roles[0].permissions_boundary.permissions_boundary_type == 'Policy'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - '"TagA" in role_info.iam_roles[0].tags'
-    - role_info.iam_roles[0].tags.TagA == "ValueA"
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role" + test_path + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].description == "Ansible Test Role {{ resource_prefix }}"
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 0
+      - role_info.iam_roles[0].managed_policies | length == 2
+      - safe_managed_policy in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name") | list | flatten )
+      - custom_policy_name in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name") | list | flatten )
+      - role_info.iam_roles[0].max_session_duration == 43200
+      - role_info.iam_roles[0].path == test_path
+      - role_info.iam_roles[0].permissions_boundary.permissions_boundary_arn == boundary_policy
+      - role_info.iam_roles[0].permissions_boundary.permissions_boundary_type == 'Policy'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - '"TagA" in role_info.iam_roles[0].tags'
+      - role_info.iam_roles[0].tags.TagA == "ValueA"

--- a/tests/integration/targets/iam_role/tasks/creation_deletion.yml
+++ b/tests/integration/targets/iam_role/tasks/creation_deletion.yml
@@ -1,376 +1,374 @@
+---
 - name: Try running some rapid fire create/delete tests
   block:
-  - name: Minimal IAM Role without instance profile (rapid)
-    iam_role:
-      name: '{{ test_role }}'
-      create_instance_profile: no
-    register: iam_role
-  - name: Minimal IAM Role without instance profile (rapid)
-    iam_role:
-      name: '{{ test_role }}'
-      create_instance_profile: no
-    register: iam_role_again
-  - assert:
-      that:
-      - iam_role is changed
-      - iam_role_again is not changed
+    - name: Minimal IAM Role without instance profile (rapid)
+      community.aws.iam_role:
+        name: "{{ test_role }}"
+        create_instance_profile: false
+      register: iam_role
+    - name: Minimal IAM Role without instance profile (rapid)
+      community.aws.iam_role:
+        name: "{{ test_role }}"
+        create_instance_profile: false
+      register: iam_role_again
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - iam_role_again is not changed
 
-  - name: Remove IAM Role (rapid)
-    iam_role:
-      state: absent
-      name: '{{ test_role }}'
-    register: iam_role
-  - name: Remove IAM Role (rapid)
-    iam_role:
-      state: absent
-      name: '{{ test_role }}'
-    register: iam_role_again
-  - assert:
-      that:
-      - iam_role is changed
-      - iam_role_again is not changed
+    - name: Remove IAM Role (rapid)
+      community.aws.iam_role:
+        state: absent
+        name: "{{ test_role }}"
+      register: iam_role
+    - name: Remove IAM Role (rapid)
+      community.aws.iam_role:
+        state: absent
+        name: "{{ test_role }}"
+      register: iam_role_again
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - iam_role_again is not changed
 
-  - name: Minimal IAM Role without instance profile (rapid)
-    iam_role:
-      name: '{{ test_role }}'
-      create_instance_profile: no
-    register: iam_role
-  - name: Remove IAM Role (rapid)
-    iam_role:
-      state: absent
-      name: '{{ test_role }}'
-    register: iam_role_again
-  - assert:
-      that:
-      - iam_role is changed
-      - iam_role_again is changed
+    - name: Minimal IAM Role without instance profile (rapid)
+      community.aws.iam_role:
+        name: "{{ test_role }}"
+        create_instance_profile: false
+      register: iam_role
+    - name: Remove IAM Role (rapid)
+      community.aws.iam_role:
+        state: absent
+        name: "{{ test_role }}"
+      register: iam_role_again
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - iam_role_again is changed
 
 # ===================================================================
 # Role Creation
 # (without Instance profile)
 - name: iam_role_info before Role creation (no args)
-  iam_role_info:
+  community.aws.iam_role_info:
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
+      - role_info is succeeded
 
 - name: iam_role_info before Role creation (search for test role)
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 0
+      - role_info is succeeded
+      - role_info.iam_roles | length == 0
 
 - name: Minimal IAM Role (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
-    create_instance_profile: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    create_instance_profile: false
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: iam_role_info after Role creation in check_mode
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 0
+      - role_info is succeeded
+      - role_info.iam_roles | length == 0
 
 - name: Minimal IAM Role without instance profile
-  iam_role:
-    name: '{{ test_role }}'
-    create_instance_profile: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    create_instance_profile: false
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
-    - iam_role.iam_role.arn.startswith("arn")
-    - iam_role.iam_role.arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in iam_role.iam_role'
-    - '"assume_role_policy_document_raw" in iam_role.iam_role'
-    - iam_role.iam_role.assume_role_policy_document_raw == assume_deny_policy
-    - iam_role.iam_role.attached_policies | length == 0
-    - iam_role.iam_role.max_session_duration == 3600
-    - iam_role.iam_role.path == '/'
-    - iam_role.iam_role.role_name == test_role
-    - '"create_date" in iam_role.iam_role'
-    - '"role_id" in iam_role.iam_role'
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
+      - iam_role.iam_role.arn.startswith("arn")
+      - iam_role.iam_role.arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in iam_role.iam_role'
+      - '"assume_role_policy_document_raw" in iam_role.iam_role'
+      - iam_role.iam_role.assume_role_policy_document_raw == assume_deny_policy
+      - iam_role.iam_role.attached_policies | length == 0
+      - iam_role.iam_role.max_session_duration == 3600
+      - iam_role.iam_role.path == '/'
+      - iam_role.iam_role.role_name == test_role
+      - '"create_date" in iam_role.iam_role'
+      - '"role_id" in iam_role.iam_role'
 
 - name: Minimal IAM Role without instance profile (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
-    create_instance_profile: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    create_instance_profile: false
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Minimal IAM Role without instance profile (no change)
-  iam_role:
-    name: '{{ test_role }}'
-    create_instance_profile: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    create_instance_profile: false
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
 
 - name: iam_role_info after Role creation
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"assume_role_policy_document_raw" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - '"description" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].assume_role_policy_document_raw == assume_deny_policy
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 0
-    - role_info.iam_roles[0].managed_policies | length == 0
-    - role_info.iam_roles[0].max_session_duration == 3600
-    - role_info.iam_roles[0].path == '/'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 0
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"assume_role_policy_document_raw" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - '"description" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].assume_role_policy_document_raw == assume_deny_policy
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 0
+      - role_info.iam_roles[0].managed_policies | length == 0
+      - role_info.iam_roles[0].max_session_duration == 3600
+      - role_info.iam_roles[0].path == '/'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 0
 
 - name: Remove IAM Role
-  iam_role:
+  community.aws.iam_role:
     state: absent
-    name: '{{ test_role }}'
-    delete_instance_profile: yes
+    name: "{{ test_role }}"
+    delete_instance_profile: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: iam_role_info after Role deletion
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 0
+      - role_info is succeeded
+      - role_info.iam_roles | length == 0
 
 # ------------------------------------------------------------------------------------------
 
 # (with path)
 - name: Minimal IAM Role with path (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
-    path: '{{ test_path }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    path: "{{ test_path }}"
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: Minimal IAM Role with path
-  iam_role:
-    name: '{{ test_role }}'
-    path: '{{ test_path }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    path: "{{ test_path }}"
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
-    - iam_role.iam_role.arn.startswith("arn")
-    - iam_role.iam_role.arn.endswith("role" + test_path + test_role )
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
+      - iam_role.iam_role.arn.startswith("arn")
+      - iam_role.iam_role.arn.endswith("role" + test_path + test_role )
       # Would be nice to test the contents...
-    - '"assume_role_policy_document" in iam_role.iam_role'
-    - iam_role.iam_role.attached_policies | length == 0
-    - iam_role.iam_role.max_session_duration == 3600
-    - iam_role.iam_role.path == '{{ test_path }}'
-    - iam_role.iam_role.role_name == test_role
-    - '"create_date" in iam_role.iam_role'
-    - '"role_id" in iam_role.iam_role'
+      - '"assume_role_policy_document" in iam_role.iam_role'
+      - iam_role.iam_role.attached_policies | length == 0
+      - iam_role.iam_role.max_session_duration == 3600
+      - iam_role.iam_role.path == '{{ test_path }}'
+      - iam_role.iam_role.role_name == test_role
+      - '"create_date" in iam_role.iam_role'
+      - '"role_id" in iam_role.iam_role'
 
 - name: Minimal IAM Role with path (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
-    path: '{{ test_path }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    path: "{{ test_path }}"
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Minimal IAM Role with path (no change)
-  iam_role:
-    name: '{{ test_role }}'
-    path: '{{ test_path }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    path: "{{ test_path }}"
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
 
 - name: iam_role_info after Role creation
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role" + test_path + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - '"description" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile"
-      + test_path + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 0
-    - role_info.iam_roles[0].max_session_duration == 3600
-    - role_info.iam_roles[0].path == '{{ test_path }}'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 0
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role" + test_path + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - '"description" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile" + test_path + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 0
+      - role_info.iam_roles[0].max_session_duration == 3600
+      - role_info.iam_roles[0].path == '{{ test_path }}'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 0
 
 - name: iam_role_info after Role creation (searching a path)
-  iam_role_info:
-    path_prefix: '{{ test_path }}'
+  community.aws.iam_role_info:
+    path_prefix: "{{ test_path }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role" + test_path + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - '"description" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile"
-      + test_path + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 0
-    - role_info.iam_roles[0].max_session_duration == 3600
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].path == '{{ test_path }}'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 0
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role" + test_path + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - '"description" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile" + test_path + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 0
+      - role_info.iam_roles[0].max_session_duration == 3600
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].path == '{{ test_path }}'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 0
 
 - name: Remove IAM Role
-  iam_role:
+  community.aws.iam_role:
     state: absent
-    name: '{{ test_role }}'
-    path: '{{ test_path }}'
-    delete_instance_profile: yes
+    name: "{{ test_role }}"
+    path: "{{ test_path }}"
+    delete_instance_profile: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: iam_role_info after Role deletion
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 0
+      - role_info is succeeded
+      - role_info.iam_roles | length == 0
 
 # ------------------------------------------------------------------------------------------
 
 # (with Instance profile)
 - name: Minimal IAM Role with instance profile - check mode
-  iam_role:
-    name: '{{ test_role }}'
-    create_instance_profile: yes
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    create_instance_profile: true
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: Minimal IAM Role with instance profile
-  iam_role:
-    name: '{{ test_role }}'
-    create_instance_profile: yes
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    create_instance_profile: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
-    - iam_role.iam_role.arn.startswith("arn")
-    - iam_role.iam_role.arn.endswith("role/" + test_role )
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
+      - iam_role.iam_role.arn.startswith("arn")
+      - iam_role.iam_role.arn.endswith("role/" + test_role )
       # Would be nice to test the contents...
-    - '"assume_role_policy_document" in iam_role.iam_role'
-    - iam_role.iam_role.attached_policies | length == 0
-    - iam_role.iam_role.max_session_duration == 3600
-    - iam_role.iam_role.path == '/'
-    - iam_role.iam_role.role_name == test_role
-    - '"create_date" in iam_role.iam_role'
-    - '"role_id" in iam_role.iam_role'
+      - '"assume_role_policy_document" in iam_role.iam_role'
+      - iam_role.iam_role.attached_policies | length == 0
+      - iam_role.iam_role.max_session_duration == 3600
+      - iam_role.iam_role.path == '/'
+      - iam_role.iam_role.role_name == test_role
+      - '"create_date" in iam_role.iam_role'
+      - '"role_id" in iam_role.iam_role'
 
 - name: Minimal IAM Role wth instance profile (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
-    create_instance_profile: yes
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    create_instance_profile: true
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Minimal IAM Role wth instance profile (no change)
-  iam_role:
-    name: '{{ test_role }}'
-    create_instance_profile: yes
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    create_instance_profile: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
 
 - name: iam_role_info after Role creation
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - '"description" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/"
-      + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 0
-    - role_info.iam_roles[0].max_session_duration == 3600
-    - role_info.iam_roles[0].path == '/'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 0
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - '"description" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/" + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 0
+      - role_info.iam_roles[0].max_session_duration == 3600
+      - role_info.iam_roles[0].path == '/'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 0

--- a/tests/integration/targets/iam_role/tasks/description_update.yml
+++ b/tests/integration/targets/iam_role/tasks/description_update.yml
@@ -1,143 +1,138 @@
+---
 - name: Add Description (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     description: Ansible Test Role {{ resource_prefix }}
-  check_mode: yes
+  check_mode: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: Add Description
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     description: Ansible Test Role {{ resource_prefix }}
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
-    - iam_role.iam_role.description == 'Ansible Test Role {{ resource_prefix }}'
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
+      - iam_role.iam_role.description == 'Ansible Test Role {{ resource_prefix }}'
 
 - name: Add Description (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     description: Ansible Test Role {{ resource_prefix }}
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Add Description (no change)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     description: Ansible Test Role {{ resource_prefix }}
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
-    - iam_role.iam_role.description == 'Ansible Test Role {{ resource_prefix }}'
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
+      - iam_role.iam_role.description == 'Ansible Test Role {{ resource_prefix }}'
 
 - name: iam_role_info after adding Description
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].description == "Ansible Test Role {{ resource_prefix
-      }}"
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/"
-      + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 0
-    - role_info.iam_roles[0].max_session_duration == 43200
-    - role_info.iam_roles[0].path == '/'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 0
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].description == "Ansible Test Role {{ resource_prefix }}"
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/" + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 0
+      - role_info.iam_roles[0].max_session_duration == 43200
+      - role_info.iam_roles[0].path == '/'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 0
 
 # ------------------------------------------------------------------------------------------
 
 - name: Update Description (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     description: Ansible Test Role (updated) {{ resource_prefix }}
-  check_mode: yes
+  check_mode: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: Update Description
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     description: Ansible Test Role (updated) {{ resource_prefix }}
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
-    - iam_role.iam_role.description == 'Ansible Test Role (updated) {{ resource_prefix
-      }}'
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
+      - iam_role.iam_role.description == 'Ansible Test Role (updated) {{ resource_prefix }}'
 
 - name: Update Description (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     description: Ansible Test Role (updated) {{ resource_prefix }}
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Update Description (no change)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     description: Ansible Test Role (updated) {{ resource_prefix }}
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
-    - iam_role.iam_role.description == 'Ansible Test Role (updated) {{ resource_prefix
-      }}'
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
+      - iam_role.iam_role.description == 'Ansible Test Role (updated) {{ resource_prefix }}'
 
 - name: iam_role_info after updating Description
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix
-      }}"
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/"
-      + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 0
-    - role_info.iam_roles[0].max_session_duration == 43200
-    - role_info.iam_roles[0].path == '/'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 0
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix }}"
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/" + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 0
+      - role_info.iam_roles[0].max_session_duration == 43200
+      - role_info.iam_roles[0].path == '/'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 0

--- a/tests/integration/targets/iam_role/tasks/inline_policy_update.yml
+++ b/tests/integration/targets/iam_role/tasks/inline_policy_update.yml
@@ -1,49 +1,46 @@
+---
 - name: Attach inline policy a
-  iam_policy:
+  amazon.aws.iam_policy:
     state: present
     iam_type: role
-    iam_name: '{{ test_role }}'
+    iam_name: "{{ test_role }}"
     policy_name: inline-policy-a
     policy_json: '{{ lookup("file", "deny-all-a.json") }}'
 - name: Attach inline policy b
-  iam_policy:
+  amazon.aws.iam_policy:
     state: present
     iam_type: role
-    iam_name: '{{ test_role }}'
+    iam_name: "{{ test_role }}"
     policy_name: inline-policy-b
     policy_json: '{{ lookup("file", "deny-all-b.json") }}'
 - name: iam_role_info after attaching inline policies (using iam_policy)
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix
-      }}"
-    - role_info.iam_roles[0].inline_policies | length == 2
-    - '"inline-policy-a" in role_info.iam_roles[0].inline_policies'
-    - '"inline-policy-b" in role_info.iam_roles[0].inline_policies'
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/"
-      + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 1
-    - safe_managed_policy not in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name")
-      | list | flatten )
-    - custom_policy_name in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name")
-      | list | flatten )
-    - role_info.iam_roles[0].max_session_duration == 43200
-    - role_info.iam_roles[0].path == '/'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 1
-    - '"TagB" in role_info.iam_roles[0].tags'
-    - role_info.iam_roles[0].tags.TagB == "ValueB"
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix }}"
+      - role_info.iam_roles[0].inline_policies | length == 2
+      - '"inline-policy-a" in role_info.iam_roles[0].inline_policies'
+      - '"inline-policy-b" in role_info.iam_roles[0].inline_policies'
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/" + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 1
+      - safe_managed_policy not in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name") | list | flatten )
+      - custom_policy_name in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name") | list | flatten )
+      - role_info.iam_roles[0].max_session_duration == 43200
+      - role_info.iam_roles[0].path == '/'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 1
+      - '"TagB" in role_info.iam_roles[0].tags'
+      - role_info.iam_roles[0].tags.TagB == "ValueB"

--- a/tests/integration/targets/iam_role/tasks/main.yml
+++ b/tests/integration/targets/iam_role/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 # Tests for iam_role and iam_role_info
 #
 # Tests:
@@ -17,67 +18,65 @@
 # - There are some known timing issues with boto3 returning before actions
 #   complete in the case of problems with "changed" status it's worth enabling
 #   the standard_pauses and paranoid_pauses options as a first step in debugging
-
-
 - name: Setup AWS connection info
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
     iam_role:
       assume_role_policy_document: '{{ lookup("file", "deny-assume.json") }}'
   collections:
-  - community.general
+    - community.general
   block:
-  - set_fact:
-      assume_deny_policy: '{{ lookup("file", "deny-assume.json") | from_json }}'
-  - include_tasks: parameter_checks.yml
-  - name: Create Safe IAM Managed Policy
-    iam_managed_policy:
-      state: present
-      policy_name: '{{ custom_policy_name }}'
-      policy_description: A safe (deny-all) managed policy
-      policy: "{{ lookup('file', 'deny-all.json') }}"
-    register: create_managed_policy
-  - assert:
-      that:
-      - create_managed_policy is succeeded
+    - ansible.builtin.set_fact:
+        assume_deny_policy: '{{ lookup("file", "deny-assume.json") | from_json }}'
+    - ansible.builtin.include_tasks: parameter_checks.yml
+    - name: Create Safe IAM Managed Policy
+      community.aws.iam_managed_policy:
+        state: present
+        policy_name: "{{ custom_policy_name }}"
+        policy_description: A safe (deny-all) managed policy
+        policy: "{{ lookup('file', 'deny-all.json') }}"
+      register: create_managed_policy
+    - ansible.builtin.assert:
+        that:
+          - create_managed_policy is succeeded
 
     # ===================================================================
     # Rapid Role Creation and deletion
-  - include_tasks: creation_deletion.yml
-  - include_tasks: max_session_update.yml
-  - include_tasks: description_update.yml
-  - include_tasks: tags_update.yml
-  - include_tasks: policy_update.yml
-  - include_tasks: inline_policy_update.yml
-  - include_tasks: role_removal.yml
-  - include_tasks: boundary_policy.yml
-  - include_tasks: complex_role_creation.yml
+    - ansible.builtin.include_tasks: creation_deletion.yml
+    - ansible.builtin.include_tasks: max_session_update.yml
+    - ansible.builtin.include_tasks: description_update.yml
+    - ansible.builtin.include_tasks: tags_update.yml
+    - ansible.builtin.include_tasks: policy_update.yml
+    - ansible.builtin.include_tasks: inline_policy_update.yml
+    - ansible.builtin.include_tasks: role_removal.yml
+    - ansible.builtin.include_tasks: boundary_policy.yml
+    - ansible.builtin.include_tasks: complex_role_creation.yml
   always:
     # ===================================================================
     # Cleanup
 
-  - name: Remove IAM Role
-    iam_role:
-      state: absent
-      name: '{{ test_role }}'
-      delete_instance_profile: yes
-    ignore_errors: true
-  - name: Remove IAM Role (with path)
-    iam_role:
-      state: absent
-      name: '{{ test_role }}'
-      path: '{{ test_path }}'
-      delete_instance_profile: yes
-    ignore_errors: true
-  - name: iam_role_info after Role deletion
-    iam_role_info:
-      name: '{{ test_role }}'
-    ignore_errors: true
-  - name: Remove test managed policy
-    iam_managed_policy:
-      state: absent
-      policy_name: '{{ custom_policy_name }}'
+    - name: Remove IAM Role
+      community.aws.iam_role:
+        state: absent
+        name: "{{ test_role }}"
+        delete_instance_profile: true
+      ignore_errors: true
+    - name: Remove IAM Role (with path)
+      community.aws.iam_role:
+        state: absent
+        name: "{{ test_role }}"
+        path: "{{ test_path }}"
+        delete_instance_profile: true
+      ignore_errors: true
+    - name: iam_role_info after Role deletion
+      community.aws.iam_role_info:
+        name: "{{ test_role }}"
+      ignore_errors: true
+    - name: Remove test managed policy
+      community.aws.iam_managed_policy:
+        state: absent
+        policy_name: "{{ custom_policy_name }}"

--- a/tests/integration/targets/iam_role/tasks/max_session_update.yml
+++ b/tests/integration/targets/iam_role/tasks/max_session_update.yml
@@ -1,66 +1,66 @@
+---
 - name: Update Max Session Duration (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     max_session_duration: 43200
-  check_mode: yes
+  check_mode: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: Update Max Session Duration
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     max_session_duration: 43200
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
-    - iam_role.iam_role.max_session_duration == 43200
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
+      - iam_role.iam_role.max_session_duration == 43200
 
 - name: Update Max Session Duration (no change)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     max_session_duration: 43200
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Update Max Session Duration (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     max_session_duration: 43200
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: iam_role_info after updating Max Session Duration
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - '"description" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/"
-      + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 0
-    - role_info.iam_roles[0].max_session_duration == 43200
-    - role_info.iam_roles[0].path == '/'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 0
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - '"description" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/" + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 0
+      - role_info.iam_roles[0].max_session_duration == 43200
+      - role_info.iam_roles[0].path == '/'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 0

--- a/tests/integration/targets/iam_role/tasks/parameter_checks.yml
+++ b/tests/integration/targets/iam_role/tasks/parameter_checks.yml
@@ -1,82 +1,83 @@
+---
 # Parameter Checks
 - name: Friendly message when creating an instance profile and adding a boundary profile
-  iam_role:
-    name: '{{ test_role }}'
-    boundary: '{{ boundary_policy }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    boundary: "{{ boundary_policy }}"
   register: iam_role
-  ignore_errors: yes
-- assert:
+  ignore_errors: true
+- ansible.builtin.assert:
     that:
-    - iam_role is failed
-    - '"boundary policy" in iam_role.msg'
-    - '"create_instance_profile" in iam_role.msg'
-    - '"false" in iam_role.msg'
+      - iam_role is failed
+      - '"boundary policy" in iam_role.msg'
+      - '"create_instance_profile" in iam_role.msg'
+      - '"false" in iam_role.msg'
 
 - name: Friendly message when boundary profile is not an ARN
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     boundary: AWSDenyAll
-    create_instance_profile: no
+    create_instance_profile: false
   register: iam_role
-  ignore_errors: yes
-- assert:
+  ignore_errors: true
+- ansible.builtin.assert:
     that:
-    - iam_role is failed
-    - '"Boundary policy" in iam_role.msg'
-    - '"ARN" in iam_role.msg'
+      - iam_role is failed
+      - '"Boundary policy" in iam_role.msg'
+      - '"ARN" in iam_role.msg'
 
 - name: Friendly message when "present" without assume_role_policy_document
-  module_defaults: {iam_role: {}}
-  iam_role:
-    name: '{{ test_role }}'
+  module_defaults: { iam_role: {}}
+  community.aws.iam_role:
+    name: "{{ test_role }}"
   register: iam_role
-  ignore_errors: yes
-- assert:
+  ignore_errors: true
+- ansible.builtin.assert:
     that:
-    - iam_role is failed
-    - iam_role.msg.startswith("state is present but all of the following are missing")
-    - '"assume_role_policy_document" in iam_role.msg'
+      - iam_role is failed
+      - iam_role.msg.startswith("state is present but all of the following are missing")
+      - '"assume_role_policy_document" in iam_role.msg'
 
 - name: Maximum Session Duration needs to be between 1 and 12 hours
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     max_session_duration: 3599
   register: iam_role
-  ignore_errors: yes
-- assert:
+  ignore_errors: true
+- ansible.builtin.assert:
     that:
-    - iam_role is failed
-    - '"max_session_duration must be between" in iam_role.msg'
+      - iam_role is failed
+      - '"max_session_duration must be between" in iam_role.msg'
 
 - name: Maximum Session Duration needs to be between 1 and 12 hours
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     max_session_duration: 43201
   register: iam_role
-  ignore_errors: yes
-- assert:
+  ignore_errors: true
+- ansible.builtin.assert:
     that:
-    - iam_role is failed
-    - '"max_session_duration must be between" in iam_role.msg'
+      - iam_role is failed
+      - '"max_session_duration must be between" in iam_role.msg'
 
 - name: Role Paths must start with /
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     path: test/
   register: iam_role
-  ignore_errors: yes
-- assert:
+  ignore_errors: true
+- ansible.builtin.assert:
     that:
-    - iam_role is failed
-    - '"path must begin and end with /" in iam_role.msg'
+      - iam_role is failed
+      - '"path must begin and end with /" in iam_role.msg'
 
 - name: Role Paths must end with /
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     path: /test
   register: iam_role
-  ignore_errors: yes
-- assert:
+  ignore_errors: true
+- ansible.builtin.assert:
     that:
-    - iam_role is failed
-    - '"path must begin and end with /" in iam_role.msg'
+      - iam_role is failed
+      - '"path must begin and end with /" in iam_role.msg'

--- a/tests/integration/targets/iam_role/tasks/policy_update.yml
+++ b/tests/integration/targets/iam_role/tasks/policy_update.yml
@@ -1,246 +1,235 @@
+---
 - name: Add Managed Policy (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
-    purge_policies: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_policies: false
     managed_policy:
-    - '{{ safe_managed_policy }}'
-  check_mode: yes
+      - "{{ safe_managed_policy }}"
+  check_mode: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: Add Managed Policy
-  iam_role:
-    name: '{{ test_role }}'
-    purge_policies: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_policies: false
     managed_policy:
-    - '{{ safe_managed_policy }}'
+      - "{{ safe_managed_policy }}"
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
 
 - name: Add Managed Policy (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
-    purge_policies: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_policies: false
     managed_policy:
-    - '{{ safe_managed_policy }}'
+      - "{{ safe_managed_policy }}"
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Add Managed Policy (no change)
-  iam_role:
-    name: '{{ test_role }}'
-    purge_policies: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_policies: false
     managed_policy:
-    - '{{ safe_managed_policy }}'
+      - "{{ safe_managed_policy }}"
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
 
 - name: iam_role_info after adding Managed Policy
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix
-      }}"
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/"
-      + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 1
-    - safe_managed_policy in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name")
-      | list | flatten )
-    - custom_policy_name not in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name")
-      | list | flatten )
-    - role_info.iam_roles[0].max_session_duration == 43200
-    - role_info.iam_roles[0].path == '/'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 1
-    - '"TagB" in role_info.iam_roles[0].tags'
-    - role_info.iam_roles[0].tags.TagB == "ValueB"
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix }}"
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/" + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 1
+      - safe_managed_policy in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name") | list | flatten )
+      - custom_policy_name not in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name") | list | flatten )
+      - role_info.iam_roles[0].max_session_duration == 43200
+      - role_info.iam_roles[0].path == '/'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 1
+      - '"TagB" in role_info.iam_roles[0].tags'
+      - role_info.iam_roles[0].tags.TagB == "ValueB"
 
 # ------------------------------------------------------------------------------------------
 
 - name: Update Managed Policy without purge (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
-    purge_policies: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_policies: false
     managed_policy:
-    - '{{ custom_policy_name }}'
-  check_mode: yes
+      - "{{ custom_policy_name }}"
+  check_mode: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: Update Managed Policy without purge
-  iam_role:
-    name: '{{ test_role }}'
-    purge_policies: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_policies: false
     managed_policy:
-    - '{{ custom_policy_name }}'
+      - "{{ custom_policy_name }}"
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
 
 - name: Update Managed Policy without purge (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
-    purge_policies: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_policies: false
     managed_policy:
-    - '{{ custom_policy_name }}'
+      - "{{ custom_policy_name }}"
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Update Managed Policy without purge (no change)
-  iam_role:
-    name: '{{ test_role }}'
-    purge_policies: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_policies: false
     managed_policy:
-    - '{{ custom_policy_name }}'
+      - "{{ custom_policy_name }}"
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
 
 - name: iam_role_info after updating Managed Policy without purge
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix
-      }}"
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/"
-      + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 2
-    - safe_managed_policy in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name")
-      | list | flatten )
-    - custom_policy_name in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name")
-      | list | flatten )
-    - role_info.iam_roles[0].max_session_duration == 43200
-    - role_info.iam_roles[0].path == '/'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 1
-    - '"TagB" in role_info.iam_roles[0].tags'
-    - role_info.iam_roles[0].tags.TagB == "ValueB"
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix }}"
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/" + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 2
+      - safe_managed_policy in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name") | list | flatten )
+      - custom_policy_name in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name") | list | flatten )
+      - role_info.iam_roles[0].max_session_duration == 43200
+      - role_info.iam_roles[0].path == '/'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 1
+      - '"TagB" in role_info.iam_roles[0].tags'
+      - role_info.iam_roles[0].tags.TagB == "ValueB"
 
 # ------------------------------------------------------------------------------------------
 
 # Managed Policies are purged by default
 - name: Update Managed Policy with purge (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     managed_policy:
-    - '{{ custom_policy_name }}'
-  check_mode: yes
+      - "{{ custom_policy_name }}"
+  check_mode: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: Update Managed Policy with purge
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     managed_policy:
-    - '{{ custom_policy_name }}'
+      - "{{ custom_policy_name }}"
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
 
 - name: Update Managed Policy with purge (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     managed_policy:
-    - '{{ custom_policy_name }}'
+      - "{{ custom_policy_name }}"
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Update Managed Policy with purge (no change)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     managed_policy:
-    - '{{ custom_policy_name }}'
+      - "{{ custom_policy_name }}"
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
 
 - name: iam_role_info after updating Managed Policy with purge
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix
-      }}"
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/"
-      + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 1
-    - safe_managed_policy not in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name")
-      | list | flatten )
-    - custom_policy_name in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name")
-      | list | flatten )
-    - role_info.iam_roles[0].max_session_duration == 43200
-    - role_info.iam_roles[0].path == '/'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 1
-    - '"TagB" in role_info.iam_roles[0].tags'
-    - role_info.iam_roles[0].tags.TagB == "ValueB"
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix }}"
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/" + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 1
+      - safe_managed_policy not in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name") | list | flatten )
+      - custom_policy_name in ( role_info | community.general.json_query("iam_roles[*].managed_policies[*].policy_name") | list | flatten )
+      - role_info.iam_roles[0].max_session_duration == 43200
+      - role_info.iam_roles[0].path == '/'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 1
+      - '"TagB" in role_info.iam_roles[0].tags'
+      - role_info.iam_roles[0].tags.TagB == "ValueB"

--- a/tests/integration/targets/iam_role/tasks/role_removal.yml
+++ b/tests/integration/targets/iam_role/tasks/role_removal.yml
@@ -1,59 +1,60 @@
+---
 - name: Remove IAM Role (CHECK MODE)
-  iam_role:
+  community.aws.iam_role:
     state: absent
-    name: '{{ test_role }}'
-    delete_instance_profile: yes
-  check_mode: yes
+    name: "{{ test_role }}"
+    delete_instance_profile: true
+  check_mode: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: iam_role_info after deleting role in check mode
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
 
 - name: Remove IAM Role
-  iam_role:
+  community.aws.iam_role:
     state: absent
-    name: '{{ test_role }}'
-    delete_instance_profile: yes
+    name: "{{ test_role }}"
+    delete_instance_profile: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: iam_role_info after deleting role
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 0
+      - role_info is succeeded
+      - role_info.iam_roles | length == 0
 
 - name: Remove IAM Role (should be gone already) - check mode
-  iam_role:
+  community.aws.iam_role:
     state: absent
-    name: '{{ test_role }}'
-    delete_instance_profile: yes
+    name: "{{ test_role }}"
+    delete_instance_profile: true
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Remove IAM Role (should be gone already)
-  iam_role:
+  community.aws.iam_role:
     state: absent
-    name: '{{ test_role }}'
-    delete_instance_profile: yes
+    name: "{{ test_role }}"
+    delete_instance_profile: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed

--- a/tests/integration/targets/iam_role/tasks/tags_update.yml
+++ b/tests/integration/targets/iam_role/tasks/tags_update.yml
@@ -1,328 +1,321 @@
+---
 - name: Add Tag (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     tags:
       TagA: ValueA
-  check_mode: yes
+  check_mode: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: Add Tag
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     tags:
       TagA: ValueA
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
-    - iam_role.iam_role.tags | length == 1
-    - '"TagA" in iam_role.iam_role.tags'
-    - iam_role.iam_role.tags.TagA == "ValueA"
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
+      - iam_role.iam_role.tags | length == 1
+      - '"TagA" in iam_role.iam_role.tags'
+      - iam_role.iam_role.tags.TagA == "ValueA"
 
 - name: Add Tag (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     tags:
       TagA: ValueA
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Add Tag (no change)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     tags:
       TagA: ValueA
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
-    - '"TagA" in iam_role.iam_role.tags'
-    - iam_role.iam_role.tags.TagA == "ValueA"
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
+      - '"TagA" in iam_role.iam_role.tags'
+      - iam_role.iam_role.tags.TagA == "ValueA"
 
 - name: iam_role_info after adding Tags
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix
-      }}"
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/"
-      + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 0
-    - role_info.iam_roles[0].max_session_duration == 43200
-    - role_info.iam_roles[0].path == '/'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 1
-    - '"TagA" in role_info.iam_roles[0].tags'
-    - role_info.iam_roles[0].tags.TagA == "ValueA"
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix }}"
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/" + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 0
+      - role_info.iam_roles[0].max_session_duration == 43200
+      - role_info.iam_roles[0].path == '/'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 1
+      - '"TagA" in role_info.iam_roles[0].tags'
+      - role_info.iam_roles[0].tags.TagA == "ValueA"
 
 # ------------------------------------------------------------------------------------------
 
 - name: Update Tag (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     tags:
       TagA: AValue
-  check_mode: yes
+  check_mode: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: Update Tag
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     tags:
       TagA: AValue
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
-    - '"TagA" in iam_role.iam_role.tags'
-    - iam_role.iam_role.tags.TagA == "AValue"
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
+      - '"TagA" in iam_role.iam_role.tags'
+      - iam_role.iam_role.tags.TagA == "AValue"
 
 - name: Update Tag (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     tags:
       TagA: AValue
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Update Tag (no change)
-  iam_role:
-    name: '{{ test_role }}'
+  community.aws.iam_role:
+    name: "{{ test_role }}"
     tags:
       TagA: AValue
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
-    - '"TagA" in iam_role.iam_role.tags'
-    - iam_role.iam_role.tags.TagA == "AValue"
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
+      - '"TagA" in iam_role.iam_role.tags'
+      - iam_role.iam_role.tags.TagA == "AValue"
 
 - name: iam_role_info after updating Tag
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix
-      }}"
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/"
-      + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 0
-    - role_info.iam_roles[0].max_session_duration == 43200
-    - role_info.iam_roles[0].path == '/'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 1
-    - '"TagA" in role_info.iam_roles[0].tags'
-    - role_info.iam_roles[0].tags.TagA == "AValue"
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix }}"
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/" + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 0
+      - role_info.iam_roles[0].max_session_duration == 43200
+      - role_info.iam_roles[0].path == '/'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 1
+      - '"TagA" in role_info.iam_roles[0].tags'
+      - role_info.iam_roles[0].tags.TagA == "AValue"
 
 # ------------------------------------------------------------------------------------------
 
 - name: Add second Tag without purge (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
-    purge_tags: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_tags: false
     tags:
       TagB: ValueB
-  check_mode: yes
+  check_mode: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: Add second Tag without purge
-  iam_role:
-    name: '{{ test_role }}'
-    purge_tags: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_tags: false
     tags:
       TagB: ValueB
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
-    - '"TagB" in iam_role.iam_role.tags'
-    - iam_role.iam_role.tags.TagB == "ValueB"
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
+      - '"TagB" in iam_role.iam_role.tags'
+      - iam_role.iam_role.tags.TagB == "ValueB"
 
 - name: Add second Tag without purge (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
-    purge_tags: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_tags: false
     tags:
       TagB: ValueB
   register: iam_role
-  check_mode: yes
-- assert:
+  check_mode: true
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Add second Tag without purge (no change)
-  iam_role:
-    name: '{{ test_role }}'
-    purge_tags: no
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_tags: false
     tags:
       TagB: ValueB
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
-    - '"TagB" in iam_role.iam_role.tags'
-    - iam_role.iam_role.tags.TagB == "ValueB"
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
+      - '"TagB" in iam_role.iam_role.tags'
+      - iam_role.iam_role.tags.TagB == "ValueB"
 
 - name: iam_role_info after adding second Tag without purge
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix
-      }}"
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/"
-      + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 0
-    - role_info.iam_roles[0].max_session_duration == 43200
-    - role_info.iam_roles[0].path == '/'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 2
-    - '"TagA" in role_info.iam_roles[0].tags'
-    - role_info.iam_roles[0].tags.TagA == "AValue"
-    - '"TagB" in role_info.iam_roles[0].tags'
-    - role_info.iam_roles[0].tags.TagB == "ValueB"
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix }}"
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/" + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 0
+      - role_info.iam_roles[0].max_session_duration == 43200
+      - role_info.iam_roles[0].path == '/'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 2
+      - '"TagA" in role_info.iam_roles[0].tags'
+      - role_info.iam_roles[0].tags.TagA == "AValue"
+      - '"TagB" in role_info.iam_roles[0].tags'
+      - role_info.iam_roles[0].tags.TagB == "ValueB"
 
 # ------------------------------------------------------------------------------------------
 
 - name: Purge first tag (CHECK MODE)
-  iam_role:
-    name: '{{ test_role }}'
-    purge_tags: yes
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_tags: true
     tags:
       TagB: ValueB
-  check_mode: yes
+  check_mode: true
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
+      - iam_role is changed
 
 - name: Purge first tag
-  iam_role:
-    name: '{{ test_role }}'
-    purge_tags: yes
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_tags: true
     tags:
       TagB: ValueB
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is changed
-    - iam_role.iam_role.role_name == test_role
-    - '"TagB" in iam_role.iam_role.tags'
-    - iam_role.iam_role.tags.TagB == "ValueB"
+      - iam_role is changed
+      - iam_role.iam_role.role_name == test_role
+      - '"TagB" in iam_role.iam_role.tags'
+      - iam_role.iam_role.tags.TagB == "ValueB"
 
 - name: Purge first tag (no change) - check mode
-  iam_role:
-    name: '{{ test_role }}'
-    purge_tags: yes
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_tags: true
     tags:
       TagB: ValueB
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
+      - iam_role is not changed
 
 - name: Purge first tag (no change)
-  iam_role:
-    name: '{{ test_role }}'
-    purge_tags: yes
+  community.aws.iam_role:
+    name: "{{ test_role }}"
+    purge_tags: true
     tags:
       TagB: ValueB
   register: iam_role
-- assert:
+- ansible.builtin.assert:
     that:
-    - iam_role is not changed
-    - iam_role.iam_role.role_name == test_role
-    - '"TagB" in iam_role.iam_role.tags'
-    - iam_role.iam_role.tags.TagB == "ValueB"
+      - iam_role is not changed
+      - iam_role.iam_role.role_name == test_role
+      - '"TagB" in iam_role.iam_role.tags'
+      - iam_role.iam_role.tags.TagB == "ValueB"
 
 - name: iam_role_info after purging first Tag
-  iam_role_info:
-    name: '{{ test_role }}'
+  community.aws.iam_role_info:
+    name: "{{ test_role }}"
   register: role_info
-- assert:
+- ansible.builtin.assert:
     that:
-    - role_info is succeeded
-    - role_info.iam_roles | length == 1
-    - role_info.iam_roles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].arn.endswith("role/" + test_role )
-    - '"assume_role_policy_document" in role_info.iam_roles[0]'
-    - '"create_date" in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix
-      }}"
-    - role_info.iam_roles[0].inline_policies | length == 0
-    - role_info.iam_roles[0].instance_profiles | length == 1
-    - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
-    - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
-    - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/"
-      + test_role)
-    - role_info.iam_roles[0].managed_policies | length == 0
-    - role_info.iam_roles[0].max_session_duration == 43200
-    - role_info.iam_roles[0].path == '/'
-    - '"permissions_boundary" not in role_info.iam_roles[0]'
-    - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
-    - role_info.iam_roles[0].role_name == test_role
-    - role_info.iam_roles[0].tags | length == 1
-    - '"TagA" not in role_info.iam_roles[0].tags'
-    - '"TagB" in role_info.iam_roles[0].tags'
-    - role_info.iam_roles[0].tags.TagB == "ValueB"
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role/" + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].description == "Ansible Test Role (updated) {{ resource_prefix }}"
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile/" + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 0
+      - role_info.iam_roles[0].max_session_duration == 43200
+      - role_info.iam_roles[0].path == '/'
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 1
+      - '"TagA" not in role_info.iam_roles[0].tags'
+      - '"TagB" in role_info.iam_roles[0].tags'
+      - role_info.iam_roles[0].tags.TagB == "ValueB"

--- a/tests/integration/targets/iam_user/defaults/main.yml
+++ b/tests/integration/targets/iam_user/defaults/main.yml
@@ -1,10 +1,11 @@
-test_group: '{{ resource_prefix }}-group'
+---
+test_group: "{{ resource_prefix }}-group"
 test_path: /
-test_user: '{{ test_users[0] }}'
-test_user3: '{{ test_users[2] }}'
+test_user: "{{ test_users[0] }}"
+test_user3: "{{ test_users[2] }}"
 test_password: ATotallySecureUncrackablePassword1!
 test_new_password: ATotallyNewSecureUncrackablePassword1!
 test_users:
-- '{{ resource_prefix }}-user-a'
-- '{{ resource_prefix }}-user-b'
-- '{{ resource_prefix }}-user-c'
+  - "{{ resource_prefix }}-user-a"
+  - "{{ resource_prefix }}-user-b"
+  - "{{ resource_prefix }}-user-c"

--- a/tests/integration/targets/iam_user/meta/main.yml
+++ b/tests/integration/targets/iam_user/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/iam_user/tasks/main.yml
+++ b/tests/integration/targets/iam_user/tasks/main.yml
@@ -1,798 +1,799 @@
+---
 - name: set up aws connection info
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-  - name: ensure improper usage of parameters fails gracefully
-    iam_user_info:
-      path: '{{ test_path }}'
-      group: '{{ test_group }}'
-    ignore_errors: yes
-    register: iam_user_info_path_group
-  - assert:
-      that:
-      - iam_user_info_path_group is failed
-      - 'iam_user_info_path_group.msg == "parameters are mutually exclusive: group|path"'
+    - name: ensure improper usage of parameters fails gracefully
+      amazon.aws.iam_user_info:
+        path: "{{ test_path }}"
+        group: "{{ test_group }}"
+      ignore_errors: true
+      register: iam_user_info_path_group
+    - ansible.builtin.assert:
+        that:
+          - iam_user_info_path_group is failed
+          - 'iam_user_info_path_group.msg == "parameters are mutually exclusive: group|path"'
 
-  - name: create test user (check mode)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-    check_mode: yes
-    register: iam_user
-  - name: assert that the user would be created
-    assert:
-      that:
-      - iam_user is changed
+    - name: create test user (check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+      check_mode: true
+      register: iam_user
+    - name: assert that the user would be created
+      ansible.builtin.assert:
+        that:
+          - iam_user is changed
 
-  - name: create test user
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-    register: iam_user
-  - name: assert that the user is created
-    assert:
-      that:
-      - iam_user is changed
+    - name: create test user
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+      register: iam_user
+    - name: assert that the user is created
+      ansible.builtin.assert:
+        that:
+          - iam_user is changed
 
-  - name: ensure test user exists (no change - check mode)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-    register: iam_user
-    check_mode: yes
-  - name: assert that user would not change
-    assert:
-      that:
-      - iam_user is not changed
+    - name: ensure test user exists (no change - check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+      register: iam_user
+      check_mode: true
+    - name: assert that user would not change
+      ansible.builtin.assert:
+        that:
+          - iam_user is not changed
 
-  - name: ensure test user exists (no change)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-    register: iam_user
-  - name: assert that the user wasn't changed
-    assert:
-      that:
-      - iam_user is not changed
+    - name: ensure test user exists (no change)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+      register: iam_user
+    - name: assert that the user wasn't changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is not changed
 
-  - name: ensure the info used to validate other tests is valid
-    set_fact:
-      test_iam_user: '{{ iam_user.iam_user.user }}'
-  - assert:
-      that:
-      - test_iam_user.arn.startswith("arn:aws:iam")
-      - test_iam_user.arn.endswith("user/" + test_user )
-      - test_iam_user.create_date is not none
-      - test_iam_user.path == '{{ test_path }}'
-      - test_iam_user.user_id is not none
-      - test_iam_user.user_name == '{{ test_user }}'
-      - test_iam_user.tags | length == 0
+    - name: ensure the info used to validate other tests is valid
+      ansible.builtin.set_fact:
+        test_iam_user: "{{ iam_user.iam_user.user }}"
+    - ansible.builtin.assert:
+        that:
+          - test_iam_user.arn.startswith("arn:aws:iam")
+          - test_iam_user.arn.endswith("user/" + test_user )
+          - test_iam_user.create_date is not none
+          - test_iam_user.path == '{{ test_path }}'
+          - test_iam_user.user_id is not none
+          - test_iam_user.user_name == '{{ test_user }}'
+          - test_iam_user.tags | length == 0
 
-  - name: get info on IAM user(s)
-    iam_user_info:
-    register: iam_user_info
-  - assert:
-      that:
-      - iam_user_info.iam_users | length != 0
+    - name: get info on IAM user(s)
+      amazon.aws.iam_user_info:
+      register: iam_user_info
+    - ansible.builtin.assert:
+        that:
+          - iam_user_info.iam_users | length != 0
 
-  - name: get info on IAM user(s) with name
-    iam_user_info:
-      name: '{{ test_user }}'
-    register: iam_user_info
-  - assert:
-      that:
-      - iam_user_info.iam_users | length == 1
-      - iam_user_info.iam_users[0].arn == test_iam_user.arn
-      - iam_user_info.iam_users[0].create_date == test_iam_user.create_date
-      - iam_user_info.iam_users[0].path == test_iam_user.path
-      - iam_user_info.iam_users[0].user_id == test_iam_user.user_id
-      - iam_user_info.iam_users[0].user_name == test_iam_user.user_name
-      - iam_user_info.iam_users[0].tags | length == 0
+    - name: get info on IAM user(s) with name
+      amazon.aws.iam_user_info:
+        name: "{{ test_user }}"
+      register: iam_user_info
+    - ansible.builtin.assert:
+        that:
+          - iam_user_info.iam_users | length == 1
+          - iam_user_info.iam_users[0].arn == test_iam_user.arn
+          - iam_user_info.iam_users[0].create_date == test_iam_user.create_date
+          - iam_user_info.iam_users[0].path == test_iam_user.path
+          - iam_user_info.iam_users[0].user_id == test_iam_user.user_id
+          - iam_user_info.iam_users[0].user_name == test_iam_user.user_name
+          - iam_user_info.iam_users[0].tags | length == 0
 
-  # ------------------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------------------
 
-  - name: create test user with password (check mode)
-    iam_user:
-      name: '{{ test_user3 }}'
-      password: '{{ test_password }}'
-      state: present
-    check_mode: yes
-    register: iam_user
-  - name: assert that the second user would be created
-    assert:
-      that:
-      - iam_user is changed
+    - name: create test user with password (check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user3 }}"
+        password: "{{ test_password }}"
+        state: present
+      check_mode: true
+      register: iam_user
+    - name: assert that the second user would be created
+      ansible.builtin.assert:
+        that:
+          - iam_user is changed
 
-  - name: create second test user with password
-    iam_user:
-      name: '{{ test_user3 }}'
-      password: '{{ test_password }}'
-      password_reset_required: yes
-      state: present
-      wait: false
-    register: iam_user
-  - name: assert that the second user is created
-    assert:
-      that:
-      - iam_user is changed
-      - iam_user.iam_user.user.password_reset_required
+    - name: create second test user with password
+      amazon.aws.iam_user:
+        name: "{{ test_user3 }}"
+        password: "{{ test_password }}"
+        password_reset_required: true
+        state: present
+        wait: false
+      register: iam_user
+    - name: assert that the second user is created
+      ansible.builtin.assert:
+        that:
+          - iam_user is changed
+          - iam_user.iam_user.user.password_reset_required
 
-  - name: get info on IAM user(s) on path
-    iam_user_info:
-      path: '{{ test_path }}'
-      name: '{{ test_user }}'
-    register: iam_user_info
-  - assert:
-      that:
-      - iam_user_info.iam_users | length == 1
-      - iam_user_info.iam_users[0].arn == test_iam_user.arn
-      - iam_user_info.iam_users[0].create_date == test_iam_user.create_date
-      - iam_user_info.iam_users[0].path == test_iam_user.path
-      - iam_user_info.iam_users[0].user_id == test_iam_user.user_id
-      - iam_user_info.iam_users[0].user_name == test_iam_user.user_name
-      - iam_user_info.iam_users[0].tags | length == 0
+    - name: get info on IAM user(s) on path
+      amazon.aws.iam_user_info:
+        path: "{{ test_path }}"
+        name: "{{ test_user }}"
+      register: iam_user_info
+    - ansible.builtin.assert:
+        that:
+          - iam_user_info.iam_users | length == 1
+          - iam_user_info.iam_users[0].arn == test_iam_user.arn
+          - iam_user_info.iam_users[0].create_date == test_iam_user.create_date
+          - iam_user_info.iam_users[0].path == test_iam_user.path
+          - iam_user_info.iam_users[0].user_id == test_iam_user.user_id
+          - iam_user_info.iam_users[0].user_name == test_iam_user.user_name
+          - iam_user_info.iam_users[0].tags | length == 0
 
-  # ------------------------------------------------------------------------------------------
-  ## Test tags creation / updates
-  - name: Add Tag (check mode)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      tags:
-        TagA: ValueA
-    register: iam_user
-    check_mode: yes
-  - assert:
-      that:
-      - iam_user is changed
+    # ------------------------------------------------------------------------------------------
+    ## Test tags creation / updates
+    - name: Add Tag (check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        tags:
+          TagA: ValueA
+      register: iam_user
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - iam_user is changed
 
-  - name: Add Tag
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      tags:
-        TagA: ValueA
-    register: iam_user
-  - assert:
-      that:
-      - iam_user is changed
-      - iam_user.iam_user.user.user_name == test_user
-      - iam_user.iam_user.user.tags | length == 1
-      - '"TagA" in iam_user.iam_user.user.tags'
-      - iam_user.iam_user.user.tags.TagA == "ValueA"
+    - name: Add Tag
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        tags:
+          TagA: ValueA
+      register: iam_user
+    - ansible.builtin.assert:
+        that:
+          - iam_user is changed
+          - iam_user.iam_user.user.user_name == test_user
+          - iam_user.iam_user.user.tags | length == 1
+          - '"TagA" in iam_user.iam_user.user.tags'
+          - iam_user.iam_user.user.tags.TagA == "ValueA"
 
-  - name: Add Tag (no change - check mode)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      tags:
-        TagA: ValueA
-    register: iam_user
-    check_mode: yes
-  - assert:
-      that:
-      - iam_user is not changed
+    - name: Add Tag (no change - check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        tags:
+          TagA: ValueA
+      register: iam_user
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - iam_user is not changed
 
-  - name: Add Tag (no change)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      tags:
-        TagA: ValueA
-    register: iam_user
-  - assert:
-      that:
-      - iam_user is not changed
-      - iam_user.iam_user.user.user_name == test_user
-      - iam_user.iam_user.user.tags | length == 1
-      - '"TagA" in iam_user.iam_user.user.tags'
-      - iam_user.iam_user.user.tags.TagA == "ValueA"
+    - name: Add Tag (no change)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        tags:
+          TagA: ValueA
+      register: iam_user
+    - ansible.builtin.assert:
+        that:
+          - iam_user is not changed
+          - iam_user.iam_user.user.user_name == test_user
+          - iam_user.iam_user.user.tags | length == 1
+          - '"TagA" in iam_user.iam_user.user.tags'
+          - iam_user.iam_user.user.tags.TagA == "ValueA"
 
-  - name: Extend Tags
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      purge_tags: no
-      tags:
-        tag_b: value_b
-        Tag C: Value C
-        tag d: value d
-    register: iam_user
-  - assert:
-      that:
-      - iam_user is changed
-      - iam_user.iam_user.user.user_name == test_user
-      - iam_user.iam_user.user.tags | length == 4
-      - '"TagA" in iam_user.iam_user.user.tags'
-      - '"tag_b" in iam_user.iam_user.user.tags'
-      - '"Tag C" in iam_user.iam_user.user.tags'
-      - '"tag d" in iam_user.iam_user.user.tags'
-      - iam_user.iam_user.user.tags.TagA == "ValueA"
-      - iam_user.iam_user.user.tags.tag_b == "value_b"
-      - iam_user.iam_user.user.tags["Tag C"] == "Value C"
-      - iam_user.iam_user.user.tags["tag d"] == "value d"
+    - name: Extend Tags
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        purge_tags: false
+        tags:
+          tag_b: value_b
+          Tag C: Value C
+          tag d: value d
+      register: iam_user
+    - ansible.builtin.assert:
+        that:
+          - iam_user is changed
+          - iam_user.iam_user.user.user_name == test_user
+          - iam_user.iam_user.user.tags | length == 4
+          - '"TagA" in iam_user.iam_user.user.tags'
+          - '"tag_b" in iam_user.iam_user.user.tags'
+          - '"Tag C" in iam_user.iam_user.user.tags'
+          - '"tag d" in iam_user.iam_user.user.tags'
+          - iam_user.iam_user.user.tags.TagA == "ValueA"
+          - iam_user.iam_user.user.tags.tag_b == "value_b"
+          - iam_user.iam_user.user.tags["Tag C"] == "Value C"
+          - iam_user.iam_user.user.tags["tag d"] == "value d"
 
-  - name: Create user without Tag (no change)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-    register: iam_user
-  - assert:
-      that:
-      - iam_user is not changed
-      - iam_user.iam_user.user.user_name == test_user
-      - iam_user.iam_user.user.tags | length == 4
+    - name: Create user without Tag (no change)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+      register: iam_user
+    - ansible.builtin.assert:
+        that:
+          - iam_user is not changed
+          - iam_user.iam_user.user.user_name == test_user
+          - iam_user.iam_user.user.tags | length == 4
 
-  - name: Remove all Tags (check mode)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      tags: {}
-    check_mode: yes
-    register: iam_user
-  - assert:
-      that:
-      - iam_user is changed
+    - name: Remove all Tags (check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        tags: {}
+      check_mode: true
+      register: iam_user
+    - ansible.builtin.assert:
+        that:
+          - iam_user is changed
 
-  - name: Remove 3 Tags
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      tags:
-        TagA: ValueA
-    register: iam_user
-  - assert:
-      that:
-      - iam_user is changed
-      - iam_user.iam_user.user.user_name == test_user
-      - iam_user.iam_user.user.tags | length == 1
-      - '"TagA" in iam_user.iam_user.user.tags'
-      - iam_user.iam_user.user.tags.TagA == "ValueA"
+    - name: Remove 3 Tags
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        tags:
+          TagA: ValueA
+      register: iam_user
+    - ansible.builtin.assert:
+        that:
+          - iam_user is changed
+          - iam_user.iam_user.user.user_name == test_user
+          - iam_user.iam_user.user.tags | length == 1
+          - '"TagA" in iam_user.iam_user.user.tags'
+          - iam_user.iam_user.user.tags.TagA == "ValueA"
 
-  - name: Change Tag (check mode)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      tags:
-        TagA: AnotherValueA
-    register: iam_user
-    check_mode: yes
-  - assert:
-      that:
-      - iam_user is changed
+    - name: Change Tag (check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        tags:
+          TagA: AnotherValueA
+      register: iam_user
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - iam_user is changed
 
-  - name: Change Tag
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      tags:
-        TagA: AnotherValueA
-    register: iam_user
-  - assert:
-      that:
-      - iam_user is changed
-      - iam_user.iam_user.user.user_name == test_user
-      - iam_user.iam_user.user.tags | length == 1
-      - '"TagA" in iam_user.iam_user.user.tags'
-      - iam_user.iam_user.user.tags.TagA == "AnotherValueA"
+    - name: Change Tag
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        tags:
+          TagA: AnotherValueA
+      register: iam_user
+    - ansible.builtin.assert:
+        that:
+          - iam_user is changed
+          - iam_user.iam_user.user.user_name == test_user
+          - iam_user.iam_user.user.tags | length == 1
+          - '"TagA" in iam_user.iam_user.user.tags'
+          - iam_user.iam_user.user.tags.TagA == "AnotherValueA"
 
-  - name: Remove All Tags
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      tags: {}
-    register: iam_user
-  - assert:
-      that:
-      - iam_user is changed
-      - iam_user.iam_user.user.user_name == test_user
-      - iam_user.iam_user.user.tags | length == 0
+    - name: Remove All Tags
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        tags: {}
+      register: iam_user
+    - ansible.builtin.assert:
+        that:
+          - iam_user is changed
+          - iam_user.iam_user.user.user_name == test_user
+          - iam_user.iam_user.user.tags | length == 0
 
-  - name: Remove All Tags (no change)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      tags: {}
-    register: iam_user
-  - assert:
-      that:
-      - iam_user is not changed
-      - iam_user.iam_user.user.user_name == test_user
-      - iam_user.iam_user.user.tags | length == 0
+    - name: Remove All Tags (no change)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        tags: {}
+      register: iam_user
+    - ansible.builtin.assert:
+        that:
+          - iam_user is not changed
+          - iam_user.iam_user.user.user_name == test_user
+          - iam_user.iam_user.user.tags | length == 0
 
-  # ------------------------------------------------------------------------------------------
-  ## Test user password update
-  - name: test update IAM password with on_create only (check mode)
-    iam_user:
-      name: '{{ test_user3 }}'
-      password: '{{ test_new_password }}'
-      update_password: on_create
-      state: present
-    register: iam_user_update
-    check_mode: yes
-  - assert:
-      that:
-      - iam_user_update is not changed
+    # ------------------------------------------------------------------------------------------
+    ## Test user password update
+    - name: test update IAM password with on_create only (check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user3 }}"
+        password: "{{ test_new_password }}"
+        update_password: on_create
+        state: present
+      register: iam_user_update
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - iam_user_update is not changed
 
-  - name: test update IAM password with on_create only
-    iam_user:
-      name: '{{ test_user3 }}'
-      password: '{{ test_new_password }}'
-      update_password: on_create
-      state: present
-    register: iam_user_update
-  - assert:
-      that:
-      - iam_user_update is not changed
+    - name: test update IAM password with on_create only
+      amazon.aws.iam_user:
+        name: "{{ test_user3 }}"
+        password: "{{ test_new_password }}"
+        update_password: on_create
+        state: present
+      register: iam_user_update
+    - ansible.builtin.assert:
+        that:
+          - iam_user_update is not changed
 
-  - name: update IAM password (check mode)
-    iam_user:
-      name: '{{ test_user3 }}'
-      password: '{{ test_new_password }}'
-      state: present
-    register: iam_user_update
-    check_mode: yes
-  - assert:
-      that:
-      - iam_user_update is changed
+    - name: update IAM password (check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user3 }}"
+        password: "{{ test_new_password }}"
+        state: present
+      register: iam_user_update
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - iam_user_update is changed
 
-  # flakey, there is no waiter for login profiles
-  # Login Profile for User ansible-user-c cannot be modified while login profile is being created.
-  - name: update IAM password
-    iam_user:
-      name: '{{ test_user3 }}'
-      password: '{{ test_new_password }}'
-      state: present
-    register: iam_user_update
-    until: iam_user_update.failed == false
-    delay: 3
-    retries: 5
-  - assert:
-      that:
-      - iam_user_update is changed
-      - iam_user_update.iam_user.user.user_name == test_user3
+    # flakey, there is no waiter for login profiles
+    # Login Profile for User ansible-user-c cannot be modified while login profile is being created.
+    - name: update IAM password
+      amazon.aws.iam_user:
+        name: "{{ test_user3 }}"
+        password: "{{ test_new_password }}"
+        state: present
+      register: iam_user_update
+      until: iam_user_update.failed == false
+      delay: 3
+      retries: 5
+    - ansible.builtin.assert:
+        that:
+          - iam_user_update is changed
+          - iam_user_update.iam_user.user.user_name == test_user3
 
-  # ===========================================
-  # Test Managed Policy management
-  #
-  # Use a couple of benign policies for testing:
-  # - AWSDenyAll
-  # - ServiceQuotasReadOnlyAccess
-  #
-  - name: attach managed policy to user (check mode)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - arn:aws:iam::aws:policy/AWSDenyAll
-    register: iam_user
-    check_mode: yes
-  - name: assert that the user is changed
-    assert:
-      that:
-      - iam_user is changed
+    # ===========================================
+    # Test Managed Policy management
+    #
+    # Use a couple of benign policies for testing:
+    # - AWSDenyAll
+    # - ServiceQuotasReadOnlyAccess
+    #
+    - name: attach managed policy to user (check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - arn:aws:iam::aws:policy/AWSDenyAll
+      register: iam_user
+      check_mode: true
+    - name: assert that the user is changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is changed
 
-  - name: attach managed policy to user
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - arn:aws:iam::aws:policy/AWSDenyAll
-    register: iam_user
-  - name: assert that the user is changed
-    assert:
-      that:
-      - iam_user is changed
+    - name: attach managed policy to user
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - arn:aws:iam::aws:policy/AWSDenyAll
+      register: iam_user
+    - name: assert that the user is changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is changed
 
-  - name: ensure managed policy is attached to user (no change - check mode)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - arn:aws:iam::aws:policy/AWSDenyAll
-    register: iam_user
-    check_mode: yes
-  - name: assert that the user hasn't changed
-    assert:
-      that:
-      - iam_user is not changed
+    - name: ensure managed policy is attached to user (no change - check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - arn:aws:iam::aws:policy/AWSDenyAll
+      register: iam_user
+      check_mode: true
+    - name: assert that the user hasn't changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is not changed
 
-  - name: ensure managed policy is attached to user (no change)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - arn:aws:iam::aws:policy/AWSDenyAll
-    register: iam_user
-  - name: assert that the user hasn't changed
-    assert:
-      that:
-      - iam_user is not changed
+    - name: ensure managed policy is attached to user (no change)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - arn:aws:iam::aws:policy/AWSDenyAll
+      register: iam_user
+    - name: assert that the user hasn't changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is not changed
 
-  # ------------------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------------------
 
-  - name: attach different managed policy to user (check mode)
-    check_mode: yes
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
-      purge_policy: no
-    register: iam_user
-  - name: assert that the user changed
-    assert:
-      that:
-      - iam_user is changed
+    - name: attach different managed policy to user (check mode)
+      check_mode: true
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
+        purge_policy: false
+      register: iam_user
+    - name: assert that the user changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is changed
 
-  - name: attach different managed policy to user
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
-      purge_policy: no
-    register: iam_user
-  - name: assert that the user changed
-    assert:
-      that:
-      - iam_user is changed
+    - name: attach different managed policy to user
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
+        purge_policy: false
+      register: iam_user
+    - name: assert that the user changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is changed
 
-  - name: attach different managed policy to user (no change - check mode)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
-      purge_policy: no
-    register: iam_user
-    check_mode: yes
-  - name: assert that the user hasn't changed
-    assert:
-      that:
-      - iam_user is not changed
+    - name: attach different managed policy to user (no change - check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
+        purge_policy: false
+      register: iam_user
+      check_mode: true
+    - name: assert that the user hasn't changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is not changed
 
-  - name: Check first policy wasn't purged
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
-      - arn:aws:iam::aws:policy/AWSDenyAll
-      purge_policy: no
-    register: iam_user
-  - name: assert that the user hasn't changed
-    assert:
-      that:
-      - iam_user is not changed
+    - name: Check first policy wasn't purged
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
+          - arn:aws:iam::aws:policy/AWSDenyAll
+        purge_policy: false
+      register: iam_user
+    - name: assert that the user hasn't changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is not changed
 
-  - name: Check that managed policy order doesn't matter
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - arn:aws:iam::aws:policy/AWSDenyAll
-      - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
-      purge_policy: no
-    register: iam_user
-  - name: assert that the user hasn't changed
-    assert:
-      that:
-      - iam_user is not changed
+    - name: Check that managed policy order doesn't matter
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - arn:aws:iam::aws:policy/AWSDenyAll
+          - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
+        purge_policy: false
+      register: iam_user
+    - name: assert that the user hasn't changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is not changed
 
-  - name: Check that policy doesn't require full ARN path
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - AWSDenyAll
-      - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
-      purge_policy: no
-    register: iam_user
-  - name: assert that the user hasn't changed
-    assert:
-      that:
-      - iam_user is not changed
+    - name: Check that policy doesn't require full ARN path
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - AWSDenyAll
+          - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
+        purge_policy: false
+      register: iam_user
+    - name: assert that the user hasn't changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is not changed
 
-  # ------------------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------------------
 
-  - name: Remove one of the managed policies - with purge (check mode)
-    check_mode: yes
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
-      purge_policy: yes
-    register: iam_user
-  - name: assert that the user changed
-    assert:
-      that:
-      - iam_user is changed
+    - name: Remove one of the managed policies - with purge (check mode)
+      check_mode: true
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
+        purge_policy: true
+      register: iam_user
+    - name: assert that the user changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is changed
 
-  - name: Remove one of the managed policies - with purge
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
-      purge_policy: yes
-    register: iam_user
-  - name: assert that the user changed
-    assert:
-      that:
-      - iam_user is changed
+    - name: Remove one of the managed policies - with purge
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
+        purge_policy: true
+      register: iam_user
+    - name: assert that the user changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is changed
 
-  - name: Remove one of the managed policies - with purge (no change - check mode)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
-      purge_policy: yes
-    register: iam_user
-    check_mode: yes
-  - name: assert that the user hasn't changed
-    assert:
-      that:
-      - iam_user is not changed
+    - name: Remove one of the managed policies - with purge (no change - check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
+        purge_policy: true
+      register: iam_user
+      check_mode: true
+    - name: assert that the user hasn't changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is not changed
 
-  - name: Remove one of the managed policies - with purge (no change)
-    iam_user:
-      name: '{{ test_user }}'
-      state: present
-      managed_policy:
-      - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
-      purge_policy: yes
-    register: iam_user
-  - name: assert that the user hasn't changed
-    assert:
-      that:
-      - iam_user is not changed
+    - name: Remove one of the managed policies - with purge (no change)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: present
+        managed_policy:
+          - arn:aws:iam::aws:policy/ServiceQuotasReadOnlyAccess
+        purge_policy: true
+      register: iam_user
+    - name: assert that the user hasn't changed
+      ansible.builtin.assert:
+        that:
+          - iam_user is not changed
 
-  # ------------------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------------------
 
-  - name: ensure group exists
-    iam_group:
-      name: '{{ test_group }}'
-      users:
-      - '{{ test_user }}'
-      state: present
-    register: iam_group
-  - assert:
-      that:
-      - iam_group.changed
-      - iam_group.iam_group.users
+    - name: ensure group exists
+      community.aws.iam_group:
+        name: "{{ test_group }}"
+        users:
+          - "{{ test_user }}"
+        state: present
+      register: iam_group
+    - ansible.builtin.assert:
+        that:
+          - iam_group.changed
+          - iam_group.iam_group.users
 
-  - name: get info on IAM user(s) in group
-    iam_user_info:
-      group: '{{ test_group }}'
-      name: '{{ test_user }}'
-    register: iam_user_info
-  - assert:
-      that:
-      - iam_user_info.iam_users | length == 1
-      - iam_user_info.iam_users[0].arn == test_iam_user.arn
-      - iam_user_info.iam_users[0].create_date == test_iam_user.create_date
-      - iam_user_info.iam_users[0].path == test_iam_user.path
-      - iam_user_info.iam_users[0].user_id == test_iam_user.user_id
-      - iam_user_info.iam_users[0].user_name == test_iam_user.user_name
-      - iam_user_info.iam_users[0].tags | length == 0
+    - name: get info on IAM user(s) in group
+      amazon.aws.iam_user_info:
+        group: "{{ test_group }}"
+        name: "{{ test_user }}"
+      register: iam_user_info
+    - ansible.builtin.assert:
+        that:
+          - iam_user_info.iam_users | length == 1
+          - iam_user_info.iam_users[0].arn == test_iam_user.arn
+          - iam_user_info.iam_users[0].create_date == test_iam_user.create_date
+          - iam_user_info.iam_users[0].path == test_iam_user.path
+          - iam_user_info.iam_users[0].user_id == test_iam_user.user_id
+          - iam_user_info.iam_users[0].user_name == test_iam_user.user_name
+          - iam_user_info.iam_users[0].tags | length == 0
 
-  - name: remove user from group
-    iam_group:
-      name: '{{ test_group }}'
-      purge_users: true
-      users: []
-      state: present
-    register: iam_group
-  - name: get info on IAM user(s) after removing from group
-    iam_user_info:
-      group: '{{ test_group }}'
-      name: '{{ test_user }}'
-    register: iam_user_info
-  - name: assert empty list of users for group are returned
-    assert:
-      that:
-      - iam_user_info.iam_users | length == 0
+    - name: remove user from group
+      community.aws.iam_group:
+        name: "{{ test_group }}"
+        purge_users: true
+        users: []
+        state: present
+      register: iam_group
+    - name: get info on IAM user(s) after removing from group
+      amazon.aws.iam_user_info:
+        group: "{{ test_group }}"
+        name: "{{ test_user }}"
+      register: iam_user_info
+    - name: assert empty list of users for group are returned
+      ansible.builtin.assert:
+        that:
+          - iam_user_info.iam_users | length == 0
 
-  - name: ensure ansible users exist
-    iam_user:
-      name: '{{ item }}'
-      state: present
-    with_items: '{{ test_users }}'
-  - name: get info on multiple IAM user(s)
-    iam_user_info:
-    register: iam_user_info
-  - assert:
-      that:
-      - iam_user_info.iam_users | length != 0
+    - name: ensure ansible users exist
+      amazon.aws.iam_user:
+        name: "{{ item }}"
+        state: present
+      with_items: "{{ test_users }}"
+    - name: get info on multiple IAM user(s)
+      amazon.aws.iam_user_info:
+      register: iam_user_info
+    - ansible.builtin.assert:
+        that:
+          - iam_user_info.iam_users | length != 0
 
-  - name: ensure multiple user group exists with single user
-    iam_group:
-      name: '{{ test_group }}'
-      users:
-      - '{{ test_user }}'
-      state: present
-    register: iam_group
-  - name: get info on IAM user(s) in group
-    iam_user_info:
-      group: '{{ test_group }}'
-    register: iam_user_info
-  - assert:
-      that:
-      - iam_user_info.iam_users | length == 1
+    - name: ensure multiple user group exists with single user
+      community.aws.iam_group:
+        name: "{{ test_group }}"
+        users:
+          - "{{ test_user }}"
+        state: present
+      register: iam_group
+    - name: get info on IAM user(s) in group
+      amazon.aws.iam_user_info:
+        group: "{{ test_group }}"
+      register: iam_user_info
+    - ansible.builtin.assert:
+        that:
+          - iam_user_info.iam_users | length == 1
 
-  - name: add all users to group
-    iam_group:
-      name: '{{ test_group }}'
-      users: '{{ test_users }}'
-      state: present
-    register: iam_group
-  - name: get info on multiple IAM user(s) in group
-    iam_user_info:
-      group: '{{ test_group }}'
-    register: iam_user_info
-  - assert:
-      that:
-      - iam_user_info.iam_users | length == test_users | length
+    - name: add all users to group
+      community.aws.iam_group:
+        name: "{{ test_group }}"
+        users: "{{ test_users }}"
+        state: present
+      register: iam_group
+    - name: get info on multiple IAM user(s) in group
+      amazon.aws.iam_user_info:
+        group: "{{ test_group }}"
+      register: iam_user_info
+    - ansible.builtin.assert:
+        that:
+          - iam_user_info.iam_users | length == test_users | length
 
-  - name: purge users from group
-    iam_group:
-      name: '{{ test_group }}'
-      purge_users: true
-      users: []
-      state: present
-    register: iam_group
-  - name: ensure info is empty for empty group
-    iam_user_info:
-      group: '{{ test_group }}'
-    register: iam_user_info
-  - assert:
-      that:
-      - iam_user_info.iam_users | length == 0
+    - name: purge users from group
+      community.aws.iam_group:
+        name: "{{ test_group }}"
+        purge_users: true
+        users: []
+        state: present
+      register: iam_group
+    - name: ensure info is empty for empty group
+      amazon.aws.iam_user_info:
+        group: "{{ test_group }}"
+      register: iam_user_info
+    - ansible.builtin.assert:
+        that:
+          - iam_user_info.iam_users | length == 0
 
-  - name: get info on IAM user(s) after removing from group
-    iam_user_info:
-      group: '{{ test_group }}'
-    register: iam_user_info
-  - name: assert empty list of users for group are returned
-    assert:
-      that:
-      - iam_user_info.iam_users | length == 0
+    - name: get info on IAM user(s) after removing from group
+      amazon.aws.iam_user_info:
+        group: "{{ test_group }}"
+      register: iam_user_info
+    - name: assert empty list of users for group are returned
+      ansible.builtin.assert:
+        that:
+          - iam_user_info.iam_users | length == 0
 
-  - name: remove group
-    iam_group:
-      name: '{{ test_group }}'
-      state: absent
-    register: iam_group
-  - name: assert that group was removed
-    assert:
-      that:
-      - iam_group.changed
-      - iam_group
+    - name: remove group
+      community.aws.iam_group:
+        name: "{{ test_group }}"
+        state: absent
+      register: iam_group
+    - name: assert that group was removed
+      ansible.builtin.assert:
+        that:
+          - iam_group.changed
+          - iam_group
 
-  - name: Test remove group again (idempotency)
-    iam_group:
-      name: '{{ test_group }}'
-      state: absent
-    register: iam_group
-  - name: assert that group remove is not changed
-    assert:
-      that:
-      - not iam_group.changed
+    - name: Test remove group again (idempotency)
+      community.aws.iam_group:
+        name: "{{ test_group }}"
+        state: absent
+      register: iam_group
+    - name: assert that group remove is not changed
+      ansible.builtin.assert:
+        that:
+          - not iam_group.changed
 
-  # ------------------------------------------------------------------------------------------
+    # ------------------------------------------------------------------------------------------
 
-  - name: Remove user with attached policy (check mode)
-    iam_user:
-      name: '{{ test_user }}'
-      state: absent
-    register: iam_user
-    check_mode: yes
-  - name: get info on IAM user(s) after deleting in check mode
-    iam_user_info:
-      name: '{{ test_user }}'
-    register: iam_user_info
-  - name: Assert user was not removed in check mode
-    assert:
-      that:
-      - iam_user.changed
-      - iam_user_info.iam_users | length == 1
+    - name: Remove user with attached policy (check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: absent
+      register: iam_user
+      check_mode: true
+    - name: get info on IAM user(s) after deleting in check mode
+      amazon.aws.iam_user_info:
+        name: "{{ test_user }}"
+      register: iam_user_info
+    - name: Assert user was not removed in check mode
+      ansible.builtin.assert:
+        that:
+          - iam_user.changed
+          - iam_user_info.iam_users | length == 1
 
-  - name: Remove user with attached policy
-    iam_user:
-      name: '{{ test_user }}'
-      state: absent
-    register: iam_user
-  - name: get info on IAM user(s) after deleting
-    iam_user_info:
-      name: '{{ test_user }}'
-    register: iam_user_info
-  - name: Assert user was removed
-    assert:
-      that:
-      - iam_user.changed
-      - iam_user_info.iam_users | length == 0
+    - name: Remove user with attached policy
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: absent
+      register: iam_user
+    - name: get info on IAM user(s) after deleting
+      amazon.aws.iam_user_info:
+        name: "{{ test_user }}"
+      register: iam_user_info
+    - name: Assert user was removed
+      ansible.builtin.assert:
+        that:
+          - iam_user.changed
+          - iam_user_info.iam_users | length == 0
 
-  - name: Remove user with attached policy (idempotent - check mode)
-    iam_user:
-      name: '{{ test_user }}'
-      state: absent
-    register: iam_user
-    check_mode: yes
-  - name: Assert no change
-    assert:
-      that:
-      - not iam_user.changed
+    - name: Remove user with attached policy (idempotent - check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: absent
+      register: iam_user
+      check_mode: true
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - not iam_user.changed
 
-  - name: Remove user with attached policy (idempotent)
-    iam_user:
-      name: '{{ test_user }}'
-      state: absent
-    register: iam_user
-  - name: Assert no change
-    assert:
-      that:
-      - not iam_user.changed
+    - name: Remove user with attached policy (idempotent)
+      amazon.aws.iam_user:
+        name: "{{ test_user }}"
+        state: absent
+      register: iam_user
+    - name: Assert no change
+      ansible.builtin.assert:
+        that:
+          - not iam_user.changed
 
-  # ------------------------------------------------------------------------------------------
-  ## Test user password removal
-  - name: Delete IAM password (check mode)
-    iam_user:
-      name: '{{ test_user3 }}'
-      remove_password: yes
-      state: present
-    register: iam_user_password_removal
-    check_mode: yes
-  - assert:
-      that:
-      - iam_user_password_removal is changed
+    # ------------------------------------------------------------------------------------------
+    ## Test user password removal
+    - name: Delete IAM password (check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user3 }}"
+        remove_password: true
+        state: present
+      register: iam_user_password_removal
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - iam_user_password_removal is changed
 
-  - name: Delete IAM password
-    iam_user:
-      name: '{{ test_user3 }}'
-      remove_password: yes
-      state: present
-    register: iam_user_password_removal
-  - assert:
-      that:
-      - iam_user_password_removal is changed
+    - name: Delete IAM password
+      amazon.aws.iam_user:
+        name: "{{ test_user3 }}"
+        remove_password: true
+        state: present
+      register: iam_user_password_removal
+    - ansible.builtin.assert:
+        that:
+          - iam_user_password_removal is changed
 
-  - name: Delete IAM password again (check mode)
-    iam_user:
-      name: '{{ test_user3 }}'
-      remove_password: yes
-      state: present
-    register: iam_user_password_removal
-    check_mode: yes
-  - assert:
-      that:
-      - iam_user_password_removal is not changed
+    - name: Delete IAM password again (check mode)
+      amazon.aws.iam_user:
+        name: "{{ test_user3 }}"
+        remove_password: true
+        state: present
+      register: iam_user_password_removal
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - iam_user_password_removal is not changed
 
-  - name: Delete IAM password again
-    iam_user:
-      name: '{{ test_user3 }}'
-      remove_password: yes
-      state: present
-    register: iam_user_password_removal
-  - assert:
-      that:
-      - iam_user_password_removal is not changed
+    - name: Delete IAM password again
+      amazon.aws.iam_user:
+        name: "{{ test_user3 }}"
+        remove_password: true
+        state: present
+      register: iam_user_password_removal
+    - ansible.builtin.assert:
+        that:
+          - iam_user_password_removal is not changed
 
   always:
-  - name: remove group
-    iam_group:
-      name: '{{ test_group }}'
-      state: absent
-    ignore_errors: yes
-  - name: remove ansible users
-    iam_user:
-      name: '{{ item }}'
-      state: absent
-    with_items: '{{ test_users }}'
-    ignore_errors: yes
+    - name: remove group
+      community.aws.iam_group:
+        name: "{{ test_group }}"
+        state: absent
+      ignore_errors: true
+    - name: remove ansible users
+      amazon.aws.iam_user:
+        name: "{{ item }}"
+        state: absent
+      with_items: "{{ test_users }}"
+      ignore_errors: true

--- a/tests/integration/targets/inventory_aws_ec2/meta/main.yml
+++ b/tests/integration/targets/inventory_aws_ec2/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/create_environment_script.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/create_environment_script.yml
@@ -1,9 +1,9 @@
 ---
 - hosts: localhost
   connection: local
-  gather_facts: no
+  gather_facts: false
   tasks:
-  - name: 'Write access key to file we can source'
-    copy:
-      dest: '../access_key.sh'
-      content: 'export MY_ACCESS_KEY="{{ aws_access_key }}"'
+    - name: Write access key to file we can source
+      ansible.builtin.copy:
+        dest: ../access_key.sh
+        content: export MY_ACCESS_KEY="{{ aws_access_key }}"

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/create_inventory_config.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/create_inventory_config.yml
@@ -1,11 +1,11 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   vars:
-    template_name: "../templates/{{ template | default('inventory.yml.j2') }}"
+    template_name: ../templates/{{ template | default('inventory.yml.j2') }}
   tasks:
     - name: write inventory config file
-      copy:
+      ansible.builtin.copy:
         dest: ../test.aws_ec2.yml
         content: "{{ lookup('template', template_name) }}"

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/empty_inventory_config.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/empty_inventory_config.yml
@@ -1,9 +1,9 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: write inventory config file
-      copy:
+      ansible.builtin.copy:
         dest: ../test.aws_ec2.yml
         content: ""

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/manage_ec2_instances.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/manage_ec2_instances.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
 
   collections:
     - amazon.aws
@@ -12,10 +12,10 @@
 
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
   tasks:
-    - include_tasks: "tasks/{{ task }}.yml"
+    - ansible.builtin.include_tasks: tasks/{{ task }}.yml

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/populate_cache.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/populate_cache.yml
@@ -1,19 +1,17 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   environment: "{{ ansible_test.environment }}"
   tasks:
-
     - module_defaults:
         group/aws:
-          access_key: '{{ aws_access_key }}'
-          secret_key: '{{ aws_secret_key }}'
-          session_token: '{{ security_token | default(omit) }}'
-          region: '{{ aws_region }}'
+          access_key: "{{ aws_access_key }}"
+          secret_key: "{{ aws_secret_key }}"
+          session_token: "{{ security_token | default(omit) }}"
+          region: "{{ aws_region }}"
       block:
-
-        - debug:
+        - ansible.builtin.debug:
             var: groups
 
-        - include_tasks: tasks/tear_down.yml
+        - ansible.builtin.include_tasks: tasks/tear_down.yml

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_invalid_aws_ec2_inventory_config.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_invalid_aws_ec2_inventory_config.yml
@@ -1,9 +1,9 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: assert inventory was not populated by aws_ec2 inventory plugin
-      assert:
+      ansible.builtin.assert:
         that:
           - "'aws_ec2' not in groups"

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_inventory_cache.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_inventory_cache.yml
@@ -1,18 +1,17 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: assert cache was used to populate inventory
-      assert:
+      ansible.builtin.assert:
         that:
           - "'aws_ec2' in groups"
-          - "groups.aws_ec2 | length > 0"
+          - groups.aws_ec2 | length > 0
 
-    - meta: refresh_inventory
-
+    - ansible.builtin.meta: refresh_inventory
     - name: assert refresh_inventory updated the cache
-      assert:
+      ansible.builtin.assert:
         that:
           - "'aws_ec2' in groups"
-          - "not groups.aws_ec2"
+          - not groups.aws_ec2

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_inventory_ssm.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_inventory_ssm.yml
@@ -10,57 +10,55 @@
 
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
   vars:
     ami_details:
-        owner: 125523088429
-        name: Fedora-Cloud-Base-37-1.2.x86_64*
-        user_data: |
-            #!/bin/sh
-            sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
-            sudo systemctl start amazon-ssm-agent
-        os_type: linux
+      owner: 125523088429
+      name: Fedora-Cloud-Base-37-1.2.x86_64*
+      user_data: |
+        #!/bin/sh
+        sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
+        sudo systemctl start amazon-ssm-agent
+      os_type: linux
     iam_role_name: "{{ resource_prefix }}-inventory-ssm"
 
   tasks:
     - block:
-
         # Create VPC, subnet, security group, and find image_id to create instance
-        - include_tasks: tasks/setup.yml
-
+        - ansible.builtin.include_tasks: tasks/setup.yml
         - name: Ensure IAM instance role exists
-          iam_role:
+          community.aws.iam_role:
             name: "{{ iam_role_name }}"
             assume_role_policy_document: "{{ lookup('file', 'files/ec2-trust-policy.json') }}"
             state: present
-            create_instance_profile: yes
+            create_instance_profile: true
             managed_policy:
-            - AmazonSSMManagedInstanceCore
-            wait: True
+              - AmazonSSMManagedInstanceCore
+            wait: true
           register: role_output
 
         - name: AMI Lookup (ami_info)
-          ec2_ami_info:
+          amazon.aws.ec2_ami_info:
             owners: '{{ ami_details.owner | default("amazon") }}'
             filters:
-              name: '{{ ami_details.name }}'
+              name: "{{ ami_details.name }}"
           register: ec2_amis
           no_log: true
 
         - name: Set facts with latest AMIs
           vars:
             latest_ami: '{{ ec2_amis.images | default([]) | sort(attribute="creation_date") | last }}'
-          set_fact:
-            latest_ami_id: '{{ ssm_amis | default(latest_ami.image_id) }}'
+          ansible.builtin.set_fact:
+            latest_ami_id: "{{ ssm_amis | default(latest_ami.image_id) }}"
 
         - name: Create EC2 instance
-          ec2_instance:
-            instance_type: "t3.micro"
-            ebs_optimized: True
+          amazon.aws.ec2_instance:
+            instance_type: t3.micro
+            ebs_optimized: true
             image_id: "{{ latest_ami_id }}"
             wait: "yes"
             instance_role: "{{ role_output.iam_role.role_name }}"
@@ -68,22 +66,22 @@
             user_data: "{{ ami_details.user_data }}"
             state: running
             tags:
-              TestPrefix: '{{ resource_prefix }}'
+              TestPrefix: "{{ resource_prefix }}"
           register: instance_output
 
-        - set_fact:
+        - ansible.builtin.set_fact:
             instances_ids: "{{ [instance_output.instance_ids[0]] }}"
 
         - name: Get ssm inventory information
           ssm_inventory_info:
-            instance_id: '{{ instance_output.instance_ids[0] }}'
+            instance_id: "{{ instance_output.instance_ids[0] }}"
           register: result
           until: result.ssm_inventory != {}
           retries: 18
           delay: 10
 
         - name: validate EC2 ssm-configured instance
-          assert:
+          ansible.builtin.assert:
             that:
               - result.ssm_inventory != {}
 
@@ -91,22 +89,20 @@
         - name: Create another EC2 instance without SSM configured
           amazon.aws.ec2_instance:
             name: "{{ resource_prefix }}-inventory-std"
-            instance_type: "t3.micro"
+            instance_type: t3.micro
             image_id: "{{ latest_ami_id }}"
             wait: true
             state: running
           register: _instance
 
-        - set_fact:
+        - ansible.builtin.set_fact:
             instances_ids: "{{ instances_ids + _instance.instance_ids }}"
 
         # refresh inventory
-        - meta: refresh_inventory
-
-        - debug: var=hostvars
-
+        - ansible.builtin.meta: refresh_inventory
+        - ansible.builtin.debug: var=hostvars
         - name: assert hostvars was populated with ssm_inventory information
-          assert:
+          ansible.builtin.assert:
             that:
               - ssm_hostname in hostvars
               - std_hostname in hostvars
@@ -116,15 +112,15 @@
               - hostvars[ssm_hostname].ssm_inventory["platform_name"] == "Fedora Linux"
               - '"ssm_inventory" not in hostvars[std_hostname]'
           vars:
-            ssm_hostname: '{{ resource_prefix }}-inventory-ssm'
-            std_hostname: '{{ resource_prefix }}-inventory-std'
+            ssm_hostname: "{{ resource_prefix }}-inventory-ssm"
+            std_hostname: "{{ resource_prefix }}-inventory-std"
 
       always:
         - name: Delete IAM role
-          iam_role:
+          community.aws.iam_role:
             name: "{{ iam_role_name }}"
             state: absent
-            wait: True
+            wait: true
 
         - name: Delete EC2 instances
           amazon.aws.ec2_instance:

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory.yml
@@ -1,12 +1,12 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   environment: "{{ ansible_test.environment }}"
   tasks:
     - name: assert group was populated with inventory and is no longer empty
-      assert:
+      ansible.builtin.assert:
         that:
           - "'aws_ec2' in groups"
-          - "groups.aws_ec2 | length == 1"
-          - "groups.aws_ec2.0 == '{{ resource_prefix }}'"
+          - groups.aws_ec2 | length == 1
+          - groups.aws_ec2.0 == '{{ resource_prefix }}'

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_concatenation.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_concatenation.yml
@@ -1,42 +1,37 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   environment: "{{ ansible_test.environment }}"
   tasks:
-
     - module_defaults:
         group/aws:
-          access_key: '{{ aws_access_key }}'
-          secret_key: '{{ aws_secret_key }}'
-          session_token: '{{ security_token | default(omit) }}'
-          region: '{{ aws_region }}'
+          access_key: "{{ aws_access_key }}"
+          secret_key: "{{ aws_secret_key }}"
+          session_token: "{{ security_token | default(omit) }}"
+          region: "{{ aws_region }}"
       block:
-
         # Create VPC, subnet, security group, and find image_id to create instance
-        - include_tasks: tasks/setup.yml
-
-        # Create new host, refresh inventory
+        - ansible.builtin.include_tasks: tasks/setup.yml
         - name: create a new host
-          ec2_instance:
-            image_id: '{{ image_id }}'
-            name: '{{ resource_prefix }}'
+          amazon.aws.ec2_instance:
+            image_id: "{{ image_id }}"
+            name: "{{ resource_prefix }}"
             tags:
               OtherTag: value
             purge_tags: true
             instance_type: t2.micro
-            security_groups: '{{ sg_id }}'
-            vpc_subnet_id: '{{ subnet_id }}'
+            security_groups: "{{ sg_id }}"
+            vpc_subnet_id: "{{ subnet_id }}"
             wait: false
           register: setup_instance
 
-        - meta: refresh_inventory
-
+        - ansible.builtin.meta: refresh_inventory
         - name: register the current hostname
-          set_fact:
-            expected_hostname: "value_{{ resource_prefix }}"
+          ansible.builtin.set_fact:
+            expected_hostname: value_{{ resource_prefix }}
 
-        - name: "Ensure we've got a hostvars entry for the new host"
-          assert:
+        - name: Ensure we've got a hostvars entry for the new host
+          ansible.builtin.assert:
             that:
               - expected_hostname in hostvars

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml
@@ -1,55 +1,49 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   environment: "{{ ansible_test.environment }}"
   tasks:
-
     - module_defaults:
         group/aws:
-          access_key: '{{ aws_access_key }}'
-          secret_key: '{{ aws_secret_key }}'
-          session_token: '{{ security_token | default(omit) }}'
-          region: '{{ aws_region }}'
+          access_key: "{{ aws_access_key }}"
+          secret_key: "{{ aws_secret_key }}"
+          session_token: "{{ security_token | default(omit) }}"
+          region: "{{ aws_region }}"
       block:
-
         # Create VPC, subnet, security group, and find image_id to create instance
 
-        - include_tasks: tasks/setup.yml
-
-        # Create new host, refresh inventory
-
+        - ansible.builtin.include_tasks: tasks/setup.yml
         - name: create a new host
-          ec2_instance:
-            image_id: '{{ image_id }}'
-            name: '{{ resource_prefix }}'
+          amazon.aws.ec2_instance:
+            image_id: "{{ image_id }}"
+            name: "{{ resource_prefix }}"
             tags:
               tag1: value1
               tag2: value2
             purge_tags: true
             instance_type: t2.micro
-            security_groups: '{{ sg_id }}'
-            vpc_subnet_id: '{{ subnet_id }}'
+            security_groups: "{{ sg_id }}"
+            vpc_subnet_id: "{{ subnet_id }}"
             wait: false
           register: setup_instance
 
-        - meta: refresh_inventory
-
+        - ansible.builtin.meta: refresh_inventory
         - name: register the keyed sg group name
-          set_fact:
-            sg_group_name: "security_groups_{{ sg_id | replace('-', '_') }}"
+          ansible.builtin.set_fact:
+            sg_group_name: security_groups_{{ sg_id | replace('-', '_') }}
 
         - name: register one of the keyed tag groups name
-          set_fact:
-            tag_group_name: "tag_Name_{{ resource_prefix | replace('-', '_') }}"
+          ansible.builtin.set_fact:
+            tag_group_name: tag_Name_{{ resource_prefix | replace('-', '_') }}
 
         - name: assert the keyed groups and groups from constructed config were added to inventory and composite var added to hostvars
-          assert:
+          ansible.builtin.assert:
             that:
               # There are 9 groups: all, ungrouped, aws_ec2, sg keyed group, 3 tag keyed group (one per tag), arch keyed group, constructed group
-              - "groups | length == 9"
-              - "groups[tag_group_name] | length == 1"
-              - "groups[sg_group_name] | length == 1"
-              - "groups.arch_x86_64 | length == 1"
-              - "groups.tag_with_name_key | length == 1"
+              - groups | length == 9
+              - groups[tag_group_name] | length == 1
+              - groups[sg_group_name] | length == 1
+              - groups.arch_x86_64 | length == 1
+              - groups.tag_with_name_key | length == 1
               - vars.hostvars[groups.aws_ec2.0]['test_compose_var_sum'] == 'value1value2'

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags.yml
@@ -4,41 +4,36 @@
   gather_facts: false
   environment: "{{ ansible_test.environment }}"
   tasks:
-
     - module_defaults:
         group/aws:
-          access_key: '{{ aws_access_key }}'
-          secret_key: '{{ aws_secret_key }}'
-          session_token: '{{ security_token | default(omit) }}'
-          region: '{{ aws_region }}'
+          access_key: "{{ aws_access_key }}"
+          secret_key: "{{ aws_secret_key }}"
+          session_token: "{{ security_token | default(omit) }}"
+          region: "{{ aws_region }}"
       block:
-
         # Create VPC, subnet, security group, and find image_id to create instance
-        - include_tasks: tasks/setup.yml
-
-        # Create new host
+        - ansible.builtin.include_tasks: tasks/setup.yml
         - name: create a new host
-          ec2_instance:
-            image_id: '{{ image_id }}'
-            name: '{{ resource_prefix }}'
+          amazon.aws.ec2_instance:
+            image_id: "{{ image_id }}"
+            name: "{{ resource_prefix }}"
             tags:
               Tag1: Test1
               Tag2: Test2
             purge_tags: true
             instance_type: t2.micro
-            security_groups: '{{ sg_id }}'
-            vpc_subnet_id: '{{ subnet_id }}'
+            security_groups: "{{ sg_id }}"
+            vpc_subnet_id: "{{ subnet_id }}"
             wait: false
           register: setup_instance
 
         # refresh inventory
-        - meta: refresh_inventory
-
-        - debug:
+        - ansible.builtin.meta: refresh_inventory
+        - ansible.builtin.debug:
             var: groups
 
         - name: assert groups and hostvars were populated with inventory
-          assert:
+          ansible.builtin.assert:
             that:
               - "'aws_ec2' in groups"
               - groups['aws_ec2'] | length == 1

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags_classic.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_using_tags_classic.yml
@@ -4,41 +4,36 @@
   gather_facts: false
   environment: "{{ ansible_test.environment }}"
   tasks:
-
     - module_defaults:
         group/aws:
-          access_key: '{{ aws_access_key }}'
-          secret_key: '{{ aws_secret_key }}'
-          session_token: '{{ security_token | default(omit) }}'
-          region: '{{ aws_region }}'
+          access_key: "{{ aws_access_key }}"
+          secret_key: "{{ aws_secret_key }}"
+          session_token: "{{ security_token | default(omit) }}"
+          region: "{{ aws_region }}"
       block:
-
         # Create VPC, subnet, security group, and find image_id to create instance
-        - include_tasks: tasks/setup.yml
-
-        # Create new host
+        - ansible.builtin.include_tasks: tasks/setup.yml
         - name: create a new host
-          ec2_instance:
-            image_id: '{{ image_id }}'
-            name: '{{ resource_prefix }}'
+          amazon.aws.ec2_instance:
+            image_id: "{{ image_id }}"
+            name: "{{ resource_prefix }}"
             tags:
               Tag1: Test1
               Tag2: Test2
             purge_tags: true
             instance_type: t2.micro
-            security_groups: '{{ sg_id }}'
-            vpc_subnet_id: '{{ subnet_id }}'
+            security_groups: "{{ sg_id }}"
+            vpc_subnet_id: "{{ subnet_id }}"
             wait: false
           register: setup_instance
 
         # refresh inventory
-        - meta: refresh_inventory
-
-        - debug:
+        - ansible.builtin.meta: refresh_inventory
+        - ansible.builtin.debug:
             var: groups
 
         - name: assert groups and hostvars were populated with inventory
-          assert:
+          ansible.builtin.assert:
             that:
               - "'aws_ec2' in groups"
               - groups['aws_ec2'] | length == 1

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostvars_prefix_suffix.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostvars_prefix_suffix.yml
@@ -1,42 +1,37 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   environment: "{{ ansible_test.environment }}"
   tasks:
-
     - module_defaults:
         group/aws:
-          access_key: '{{ aws_access_key }}'
-          secret_key: '{{ aws_secret_key }}'
-          session_token: '{{ security_token | default(omit) }}'
-          region: '{{ aws_region }}'
+          access_key: "{{ aws_access_key }}"
+          secret_key: "{{ aws_secret_key }}"
+          session_token: "{{ security_token | default(omit) }}"
+          region: "{{ aws_region }}"
       block:
-
         # Create VPC, subnet, security group, and find image_id to create instance
 
-        - include_tasks: tasks/setup.yml
-
-        # Create new host, refresh inventory
+        - ansible.builtin.include_tasks: tasks/setup.yml
         - name: create a new host
-          ec2_instance:
-            image_id: '{{ image_id }}'
-            name: '{{ resource_prefix }}_1'
+          amazon.aws.ec2_instance:
+            image_id: "{{ image_id }}"
+            name: "{{ resource_prefix }}_1"
             tags:
               tag_instance1: foo
             purge_tags: true
             instance_type: t2.micro
-            security_groups: '{{ sg_id }}'
-            vpc_subnet_id: '{{ subnet_id }}'
-            wait: no
+            security_groups: "{{ sg_id }}"
+            vpc_subnet_id: "{{ subnet_id }}"
+            wait: false
           register: setup_instance_1
 
-        - meta: refresh_inventory
-
+        - ansible.builtin.meta: refresh_inventory
         - name: assert the hostvars are defined with prefix and/or suffix
-          assert:
+          ansible.builtin.assert:
             that:
-              - "hostvars['{{ resource_prefix }}_1'].{{ vars_prefix }}instance_type{{ vars_suffix }} == 't2.micro'"
+              - hostvars['{{ resource_prefix }}_1'].{{ vars_prefix }}instance_type{{ vars_suffix }} == 't2.micro'
               - "'{{ vars_prefix }}instance_type{{ vars_suffix }}' in hostvars['{{ resource_prefix }}_1']"
               - "'{{ vars_prefix }}image_id{{ vars_suffix }}' in hostvars['{{ resource_prefix }}_1']"
               - "'{{ vars_prefix }}instance_id{{ vars_suffix }}' in hostvars['{{ resource_prefix }}_1']"

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_include_or_exclude_filters.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_include_or_exclude_filters.yml
@@ -1,63 +1,58 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   environment: "{{ ansible_test.environment }}"
   tasks:
-
     - module_defaults:
         group/aws:
-          access_key: '{{ aws_access_key }}'
-          secret_key: '{{ aws_secret_key }}'
-          session_token: '{{ security_token | default(omit) }}'
-          region: '{{ aws_region }}'
+          access_key: "{{ aws_access_key }}"
+          secret_key: "{{ aws_secret_key }}"
+          session_token: "{{ security_token | default(omit) }}"
+          region: "{{ aws_region }}"
       block:
-
         # Create VPC, subnet, security group, and find image_id to create instance
 
-        - include_tasks: tasks/setup.yml
-
-        # Create new host, refresh inventory
+        - ansible.builtin.include_tasks: tasks/setup.yml
         - name: create a new host (1/3)
-          ec2_instance:
-            image_id: '{{ image_id }}'
-            name: '{{ resource_prefix }}_1'
+          amazon.aws.ec2_instance:
+            image_id: "{{ image_id }}"
+            name: "{{ resource_prefix }}_1"
             tags:
               tag_instance1: foo
             instance_type: t2.micro
-            security_groups: '{{ sg_id }}'
-            vpc_subnet_id: '{{ subnet_id }}'
-            wait: no
+            security_groups: "{{ sg_id }}"
+            vpc_subnet_id: "{{ subnet_id }}"
+            wait: false
 
         - name: create a new host (2/3)
-          ec2_instance:
-            image_id: '{{ image_id }}'
-            name: '{{ resource_prefix }}_2'
+          amazon.aws.ec2_instance:
+            image_id: "{{ image_id }}"
+            name: "{{ resource_prefix }}_2"
             tags:
               tag_instance2: bar
             instance_type: t2.micro
-            security_groups: '{{ sg_id }}'
-            vpc_subnet_id: '{{ subnet_id }}'
-            wait: no
+            security_groups: "{{ sg_id }}"
+            vpc_subnet_id: "{{ subnet_id }}"
+            wait: false
 
         - name: create a new host (3/3)
-          ec2_instance:
-            image_id: '{{ image_id }}'
-            name: '{{ resource_prefix }}_3'
+          amazon.aws.ec2_instance:
+            image_id: "{{ image_id }}"
+            name: "{{ resource_prefix }}_3"
             tags:
               tag_instance3: bar
             instance_type: t2.micro
-            security_groups: '{{ sg_id }}'
-            vpc_subnet_id: '{{ subnet_id }}'
-            wait: no
+            security_groups: "{{ sg_id }}"
+            vpc_subnet_id: "{{ subnet_id }}"
+            wait: false
 
-        - meta: refresh_inventory
-
+        - ansible.builtin.meta: refresh_inventory
         - name: assert the keyed groups and groups from constructed config were added to inventory and composite var added to hostvars
-          assert:
+          ansible.builtin.assert:
             that:
               # There are 9 groups: all, ungrouped, aws_ec2, sg keyed group, 3 tag keyed group (one per tag), arch keyed group, constructed group
-              - "groups['all'] | length == 2"
+              - groups['all'] | length == 2
               - "'{{ resource_prefix }}_1' in groups['all']"
               - "'{{ resource_prefix }}_2' in groups['all']"
-              - "not ('{{ resource_prefix }}_3' in groups['all'])"
+              - not ('{{ resource_prefix }}_3' in groups['all'])

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_literal_string.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_literal_string.yml
@@ -1,42 +1,37 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   environment: "{{ ansible_test.environment }}"
   tasks:
-
     - module_defaults:
         group/aws:
-          access_key: '{{ aws_access_key }}'
-          secret_key: '{{ aws_secret_key }}'
-          session_token: '{{ security_token | default(omit) }}'
-          region: '{{ aws_region }}'
+          access_key: "{{ aws_access_key }}"
+          secret_key: "{{ aws_secret_key }}"
+          session_token: "{{ security_token | default(omit) }}"
+          region: "{{ aws_region }}"
       block:
-
         # Create VPC, subnet, security group, and find image_id to create instance
-        - include_tasks: tasks/setup.yml
-
-        # Create new host, refresh inventory
+        - ansible.builtin.include_tasks: tasks/setup.yml
         - name: create a new host
-          ec2_instance:
-            image_id: '{{ image_id }}'
-            name: '{{ resource_prefix }}'
+          amazon.aws.ec2_instance:
+            image_id: "{{ image_id }}"
+            name: "{{ resource_prefix }}"
             tags:
               OtherTag: value
             purge_tags: true
             instance_type: t2.micro
-            security_groups: '{{ sg_id }}'
-            vpc_subnet_id: '{{ subnet_id }}'
-            wait: no
+            security_groups: "{{ sg_id }}"
+            vpc_subnet_id: "{{ subnet_id }}"
+            wait: false
           register: setup_instance
 
-        - meta: refresh_inventory
-
+        - ansible.builtin.meta: refresh_inventory
         - name: register the current hostname
-          set_fact:
-            expected_hostname: "aws-{{ resource_prefix }}"
+          ansible.builtin.set_fact:
+            expected_hostname: aws-{{ resource_prefix }}
 
-        - name: "Ensure we've got a hostvars entry for the new host"
-          assert:
+        - name: Ensure we've got a hostvars entry for the new host
+          ansible.builtin.assert:
             that:
               - expected_hostname in hostvars

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_use_contrib_script_keys.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_use_contrib_script_keys.yml
@@ -1,42 +1,37 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   environment: "{{ ansible_test.environment }}"
   tasks:
-
     - module_defaults:
         group/aws:
-          access_key: '{{ aws_access_key }}'
-          secret_key: '{{ aws_secret_key }}'
-          session_token: '{{ security_token | default(omit) }}'
-          region: '{{ aws_region }}'
+          access_key: "{{ aws_access_key }}"
+          secret_key: "{{ aws_secret_key }}"
+          session_token: "{{ security_token | default(omit) }}"
+          region: "{{ aws_region }}"
       block:
-
         # Create VPC, subnet, security group, and find image_id to create instance
-        - include_tasks: tasks/setup.yml
-
-        # Create new host, refresh inventory
+        - ansible.builtin.include_tasks: tasks/setup.yml
         - name: create a new host
-          ec2_instance:
-            image_id: '{{ image_id }}'
-            name: '{{ resource_prefix }}:/aa'
+          amazon.aws.ec2_instance:
+            image_id: "{{ image_id }}"
+            name: "{{ resource_prefix }}:/aa"
             tags:
               OtherTag: value
             instance_type: t2.micro
-            security_groups: '{{ sg_id }}'
-            vpc_subnet_id: '{{ subnet_id }}'
-            wait: no
+            security_groups: "{{ sg_id }}"
+            vpc_subnet_id: "{{ subnet_id }}"
+            wait: false
           register: setup_instance
 
-        - meta: refresh_inventory
-
+        - ansible.builtin.meta: refresh_inventory
         - name: "register the current hostname, the : and / a replaced with _"
-          set_fact:
+          ansible.builtin.set_fact:
             expected_hostname: "{{ resource_prefix }}__aa"
 
-        - name: "Ensure we've got a hostvars entry for the new host"
-          assert:
+        - name: Ensure we've got a hostvars entry for the new host
+          ansible.builtin.assert:
             that:
               - expected_hostname in hostvars
               - hostvars[expected_hostname].ec2_tag_OtherTag == "value"

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/vars/main.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 test_instances:
-  - name: '{{ resource_prefix }}'
+  - name: "{{ resource_prefix }}"
     instance_type: t2.micro
     tags:
       OtherTag: value

--- a/tests/integration/targets/inventory_aws_ec2/tasks/setup.yml
+++ b/tests/integration/targets/inventory_aws_ec2/tasks/setup.yml
@@ -4,63 +4,63 @@
     filters:
       architecture: x86_64
       # CentOS Community Platform Engineering (CPE)
-      owner-id: '125523088429'
+      owner-id: "125523088429"
       virtualization-type: hvm
       root-device-type: ebs
-      name: 'Fedora-Cloud-Base-37-1.2.x86_64*'
+      name: Fedora-Cloud-Base-37-1.2.x86_64*
   register: fedora_images
 
 - name: Set image id, vpc cidr and subnet cidr
   ansible.builtin.set_fact:
-    image_id: '{{ fedora_images.images.0.image_id }}'
-    vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'
-    subnet_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/24'
+    image_id: "{{ fedora_images.images.0.image_id }}"
+    vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/16
+    subnet_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/24
 
 - name: create a VPC to work in
   amazon.aws.ec2_vpc_net:
-    cidr_block: '{{ vpc_cidr }}'
+    cidr_block: "{{ vpc_cidr }}"
     state: present
-    name: '{{ resource_prefix }}_setup'
+    name: "{{ resource_prefix }}_setup"
     resource_tags:
-      Name: '{{ resource_prefix }}_setup'
+      Name: "{{ resource_prefix }}_setup"
   register: setup_vpc
 
 - name: Set vpc id
   ansible.builtin.set_fact:
-    vpc_id: '{{ setup_vpc.vpc.id }}'
+    vpc_id: "{{ setup_vpc.vpc.id }}"
 
 - name: create a subnet to use for creating an ec2 instance
   amazon.aws.ec2_vpc_subnet:
-    az: '{{ aws_region }}a'
-    vpc_id: '{{ setup_vpc.vpc.id }}'
-    cidr: '{{ subnet_cidr }}'
+    az: "{{ aws_region }}a"
+    vpc_id: "{{ setup_vpc.vpc.id }}"
+    cidr: "{{ subnet_cidr }}"
     state: present
     resource_tags:
-      Name: '{{ resource_prefix }}_setup'
+      Name: "{{ resource_prefix }}_setup"
   register: setup_subnet
 
 - name: Set subnet id
   ansible.builtin.set_fact:
-    subnet_id: '{{ setup_subnet.subnet.id }}'
+    subnet_id: "{{ setup_subnet.subnet.id }}"
 
 - name: create a security group to use for creating an ec2 instance
   ec2_security_group:
-    name: '{{ resource_prefix }}_setup'
-    description: 'created by Ansible integration tests'
+    name: "{{ resource_prefix }}_setup"
+    description: created by Ansible integration tests
     state: present
-    vpc_id: '{{ setup_vpc.vpc.id }}'
+    vpc_id: "{{ setup_vpc.vpc.id }}"
   register: setup_sg
 
 - name: Set sg id
   ansible.builtin.set_fact:
-    sg_id: '{{ setup_sg.group_id }}'
+    sg_id: "{{ setup_sg.group_id }}"
 
 - name: Create ec2 instance
-  ec2_instance:
-    image_id: '{{ image_id }}'
-    name: '{{ resource_prefix }}'
+  amazon.aws.ec2_instance:
+    image_id: "{{ image_id }}"
+    name: "{{ resource_prefix }}"
     instance_type: t2.micro
-    security_groups: '{{ sg_id }}'
-    vpc_subnet_id: '{{ subnet_id }}'
+    security_groups: "{{ sg_id }}"
+    vpc_subnet_id: "{{ subnet_id }}"
     wait: false
   register: setup_instance

--- a/tests/integration/targets/inventory_aws_ec2/tasks/tear_down.yml
+++ b/tests/integration/targets/inventory_aws_ec2/tasks/tear_down.yml
@@ -1,13 +1,13 @@
 ---
 - name: Set facts vpc_cidr, subnet_cidr
   ansible.builtin.set_fact:
-    vpc_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/16'
-    subnet_cidr: '10.{{ 256 | random(seed=resource_prefix) }}.0.0/24'
+    vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/16
+    subnet_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/24
 
 - name: describe vpc
-  ec2_vpc_net_info:
+  amazon.aws.ec2_vpc_net_info:
     filters:
-      tag:Name: '{{ resource_prefix }}_setup'
+      tag:Name: "{{ resource_prefix }}_setup"
   register: vpc_info
 
 - name: Tear down
@@ -17,43 +17,43 @@
         vpc_id: "{{ vpc_info.vpcs.0.vpc_id }}"
 
     - name: list existing instances
-      ec2_instance_info:
+      amazon.aws.ec2_instance_info:
         filters:
           vpc-id: "{{ vpc_id }}"
       register: existing
 
     - name: remove ec2 instances
-      ec2_instance:
+      amazon.aws.ec2_instance:
         instance_ids: "{{ existing.instances | map(attribute='instance_id') | list }}"
         wait: true
         state: absent
 
     - name: remove setup security group
       ec2_security_group:
-        name: '{{ resource_prefix }}_setup'
-        description: 'created by Ansible integration tests'
+        name: "{{ resource_prefix }}_setup"
+        description: created by Ansible integration tests
         state: absent
-        vpc_id: '{{ vpc_id }}'
+        vpc_id: "{{ vpc_id }}"
       ignore_errors: true
 
     - name: remove setup subnet
-      ec2_vpc_subnet:
-        az: '{{ aws_region }}a'
-        tags: '{{ resource_prefix }}_setup'
-        vpc_id: '{{ vpc_id }}'
-        cidr: '{{ subnet_cidr }}'
+      amazon.aws.ec2_vpc_subnet:
+        az: "{{ aws_region }}a"
+        tags: "{{ resource_prefix }}_setup"
+        vpc_id: "{{ vpc_id }}"
+        cidr: "{{ subnet_cidr }}"
         state: absent
         resource_tags:
-          Name: '{{ resource_prefix }}_setup'
+          Name: "{{ resource_prefix }}_setup"
       ignore_errors: true
 
     - name: remove setup VPC
-      ec2_vpc_net:
-        cidr_block: '{{ vpc_cidr }}'
+      amazon.aws.ec2_vpc_net:
+        cidr_block: "{{ vpc_cidr }}"
         state: absent
-        name: '{{ resource_prefix }}_setup'
+        name: "{{ resource_prefix }}_setup"
         resource_tags:
-          Name: '{{ resource_prefix }}_setup'
+          Name: "{{ resource_prefix }}_setup"
       ignore_errors: true
 
   when: vpc_info.vpcs | length > 0

--- a/tests/integration/targets/inventory_aws_ec2/tasks/test_refresh_inventory.yml
+++ b/tests/integration/targets/inventory_aws_ec2/tasks/test_refresh_inventory.yml
@@ -1,12 +1,12 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   tasks:
     - block:
-      - name: assert group was populated with inventory and is no longer empty
-        assert:
-          that:
-            - "'aws_ec2' in groups"
-            - "groups.aws_ec2 | length == 1"
-            - "groups.aws_ec2.0 == '{{ resource_prefix }}'"
+        - name: assert group was populated with inventory and is no longer empty
+          assert:
+            that:
+              - "'aws_ec2' in groups"
+              - groups.aws_ec2 | length == 1
+              - groups.aws_ec2.0 == '{{ resource_prefix }}'

--- a/tests/integration/targets/inventory_aws_rds/meta/main.yml
+++ b/tests/integration/targets/inventory_aws_rds/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/inventory_aws_rds/playbooks/create_inventory_config.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/create_inventory_config.yml
@@ -1,16 +1,16 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
 
   vars:
-    template_name: "../templates/{{ template | default('inventory.j2') }}"
+    template_name: ../templates/{{ template | default('inventory.j2') }}
 
   vars_files:
     - vars/main.yml
 
   tasks:
     - name: write inventory config file
-      copy:
+      ansible.builtin.copy:
         dest: ../test.aws_rds.yml
         content: "{{ lookup('template', template_name) }}"

--- a/tests/integration/targets/inventory_aws_rds/playbooks/empty_inventory_config.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/empty_inventory_config.yml
@@ -1,9 +1,9 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: write inventory config file
-      copy:
+      ansible.builtin.copy:
         dest: ../test.aws_rds.yml
         content: ""

--- a/tests/integration/targets/inventory_aws_rds/playbooks/populate_cache.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/populate_cache.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
 
   environment: "{{ ansible_test.environment }}"
 
@@ -14,22 +14,21 @@
 
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
   tasks:
     - name: refresh inventory to populate cache
-      meta: refresh_inventory
-
+      ansible.builtin.meta: refresh_inventory
     - name: assert group was populated with inventory but is empty
-      assert:
+      ansible.builtin.assert:
         that:
           - "'aws_rds' in groups"
-          - "groups.aws_rds | length == 1"
+          - groups.aws_rds | length == 1
 
     - name: Delete RDS instance
-      include_tasks: tasks/rds_instance_delete.yml
+      ansible.builtin.include_tasks: tasks/rds_instance_delete.yml
       vars:
         aws_api_wait: true

--- a/tests/integration/targets/inventory_aws_rds/playbooks/setup_instance.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/setup_instance.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
 
   environment: "{{ ansible_test.environment }}"
 
@@ -14,10 +14,10 @@
 
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
   tasks:
-    - include_tasks: 'tasks/rds_instance_{{ operation }}.yml'
+    - ansible.builtin.include_tasks: tasks/rds_instance_{{ operation }}.yml

--- a/tests/integration/targets/inventory_aws_rds/playbooks/tasks/rds_instance_create.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/tasks/rds_instance_create.yml
@@ -1,12 +1,12 @@
 ---
 - name: Create minimal RDS instance in default VPC and default subnet group
-  rds_instance:
+  amazon.aws.rds_instance:
     state: present
     engine: "{{ instance_engine }}"
     db_instance_class: db.t2.micro
     allocated_storage: 20
-    instance_id: '{{ instance_id }}'
-    master_username: 'ansibletestuser'
-    master_user_password: 'password-{{ resource_prefix | regex_findall(".{8}$") | first }}'
+    instance_id: "{{ instance_id }}"
+    master_username: ansibletestuser
+    master_user_password: password-{{ resource_prefix | regex_findall(".{8}$") | first }}
     tags: "{{ resource_tags | default(omit) }}"
     wait: "{{ aws_api_wait | default(false) }}"

--- a/tests/integration/targets/inventory_aws_rds/playbooks/tasks/rds_instance_delete.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/tasks/rds_instance_delete.yml
@@ -1,8 +1,8 @@
 ---
 - name: remove mariadb instance
-  rds_instance:
+  amazon.aws.rds_instance:
     state: absent
     engine: "{{ instance_engine }}"
-    skip_final_snapshot: yes
-    instance_id: '{{ instance_id }}'
+    skip_final_snapshot: true
+    instance_id: "{{ instance_id }}"
     wait: "{{ aws_api_wait | default(false) }}"

--- a/tests/integration/targets/inventory_aws_rds/playbooks/test_invalid_aws_rds_inventory_config.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/test_invalid_aws_rds_inventory_config.yml
@@ -1,9 +1,9 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: assert inventory was not populated by aws_rds inventory plugin
-      assert:
+      ansible.builtin.assert:
         that:
           - "'aws_rds' not in groups"

--- a/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_cache.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_cache.yml
@@ -1,18 +1,17 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   tasks:
     - name: assert cache was used to populate inventory
-      assert:
+      ansible.builtin.assert:
         that:
           - "'aws_rds' in groups"
-          - "groups.aws_rds | length == 1"
+          - groups.aws_rds | length == 1
 
-    - meta: refresh_inventory
-
+    - ansible.builtin.meta: refresh_inventory
     - name: assert refresh_inventory updated the cache
-      assert:
+      ansible.builtin.assert:
         that:
           - "'aws_rds' in groups"
-          - "not groups.aws_rds"
+          - not groups.aws_rds

--- a/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_no_hosts.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_no_hosts.yml
@@ -1,14 +1,14 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
   environment: "{{ ansible_test.environment }}"
   collections:
     - amazon.aws
     - community.aws
   tasks:
     - name: assert group was populated with inventory but is empty
-      assert:
+      ansible.builtin.assert:
         that:
           - "'aws_rds' in groups"
-          - "not groups.aws_rds"
+          - not groups.aws_rds

--- a/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_with_hostvars_prefix_suffix.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_with_hostvars_prefix_suffix.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
 
   environment: "{{ ansible_test.environment }}"
 
@@ -14,19 +14,18 @@
 
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
   tasks:
-
     - name: assert the hostvars are defined with prefix and/or suffix
-      assert:
+      ansible.builtin.assert:
         that:
-          - "hostvars[instance_id].{{ vars_prefix }}db_instance_class{{ vars_suffix }} == 'db.t2.micro'"
-          - "hostvars[instance_id].{{ vars_prefix }}engine{{ vars_suffix }} == '{{ instance_engine }}'"
-          - "hostvars[instance_id].{{ vars_prefix }}db_instance_status{{ vars_suffix }} in ('available', 'creating')"
+          - hostvars[instance_id].{{ vars_prefix }}db_instance_class{{ vars_suffix }} == 'db.t2.micro'
+          - hostvars[instance_id].{{ vars_prefix }}engine{{ vars_suffix }} == '{{ instance_engine }}'
+          - hostvars[instance_id].{{ vars_prefix }}db_instance_status{{ vars_suffix }} in ('available', 'creating')
           - "'db_instance_class' not in hostvars[instance_id]"
           - "'engine' not in hostvars[instance_id]"
           - "'db_instance_status' not in hostvars[instance_id]"

--- a/tests/integration/targets/inventory_aws_rds/playbooks/test_populating_inventory.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/test_populating_inventory.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
 
   environment: "{{ ansible_test.environment }}"
 
@@ -10,8 +10,8 @@
 
   tasks:
     - name: assert aws_rds inventory group contains RDS instance created by previous playbook
-      assert:
+      ansible.builtin.assert:
         that:
           - "'aws_rds' in groups"
-          - "groups.aws_rds | length == 1"
-          - "groups.aws_rds.0 == '{{ instance_id }}'"
+          - groups.aws_rds | length == 1
+          - groups.aws_rds.0 == '{{ instance_id }}'

--- a/tests/integration/targets/inventory_aws_rds/playbooks/test_populating_inventory_with_constructed.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/test_populating_inventory_with_constructed.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: 127.0.0.1
   connection: local
-  gather_facts: no
+  gather_facts: false
 
   environment: "{{ ansible_test.environment }}"
 
@@ -14,35 +14,34 @@
 
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
   tasks:
-
     - name: Get RDS instance info
-      rds_instance_info:
-        db_instance_identifier: '{{ instance_id }}'
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ instance_id }}"
       register: db_info
 
-    - debug:
+    - ansible.builtin.debug:
         var: groups
 
-    - name: 'generate expected group name based off the db parameter groups'
+    - name: generate expected group name based off the db parameter groups
       vars:
-        parameter_group_name: '{{ db_info.instances[0].db_parameter_groups[0].db_parameter_group_name }}'
-      set_fact:
-        parameter_group_key: 'rds_parameter_group_{{ parameter_group_name | replace(".", "_") }}'
+        parameter_group_name: "{{ db_info.instances[0].db_parameter_groups[0].db_parameter_group_name }}"
+      ansible.builtin.set_fact:
+        parameter_group_key: rds_parameter_group_{{ parameter_group_name | replace(".", "_") }}
 
     - name: assert the keyed groups from constructed config were added to inventory
-      assert:
+      ansible.builtin.assert:
         that:
           # There are 6 groups: all, ungrouped, aws_rds, tag keyed group, engine keyed group, parameter group keyed group
-          - "groups | length == 6"
+          - groups | length == 6
           - '"all" in groups'
           - '"ungrouped" in groups'
           - '"aws_rds" in groups'
           - '"tag_workload_type_other" in groups'
           - '"rds_mariadb" in groups'
-          - 'parameter_group_key in groups'
+          - parameter_group_key in groups

--- a/tests/integration/targets/inventory_aws_rds/playbooks/vars/main.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/vars/main.yml
@@ -1,6 +1,6 @@
 ---
 instance_id: "{{ resource_prefix }}-mariadb"
-instance_engine: "mariadb"
+instance_engine: mariadb
 resource_tags:
   workload_type: other
 aws_inventory_cache_dir: ""

--- a/tests/integration/targets/kms_key/main.yml
+++ b/tests/integration/targets/kms_key/main.yml
@@ -1,9 +1,10 @@
+---
 # Beware: most of our tests here are run in parallel.
 # To add new tests you'll need to add a new host to the inventory and a matching
 # '{{ inventory_hostname }}'.yml file in roles/aws_kms/tasks/
 
 - hosts: all
-  gather_facts: no
+  gather_facts: false
   strategy: free
   roles:
-  - aws_kms
+    - aws_kms

--- a/tests/integration/targets/kms_key/meta/main.yml
+++ b/tests/integration/targets/kms_key/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/kms_key/roles/aws_kms/defaults/main.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/defaults/main.yml
@@ -1,2 +1,2 @@
-kms_key_alias: ansible-test-{{ inventory_hostname | replace('_','-') }}{{ tiny_prefix
-  }}
+---
+kms_key_alias: ansible-test-{{ inventory_hostname | replace('_','-') }}{{ tiny_prefix }}

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/main.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/main.yml
@@ -1,11 +1,12 @@
+---
 - name: kms_key integration tests
   collections:
-  - community.aws
+    - community.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-  - include_tasks: ./test_{{ inventory_hostname }}.yml
+    - ansible.builtin.include_tasks: ./test_{{ inventory_hostname }}.yml

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_grants.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_grants.yml
@@ -1,350 +1,350 @@
+---
 - block:
     # ============================================================
     #   PREPARATION
     #
     # Get some information about who we are before starting our tests
     # we'll need this as soon as we start working on the policies
-  - name: get ARN of calling user
-    aws_caller_info:
-    register: aws_caller_info
-  - name: create an IAM role that can do nothing
-    iam_role:
-      name: '{{ kms_key_alias }}'
-      state: present
-      assume_role_policy_document: '{"Version": "2012-10-17", "Statement": {"Action":
-        "sts:AssumeRole", "Principal": {"Service": "ec2.amazonaws.com"}, "Effect":
-        "Deny"} }'
-    register: iam_role_result
-  - name: create a key
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      tags:
-        Hello: World
-      state: present
-      enabled: yes
-      enable_key_rotation: no
-    register: key
-  - name: assert that state is enabled
-    assert:
-      that:
-      - key is changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
+    - name: get ARN of calling user
+      amazon.aws.aws_caller_info:
+      register: aws_caller_info
+    - name: create an IAM role that can do nothing
+      community.aws.iam_role:
+        name: "{{ kms_key_alias }}"
+        state: present
+        assume_role_policy_document: '{"Version": "2012-10-17", "Statement": {"Action": "sts:AssumeRole", "Principal": {"Service": "ec2.amazonaws.com"}, "Effect":
+          "Deny"} }'
+      register: iam_role_result
+    - name: create a key
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        tags:
+          Hello: World
+        state: present
+        enabled: true
+        enable_key_rotation: false
+      register: key
+    - name: assert that state is enabled
+      ansible.builtin.assert:
+        that:
+          - key is changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Add grant - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      purge_grants: yes
-      grants:
-      - name: test_grant
-        grantee_principal: '{{ iam_role_result.iam_role.arn }}'
-        retiring_principal: '{{ aws_caller_info.arn }}'
-        constraints:
-          encryption_context_equals:
-            environment: test
-            application: testapp
-        operations:
-        - Decrypt
-        - RetireGrant
-    register: key
-    check_mode: yes
-  - name: assert grant would have been added
-    assert:
-      that:
-      - key.changed
+    - name: Add grant - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        purge_grants: true
+        grants:
+          - name: test_grant
+            grantee_principal: "{{ iam_role_result.iam_role.arn }}"
+            retiring_principal: "{{ aws_caller_info.arn }}"
+            constraints:
+              encryption_context_equals:
+                environment: test
+                application: testapp
+            operations:
+              - Decrypt
+              - RetireGrant
+      register: key
+      check_mode: true
+    - name: assert grant would have been added
+      ansible.builtin.assert:
+        that:
+          - key.changed
 
     # Roles can take a little while to get ready, pause briefly to give it chance
-  - wait_for:
-      timeout: 20
-  - name: Add grant
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      purge_grants: yes
-      grants:
-      - name: test_grant
-        grantee_principal: '{{ iam_role_result.iam_role.arn }}'
-        retiring_principal: '{{ aws_caller_info.arn }}'
-        constraints:
-          encryption_context_equals:
-            environment: test
-            application: testapp
-        operations:
-        - Decrypt
-        - RetireGrant
-    register: key
-  - name: assert grant added
-    assert:
-      that:
-      - key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 1
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
+    - ansible.builtin.wait_for:
+        timeout: 20
+    - name: Add grant
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        purge_grants: true
+        grants:
+          - name: test_grant
+            grantee_principal: "{{ iam_role_result.iam_role.arn }}"
+            retiring_principal: "{{ aws_caller_info.arn }}"
+            constraints:
+              encryption_context_equals:
+                environment: test
+                application: testapp
+            operations:
+              - Decrypt
+              - RetireGrant
+      register: key
+    - name: assert grant added
+      ansible.builtin.assert:
+        that:
+          - key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 1
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
 
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  - name: Add grant (idempotence) - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      purge_grants: yes
-      grants:
-      - name: test_grant
-        grantee_principal: '{{ iam_role_result.iam_role.arn }}'
-        retiring_principal: '{{ aws_caller_info.arn }}'
-        constraints:
-          encryption_context_equals:
-            environment: test
-            application: testapp
-        operations:
-        - Decrypt
-        - RetireGrant
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - not key.changed
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+    - name: Add grant (idempotence) - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        purge_grants: true
+        grants:
+          - name: test_grant
+            grantee_principal: "{{ iam_role_result.iam_role.arn }}"
+            retiring_principal: "{{ aws_caller_info.arn }}"
+            constraints:
+              encryption_context_equals:
+                environment: test
+                application: testapp
+            operations:
+              - Decrypt
+              - RetireGrant
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
 
-  - name: Add grant (idempotence)
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      purge_grants: yes
-      grants:
-      - name: test_grant
-        grantee_principal: '{{ iam_role_result.iam_role.arn }}'
-        retiring_principal: '{{ aws_caller_info.arn }}'
-        constraints:
-          encryption_context_equals:
-            environment: test
-            application: testapp
-        operations:
-        - Decrypt
-        - RetireGrant
-    register: key
-  - assert:
-      that:
-      - not key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 1
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
+    - name: Add grant (idempotence)
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        purge_grants: true
+        grants:
+          - name: test_grant
+            grantee_principal: "{{ iam_role_result.iam_role.arn }}"
+            retiring_principal: "{{ aws_caller_info.arn }}"
+            constraints:
+              encryption_context_equals:
+                environment: test
+                application: testapp
+            operations:
+              - Decrypt
+              - RetireGrant
+      register: key
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 1
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
 
-  - name: Add a second grant
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      grants:
-      - name: another_grant
-        grantee_principal: '{{ iam_role_result.iam_role.arn }}'
-        retiring_principal: '{{ aws_caller_info.arn }}'
-        constraints:
-          encryption_context_equals:
-            Environment: second
-            Application: anotherapp
-        operations:
-        - Decrypt
-        - RetireGrant
-    register: key
-  - name: Assert grant added
-    assert:
-      that:
-      - key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 2
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
+    - name: Add a second grant
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        grants:
+          - name: another_grant
+            grantee_principal: "{{ iam_role_result.iam_role.arn }}"
+            retiring_principal: "{{ aws_caller_info.arn }}"
+            constraints:
+              encryption_context_equals:
+                Environment: second
+                Application: anotherapp
+            operations:
+              - Decrypt
+              - RetireGrant
+      register: key
+    - name: Assert grant added
+      ansible.builtin.assert:
+        that:
+          - key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 2
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
 
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  - name: Add a second grant again
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      grants:
-      - name: another_grant
-        grantee_principal: '{{ iam_role_result.iam_role.arn }}'
-        retiring_principal: '{{ aws_caller_info.arn }}'
-        constraints:
-          encryption_context_equals:
-            Environment: second
-            Application: anotherapp
-        operations:
-        - Decrypt
-        - RetireGrant
-    register: key
-  - name: Assert grant added
-    assert:
-      that:
-      - not key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 2
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+    - name: Add a second grant again
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        grants:
+          - name: another_grant
+            grantee_principal: "{{ iam_role_result.iam_role.arn }}"
+            retiring_principal: "{{ aws_caller_info.arn }}"
+            constraints:
+              encryption_context_equals:
+                Environment: second
+                Application: anotherapp
+            operations:
+              - Decrypt
+              - RetireGrant
+      register: key
+    - name: Assert grant added
+      ansible.builtin.assert:
+        that:
+          - not key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 2
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
 
-  - name: Update the grants with purge_grants set
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      purge_grants: yes
-      grants:
-      - name: third_grant
-        grantee_principal: '{{ iam_role_result.iam_role.arn }}'
-        retiring_principal: '{{ aws_caller_info.arn }}'
-        constraints:
-          encryption_context_equals:
-            environment: third
-            application: onemoreapp
-        operations:
-        - Decrypt
-        - RetireGrant
-    register: key
-  - name: Assert grants replaced
-    assert:
-      that:
-      - key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 1
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
+    - name: Update the grants with purge_grants set
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        purge_grants: true
+        grants:
+          - name: third_grant
+            grantee_principal: "{{ iam_role_result.iam_role.arn }}"
+            retiring_principal: "{{ aws_caller_info.arn }}"
+            constraints:
+              encryption_context_equals:
+                environment: third
+                application: onemoreapp
+            operations:
+              - Decrypt
+              - RetireGrant
+      register: key
+    - name: Assert grants replaced
+      ansible.builtin.assert:
+        that:
+          - key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 1
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
 
-  - name: Update third grant to change encryption context equals to subset
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      grants:
-      - name: third_grant
-        grantee_principal: '{{ iam_role_result.iam_role.arn }}'
-        retiring_principal: '{{ aws_caller_info.arn }}'
-        constraints:
-          encryption_context_subset:
-            environment: third
-            application: onemoreapp
-        operations:
-        - Decrypt
-        - RetireGrant
-    register: key
-  - name: Assert grants replaced
-    assert:
-      that:
-      - key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 1
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
-      - "'encryption_context_equals' not in key.grants[0].constraints"
-      - "'encryption_context_subset' in key.grants[0].constraints"
+    - name: Update third grant to change encryption context equals to subset
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        grants:
+          - name: third_grant
+            grantee_principal: "{{ iam_role_result.iam_role.arn }}"
+            retiring_principal: "{{ aws_caller_info.arn }}"
+            constraints:
+              encryption_context_subset:
+                environment: third
+                application: onemoreapp
+            operations:
+              - Decrypt
+              - RetireGrant
+      register: key
+    - name: Assert grants replaced
+      ansible.builtin.assert:
+        that:
+          - key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 1
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
+          - "'encryption_context_equals' not in key.grants[0].constraints"
+          - "'encryption_context_subset' in key.grants[0].constraints"
 
   always:
     # ============================================================
     #   CLEAN-UP
-  - name: finish off by deleting keys
-    kms_key:
-      state: absent
-      alias: '{{ kms_key_alias }}'
-      pending_window: 7
-    ignore_errors: true
-  - name: remove the IAM role
-    iam_role:
-      name: '{{ kms_key_alias }}'
-      state: absent
-    ignore_errors: true
+    - name: finish off by deleting keys
+      kms_key:
+        state: absent
+        alias: "{{ kms_key_alias }}"
+        pending_window: 7
+      ignore_errors: true
+    - name: remove the IAM role
+      community.aws.iam_role:
+        name: "{{ kms_key_alias }}"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_modify.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_modify.yml
@@ -1,279 +1,278 @@
+---
 - block:
     # ============================================================
     #   PREPARATION
     #
     # Get some information about who we are before starting our tests
     # we'll need this as soon as we start working on the policies
-  - name: get ARN of calling user
-    aws_caller_info:
-    register: aws_caller_info
-  - name: create an IAM role that can do nothing
-    iam_role:
-      name: '{{ kms_key_alias }}'
-      state: present
-      assume_role_policy_document: '{"Version": "2012-10-17", "Statement": {"Action":
-        "sts:AssumeRole", "Principal": {"Service": "ec2.amazonaws.com"}, "Effect":
-        "Deny"} }'
-    register: iam_role_result
-  - name: create a key
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      tags:
-        Hello: World
-      state: present
-      enabled: yes
-      enable_key_rotation: no
-    register: key
-  - name: assert that state is enabled
-    assert:
-      that:
-      - key is changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
+    - name: get ARN of calling user
+      amazon.aws.aws_caller_info:
+      register: aws_caller_info
+    - name: create an IAM role that can do nothing
+      community.aws.iam_role:
+        name: "{{ kms_key_alias }}"
+        state: present
+        assume_role_policy_document: '{"Version": "2012-10-17", "Statement": {"Action": "sts:AssumeRole", "Principal": {"Service": "ec2.amazonaws.com"}, "Effect":
+          "Deny"} }'
+      register: iam_role_result
+    - name: create a key
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        tags:
+          Hello: World
+        state: present
+        enabled: true
+        enable_key_rotation: false
+      register: key
+    - name: assert that state is enabled
+      ansible.builtin.assert:
+        that:
+          - key is changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Save IDs for later
-    set_fact:
-      kms_key_id: '{{ key.key_id }}'
-      kms_key_arn: '{{ key.key_arn }}'
-  - name: find facts about the key (by ID)
-    kms_key_info:
-      key_id: '{{ kms_key_id }}'
-    register: new_key
-  - name: check that a key was found
-    assert:
-      that:
-      - '"key_id" in new_key.kms_keys[0]'
-      - new_key.kms_keys[0].key_id | length >= 36
-      - not new_key.kms_keys[0].key_id.startswith("arn:aws")
-      - '"key_arn" in new_key.kms_keys[0]'
-      - new_key.kms_keys[0].key_arn.endswith(new_key.kms_keys[0].key_id)
-      - new_key.kms_keys[0].key_arn.startswith("arn:aws")
-      - new_key.kms_keys[0].key_state == "Enabled"
-      - new_key.kms_keys[0].enabled == True
-      - new_key.kms_keys[0].tags | length == 1
-      - new_key.kms_keys[0].tags['Hello'] == 'World'
-      - new_key.kms_keys[0].enable_key_rotation == False
-      - new_key.kms_keys[0].key_usage == 'ENCRYPT_DECRYPT'
-      - new_key.kms_keys[0].customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - new_key.kms_keys[0].grants | length == 0
-      - new_key.kms_keys[0].key_policies | length == 1
-      - new_key.kms_keys[0].key_policies[0].Id == 'key-default-1'
-      - new_key.kms_keys[0].description == ''
+    - name: Save IDs for later
+      ansible.builtin.set_fact:
+        kms_key_id: "{{ key.key_id }}"
+        kms_key_arn: "{{ key.key_arn }}"
+    - name: find facts about the key (by ID)
+      kms_key_info:
+        key_id: "{{ kms_key_id }}"
+      register: new_key
+    - name: check that a key was found
+      ansible.builtin.assert:
+        that:
+          - '"key_id" in new_key.kms_keys[0]'
+          - new_key.kms_keys[0].key_id | length >= 36
+          - not new_key.kms_keys[0].key_id.startswith("arn:aws")
+          - '"key_arn" in new_key.kms_keys[0]'
+          - new_key.kms_keys[0].key_arn.endswith(new_key.kms_keys[0].key_id)
+          - new_key.kms_keys[0].key_arn.startswith("arn:aws")
+          - new_key.kms_keys[0].key_state == "Enabled"
+          - new_key.kms_keys[0].enabled == True
+          - new_key.kms_keys[0].tags | length == 1
+          - new_key.kms_keys[0].tags['Hello'] == 'World'
+          - new_key.kms_keys[0].enable_key_rotation == False
+          - new_key.kms_keys[0].key_usage == 'ENCRYPT_DECRYPT'
+          - new_key.kms_keys[0].customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - new_key.kms_keys[0].grants | length == 0
+          - new_key.kms_keys[0].key_policies | length == 1
+          - new_key.kms_keys[0].key_policies[0].Id == 'key-default-1'
+          - new_key.kms_keys[0].description == ''
 
-  - name: Update policy - check mode
-    kms_key:
-      key_id: '{{ kms_key_id }}'
-      policy: "{{ lookup('template', 'console-policy.j2') }}"
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - key is changed
+    - name: Update policy - check mode
+      kms_key:
+        key_id: "{{ kms_key_id }}"
+        policy: "{{ lookup('template', 'console-policy.j2') }}"
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - key is changed
 
-  - name: Update policy
-    kms_key:
-      key_id: '{{ kms_key_id }}'
-      policy: "{{ lookup('template', 'console-policy.j2') }}"
-    register: key
-  - name: Policy should have been changed
-    assert:
-      that:
-      - key is changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-consolepolicy-3'
-      - key.description == ''
+    - name: Update policy
+      kms_key:
+        key_id: "{{ kms_key_id }}"
+        policy: "{{ lookup('template', 'console-policy.j2') }}"
+      register: key
+    - name: Policy should have been changed
+      ansible.builtin.assert:
+        that:
+          - key is changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-consolepolicy-3'
+          - key.description == ''
 
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  - name: Update policy (idempotence) - check mode
-    kms_key:
-      alias: alias/{{ kms_key_alias }}
-      policy: "{{ lookup('template', 'console-policy.j2') }}"
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - not key.changed
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+    - name: Update policy (idempotence) - check mode
+      kms_key:
+        alias: alias/{{ kms_key_alias }}
+        policy: "{{ lookup('template', 'console-policy.j2') }}"
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
 
-  - name: Update policy (idempotence)
-    kms_key:
-      alias: alias/{{ kms_key_alias }}
-      policy: "{{ lookup('template', 'console-policy.j2') }}"
-    register: key
-  - assert:
-      that:
-      - not key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-consolepolicy-3'
-      - key.description == ''
-
-    # ------------------------------------------------------------------------------------------
-
-  - name: Update description - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      description: test key for testing
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - key.changed
-
-  - name: Update description
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      description: test key for testing
-    register: key
-  - assert:
-      that:
-      - key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-consolepolicy-3'
-      - key.description == 'test key for testing'
-
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  - name: Update description (idempotence) - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      description: test key for testing
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - not key.changed
-
-  - name: Update description (idempotence)
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      description: test key for testing
-    register: key
-  - assert:
-      that:
-      - not key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-consolepolicy-3'
-      - key.description == 'test key for testing'
+    - name: Update policy (idempotence)
+      kms_key:
+        alias: alias/{{ kms_key_alias }}
+        policy: "{{ lookup('template', 'console-policy.j2') }}"
+      register: key
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-consolepolicy-3'
+          - key.description == ''
 
     # ------------------------------------------------------------------------------------------
 
-  - name: update policy to remove access to key rotation status
-    kms_key:
-      alias: alias/{{ kms_key_alias }}
-      policy: "{{ lookup('template', 'console-policy-no-key-rotation.j2') }}"
-    register: key
-  - assert:
-      that:
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation is none
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-consolepolicy-3'
-      - key.description == 'test key for testing'
-      - "'Disable access to key rotation status' in {{ key.key_policies[0].Statement\
-        \ | map(attribute='Sid') }}"
+    - name: Update description - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        description: test key for testing
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - key.changed
+
+    - name: Update description
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        description: test key for testing
+      register: key
+    - ansible.builtin.assert:
+        that:
+          - key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-consolepolicy-3'
+          - key.description == 'test key for testing'
+
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+    - name: Update description (idempotence) - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        description: test key for testing
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
+
+    - name: Update description (idempotence)
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        description: test key for testing
+      register: key
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-consolepolicy-3'
+          - key.description == 'test key for testing'
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: update policy to remove access to key rotation status
+      kms_key:
+        alias: alias/{{ kms_key_alias }}
+        policy: "{{ lookup('template', 'console-policy-no-key-rotation.j2') }}"
+      register: key
+    - ansible.builtin.assert:
+        that:
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation is none
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-consolepolicy-3'
+          - key.description == 'test key for testing'
+          - "'Disable access to key rotation status' in {{ key.key_policies[0].Statement | map(attribute='Sid') }}"
 
   always:
     # ============================================================
     #   CLEAN-UP
-  - name: finish off by deleting keys
-    kms_key:
-      state: absent
-      alias: '{{ kms_key_alias }}'
-      pending_window: 7
-    ignore_errors: true
-  - name: remove the IAM role
-    iam_role:
-      name: '{{ kms_key_alias }}'
-      state: absent
-    ignore_errors: true
+    - name: finish off by deleting keys
+      kms_key:
+        state: absent
+        alias: "{{ kms_key_alias }}"
+        pending_window: 7
+      ignore_errors: true
+    - name: remove the IAM role
+      community.aws.iam_role:
+        name: "{{ kms_key_alias }}"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_multi_region.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_multi_region.yml
@@ -1,100 +1,101 @@
+---
 - block:
     # ============================================================
     #   PREPARATION
     #
     # Get some information about who we are before starting our tests
     # we'll need this as soon as we start working on the policies
-  - name: get ARN of calling user
-    aws_caller_info:
-    register: aws_caller_info
-  - name: See whether key exists and its current state
-    kms_key_info:
-      alias: '{{ kms_key_alias }}'
-  - name: create a multi region key - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}-check'
-      tags:
-        Hello: World
-      state: present
-      multi_region: True
-      enabled: yes
-    register: key_check
-    check_mode: yes
-  - name: find facts about the check mode key
-    kms_key_info:
-      alias: '{{ kms_key_alias }}-check'
-    register: check_key
-  - name: ensure that check mode worked as expected
-    assert:
-      that:
-      - check_key.kms_keys | length == 0
-      - key_check is changed
+    - name: get ARN of calling user
+      amazon.aws.aws_caller_info:
+      register: aws_caller_info
+    - name: See whether key exists and its current state
+      kms_key_info:
+        alias: "{{ kms_key_alias }}"
+    - name: create a multi region key - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}-check"
+        tags:
+          Hello: World
+        state: present
+        multi_region: true
+        enabled: true
+      register: key_check
+      check_mode: true
+    - name: find facts about the check mode key
+      kms_key_info:
+        alias: "{{ kms_key_alias }}-check"
+      register: check_key
+    - name: ensure that check mode worked as expected
+      ansible.builtin.assert:
+        that:
+          - check_key.kms_keys | length == 0
+          - key_check is changed
 
-  - name: create a multi region key
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      tags:
-        Hello: World
-      state: present
-      enabled: yes
-      multi_region: True
-      enable_key_rotation: no
-    register: key
-  - name: assert that state is enabled
-    assert:
-      that:
-      - key is changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
-      - key.multi_region == True
+    - name: create a multi region key
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        tags:
+          Hello: World
+        state: present
+        enabled: true
+        multi_region: true
+        enable_key_rotation: false
+      register: key
+    - name: assert that state is enabled
+      ansible.builtin.assert:
+        that:
+          - key is changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
+          - key.multi_region == True
 
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  
-  - name: create a key (expect failure)
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      tags:
-        Hello: World
-      state: present
-      enabled: yes
-      multi_region: True
-    register: result
-    ignore_errors: True
-  
-  - assert:
-      that:
-      - result is failed
-      - result.msg != "MODULE FAILURE"
-      - result.changed == False
-      - '"You cannot change the multi-region property on an existing key." in result.msg'
-      
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+
+    - name: create a key (expect failure)
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        tags:
+          Hello: World
+        state: present
+        enabled: true
+        multi_region: true
+      register: result
+      ignore_errors: true
+
+    - ansible.builtin.assert:
+        that:
+          - result is failed
+          - result.msg != "MODULE FAILURE"
+          - result.changed == False
+          - '"You cannot change the multi-region property on an existing key." in result.msg'
+
   always:
     # ============================================================
     #   CLEAN-UP
-  - name: finish off by deleting keys
-    kms_key:
-      state: absent
-      alias: '{{ item }}'
-      pending_window: 7
-    ignore_errors: true
-    loop:
-    - '{{ kms_key_alias }}'
-    - '{{ kms_key_alias }}-diff-spec-usage'
-    - '{{ kms_key_alias }}-check'
+    - name: finish off by deleting keys
+      kms_key:
+        state: absent
+        alias: "{{ item }}"
+        pending_window: 7
+      ignore_errors: true
+      loop:
+        - "{{ kms_key_alias }}"
+        - "{{ kms_key_alias }}-diff-spec-usage"
+        - "{{ kms_key_alias }}-check"

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_states.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_states.yml
@@ -1,522 +1,520 @@
+---
 - block:
     # ============================================================
     #   PREPARATION
     #
     # Get some information about who we are before starting our tests
     # we'll need this as soon as we start working on the policies
-  - name: get ARN of calling user
-    aws_caller_info:
-    register: aws_caller_info
-  - name: See whether key exists and its current state
-    kms_key_info:
-      alias: '{{ kms_key_alias }}'
-  - name: create a key - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}-check'
-      tags:
-        Hello: World
-      state: present
-      enabled: yes
-    register: key_check
-    check_mode: yes
-  - name: find facts about the check mode key
-    kms_key_info:
-      alias: '{{ kms_key_alias }}-check'
-    register: check_key
-  - name: ensure that check mode worked as expected
-    assert:
-      that:
-      - check_key.kms_keys | length == 0
-      - key_check is changed
+    - name: get ARN of calling user
+      amazon.aws.aws_caller_info:
+      register: aws_caller_info
+    - name: See whether key exists and its current state
+      kms_key_info:
+        alias: "{{ kms_key_alias }}"
+    - name: create a key - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}-check"
+        tags:
+          Hello: World
+        state: present
+        enabled: true
+      register: key_check
+      check_mode: true
+    - name: find facts about the check mode key
+      kms_key_info:
+        alias: "{{ kms_key_alias }}-check"
+      register: check_key
+    - name: ensure that check mode worked as expected
+      ansible.builtin.assert:
+        that:
+          - check_key.kms_keys | length == 0
+          - key_check is changed
 
-  - name: create a key
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      tags:
-        Hello: World
-      state: present
-      enabled: yes
-      enable_key_rotation: no
-    register: key
-  - name: assert that state is enabled
-    assert:
-      that:
-      - key is changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
-      - key.multi_region == False
+    - name: create a key
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        tags:
+          Hello: World
+        state: present
+        enabled: true
+        enable_key_rotation: false
+      register: key
+    - name: assert that state is enabled
+      ansible.builtin.assert:
+        that:
+          - key is changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
+          - key.multi_region == False
 
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  - name: create a key (idempotence) - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      tags:
-        Hello: World
-      state: present
-      enabled: yes
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - key is not changed
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+    - name: create a key (idempotence) - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        tags:
+          Hello: World
+        state: present
+        enabled: true
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - key is not changed
 
-  - name: create a key (idempotence)
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      tags:
-        Hello: World
-      state: present
-      enabled: yes
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - key is not changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
-      - key.multi_region == False
-
-    # ------------------------------------------------------------------------------------------
-
-  - name: Save IDs for later
-    set_fact:
-      kms_key_id: '{{ key.key_id }}'
-      kms_key_arn: '{{ key.key_arn }}'
-  - name: Enable key rotation - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      tags:
-        Hello: World
-      state: present
-      enabled: yes
-      enable_key_rotation: yes
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - key.changed
-
-  - name: Enable key rotation
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      tags:
-        Hello: World
-      state: present
-      enabled: yes
-      enable_key_rotation: yes
-    register: key
-  - name: assert that key rotation is enabled
-    assert:
-      that:
-      - key is changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == True
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
-
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  - name: Enable key rotation (idempotence) - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      tags:
-        Hello: World
-      state: present
-      enabled: yes
-      enable_key_rotation: yes
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - not key.changed
-
-  - name: Enable key rotation (idempotence)
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      tags:
-        Hello: World
-      state: present
-      enabled: yes
-      enable_key_rotation: yes
-    register: key
-  - assert:
-      that:
-      - not key is changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == True
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
+    - name: create a key (idempotence)
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        tags:
+          Hello: World
+        state: present
+        enabled: true
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - key is not changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
+          - key.multi_region == False
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Disable key - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      enabled: no
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - key.changed
+    - name: Save IDs for later
+      ansible.builtin.set_fact:
+        kms_key_id: "{{ key.key_id }}"
+        kms_key_arn: "{{ key.key_arn }}"
+    - name: Enable key rotation - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        tags:
+          Hello: World
+        state: present
+        enabled: true
+        enable_key_rotation: true
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - key.changed
 
-  - name: Disable key
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      enabled: no
-    register: key
-  - name: assert that state is disabled
-    assert:
-      that:
-      - key is changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Disabled"
-      - key.enabled == False
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == True
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
+    - name: Enable key rotation
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        tags:
+          Hello: World
+        state: present
+        enabled: true
+        enable_key_rotation: true
+      register: key
+    - name: assert that key rotation is enabled
+      ansible.builtin.assert:
+        that:
+          - key is changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == True
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
 
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  - name: Disable key (idempotence) - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      enabled: no
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - not key.changed
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+    - name: Enable key rotation (idempotence) - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        tags:
+          Hello: World
+        state: present
+        enabled: true
+        enable_key_rotation: true
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
 
-  - name: Disable key (idempotence)
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      enabled: no
-    register: key
-  - assert:
-      that:
-      - not key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Disabled"
-      - key.enabled == False
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == True
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
+    - name: Enable key rotation (idempotence)
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        tags:
+          Hello: World
+        state: present
+        enabled: true
+        enable_key_rotation: true
+      register: key
+    - ansible.builtin.assert:
+        that:
+          - not key is changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == True
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Delete key - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: absent
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - key is changed
+    - name: Disable key - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        enabled: false
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - key.changed
 
-  - name: Delete key
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: absent
-    register: key
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  - name: Assert that state is pending deletion
-    vars:
-      now_time: '{{ lookup("pipe", "date -u +%Y-%m-%d\ %H:%M:%S") }}'
-      deletion_time: '{{ key.deletion_date[:19] | to_datetime("%Y-%m-%dT%H:%M:%S")
-        }}'
-    assert:
-      that:
-      - key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "PendingDeletion"
-      - key.enabled == False
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == False
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
+    - name: Disable key
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        enabled: false
+      register: key
+    - name: assert that state is disabled
+      ansible.builtin.assert:
+        that:
+          - key is changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Disabled"
+          - key.enabled == False
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == True
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
+
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+    - name: Disable key (idempotence) - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        enabled: false
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
+
+    - name: Disable key (idempotence)
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        enabled: false
+      register: key
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Disabled"
+          - key.enabled == False
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == True
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Delete key - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: absent
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - key is changed
+
+    - name: Delete key
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: absent
+      register: key
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+    - name: Assert that state is pending deletion
+      vars:
+        now_time: '{{ lookup("pipe", "date -u +%Y-%m-%d\ %H:%M:%S") }}'
+        deletion_time: '{{ key.deletion_date[:19] | to_datetime("%Y-%m-%dT%H:%M:%S") }}'
+      ansible.builtin.assert:
+        that:
+          - key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "PendingDeletion"
+          - key.enabled == False
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == False
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
           # Times won't be perfect, allow a 24 hour window
-      - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days <= 30
-      - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days >= 29
+          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days <= 30
+          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days >= 29
 
-  - name: Delete key (idempotence) - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: absent
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - not key.changed
+    - name: Delete key (idempotence) - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: absent
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
 
-  - name: Delete key (idempotence)
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: absent
-    register: key
-  - vars:
-      now_time: '{{ lookup("pipe", "date -u +%Y-%m-%d\ %H:%M:%S") }}'
-      deletion_time: '{{ key.deletion_date[:19] | to_datetime("%Y-%m-%dT%H:%M:%S")
-        }}'
-    assert:
-      that:
-      - not key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "PendingDeletion"
-      - key.enabled == False
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == False
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
+    - name: Delete key (idempotence)
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: absent
+      register: key
+    - vars:
+        now_time: '{{ lookup("pipe", "date -u +%Y-%m-%d\ %H:%M:%S") }}'
+        deletion_time: '{{ key.deletion_date[:19] | to_datetime("%Y-%m-%dT%H:%M:%S") }}'
+      ansible.builtin.assert:
+        that:
+          - not key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "PendingDeletion"
+          - key.enabled == False
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == False
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
           # Times won't be perfect, allow a 24 hour window
-      - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days <= 30
-      - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days >= 29
+          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days <= 30
+          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days >= 29
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Cancel key deletion - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - key.changed
+    - name: Cancel key deletion - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - key.changed
 
-  - name: Cancel key deletion
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-    register: key
-  - assert:
-      that:
-      - key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == True
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
-      - "'deletion_date' not in key"
+    - name: Cancel key deletion
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+      register: key
+    - ansible.builtin.assert:
+        that:
+          - key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == True
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
+          - "'deletion_date' not in key"
 
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  - name: Cancel key deletion (idempotence) - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - not key.changed
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+    - name: Cancel key deletion (idempotence) - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
 
-  - name: Cancel key deletion (idempotence)
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-    register: key
-  - assert:
-      that:
-      - not key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == True
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
-      - "'deletion_date' not in key"
+    - name: Cancel key deletion (idempotence)
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+      register: key
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == True
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
+          - "'deletion_date' not in key"
 
     # ------------------------------------------------------------------------------------------
 
-  - name: delete the key with a specific deletion window
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: absent
-      pending_window: 7
-    register: delete_kms
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  - name: assert that state is pending deletion
-    vars:
-      now_time: '{{ lookup("pipe", "date -u +%Y-%m-%d\ %H:%M:%S") }}'
-      deletion_time: '{{ delete_kms.deletion_date[:19] | to_datetime("%Y-%m-%dT%H:%M:%S")
-        }}'
-    assert:
-      that:
-      - delete_kms.key_state == "PendingDeletion"
-      - delete_kms.changed
+    - name: delete the key with a specific deletion window
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: absent
+        pending_window: 7
+      register: delete_kms
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+    - name: assert that state is pending deletion
+      vars:
+        now_time: '{{ lookup("pipe", "date -u +%Y-%m-%d\ %H:%M:%S") }}'
+        deletion_time: '{{ delete_kms.deletion_date[:19] | to_datetime("%Y-%m-%dT%H:%M:%S") }}'
+      ansible.builtin.assert:
+        that:
+          - delete_kms.key_state == "PendingDeletion"
+          - delete_kms.changed
           # Times won't be perfect, allow a 24 hour window
-      - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days <= 7
-      - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days >= 6
+          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days <= 7
+          - (( deletion_time | to_datetime ) - ( now_time | to_datetime )).days >= 6
 
     # ============================================================
     # test different key usage and specs
-  - name: create kms key with different specs
-    kms_key:
-      alias: '{{ kms_key_alias }}-diff-spec-usage'
-      purge_grants: yes
-      key_spec: ECC_NIST_P256
-      key_usage: SIGN_VERIFY
-    register: create_diff_kms
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  - name: verify different specs on kms key
-    assert:
-      that:
-      - '"key_id" in create_diff_kms'
-      - create_diff_kms.key_id | length >= 36
-      - not create_diff_kms.key_id.startswith("arn:aws")
-      - '"key_arn" in create_diff_kms'
-      - create_diff_kms.key_arn.endswith(create_diff_kms.key_id)
-      - create_diff_kms.key_arn.startswith("arn:aws")
-      - create_diff_kms.key_usage == 'SIGN_VERIFY'
-      - create_diff_kms.customer_master_key_spec == 'ECC_NIST_P256'
+    - name: create kms key with different specs
+      kms_key:
+        alias: "{{ kms_key_alias }}-diff-spec-usage"
+        purge_grants: true
+        key_spec: ECC_NIST_P256
+        key_usage: SIGN_VERIFY
+      register: create_diff_kms
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+    - name: verify different specs on kms key
+      ansible.builtin.assert:
+        that:
+          - '"key_id" in create_diff_kms'
+          - create_diff_kms.key_id | length >= 36
+          - not create_diff_kms.key_id.startswith("arn:aws")
+          - '"key_arn" in create_diff_kms'
+          - create_diff_kms.key_arn.endswith(create_diff_kms.key_id)
+          - create_diff_kms.key_arn.startswith("arn:aws")
+          - create_diff_kms.key_usage == 'SIGN_VERIFY'
+          - create_diff_kms.customer_master_key_spec == 'ECC_NIST_P256'
 
   always:
     # ============================================================
     #   CLEAN-UP
-  - name: finish off by deleting keys
-    kms_key:
-      state: absent
-      alias: '{{ item }}'
-      pending_window: 7
-    ignore_errors: true
-    loop:
-    - '{{ kms_key_alias }}'
-    - '{{ kms_key_alias }}-diff-spec-usage'
-    - '{{ kms_key_alias }}-check'
+    - name: finish off by deleting keys
+      kms_key:
+        state: absent
+        alias: "{{ item }}"
+        pending_window: 7
+      ignore_errors: true
+      loop:
+        - "{{ kms_key_alias }}"
+        - "{{ kms_key_alias }}-diff-spec-usage"
+        - "{{ kms_key_alias }}-check"

--- a/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_tagging.yml
+++ b/tests/integration/targets/kms_key/roles/aws_kms/tasks/test_tagging.yml
@@ -1,187 +1,188 @@
+---
 - block:
     # ============================================================
     #   PREPARATION
     #
     # Get some information about who we are before starting our tests
     # we'll need this as soon as we start working on the policies
-  - name: get ARN of calling user
-    aws_caller_info:
-    register: aws_caller_info
-  - name: create a key
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      tags:
-        Hello: World
-      state: present
-      enabled: yes
-      enable_key_rotation: no
-    register: key
-  - name: assert that state is enabled
-    assert:
-      that:
-      - key is changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 1
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
+    - name: get ARN of calling user
+      amazon.aws.aws_caller_info:
+      register: aws_caller_info
+    - name: create a key
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        tags:
+          Hello: World
+        state: present
+        enabled: true
+        enable_key_rotation: false
+      register: key
+    - name: assert that state is enabled
+      ansible.builtin.assert:
+        that:
+          - key is changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 1
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Tag encryption key
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      tags:
-        tag_one: tag_one
-        tag_two: tag_two
-      purge_tags: no
-    register: key
-  - name: Assert tags added
-    assert:
-      that:
-      - key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 3
-      - key.tags['Hello'] == 'World'
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
-      - "'tag_one' in key.tags"
-      - "'tag_two' in key.tags"
+    - name: Tag encryption key
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        tags:
+          tag_one: tag_one
+          tag_two: tag_two
+        purge_tags: false
+      register: key
+    - name: Assert tags added
+      ansible.builtin.assert:
+        that:
+          - key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 3
+          - key.tags['Hello'] == 'World'
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
+          - "'tag_one' in key.tags"
+          - "'tag_two' in key.tags"
 
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  - name: Modify tags - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      purge_tags: yes
-      tags:
-        tag_two: tag_two_updated
-        Tag Three: '{{ resource_prefix }}'
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - key.changed
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+    - name: Modify tags - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        purge_tags: true
+        tags:
+          tag_two: tag_two_updated
+          Tag Three: "{{ resource_prefix }}"
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - key.changed
 
-  - name: Modify tags
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      purge_tags: yes
-      tags:
-        tag_two: tag_two_updated
-        Tag Three: '{{ resource_prefix }}'
-    register: key
-  - name: Assert tags correctly changed
-    assert:
-      that:
-      - key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 2
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
-      - "'tag_one' not in key.tags"
-      - "'tag_two' in key.tags"
-      - key.tags.tag_two == 'tag_two_updated'
-      - "'Tag Three' in key.tags"
-      - key.tags['Tag Three'] == resource_prefix
+    - name: Modify tags
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        purge_tags: true
+        tags:
+          tag_two: tag_two_updated
+          Tag Three: "{{ resource_prefix }}"
+      register: key
+    - name: Assert tags correctly changed
+      ansible.builtin.assert:
+        that:
+          - key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 2
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
+          - "'tag_one' not in key.tags"
+          - "'tag_two' in key.tags"
+          - key.tags.tag_two == 'tag_two_updated'
+          - "'Tag Three' in key.tags"
+          - key.tags['Tag Three'] == resource_prefix
 
-  - name: Sleep to wait for updates to propagate
-    wait_for:
-      timeout: 45
-  - name: Modify tags (idempotence) - check mode
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      purge_tags: yes
-      tags:
-        tag_two: tag_two_updated
-        Tag Three: '{{ resource_prefix }}'
-    register: key
-    check_mode: yes
-  - assert:
-      that:
-      - not key.changed
+    - name: Sleep to wait for updates to propagate
+      ansible.builtin.wait_for:
+        timeout: 45
+    - name: Modify tags (idempotence) - check mode
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        purge_tags: true
+        tags:
+          tag_two: tag_two_updated
+          Tag Three: "{{ resource_prefix }}"
+      register: key
+      check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
 
-  - name: Modify tags (idempotence)
-    kms_key:
-      alias: '{{ kms_key_alias }}'
-      state: present
-      purge_tags: yes
-      tags:
-        tag_two: tag_two_updated
-        Tag Three: '{{ resource_prefix }}'
-    register: key
-  - assert:
-      that:
-      - not key.changed
-      - '"key_id" in key'
-      - key.key_id | length >= 36
-      - not key.key_id.startswith("arn:aws")
-      - '"key_arn" in key'
-      - key.key_arn.endswith(key.key_id)
-      - key.key_arn.startswith("arn:aws")
-      - key.key_state == "Enabled"
-      - key.enabled == True
-      - key.tags | length == 2
-      - key.enable_key_rotation == false
-      - key.key_usage == 'ENCRYPT_DECRYPT'
-      - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
-      - key.grants | length == 0
-      - key.key_policies | length == 1
-      - key.key_policies[0].Id == 'key-default-1'
-      - key.description == ''
-      - "'tag_one' not in key.tags"
-      - "'tag_two' in key.tags"
-      - key.tags.tag_two == 'tag_two_updated'
-      - "'Tag Three' in key.tags"
-      - key.tags['Tag Three'] == resource_prefix
+    - name: Modify tags (idempotence)
+      kms_key:
+        alias: "{{ kms_key_alias }}"
+        state: present
+        purge_tags: true
+        tags:
+          tag_two: tag_two_updated
+          Tag Three: "{{ resource_prefix }}"
+      register: key
+    - ansible.builtin.assert:
+        that:
+          - not key.changed
+          - '"key_id" in key'
+          - key.key_id | length >= 36
+          - not key.key_id.startswith("arn:aws")
+          - '"key_arn" in key'
+          - key.key_arn.endswith(key.key_id)
+          - key.key_arn.startswith("arn:aws")
+          - key.key_state == "Enabled"
+          - key.enabled == True
+          - key.tags | length == 2
+          - key.enable_key_rotation == false
+          - key.key_usage == 'ENCRYPT_DECRYPT'
+          - key.customer_master_key_spec == 'SYMMETRIC_DEFAULT'
+          - key.grants | length == 0
+          - key.key_policies | length == 1
+          - key.key_policies[0].Id == 'key-default-1'
+          - key.description == ''
+          - "'tag_one' not in key.tags"
+          - "'tag_two' in key.tags"
+          - key.tags.tag_two == 'tag_two_updated'
+          - "'Tag Three' in key.tags"
+          - key.tags['Tag Three'] == resource_prefix
 
   always:
     # ============================================================
     #   CLEAN-UP
-  - name: finish off by deleting keys
-    kms_key:
-      state: absent
-      alias: '{{ kms_key_alias }}'
-      pending_window: 7
-    ignore_errors: true
+    - name: finish off by deleting keys
+      kms_key:
+        state: absent
+        alias: "{{ kms_key_alias }}"
+        pending_window: 7
+      ignore_errors: true

--- a/tests/integration/targets/lambda/defaults/main.yml
+++ b/tests/integration/targets/lambda/defaults/main.yml
@@ -1,7 +1,8 @@
+---
 # defaults file for lambda integration test
 # IAM role names have to be less than 64 characters
 # we hash the resource_prefix to get a shorter, unique string
-lambda_function_name: '{{ tiny_prefix }}'
+lambda_function_name: "{{ tiny_prefix }}"
 lambda_role_name: ansible-test-{{ tiny_prefix }}-lambda
 
 lambda_python_runtime: python3.9
@@ -9,5 +10,5 @@ lambda_python_handler: mini_lambda.handler
 lambda_python_layers_names:
   - "{{ tiny_prefix }}-layer-01"
   - "{{ tiny_prefix }}-layer-02"
-lambda_function_name_with_layer: '{{ tiny_prefix }}-func-with-layer'
-lambda_function_name_with_multiple_layer: '{{ tiny_prefix }}-func-with-mutiplelayer'
+lambda_function_name_with_layer: "{{ tiny_prefix }}-func-with-layer"
+lambda_function_name_with_multiple_layer: "{{ tiny_prefix }}-func-with-mutiplelayer"

--- a/tests/integration/targets/lambda/meta/main.yml
+++ b/tests/integration/targets/lambda/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
-- role: setup_remote_tmp_dir
+  - role: setup_remote_tmp_dir

--- a/tests/integration/targets/lambda/tasks/main.yml
+++ b/tests/integration/targets/lambda/tasks/main.yml
@@ -1,807 +1,801 @@
+---
 - name: set connection information for AWS modules and run tests
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   collections:
-  - community.general
+    - community.general
   block:
   # https://github.com/ansible/ansible/issues/77257
-  - name: Set async_dir for HOME env
-    ansible.builtin.set_fact:
-      ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async_{{ tiny_prefix }}/"
-    when: (lookup('env', 'HOME'))
-  # Preparation
-  - name: create minimal lambda role
-    iam_role:
-      name: '{{ lambda_role_name }}'
-      assume_role_policy_document: '{{ lookup("file", "minimal_trust_policy.json")
-        }}'
-      create_instance_profile: false
-      managed_policies:
-      - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
-    register: iam_role
-  - name: wait 10 seconds for role to become available
-    pause:
-      seconds: 10
-    when: iam_role.changed
-  - name: move lambda into place for archive module
-    copy:
-      src: mini_lambda.py
-      dest: '{{ output_dir }}/mini_lambda.py'
-      mode: preserve
-  - name: bundle lambda into a zip
-    register: zip_res
-    archive:
-      format: zip
-      path: '{{ output_dir }}/mini_lambda.py'
-      dest: '{{ output_dir }}/mini_lambda.zip'
+    - name: Set async_dir for HOME env
+      ansible.builtin.set_fact:
+        ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async_{{ tiny_prefix }}/"
+      when: (lookup('env', 'HOME'))
+    # Preparation
+    - name: create minimal lambda role
+      community.aws.iam_role:
+        name: "{{ lambda_role_name }}"
+        assume_role_policy_document: '{{ lookup("file", "minimal_trust_policy.json") }}'
+        create_instance_profile: false
+        managed_policies:
+          - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
+      register: iam_role
+    - name: wait 10 seconds for role to become available
+      ansible.builtin.pause:
+        seconds: 10
+      when: iam_role.changed
+    - name: move lambda into place for archive module
+      ansible.builtin.copy:
+        src: mini_lambda.py
+        dest: "{{ output_dir }}/mini_lambda.py"
+        mode: preserve
+    - name: bundle lambda into a zip
+      register: zip_res
+      community.general.archive:
+        format: zip
+        path: "{{ output_dir }}/mini_lambda.py"
+        dest: "{{ output_dir }}/mini_lambda.zip"
 
-  # Parameter tests
-  - name: test with no parameters
-    lambda:
-    register: result
-    ignore_errors: true
-  - name: assert failure when called with no parameters
-    assert:
-      that:
-      - result.failed
-      - 'result.msg.startswith("missing required arguments: ")'
-      - '"name" in result.msg'
+    # Parameter tests
+    - name: test with no parameters
+      amazon.aws.lambda:
+      register: result
+      ignore_errors: true
+    - name: assert failure when called with no parameters
+      ansible.builtin.assert:
+        that:
+          - result.failed
+          - 'result.msg.startswith("missing required arguments: ")'
+          - '"name" in result.msg'
 
-  - name: test with no parameters except state absent
-    lambda:
-      state: absent
-    register: result
-    ignore_errors: true
-  - name: assert failure when called with no parameters
-    assert:
-      that:
-      - result.failed
-      - 'result.msg.startswith("missing required arguments: name")'
+    - name: test with no parameters except state absent
+      amazon.aws.lambda:
+        state: absent
+      register: result
+      ignore_errors: true
+    - name: assert failure when called with no parameters
+      ansible.builtin.assert:
+        that:
+          - result.failed
+          - 'result.msg.startswith("missing required arguments: name")'
 
-  - name: test with no role or handler
-    lambda:
-      name: ansible-testing-fake-should-not-be-created
-      runtime: '{{ lambda_python_runtime }}'
-    register: result
-    ignore_errors: true
-  - name: assert failure when called with no parameters
-    assert:
-      that:
-      - result.failed
-      - 'result.msg.startswith("state is present but all of the following are missing:
-        ")'
-      - '"handler" in result.msg'
-      - '"role" in result.msg'
+    - name: test with no role or handler
+      amazon.aws.lambda:
+        name: ansible-testing-fake-should-not-be-created
+        runtime: "{{ lambda_python_runtime }}"
+      register: result
+      ignore_errors: true
+    - name: assert failure when called with no parameters
+      ansible.builtin.assert:
+        that:
+          - result.failed
+          - 'result.msg.startswith("state is present but all of the following are missing: ")'
+          - '"handler" in result.msg'
+          - '"role" in result.msg'
 
-  - name: test execute lambda with no function arn or name
-    lambda_execute:
-    register: result
-    ignore_errors: true
-  - name: assert failure when called with no parameters
-    assert:
-      that:
-      - result.failed
-      - "result.msg == 'one of the following is required: name, function_arn'"
+    - name: test execute lambda with no function arn or name
+      lambda_execute:
+      register: result
+      ignore_errors: true
+    - name: assert failure when called with no parameters
+      ansible.builtin.assert:
+        that:
+          - result.failed
+          - "result.msg == 'one of the following is required: name, function_arn'"
 
-  - name: test state=present with security group but no vpc
-    lambda:
-      name: '{{ lambda_function_name }}'
-      runtime: '{{ lambda_python_runtime }}'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{ zip_res.dest }}'
-      handler: '{{ omit }}'
-      description: '{{ omit }}'
-      vpc_subnet_ids: '{{ omit }}'
-      vpc_security_group_ids: sg-FA6E
-      environment_variables: '{{ omit }}'
-      dead_letter_arn: '{{ omit }}'
-    register: result
-    ignore_errors: true
-  - name: assert lambda fails with proper message
-    assert:
-      that:
-      - result is failed
-      - result.msg != "MODULE FAILURE"
-      - result.changed == False
-      - '"parameters are required together" in result.msg'
+    - name: test state=present with security group but no vpc
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        runtime: "{{ lambda_python_runtime }}"
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{ zip_res.dest }}"
+        handler: "{{ omit }}"
+        description: "{{ omit }}"
+        vpc_subnet_ids: "{{ omit }}"
+        vpc_security_group_ids: sg-FA6E
+        environment_variables: "{{ omit }}"
+        dead_letter_arn: "{{ omit }}"
+      register: result
+      ignore_errors: true
+    - name: assert lambda fails with proper message
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - result.msg != "MODULE FAILURE"
+          - result.changed == False
+          - '"parameters are required together" in result.msg'
 
-  - name: test state=present with incomplete layers
-    lambda:
-      name: '{{ lambda_function_name }}'
-      runtime: '{{ lambda_python_runtime }}'
-      role: '{{ lambda_role_name }}'
-      handler: mini_lambda.handler
-      zip_file: '{{ zip_res.dest }}'
-      layers:
-        - layer_name: test-layer
-    check_mode: true
-    register: result
-    ignore_errors: true
-  - name: assert lambda fails with proper message
-    assert:
-      that:
-      - result is failed
-      - result is not changed
-      - '"parameters are required together: layer_name, version found in layers" in result.msg'
+    - name: test state=present with incomplete layers
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        runtime: "{{ lambda_python_runtime }}"
+        role: "{{ lambda_role_name }}"
+        handler: mini_lambda.handler
+        zip_file: "{{ zip_res.dest }}"
+        layers:
+          - layer_name: test-layer
+      check_mode: true
+      register: result
+      ignore_errors: true
+    - name: assert lambda fails with proper message
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - result is not changed
+          - '"parameters are required together: layer_name, version found in layers" in result.msg'
 
-  - name: test state=present with incomplete layers
-    lambda:
-      name: '{{ lambda_function_name }}'
-      runtime: '{{ lambda_python_runtime }}'
-      role: '{{ lambda_role_name }}'
-      handler: mini_lambda.handler
-      zip_file: '{{ zip_res.dest }}'
-      layers:
-        - layer_version_arn: 'arn:aws:lambda:us-east-2:123456789012:layer:blank-java-lib:7'
-          version: 9
-    check_mode: true
-    register: result
-    ignore_errors: true
-  - name: assert lambda fails with proper message
-    assert:
-      that:
-      - result is failed
-      - result is not changed
-      - '"parameters are mutually exclusive: version|layer_version_arn found in layers" in result.msg'
+    - name: test state=present with incomplete layers
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        runtime: "{{ lambda_python_runtime }}"
+        role: "{{ lambda_role_name }}"
+        handler: mini_lambda.handler
+        zip_file: "{{ zip_res.dest }}"
+        layers:
+          - layer_version_arn: arn:aws:lambda:us-east-2:123456789012:layer:blank-java-lib:7
+            version: 9
+      check_mode: true
+      register: result
+      ignore_errors: true
+    - name: assert lambda fails with proper message
+      ansible.builtin.assert:
+        that:
+          - result is failed
+          - result is not changed
+          - '"parameters are mutually exclusive: version|layer_version_arn found in layers" in result.msg'
 
-  # Prepare minimal Lambda
-  - name: test state=present - upload the lambda (check mode)
-    lambda:
-      name: '{{ lambda_function_name }}'
-      runtime: '{{ lambda_python_runtime }}'
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{ zip_res.dest }}'
-      architecture: arm64
-    register: result
-    check_mode: yes
-  - name: assert lambda upload succeeded
-    assert:
-      that:
-      - result.changed
+    # Prepare minimal Lambda
+    - name: test state=present - upload the lambda (check mode)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        runtime: "{{ lambda_python_runtime }}"
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{ zip_res.dest }}"
+        architecture: arm64
+      register: result
+      check_mode: true
+    - name: assert lambda upload succeeded
+      ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: test state=present - upload the lambda
-    lambda:
-      name: '{{ lambda_function_name }}'
-      runtime: '{{ lambda_python_runtime }}'
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{ zip_res.dest }}'
-      architecture: arm64
-    register: result
-  - name: assert lambda upload succeeded
-    assert:
-      that:
-      - result.changed
-      - result.configuration.tracing_config.mode == "PassThrough"
-      - result.configuration.architectures == ['arm64']
+    - name: test state=present - upload the lambda
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        runtime: "{{ lambda_python_runtime }}"
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{ zip_res.dest }}"
+        architecture: arm64
+      register: result
+    - name: assert lambda upload succeeded
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.configuration.tracing_config.mode == "PassThrough"
+          - result.configuration.architectures == ['arm64']
 
-  - name: Save Lambda ARN
-    ansible.builtin.set_fact:
-      lambda_function_arn: "{{ result['configuration']['function_arn'] }}"
+    - name: Save Lambda ARN
+      ansible.builtin.set_fact:
+        lambda_function_arn: "{{ result['configuration']['function_arn'] }}"
 
-  - include_tasks: tagging.yml
+    - ansible.builtin.include_tasks: tagging.yml
+    - name: test lambda works (check mode)
+      lambda_execute:
+        name: "{{lambda_function_name}}"
+        payload:
+          name: Mr Ansible Tests
+      register: result
+      check_mode: true
+    - name: assert check mode works correctly
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - "'result' not in result"
 
-  # Test basic operation of Uploaded lambda
-  - name: test lambda works (check mode)
-    lambda_execute:
-      name: '{{lambda_function_name}}'
-      payload:
-        name: Mr Ansible Tests
-    register: result
-    check_mode: yes
-  - name: assert check mode works correctly
-    assert:
-      that:
-      - result.changed
-      - "'result' not in result"
+    - name: test lambda works
+      lambda_execute:
+        name: "{{lambda_function_name}}"
+        payload:
+          name: Mr Ansible Tests
+      register: result
+    - name: assert lambda manages to respond as expected
+      ansible.builtin.assert:
+        that:
+          - result is not failed
+          - result.result.output.message == "hello Mr Ansible Tests"
 
-  - name: test lambda works
-    lambda_execute:
-      name: '{{lambda_function_name}}'
-      payload:
-        name: Mr Ansible Tests
-    register: result
-  - name: assert lambda manages to respond as expected
-    assert:
-      that:
-      - result is not failed
-      - result.result.output.message == "hello Mr Ansible Tests"
+    - name: test execute lambda with function arn
+      lambda_execute:
+        function_arn: "{{ lambda_function_arn }}"
+        payload:
+          name: Mr Ansible Tests
+      register: result
+    - name: assert lambda manages to respond as expected
+      ansible.builtin.assert:
+        that:
+          - result is not failed
+          - result.result.output.message == "hello Mr Ansible Tests"
 
-  - name: test execute lambda with function arn
-    lambda_execute:
-      function_arn: "{{ lambda_function_arn }}"
-      payload:
-        name: Mr Ansible Tests
-    register: result
-  - name: assert lambda manages to respond as expected
-    assert:
-      that:
-      - result is not failed
-      - result.result.output.message == "hello Mr Ansible Tests"
+    # Test updating Lambda
+    - name: test lambda config updates (check mode)
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        runtime: nodejs14.x
+        tracing_mode: Active
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        tags:
+          CamelCase: ACamelCaseValue
+          snake_case: a_snake_case_value
+          Spaced key: A value with spaces
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not failed
+          - update_result.changed == True
 
-  # Test updating Lambda
-  - name: test lambda config updates (check mode)
-    lambda:
-      name: '{{lambda_function_name}}'
-      runtime: nodejs14.x
-      tracing_mode: Active
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      tags:
-        CamelCase: ACamelCaseValue
-        snake_case: a_snake_case_value
-        Spaced key: A value with spaces
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not failed
-      - update_result.changed == True
+    - name: test lambda config updates
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        runtime: nodejs14.x
+        tracing_mode: Active
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        tags:
+          CamelCase: ACamelCaseValue
+          snake_case: a_snake_case_value
+          Spaced key: A value with spaces
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not failed
+          - update_result.changed == True
+          - update_result.configuration.runtime == 'nodejs14.x'
+          - update_result.configuration.tracing_config.mode == 'Active'
 
-  - name: test lambda config updates
-    lambda:
-      name: '{{lambda_function_name}}'
-      runtime: nodejs14.x
-      tracing_mode: Active
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      tags:
-        CamelCase: ACamelCaseValue
-        snake_case: a_snake_case_value
-        Spaced key: A value with spaces
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not failed
-      - update_result.changed == True
-      - update_result.configuration.runtime == 'nodejs14.x'
-      - update_result.configuration.tracing_config.mode == 'Active'
+    - name: test no changes are made with the same parameters repeated (check mode)
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        runtime: nodejs14.x
+        tracing_mode: Active
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        tags:
+          CamelCase: ACamelCaseValue
+          snake_case: a_snake_case_value
+          Spaced key: A value with spaces
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not failed
+          - update_result.changed == False
 
-  - name: test no changes are made with the same parameters repeated (check mode)
-    lambda:
-      name: '{{lambda_function_name}}'
-      runtime: nodejs14.x
-      tracing_mode: Active
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      tags:
-        CamelCase: ACamelCaseValue
-        snake_case: a_snake_case_value
-        Spaced key: A value with spaces
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not failed
-      - update_result.changed == False
+    - name: test no changes are made with the same parameters repeated
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        runtime: nodejs14.x
+        tracing_mode: Active
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        tags:
+          CamelCase: ACamelCaseValue
+          snake_case: a_snake_case_value
+          Spaced key: A value with spaces
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not failed
+          - update_result.changed == False
+          - update_result.configuration.runtime == 'nodejs14.x'
+          - update_result.configuration.tracing_config.mode == 'Active'
 
-  - name: test no changes are made with the same parameters repeated
-    lambda:
-      name: '{{lambda_function_name}}'
-      runtime: nodejs14.x
-      tracing_mode: Active
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      tags:
-        CamelCase: ACamelCaseValue
-        snake_case: a_snake_case_value
-        Spaced key: A value with spaces
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not failed
-      - update_result.changed == False
-      - update_result.configuration.runtime == 'nodejs14.x'
-      - update_result.configuration.tracing_config.mode == 'Active'
+    - name: reset config updates for the following tests
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        runtime: "{{ lambda_python_runtime }}"
+        tracing_mode: PassThrough
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+      register: result
+    - name: assert that reset succeeded
+      ansible.builtin.assert:
+        that:
+          - result is not failed
+          - result.changed == True
+          - result.configuration.runtime == lambda_python_runtime
+          - result.configuration.tracing_config.mode == 'PassThrough'
 
-  - name: reset config updates for the following tests
-    lambda:
-      name: '{{lambda_function_name}}'
-      runtime: '{{ lambda_python_runtime }}'
-      tracing_mode: PassThrough
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-    register: result
-  - name: assert that reset succeeded
-    assert:
-      that:
-      - result is not failed
-      - result.changed == True
-      - result.configuration.runtime == lambda_python_runtime
-      - result.configuration.tracing_config.mode == 'PassThrough'
+    # Test lambda_info
+    - name: lambda_info | Gather all infos for all lambda functions
+      amazon.aws.lambda_info:
+        query: all
+      register: lambda_infos_all
+      check_mode: true
+    - name: lambda_info | Assert successfull retrieval of all information 1
+      vars:
+        lambda_info: "{{ lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first }}"
+      ansible.builtin.assert:
+        that:
+          - lambda_infos_all is not failed
+          - lambda_infos_all.functions | length > 0
+          - lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | length == 1
+          - lambda_info.runtime == lambda_python_runtime
+          - lambda_info.description == ""
+          - lambda_info.function_arn is defined
+          - lambda_info.handler == lambda_python_handler
+          - lambda_info.versions is defined
+          - lambda_info.aliases is defined
+          - lambda_info.policy is defined
+          - lambda_info.mappings is defined
+          - lambda_info.tags is defined
+          - lambda_info.architectures == ['arm64']
 
-  # Test lambda_info
-  - name: lambda_info | Gather all infos for all lambda functions
-    lambda_info:
-      query: all
-    register: lambda_infos_all
-    check_mode: yes
-  - name: lambda_info | Assert successfull retrieval of all information 1
-    vars:
-      lambda_info: "{{ lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | first }}"
-    assert:
-      that:
-      - lambda_infos_all is not failed
-      - lambda_infos_all.functions | length > 0
-      - lambda_infos_all.functions | selectattr('function_name', 'eq', lambda_function_name) | length == 1
-      - lambda_info.runtime == lambda_python_runtime
-      - lambda_info.description == ""
-      - lambda_info.function_arn is defined
-      - lambda_info.handler == lambda_python_handler
-      - lambda_info.versions is defined
-      - lambda_info.aliases is defined
-      - lambda_info.policy is defined
-      - lambda_info.mappings is defined
-      - lambda_info.tags is defined
-      - lambda_info.architectures == ['arm64']
+    - name: lambda_info | Ensure default query value is 'config' when function name omitted
+      amazon.aws.lambda_info:
+      register: lambda_infos_query_config
+      check_mode: true
+    - name: lambda_info | Assert successfull retrieval of all information 2
+      vars:
+        lambda_info: "{{ lambda_infos_query_config.functions | selectattr('function_name', 'eq', lambda_function_name) | first }}"
+      ansible.builtin.assert:
+        that:
+          - lambda_infos_query_config is not failed
+          - lambda_infos_query_config.functions | length > 0
+          - lambda_infos_query_config.functions | selectattr('function_name', 'eq', lambda_function_name) | length == 1
+          - lambda_info.runtime == lambda_python_runtime
+          - lambda_info.description == ""
+          - lambda_info.function_arn is defined
+          - lambda_info.handler == lambda_python_handler
+          - lambda_info.versions is not defined
+          - lambda_info.aliases is not defined
+          - lambda_info.policy is not defined
+          - lambda_info.mappings is not defined
+          - lambda_info.tags is not defined
 
-  - name: lambda_info | Ensure default query value is 'config' when function name
-      omitted
-    lambda_info:
-    register: lambda_infos_query_config
-    check_mode: yes
-  - name: lambda_info | Assert successfull retrieval of all information 2
-    vars:
-      lambda_info: "{{ lambda_infos_query_config.functions | selectattr('function_name', 'eq', lambda_function_name) | first }}"
-    assert:
-      that:
-      - lambda_infos_query_config is not failed
-      - lambda_infos_query_config.functions | length > 0
-      - lambda_infos_query_config.functions | selectattr('function_name', 'eq', lambda_function_name) | length == 1
-      - lambda_info.runtime == lambda_python_runtime
-      - lambda_info.description == ""
-      - lambda_info.function_arn is defined
-      - lambda_info.handler == lambda_python_handler
-      - lambda_info.versions is not defined
-      - lambda_info.aliases is not defined
-      - lambda_info.policy is not defined
-      - lambda_info.mappings is not defined
-      - lambda_info.tags is not defined
+    - name: lambda_info | Ensure default query value is 'all' when function name specified
+      amazon.aws.lambda_info:
+        name: "{{ lambda_function_name }}"
+      register: lambda_infos_query_all
+    - name: lambda_info | Assert successfull retrieval of all information 3
+      ansible.builtin.assert:
+        that:
+          - lambda_infos_query_all is not failed
+          - lambda_infos_query_all.functions | length == 1
+          - lambda_infos_query_all.functions[0].versions|length > 0
+          - lambda_infos_query_all.functions[0].function_name is defined
+          - lambda_infos_query_all.functions[0].policy is defined
+          - lambda_infos_query_all.functions[0].aliases is defined
+          - lambda_infos_query_all.functions[0].mappings is defined
+          - lambda_infos_query_all.functions[0].tags is defined
 
-  - name: lambda_info | Ensure default query value is 'all' when function name specified
-    lambda_info:
-      name: '{{ lambda_function_name }}'
-    register: lambda_infos_query_all
-  - name: lambda_info | Assert successfull retrieval of all information 3
-    assert:
-      that:
-      - lambda_infos_query_all is not failed
-      - lambda_infos_query_all.functions | length == 1
-      - lambda_infos_query_all.functions[0].versions|length > 0
-      - lambda_infos_query_all.functions[0].function_name is defined
-      - lambda_infos_query_all.functions[0].policy is defined
-      - lambda_infos_query_all.functions[0].aliases is defined
-      - lambda_infos_query_all.functions[0].mappings is defined
-      - lambda_infos_query_all.functions[0].tags is defined
+    - name: lambda_info | Gather version infos for given lambda function
+      amazon.aws.lambda_info:
+        name: "{{ lambda_function_name }}"
+        query: versions
+      register: lambda_infos_versions
+    - name: lambda_info | Assert successfull retrieval of versions information
+      ansible.builtin.assert:
+        that:
+          - lambda_infos_versions is not failed
+          - lambda_infos_versions.functions | length == 1
+          - lambda_infos_versions.functions[0].versions|length > 0
+          - lambda_infos_versions.functions[0].function_name == lambda_function_name
+          - lambda_infos_versions.functions[0].policy is undefined
+          - lambda_infos_versions.functions[0].aliases is undefined
+          - lambda_infos_versions.functions[0].mappings is undefined
+          - lambda_infos_versions.functions[0].tags is undefined
 
-  - name: lambda_info | Gather version infos for given lambda function
-    lambda_info:
-      name: '{{ lambda_function_name }}'
-      query: versions
-    register: lambda_infos_versions
-  - name: lambda_info | Assert successfull retrieval of versions information
-    assert:
-      that:
-      - lambda_infos_versions is not failed
-      - lambda_infos_versions.functions | length == 1
-      - lambda_infos_versions.functions[0].versions|length > 0
-      - lambda_infos_versions.functions[0].function_name == lambda_function_name
-      - lambda_infos_versions.functions[0].policy is undefined
-      - lambda_infos_versions.functions[0].aliases is undefined
-      - lambda_infos_versions.functions[0].mappings is undefined
-      - lambda_infos_versions.functions[0].tags is undefined
+    - name: lambda_info | Gather config infos for given lambda function
+      amazon.aws.lambda_info:
+        name: "{{ lambda_function_name }}"
+        query: config
+      register: lambda_infos_config
+    - name: lambda_info | Assert successfull retrieval of config information
+      ansible.builtin.assert:
+        that:
+          - lambda_infos_config is not failed
+          - lambda_infos_config.functions | length == 1
+          - lambda_infos_config.functions[0].function_name == lambda_function_name
+          - lambda_infos_config.functions[0].description is defined
+          - lambda_infos_config.functions[0].versions is undefined
+          - lambda_infos_config.functions[0].policy is undefined
+          - lambda_infos_config.functions[0].aliases is undefined
+          - lambda_infos_config.functions[0].mappings is undefined
+          - lambda_infos_config.functions[0].tags is undefined
 
-  - name: lambda_info | Gather config infos for given lambda function
-    lambda_info:
-      name: '{{ lambda_function_name }}'
-      query: config
-    register: lambda_infos_config
-  - name: lambda_info | Assert successfull retrieval of config information
-    assert:
-      that:
-      - lambda_infos_config is not failed
-      - lambda_infos_config.functions | length == 1
-      - lambda_infos_config.functions[0].function_name == lambda_function_name
-      - lambda_infos_config.functions[0].description is defined
-      - lambda_infos_config.functions[0].versions is undefined
-      - lambda_infos_config.functions[0].policy is undefined
-      - lambda_infos_config.functions[0].aliases is undefined
-      - lambda_infos_config.functions[0].mappings is undefined
-      - lambda_infos_config.functions[0].tags is undefined
+    - name: lambda_info | Gather policy infos for given lambda function
+      amazon.aws.lambda_info:
+        name: "{{ lambda_function_name }}"
+        query: policy
+      register: lambda_infos_policy
+    - name: lambda_info | Assert successfull retrieval of policy information
+      ansible.builtin.assert:
+        that:
+          - lambda_infos_policy is not failed
+          - lambda_infos_policy.functions | length == 1
+          - lambda_infos_policy.functions[0].policy is defined
+          - lambda_infos_policy.functions[0].versions is undefined
+          - lambda_infos_policy.functions[0].function_name == lambda_function_name
+          - lambda_infos_policy.functions[0].aliases is undefined
+          - lambda_infos_policy.functions[0].mappings is undefined
+          - lambda_infos_policy.functions[0].tags is undefined
 
-  - name: lambda_info | Gather policy infos for given lambda function
-    lambda_info:
-      name: '{{ lambda_function_name }}'
-      query: policy
-    register: lambda_infos_policy
-  - name: lambda_info | Assert successfull retrieval of policy information
-    assert:
-      that:
-      - lambda_infos_policy is not failed
-      - lambda_infos_policy.functions | length == 1
-      - lambda_infos_policy.functions[0].policy is defined
-      - lambda_infos_policy.functions[0].versions is undefined
-      - lambda_infos_policy.functions[0].function_name == lambda_function_name
-      - lambda_infos_policy.functions[0].aliases is undefined
-      - lambda_infos_policy.functions[0].mappings is undefined
-      - lambda_infos_policy.functions[0].tags is undefined
+    - name: lambda_info | Gather aliases infos for given lambda function
+      amazon.aws.lambda_info:
+        name: "{{ lambda_function_name }}"
+        query: aliases
+      register: lambda_infos_aliases
+    - name: lambda_info | Assert successfull retrieval of aliases information
+      ansible.builtin.assert:
+        that:
+          - lambda_infos_aliases is not failed
+          - lambda_infos_aliases.functions | length == 1
+          - lambda_infos_aliases.functions[0].aliases is defined
+          - lambda_infos_aliases.functions[0].versions is undefined
+          - lambda_infos_aliases.functions[0].function_name == lambda_function_name
+          - lambda_infos_aliases.functions[0].policy is undefined
+          - lambda_infos_aliases.functions[0].mappings is undefined
+          - lambda_infos_aliases.functions[0].tags is undefined
 
-  - name: lambda_info | Gather aliases infos for given lambda function
-    lambda_info:
-      name: '{{ lambda_function_name }}'
-      query: aliases
-    register: lambda_infos_aliases
-  - name: lambda_info | Assert successfull retrieval of aliases information
-    assert:
-      that:
-      - lambda_infos_aliases is not failed
-      - lambda_infos_aliases.functions | length == 1
-      - lambda_infos_aliases.functions[0].aliases is defined
-      - lambda_infos_aliases.functions[0].versions is undefined
-      - lambda_infos_aliases.functions[0].function_name == lambda_function_name
-      - lambda_infos_aliases.functions[0].policy is undefined
-      - lambda_infos_aliases.functions[0].mappings is undefined
-      - lambda_infos_aliases.functions[0].tags is undefined
+    - name: lambda_info | Gather mappings infos for given lambda function
+      amazon.aws.lambda_info:
+        name: "{{ lambda_function_name }}"
+        query: mappings
+      register: lambda_infos_mappings
+    - name: lambda_info | Assert successfull retrieval of mappings information
+      ansible.builtin.assert:
+        that:
+          - lambda_infos_mappings is not failed
+          - lambda_infos_mappings.functions | length == 1
+          - lambda_infos_mappings.functions[0].mappings is defined
+          - lambda_infos_mappings.functions[0].versions is undefined
+          - lambda_infos_mappings.functions[0].function_name == lambda_function_name
+          - lambda_infos_mappings.functions[0].aliases is undefined
+          - lambda_infos_mappings.functions[0].policy is undefined
+          - lambda_infos_mappings.functions[0].tags is undefined
 
-  - name: lambda_info | Gather mappings infos for given lambda function
-    lambda_info:
-      name: '{{ lambda_function_name }}'
-      query: mappings
-    register: lambda_infos_mappings
-  - name: lambda_info | Assert successfull retrieval of mappings information
-    assert:
-      that:
-      - lambda_infos_mappings is not failed
-      - lambda_infos_mappings.functions | length == 1
-      - lambda_infos_mappings.functions[0].mappings is defined
-      - lambda_infos_mappings.functions[0].versions is undefined
-      - lambda_infos_mappings.functions[0].function_name == lambda_function_name
-      - lambda_infos_mappings.functions[0].aliases is undefined
-      - lambda_infos_mappings.functions[0].policy is undefined
-      - lambda_infos_mappings.functions[0].tags is undefined
+    # 2023-06-27
+    # An explicit "None" is no longer permitted by Ansible for parameters with a type other than "raw"
+    # (None is still the implicit value for "not set")
+    #
+    # # More Lambda update tests
+    # - name: test state=present with all nullable variables explicitly set to null
+    #   lambda:
+    #     name: '{{lambda_function_name}}'
+    #     runtime: '{{ lambda_python_runtime }}'
+    #     role: '{{ lambda_role_name }}'
+    #     zip_file: '{{zip_res.dest}}'
+    #     handler: '{{ lambda_python_handler }}'
+    #     description:
+    #     vpc_subnet_ids:
+    #     vpc_security_group_ids:
+    #     environment_variables:
+    #     dead_letter_arn:
+    #   register: result
+    # - name: assert lambda remains as before
+    #   assert:
+    #     that:
+    #     - result is not failed
+    #     - result.changed == False
 
-  # 2023-06-27
-  # An explicit "None" is no longer permitted by Ansible for parameters with a type other than "raw"
-  # (None is still the implicit value for "not set")
-  #
-  # # More Lambda update tests
-  # - name: test state=present with all nullable variables explicitly set to null
-  #   lambda:
-  #     name: '{{lambda_function_name}}'
-  #     runtime: '{{ lambda_python_runtime }}'
-  #     role: '{{ lambda_role_name }}'
-  #     zip_file: '{{zip_res.dest}}'
-  #     handler: '{{ lambda_python_handler }}'
-  #     description:
-  #     vpc_subnet_ids:
-  #     vpc_security_group_ids:
-  #     environment_variables:
-  #     dead_letter_arn:
-  #   register: result
-  # - name: assert lambda remains as before
-  #   assert:
-  #     that:
-  #     - result is not failed
-  #     - result.changed == False
+    - name: test putting an environment variable changes lambda (check mode)
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        runtime: "{{ lambda_python_runtime }}"
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{zip_res.dest}}"
+        environment_variables:
+          EXTRA_MESSAGE: I think you are great!!
+      register: result
+      check_mode: true
+    - name: assert lambda upload succeeded
+      ansible.builtin.assert:
+        that:
+          - result is not failed
+          - result.changed == True
 
-  - name: test putting an environment variable changes lambda (check mode)
-    lambda:
-      name: '{{lambda_function_name}}'
-      runtime: '{{ lambda_python_runtime }}'
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{zip_res.dest}}'
-      environment_variables:
-        EXTRA_MESSAGE: I think you are great!!
-    register: result
-    check_mode: yes
-  - name: assert lambda upload succeeded
-    assert:
-      that:
-      - result is not failed
-      - result.changed == True
+    - name: test putting an environment variable changes lambda
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        runtime: "{{ lambda_python_runtime }}"
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{zip_res.dest}}"
+        environment_variables:
+          EXTRA_MESSAGE: I think you are great!!
+      register: result
+    - name: assert lambda upload succeeded
+      ansible.builtin.assert:
+        that:
+          - result is not failed
+          - result.changed == True
+          - result.configuration.environment.variables.extra_message == "I think you are great!!"
 
-  - name: test putting an environment variable changes lambda
-    lambda:
-      name: '{{lambda_function_name}}'
-      runtime: '{{ lambda_python_runtime }}'
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{zip_res.dest}}'
-      environment_variables:
-        EXTRA_MESSAGE: I think you are great!!
-    register: result
-  - name: assert lambda upload succeeded
-    assert:
-      that:
-      - result is not failed
-      - result.changed == True
-      - result.configuration.environment.variables.extra_message == "I think you are
-        great!!"
+    - name: test lambda works
+      lambda_execute:
+        name: "{{lambda_function_name}}"
+        payload:
+          name: Mr Ansible Tests
+      register: result
+    - name: assert lambda manages to respond as expected
+      ansible.builtin.assert:
+        that:
+          - result is not failed
+          - result.result.output.message == "hello Mr Ansible Tests. I think you are great!!"
 
-  - name: test lambda works
-    lambda_execute:
-      name: '{{lambda_function_name}}'
-      payload:
-        name: Mr Ansible Tests
-    register: result
-  - name: assert lambda manages to respond as expected
-    assert:
-      that:
-      - result is not failed
-      - result.result.output.message == "hello Mr Ansible Tests. I think you are great!!"
+    # Deletion behavious
+    - name: test state=absent (expect changed=True) (check mode)
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        state: absent
+      register: result
+      check_mode: true
 
-  # Deletion behavious
-  - name: test state=absent (expect changed=True) (check mode)
-    lambda:
-      name: '{{lambda_function_name}}'
-      state: absent
-    register: result
-    check_mode: yes
+    - name: assert state=absent
+      ansible.builtin.assert:
+        that:
+          - result is not failed
+          - result is changed
 
-  - name: assert state=absent
-    assert:
-      that:
-      - result is not failed
-      - result is changed
+    - name: test state=absent (expect changed=True)
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        state: absent
+      register: result
 
-  - name: test state=absent (expect changed=True)
-    lambda:
-      name: '{{lambda_function_name}}'
-      state: absent
-    register: result
+    - name: assert state=absent
+      ansible.builtin.assert:
+        that:
+          - result is not failed
+          - result is changed
 
-  - name: assert state=absent
-    assert:
-      that:
-      - result is not failed
-      - result is changed
+    - name: test state=absent (expect changed=False) when already deleted (check mode)
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        state: absent
+      register: result
+      check_mode: true
 
-  - name: test state=absent (expect changed=False) when already deleted (check mode)
-    lambda:
-      name: '{{lambda_function_name}}'
-      state: absent
-    register: result
-    check_mode: yes
+    - name: assert state=absent
+      ansible.builtin.assert:
+        that:
+          - result is not failed
+          - result is not changed
 
-  - name: assert state=absent
-    assert:
-      that:
-      - result is not failed
-      - result is not changed
+    - name: test state=absent (expect changed=False) when already deleted
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        state: absent
+      register: result
 
-  - name: test state=absent (expect changed=False) when already deleted
-    lambda:
-      name: '{{lambda_function_name}}'
-      state: absent
-    register: result
+    - name: assert state=absent
+      ansible.builtin.assert:
+        that:
+          - result is not failed
+          - result is not changed
 
-  - name: assert state=absent
-    assert:
-      that:
-      - result is not failed
-      - result is not changed
+    # Parallel creations and deletions
+    - name: parallel lambda creation 1/4
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}_1"
+        runtime: "{{ lambda_python_runtime }}"
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{zip_res.dest}}"
+      async: 1000
+      register: async_1
+    - name: parallel lambda creation 2/4
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}_2"
+        runtime: "{{ lambda_python_runtime }}"
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{zip_res.dest}}"
+      async: 1000
+      register: async_2
+    - name: parallel lambda creation 3/4
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}_3"
+        runtime: "{{ lambda_python_runtime }}"
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{zip_res.dest}}"
+      async: 1000
+      register: async_3
+    - name: parallel lambda creation 4/4
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}_4"
+        runtime: "{{ lambda_python_runtime }}"
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{zip_res.dest}}"
+      register: result
+    - name: assert lambda manages to respond as expected
+      ansible.builtin.assert:
+        that:
+          - result is not failed
+    - name: parallel lambda deletion 1/4
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}_1"
+        state: absent
+        zip_file: "{{zip_res.dest}}"
+      async: 1000
+      register: async_1
+    - name: parallel lambda deletion 2/4
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}_2"
+        state: absent
+        zip_file: "{{zip_res.dest}}"
+      async: 1000
+      register: async_2
+    - name: parallel lambda deletion 3/4
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}_3"
+        state: absent
+        zip_file: "{{zip_res.dest}}"
+      async: 1000
+      register: async_3
+    - name: parallel lambda deletion 4/4
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}_4"
+        state: absent
+        zip_file: "{{zip_res.dest}}"
+      register: result
+    - name: assert lambda creation has succeeded
+      ansible.builtin.assert:
+        that:
+          - result is not failed
 
-  # Parallel creations and deletions
-  - name: parallel lambda creation 1/4
-    lambda:
-      name: '{{lambda_function_name}}_1'
-      runtime: '{{ lambda_python_runtime }}'
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{zip_res.dest}}'
-    async: 1000
-    register: async_1
-  - name: parallel lambda creation 2/4
-    lambda:
-      name: '{{lambda_function_name}}_2'
-      runtime: '{{ lambda_python_runtime }}'
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{zip_res.dest}}'
-    async: 1000
-    register: async_2
-  - name: parallel lambda creation 3/4
-    lambda:
-      name: '{{lambda_function_name}}_3'
-      runtime: '{{ lambda_python_runtime }}'
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{zip_res.dest}}'
-    async: 1000
-    register: async_3
-  - name: parallel lambda creation 4/4
-    lambda:
-      name: '{{lambda_function_name}}_4'
-      runtime: '{{ lambda_python_runtime }}'
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{zip_res.dest}}'
-    register: result
-  - name: assert lambda manages to respond as expected
-    assert:
-      that:
-      - result is not failed
-  - name: parallel lambda deletion 1/4
-    lambda:
-      name: '{{lambda_function_name}}_1'
-      state: absent
-      zip_file: '{{zip_res.dest}}'
-    async: 1000
-    register: async_1
-  - name: parallel lambda deletion 2/4
-    lambda:
-      name: '{{lambda_function_name}}_2'
-      state: absent
-      zip_file: '{{zip_res.dest}}'
-    async: 1000
-    register: async_2
-  - name: parallel lambda deletion 3/4
-    lambda:
-      name: '{{lambda_function_name}}_3'
-      state: absent
-      zip_file: '{{zip_res.dest}}'
-    async: 1000
-    register: async_3
-  - name: parallel lambda deletion 4/4
-    lambda:
-      name: '{{lambda_function_name}}_4'
-      state: absent
-      zip_file: '{{zip_res.dest}}'
-    register: result
-  - name: assert lambda creation has succeeded
-    assert:
-      that:
-      - result is not failed
+    # Test creation with layers
+    - name: Create temporary directory for testing
+      ansible.builtin.tempfile:
+        suffix: lambda
+        state: directory
+      register: test_dir
 
-  # Test creation with layers
-  - name: Create temporary directory for testing
-    tempfile:
-      suffix: lambda
-      state: directory
-    register: test_dir
+    - name: Create python directory for lambda layer
+      ansible.builtin.file:
+        path: "{{ remote_tmp_dir }}/python"
+        state: directory
 
-  - name: Create python directory for lambda layer
-    file:
-      path: "{{ remote_tmp_dir }}/python"
-      state: directory
+    - name: Create lambda layer library
+      ansible.builtin.copy:
+        content: |
+          def hello():
+            print("Hello from the ansible amazon.aws lambda layer")
+            return 1
+        dest: "{{ remote_tmp_dir }}/python/lambda_layer.py"
 
-  - name: Create lambda layer library
-    copy:
-      content: |
-        def hello():
-          print("Hello from the ansible amazon.aws lambda layer")
-          return 1
-      dest: "{{ remote_tmp_dir }}/python/lambda_layer.py"
+    - name: Create lambda layer archive
+      community.general.archive:
+        format: zip
+        path: "{{ remote_tmp_dir }}"
+        dest: "{{ remote_tmp_dir }}/lambda_layer.zip"
 
-  - name: Create lambda layer archive
-    archive:
-      format: zip
-      path: "{{ remote_tmp_dir }}"
-      dest: "{{ remote_tmp_dir }}/lambda_layer.zip"
+    - name: Create lambda layer
+      lambda_layer:
+        name: "{{ lambda_python_layers_names[0] }}"
+        description: "{{ lambda_python_layers_names[0] }} lambda layer"
+        content:
+          zip_file: "{{ remote_tmp_dir }}/lambda_layer.zip"
+      register: first_layer
 
-  - name: Create lambda layer
-    lambda_layer:
-      name: "{{ lambda_python_layers_names[0] }}"
-      description: '{{ lambda_python_layers_names[0] }} lambda layer'
-      content:
-        zip_file: "{{ remote_tmp_dir }}/lambda_layer.zip"
-    register: first_layer
+    - name: Create another lambda layer
+      lambda_layer:
+        name: "{{ lambda_python_layers_names[1] }}"
+        description: "{{ lambda_python_layers_names[1] }} lambda layer"
+        content:
+          zip_file: "{{ remote_tmp_dir }}/lambda_layer.zip"
+      register: second_layer
 
-  - name: Create another lambda layer
-    lambda_layer:
-      name: "{{ lambda_python_layers_names[1] }}"
-      description: '{{ lambda_python_layers_names[1] }} lambda layer'
-      content:
-        zip_file: "{{ remote_tmp_dir }}/lambda_layer.zip"
-    register: second_layer
+    - name: Create lambda function with layers
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name_with_layer }}"
+        runtime: "{{ lambda_python_runtime }}"
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{ zip_res.dest }}"
+        layers:
+          - layer_version_arn: "{{ first_layer.layer_versions.0.layer_version_arn }}"
+      register: result
+    - name: Validate that lambda function was created with expected property
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - '"layers" in result.configuration'
+          - result.configuration.layers | length == 1
+          - result.configuration.layers.0.arn == first_layer.layer_versions.0.layer_version_arn
 
-  - name: Create lambda function with layers
-    lambda:
-      name: '{{ lambda_function_name_with_layer }}'
-      runtime: '{{ lambda_python_runtime }}'
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{ zip_res.dest }}'
-      layers:
-        - layer_version_arn: "{{ first_layer.layer_versions.0.layer_version_arn }}"
-    register: result
-  - name: Validate that lambda function was created with expected property
-    assert:
-      that:
-        - result is changed
-        - '"layers" in result.configuration'
-        - result.configuration.layers | length == 1
-        - result.configuration.layers.0.arn == first_layer.layer_versions.0.layer_version_arn
+    - name: Create lambda function with layers once again (validate idempotency)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name_with_layer }}"
+        runtime: "{{ lambda_python_runtime }}"
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{ zip_res.dest }}"
+        layers:
+          - layer_version_arn: "{{ first_layer.layer_versions.0.layer_version_arn }}"
+      register: result
+    - name: Validate that no change were made
+      ansible.builtin.assert:
+        that:
+          - result is not changed
 
-  - name: Create lambda function with layers once again (validate idempotency)
-    lambda:
-      name: '{{ lambda_function_name_with_layer }}'
-      runtime: '{{ lambda_python_runtime }}'
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{ zip_res.dest }}'
-      layers:
-        - layer_version_arn: "{{ first_layer.layer_versions.0.layer_version_arn }}"
-    register: result
-  - name: Validate that no change were made
-    assert:
-      that:
-        - result is not changed
+    - name: Create lambda function with mutiple layers
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name_with_multiple_layer }}"
+        runtime: "{{ lambda_python_runtime }}"
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{ zip_res.dest }}"
+        layers:
+          - layer_version_arn: "{{ first_layer.layer_versions.0.layer_version_arn }}"
+          - layer_name: "{{ second_layer.layer_versions.0.layer_arn }}"
+            version: "{{ second_layer.layer_versions.0.version }}"
+      register: result
+    - name: Validate that lambda function was created with expected property
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - '"layers" in result.configuration'
+          - result.configuration.layers | length == 2
+          - first_layer.layer_versions.0.layer_version_arn in lambda_layer_versions
+          - second_layer.layer_versions.0.layer_version_arn in lambda_layer_versions
+      vars:
+        lambda_layer_versions: "{{ result.configuration.layers | map(attribute='arn') | list }}"
 
-  - name: Create lambda function with mutiple layers
-    lambda:
-      name: '{{ lambda_function_name_with_multiple_layer }}'
-      runtime: '{{ lambda_python_runtime }}'
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{ zip_res.dest }}'
-      layers:
-        - layer_version_arn: "{{ first_layer.layer_versions.0.layer_version_arn }}"
-        - layer_name: "{{ second_layer.layer_versions.0.layer_arn }}"
-          version: "{{ second_layer.layer_versions.0.version }}"
-    register: result
-  - name: Validate that lambda function was created with expected property
-    assert:
-      that:
-        - result is changed
-        - '"layers" in result.configuration'
-        - result.configuration.layers | length == 2
-        - first_layer.layer_versions.0.layer_version_arn in lambda_layer_versions
-        - second_layer.layer_versions.0.layer_version_arn in lambda_layer_versions
-    vars:
-      lambda_layer_versions: "{{ result.configuration.layers | map(attribute='arn') | list }}"
-
-  - name: Create lambda function with mutiple layers and changing layers order (idempotency)
-    lambda:
-      name: '{{ lambda_function_name_with_multiple_layer }}'
-      runtime: '{{ lambda_python_runtime }}'
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{ zip_res.dest }}'
-      layers:
-        - layer_version_arn: "{{ second_layer.layer_versions.0.layer_version_arn }}"
-        - layer_name: "{{ first_layer.layer_versions.0.layer_arn }}"
-          version: "{{ first_layer.layer_versions.0.version }}"
-    register: result
-  - name: Validate that lambda function was created with expected property
-    assert:
-      that:
-        - result is not changed
+    - name: Create lambda function with mutiple layers and changing layers order (idempotency)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name_with_multiple_layer }}"
+        runtime: "{{ lambda_python_runtime }}"
+        handler: "{{ lambda_python_handler }}"
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{ zip_res.dest }}"
+        layers:
+          - layer_version_arn: "{{ second_layer.layer_versions.0.layer_version_arn }}"
+          - layer_name: "{{ first_layer.layer_versions.0.layer_arn }}"
+            version: "{{ first_layer.layer_versions.0.version }}"
+      register: result
+    - name: Validate that lambda function was created with expected property
+      ansible.builtin.assert:
+        that:
+          - result is not changed
 
   always:
+    - name: Delete lambda layers
+      lambda_layer:
+        name: "{{ item }}"
+        version: -1
+        state: absent
+      ignore_errors: true
+      with_items: "{{ lambda_python_layers_names }}"
 
-  - name: Delete lambda layers
-    lambda_layer:
-      name: "{{ item }}"
-      version: -1
-      state: absent
-    ignore_errors: true
-    with_items: "{{ lambda_python_layers_names }}"
+    - name: ensure functions are absent at end of test
+      amazon.aws.lambda:
+        name: "{{ item }}"
+        state: absent
+      ignore_errors: true
+      with_items:
+        - "{{ lambda_function_name }}"
+        - "{{ lambda_function_name }}_1"
+        - "{{ lambda_function_name }}_2"
+        - "{{ lambda_function_name }}_3"
+        - "{{ lambda_function_name }}_4"
 
-  - name: ensure functions are absent at end of test
-    lambda:
-      name: '{{ item }}'
-      state: absent
-    ignore_errors: true
-    with_items:
-    - '{{ lambda_function_name }}'
-    - '{{ lambda_function_name }}_1'
-    - '{{ lambda_function_name }}_2'
-    - '{{ lambda_function_name }}_3'
-    - '{{ lambda_function_name }}_4'
-
-  - name: ensure role has been removed at end of test
-    iam_role:
-      name: '{{ lambda_role_name }}'
-      state: absent
-    ignore_errors: true
+    - name: ensure role has been removed at end of test
+      community.aws.iam_role:
+        name: "{{ lambda_role_name }}"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/lambda/tasks/tagging.yml
+++ b/tests/integration/targets/lambda/tasks/tagging.yml
@@ -1,3 +1,4 @@
+---
 - name: Tests relating to tagging lambda
   vars:
     first_tags:
@@ -28,219 +29,217 @@
   # Mandatory settings
   module_defaults:
     amazon.aws.lambda:
-      runtime: '{{ lambda_python_runtime }}'
-      handler: '{{ lambda_python_handler }}'
-      role: '{{ lambda_role_name }}'
+      runtime: "{{ lambda_python_runtime }}"
+      handler: "{{ lambda_python_handler }}"
+      role: "{{ lambda_role_name }}"
   block:
-
   ###
 
-  - name: test adding tags to lambda (check mode)
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: '{{ first_tags }}'
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
+    - name: test adding tags to lambda (check mode)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: "{{ first_tags }}"
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
 
-  - name: test adding tags to lambda
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: '{{ first_tags }}'
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - update_result.tags == first_tags
+    - name: test adding tags to lambda
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: "{{ first_tags }}"
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - update_result.tags == first_tags
 
-  - name: test adding tags to lambda - idempotency (check mode)
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: '{{ first_tags }}'
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
+    - name: test adding tags to lambda - idempotency (check mode)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: "{{ first_tags }}"
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
 
-  - name: test adding tags to lambda - idempotency
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: '{{ first_tags }}'
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.tags == first_tags
+    - name: test adding tags to lambda - idempotency
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: "{{ first_tags }}"
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.tags == first_tags
 
-  ###
+    ###
 
-  - name: test updating tags with purge on lambda (check mode)
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: '{{ second_tags }}'
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
+    - name: test updating tags with purge on lambda (check mode)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: "{{ second_tags }}"
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
 
-  - name: test updating tags with purge on lambda
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: '{{ second_tags }}'
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - update_result.tags == second_tags
+    - name: test updating tags with purge on lambda
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: "{{ second_tags }}"
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - update_result.tags == second_tags
 
-  - name: test updating tags with purge on lambda - idempotency (check mode)
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: '{{ second_tags }}'
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
+    - name: test updating tags with purge on lambda - idempotency (check mode)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: "{{ second_tags }}"
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
 
-  - name: test updating tags with purge on lambda - idempotency
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: '{{ second_tags }}'
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.tags == second_tags
+    - name: test updating tags with purge on lambda - idempotency
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: "{{ second_tags }}"
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.tags == second_tags
 
-  ###
+    ###
 
-  - name: test updating tags without purge on lambda (check mode)
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: '{{ third_tags }}'
-      purge_tags: false
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
+    - name: test updating tags without purge on lambda (check mode)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
 
-  - name: test updating tags without purge on lambda
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: '{{ third_tags }}'
-      purge_tags: false
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - update_result.tags == final_tags
+    - name: test updating tags without purge on lambda
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - update_result.tags == final_tags
 
-  - name: test updating tags without purge on lambda - idempotency (check mode)
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: '{{ third_tags }}'
-      purge_tags: false
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
+    - name: test updating tags without purge on lambda - idempotency (check mode)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
 
-  - name: test updating tags without purge on lambda - idempotency
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: '{{ third_tags }}'
-      purge_tags: false
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.tags == final_tags
+    - name: test updating tags without purge on lambda - idempotency
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: "{{ third_tags }}"
+        purge_tags: false
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.tags == final_tags
 
-  ###
+    ###
 
-  - name: test no tags param lambda (check mode)
-    lambda:
-      name: '{{ lambda_function_name }}'
-    register: update_result
-    check_mode: yes
-  - name: assert no change
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.tags == final_tags
+    - name: test no tags param lambda (check mode)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+      register: update_result
+      check_mode: true
+    - name: assert no change
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.tags == final_tags
 
+    - name: test no tags param lambda
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+      register: update_result
+    - name: assert no change
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.tags == final_tags
 
-  - name: test no tags param lambda
-    lambda:
-      name: '{{ lambda_function_name }}'
-    register: update_result
-  - name: assert no change
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.tags == final_tags
+    ###
 
-  ###
+    - name: test removing tags from lambda (check mode)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: {}
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
 
-  - name: test removing tags from lambda (check mode)
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: {}
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
+    - name: test removing tags from lambda
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: {}
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is changed
+          - update_result.tags == {}
 
-  - name: test removing tags from lambda
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: {}
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is changed
-      - update_result.tags == {}
+    - name: test removing tags from lambda - idempotency (check mode)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: {}
+      register: update_result
+      check_mode: true
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
 
-  - name: test removing tags from lambda - idempotency (check mode)
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: {}
-    register: update_result
-    check_mode: yes
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-
-  - name: test removing tags from lambda - idempotency
-    lambda:
-      name: '{{ lambda_function_name }}'
-      tags: {}
-    register: update_result
-  - name: assert that update succeeded
-    assert:
-      that:
-      - update_result is not changed
-      - update_result.tags == {}
+    - name: test removing tags from lambda - idempotency
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        tags: {}
+      register: update_result
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - update_result is not changed
+          - update_result.tags == {}

--- a/tests/integration/targets/lambda_alias/defaults/main.yml
+++ b/tests/integration/targets/lambda_alias/defaults/main.yml
@@ -2,5 +2,5 @@
 # defaults file for lambda integration test
 # IAM role names have to be less than 64 characters
 # we hash the resource_prefix to get a shorter, unique string
-lambda_function_name: 'ansible-test-{{ tiny_prefix }}'
-lambda_role_name: 'ansible-test-{{ tiny_prefix }}-lambda'
+lambda_function_name: ansible-test-{{ tiny_prefix }}
+lambda_role_name: ansible-test-{{ tiny_prefix }}-lambda

--- a/tests/integration/targets/lambda_alias/meta/main.yml
+++ b/tests/integration/targets/lambda_alias/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/lambda_alias/tasks/main.yml
+++ b/tests/integration/targets/lambda_alias/tasks/main.yml
@@ -1,622 +1,623 @@
+---
 - name: set connection information for AWS modules and run tests
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   collections:
     - community.general
   block:
   # ==============================================================
   # Preparation
-  - name: create minimal lambda role
-    iam_role:
-      name: '{{ lambda_role_name }}'
-      assume_role_policy_document: '{{ lookup("file", "minimal_trust_policy.json") }}'
-      create_instance_profile: false
-      managed_policies:
-      - 'arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess'
-    register: iam_role
-  - name: wait 10 seconds for role to become available
-    pause:
-      seconds: 10
-    when: iam_role.changed
-  - name: move lambda into place for archive module
-    copy:
-      src: mini_lambda.py
-      dest: '{{ output_dir }}/mini_lambda.py'
-      mode: preserve
-  - name: bundle lambda into a zip
-    register: zip_res
-    archive:
-      format: zip
-      path: '{{ output_dir }}/mini_lambda.py'
-      dest: '{{ output_dir }}/mini_lambda.zip'
+    - name: create minimal lambda role
+      community.aws.iam_role:
+        name: "{{ lambda_role_name }}"
+        assume_role_policy_document: '{{ lookup("file", "minimal_trust_policy.json") }}'
+        create_instance_profile: false
+        managed_policies:
+          - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
+      register: iam_role
+    - name: wait 10 seconds for role to become available
+      ansible.builtin.pause:
+        seconds: 10
+      when: iam_role.changed
+    - name: move lambda into place for archive module
+      ansible.builtin.copy:
+        src: mini_lambda.py
+        dest: "{{ output_dir }}/mini_lambda.py"
+        mode: preserve
+    - name: bundle lambda into a zip
+      register: zip_res
+      community.general.archive:
+        format: zip
+        path: "{{ output_dir }}/mini_lambda.py"
+        dest: "{{ output_dir }}/mini_lambda.zip"
 
-  - name: Upload test lambda (version 1)
-    lambda:
-      name: '{{ lambda_function_name }}'
-      runtime: 'python3.7'
-      handler: 'mini_lambda.handler'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{ zip_res.dest }}'
-    register: lambda_a
-  - name: assert lambda upload succeeded
-    assert:
-      that:
-      - lambda_a is changed
+    - name: Upload test lambda (version 1)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        runtime: python3.7
+        handler: mini_lambda.handler
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{ zip_res.dest }}"
+      register: lambda_a
+    - name: assert lambda upload succeeded
+      ansible.builtin.assert:
+        that:
+          - lambda_a is changed
 
-  - name: Update lambda (version 2)
-    lambda:
-      name: '{{ lambda_function_name }}'
-      runtime: 'python3.8'
-      handler: 'mini_lambda.handler'
-      role: '{{ lambda_role_name }}'
-    register: lambda_b
-  - name: assert that update succeeded
-    assert:
-      that:
-      - lambda_b is changed
+    - name: Update lambda (version 2)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        runtime: python3.8
+        handler: mini_lambda.handler
+        role: "{{ lambda_role_name }}"
+      register: lambda_b
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - lambda_b is changed
 
-  - name: Update lambda (version 3 / LATEST)
-    lambda:
-      name: '{{ lambda_function_name }}'
-      runtime: 'python3.9'
-      handler: 'mini_lambda.handler'
-      role: '{{ lambda_role_name }}'
-    register: lambda_c
-  - name: assert that update succeeded
-    assert:
-      that:
-      - lambda_c is changed
+    - name: Update lambda (version 3 / LATEST)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        runtime: python3.9
+        handler: mini_lambda.handler
+        role: "{{ lambda_role_name }}"
+      register: lambda_c
+    - name: assert that update succeeded
+      ansible.builtin.assert:
+        that:
+          - lambda_c is changed
 
-  - name: Store Lambda info
-    vars:
-      _full_arn: '{{ lambda_a.configuration.function_arn }}'
-    set_fact:
-      lambda_arn: '{{ ":".join(_full_arn.split(":")[:-1]) }}'
+    - name: Store Lambda info
+      vars:
+        _full_arn: "{{ lambda_a.configuration.function_arn }}"
+      ansible.builtin.set_fact:
+        lambda_arn: '{{ ":".join(_full_arn.split(":")[:-1]) }}'
 
-  # ==============================================================
-  # Creation of an alias
-  - name: Create an alias (check mode)
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-    check_mode: True
-    register: create_alias
-  - name: Check changed
-    assert:
-      that:
-      - create_alias is changed
+    # ==============================================================
+    # Creation of an alias
+    - name: Create an alias (check mode)
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+      check_mode: true
+      register: create_alias
+    - name: Check changed
+      ansible.builtin.assert:
+        that:
+          - create_alias is changed
 
-  - name: Create an alias
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-    register: create_alias
-  - name: Check changed and returned values
-    assert:
-      that:
-      - create_alias is changed
-      - '"alias_arn" in create_alias'
-      - create_alias.alias_arn.startswith(lambda_arn)
-      - create_alias.alias_arn.endswith("Testing")
-      - '"description" in create_alias'
-      - create_alias.description == ""
-      - '"function_version" in create_alias'
-      - create_alias.function_version == "$LATEST"
-      - '"name" in create_alias'
-      - create_alias.name == "Testing"
-      - '"revision_id" in create_alias'
-      # The revision_id doesn't line up with the revision IDs of the versions
-      # It will change any time the alias is updated
+    - name: Create an alias
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+      register: create_alias
+    - name: Check changed and returned values
+      ansible.builtin.assert:
+        that:
+          - create_alias is changed
+          - '"alias_arn" in create_alias'
+          - create_alias.alias_arn.startswith(lambda_arn)
+          - create_alias.alias_arn.endswith("Testing")
+          - '"description" in create_alias'
+          - create_alias.description == ""
+          - '"function_version" in create_alias'
+          - create_alias.function_version == "$LATEST"
+          - '"name" in create_alias'
+          - create_alias.name == "Testing"
+          - '"revision_id" in create_alias'
+    # The revision_id doesn't line up with the revision IDs of the versions
+    # It will change any time the alias is updated
 
-  - name: Create an alias - idempotency (check mode)
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-    check_mode: True
-    register: create_alias
-  - name: Check not changed
-    assert:
-      that:
-      - create_alias is not changed
+    - name: Create an alias - idempotency (check mode)
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+      check_mode: true
+      register: create_alias
+    - name: Check not changed
+      ansible.builtin.assert:
+        that:
+          - create_alias is not changed
 
-  - name: Create an alias - idempotecy
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-    register: create_alias
-  - name: Check not changed
-    assert:
-      that:
-      - create_alias is not changed
-      - '"alias_arn" in create_alias'
-      - create_alias.alias_arn.startswith(lambda_arn)
-      - create_alias.alias_arn.endswith("Testing")
-      - '"description" in create_alias'
-      - create_alias.description == ""
-      - '"function_version" in create_alias'
-      - create_alias.function_version == "$LATEST"
-      - '"name" in create_alias'
-      - create_alias.name == "Testing"
-      - '"revision_id" in create_alias'
-      # The revision_id doesn't line up with the revision IDs of the versions
-      # It will change any time the alias is updated
+    - name: Create an alias - idempotecy
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+      register: create_alias
+    - name: Check not changed
+      ansible.builtin.assert:
+        that:
+          - create_alias is not changed
+          - '"alias_arn" in create_alias'
+          - create_alias.alias_arn.startswith(lambda_arn)
+          - create_alias.alias_arn.endswith("Testing")
+          - '"description" in create_alias'
+          - create_alias.description == ""
+          - '"function_version" in create_alias'
+          - create_alias.function_version == "$LATEST"
+          - '"name" in create_alias'
+          - create_alias.name == "Testing"
+          - '"revision_id" in create_alias'
+    # The revision_id doesn't line up with the revision IDs of the versions
+    # It will change any time the alias is updated
 
-  # ==============================================================
-  # Update description of an alias when none set to start
-  - name: Update an alias description (check mode)
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      description: 'Description 1'
-    check_mode: True
-    register: update_alias_description
-  - name: Check changed
-    assert:
-      that:
-      - update_alias_description is changed
+    # ==============================================================
+    # Update description of an alias when none set to start
+    - name: Update an alias description (check mode)
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        description: Description 1
+      check_mode: true
+      register: update_alias_description
+    - name: Check changed
+      ansible.builtin.assert:
+        that:
+          - update_alias_description is changed
 
-  - name: Update an alias description
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      description: 'Description 1'
-    register: update_alias_description
-  - name: Check changed and returned values
-    assert:
-      that:
-      - update_alias_description is changed
-      - '"alias_arn" in update_alias_description'
-      - update_alias_description.alias_arn.startswith(lambda_arn)
-      - update_alias_description.alias_arn.endswith("Testing")
-      - '"description" in update_alias_description'
-      - update_alias_description.description == "Description 1"
-      - '"function_version" in update_alias_description'
-      - update_alias_description.function_version == "$LATEST"
-      - '"name" in update_alias_description'
-      - update_alias_description.name == "Testing"
-      - '"revision_id" in update_alias_description'
-      # The revision_id doesn't line up with the revision IDs of the versions
-      # It will change any time the alias is updated
+    - name: Update an alias description
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        description: Description 1
+      register: update_alias_description
+    - name: Check changed and returned values
+      ansible.builtin.assert:
+        that:
+          - update_alias_description is changed
+          - '"alias_arn" in update_alias_description'
+          - update_alias_description.alias_arn.startswith(lambda_arn)
+          - update_alias_description.alias_arn.endswith("Testing")
+          - '"description" in update_alias_description'
+          - update_alias_description.description == "Description 1"
+          - '"function_version" in update_alias_description'
+          - update_alias_description.function_version == "$LATEST"
+          - '"name" in update_alias_description'
+          - update_alias_description.name == "Testing"
+          - '"revision_id" in update_alias_description'
+    # The revision_id doesn't line up with the revision IDs of the versions
+    # It will change any time the alias is updated
 
-  - name: Update an alias description - idempotency (check mode)
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      description: 'Description 1'
-    check_mode: True
-    register: update_alias_description
-  - name: Check not changed
-    assert:
-      that:
-      - update_alias_description is not changed
+    - name: Update an alias description - idempotency (check mode)
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        description: Description 1
+      check_mode: true
+      register: update_alias_description
+    - name: Check not changed
+      ansible.builtin.assert:
+        that:
+          - update_alias_description is not changed
 
-  - name: Update an alias description - idempotecy
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      description: 'Description 1'
-    register: update_alias_description
-  - name: Check not changed
-    assert:
-      that:
-      - update_alias_description is not changed
-      - '"alias_arn" in update_alias_description'
-      - update_alias_description.alias_arn.startswith(lambda_arn)
-      - update_alias_description.alias_arn.endswith("Testing")
-      - '"description" in update_alias_description'
-      - update_alias_description.description == "Description 1"
-      - '"function_version" in update_alias_description'
-      - update_alias_description.function_version == "$LATEST"
-      - '"name" in update_alias_description'
-      - update_alias_description.name == "Testing"
-      - '"revision_id" in update_alias_description'
-      # The revision_id doesn't line up with the revision IDs of the versions
-      # It will change any time the alias is updated
+    - name: Update an alias description - idempotecy
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        description: Description 1
+      register: update_alias_description
+    - name: Check not changed
+      ansible.builtin.assert:
+        that:
+          - update_alias_description is not changed
+          - '"alias_arn" in update_alias_description'
+          - update_alias_description.alias_arn.startswith(lambda_arn)
+          - update_alias_description.alias_arn.endswith("Testing")
+          - '"description" in update_alias_description'
+          - update_alias_description.description == "Description 1"
+          - '"function_version" in update_alias_description'
+          - update_alias_description.function_version == "$LATEST"
+          - '"name" in update_alias_description'
+          - update_alias_description.name == "Testing"
+          - '"revision_id" in update_alias_description'
+    # The revision_id doesn't line up with the revision IDs of the versions
+    # It will change any time the alias is updated
 
-  # ==============================================================
-  # Update description of an alias when one set to start
-  - name: Update an alias description again (check mode)
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      description: 'description 2'
-    check_mode: True
-    register: update_alias_description
-  - name: Check changed
-    assert:
-      that:
-      - update_alias_description is changed
+    # ==============================================================
+    # Update description of an alias when one set to start
+    - name: Update an alias description again (check mode)
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        description: description 2
+      check_mode: true
+      register: update_alias_description
+    - name: Check changed
+      ansible.builtin.assert:
+        that:
+          - update_alias_description is changed
 
-  - name: Update an alias description again
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      description: 'description 2'
-    register: update_alias_description
-  - name: Check changed and returned values
-    assert:
-      that:
-      - update_alias_description is changed
-      - '"alias_arn" in update_alias_description'
-      - update_alias_description.alias_arn.startswith(lambda_arn)
-      - update_alias_description.alias_arn.endswith("Testing")
-      - '"description" in update_alias_description'
-      - update_alias_description.description == "description 2"
-      - '"function_version" in update_alias_description'
-      - update_alias_description.function_version == "$LATEST"
-      - '"name" in update_alias_description'
-      - update_alias_description.name == "Testing"
-      - '"revision_id" in update_alias_description'
-      # The revision_id doesn't line up with the revision IDs of the versions
-      # It will change any time the alias is updated
+    - name: Update an alias description again
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        description: description 2
+      register: update_alias_description
+    - name: Check changed and returned values
+      ansible.builtin.assert:
+        that:
+          - update_alias_description is changed
+          - '"alias_arn" in update_alias_description'
+          - update_alias_description.alias_arn.startswith(lambda_arn)
+          - update_alias_description.alias_arn.endswith("Testing")
+          - '"description" in update_alias_description'
+          - update_alias_description.description == "description 2"
+          - '"function_version" in update_alias_description'
+          - update_alias_description.function_version == "$LATEST"
+          - '"name" in update_alias_description'
+          - update_alias_description.name == "Testing"
+          - '"revision_id" in update_alias_description'
+    # The revision_id doesn't line up with the revision IDs of the versions
+    # It will change any time the alias is updated
 
-  # ==============================================================
-  # Update version of an alias
-  - name: Update an alias version (check mode)
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      function_version: 1
-    check_mode: True
-    register: update_alias_version
-  - name: Check changed
-    assert:
-      that:
-      - update_alias_version is changed
+    # ==============================================================
+    # Update version of an alias
+    - name: Update an alias version (check mode)
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        function_version: 1
+      check_mode: true
+      register: update_alias_version
+    - name: Check changed
+      ansible.builtin.assert:
+        that:
+          - update_alias_version is changed
 
-  - name: Update an alias version
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      function_version: 1
-    register: update_alias_version
-  - name: Check changed and returned values
-    assert:
-      that:
-      - update_alias_version is changed
-      - '"alias_arn" in update_alias_version'
-      - update_alias_version.alias_arn.startswith(lambda_arn)
-      - update_alias_version.alias_arn.endswith("Testing")
-      - '"description" in update_alias_version'
-      - update_alias_version.description == "description 2"
-      - '"function_version" in update_alias_version'
-      - update_alias_version.function_version == "1"
-      - '"name" in update_alias_version'
-      - update_alias_version.name == "Testing"
-      - '"revision_id" in update_alias_version'
-      # The revision_id doesn't line up with the revision IDs of the versions
-      # It will change any time the alias is updated
+    - name: Update an alias version
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        function_version: 1
+      register: update_alias_version
+    - name: Check changed and returned values
+      ansible.builtin.assert:
+        that:
+          - update_alias_version is changed
+          - '"alias_arn" in update_alias_version'
+          - update_alias_version.alias_arn.startswith(lambda_arn)
+          - update_alias_version.alias_arn.endswith("Testing")
+          - '"description" in update_alias_version'
+          - update_alias_version.description == "description 2"
+          - '"function_version" in update_alias_version'
+          - update_alias_version.function_version == "1"
+          - '"name" in update_alias_version'
+          - update_alias_version.name == "Testing"
+          - '"revision_id" in update_alias_version'
+    # The revision_id doesn't line up with the revision IDs of the versions
+    # It will change any time the alias is updated
 
-  - name: Update an alias version - idempotency (check mode)
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      function_version: 1
-    check_mode: True
-    register: update_alias_version
-  - name: Check not changed
-    assert:
-      that:
-      - update_alias_version is not changed
+    - name: Update an alias version - idempotency (check mode)
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        function_version: 1
+      check_mode: true
+      register: update_alias_version
+    - name: Check not changed
+      ansible.builtin.assert:
+        that:
+          - update_alias_version is not changed
 
-  - name: Update an alias version - idempotecy
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      function_version: 1
-    register: update_alias_version
-  - name: Check not changed
-    assert:
-      that:
-      - update_alias_version is not changed
-      - '"alias_arn" in update_alias_version'
-      - update_alias_version.alias_arn.startswith(lambda_arn)
-      - update_alias_version.alias_arn.endswith("Testing")
-      - '"description" in update_alias_version'
-      - update_alias_version.description == "description 2"
-      - '"function_version" in update_alias_version'
-      - update_alias_version.function_version == "1"
-      - '"name" in update_alias_version'
-      - update_alias_version.name == "Testing"
-      - '"revision_id" in update_alias_version'
-      # The revision_id doesn't line up with the revision IDs of the versions
-      # It will change any time the alias is updated
+    - name: Update an alias version - idempotecy
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        function_version: 1
+      register: update_alias_version
+    - name: Check not changed
+      ansible.builtin.assert:
+        that:
+          - update_alias_version is not changed
+          - '"alias_arn" in update_alias_version'
+          - update_alias_version.alias_arn.startswith(lambda_arn)
+          - update_alias_version.alias_arn.endswith("Testing")
+          - '"description" in update_alias_version'
+          - update_alias_version.description == "description 2"
+          - '"function_version" in update_alias_version'
+          - update_alias_version.function_version == "1"
+          - '"name" in update_alias_version'
+          - update_alias_version.name == "Testing"
+          - '"revision_id" in update_alias_version'
+    # The revision_id doesn't line up with the revision IDs of the versions
+    # It will change any time the alias is updated
 
-  - name: Update an alias version to implied LATEST (check mode)
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
+    - name: Update an alias version to implied LATEST (check mode)
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
       # docs state that when not defined defaults to LATEST
       #function_version: 1
-    check_mode: True
-    register: update_alias_version
-  - name: Check changed
-    assert:
-      that:
-      - update_alias_version is changed
+      check_mode: true
+      register: update_alias_version
+    - name: Check changed
+      ansible.builtin.assert:
+        that:
+          - update_alias_version is changed
 
-  - name: Update an alias version to implied LATEST
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
+    - name: Update an alias version to implied LATEST
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
       # docs state that when not defined defaults to LATEST
       #function_version: 1
-    register: update_alias_version
-  - name: Check changed and returned values
-    assert:
-      that:
-      - update_alias_version is changed
-      - '"alias_arn" in update_alias_version'
-      - update_alias_version.alias_arn.startswith(lambda_arn)
-      - update_alias_version.alias_arn.endswith("Testing")
-      - '"description" in update_alias_version'
-      - update_alias_version.description == "description 2"
-      - '"function_version" in update_alias_version'
-      - update_alias_version.function_version == "$LATEST"
-      - '"name" in update_alias_version'
-      - update_alias_version.name == "Testing"
-      - '"revision_id" in update_alias_version'
-      # The revision_id doesn't line up with the revision IDs of the versions
-      # It will change any time the alias is updated
+      register: update_alias_version
+    - name: Check changed and returned values
+      ansible.builtin.assert:
+        that:
+          - update_alias_version is changed
+          - '"alias_arn" in update_alias_version'
+          - update_alias_version.alias_arn.startswith(lambda_arn)
+          - update_alias_version.alias_arn.endswith("Testing")
+          - '"description" in update_alias_version'
+          - update_alias_version.description == "description 2"
+          - '"function_version" in update_alias_version'
+          - update_alias_version.function_version == "$LATEST"
+          - '"name" in update_alias_version'
+          - update_alias_version.name == "Testing"
+          - '"revision_id" in update_alias_version'
+    # The revision_id doesn't line up with the revision IDs of the versions
+    # It will change any time the alias is updated
 
-  # Make sure that 0 also causes a change
-  - name: Update an alias version
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      function_version: 1
-    register: update_alias_version
-  - name: Check not changed
-    assert:
-      that:
-      - update_alias_version is changed
-      - '"alias_arn" in update_alias_version'
-      - update_alias_version.alias_arn.startswith(lambda_arn)
-      - update_alias_version.alias_arn.endswith("Testing")
-      - '"description" in update_alias_version'
-      - update_alias_version.description == "description 2"
-      - '"function_version" in update_alias_version'
-      - update_alias_version.function_version == "1"
-      - '"name" in update_alias_version'
-      - update_alias_version.name == "Testing"
-      - '"revision_id" in update_alias_version'
-      # The revision_id doesn't line up with the revision IDs of the versions
-      # It will change any time the alias is updated
+    # Make sure that 0 also causes a change
+    - name: Update an alias version
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        function_version: 1
+      register: update_alias_version
+    - name: Check not changed
+      ansible.builtin.assert:
+        that:
+          - update_alias_version is changed
+          - '"alias_arn" in update_alias_version'
+          - update_alias_version.alias_arn.startswith(lambda_arn)
+          - update_alias_version.alias_arn.endswith("Testing")
+          - '"description" in update_alias_version'
+          - update_alias_version.description == "description 2"
+          - '"function_version" in update_alias_version'
+          - update_alias_version.function_version == "1"
+          - '"name" in update_alias_version'
+          - update_alias_version.name == "Testing"
+          - '"revision_id" in update_alias_version'
+    # The revision_id doesn't line up with the revision IDs of the versions
+    # It will change any time the alias is updated
 
-  - name: Update an alias version to explicit LATEST with 0 (check mode)
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      function_version: 0
-    check_mode: True
-    register: update_alias_version
-  - name: Check changed
-    assert:
-      that:
-      - update_alias_version is changed
+    - name: Update an alias version to explicit LATEST with 0 (check mode)
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        function_version: 0
+      check_mode: true
+      register: update_alias_version
+    - name: Check changed
+      ansible.builtin.assert:
+        that:
+          - update_alias_version is changed
 
-  - name: Update an alias version to explicit LATEST with 0
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      function_version: 0
-    register: update_alias_version
-  - name: Check changed and returned values
-    assert:
-      that:
-      - update_alias_version is changed
-      - '"alias_arn" in update_alias_version'
-      - update_alias_version.alias_arn.startswith(lambda_arn)
-      - update_alias_version.alias_arn.endswith("Testing")
-      - '"description" in update_alias_version'
-      - update_alias_version.description == "description 2"
-      - '"function_version" in update_alias_version'
-      - update_alias_version.function_version == "$LATEST"
-      - '"name" in update_alias_version'
-      - update_alias_version.name == "Testing"
-      - '"revision_id" in update_alias_version'
-      # The revision_id doesn't line up with the revision IDs of the versions
-      # It will change any time the alias is updated
+    - name: Update an alias version to explicit LATEST with 0
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        function_version: 0
+      register: update_alias_version
+    - name: Check changed and returned values
+      ansible.builtin.assert:
+        that:
+          - update_alias_version is changed
+          - '"alias_arn" in update_alias_version'
+          - update_alias_version.alias_arn.startswith(lambda_arn)
+          - update_alias_version.alias_arn.endswith("Testing")
+          - '"description" in update_alias_version'
+          - update_alias_version.description == "description 2"
+          - '"function_version" in update_alias_version'
+          - update_alias_version.function_version == "$LATEST"
+          - '"name" in update_alias_version'
+          - update_alias_version.name == "Testing"
+          - '"revision_id" in update_alias_version'
+    # The revision_id doesn't line up with the revision IDs of the versions
+    # It will change any time the alias is updated
 
-  - name: Update an alias version to explicit LATEST with 0 - idempotency (check mode)
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      function_version: 0
-    check_mode: True
-    register: update_alias_version
-  - name: Check changed
-    assert:
-      that:
-      - update_alias_version is not changed
+    - name: Update an alias version to explicit LATEST with 0 - idempotency (check mode)
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        function_version: 0
+      check_mode: true
+      register: update_alias_version
+    - name: Check changed
+      ansible.builtin.assert:
+        that:
+          - update_alias_version is not changed
 
-  - name: Update an alias version to explicit LATEST with 0 - idempotecy
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-      function_version: 0
-    register: update_alias_version
-  - name: Check changed and returned values
-    assert:
-      that:
-      - update_alias_version is not changed
-      - '"alias_arn" in update_alias_version'
-      - update_alias_version.alias_arn.startswith(lambda_arn)
-      - update_alias_version.alias_arn.endswith("Testing")
-      - '"description" in update_alias_version'
-      - update_alias_version.description == "description 2"
-      - '"function_version" in update_alias_version'
-      - update_alias_version.function_version == "$LATEST"
-      - '"name" in update_alias_version'
-      - update_alias_version.name == "Testing"
-      - '"revision_id" in update_alias_version'
-      # The revision_id doesn't line up with the revision IDs of the versions
-      # It will change any time the alias is updated
+    - name: Update an alias version to explicit LATEST with 0 - idempotecy
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+        function_version: 0
+      register: update_alias_version
+    - name: Check changed and returned values
+      ansible.builtin.assert:
+        that:
+          - update_alias_version is not changed
+          - '"alias_arn" in update_alias_version'
+          - update_alias_version.alias_arn.startswith(lambda_arn)
+          - update_alias_version.alias_arn.endswith("Testing")
+          - '"description" in update_alias_version'
+          - update_alias_version.description == "description 2"
+          - '"function_version" in update_alias_version'
+          - update_alias_version.function_version == "$LATEST"
+          - '"name" in update_alias_version'
+          - update_alias_version.name == "Testing"
+          - '"revision_id" in update_alias_version'
+    # The revision_id doesn't line up with the revision IDs of the versions
+    # It will change any time the alias is updated
 
-  # ==============================================================
-  # Creation of an alias with all options
-  - name: Create an alias with all options (check mode)
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      description: 'Hello world'
-      name: stable
-      function_version: 1
-    check_mode: True
-    register: create_alias
-  - name: Check changed
-    assert:
-      that:
-      - create_alias is changed
+    # ==============================================================
+    # Creation of an alias with all options
+    - name: Create an alias with all options (check mode)
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        description: Hello world
+        name: stable
+        function_version: 1
+      check_mode: true
+      register: create_alias
+    - name: Check changed
+      ansible.builtin.assert:
+        that:
+          - create_alias is changed
 
-  - name: Create an alias with all options
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      description: 'Hello world'
-      name: stable
-      function_version: 1
-    register: create_alias
-  - name: Check changed and returned values
-    assert:
-      that:
-      - create_alias is changed
-      - '"alias_arn" in create_alias'
-      - create_alias.alias_arn.startswith(lambda_arn)
-      - create_alias.alias_arn.endswith("stable")
-      - '"description" in create_alias'
-      - create_alias.description == "Hello world"
-      - '"function_version" in create_alias'
-      - create_alias.function_version == "1"
-      - '"name" in create_alias'
-      - create_alias.name == "stable"
-      - '"revision_id" in create_alias'
-      # The revision_id doesn't line up with the revision IDs of the versions
-      # It will change any time the alias is updated
+    - name: Create an alias with all options
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        description: Hello world
+        name: stable
+        function_version: 1
+      register: create_alias
+    - name: Check changed and returned values
+      ansible.builtin.assert:
+        that:
+          - create_alias is changed
+          - '"alias_arn" in create_alias'
+          - create_alias.alias_arn.startswith(lambda_arn)
+          - create_alias.alias_arn.endswith("stable")
+          - '"description" in create_alias'
+          - create_alias.description == "Hello world"
+          - '"function_version" in create_alias'
+          - create_alias.function_version == "1"
+          - '"name" in create_alias'
+          - create_alias.name == "stable"
+          - '"revision_id" in create_alias'
+    # The revision_id doesn't line up with the revision IDs of the versions
+    # It will change any time the alias is updated
 
-  - name: Create an alias with all options - idempotency (check mode)
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      description: 'Hello world'
-      name: stable
-      function_version: 1
-    check_mode: True
-    register: create_alias
-  - name: Check not changed
-    assert:
-      that:
-      - create_alias is not changed
+    - name: Create an alias with all options - idempotency (check mode)
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        description: Hello world
+        name: stable
+        function_version: 1
+      check_mode: true
+      register: create_alias
+    - name: Check not changed
+      ansible.builtin.assert:
+        that:
+          - create_alias is not changed
 
-  - name: Create an alias wth all options - idempotecy
-    lambda_alias:
-      state: present
-      function_name: '{{ lambda_function_name }}'
-      description: 'Hello world'
-      name: stable
-      function_version: 1
-    register: create_alias
-  - name: Check not changed
-    assert:
-      that:
-      - create_alias is not changed
-      - '"alias_arn" in create_alias'
-      - create_alias.alias_arn.startswith(lambda_arn)
-      - create_alias.alias_arn.endswith("stable")
-      - '"description" in create_alias'
-      - create_alias.description == "Hello world"
-      - '"function_version" in create_alias'
-      - create_alias.function_version == "1"
-      - '"name" in create_alias'
-      - create_alias.name == "stable"
-      - '"revision_id" in create_alias'
-      # The revision_id doesn't line up with the revision IDs of the versions
-      # It will change any time the alias is updated
+    - name: Create an alias wth all options - idempotecy
+      amazon.aws.lambda_alias:
+        state: present
+        function_name: "{{ lambda_function_name }}"
+        description: Hello world
+        name: stable
+        function_version: 1
+      register: create_alias
+    - name: Check not changed
+      ansible.builtin.assert:
+        that:
+          - create_alias is not changed
+          - '"alias_arn" in create_alias'
+          - create_alias.alias_arn.startswith(lambda_arn)
+          - create_alias.alias_arn.endswith("stable")
+          - '"description" in create_alias'
+          - create_alias.description == "Hello world"
+          - '"function_version" in create_alias'
+          - create_alias.function_version == "1"
+          - '"name" in create_alias'
+          - create_alias.name == "stable"
+          - '"revision_id" in create_alias'
+    # The revision_id doesn't line up with the revision IDs of the versions
+    # It will change any time the alias is updated
 
-  # ==============================================================
-  # Deletion of an alias
-  - name: Delete an alias (check mode)
-    lambda_alias:
-      state: absent
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-    check_mode: True
-    register: delete_alias
-  - name: Check changed
-    assert:
-      that:
-      - delete_alias is changed
+    # ==============================================================
+    # Deletion of an alias
+    - name: Delete an alias (check mode)
+      amazon.aws.lambda_alias:
+        state: absent
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+      check_mode: true
+      register: delete_alias
+    - name: Check changed
+      ansible.builtin.assert:
+        that:
+          - delete_alias is changed
 
-  - name: Delete an alias
-    lambda_alias:
-      state: absent
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-    register: delete_alias
-  - name: Check changed
-    assert:
-      that:
-      - delete_alias is changed
+    - name: Delete an alias
+      amazon.aws.lambda_alias:
+        state: absent
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+      register: delete_alias
+    - name: Check changed
+      ansible.builtin.assert:
+        that:
+          - delete_alias is changed
 
-  - name: Delete an alias - idempotency (check mode)
-    lambda_alias:
-      state: absent
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-    check_mode: True
-    register: delete_alias
-  - name: Check not changed
-    assert:
-      that:
-      - delete_alias is not changed
+    - name: Delete an alias - idempotency (check mode)
+      amazon.aws.lambda_alias:
+        state: absent
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+      check_mode: true
+      register: delete_alias
+    - name: Check not changed
+      ansible.builtin.assert:
+        that:
+          - delete_alias is not changed
 
-  - name: Delete an alias - idempotecy
-    lambda_alias:
-      state: absent
-      function_name: '{{ lambda_function_name }}'
-      name: Testing
-    register: delete_alias
-  - name: Check not changed
-    assert:
-      that:
-      - delete_alias is not changed
+    - name: Delete an alias - idempotecy
+      amazon.aws.lambda_alias:
+        state: absent
+        function_name: "{{ lambda_function_name }}"
+        name: Testing
+      register: delete_alias
+    - name: Check not changed
+      ansible.builtin.assert:
+        that:
+          - delete_alias is not changed
 
   # ==============================================================
   # Cleanup
   always:
-  - name: ensure function is absent at end of test
-    lambda:
-      name: '{{lambda_function_name}}'
-      state: absent
-    ignore_errors: true
-  - name: ensure role has been removed at end of test
-    iam_role:
-      name: '{{ lambda_role_name }}'
-      state: absent
-      delete_instance_profile: True
-    ignore_errors: true
+    - name: ensure function is absent at end of test
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        state: absent
+      ignore_errors: true
+    - name: ensure role has been removed at end of test
+      community.aws.iam_role:
+        name: "{{ lambda_role_name }}"
+        state: absent
+        delete_instance_profile: true
+      ignore_errors: true

--- a/tests/integration/targets/lambda_event/defaults/main.yml
+++ b/tests/integration/targets/lambda_event/defaults/main.yml
@@ -1,7 +1,8 @@
+---
 # defaults file for lambda integration test
 # IAM role names have to be less than 64 characters
 # we hash the resource_prefix to get a shorter, unique string
-lambda_function_name: 'test-lambda-{{ tiny_prefix }}'
+lambda_function_name: test-lambda-{{ tiny_prefix }}
 lambda_role_name: ansible-test-{{ tiny_prefix }}-lambda
 
 dynamodb_table_name: ansible-test-{{ tiny_prefix }}

--- a/tests/integration/targets/lambda_event/meta/main.yml
+++ b/tests/integration/targets/lambda_event/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
-- role: setup_remote_tmp_dir
+  - role: setup_remote_tmp_dir

--- a/tests/integration/targets/lambda_event/tasks/main.yml
+++ b/tests/integration/targets/lambda_event/tasks/main.yml
@@ -1,117 +1,114 @@
+---
 - name: set connection information for AWS modules and run tests
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   collections:
-  - community.general
+    - community.general
   block:
+    - name: Create test resources setup
+      ansible.builtin.import_tasks: setup.yml
+    - name: Create DynamoDB stream event mapping (trigger) - check_mode
+      amazon.aws.lambda_event:
+        state: present
+        event_source: stream
+        function_arn: "{{ lambda_function_arn }}"
+        source_params:
+          source_arn: "{{ dynamo_stream_arn }}"
+          enabled: true
+          batch_size: 500
+          starting_position: LATEST
+          function_response_types:
+            - ReportBatchItemFailures
+      check_mode: true
+      register: create_lambda_event_result
 
-  - name: Create test resources setup
-    import_tasks: setup.yml
+    - ansible.builtin.assert:
+        that:
+          - create_lambda_event_result is changed
+          - create_lambda_event_result is not failed
+          - '"lambda:CreateEventSourceMapping" not in create_lambda_event_result.resource_actions'
 
-# TEST CREATE LAMBDA EVENT ========================================================================================
-  - name: Create DynamoDB stream event mapping (trigger) - check_mode
-    amazon.aws.lambda_event:
-      state: present
-      event_source: stream
-      function_arn: '{{ lambda_function_arn }}'
-      source_params:
-        source_arn: '{{ dynamo_stream_arn }}'
-        enabled: True
-        batch_size: 500
-        starting_position: LATEST
-        function_response_types:
-          - ReportBatchItemFailures
-    check_mode: true
-    register: create_lambda_event_result
+    - name: Create DynamoDB stream event mapping (trigger)
+      amazon.aws.lambda_event:
+        state: present
+        event_source: stream
+        function_arn: "{{ lambda_function_arn }}"
+        source_params:
+          source_arn: "{{ dynamo_stream_arn }}"
+          enabled: true
+          batch_size: 500
+          starting_position: LATEST
+          function_response_types:
+            - ReportBatchItemFailures
+      register: create_lambda_event_result
 
-  - assert:
-      that:
-        - create_lambda_event_result is changed
-        - create_lambda_event_result is not failed
-        - '"lambda:CreateEventSourceMapping" not in create_lambda_event_result.resource_actions'
+    - name: Get info on above trigger
+      ansible.builtin.command: aws lambda get-event-source-mapping --uuid {{ create_lambda_event_result.events.uuid }}
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: lambda_function_details
 
-  - name: Create DynamoDB stream event mapping (trigger)
-    amazon.aws.lambda_event:
-      state: present
-      event_source: stream
-      function_arn: '{{ lambda_function_arn }}'
-      source_params:
-        source_arn: '{{ dynamo_stream_arn }}'
-        enabled: True
-        batch_size: 500
-        starting_position: LATEST
-        function_response_types:
-          - ReportBatchItemFailures
-    register: create_lambda_event_result
+    - name: convert it to an object
+      ansible.builtin.set_fact:
+        lambda_function_details_obj: "{{ lambda_function_details.stdout | from_json }}"
 
-  - name: Get info on above trigger
-    command: 'aws lambda get-event-source-mapping --uuid {{ create_lambda_event_result.events.uuid }}'
-    environment:
-      AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
-      AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
-      AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
-      AWS_DEFAULT_REGION: "{{ aws_region }}"
-    register: lambda_function_details
+    - ansible.builtin.assert:
+        that:
+          - lambda_function_details_obj.FunctionResponseTypes is defined
+          - lambda_function_details_obj.FunctionResponseTypes | length > 0
+          - lambda_function_details_obj.FunctionResponseTypes[0] == "ReportBatchItemFailures"
+          - '"lambda:CreateEventSourceMapping" in create_lambda_event_result.resource_actions'
 
-  - name: convert it to an object
-    set_fact:
-      lambda_function_details_obj: "{{ lambda_function_details.stdout | from_json }}"
+    - name: Create DynamoDB stream event mapping (trigger) - check_mode - idempotency
+      amazon.aws.lambda_event:
+        state: present
+        event_source: stream
+        function_arn: "{{ lambda_function_arn }}"
+        source_params:
+          source_arn: "{{ dynamo_stream_arn }}"
+          enabled: true
+          batch_size: 500
+          starting_position: LATEST
+          function_response_types:
+            - ReportBatchItemFailures
+      check_mode: true
+      register: create_lambda_event_result
 
-  - assert:
-      that:
-        - lambda_function_details_obj.FunctionResponseTypes is defined
-        - lambda_function_details_obj.FunctionResponseTypes | length > 0
-        - lambda_function_details_obj.FunctionResponseTypes[0] == "ReportBatchItemFailures"
-        - '"lambda:CreateEventSourceMapping" in create_lambda_event_result.resource_actions'
+    - ansible.builtin.assert:
+        that:
+          - create_lambda_event_result is not changed
+          - create_lambda_event_result is not failed
+          - '"lambda:CreateEventSourceMapping" not in create_lambda_event_result.resource_actions'
 
-  - name: Create DynamoDB stream event mapping (trigger) - check_mode - idempotency
-    amazon.aws.lambda_event:
-      state: present
-      event_source: stream
-      function_arn: '{{ lambda_function_arn }}'
-      source_params:
-        source_arn: '{{ dynamo_stream_arn }}'
-        enabled: True
-        batch_size: 500
-        starting_position: LATEST
-        function_response_types:
-          - ReportBatchItemFailures
-    check_mode: true
-    register: create_lambda_event_result
+    - name: Create DynamoDB stream event mapping (trigger) - idempotency
+      amazon.aws.lambda_event:
+        state: present
+        event_source: stream
+        function_arn: "{{ lambda_function_arn }}"
+        source_params:
+          source_arn: "{{ dynamo_stream_arn }}"
+          enabled: true
+          batch_size: 500
+          starting_position: LATEST
+          function_response_types:
+            - ReportBatchItemFailures
+      register: create_lambda_event_result
 
-  - assert:
-      that:
-        - create_lambda_event_result is not changed
-        - create_lambda_event_result is not failed
-        - '"lambda:CreateEventSourceMapping" not in create_lambda_event_result.resource_actions'
+    - ansible.builtin.assert:
+        that:
+          - create_lambda_event_result is not changed
+          - create_lambda_event_result is not failed
+          - '"lambda:CreateEventSourceMapping" not in create_lambda_event_result.resource_actions'
 
-  - name: Create DynamoDB stream event mapping (trigger) - idempotency
-    amazon.aws.lambda_event:
-      state: present
-      event_source: stream
-      function_arn: '{{ lambda_function_arn }}'
-      source_params:
-        source_arn: '{{ dynamo_stream_arn }}'
-        enabled: True
-        batch_size: 500
-        starting_position: LATEST
-        function_response_types:
-          - ReportBatchItemFailures
-    register: create_lambda_event_result
-
-  - assert:
-      that:
-        - create_lambda_event_result is not changed
-        - create_lambda_event_result is not failed
-        - '"lambda:CreateEventSourceMapping" not in create_lambda_event_result.resource_actions'
-
-
-# ========================================================================================
+  # ========================================================================================
 
   always:
     - name: Clean up test resources setup
-      import_tasks: teardown.yml
+      ansible.builtin.import_tasks: teardown.yml

--- a/tests/integration/targets/lambda_event/tasks/setup.yml
+++ b/tests/integration/targets/lambda_event/tasks/setup.yml
@@ -1,7 +1,5 @@
 ---
-- debug: msg="Starting test setup......"
-
-# CREATE DYNAMO DB TABLE
+- ansible.builtin.debug: msg="Starting test setup......"
 - name: Create minimal dynamo table
   community.aws.dynamodb_table:
     name: "{{ dynamodb_table_name }}"
@@ -13,7 +11,7 @@
 
 # ENABLE DYNAMODB STREAM AND GET STREAM ARN
 - name: Enable DynamoDB stream (currently not supported by community.aws.dynamodb_table)
-  command: aws dynamodb update-table --table-name "{{ dynamodb_table_name }}" --stream-specification StreamEnabled=True,StreamViewType=KEYS_ONLY
+  ansible.builtin.command: aws dynamodb update-table --table-name "{{ dynamodb_table_name }}" --stream-specification StreamEnabled=True,StreamViewType=KEYS_ONLY
   environment:
     AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
     AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
@@ -21,10 +19,10 @@
     AWS_DEFAULT_REGION: "{{ aws_region }}"
   register: enable_stream_result
 - name: convert it to an object
-  set_fact:
+  ansible.builtin.set_fact:
     enable_stream_result: "{{ enable_stream_result.stdout | from_json }}"
 - name: Get DynamoDB stream ARN
-  set_fact:
+  ansible.builtin.set_fact:
     dynamo_stream_arn: "{{ enable_stream_result.TableDescription.LatestStreamArn }}"
 
 # CREATE MINIMAL LAMBDA FUNCTION
@@ -35,46 +33,46 @@
   when: (lookup('env', 'HOME'))
 
 - name: create minimal lambda role
-  iam_role:
-    name: '{{ lambda_role_name }}'
+  community.aws.iam_role:
+    name: "{{ lambda_role_name }}"
     assume_role_policy_document: '{{ lookup("file", "minimal_trust_policy.json")}}'
     create_instance_profile: false
     managed_policies:
-    - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
-    - arn:aws:iam::aws:policy/AWSLambdaInvocation-DynamoDB
-    - arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole
+      - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
+      - arn:aws:iam::aws:policy/AWSLambdaInvocation-DynamoDB
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole
   register: iam_role
 - name: wait 10 seconds for role to become available
-  pause:
+  ansible.builtin.pause:
     seconds: 10
   when: iam_role.changed
 
 - name: move lambda into place for archive module
-  copy:
+  ansible.builtin.copy:
     src: mini_lambda.py
-    dest: '{{ output_dir }}/mini_lambda.py'
+    dest: "{{ output_dir }}/mini_lambda.py"
     mode: preserve
 - name: bundle lambda into a zip
   register: zip_res
-  archive:
+  community.general.archive:
     format: zip
-    path: '{{ output_dir }}/mini_lambda.py'
-    dest: '{{ output_dir }}/mini_lambda.zip'
+    path: "{{ output_dir }}/mini_lambda.py"
+    dest: "{{ output_dir }}/mini_lambda.zip"
 
 - name: test state=present - upload the lambda
-  lambda:
-    name: '{{ lambda_function_name }}'
-    runtime: '{{ lambda_python_runtime }}'
-    handler: '{{ lambda_python_handler }}'
-    role: '{{ lambda_role_name }}'
-    zip_file: '{{ zip_res.dest }}'
+  amazon.aws.lambda:
+    name: "{{ lambda_function_name }}"
+    runtime: "{{ lambda_python_runtime }}"
+    handler: "{{ lambda_python_handler }}"
+    role: "{{ lambda_role_name }}"
+    zip_file: "{{ zip_res.dest }}"
     architecture: x86_64
   register: result
 
 - name: assert lambda upload succeeded
-  assert:
+  ansible.builtin.assert:
     that:
-    - result.changed
+      - result.changed
 
 - name: Get lambda function ARN
   ansible.builtin.set_fact:

--- a/tests/integration/targets/lambda_event/tasks/teardown.yml
+++ b/tests/integration/targets/lambda_event/tasks/teardown.yml
@@ -1,14 +1,13 @@
 ---
-- debug: msg="Starting test Teardown......"
-
+- ansible.builtin.debug: msg="Starting test Teardown......"
 - name: Delete DynamoDB stream event mapping (trigger)
   amazon.aws.lambda_event:
     state: absent
     event_source: stream
-    function_arn: '{{ lambda_function_arn }}'
+    function_arn: "{{ lambda_function_arn }}"
     source_params:
       source_arn: "{{ dynamo_stream_arn }}"
-      enabled: True
+      enabled: true
       batch_size: 500
       starting_position: LATEST
       function_response_types:
@@ -17,8 +16,8 @@
   ignore_errors: true
 
 - name: Delete lambda function
-  lambda:
-    name: '{{ lambda_function_name }}'
+  amazon.aws.lambda:
+    name: "{{ lambda_function_name }}"
     state: absent
 
 - name: Delete dynamo table
@@ -28,6 +27,6 @@
 
 - name: Delete the role
   community.aws.iam_role:
-    name: '{{ lambda_role_name }}'
+    name: "{{ lambda_role_name }}"
     assume_role_policy_document: '{{ lookup("file", "minimal_trust_policy.json")}}'
     state: absent

--- a/tests/integration/targets/lambda_layer/tasks/main.yml
+++ b/tests/integration/targets/lambda_layer/tasks/main.yml
@@ -1,10 +1,10 @@
 ---
 - module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
   collections:
     - amazon.aws
@@ -16,27 +16,27 @@
 
   block:
     - name: Create temporary directory
-      tempfile:
+      ansible.builtin.tempfile:
         state: directory
         suffix: .lambda_handler
       register: _dir
 
-    - copy:
+    - ansible.builtin.copy:
         content: "{{ lambda_hander_content }}"
         dest: "{{ _dir.path }}/lambda_handler.py"
         remote_src: true
 
-    - set_fact:
+    - ansible.builtin.set_fact:
         zip_file_path: "{{ _dir.path }}/lambda_handler.zip"
 
     - name: Create lambda handler archive
-      archive:
+      community.general.archive:
         path: "{{ _dir.path }}/lambda_handler.py"
         dest: "{{ zip_file_path }}"
         format: zip
 
     - name: Create S3 bucket for testing
-      s3_bucket:
+      amazon.aws.s3_bucket:
         name: "{{ s3_bucket_name }}"
         state: present
 
@@ -51,7 +51,7 @@
     - name: Create lambda layer (check_mode=true)
       lambda_layer:
         name: "{{ layer_name }}"
-        description: '{{ resource_prefix }} lambda layer first version'
+        description: "{{ resource_prefix }} lambda layer first version"
         content:
           zip_file: "{{ zip_file_path }}"
         compatible_runtimes:
@@ -66,7 +66,7 @@
       register: layers
 
     - name: Ensure lambda layer was not created
-      assert:
+      ansible.builtin.assert:
         that:
           - create_check_mode is changed
           - create_check_mode.msg == "Create operation skipped - running in check mode"
@@ -75,7 +75,7 @@
     - name: Create lambda layer (first version)
       lambda_layer:
         name: "{{ layer_name }}"
-        description: '{{ resource_prefix }} lambda layer first version'
+        description: "{{ resource_prefix }} lambda layer first version"
         content:
           zip_file: "{{ zip_file_path }}"
         compatible_runtimes:
@@ -86,7 +86,7 @@
     - name: Create another lambda layer version
       lambda_layer:
         name: "{{ layer_name }}"
-        description: '{{ resource_prefix }} lambda layer second version'
+        description: "{{ resource_prefix }} lambda layer second version"
         content:
           s3_bucket: "{{ s3_bucket_name }}"
           s3_key: "{{ s3_bucket_object }}"
@@ -98,9 +98,9 @@
     - name: Retrieve all layers with latest version
       lambda_layer_info:
       register: layers
-    
+
     - name: Ensure layer created above was found
-      assert:
+      ansible.builtin.assert:
         that:
           - '"layers_versions" in layers'
           - first_version.layer_versions | length == 1
@@ -118,7 +118,7 @@
       register: layers
 
     - name: Ensure layer created above was found
-      assert:
+      ansible.builtin.assert:
         that:
           - '"layers_versions" in layers'
           - layers.layers_versions | length == 2
@@ -143,7 +143,7 @@
       register: layers
 
     - name: Ensure no layer version was deleted
-      assert:
+      ansible.builtin.assert:
         that:
           - delete_check_mode is changed
           - delete_check_mode.layer_versions | length == 1
@@ -166,7 +166,7 @@
       register: layers
 
     - name: Ensure latest layer version was deleted
-      assert:
+      ansible.builtin.assert:
         that:
           - delete_layer is changed
           - delete_layer.layer_versions | length == 1
@@ -184,19 +184,19 @@
       register: delete_idempotent
 
     - name: Ensure nothing changed
-      assert:
+      ansible.builtin.assert:
         that:
           - delete_idempotent is not changed
 
     - name: Create multiple lambda layer versions
       lambda_layer:
         name: "{{ layer_name }}"
-        description: '{{ resource_prefix }} lambda layer version compatible with python3.{{ item }}'
+        description: "{{ resource_prefix }} lambda layer version compatible with python3.{{ item }}"
         content:
           s3_bucket: "{{ s3_bucket_name }}"
           s3_key: "{{ s3_bucket_object }}"
         compatible_runtimes:
-          - "python3.{{ item }}"
+          - python3.{{ item }}
         license_info: GPL-3.0-only
       with_items: ["9", "10"]
 
@@ -213,7 +213,7 @@
       register: layers
 
     - name: Ensure layer does not exist anymore
-      assert:
+      ansible.builtin.assert:
         that:
           - delete_layer is changed
           - delete_layer.layer_versions | length > 1
@@ -228,7 +228,7 @@
       ignore_errors: true
 
     - name: Delete temporary directory
-      file:
+      ansible.builtin.file:
         state: absent
         path: "{{ _dir.path }}"
       ignore_errors: true
@@ -241,7 +241,7 @@
       ignore_errors: true
 
     - name: Delete S3 bucket
-      s3_bucket:
+      amazon.aws.s3_bucket:
         name: "{{ s3_bucket_name }}"
         force: true
         state: absent

--- a/tests/integration/targets/lambda_policy/defaults/main.yml
+++ b/tests/integration/targets/lambda_policy/defaults/main.yml
@@ -2,5 +2,5 @@
 # defaults file for lambda_policy integration test
 # IAM role names have to be less than 64 characters
 # we hash the resource_prefix to get a shorter, unique string
-lambda_function_name: '{{ tiny_prefix }}-api-endpoint'
-lambda_role_name: 'ansible-test-{{ tiny_prefix }}-lambda-policy'
+lambda_function_name: "{{ tiny_prefix }}-api-endpoint"
+lambda_role_name: ansible-test-{{ tiny_prefix }}-lambda-policy

--- a/tests/integration/targets/lambda_policy/meta/main.yml
+++ b/tests/integration/targets/lambda_policy/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/lambda_policy/tasks/main.yml
+++ b/tests/integration/targets/lambda_policy/tasks/main.yml
@@ -1,147 +1,149 @@
+---
 - name: Integration testing for lambda_policy
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   collections:
     - community.general
     - amazon.aws
     - community.aws
   block:
-  - name: create minimal lambda role
-    iam_role:
-      name: '{{ lambda_role_name }}'
-      assume_role_policy_document: '{{ lookup("file", "minimal_trust_policy.json") }}'
-      create_instance_profile: false
-      managed_policies:
-      - 'arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess'
-    register: iam_role
-  - name: wait 10 seconds for role to become available
-    pause:
-      seconds: 10
-    when: iam_role.changed
+    - name: create minimal lambda role
+      community.aws.iam_role:
+        name: "{{ lambda_role_name }}"
+        assume_role_policy_document: '{{ lookup("file", "minimal_trust_policy.json") }}'
+        create_instance_profile: false
+        managed_policies:
+          - arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess
+      register: iam_role
+    - name: wait 10 seconds for role to become available
+      ansible.builtin.pause:
+        seconds: 10
+      when: iam_role.changed
 
-  - name: test with no parameters
-    lambda_policy: null
-    register: result
-    ignore_errors: true
-  - name: assert failure when called with no parameters
-    assert:
-      that:
-      - result.failed
-      - 'result.msg.startswith("missing required arguments: ")'
-      - '"action" in result.msg'
-      - '"function_name" in result.msg'
-      - '"principal" in result.msg'
-      - '"statement_id" in result.msg'
+    - name: test with no parameters
+      amazon.aws.lambda_policy:
+      register: result
+      ignore_errors: true
+    - name: assert failure when called with no parameters
+      ansible.builtin.assert:
+        that:
+          - result.failed
+          - 'result.msg.startswith("missing required arguments: ")'
+          - '"action" in result.msg'
+          - '"function_name" in result.msg'
+          - '"principal" in result.msg'
+          - '"statement_id" in result.msg'
 
-  - name: move lambda into place for archive module
-    copy:
-      src: mini_http_lambda.py
-      dest: '{{ output_dir }}/mini_http_lambda.py'
-      mode: preserve
-  - name: bundle lambda into a zip
-    register: zip_res
-    archive:
-      format: zip
-      path: '{{ output_dir }}/mini_http_lambda.py'
-      dest: '{{ output_dir }}/mini_http_lambda.zip'
-  - name: create minimal lambda role
-    iam_role:
-      name: ansible_lambda_role
-      assume_role_policy_document: '{{ lookup(''file'', ''minimal_trust_policy.json'', convert_data=False) }}'
-      create_instance_profile: false
-    register: iam_role
-  - name: wait 10 seconds for role to become available
-    pause:
-      seconds: 10
-    when: iam_role.changed
-  - name: test state=present - upload the lambda
-    lambda:
-      name: '{{lambda_function_name}}'
-      runtime: python3.9
-      handler: mini_http_lambda.handler
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{zip_res.dest}}'
-    register: lambda_result
-  - name: get the aws account ID for use in future commands
-    aws_caller_info: {}
-    register: aws_caller_info
-  - name: register lambda uri for use in template
-    set_fact:
-      mini_lambda_uri: arn:aws:apigateway:{{ aws_region }}:lambda:path/2015-03-31/functions/arn:aws:lambda:{{ aws_region }}:{{ aws_caller_info.account }}:function:{{ lambda_result.configuration.function_name }}/invocations
-  - name: build API file
-    template:
-      src: endpoint-test-swagger-api.yml.j2
-      dest: '{{output_dir}}/endpoint-test-swagger-api.yml.j2'
-  - name: deploy new API
-    api_gateway:
-      api_file: '{{output_dir}}/endpoint-test-swagger-api.yml.j2'
-      stage: lambdabased
-    register: create_result
-  - name: register api id for later
-    set_fact:
-      api_id: '{{ create_result.api_id }}'
-  - name: check API fails with permissions failure
-    uri:
-      url: https://{{create_result.api_id}}.execute-api.{{aws_region}}.amazonaws.com/lambdabased/mini/Mr_Ansible_Tester
-    register: unauth_uri_result
-    ignore_errors: true
-  - name: assert internal server error due to permissions
-    assert:
-      that:
-      - unauth_uri_result is failed
-      - unauth_uri_result.status == 500
-  - name: give api gateway execute permissions on lambda
-    lambda_policy:
-      function_name: '{{ lambda_function_name }}'
-      state: present
-      statement_id: api-gateway-invoke-lambdas
-      action: lambda:InvokeFunction
-      principal: apigateway.amazonaws.com
-      source_arn: arn:aws:execute-api:{{ aws_region }}:{{ aws_caller_info.account }}:*/*
-  - name: try again but with ARN
-    lambda_policy:
-      function_name: '{{ lambda_result.configuration.function_arn }}'
-      state: present
-      statement_id: api-gateway-invoke-lambdas
-      action: lambda:InvokeFunction
-      principal: apigateway.amazonaws.com
-      source_arn: arn:aws:execute-api:{{ aws_region }}:{{ aws_caller_info.account }}:*/*
-  - name: Wait for permissions to propagate
-    ansible.builtin.pause:
-      seconds: 5
-  - name: check API works with execute permissions
-    uri:
-      url: https://{{create_result.api_id}}.execute-api.{{aws_region}}.amazonaws.com/lambdabased/mini/Mr_Ansible_Tester
-    register: uri_result
-  - name: assert API works success
-    assert:
-      that:
-      - uri_result
-  - name: deploy new API
-    api_gateway:
-      api_file: '{{output_dir}}/endpoint-test-swagger-api.yml.j2'
-      stage: lambdabased
-    register: create_result
-    ignore_errors: true
+    - name: move lambda into place for archive module
+      ansible.builtin.copy:
+        src: mini_http_lambda.py
+        dest: "{{ output_dir }}/mini_http_lambda.py"
+        mode: preserve
+    - name: bundle lambda into a zip
+      register: zip_res
+      community.general.archive:
+        format: zip
+        path: "{{ output_dir }}/mini_http_lambda.py"
+        dest: "{{ output_dir }}/mini_http_lambda.zip"
+    - name: create minimal lambda role
+      community.aws.iam_role:
+        name: ansible_lambda_role
+        assume_role_policy_document: "{{ lookup('file', 'minimal_trust_policy.json', convert_data=False) }}"
+        create_instance_profile: false
+      register: iam_role
+    - name: wait 10 seconds for role to become available
+      ansible.builtin.pause:
+        seconds: 10
+      when: iam_role.changed
+    - name: test state=present - upload the lambda
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        runtime: python3.9
+        handler: mini_http_lambda.handler
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{zip_res.dest}}"
+      register: lambda_result
+    - name: get the aws account ID for use in future commands
+      amazon.aws.aws_caller_info: {}
+      register: aws_caller_info
+    - name: register lambda uri for use in template
+      ansible.builtin.set_fact:
+        mini_lambda_uri: arn:aws:apigateway:{{ aws_region }}:lambda:path/2015-03-31/functions/arn:aws:lambda:{{ aws_region }}:{{ aws_caller_info.account }}:function:{{
+          lambda_result.configuration.function_name }}/invocations
+    - name: build API file
+      ansible.builtin.template:
+        src: endpoint-test-swagger-api.yml.j2
+        dest: "{{output_dir}}/endpoint-test-swagger-api.yml.j2"
+    - name: deploy new API
+      api_gateway:
+        api_file: "{{output_dir}}/endpoint-test-swagger-api.yml.j2"
+        stage: lambdabased
+      register: create_result
+    - name: register api id for later
+      ansible.builtin.set_fact:
+        api_id: "{{ create_result.api_id }}"
+    - name: check API fails with permissions failure
+      ansible.builtin.uri:
+        url: https://{{create_result.api_id}}.execute-api.{{aws_region}}.amazonaws.com/lambdabased/mini/Mr_Ansible_Tester
+      register: unauth_uri_result
+      ignore_errors: true
+    - name: assert internal server error due to permissions
+      ansible.builtin.assert:
+        that:
+          - unauth_uri_result is failed
+          - unauth_uri_result.status == 500
+    - name: give api gateway execute permissions on lambda
+      amazon.aws.lambda_policy:
+        function_name: "{{ lambda_function_name }}"
+        state: present
+        statement_id: api-gateway-invoke-lambdas
+        action: lambda:InvokeFunction
+        principal: apigateway.amazonaws.com
+        source_arn: arn:aws:execute-api:{{ aws_region }}:{{ aws_caller_info.account }}:*/*
+    - name: try again but with ARN
+      amazon.aws.lambda_policy:
+        function_name: "{{ lambda_result.configuration.function_arn }}"
+        state: present
+        statement_id: api-gateway-invoke-lambdas
+        action: lambda:InvokeFunction
+        principal: apigateway.amazonaws.com
+        source_arn: arn:aws:execute-api:{{ aws_region }}:{{ aws_caller_info.account }}:*/*
+    - name: Wait for permissions to propagate
+      ansible.builtin.pause:
+        seconds: 5
+    - name: check API works with execute permissions
+      ansible.builtin.uri:
+        url: https://{{create_result.api_id}}.execute-api.{{aws_region}}.amazonaws.com/lambdabased/mini/Mr_Ansible_Tester
+      register: uri_result
+    - name: assert API works success
+      ansible.builtin.assert:
+        that:
+          - uri_result
+    - name: deploy new API
+      api_gateway:
+        api_file: "{{output_dir}}/endpoint-test-swagger-api.yml.j2"
+        stage: lambdabased
+      register: create_result
+      ignore_errors: true
   always:
-  - name: destroy lambda for test cleanup if created
-    lambda:
-      name: '{{lambda_function_name}}'
-      state: absent
-    register: result
-    ignore_errors: true
-  - name: destroy API for test cleanup if created
-    api_gateway:
-      state: absent
-      api_id: '{{api_id}}'
-    register: destroy_result
-    ignore_errors: true
-  - name: Clean up test role
-    iam_role:
-      name: '{{ lambda_role_name }}'
-      state: absent
-    ignore_errors: true
+    - name: destroy lambda for test cleanup if created
+      amazon.aws.lambda:
+        name: "{{lambda_function_name}}"
+        state: absent
+      register: result
+      ignore_errors: true
+    - name: destroy API for test cleanup if created
+      api_gateway:
+        state: absent
+        api_id: "{{api_id}}"
+      register: destroy_result
+      ignore_errors: true
+    - name: Clean up test role
+      community.aws.iam_role:
+        name: "{{ lambda_role_name }}"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/legacy_missing_tests/meta/main.yml
+++ b/tests/integration/targets/legacy_missing_tests/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/lookup_aws_account_attribute/meta/main.yml
+++ b/tests/integration/targets/lookup_aws_account_attribute/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/lookup_aws_account_attribute/tasks/main.yaml
+++ b/tests/integration/targets/lookup_aws_account_attribute/tasks/main.yaml
@@ -1,11 +1,12 @@
-- set_fact:
+---
+- ansible.builtin.set_fact:
     # As a lookup plugin we don't have access to module_defaults
     connection_args:
-        region: "{{ aws_region }}"
-        access_key: "{{ aws_access_key }}"
-        secret_key: "{{ aws_secret_key }}"
-        session_token: "{{ security_token | default(omit) }}"
-  no_log: True
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+  no_log: true
 
 - module_defaults:
     group/aws:
@@ -14,117 +15,93 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
   block:
-  - name: 'Check for EC2 Classic support (has-ec2-classic)'
-    set_fact:
-      has_ec2_classic: "{{ lookup('amazon.aws.aws_account_attribute',
-                                  attribute='has-ec2-classic',
-                                  wantlist=True,
-                                  **connection_args) }}"
-  - assert:
-      that:
-      - ( has_ec2_classic is sameas true ) or ( has_ec2_classic is sameas false )
+    - name: Check for EC2 Classic support (has-ec2-classic)
+      ansible.builtin.set_fact:
+        has_ec2_classic: "{{ lookup('amazon.aws.aws_account_attribute', attribute='has-ec2-classic', wantlist=True, **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - ( has_ec2_classic is sameas true ) or ( has_ec2_classic is sameas false )
 
-  - name: 'Fetch all account attributes (wantlist=True)'
-    set_fact:
-      account_attrs: "{{ lookup('amazon.aws.aws_account_attribute',
-                                wantlist=True,
-                                **connection_args) }}"
-  - assert:
-      that:
-      # Not guaranteed that there will be a default-vpc
-      - '"default-vpc" in account_attrs'
-      - '"max-elastic-ips" in account_attrs'
-      - account_attrs['max-elastic-ips'][0] | int
-      - '"max-instances" in account_attrs'
-      - account_attrs['max-instances'][0] | int
-      # EC2 and VPC are both valid values, but we can't guarantee which are available
-      - '"supported-platforms" in account_attrs'
-      - account_attrs['supported-platforms'] | difference(['VPC', 'EC2']) | length == 0
-      - '"vpc-max-elastic-ips" in account_attrs'
-      - account_attrs['vpc-max-elastic-ips'][0] | int
-      - '"vpc-max-security-groups-per-interface" in account_attrs'
-      - account_attrs['vpc-max-security-groups-per-interface'][0] | int
+    - name: Fetch all account attributes (wantlist=True)
+      ansible.builtin.set_fact:
+        account_attrs: "{{ lookup('amazon.aws.aws_account_attribute', wantlist=True, **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          # Not guaranteed that there will be a default-vpc
+          - '"default-vpc" in account_attrs'
+          - '"max-elastic-ips" in account_attrs'
+          - account_attrs['max-elastic-ips'][0] | int
+          - '"max-instances" in account_attrs'
+          - account_attrs['max-instances'][0] | int
+          # EC2 and VPC are both valid values, but we can't guarantee which are available
+          - '"supported-platforms" in account_attrs'
+          - account_attrs['supported-platforms'] | difference(['VPC', 'EC2']) | length == 0
+          - '"vpc-max-elastic-ips" in account_attrs'
+          - account_attrs['vpc-max-elastic-ips'][0] | int
+          - '"vpc-max-security-groups-per-interface" in account_attrs'
+          - account_attrs['vpc-max-security-groups-per-interface'][0] | int
 
-  # Not espcially useful, but let's be thorough and leave hints what folks could
-  # expect
-  - name: 'Fetch all account attributes (wantlist=False)'
-    set_fact:
-      account_attrs: "{{ lookup('amazon.aws.aws_account_attribute',
-                                wantlist=False,
-                                **connection_args) }}"
-  - assert:
-      that:
-      - '"default-vpc" in split_attrs'
-      - '"max-elastic-ips" in split_attrs'
-      - '"max-instances" in split_attrs'
-      - '"supported-platforms" in split_attrs'
-      - '"vpc-max-elastic-ips" in split_attrs'
-      - '"vpc-max-security-groups-per-interface" in split_attrs'
-    vars:
-      split_attrs: '{{ account_attrs.split(",") }}'
+    # Not espcially useful, but let's be thorough and leave hints what folks could
+    # expect
+    - name: Fetch all account attributes (wantlist=False)
+      ansible.builtin.set_fact:
+        account_attrs: "{{ lookup('amazon.aws.aws_account_attribute', wantlist=False, **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - '"default-vpc" in split_attrs'
+          - '"max-elastic-ips" in split_attrs'
+          - '"max-instances" in split_attrs'
+          - '"supported-platforms" in split_attrs'
+          - '"vpc-max-elastic-ips" in split_attrs'
+          - '"vpc-max-security-groups-per-interface" in split_attrs'
+      vars:
+        split_attrs: '{{ account_attrs.split(",") }}'
 
-  - name: 'Check for Default VPC (default-vpc)'
-    set_fact:
-      default_vpc: "{{ lookup('amazon.aws.aws_account_attribute',
-                              attribute='default-vpc',
-                              **connection_args) }}"
-  - assert:
-      that:
-      - (default_vpc == "none")
-          or
-        default_vpc.startswith("vpc-")
+    - name: Check for Default VPC (default-vpc)
+      ansible.builtin.set_fact:
+        default_vpc: "{{ lookup('amazon.aws.aws_account_attribute', attribute='default-vpc', **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - (default_vpc == "none") or default_vpc.startswith("vpc-")
 
-  - name: 'Check for maximum number of EIPs (max-elastic-ips)'
-    set_fact:
-      max_eips: "{{ lookup('amazon.aws.aws_account_attribute',
-                           attribute='max-elastic-ips',
-                           **connection_args) }}"
-  - assert:
-      that:
-      - max_eips | int
+    - name: Check for maximum number of EIPs (max-elastic-ips)
+      ansible.builtin.set_fact:
+        max_eips: "{{ lookup('amazon.aws.aws_account_attribute', attribute='max-elastic-ips', **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - max_eips | int
 
-  - name: 'Check for maximum number of Instances (max-instances)'
-    set_fact:
-      max_instances: "{{ lookup('amazon.aws.aws_account_attribute',
-                                attribute='max-instances',
-                                **connection_args) }}"
-  - assert:
-      that:
-      - max_instances | int
+    - name: Check for maximum number of Instances (max-instances)
+      ansible.builtin.set_fact:
+        max_instances: "{{ lookup('amazon.aws.aws_account_attribute', attribute='max-instances', **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - max_instances | int
 
-  - name: 'Check for maximum number of EIPs in a VPC (vpc-max-elastic-ips)'
-    set_fact:
-      vpc_max_eips: "{{ lookup('amazon.aws.aws_account_attribute',
-                               attribute='vpc-max-elastic-ips',
-                               **connection_args) }}"
-  - assert:
-      that:
-      - vpc_max_eips | int
+    - name: Check for maximum number of EIPs in a VPC (vpc-max-elastic-ips)
+      ansible.builtin.set_fact:
+        vpc_max_eips: "{{ lookup('amazon.aws.aws_account_attribute', attribute='vpc-max-elastic-ips', **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - vpc_max_eips | int
 
-  - name: 'Check for maximum number of Security Groups per Interface (vpc-max-security-groups-per-interface)'
-    set_fact:
-      max_sg_per_int: "{{ lookup('amazon.aws.aws_account_attribute',
-                                 attribute='vpc-max-security-groups-per-interface',
-                                 **connection_args) }}"
-  - assert:
-      that:
-      - max_sg_per_int | int
+    - name: Check for maximum number of Security Groups per Interface (vpc-max-security-groups-per-interface)
+      ansible.builtin.set_fact:
+        max_sg_per_int: "{{ lookup('amazon.aws.aws_account_attribute', attribute='vpc-max-security-groups-per-interface', **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - max_sg_per_int | int
 
-  - name: 'Check for support of Classic EC2 vs VPC (supported-platforms)'
-    set_fact:
-      supported_plat: "{{ lookup('amazon.aws.aws_account_attribute',
-                                 attribute='supported-platforms',
-                                 **connection_args) }}"
-  - assert:
-      that:
-      - supported_plat.split(',') | difference(['VPC', 'EC2']) | length == 0
+    - name: Check for support of Classic EC2 vs VPC (supported-platforms)
+      ansible.builtin.set_fact:
+        supported_plat: "{{ lookup('amazon.aws.aws_account_attribute', attribute='supported-platforms', **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - supported_plat.split(',') | difference(['VPC', 'EC2']) | length == 0
 
-  - name: 'Check for support of Classic EC2 vs VPC (supported-platforms) (wantlist)'
-    set_fact:
-      supported_plat: "{{ lookup('amazon.aws.aws_account_attribute',
-                                 attribute='supported-platforms',
-                                 wantlist=True,
-                                 **connection_args) }}"
-  - assert:
-      that:
-      - supported_plat | difference(['VPC', 'EC2']) | length == 0
+    - name: Check for support of Classic EC2 vs VPC (supported-platforms) (wantlist)
+      ansible.builtin.set_fact:
+        supported_plat: "{{ lookup('amazon.aws.aws_account_attribute', attribute='supported-platforms', wantlist=True, **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - supported_plat | difference(['VPC', 'EC2']) | length == 0

--- a/tests/integration/targets/lookup_aws_collection_constants/meta/main.yml
+++ b/tests/integration/targets/lookup_aws_collection_constants/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/lookup_aws_collection_constants/tasks/main.yaml
+++ b/tests/integration/targets/lookup_aws_collection_constants/tasks/main.yaml
@@ -1,47 +1,48 @@
-- name: 'MINIMUM_BOTOCORE_VERSION'
-  set_fact:
+---
+- name: MINIMUM_BOTOCORE_VERSION
+  ansible.builtin.set_fact:
     MINIMUM_BOTOCORE_VERSION: "{{ lookup('amazon.aws.aws_collection_constants', 'MINIMUM_BOTOCORE_VERSION') }}"
 
-- assert:
+- ansible.builtin.assert:
     that:
       - MINIMUM_BOTOCORE_VERSION.startswith("1.")
 
-- name: 'MINIMUM_BOTO3_VERSION'
-  set_fact:
+- name: MINIMUM_BOTO3_VERSION
+  ansible.builtin.set_fact:
     MINIMUM_BOTO3_VERSION: "{{ lookup('amazon.aws.aws_collection_constants', 'MINIMUM_BOTO3_VERSION') }}"
 
-- assert:
+- ansible.builtin.assert:
     that:
       - MINIMUM_BOTO3_VERSION.startswith("1.")
 
-- name: 'HAS_BOTO3'
-  set_fact:
+- name: HAS_BOTO3
+  ansible.builtin.set_fact:
     HAS_BOTO3: "{{ lookup('amazon.aws.aws_collection_constants', 'HAS_BOTO3') }}"
 
-- assert:
+- ansible.builtin.assert:
     that:
       - HAS_BOTO3 | bool
 
-- name: 'AMAZON_AWS_COLLECTION_VERSION'
-  set_fact:
+- name: AMAZON_AWS_COLLECTION_VERSION
+  ansible.builtin.set_fact:
     AMAZON_AWS_COLLECTION_VERSION: "{{ lookup('amazon.aws.aws_collection_constants', 'AMAZON_AWS_COLLECTION_VERSION') }}"
 
-- name: 'AMAZON_AWS_COLLECTION_NAME'
-  set_fact:
+- name: AMAZON_AWS_COLLECTION_NAME
+  ansible.builtin.set_fact:
     AMAZON_AWS_COLLECTION_NAME: "{{ lookup('amazon.aws.aws_collection_constants', 'AMAZON_AWS_COLLECTION_NAME') }}"
 
-- assert:
+- ansible.builtin.assert:
     that:
       - AMAZON_AWS_COLLECTION_NAME == "amazon.aws"
 
-- name: 'COMMUNITY_AWS_COLLECTION_VERSION'
-  set_fact:
+- name: COMMUNITY_AWS_COLLECTION_VERSION
+  ansible.builtin.set_fact:
     COMMUNITY_AWS_COLLECTION_VERSION: "{{ lookup('amazon.aws.aws_collection_constants', 'COMMUNITY_AWS_COLLECTION_VERSION') }}"
 
-- name: 'COMMUNITY_AWS_COLLECTION_NAME'
-  set_fact:
+- name: COMMUNITY_AWS_COLLECTION_NAME
+  ansible.builtin.set_fact:
     COMMUNITY_AWS_COLLECTION_NAME: "{{ lookup('amazon.aws.aws_collection_constants', 'COMMUNITY_AWS_COLLECTION_NAME') }}"
 
-- assert:
+- ansible.builtin.assert:
     that:
       - COMMUNITY_AWS_COLLECTION_NAME == "community.aws"

--- a/tests/integration/targets/lookup_aws_service_ip_ranges/meta/main.yml
+++ b/tests/integration/targets/lookup_aws_service_ip_ranges/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/lookup_aws_service_ip_ranges/tasks/main.yaml
+++ b/tests/integration/targets/lookup_aws_service_ip_ranges/tasks/main.yaml
@@ -1,20 +1,21 @@
+---
 - name: lookup range with no arguments
-  set_fact:
+  ansible.builtin.set_fact:
     no_params: "{{ lookup('amazon.aws.aws_service_ip_ranges') }}"
 
 - name: assert that we're returned a single string
-  assert:
+  ansible.builtin.assert:
     that:
       - no_params is defined
       - no_params is string
 
 - name: lookup range with wantlist
-  set_fact:
+  ansible.builtin.set_fact:
     want_list: "{{ lookup('amazon.aws.aws_service_ip_ranges', wantlist=True) }}"
     want_ipv6_list: "{{ lookup('amazon.aws.aws_service_ip_ranges', wantlist=True, ipv6_prefixes=True) }}"
 
 - name: assert that we're returned a list
-  assert:
+  ansible.builtin.assert:
     that:
       - want_list is defined
       - want_list is iterable
@@ -27,14 +28,13 @@
       - want_ipv6_list | length > 1
       - want_ipv6_list[0] | ansible.utils.ipv6
 
-
 - name: lookup range with service
-  set_fact:
+  ansible.builtin.set_fact:
     s3_ips: "{{ lookup('amazon.aws.aws_service_ip_ranges', service='S3', wantlist=True) }}"
     s3_ipv6s: "{{ lookup('amazon.aws.aws_service_ip_ranges', service='S3', wantlist=True, ipv6_prefixes=True) }}"
 
 - name: assert that we're returned a list
-  assert:
+  ansible.builtin.assert:
     that:
       - s3_ips is defined
       - s3_ips is iterable
@@ -48,12 +48,12 @@
       - s3_ipv6s[0] | ansible.utils.ipv6
 
 - name: lookup range with a different service
-  set_fact:
+  ansible.builtin.set_fact:
     route53_ips: "{{ lookup('amazon.aws.aws_service_ip_ranges', service='ROUTE53_HEALTHCHECKS', wantlist=True) }}"
     route53_ipv6s: "{{ lookup('amazon.aws.aws_service_ip_ranges', service='ROUTE53_HEALTHCHECKS', wantlist=True, ipv6_prefixes=True) }}"
 
 - name: assert that we're returned a list
-  assert:
+  ansible.builtin.assert:
     that:
       - route53_ips is defined
       - route53_ips is iterable
@@ -66,23 +66,22 @@
       - route53_ipv6s | length > 1
       - route53_ipv6s[0] | ansible.utils.ipv6
 
-
 - name: assert that service IPV4s and IPV6s do not overlap
-  assert:
+  ansible.builtin.assert:
     that:
       - route53_ips | intersect(s3_ips) | length == 0
       - route53_ipv6s | intersect(s3_ipv6s) | length == 0
 
 - name: lookup range with region
-  set_fact:
+  ansible.builtin.set_fact:
     us_east_1_ips: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='us-east-1', wantlist=True) }}"
 
 - name: lookup IPV6 range with region
-  set_fact:
+  ansible.builtin.set_fact:
     us_east_1_ipv6s: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='us-east-1', wantlist=True, ipv6_prefixes=True) }}"
 
 - name: assert that we're returned a list
-  assert:
+  ansible.builtin.assert:
     that:
       - us_east_1_ips is defined
       - us_east_1_ips is iterable
@@ -96,12 +95,12 @@
       - us_east_1_ipv6s[0] | ansible.utils.ipv6
 
 - name: lookup range with a different region
-  set_fact:
+  ansible.builtin.set_fact:
     eu_central_1_ips: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='eu-central-1', wantlist=True) }}"
     eu_central_1_ipv6s: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='eu-central-1', wantlist=True, ipv6_prefixes=True) }}"
 
 - name: assert that we're returned a list
-  assert:
+  ansible.builtin.assert:
     that:
       - eu_central_1_ips is defined
       - eu_central_1_ips is iterable
@@ -115,18 +114,18 @@
       - eu_central_1_ipv6s[0] | ansible.utils.ipv6
 
 - name: assert that regional IPs don't overlap
-  assert:
+  ansible.builtin.assert:
     that:
       - eu_central_1_ips | intersect(us_east_1_ips) | length == 0
       - eu_central_1_ipv6s | intersect(us_east_1_ipv6s) | length == 0
 
 - name: lookup range with service and region
-  set_fact:
+  ansible.builtin.set_fact:
     s3_us_ips: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='us-east-1', service='S3', wantlist=True) }}"
     s3_us_ipv6s: "{{ lookup('amazon.aws.aws_service_ip_ranges', region='us-east-1', service='S3', wantlist=True, ipv6_prefixes=True) }}"
 
 - name: assert that we're returned a list
-  assert:
+  ansible.builtin.assert:
     that:
       - s3_us_ips is defined
       - s3_us_ips is iterable
@@ -140,7 +139,7 @@
       - s3_us_ipv6s[0] | ansible.utils.ipv6
 
 - name: assert that the regional service IPs are a subset of the regional IPs and service IPs.
-  assert:
+  ansible.builtin.assert:
     that:
       - ( s3_us_ips | intersect(us_east_1_ips) | length ) == ( s3_us_ips | length )
       - ( s3_us_ips | intersect(s3_ips) | length ) == ( s3_us_ips | length )

--- a/tests/integration/targets/lookup_secretsmanager_secret/meta/main.yml
+++ b/tests/integration/targets/lookup_secretsmanager_secret/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/lookup_secretsmanager_secret/tasks/main.yaml
+++ b/tests/integration/targets/lookup_secretsmanager_secret/tasks/main.yaml
@@ -1,11 +1,12 @@
-- set_fact:
+---
+- ansible.builtin.set_fact:
     # As a lookup plugin we don't have access to module_defaults
     connection_args:
       region: "{{ aws_region }}"
       access_key: "{{ aws_access_key }}"
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
-  no_log: True
+  no_log: true
 
 - module_defaults:
     group/aws:
@@ -17,104 +18,103 @@
     - amazon.aws
     - community.aws
   block:
-  - name: define secret name
-    set_fact:
-      secret_name: "ansible-test-{{ tiny_prefix }}-secret"
-      secret_value: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits,punctuation length=16') }}"
-      skip: "skip"
-      warn: "warn"
+    - name: define secret name
+      ansible.builtin.set_fact:
+        secret_name: ansible-test-{{ tiny_prefix }}-secret
+        secret_value: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits,punctuation length=16') }}"
+        skip: skip
+        warn: warn
 
-  - name: lookup missing secret (skip)
-    set_fact:
-      missing_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, on_missing=skip, **connection_args) }}"
+    - name: lookup missing secret (skip)
+      ansible.builtin.set_fact:
+        missing_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, on_missing=skip, **connection_args) }}"
 
-  - name: assert that missing_secret is defined
-    assert:
-      that:
-        - missing_secret is defined
-        - missing_secret | list | length == 0
+    - name: assert that missing_secret is defined
+      ansible.builtin.assert:
+        that:
+          - missing_secret is defined
+          - missing_secret | list | length == 0
 
-  - name: lookup missing secret (warn)
-    set_fact:
-      missing_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, on_missing=warn, **connection_args) }}"
+    - name: lookup missing secret (warn)
+      ansible.builtin.set_fact:
+        missing_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, on_missing=warn, **connection_args) }}"
 
-  - name: assert that missing_secret is defined
-    assert:
-      that:
-        - missing_secret is defined
-        - missing_secret | list | length == 0
+    - name: assert that missing_secret is defined
+      ansible.builtin.assert:
+        that:
+          - missing_secret is defined
+          - missing_secret | list | length == 0
 
-  - name: lookup missing secret (error)
-    set_fact:
-      missing_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, **connection_args) }}"
-    ignore_errors: True
-    register: get_missing_secret
+    - name: lookup missing secret (error)
+      ansible.builtin.set_fact:
+        missing_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, **connection_args) }}"
+      ignore_errors: true
+      register: get_missing_secret
 
-  - name: assert that setting the missing_secret failed
-    assert:
-      that:
-        - get_missing_secret is failed
+    - name: assert that setting the missing_secret failed
+      ansible.builtin.assert:
+        that:
+          - get_missing_secret is failed
 
-  - name: create secret "{{ secret_name }}"
-    secretsmanager_secret:
-      name: "{{ secret_name }}"
-      secret: "{{ secret_value }}"
-      tags:
-        ansible-test: "aws-tests-integration"
-      state: present
+    - name: create secret "{{ secret_name }}"
+      secretsmanager_secret:
+        name: "{{ secret_name }}"
+        secret: "{{ secret_value }}"
+        tags:
+          ansible-test: aws-tests-integration
+        state: present
 
-  - name: read secret value
-    set_fact:
-      look_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, **connection_args) }}"
+    - name: read secret value
+      ansible.builtin.set_fact:
+        look_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, **connection_args) }}"
 
-  - name: assert that secret was successfully retrieved
-    assert:
-      that:
-        - look_secret == secret_value
+    - name: assert that secret was successfully retrieved
+      ansible.builtin.assert:
+        that:
+          - look_secret == secret_value
 
-  - name: delete secret
-    secretsmanager_secret:
-      name: "{{ secret_name }}"
-      state: absent
-      recovery_window: 7
+    - name: delete secret
+      secretsmanager_secret:
+        name: "{{ secret_name }}"
+        state: absent
+        recovery_window: 7
 
-  - name: lookup deleted secret (skip)
-    set_fact:
-      deleted_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, on_deleted=skip, **connection_args) }}"
+    - name: lookup deleted secret (skip)
+      ansible.builtin.set_fact:
+        deleted_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, on_deleted=skip, **connection_args) }}"
 
-  - name: assert that deleted_secret is defined
-    assert:
-      that:
-        - deleted_secret is defined
-        - deleted_secret | list | length == 0
+    - name: assert that deleted_secret is defined
+      ansible.builtin.assert:
+        that:
+          - deleted_secret is defined
+          - deleted_secret | list | length == 0
 
-  - name: lookup deleted secret (warn)
-    set_fact:
-      deleted_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, on_deleted=warn, **connection_args) }}"
+    - name: lookup deleted secret (warn)
+      ansible.builtin.set_fact:
+        deleted_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, on_deleted=warn, **connection_args) }}"
 
-  - name: assert that deleted_secret is defined
-    assert:
-      that:
-        - deleted_secret is defined
-        - deleted_secret | list | length == 0
+    - name: assert that deleted_secret is defined
+      ansible.builtin.assert:
+        that:
+          - deleted_secret is defined
+          - deleted_secret | list | length == 0
 
-  - name: lookup deleted secret (error)
-    set_fact:
-      missing_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, **connection_args) }}"
-    ignore_errors: True
-    register: get_deleted_secret
+    - name: lookup deleted secret (error)
+      ansible.builtin.set_fact:
+        missing_secret: "{{ lookup('amazon.aws.secretsmanager_secret', secret_name, **connection_args) }}"
+      ignore_errors: true
+      register: get_deleted_secret
 
-  - name: assert that setting the deleted_secret failed
-    assert:
-      that:
-        - get_deleted_secret is failed
+    - name: assert that setting the deleted_secret failed
+      ansible.builtin.assert:
+        that:
+          - get_deleted_secret is failed
 
   always:
-
   # delete secret created
-  - name: delete secret
-    secretsmanager_secret:
-      name: "{{ secret_name }}"
-      state: absent
-      recovery_window: 0
-    ignore_errors: yes
+    - name: delete secret
+      secretsmanager_secret:
+        name: "{{ secret_name }}"
+        state: absent
+        recovery_window: 0
+      ignore_errors: true

--- a/tests/integration/targets/lookup_ssm_parameter/defaults/main.yml
+++ b/tests/integration/targets/lookup_ssm_parameter/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-ssm_key_prefix: '{{ resource_prefix }}'
+ssm_key_prefix: "{{ resource_prefix }}"

--- a/tests/integration/targets/lookup_ssm_parameter/meta/main.yml
+++ b/tests/integration/targets/lookup_ssm_parameter/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/lookup_ssm_parameter/tasks/main.yml
+++ b/tests/integration/targets/lookup_ssm_parameter/tasks/main.yml
@@ -1,277 +1,276 @@
 ---
-- set_fact:
+- ansible.builtin.set_fact:
     # As a lookup plugin we don't have access to module_defaults
     connection_args:
       region: "{{ aws_region }}"
       access_key: "{{ aws_access_key }}"
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
-  no_log: True
+  no_log: true
 
-- name: 'aws_ssm lookup plugin integration tests'
+- name: aws_ssm lookup plugin integration tests
   collections:
-  - amazon.aws
-  - community.aws
+    - amazon.aws
+    - community.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   vars:
-    skip: 'skip'
-    warn: 'warn'
-    simple_name: '/{{ ssm_key_prefix }}/Simple'
-    simple_description: 'This is a simple example'
-    simple_value: 'A simple VALue'
-    updated_value: 'A simple (updated) VALue'
-    path_name: '/{{ ssm_key_prefix }}/path'
-    path_name_a: '{{ path_name }}/key_one'
-    path_shortname_a: 'key_one'
-    path_name_b: '{{ path_name }}/keyTwo'
-    path_shortname_b: 'keyTwo'
-    path_name_c: '{{ path_name }}/Nested/Key'
-    path_shortname_c: 'Key'
-    path_description: 'This is somewhere to store a set of keys'
-    path_value_a: 'value_one'
-    path_value_b: 'valueTwo'
-    path_value_c: 'Value Three'
-    missing_name: '{{ path_name }}/IDoNotExist'
+    skip: skip
+    warn: warn
+    simple_name: /{{ ssm_key_prefix }}/Simple
+    simple_description: This is a simple example
+    simple_value: A simple VALue
+    updated_value: A simple (updated) VALue
+    path_name: /{{ ssm_key_prefix }}/path
+    path_name_a: "{{ path_name }}/key_one"
+    path_shortname_a: key_one
+    path_name_b: "{{ path_name }}/keyTwo"
+    path_shortname_b: keyTwo
+    path_name_c: "{{ path_name }}/Nested/Key"
+    path_shortname_c: Key
+    path_description: This is somewhere to store a set of keys
+    path_value_a: value_one
+    path_value_b: valueTwo
+    path_value_c: Value Three
+    missing_name: "{{ path_name }}/IDoNotExist"
   block:
-
   # ============================================================
   # Simple key/value
-  - name: lookup a missing key (error)
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
-    ignore_errors: true
-    register: lookup_missing
-  - assert:
-     that:
-      - lookup_missing is failed
+    - name: lookup a missing key (error)
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
+      ignore_errors: true
+      register: lookup_missing
+    - ansible.builtin.assert:
+        that:
+          - lookup_missing is failed
 
-  - name: lookup a missing key (warn)
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, on_missing=warn, **connection_args) }}"
-    register: lookup_missing
-  - assert:
-     that:
-      - lookup_value | list | length == 0
+    - name: lookup a missing key (warn)
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, on_missing=warn, **connection_args) }}"
+      register: lookup_missing
+    - ansible.builtin.assert:
+        that:
+          - lookup_value | list | length == 0
 
-  - name: lookup a single missing key (skip)
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, on_missing=skip, **connection_args) }}"
-    register: lookup_missing
-  - assert:
-     that:
-      - lookup_value | list | length == 0
+    - name: lookup a single missing key (skip)
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, on_missing=skip, **connection_args) }}"
+      register: lookup_missing
+    - ansible.builtin.assert:
+        that:
+          - lookup_value | list | length == 0
 
-  - name: Create key/value pair in aws parameter store
-    ssm_parameter:
-      name: '{{ simple_name }}'
-      description: '{{ simple_description }}'
-      value: '{{ simple_value }}'
+    - name: Create key/value pair in aws parameter store
+      ssm_parameter:
+        name: "{{ simple_name }}"
+        description: "{{ simple_description }}"
+        value: "{{ simple_value }}"
 
-  - name: Lookup a single key
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
-  - assert:
-     that:
-      - lookup_value == simple_value
+    - name: Lookup a single key
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - lookup_value == simple_value
 
-  - name: Create key/value pair in aws parameter store
-    ssm_parameter:
-      name: '{{ simple_name }}'
-      description: '{{ simple_description }}'
-      value: '{{ simple_value }}'
+    - name: Create key/value pair in aws parameter store
+      ssm_parameter:
+        name: "{{ simple_name }}"
+        description: "{{ simple_description }}"
+        value: "{{ simple_value }}"
 
-  - name: Lookup a single key
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
-  - assert:
-     that:
-      - lookup_value == simple_value
+    - name: Lookup a single key
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - lookup_value == simple_value
 
-  - name: Update key/value pair in aws parameter store
-    ssm_parameter:
-      name: '{{ simple_name }}'
-      description: '{{ simple_description }}'
-      value: '{{ updated_value }}'
+    - name: Update key/value pair in aws parameter store
+      ssm_parameter:
+        name: "{{ simple_name }}"
+        description: "{{ simple_description }}"
+        value: "{{ updated_value }}"
 
-  - name: Lookup updated single key
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
-  - assert:
-     that:
-      - lookup_value == updated_value
+    - name: Lookup updated single key
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - lookup_value == updated_value
 
-  - name: Lookup original value from single key
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name + ':1', **connection_args) }}"
-  - assert:
-     that:
-      - lookup_value == simple_value
+    - name: Lookup original value from single key
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name + ':1', **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - lookup_value == simple_value
 
-  # ============================================================
+    # ============================================================
 
-  - name: Create nested key/value pair in aws parameter store (1)
-    ssm_parameter:
-      name: '{{ path_name_a }}'
-      description: '{{ path_description }}'
-      value: '{{ path_value_a }}'
+    - name: Create nested key/value pair in aws parameter store (1)
+      ssm_parameter:
+        name: "{{ path_name_a }}"
+        description: "{{ path_description }}"
+        value: "{{ path_value_a }}"
 
-  - name: Create nested key/value pair in aws parameter store (2)
-    ssm_parameter:
-      name: '{{ path_name_b }}'
-      description: '{{ path_description }}'
-      value: '{{ path_value_b }}'
+    - name: Create nested key/value pair in aws parameter store (2)
+      ssm_parameter:
+        name: "{{ path_name_b }}"
+        description: "{{ path_description }}"
+        value: "{{ path_value_b }}"
 
-  - name: Create nested key/value pair in aws parameter store (3)
-    ssm_parameter:
-      name: '{{ path_name_c }}'
-      description: '{{ path_description }}'
-      value: '{{ path_value_c }}'
+    - name: Create nested key/value pair in aws parameter store (3)
+      ssm_parameter:
+        name: "{{ path_name_c }}"
+        description: "{{ path_description }}"
+        value: "{{ path_value_c }}"
 
-  # ============================================================
-  - name: Lookup a keys using bypath
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, bypath=True, wantlist=True, **connection_args ) | first }}"
-  - assert:
-      that:
-      - path_name_a in lookup_value
-      - lookup_value[path_name_a] == path_value_a
-      - path_name_b in lookup_value
-      - lookup_value[path_name_b] == path_value_b
-      - lookup_value | length == 2
+    # ============================================================
+    - name: Lookup a keys using bypath
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, bypath=True, wantlist=True, **connection_args ) | first }}"
+    - ansible.builtin.assert:
+        that:
+          - path_name_a in lookup_value
+          - lookup_value[path_name_a] == path_value_a
+          - path_name_b in lookup_value
+          - lookup_value[path_name_b] == path_value_b
+          - lookup_value | length == 2
 
-  - name: Lookup a keys using bypath and recursive
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, bypath=True, recursive=True, wantlist=True, **connection_args ) | first }}"
-  - assert:
-      that:
-      - path_name_a in lookup_value
-      - lookup_value[path_name_a] == path_value_a
-      - path_name_b in lookup_value
-      - lookup_value[path_name_b] == path_value_b
-      - path_name_c in lookup_value
-      - lookup_value[path_name_c] == path_value_c
-      - lookup_value | length == 3
+    - name: Lookup a keys using bypath and recursive
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, bypath=True, recursive=True, wantlist=True, **connection_args ) | first }}"
+    - ansible.builtin.assert:
+        that:
+          - path_name_a in lookup_value
+          - lookup_value[path_name_a] == path_value_a
+          - path_name_b in lookup_value
+          - lookup_value[path_name_b] == path_value_b
+          - path_name_c in lookup_value
+          - lookup_value[path_name_c] == path_value_c
+          - lookup_value | length == 3
 
-  - name: Lookup a keys using bypath and shortname
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, bypath=True, shortnames=True, wantlist=True, **connection_args ) | first }}"
-  - assert:
-      that:
-      - path_shortname_a in lookup_value
-      - lookup_value[path_shortname_a] == path_value_a
-      - path_shortname_b in lookup_value
-      - lookup_value[path_shortname_b] == path_value_b
-      - lookup_value | length == 2
+    - name: Lookup a keys using bypath and shortname
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, bypath=True, shortnames=True, wantlist=True, **connection_args ) | first }}"
+    - ansible.builtin.assert:
+        that:
+          - path_shortname_a in lookup_value
+          - lookup_value[path_shortname_a] == path_value_a
+          - path_shortname_b in lookup_value
+          - lookup_value[path_shortname_b] == path_value_b
+          - lookup_value | length == 2
 
-  - name: Lookup a keys using bypath and recursive and shortname
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, bypath=True, recursive=True, shortnames=True, wantlist=True, **connection_args ) | first }}"
-  - assert:
-      that:
-      - path_shortname_a in lookup_value
-      - lookup_value[path_shortname_a] == path_value_a
-      - path_shortname_b in lookup_value
-      - lookup_value[path_shortname_b] == path_value_b
-      - path_shortname_c in lookup_value
-      - lookup_value[path_shortname_c] == path_value_c
-      - lookup_value | length == 3
+    - name: Lookup a keys using bypath and recursive and shortname
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, bypath=True, recursive=True, shortnames=True, wantlist=True, **connection_args ) | first }}"
+    - ansible.builtin.assert:
+        that:
+          - path_shortname_a in lookup_value
+          - lookup_value[path_shortname_a] == path_value_a
+          - path_shortname_b in lookup_value
+          - lookup_value[path_shortname_b] == path_value_b
+          - path_shortname_c in lookup_value
+          - lookup_value[path_shortname_c] == path_value_c
+          - lookup_value | length == 3
 
-  # ============================================================
+    # ============================================================
 
-  - name: Explicitly lookup two keys
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, path_name_a, wantlist=True, **connection_args) }}"
-  - assert:
-     that:
-      - lookup_value | list | length == 2
-      - lookup_value[0] == updated_value
-      - lookup_value[1] == path_value_a
+    - name: Explicitly lookup two keys
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, path_name_a, wantlist=True, **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - lookup_value | list | length == 2
+          - lookup_value[0] == updated_value
+          - lookup_value[1] == path_value_a
 
-  ###
+    ###
 
-  - name: Explicitly lookup two keys - one missing
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, missing_name, wantlist=True, **connection_args) }}"
-    ignore_errors: True
-    register: lookup_missing
-  - assert:
-     that:
-      - lookup_missing is failed
+    - name: Explicitly lookup two keys - one missing
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, missing_name, wantlist=True, **connection_args) }}"
+      ignore_errors: true
+      register: lookup_missing
+    - ansible.builtin.assert:
+        that:
+          - lookup_missing is failed
 
-  - name: Explicitly lookup two keys - one missing (skip)
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, missing_name, on_missing=skip, wantlist=True, **connection_args) }}"
-  - assert:
-     that:
-      - lookup_value | list | length == 2
-      - lookup_value[0] == updated_value
-      - lookup_value | bool == False
+    - name: Explicitly lookup two keys - one missing (skip)
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', simple_name, missing_name, on_missing=skip, wantlist=True, **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - lookup_value | list | length == 2
+          - lookup_value[0] == updated_value
+          - lookup_value | bool == False
 
-  ###
+    ###
 
-  - name: Explicitly lookup two paths - one missing
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, missing_name, bypath=True, wantlist=True, **connection_args) }}"
-    ignore_errors: True
-    register: lookup_missing
-  - assert:
-     that:
-      - lookup_missing is failed
+    - name: Explicitly lookup two paths - one missing
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, missing_name, bypath=True, wantlist=True, **connection_args) }}"
+      ignore_errors: true
+      register: lookup_missing
+    - ansible.builtin.assert:
+        that:
+          - lookup_missing is failed
 
-  - name: Explicitly lookup two paths - one missing (skip)
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, missing_name, on_missing=skip, bypath=True, wantlist=True, **connection_args) }}"
-  - assert:
-     that:
-      - lookup_value | list | length == 2
-      - lookup_value[1] | bool == False
-      - path_name_a in lookup_value[0]
-      - lookup_value[0][path_name_a] == path_value_a
-      - path_name_b in lookup_value[0]
-      - lookup_value[0][path_name_b] == path_value_b
-      - lookup_value[0] | length == 2
+    - name: Explicitly lookup two paths - one missing (skip)
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, missing_name, on_missing=skip, bypath=True, wantlist=True, **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - lookup_value | list | length == 2
+          - lookup_value[1] | bool == False
+          - path_name_a in lookup_value[0]
+          - lookup_value[0][path_name_a] == path_value_a
+          - path_name_b in lookup_value[0]
+          - lookup_value[0][path_name_b] == path_value_b
+          - lookup_value[0] | length == 2
 
-  ###
+    ###
 
-  - name: Explicitly lookup two paths with recurse - one missing
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, missing_name, bypath=True, recursive=True, wantlist=True, **connection_args) }}"
-    ignore_errors: True
-    register: lookup_missing
-  - assert:
-     that:
-      - lookup_missing is failed
+    - name: Explicitly lookup two paths with recurse - one missing
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, missing_name, bypath=True, recursive=True, wantlist=True, **connection_args) }}"
+      ignore_errors: true
+      register: lookup_missing
+    - ansible.builtin.assert:
+        that:
+          - lookup_missing is failed
 
-  - name: Explicitly lookup two paths with recurse - one missing (skip)
-    set_fact:
-      lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, missing_name, on_missing=skip, bypath=True, recursive=True, wantlist=True, **connection_args) }}"
-  - assert:
-     that:
-      - lookup_value | list | length == 2
-      - lookup_value[1] | bool == False
-      - path_name_a in lookup_value[0]
-      - lookup_value[0][path_name_a] == path_value_a
-      - path_name_b in lookup_value[0]
-      - lookup_value[0][path_name_b] == path_value_b
-      - path_name_c in lookup_value[0]
-      - lookup_value[0][path_name_c] == path_value_c
-      - lookup_value[0] | length == 3
+    - name: Explicitly lookup two paths with recurse - one missing (skip)
+      ansible.builtin.set_fact:
+        lookup_value: "{{ lookup('amazon.aws.aws_ssm', path_name, missing_name, on_missing=skip, bypath=True, recursive=True, wantlist=True, **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - lookup_value | list | length == 2
+          - lookup_value[1] | bool == False
+          - path_name_a in lookup_value[0]
+          - lookup_value[0][path_name_a] == path_value_a
+          - path_name_b in lookup_value[0]
+          - lookup_value[0][path_name_b] == path_value_b
+          - path_name_c in lookup_value[0]
+          - lookup_value[0][path_name_c] == path_value_c
+          - lookup_value[0] | length == 3
 
   always:
   # ============================================================
-  - name: Delete remaining key/value pairs in aws parameter store
-    ssm_parameter:
-      name: "{{item}}"
-      state: absent
-    ignore_errors: True
-    with_items:
-      - '{{ path_name_c }}'
-      - '{{ path_name_b }}'
-      - '{{ path_name_c }}'
-      - '{{ path_name }}'
-      - '{{ simple_name }}'
+    - name: Delete remaining key/value pairs in aws parameter store
+      ssm_parameter:
+        name: "{{item}}"
+        state: absent
+      ignore_errors: true
+      with_items:
+        - "{{ path_name_c }}"
+        - "{{ path_name_b }}"
+        - "{{ path_name_c }}"
+        - "{{ path_name }}"
+        - "{{ simple_name }}"

--- a/tests/integration/targets/module_utils_botocore_recorder/main.yml
+++ b/tests/integration/targets/module_utils_botocore_recorder/main.yml
@@ -7,6 +7,6 @@
     - name: Get called information
       amazon.aws.aws_caller_info:
       register: result
-    - assert:
+    - ansible.builtin.assert:
         that:
-         - lookup('ansible.builtin.env', '_ANSIBLE_PLACEBO_RECORD') or (lookup('ansible.builtin.env', '_ANSIBLE_PLACEBO_REPLAY') and result.user_id == "AWZBREIZHEOMABRONIFVGFS6GH")
+          - lookup('ansible.builtin.env', '_ANSIBLE_PLACEBO_RECORD') or (lookup('ansible.builtin.env', '_ANSIBLE_PLACEBO_REPLAY') and result.user_id == "AWZBREIZHEOMABRONIFVGFS6GH")

--- a/tests/integration/targets/module_utils_core/main.yml
+++ b/tests/integration/targets/module_utils_core/main.yml
@@ -1,8 +1,9 @@
+---
 - hosts: all
-  gather_facts: no
+  gather_facts: false
   collections:
-  - amazon.aws
-  - community.aws
+    - amazon.aws
+    - community.aws
   roles:
   # Test the behaviour of module_utils.core.AnsibleAWSModule.client (boto3)
-  - 'ansibleawsmodule.client'
+    - ansibleawsmodule.client

--- a/tests/integration/targets/module_utils_core/meta/main.yml
+++ b/tests/integration/targets/module_utils_core/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/meta/main.yml
+++ b/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/meta/main.yml
@@ -1,3 +1,4 @@
+---
 dependencies: []
 collections:
   - amazon.aws

--- a/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/ca_bundle.yml
+++ b/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/ca_bundle.yml
@@ -1,202 +1,202 @@
 ---
-- name: 'Create temporary location for CA files'
-  tempfile:
+- name: Create temporary location for CA files
+  ansible.builtin.tempfile:
     state: directory
-    suffix: 'test-CAs'
+    suffix: test-CAs
   register: ca_tmp
 
-- name: 'Ensure we have Amazons root CA available to us'
-  copy:
-    src: 'amazonroot.pem'
-    dest: '{{ ca_tmp.path }}/amazonroot.pem'
-    mode: 0644
+- name: Ensure we have Amazons root CA available to us
+  ansible.builtin.copy:
+    src: amazonroot.pem
+    dest: "{{ ca_tmp.path }}/amazonroot.pem"
+    mode: "0644"
 
-- name: 'Ensure we have a another CA (ISRG-X1) bundle available to us'
-  copy:
-    src: 'isrg-x1.pem'
-    dest: '{{ ca_tmp.path }}/isrg-x1.pem'
-    mode: 0644
+- name: Ensure we have a another CA (ISRG-X1) bundle available to us
+  ansible.builtin.copy:
+    src: isrg-x1.pem
+    dest: "{{ ca_tmp.path }}/isrg-x1.pem"
+    mode: "0644"
 
 ##################################################################################
 # Test disabling cert validation (make sure we don't error)
 
-- name: 'Test basic operation using default CA bundle (no validation) - parameter'
+- name: Test basic operation using default CA bundle (no validation) - parameter
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
-    validate_certs: False
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
+    validate_certs: false
   register: default_bundle_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - default_bundle_result is successful
+      - default_bundle_result is successful
 
 ##################################################################################
 # Tests using Amazon's CA (the one the endpoint certs should be signed with)
 
-- name: 'Test basic operation using Amazons root CA - parameter'
+- name: Test basic operation using Amazons root CA - parameter
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
-    aws_ca_bundle: '{{ ca_tmp.path }}/amazonroot.pem'
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
+    aws_ca_bundle: "{{ ca_tmp.path }}/amazonroot.pem"
   register: amazon_ca_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - amazon_ca_result is successful
+      - amazon_ca_result is successful
 
-- name: 'Test basic operation using Amazons root CA - environment'
+- name: Test basic operation using Amazons root CA - environment
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
   environment:
-    AWS_CA_BUNDLE: '{{ ca_tmp.path }}/amazonroot.pem'
+    AWS_CA_BUNDLE: "{{ ca_tmp.path }}/amazonroot.pem"
   register: amazon_ca_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - amazon_ca_result is successful
+      - amazon_ca_result is successful
 
-- name: 'Test basic operation using Amazons root CA (no validation) - parameter'
+- name: Test basic operation using Amazons root CA (no validation) - parameter
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
-    aws_ca_bundle: '{{ ca_tmp.path }}/amazonroot.pem'
-    validate_certs: False
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
+    aws_ca_bundle: "{{ ca_tmp.path }}/amazonroot.pem"
+    validate_certs: false
   register: amazon_ca_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - amazon_ca_result is successful
+      - amazon_ca_result is successful
 
-- name: 'Test basic operation using Amazons root CA (no validation) - environment'
+- name: Test basic operation using Amazons root CA (no validation) - environment
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
-    validate_certs: False
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
+    validate_certs: false
   environment:
-    AWS_CA_BUNDLE: '{{ ca_tmp.path }}/amazonroot.pem'
+    AWS_CA_BUNDLE: "{{ ca_tmp.path }}/amazonroot.pem"
   register: amazon_ca_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - amazon_ca_result is successful
+      - amazon_ca_result is successful
 
 ##################################################################################
 # Tests using ISRG's CA (one that the endpoint certs *aren't* signed with)
 
-- name: 'Test basic operation using a different CA - parameter'
+- name: Test basic operation using a different CA - parameter
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
-    aws_ca_bundle: '{{ ca_tmp.path }}/isrg-x1.pem'
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
+    aws_ca_bundle: "{{ ca_tmp.path }}/isrg-x1.pem"
   register: isrg_ca_result
-  ignore_errors: yes
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - isrg_ca_result is failed
-    # Caught when we try to do something, and passed to fail_json_aws
-    - '"CERTIFICATE_VERIFY_FAILED" in isrg_ca_result.msg'
-    - '"Fail JSON AWS" in isrg_ca_result.msg'
+      - isrg_ca_result is failed
+      # Caught when we try to do something, and passed to fail_json_aws
+      - '"CERTIFICATE_VERIFY_FAILED" in isrg_ca_result.msg'
+      - '"Fail JSON AWS" in isrg_ca_result.msg'
 
-- name: 'Test basic operation using a different CA - environment'
+- name: Test basic operation using a different CA - environment
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
   environment:
-    AWS_CA_BUNDLE: '{{ ca_tmp.path }}/isrg-x1.pem'
+    AWS_CA_BUNDLE: "{{ ca_tmp.path }}/isrg-x1.pem"
   register: isrg_ca_result
-  ignore_errors: yes
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - isrg_ca_result is failed
-    # Caught when we try to do something, and passed to fail_json_aws
-    - '"CERTIFICATE_VERIFY_FAILED" in isrg_ca_result.msg'
-    - '"Fail JSON AWS" in isrg_ca_result.msg'
+      - isrg_ca_result is failed
+      # Caught when we try to do something, and passed to fail_json_aws
+      - '"CERTIFICATE_VERIFY_FAILED" in isrg_ca_result.msg'
+      - '"Fail JSON AWS" in isrg_ca_result.msg'
 
-- name: 'Test basic operation using a different CA (no validation) - parameter'
+- name: Test basic operation using a different CA (no validation) - parameter
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
-    aws_ca_bundle: '{{ ca_tmp.path }}/isrg-x1.pem'
-    validate_certs: False
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
+    aws_ca_bundle: "{{ ca_tmp.path }}/isrg-x1.pem"
+    validate_certs: false
   register: isrg_ca_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - isrg_ca_result is successful
+      - isrg_ca_result is successful
 
-- name: 'Test basic operation using a different CA (no validation) - environment'
+- name: Test basic operation using a different CA (no validation) - environment
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
-    validate_certs: False
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
+    validate_certs: false
   environment:
-    AWS_CA_BUNDLE: '{{ ca_tmp.path }}/isrg-x1.pem'
+    AWS_CA_BUNDLE: "{{ ca_tmp.path }}/isrg-x1.pem"
   register: isrg_ca_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - isrg_ca_result is successful
+      - isrg_ca_result is successful
 
 ##################################################################################
 # https://github.com/ansible-collections/amazon.aws/issues/129
-- name: 'Test CA bundle is used when authenticating with a profile - implied validation'
+- name: Test CA bundle is used when authenticating with a profile - implied validation
   example_module:
-    profile: 'test_profile'
-    aws_ca_bundle: '{{ ca_tmp.path }}/isrg-x1.pem'
+    profile: test_profile
+    aws_ca_bundle: "{{ ca_tmp.path }}/isrg-x1.pem"
   register: isrg_ca_result
-  ignore_errors: yes
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - isrg_ca_result is failed
-    # Caught when we try to do something, and passed to fail_json_aws
-    - '"CERTIFICATE_VERIFY_FAILED" in isrg_ca_result.msg'
-    - '"Fail JSON AWS" in isrg_ca_result.msg'
+      - isrg_ca_result is failed
+      # Caught when we try to do something, and passed to fail_json_aws
+      - '"CERTIFICATE_VERIFY_FAILED" in isrg_ca_result.msg'
+      - '"Fail JSON AWS" in isrg_ca_result.msg'
 
-- name: 'Test CA bundle is used when authenticating with a profile - explicit validation'
+- name: Test CA bundle is used when authenticating with a profile - explicit validation
   example_module:
-    profile: 'test_profile'
-    aws_ca_bundle: '{{ ca_tmp.path }}/isrg-x1.pem'
-    validate_certs: True
+    profile: test_profile
+    aws_ca_bundle: "{{ ca_tmp.path }}/isrg-x1.pem"
+    validate_certs: true
   register: isrg_ca_result
-  ignore_errors: yes
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - isrg_ca_result is failed
-    # Caught when we try to do something, and passed to fail_json_aws
-    - '"CERTIFICATE_VERIFY_FAILED" in isrg_ca_result.msg'
-    - '"Fail JSON AWS" in isrg_ca_result.msg'
+      - isrg_ca_result is failed
+      # Caught when we try to do something, and passed to fail_json_aws
+      - '"CERTIFICATE_VERIFY_FAILED" in isrg_ca_result.msg'
+      - '"Fail JSON AWS" in isrg_ca_result.msg'
 
-- name: 'Test CA bundle is used when authenticating with a profile - explicitly disable validation'
+- name: Test CA bundle is used when authenticating with a profile - explicitly disable validation
   example_module:
-    profile: 'test_profile'
-    aws_ca_bundle: '{{ ca_tmp.path }}/isrg-x1.pem'
-    validate_certs: False
+    profile: test_profile
+    aws_ca_bundle: "{{ ca_tmp.path }}/isrg-x1.pem"
+    validate_certs: false
   register: isrg_ca_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - isrg_ca_result is success
+      - isrg_ca_result is success

--- a/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/credentials.yml
+++ b/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/credentials.yml
@@ -2,160 +2,160 @@
 ##################################################################################
 # Tests using standard credential parameters
 
-- name: 'Test basic operation using simple credentials (simple-parameters)'
+- name: Test basic operation using simple credentials (simple-parameters)
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
   register: credential_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - credential_result is successful
+      - credential_result is successful
 
-- name: 'Test basic operation using simple credentials (aws-parameters)'
+- name: Test basic operation using simple credentials (aws-parameters)
   example_module:
-    aws_region: '{{ aws_region }}'
-    aws_access_key: '{{ aws_access_key }}'
-    aws_secret_key: '{{ aws_secret_key }}'
-    aws_security_token: '{{ security_token }}'
+    aws_region: "{{ aws_region }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token }}"
   register: credential_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - credential_result is successful
+      - credential_result is successful
 
-- name: 'Test basic operation using simple credentials (ec2-parameters)'
+- name: Test basic operation using simple credentials (ec2-parameters)
   example_module:
-    ec2_region: '{{ aws_region }}'
-    ec2_access_key: '{{ aws_access_key }}'
-    ec2_secret_key: '{{ aws_secret_key }}'
-    access_token: '{{ security_token }}'
+    ec2_region: "{{ aws_region }}"
+    ec2_access_key: "{{ aws_access_key }}"
+    ec2_secret_key: "{{ aws_secret_key }}"
+    access_token: "{{ security_token }}"
   register: credential_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - credential_result is successful
+      - credential_result is successful
 
 ##################################################################################
 # Tests using standard credentials from environment variables
 
-- name: 'Test basic operation using simple credentials (aws-environment)'
+- name: Test basic operation using simple credentials (aws-environment)
   example_module:
   environment:
-    AWS_REGION: '{{ aws_region }}'
-    AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
-    AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
-    AWS_SECURITY_TOKEN: '{{ security_token }}'
+    AWS_REGION: "{{ aws_region }}"
+    AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+    AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+    AWS_SECURITY_TOKEN: "{{ security_token }}"
   register: credential_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - credential_result is successful
+      - credential_result is successful
 
-- name: 'Test basic operation using simple credentials (aws2-environment)'
+- name: Test basic operation using simple credentials (aws2-environment)
   example_module:
   environment:
-    AWS_DEFAULT_REGION: '{{ aws_region }}'
-    AWS_ACCESS_KEY: '{{ aws_access_key }}'
-    AWS_SECRET_KEY: '{{ aws_secret_key }}'
-    AWS_SESSION_TOKEN: '{{ security_token }}'
+    AWS_DEFAULT_REGION: "{{ aws_region }}"
+    AWS_ACCESS_KEY: "{{ aws_access_key }}"
+    AWS_SECRET_KEY: "{{ aws_secret_key }}"
+    AWS_SESSION_TOKEN: "{{ security_token }}"
   register: credential_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - credential_result is successful
+      - credential_result is successful
 
-- name: 'Test basic operation using simple credentials (ec2-environment)'
+- name: Test basic operation using simple credentials (ec2-environment)
   example_module:
   environment:
-    EC2_REGION: '{{ aws_region }}'
-    EC2_ACCESS_KEY: '{{ aws_access_key }}'
-    EC2_SECRET_KEY: '{{ aws_secret_key }}'
-    EC2_SECURITY_TOKEN: '{{ security_token }}'
+    EC2_REGION: "{{ aws_region }}"
+    EC2_ACCESS_KEY: "{{ aws_access_key }}"
+    EC2_SECRET_KEY: "{{ aws_secret_key }}"
+    EC2_SECURITY_TOKEN: "{{ security_token }}"
   register: credential_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - credential_result is successful
+      - credential_result is successful
 
 ##################################################################################
 # Tests for missing parameters
 
-- name: 'Test with missing region'
+- name: Test with missing region
   example_module:
-    region: '{{ omit }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
+    region: "{{ omit }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
   register: missing_region
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - missing_region is failed
-    - '"requires a region" in missing_region.msg'
+      - missing_region is failed
+      - '"requires a region" in missing_region.msg'
 
-- name: 'Test with missing access key'
+- name: Test with missing access key
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ omit }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    access_key: "{{ omit }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
   register: missing_access
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - missing_access is failed
-    - '"Partial credentials found" in missing_access.msg'
-    - '"aws_access_key_id" in missing_access.msg'
+      - missing_access is failed
+      - '"Partial credentials found" in missing_access.msg'
+      - '"aws_access_key_id" in missing_access.msg'
 
-- name: 'Test with missing secret key'
+- name: Test with missing secret key
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ omit }}'
-    security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ omit }}"
+    security_token: "{{ security_token }}"
   register: missing_secret
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - missing_secret is failed
-    - '"Partial credentials found" in missing_secret.msg'
-    - '"aws_secret_access_key" in missing_secret.msg'
+      - missing_secret is failed
+      - '"Partial credentials found" in missing_secret.msg'
+      - '"aws_secret_access_key" in missing_secret.msg'
 
-- name: 'Test with missing security token'
+- name: Test with missing security token
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ omit }}'
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ omit }}"
   register: missing_token
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - missing_token is failed
-    # Caught when we try to do something, and passed to fail_json_aws
-    - '"AuthFailure" in missing_token.msg'
-    - '"Fail JSON AWS" in missing_token.msg'
-    - '"error" in missing_token'
-    - '"code" in missing_token.error'
-    - missing_token.error.code == 'AuthFailure'
-    - '"message" in missing_token.error'
+      - missing_token is failed
+      # Caught when we try to do something, and passed to fail_json_aws
+      - '"AuthFailure" in missing_token.msg'
+      - '"Fail JSON AWS" in missing_token.msg'
+      - '"error" in missing_token'
+      - '"code" in missing_token.error'
+      - missing_token.error.code == 'AuthFailure'
+      - '"message" in missing_token.error'
 
 ##################################################################################
 # Run an additional authentication request to ensure that we're out of any
 # deny-lists caused by bad requests
-- name: 'Perform valid authentication to avoid deny-listing'
+- name: Perform valid authentication to avoid deny-listing
   example_module:
-    aws_region: '{{ aws_region }}'
-    aws_access_key: '{{ aws_access_key }}'
-    aws_secret_key: '{{ aws_secret_key }}'
-    aws_security_token: '{{ security_token }}'
+    aws_region: "{{ aws_region }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token }}"
   register: anti_denylist
   until: anti_denylist is success
   retries: 5
@@ -164,117 +164,117 @@
 ##################################################################################
 # Tests for bad parameters
 
-- name: 'Test with bad region'
+- name: Test with bad region
   example_module:
-    region: 'junk-example'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
+    region: junk-example
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
   register: bad_region
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - bad_region is failed
-    - '"msg" in bad_region'
-    - '"Could not connect to the endpoint URL" in bad_region.msg'
-    - '"Fail JSON AWS" in bad_region.msg'
-    - '"ec2.junk-example" in bad_region.msg'
+      - bad_region is failed
+      - '"msg" in bad_region'
+      - '"Could not connect to the endpoint URL" in bad_region.msg'
+      - '"Fail JSON AWS" in bad_region.msg'
+      - '"ec2.junk-example" in bad_region.msg'
 
-- name: 'Test with bad access key'
+- name: Test with bad access key
   example_module:
-    region: '{{ aws_region }}'
-    access_key: 'junk-example'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    access_key: junk-example
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
   register: bad_access
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - bad_access is failed
-    # Caught when we try to do something, and passed to fail_json_aws
-    - '"AuthFailure" in bad_access.msg'
-    - '"Fail JSON AWS" in bad_access.msg'
-    - '"error" in bad_access'
-    - '"code" in bad_access.error'
-    - bad_access.error.code == 'AuthFailure'
-    - '"message" in bad_access.error'
+      - bad_access is failed
+      # Caught when we try to do something, and passed to fail_json_aws
+      - '"AuthFailure" in bad_access.msg'
+      - '"Fail JSON AWS" in bad_access.msg'
+      - '"error" in bad_access'
+      - '"code" in bad_access.error'
+      - bad_access.error.code == 'AuthFailure'
+      - '"message" in bad_access.error'
 
 # Run an additional authentication request to ensure that we're out of any
 # deny-lists caused by bad requests
-- name: 'Perform valid authentication to avoid deny-listing'
+- name: Perform valid authentication to avoid deny-listing
   example_module:
-    aws_region: '{{ aws_region }}'
-    aws_access_key: '{{ aws_access_key }}'
-    aws_secret_key: '{{ aws_secret_key }}'
-    aws_security_token: '{{ security_token }}'
+    aws_region: "{{ aws_region }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token }}"
   register: anti_denylist
   until: anti_denylist is success
   retries: 5
   delay: 5
 
-- name: 'Test with bad secret key'
+- name: Test with bad secret key
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: 'junk-example'
-    security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: junk-example
+    security_token: "{{ security_token }}"
   register: bad_secret
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - bad_secret is failed
-    # Caught when we try to do something, and passed to fail_json_aws
-    - '"AuthFailure" in bad_secret.msg'
-    - '"Fail JSON AWS" in bad_secret.msg'
-    - '"error" in bad_secret'
-    - '"code" in bad_secret.error'
-    - bad_secret.error.code == 'AuthFailure'
-    - '"message" in bad_secret.error'
+      - bad_secret is failed
+      # Caught when we try to do something, and passed to fail_json_aws
+      - '"AuthFailure" in bad_secret.msg'
+      - '"Fail JSON AWS" in bad_secret.msg'
+      - '"error" in bad_secret'
+      - '"code" in bad_secret.error'
+      - bad_secret.error.code == 'AuthFailure'
+      - '"message" in bad_secret.error'
 
 # Run an additional authentication request to ensure that we're out of any
 # deny-lists caused by bad requests
-- name: 'Perform valid authentication to avoid deny-listing'
+- name: Perform valid authentication to avoid deny-listing
   example_module:
-    aws_region: '{{ aws_region }}'
-    aws_access_key: '{{ aws_access_key }}'
-    aws_secret_key: '{{ aws_secret_key }}'
-    aws_security_token: '{{ security_token }}'
+    aws_region: "{{ aws_region }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token }}"
   register: anti_denylist
   until: anti_denylist is success
   retries: 5
   delay: 5
 
-- name: 'Test with bad security token'
+- name: Test with bad security token
   example_module:
-    region: '{{ aws_region }}'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: 'junk-example'
+    region: "{{ aws_region }}"
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: junk-example
   register: bad_token
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - bad_token is failed
-    # Caught when we try to do something, and passed to fail_json_aws
-    - '"AuthFailure" in bad_token.msg'
-    - '"Fail JSON AWS" in bad_token.msg'
-    - '"error" in bad_token'
-    - '"code" in bad_token.error'
-    - bad_token.error.code == 'AuthFailure'
-    - '"message" in bad_token.error'
+      - bad_token is failed
+      # Caught when we try to do something, and passed to fail_json_aws
+      - '"AuthFailure" in bad_token.msg'
+      - '"Fail JSON AWS" in bad_token.msg'
+      - '"error" in bad_token'
+      - '"code" in bad_token.error'
+      - bad_token.error.code == 'AuthFailure'
+      - '"message" in bad_token.error'
 
 # Run an additional authentication request to ensure that we're out of any
 # deny-lists caused by bad requests
-- name: 'Perform valid authentication to avoid deny-listing'
+- name: Perform valid authentication to avoid deny-listing
   example_module:
-    aws_region: '{{ aws_region }}'
-    aws_access_key: '{{ aws_access_key }}'
-    aws_secret_key: '{{ aws_secret_key }}'
-    aws_security_token: '{{ security_token }}'
+    aws_region: "{{ aws_region }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token }}"
   register: anti_denylist
   until: anti_denylist is success
   retries: 5

--- a/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/endpoints.yml
+++ b/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/endpoints.yml
@@ -2,122 +2,122 @@
 ##################################################################################
 # Tests using Endpoints
 
-- name: 'Test basic operation using standard endpoint (aws-parameters)'
+- name: Test basic operation using standard endpoint (aws-parameters)
   example_module:
-    region: '{{ aws_region }}'
-    aws_endpoint_url: 'https://ec2.{{ aws_region }}.amazonaws.com'
-    aws_access_key: '{{ aws_access_key }}'
-    aws_secret_key: '{{ aws_secret_key }}'
-    aws_security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    aws_endpoint_url: https://ec2.{{ aws_region }}.amazonaws.com
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token }}"
   register: standard_endpoint_result
 
-- name: 'Check that we connected to the standard endpoint'
-  assert:
+- name: Check that we connected to the standard endpoint
+  ansible.builtin.assert:
     that:
-    - standard_endpoint_result is successful
-    - '"ec2:DescribeImages" in standard_endpoint_result.resource_actions'
+      - standard_endpoint_result is successful
+      - '"ec2:DescribeImages" in standard_endpoint_result.resource_actions'
 
 # The FIPS endpoints aren't available in every region, this will trigger errors
 # outside of: [ us-east-1, us-east-2, us-west-1, us-west-2 ]
 
-- name: 'Test basic operation using FIPS endpoint (aws-parameters)'
+- name: Test basic operation using FIPS endpoint (aws-parameters)
   example_module:
-    region: '{{ aws_region }}'
-    aws_endpoint_url: 'https://ec2-fips.us-east-1.amazonaws.com'
-    aws_access_key: '{{ aws_access_key }}'
-    aws_secret_key: '{{ aws_secret_key }}'
-    aws_security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    aws_endpoint_url: https://ec2-fips.us-east-1.amazonaws.com
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token }}"
   register: fips_endpoint_result
 
-- name: 'Check that we connected to the FIPS endpoint'
-  assert:
+- name: Check that we connected to the FIPS endpoint
+  ansible.builtin.assert:
     that:
-    - fips_endpoint_result is successful
-    - '"ec2-fips:DescribeImages" in fips_endpoint_result.resource_actions'
+      - fips_endpoint_result is successful
+      - '"ec2-fips:DescribeImages" in fips_endpoint_result.resource_actions'
 
-- name: 'Test basic operation using FIPS endpoint (aws-parameters)'
+- name: Test basic operation using FIPS endpoint (aws-parameters)
   example_module:
-    region: '{{ aws_region }}'
-    endpoint_url: 'https://ec2-fips.us-east-1.amazonaws.com'
-    aws_access_key: '{{ aws_access_key }}'
-    aws_secret_key: '{{ aws_secret_key }}'
-    aws_security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    endpoint_url: https://ec2-fips.us-east-1.amazonaws.com
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token }}"
   register: fips_endpoint_result
 
-- name: 'Check that we connected to the FIPS endpoint'
-  assert:
+- name: Check that we connected to the FIPS endpoint
+  ansible.builtin.assert:
     that:
-    - fips_endpoint_result is successful
-    - '"ec2-fips:DescribeImages" in fips_endpoint_result.resource_actions'
+      - fips_endpoint_result is successful
+      - '"ec2-fips:DescribeImages" in fips_endpoint_result.resource_actions'
 
-- name: 'Test basic operation using FIPS endpoint (aws-parameters)'
+- name: Test basic operation using FIPS endpoint (aws-parameters)
   example_module:
-    region: '{{ aws_region }}'
-    ec2_url: 'https://ec2-fips.us-east-1.amazonaws.com'
-    aws_access_key: '{{ aws_access_key }}'
-    aws_secret_key: '{{ aws_secret_key }}'
-    aws_security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    ec2_url: https://ec2-fips.us-east-1.amazonaws.com
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token }}"
   register: fips_endpoint_result
 
-- name: 'Check that we connected to the FIPS endpoint'
-  assert:
+- name: Check that we connected to the FIPS endpoint
+  ansible.builtin.assert:
     that:
-    - fips_endpoint_result is successful
-    - '"ec2-fips:DescribeImages" in fips_endpoint_result.resource_actions'
+      - fips_endpoint_result is successful
+      - '"ec2-fips:DescribeImages" in fips_endpoint_result.resource_actions'
 
 ##################################################################################
 # Tests using environment variables
 
-- name: 'Test basic operation using FIPS endpoint (aws-environment)'
+- name: Test basic operation using FIPS endpoint (aws-environment)
   example_module:
-    region: '{{ aws_region }}'
-    aws_access_key: '{{ aws_access_key }}'
-    aws_secret_key: '{{ aws_secret_key }}'
-    aws_security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token }}"
   environment:
-    AWS_URL: 'https://ec2-fips.us-east-1.amazonaws.com'
+    AWS_URL: https://ec2-fips.us-east-1.amazonaws.com
   register: fips_endpoint_result
 
-- name: 'Check that we connected to the FIPS endpoint'
-  assert:
+- name: Check that we connected to the FIPS endpoint
+  ansible.builtin.assert:
     that:
-    - fips_endpoint_result is successful
-    - '"ec2-fips:DescribeImages" in fips_endpoint_result.resource_actions'
+      - fips_endpoint_result is successful
+      - '"ec2-fips:DescribeImages" in fips_endpoint_result.resource_actions'
 
-- name: 'Test basic operation using FIPS endpoint (ec2-environment)'
+- name: Test basic operation using FIPS endpoint (ec2-environment)
   example_module:
-    region: '{{ aws_region }}'
-    aws_access_key: '{{ aws_access_key }}'
-    aws_secret_key: '{{ aws_secret_key }}'
-    aws_security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token }}"
   environment:
-    EC2_URL: 'https://ec2-fips.us-east-1.amazonaws.com'
+    EC2_URL: https://ec2-fips.us-east-1.amazonaws.com
   register: fips_endpoint_result
 
-- name: 'Check that we connected to the FIPS endpoint'
-  assert:
+- name: Check that we connected to the FIPS endpoint
+  ansible.builtin.assert:
     that:
-    - fips_endpoint_result is successful
-    - '"ec2-fips:DescribeImages" in fips_endpoint_result.resource_actions'
+      - fips_endpoint_result is successful
+      - '"ec2-fips:DescribeImages" in fips_endpoint_result.resource_actions'
 
 ##################################################################################
 # Tests using a bad endpoint URL
 #   - This demonstrates that endpoint_url overrode region
 
-- name: 'Test with bad endpoint URL'
+- name: Test with bad endpoint URL
   example_module:
-    region: '{{ aws_region }}'
-    endpoint_url: 'https://junk.{{ aws_region }}.amazonaws.com'
-    access_key: '{{ aws_access_key }}'
-    secret_key: '{{ aws_secret_key }}'
-    security_token: '{{ security_token }}'
+    region: "{{ aws_region }}"
+    endpoint_url: https://junk.{{ aws_region }}.amazonaws.com
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    security_token: "{{ security_token }}"
   register: bad_endpoint
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - bad_endpoint is failed
-    - '"msg" in bad_endpoint'
-    - '"Could not connect to the endpoint URL" in bad_endpoint.msg'
-    - '"Fail JSON AWS" in bad_endpoint.msg'
-    - '"junk.{{ aws_region }}.amazonaws.com" in bad_endpoint.msg'
+      - bad_endpoint is failed
+      - '"msg" in bad_endpoint'
+      - '"Could not connect to the endpoint URL" in bad_endpoint.msg'
+      - '"Fail JSON AWS" in bad_endpoint.msg'
+      - '"junk.{{ aws_region }}.amazonaws.com" in bad_endpoint.msg'

--- a/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/main.yml
+++ b/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/main.yml
@@ -1,12 +1,9 @@
 ---
-- name: 'Tests around standard credentials'
-  include_tasks: 'credentials.yml'
-
-- name: 'Tests around profiles'
-  include_tasks: 'profiles.yml'
-
-- name: 'Tests around endpoints'
-  include_tasks: 'endpoints.yml'
-
-- name: 'Tests around CA Bundles'
-  include_tasks: 'ca_bundle.yml'
+- name: Tests around standard credentials
+  ansible.builtin.include_tasks: credentials.yml
+- name: Tests around profiles
+  ansible.builtin.include_tasks: profiles.yml
+- name: Tests around endpoints
+  ansible.builtin.include_tasks: endpoints.yml
+- name: Tests around CA Bundles
+  ansible.builtin.include_tasks: ca_bundle.yml

--- a/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/profiles.yml
+++ b/tests/integration/targets/module_utils_core/roles/ansibleawsmodule.client/tasks/profiles.yml
@@ -2,73 +2,73 @@
 ##################################################################################
 # Tests using profiles instead of directly consuming credentials
 
-- name: 'Test basic operation using profile (simple-parameters)'
+- name: Test basic operation using profile (simple-parameters)
   example_module:
-    profile: 'test_profile'
+    profile: test_profile
   register: profile_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - profile_result is successful
+      - profile_result is successful
 
-- name: 'Test basic operation using profile (aws-parameters)'
+- name: Test basic operation using profile (aws-parameters)
   example_module:
-    aws_profile: 'test_profile'
+    aws_profile: test_profile
   register: profile_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - profile_result is successful
+      - profile_result is successful
 
-- name: 'Test basic operation using profile (aws-environment)'
-  example_module:
-  environment:
-    AWS_PROFILE: 'test_profile'
-  register: profile_result
-
-- assert:
-    that:
-    - profile_result is successful
-
-- name: 'Test basic operation using profile (aws2-environment)'
+- name: Test basic operation using profile (aws-environment)
   example_module:
   environment:
-    AWS_DEFAULT_PROFILE: 'test_profile'
+    AWS_PROFILE: test_profile
   register: profile_result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - profile_result is successful
+      - profile_result is successful
+
+- name: Test basic operation using profile (aws2-environment)
+  example_module:
+  environment:
+    AWS_DEFAULT_PROFILE: test_profile
+  register: profile_result
+
+- ansible.builtin.assert:
+    that:
+      - profile_result is successful
 
 ##################################################################################
 # Tests with bad profile
 
-- name: 'Test with bad profile'
+- name: Test with bad profile
   example_module:
-    profile: 'junk-profile'
+    profile: junk-profile
   register: bad_profile
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - bad_profile is failed
-    - '"msg" in bad_profile'
-    - '"junk-profile" in bad_profile.msg'
-    - '"could not be found" in bad_profile.msg'
+      - bad_profile is failed
+      - '"msg" in bad_profile'
+      - '"junk-profile" in bad_profile.msg'
+      - '"could not be found" in bad_profile.msg'
 
-- name: 'Test with profile and credentials (should error)'
+- name: Test with profile and credentials (should error)
   example_module:
-    profile: 'test_profile'
-    aws_region: '{{ aws_region }}'
-    aws_access_key: '{{ aws_access_key }}'
-    aws_secret_key: '{{ aws_secret_key }}'
-    aws_security_token: '{{ security_token }}'
+    profile: test_profile
+    aws_region: "{{ aws_region }}"
+    aws_access_key: "{{ aws_access_key }}"
+    aws_secret_key: "{{ aws_secret_key }}"
+    aws_security_token: "{{ security_token }}"
   register: bad_profile
-  ignore_errors: True
+  ignore_errors: true
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - bad_profile is failed
-    - '"msg" in bad_profile'
-    - '"Passing both" in bad_profile.msg'
-    - '"not supported" in bad_profile.msg'
+      - bad_profile is failed
+      - '"msg" in bad_profile'
+      - '"Passing both" in bad_profile.msg'
+      - '"not supported" in bad_profile.msg'

--- a/tests/integration/targets/module_utils_core/setup.yml
+++ b/tests/integration/targets/module_utils_core/setup.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: localhost
   connection: local
-  gather_facts: no
+  gather_facts: false
   tasks:
   # ===========================================================
   # While CI uses a dedicated session, the easiest way to run
@@ -11,30 +11,30 @@
   # credentials if we're not already using a session
   # Note: this can't be done within a session, hence the slightly
   # strange dance
-  - name: 'Get a session token if we are using a basic key'
-    when:
-    - security_token is not defined
-    block:
-    - name: 'Get a session token'
-      sts_session_token:
-        region: '{{ aws_region }}'
-        aws_access_key: '{{ aws_access_key }}'
-        aws_secret_key: '{{ aws_secret_key }}'
-      register: session_token
-      no_log: true
-    - name: 'Override initial tokens'
-      set_fact:
-        session_access_key: '{{ session_token.sts_creds.access_key }}'
-        session_secret_key: '{{ session_token.sts_creds.secret_key }}'
-        session_security_token: '{{ session_token.sts_creds.session_token }}'
-      no_log: true
+    - name: Get a session token if we are using a basic key
+      when:
+        - security_token is not defined
+      block:
+        - name: Get a session token
+          community.aws.sts_session_token:
+            region: "{{ aws_region }}"
+            aws_access_key: "{{ aws_access_key }}"
+            aws_secret_key: "{{ aws_secret_key }}"
+          register: session_token
+          no_log: true
+        - name: Override initial tokens
+          ansible.builtin.set_fact:
+            session_access_key: "{{ session_token.sts_creds.access_key }}"
+            session_secret_key: "{{ session_token.sts_creds.secret_key }}"
+            session_security_token: "{{ session_token.sts_creds.session_token }}"
+          no_log: true
 
-  - name: 'Write out credentials'
-    template:
-      dest: './session_credentials.yml'
-      src: 'session_credentials.yml.j2'
+    - name: Write out credentials
+      ansible.builtin.template:
+        dest: ./session_credentials.yml
+        src: session_credentials.yml.j2
 
-  - name: 'Write out boto config file'
-    template:
-      dest: './boto3_config'
-      src: 'boto_config.j2'
+    - name: Write out boto config file
+      ansible.builtin.template:
+        dest: ./boto3_config
+        src: boto_config.j2

--- a/tests/integration/targets/module_utils_waiter/main.yml
+++ b/tests/integration/targets/module_utils_waiter/main.yml
@@ -1,7 +1,8 @@
+---
 - hosts: all
-  gather_facts: no
+  gather_facts: false
   collections:
-  - amazon.aws
+    - amazon.aws
   roles:
   # Test the behaviour of module_utils.core.AnsibleAWSModule.client (boto3)
-  - 'get_waiter'
+    - get_waiter

--- a/tests/integration/targets/module_utils_waiter/meta/main.yml
+++ b/tests/integration/targets/module_utils_waiter/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/module_utils_waiter/roles/get_waiter/meta/main.yml
+++ b/tests/integration/targets/module_utils_waiter/roles/get_waiter/meta/main.yml
@@ -1,3 +1,4 @@
+---
 dependencies: []
 collections:
   - amazon.aws

--- a/tests/integration/targets/module_utils_waiter/roles/get_waiter/tasks/main.yml
+++ b/tests/integration/targets/module_utils_waiter/roles/get_waiter/tasks/main.yml
@@ -1,36 +1,36 @@
 ---
 - module_defaults:
     example_module:
-      region: '{{ aws_region }}'
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   block:
-  - name: 'Attempt to get a waiter (no retry decorator)'
-    example_module:
-      client: 'ec2'
-      waiter_name: 'internet_gateway_exists'
-    register: test_no_decorator
+    - name: Attempt to get a waiter (no retry decorator)
+      example_module:
+        client: ec2
+        waiter_name: internet_gateway_exists
+      register: test_no_decorator
 
-  - assert:
-      that:
-      - test_no_decorator is succeeded
-      # Standard methods on a boto3 wrapper
-      - '"wait" in test_no_decorator.waiter_attributes'
-      - '"name" in test_no_decorator.waiter_attributes'
-      - '"config" in test_no_decorator.waiter_attributes'
+    - ansible.builtin.assert:
+        that:
+          - test_no_decorator is succeeded
+          # Standard methods on a boto3 wrapper
+          - '"wait" in test_no_decorator.waiter_attributes'
+          - '"name" in test_no_decorator.waiter_attributes'
+          - '"config" in test_no_decorator.waiter_attributes'
 
-  - name: 'Attempt to get a waiter (with decorator)'
-    example_module:
-      client: 'ec2'
-      waiter_name: 'internet_gateway_exists'
-      with_decorator: True
-    register: test_with_decorator
+    - name: Attempt to get a waiter (with decorator)
+      example_module:
+        client: ec2
+        waiter_name: internet_gateway_exists
+        with_decorator: true
+      register: test_with_decorator
 
-  - assert:
-      that:
-      - test_with_decorator is succeeded
-      # Standard methods on a boto3 wrapper
-      - '"wait" in test_with_decorator.waiter_attributes'
-      - '"name" in test_with_decorator.waiter_attributes'
-      - '"config" in test_with_decorator.waiter_attributes'
+    - ansible.builtin.assert:
+        that:
+          - test_with_decorator is succeeded
+          # Standard methods on a boto3 wrapper
+          - '"wait" in test_with_decorator.waiter_attributes'
+          - '"name" in test_with_decorator.waiter_attributes'
+          - '"config" in test_with_decorator.waiter_attributes'

--- a/tests/integration/targets/rds_cluster_create/defaults/main.yml
+++ b/tests/integration/targets/rds_cluster_create/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 # defaults file for rds_cluster
 
 # Create cluster

--- a/tests/integration/targets/rds_cluster_create/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_create/tasks/main.yaml
@@ -1,129 +1,127 @@
+---
 - module_defaults:
     group/aws:
-      region: '{{ aws_region }}'
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   block:
-  - name: Ensure the resource doesn't exist
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: absent
-      engine: '{{ engine}}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      skip_final_snapshot: true
-    register: _result_delete_db_cluster
+    - name: Ensure the resource doesn't exist
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: absent
+        engine: "{{ engine}}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        skip_final_snapshot: true
+      register: _result_delete_db_cluster
 
-  - assert:
-      that:
-      - not _result_delete_db_cluster.changed
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - not _result_delete_db_cluster.changed
+      ignore_errors: true
 
-  - name: Get info of all existing clusters
-    rds_cluster_info:
-    register: _result_cluster_info
+    - name: Get info of all existing clusters
+      rds_cluster_info:
+      register: _result_cluster_info
 
-  - assert:
-      that:
-      - _result_cluster_info is successful
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_info is successful
 
-  - name: Create minimal aurora cluster in default VPC and default subnet group (CHECK
-      MODE)
-    rds_cluster:
-      engine: '{{ engine }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      cluster_id: '{{ cluster_id }}'
-      tags: '{{ tags_create }}'
-    register: _result_create_db_cluster
-    check_mode: true
+    - name: Create minimal aurora cluster in default VPC and default subnet group (CHECK MODE)
+      rds_cluster:
+        engine: "{{ engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        cluster_id: "{{ cluster_id }}"
+        tags: "{{ tags_create }}"
+      register: _result_create_db_cluster
+      check_mode: true
 
-  - assert:
-      that:
-      - _result_create_db_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_create_db_cluster.changed
 
-  - name: Create minimal aurora cluster in default VPC and default subnet group
-    rds_cluster:
-      engine: '{{ engine }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      cluster_id: '{{ cluster_id }}'
-      tags: '{{ tags_create }}'
-    register: _result_create_db_cluster
+    - name: Create minimal aurora cluster in default VPC and default subnet group
+      rds_cluster:
+        engine: "{{ engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        cluster_id: "{{ cluster_id }}"
+        tags: "{{ tags_create }}"
+      register: _result_create_db_cluster
 
-  - assert:
-      that:
-      - _result_create_db_cluster.changed
-      - "'allocated_storage' in _result_create_db_cluster"
-      - _result_create_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_create_db_cluster"
-      - _result_create_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_create_db_cluster"
-      - "'db_cluster_identifier' in _result_create_db_cluster"
-      - _result_create_db_cluster.db_cluster_identifier == cluster_id
-      - "'db_cluster_parameter_group' in _result_create_db_cluster"
-      - "'db_cluster_resource_id' in _result_create_db_cluster"
-      - "'endpoint' in _result_create_db_cluster"
-      - "'engine' in _result_create_db_cluster"
-      - _result_create_db_cluster.engine == engine
-      - "'engine_mode' in _result_create_db_cluster"
-      - _result_create_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_create_db_cluster"
-      - "'master_username' in _result_create_db_cluster"
-      - _result_create_db_cluster.master_username == username
-      - "'port' in _result_create_db_cluster"
-      - _result_create_db_cluster.port == {{ port }}
-      - "'status' in _result_create_db_cluster"
-      - _result_create_db_cluster.status == 'available'
-      - _result_create_db_cluster.storage_encrypted == false
-      - "'tags' in _result_create_db_cluster"
-      - _result_create_db_cluster.tags | length == 2
-      - _result_create_db_cluster.tags["Created_By"] == "{{ tags_create["Created_By"]}}"
-      - _result_create_db_cluster.tags["Name"] == "{{ tags_create["Name"]}}"
-      - "'vpc_security_groups' in _result_create_db_cluster"
-  - name: Get info of the existing cluster
-    rds_cluster_info:
-      cluster_id: '{{ cluster_id }}'
-    register: result_cluster_info
+    - ansible.builtin.assert:
+        that:
+          - _result_create_db_cluster.changed
+          - "'allocated_storage' in _result_create_db_cluster"
+          - _result_create_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_create_db_cluster"
+          - _result_create_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_create_db_cluster"
+          - "'db_cluster_identifier' in _result_create_db_cluster"
+          - _result_create_db_cluster.db_cluster_identifier == cluster_id
+          - "'db_cluster_parameter_group' in _result_create_db_cluster"
+          - "'db_cluster_resource_id' in _result_create_db_cluster"
+          - "'endpoint' in _result_create_db_cluster"
+          - "'engine' in _result_create_db_cluster"
+          - _result_create_db_cluster.engine == engine
+          - "'engine_mode' in _result_create_db_cluster"
+          - _result_create_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_create_db_cluster"
+          - "'master_username' in _result_create_db_cluster"
+          - _result_create_db_cluster.master_username == username
+          - "'port' in _result_create_db_cluster"
+          - _result_create_db_cluster.port == {{ port }}
+          - "'status' in _result_create_db_cluster"
+          - _result_create_db_cluster.status == 'available'
+          - _result_create_db_cluster.storage_encrypted == false
+          - "'tags' in _result_create_db_cluster"
+          - _result_create_db_cluster.tags | length == 2
+          - _result_create_db_cluster.tags["Created_By"] == "{{ tags_create["Created_By"]}}"
+          - _result_create_db_cluster.tags["Name"] == "{{ tags_create["Name"]}}"
+          - "'vpc_security_groups' in _result_create_db_cluster"
+    - name: Get info of the existing cluster
+      rds_cluster_info:
+        cluster_id: "{{ cluster_id }}"
+      register: result_cluster_info
 
-  - assert:
-      that:
-      - result_cluster_info is successful
+    - ansible.builtin.assert:
+        that:
+          - result_cluster_info is successful
 
-  - name: Create minimal aurora cluster in default VPC and default subnet group -
-      idempotence (CHECK MODE)
-    rds_cluster:
-      engine: '{{ engine }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      cluster_id: '{{ cluster_id }}'
-      tags: '{{ tags_create }}'
-    register: _result_create_db_cluster
-    check_mode: true
+    - name: Create minimal aurora cluster in default VPC and default subnet group - idempotence (CHECK MODE)
+      rds_cluster:
+        engine: "{{ engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        cluster_id: "{{ cluster_id }}"
+        tags: "{{ tags_create }}"
+      register: _result_create_db_cluster
+      check_mode: true
 
-  - assert:
-      that:
-      - not _result_create_db_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_create_db_cluster.changed
 
-  - name: Create minimal aurora cluster in default VPC and default subnet group -
-      idempotence
-    rds_cluster:
-      engine: '{{ engine }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      cluster_id: '{{ cluster_id }}'
-      tags: '{{ tags_create }}'
-    register: _result_create_db_cluster
+    - name: Create minimal aurora cluster in default VPC and default subnet group - idempotence
+      rds_cluster:
+        engine: "{{ engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        cluster_id: "{{ cluster_id }}"
+        tags: "{{ tags_create }}"
+      register: _result_create_db_cluster
 
-  - assert:
-      that:
-      - not _result_create_db_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_create_db_cluster.changed
 
   always:
-  - name: Delete DB cluster without creating a final snapshot
-    rds_cluster:
-      state: absent
-      cluster_id: '{{ cluster_id }}'
-      skip_final_snapshot: true
-    ignore_errors: true
+    - name: Delete DB cluster without creating a final snapshot
+      rds_cluster:
+        state: absent
+        cluster_id: "{{ cluster_id }}"
+        skip_final_snapshot: true
+      ignore_errors: true

--- a/tests/integration/targets/rds_cluster_create_sgs/defaults/main.yml
+++ b/tests/integration/targets/rds_cluster_create_sgs/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 # defaults file for rds_cluster
 
 # Create cluster
@@ -11,12 +12,12 @@ port: 3306
 vpc_name: ansible-test-vpc-{{ tiny_prefix }}
 vpc_cidr: 10.{{ 256 | random(seed=tiny_prefix) }}.0.0/16
 subnets:
-- {cidr: '10.{{ 256 | random(seed=tiny_prefix) }}.1.0/24', zone: '{{ aws_region }}a'}
-- {cidr: '10.{{ 256 | random(seed=tiny_prefix) }}.2.0/24', zone: '{{ aws_region }}b'}
-- {cidr: '10.{{ 256 | random(seed=tiny_prefix) }}.3.0/24', zone: '{{ aws_region }}c'}
-- {cidr: '10.{{ 256 | random(seed=tiny_prefix) }}.4.0/24', zone: '{{ aws_region }}d'}
+  - { cidr: "10.{{ 256 | random(seed=tiny_prefix) }}.1.0/24", zone: "{{ aws_region }}a" }
+  - { cidr: "10.{{ 256 | random(seed=tiny_prefix) }}.2.0/24", zone: "{{ aws_region }}b" }
+  - { cidr: "10.{{ 256 | random(seed=tiny_prefix) }}.3.0/24", zone: "{{ aws_region }}c" }
+  - { cidr: "10.{{ 256 | random(seed=tiny_prefix) }}.4.0/24", zone: "{{ aws_region }}d" }
 
 security_groups:
-- '{{ tiny_prefix }}-sg-1'
-- '{{ tiny_prefix }}-sg-2'
-- '{{ tiny_prefix }}-sg-3'
+  - "{{ tiny_prefix }}-sg-1"
+  - "{{ tiny_prefix }}-sg-2"
+  - "{{ tiny_prefix }}-sg-3"

--- a/tests/integration/targets/rds_cluster_create_sgs/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_create_sgs/tasks/main.yaml
@@ -1,214 +1,212 @@
+---
 - module_defaults:
     group/aws:
-      region: '{{ aws_region }}'
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   block:
-  - name: Ensure the resource doesn't exist
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: absent
-      engine: '{{ engine}}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      skip_final_snapshot: true
-    register: _result_delete_db_cluster
+    - name: Ensure the resource doesn't exist
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: absent
+        engine: "{{ engine}}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        skip_final_snapshot: true
+      register: _result_delete_db_cluster
 
-  - assert:
-      that:
-      - not _result_delete_db_cluster.changed
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - not _result_delete_db_cluster.changed
+      ignore_errors: true
 
-  - name: Create a VPC
-    ec2_vpc_net:
-      name: '{{ vpc_name }}'
-      state: present
-      cidr_block: '{{ vpc_cidr }}'
-      tags:
-        Name: '{{ vpc_name }}'
-        Description: Created by rds_cluster integration tests
-    register: _result_create_vpc
+    - name: Create a VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ vpc_name }}"
+        state: present
+        cidr_block: "{{ vpc_cidr }}"
+        tags:
+          Name: "{{ vpc_name }}"
+          Description: Created by rds_cluster integration tests
+      register: _result_create_vpc
 
-  - name: Create subnets
-    ec2_vpc_subnet:
-      cidr: '{{ item.cidr }}'
-      az: '{{ item.zone }}'
-      vpc_id: '{{ _result_create_vpc.vpc.id }}'
-      tags:
-        Name: '{{ resource_prefix }}-subnet'
-        Description: created by rds_cluster integration tests
-      state: present
-    register: _result_create_subnet
-    loop: '{{ subnets }}'
+    - name: Create subnets
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ item.cidr }}"
+        az: "{{ item.zone }}"
+        vpc_id: "{{ _result_create_vpc.vpc.id }}"
+        tags:
+          Name: "{{ resource_prefix }}-subnet"
+          Description: created by rds_cluster integration tests
+        state: present
+      register: _result_create_subnet
+      loop: "{{ subnets }}"
 
-  - name: Create security groups
-    ec2_security_group:
-      name: '{{ item }}'
-      description: Created by rds_cluster integration tests
-      state: present
-    register: _result_create_sg
-    loop: '{{ security_groups }}'
+    - name: Create security groups
+      ec2_security_group:
+        name: "{{ item }}"
+        description: Created by rds_cluster integration tests
+        state: present
+      register: _result_create_sg
+      loop: "{{ security_groups }}"
 
-  - name: Create an RDS cluster in the VPC with two security groups
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      engine: '{{ engine }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      vpc_security_group_ids:
-      - '{{ _result_create_sg.results.0.group_id }}'
-      - '{{ _result_create_sg.results.1.group_id }}'
-    register: _result_create_db_cluster
+    - name: Create an RDS cluster in the VPC with two security groups
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        engine: "{{ engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        vpc_security_group_ids:
+          - "{{ _result_create_sg.results.0.group_id }}"
+          - "{{ _result_create_sg.results.1.group_id }}"
+      register: _result_create_db_cluster
 
-  - assert:
-      that:
-      - _result_create_db_cluster.changed
-      - "'allocated_storage' in _result_create_db_cluster"
-      - _result_create_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_create_db_cluster"
-      - _result_create_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_create_db_cluster"
-      - "'db_cluster_identifier' in _result_create_db_cluster"
-      - _result_create_db_cluster.db_cluster_identifier == cluster_id
-      - "'db_cluster_parameter_group' in _result_create_db_cluster"
-      - "'db_cluster_resource_id' in _result_create_db_cluster"
-      - "'endpoint' in _result_create_db_cluster"
-      - "'engine' in _result_create_db_cluster"
-      - _result_create_db_cluster.engine == engine
-      - "'engine_mode' in _result_create_db_cluster"
-      - _result_create_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_create_db_cluster"
-      - "'master_username' in _result_create_db_cluster"
-      - _result_create_db_cluster.master_username == username
-      - "'port' in _result_create_db_cluster"
-      - _result_create_db_cluster.port == {{ port }}
-      - "'status' in _result_create_db_cluster"
-      - _result_create_db_cluster.status == 'available'
-      - _result_create_db_cluster.storage_encrypted == false
-      - "'tags' in _result_create_db_cluster"
-      - "'vpc_security_groups' in _result_create_db_cluster"
-      - _result_create_db_cluster.vpc_security_groups | selectattr('status', 'in',
-        ['active', 'adding']) | list | length == 2
+    - ansible.builtin.assert:
+        that:
+          - _result_create_db_cluster.changed
+          - "'allocated_storage' in _result_create_db_cluster"
+          - _result_create_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_create_db_cluster"
+          - _result_create_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_create_db_cluster"
+          - "'db_cluster_identifier' in _result_create_db_cluster"
+          - _result_create_db_cluster.db_cluster_identifier == cluster_id
+          - "'db_cluster_parameter_group' in _result_create_db_cluster"
+          - "'db_cluster_resource_id' in _result_create_db_cluster"
+          - "'endpoint' in _result_create_db_cluster"
+          - "'engine' in _result_create_db_cluster"
+          - _result_create_db_cluster.engine == engine
+          - "'engine_mode' in _result_create_db_cluster"
+          - _result_create_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_create_db_cluster"
+          - "'master_username' in _result_create_db_cluster"
+          - _result_create_db_cluster.master_username == username
+          - "'port' in _result_create_db_cluster"
+          - _result_create_db_cluster.port == {{ port }}
+          - "'status' in _result_create_db_cluster"
+          - _result_create_db_cluster.status == 'available'
+          - _result_create_db_cluster.storage_encrypted == false
+          - "'tags' in _result_create_db_cluster"
+          - "'vpc_security_groups' in _result_create_db_cluster"
+          - _result_create_db_cluster.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 2
 
-  - name: Add a new security group without purge (check_mode)
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: present
-      vpc_security_group_ids:
-      - '{{ _result_create_sg.results.2.group_id }}'
-      apply_immediately: true
-      purge_security_groups: false
-    check_mode: true
-    register: _result_create_db_cluster
+    - name: Add a new security group without purge (check_mode)
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: present
+        vpc_security_group_ids:
+          - "{{ _result_create_sg.results.2.group_id }}"
+        apply_immediately: true
+        purge_security_groups: false
+      check_mode: true
+      register: _result_create_db_cluster
 
-  - assert:
-      that:
-      - _result_create_db_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_create_db_cluster.changed
 
-  - name: Add a new security group without purge
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: present
-      vpc_security_group_ids:
-      - '{{ _result_create_sg.results.2.group_id }}'
-      apply_immediately: true
-      purge_security_groups: false
-    register: _result_create_db_cluster
+    - name: Add a new security group without purge
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: present
+        vpc_security_group_ids:
+          - "{{ _result_create_sg.results.2.group_id }}"
+        apply_immediately: true
+        purge_security_groups: false
+      register: _result_create_db_cluster
 
-  - assert:
-      that:
-      - _result_create_db_cluster.changed
-      - "'allocated_storage' in _result_create_db_cluster"
-      - _result_create_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_create_db_cluster"
-      - _result_create_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_create_db_cluster"
-      - "'db_cluster_identifier' in _result_create_db_cluster"
-      - _result_create_db_cluster.db_cluster_identifier == cluster_id
-      - "'db_cluster_parameter_group' in _result_create_db_cluster"
-      - "'db_cluster_resource_id' in _result_create_db_cluster"
-      - "'endpoint' in _result_create_db_cluster"
-      - "'engine' in _result_create_db_cluster"
-      - _result_create_db_cluster.engine == engine
-      - "'engine_mode' in _result_create_db_cluster"
-      - _result_create_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_create_db_cluster"
-      - "'master_username' in _result_create_db_cluster"
-      - _result_create_db_cluster.master_username == username
-      - "'port' in _result_create_db_cluster"
-      - _result_create_db_cluster.port == {{ port }}
-      - "'status' in _result_create_db_cluster"
-      - _result_create_db_cluster.status == 'available'
-      - _result_create_db_cluster.storage_encrypted == false
-      - "'tags' in _result_create_db_cluster"
-      - "'vpc_security_groups' in _result_create_db_cluster"
-      - _result_create_db_cluster.vpc_security_groups | selectattr('status', 'in',
-        ['active', 'adding']) | list | length == 3
+    - ansible.builtin.assert:
+        that:
+          - _result_create_db_cluster.changed
+          - "'allocated_storage' in _result_create_db_cluster"
+          - _result_create_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_create_db_cluster"
+          - _result_create_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_create_db_cluster"
+          - "'db_cluster_identifier' in _result_create_db_cluster"
+          - _result_create_db_cluster.db_cluster_identifier == cluster_id
+          - "'db_cluster_parameter_group' in _result_create_db_cluster"
+          - "'db_cluster_resource_id' in _result_create_db_cluster"
+          - "'endpoint' in _result_create_db_cluster"
+          - "'engine' in _result_create_db_cluster"
+          - _result_create_db_cluster.engine == engine
+          - "'engine_mode' in _result_create_db_cluster"
+          - _result_create_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_create_db_cluster"
+          - "'master_username' in _result_create_db_cluster"
+          - _result_create_db_cluster.master_username == username
+          - "'port' in _result_create_db_cluster"
+          - _result_create_db_cluster.port == {{ port }}
+          - "'status' in _result_create_db_cluster"
+          - _result_create_db_cluster.status == 'available'
+          - _result_create_db_cluster.storage_encrypted == false
+          - "'tags' in _result_create_db_cluster"
+          - "'vpc_security_groups' in _result_create_db_cluster"
+          - _result_create_db_cluster.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 3
 
-  - name: Add a new security group without purge (test idempotence)
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: present
-      vpc_security_group_ids:
-      - '{{ _result_create_sg.results.2.group_id }}'
-      apply_immediately: true
-      purge_security_groups: false
-    register: _result_create_db_cluster
+    - name: Add a new security group without purge (test idempotence)
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: present
+        vpc_security_group_ids:
+          - "{{ _result_create_sg.results.2.group_id }}"
+        apply_immediately: true
+        purge_security_groups: false
+      register: _result_create_db_cluster
 
-  - assert:
-      that:
-      - not _result_create_db_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_create_db_cluster.changed
 
-  - name: Add a security group with purge
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: present
-      vpc_security_group_ids:
-      - '{{ _result_create_sg .results.2.group_id }}'
-      apply_immediately: true
-    register: _result_create_db_cluster
+    - name: Add a security group with purge
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: present
+        vpc_security_group_ids:
+          - "{{ _result_create_sg .results.2.group_id }}"
+        apply_immediately: true
+      register: _result_create_db_cluster
 
-  - assert:
-      that:
-      - _result_create_db_cluster.changed
-      - _result_create_db_cluster.db_cluster_identifier == '{{ cluster_id }}'
-      - _result_create_db_cluster.vpc_security_groups | selectattr('status', 'in',
-        ['active', 'adding']) | list | length == 1
+    - ansible.builtin.assert:
+        that:
+          - _result_create_db_cluster.changed
+          - _result_create_db_cluster.db_cluster_identifier == '{{ cluster_id }}'
+          - _result_create_db_cluster.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 1
 
   always:
-  - name: Delete DB cluster without creating a final snapshot
-    rds_cluster:
-      state: absent
-      cluster_id: '{{ cluster_id }}'
-      skip_final_snapshot: true
-    ignore_errors: true
+    - name: Delete DB cluster without creating a final snapshot
+      rds_cluster:
+        state: absent
+        cluster_id: "{{ cluster_id }}"
+        skip_final_snapshot: true
+      ignore_errors: true
 
-  - name: Remove security groups
-    ec2_security_group:
-      name: '{{ item }}'
-      description: created by rds_cluster integration tests
-      state: absent
-    loop: '{{ security_groups }}'
+    - name: Remove security groups
+      ec2_security_group:
+        name: "{{ item }}"
+        description: created by rds_cluster integration tests
+        state: absent
+      loop: "{{ security_groups }}"
 
-  - name: Remove subnets
-    ec2_vpc_subnet:
-      cidr: '{{ item.cidr }}'
-      az: '{{ item.zone }}'
-      vpc_id: '{{ _result_create_vpc.vpc.id }}'
-      tags:
-        Name: '{{ resource_prefix }}-subnet'
-        Description: Created by rds_cluster integration tests
-      state: absent
-    ignore_errors: yes
-    loop: '{{ subnets }}'
+    - name: Remove subnets
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ item.cidr }}"
+        az: "{{ item.zone }}"
+        vpc_id: "{{ _result_create_vpc.vpc.id }}"
+        tags:
+          Name: "{{ resource_prefix }}-subnet"
+          Description: Created by rds_cluster integration tests
+        state: absent
+      ignore_errors: true
+      loop: "{{ subnets }}"
 
-  - name: Delete VPC
-    ec2_vpc_net:
-      name: '{{ vpc_name }}'
-      state: absent
-      cidr_block: '{{ vpc_cidr }}'
-      tags:
-        Name: '{{ vpc_name }}'
-        Description: Created by rds_cluster integration tests
-    ignore_errors: yes
+    - name: Delete VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ vpc_name }}"
+        state: absent
+        cidr_block: "{{ vpc_cidr }}"
+        tags:
+          Name: "{{ vpc_name }}"
+          Description: Created by rds_cluster integration tests
+      ignore_errors: true

--- a/tests/integration/targets/rds_cluster_modify/defaults/main.yml
+++ b/tests/integration/targets/rds_cluster_modify/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 # defaults file for rds_cluster
 
 # Create cluster

--- a/tests/integration/targets/rds_cluster_modify/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_modify/tasks/main.yaml
@@ -1,282 +1,277 @@
+---
 - module_defaults:
     group/aws:
-      region: '{{ aws_region }}'
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   block:
-
   # Disabled: Below tests require use of more than 1 region, not supported by CI at the moment
   # Tests have been ran, tested, and verified locally on us-west-2 (primary), eu-north-1 (replica)
   # - name: Run tests for testing remove cluster from global db
   #   import_tasks: remove_from_global_db.yaml
 
-  - name: Ensure the resource doesn't exist
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: absent
-      engine: '{{ engine}}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      skip_final_snapshot: true
-    register: _result_delete_db_cluster
+    - name: Ensure the resource doesn't exist
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: absent
+        engine: "{{ engine}}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        skip_final_snapshot: true
+      register: _result_delete_db_cluster
 
-  - assert:
-      that:
-      - not _result_delete_db_cluster.changed
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - not _result_delete_db_cluster.changed
+      ignore_errors: true
 
-  # Follow up to Aurora Serverless V2 release, we use an aurora-mysql to
-  # avoid the following error when we try to adjust the port:
-  # You currently can't modify EndpointPort with Aurora Serverless.
-  - name: Create an Aurora-MySQL DB cluster
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: present
-      engine: aurora-mysql
-      engine_mode: provisioned
-      username: '{{ username }}'
-      password: '{{ password }}'
-    register: _result_create_source_db_cluster
+    # Follow up to Aurora Serverless V2 release, we use an aurora-mysql to
+    # avoid the following error when we try to adjust the port:
+    # You currently can't modify EndpointPort with Aurora Serverless.
+    - name: Create an Aurora-MySQL DB cluster
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: present
+        engine: aurora-mysql
+        engine_mode: provisioned
+        username: "{{ username }}"
+        password: "{{ password }}"
+      register: _result_create_source_db_cluster
 
-  - assert:
-      that:
-      - _result_create_source_db_cluster.changed
-      - _result_create_source_db_cluster.changed
-      - "'allocated_storage' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.db_cluster_identifier == '{{ cluster_id }}'
-      - "'db_cluster_parameter_group' in _result_create_source_db_cluster"
-      - "'db_cluster_resource_id' in _result_create_source_db_cluster"
-      - "'endpoint' in _result_create_source_db_cluster"
-      - "'engine' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.engine == "aurora-mysql"
-      - "'engine_mode' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_create_source_db_cluster"
-      - "'master_username' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.master_username == username
-      - "'port' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.port == {{ port }}
-      - "'status' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.status == "available"
-      - "'tags' in _result_create_source_db_cluster"
-      - "'vpc_security_groups' in _result_create_source_db_cluster"
+    - ansible.builtin.assert:
+        that:
+          - _result_create_source_db_cluster.changed
+          - _result_create_source_db_cluster.changed
+          - "'allocated_storage' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.db_cluster_identifier == '{{ cluster_id }}'
+          - "'db_cluster_parameter_group' in _result_create_source_db_cluster"
+          - "'db_cluster_resource_id' in _result_create_source_db_cluster"
+          - "'endpoint' in _result_create_source_db_cluster"
+          - "'engine' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.engine == "aurora-mysql"
+          - "'engine_mode' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_create_source_db_cluster"
+          - "'master_username' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.master_username == username
+          - "'port' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.port == {{ port }}
+          - "'status' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.status == "available"
+          - "'tags' in _result_create_source_db_cluster"
+          - "'vpc_security_groups' in _result_create_source_db_cluster"
 
-  - name: Modify DB cluster password
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: present
-      password: '{{ new_password }}'
-      force_update_password: true
-      apply_immediately: true
-    register: _result_modify_password
+    - name: Modify DB cluster password
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: present
+        password: "{{ new_password }}"
+        force_update_password: true
+        apply_immediately: true
+      register: _result_modify_password
 
-  - assert:
-      that:
-      - _result_modify_password.changed
-      - "'allocated_storage' in _result_modify_password"
-      - _result_modify_password.allocated_storage == 1
-      - "'cluster_create_time' in _result_modify_password"
-      - _result_modify_password.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_modify_password"
-      - _result_modify_password.db_cluster_identifier == '{{ cluster_id }}'
-      - "'db_cluster_parameter_group' in _result_modify_password"
-      - "'db_cluster_resource_id' in _result_modify_password"
-      - "'endpoint' in _result_modify_password"
-      - "'engine' in _result_modify_password"
-      - _result_modify_password.engine == "aurora-mysql"
-      - "'engine_mode' in _result_modify_password"
-      - _result_modify_password.engine_mode == "provisioned"
-      - "'engine_version' in _result_modify_password"
-      - "'master_username' in _result_modify_password"
-      - _result_modify_password.master_username == username
-      - "'port' in _result_create_source_db_cluster"
-      - _result_modify_password.port == {{ port }}
-      - "'status' in _result_modify_password"
-      - _result_modify_password.status == "available"
-      - "'tags' in _result_modify_password"
-      - "'vpc_security_groups' in _result_modify_password"
+    - ansible.builtin.assert:
+        that:
+          - _result_modify_password.changed
+          - "'allocated_storage' in _result_modify_password"
+          - _result_modify_password.allocated_storage == 1
+          - "'cluster_create_time' in _result_modify_password"
+          - _result_modify_password.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_modify_password"
+          - _result_modify_password.db_cluster_identifier == '{{ cluster_id }}'
+          - "'db_cluster_parameter_group' in _result_modify_password"
+          - "'db_cluster_resource_id' in _result_modify_password"
+          - "'endpoint' in _result_modify_password"
+          - "'engine' in _result_modify_password"
+          - _result_modify_password.engine == "aurora-mysql"
+          - "'engine_mode' in _result_modify_password"
+          - _result_modify_password.engine_mode == "provisioned"
+          - "'engine_version' in _result_modify_password"
+          - "'master_username' in _result_modify_password"
+          - _result_modify_password.master_username == username
+          - "'port' in _result_create_source_db_cluster"
+          - _result_modify_password.port == {{ port }}
+          - "'status' in _result_modify_password"
+          - _result_modify_password.status == "available"
+          - "'tags' in _result_modify_password"
+          - "'vpc_security_groups' in _result_modify_password"
 
-  - name: Modify DB cluster port
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: present
-      port: '{{ new_port }}'
-    register: _result_modify_port
+    - name: Modify DB cluster port
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: present
+        port: "{{ new_port }}"
+      register: _result_modify_port
 
-  - assert:
-      that:
-      - _result_modify_port.changed
-      - "'allocated_storage' in _result_modify_port"
-      - _result_modify_port.allocated_storage == 1
-      - "'cluster_create_time' in _result_modify_port"
-      - _result_modify_port.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_modify_port"
-      - _result_modify_port.db_cluster_identifier == '{{ cluster_id }}'
-      - "'db_cluster_parameter_group' in _result_modify_port"
-      - "'db_cluster_resource_id' in _result_modify_port"
-      - "'endpoint' in _result_modify_port"
-      - "'engine' in _result_modify_port"
-      - _result_modify_port.engine == "aurora-mysql"
-      - "'engine_mode' in _result_modify_port"
-      - _result_modify_port.engine_mode == "provisioned"
-      - "'engine_version' in _result_modify_port"
-      - "'master_username' in _result_modify_port"
-      - _result_modify_port.master_username == username
-      - "'port' in _result_modify_port"
-      - _result_modify_port.port == {{ new_port }}
-      - "'status' in _result_modify_port"
-      - _result_modify_port.status == "available"
-      - "'tags' in _result_modify_port"
-      - "'vpc_security_groups' in _result_modify_port"
+    - ansible.builtin.assert:
+        that:
+          - _result_modify_port.changed
+          - "'allocated_storage' in _result_modify_port"
+          - _result_modify_port.allocated_storage == 1
+          - "'cluster_create_time' in _result_modify_port"
+          - _result_modify_port.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_modify_port"
+          - _result_modify_port.db_cluster_identifier == '{{ cluster_id }}'
+          - "'db_cluster_parameter_group' in _result_modify_port"
+          - "'db_cluster_resource_id' in _result_modify_port"
+          - "'endpoint' in _result_modify_port"
+          - "'engine' in _result_modify_port"
+          - _result_modify_port.engine == "aurora-mysql"
+          - "'engine_mode' in _result_modify_port"
+          - _result_modify_port.engine_mode == "provisioned"
+          - "'engine_version' in _result_modify_port"
+          - "'master_username' in _result_modify_port"
+          - _result_modify_port.master_username == username
+          - "'port' in _result_modify_port"
+          - _result_modify_port.port == {{ new_port }}
+          - "'status' in _result_modify_port"
+          - _result_modify_port.status == "available"
+          - "'tags' in _result_modify_port"
+          - "'vpc_security_groups' in _result_modify_port"
 
-  - name: Modify DB cluster identifier
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: present
-      purge_tags: false
-      new_cluster_id: '{{ new_cluster_id }}'
-      apply_immediately: true
-    register: _result_modify_id
+    - name: Modify DB cluster identifier
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: present
+        purge_tags: false
+        new_cluster_id: "{{ new_cluster_id }}"
+        apply_immediately: true
+      register: _result_modify_id
 
-  - assert:
-      that:
-      - _result_modify_id.changed
-      - "'allocated_storage' in _result_modify_id"
-      - _result_modify_id.allocated_storage == 1
-      - "'cluster_create_time' in _result_modify_id"
-      - _result_modify_id.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_modify_id"
-      - _result_modify_id.db_cluster_identifier == '{{ new_cluster_id }}'
-      - "'db_cluster_parameter_group' in _result_modify_id"
-      - "'db_cluster_resource_id' in _result_modify_id"
-      - "'endpoint' in _result_modify_id"
-      - "'engine' in _result_modify_id"
-      - _result_modify_id.engine == "aurora-mysql"
-      - "'engine_mode' in _result_modify_id"
-      - _result_modify_id.engine_mode == "provisioned"
-      - "'engine_version' in _result_modify_id"
-      - "'master_username' in _result_modify_id"
-      - _result_modify_id.master_username == username
-      - "'port' in _result_modify_id"
-      - _result_modify_id.port == {{ new_port }}
-      - "'status' in _result_modify_id"
-      - _result_modify_id.status == "available"
-      - "'tags' in _result_modify_id"
-      - "'vpc_security_groups' in _result_modify_id"
+    - ansible.builtin.assert:
+        that:
+          - _result_modify_id.changed
+          - "'allocated_storage' in _result_modify_id"
+          - _result_modify_id.allocated_storage == 1
+          - "'cluster_create_time' in _result_modify_id"
+          - _result_modify_id.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_modify_id"
+          - _result_modify_id.db_cluster_identifier == '{{ new_cluster_id }}'
+          - "'db_cluster_parameter_group' in _result_modify_id"
+          - "'db_cluster_resource_id' in _result_modify_id"
+          - "'endpoint' in _result_modify_id"
+          - "'engine' in _result_modify_id"
+          - _result_modify_id.engine == "aurora-mysql"
+          - "'engine_mode' in _result_modify_id"
+          - _result_modify_id.engine_mode == "provisioned"
+          - "'engine_version' in _result_modify_id"
+          - "'master_username' in _result_modify_id"
+          - _result_modify_id.master_username == username
+          - "'port' in _result_modify_id"
+          - _result_modify_id.port == {{ new_port }}
+          - "'status' in _result_modify_id"
+          - _result_modify_id.status == "available"
+          - "'tags' in _result_modify_id"
+          - "'vpc_security_groups' in _result_modify_id"
 
-  - name: Check if DB cluster parameter group exists
-    command: aws rds describe-db-cluster-parameter-groups --db-cluster-parameter-group-name
-      {{ new_db_parameter_group_name }}
-    environment:
-      AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
-      AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
-      AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
-      AWS_DEFAULT_REGION: '{{ aws_region }}'
-    register: _result_check_db_parameter_group
-    ignore_errors: true
-    changed_when: _result_check_db_parameter_group.rc == 0
+    - name: Check if DB cluster parameter group exists
+      ansible.builtin.command: aws rds describe-db-cluster-parameter-groups --db-cluster-parameter-group-name {{ new_db_parameter_group_name }}
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: _result_check_db_parameter_group
+      ignore_errors: true
+      changed_when: _result_check_db_parameter_group.rc == 0
 
-  - name: Create DB cluster parameter group if not exists
-    command: aws rds create-db-cluster-parameter-group --db-cluster-parameter-group-name
-      {{ new_db_parameter_group_name }} --db-parameter-group-family aurora-mysql8.0 --description
-      "Test DB cluster parameter group"
-    environment:
-      AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
-      AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
-      AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
-      AWS_DEFAULT_REGION: '{{ aws_region }}'
-    register: _result_create_db_parameter_group
-    when: _result_check_db_parameter_group.rc != 0
+    - name: Create DB cluster parameter group if not exists
+      ansible.builtin.command: aws rds create-db-cluster-parameter-group --db-cluster-parameter-group-name {{ new_db_parameter_group_name }} --db-parameter-group-family
+        aurora-mysql8.0 --description "Test DB cluster parameter group"
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      register: _result_create_db_parameter_group
+      when: _result_check_db_parameter_group.rc != 0
 
-  - name: Modify DB cluster parameter group
-    rds_cluster:
-      id: '{{ new_cluster_id }}'
-      state: present
-      db_cluster_parameter_group_name: '{{ new_db_parameter_group_name }}'
-      apply_immediately: true
-    register: _result_modify_db_parameter_group_name
+    - name: Modify DB cluster parameter group
+      rds_cluster:
+        id: "{{ new_cluster_id }}"
+        state: present
+        db_cluster_parameter_group_name: "{{ new_db_parameter_group_name }}"
+        apply_immediately: true
+      register: _result_modify_db_parameter_group_name
 
-  - assert:
-      that:
-      - _result_modify_db_parameter_group_name.changed
-      - "'allocated_storage' in _result_modify_db_parameter_group_name"
-      - _result_modify_db_parameter_group_name.allocated_storage == 1
-      - "'cluster_create_time' in _result_modify_db_parameter_group_name"
-      - _result_modify_db_parameter_group_name.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_modify_db_parameter_group_name"
-      - _result_modify_db_parameter_group_name.db_cluster_identifier == '{{ new_cluster_id
-        }}'
-      - "'db_cluster_parameter_group' in _result_modify_db_parameter_group_name"
-      - "'db_cluster_resource_id' in _result_modify_db_parameter_group_name"
-      - "'endpoint' in _result_modify_db_parameter_group_name"
-      - "'engine' in _result_modify_db_parameter_group_name"
-      - _result_modify_db_parameter_group_name.engine == "aurora-mysql"
-      - "'engine_mode' in _result_modify_db_parameter_group_name"
-      - _result_modify_db_parameter_group_name.engine_mode == "provisioned"
-      - "'engine_version' in _result_modify_db_parameter_group_name"
-      - "'master_username' in _result_modify_db_parameter_group_name"
-      - _result_modify_db_parameter_group_name.master_username == username
-      - "'port' in _result_modify_db_parameter_group_name"
-      - _result_modify_db_parameter_group_name.db_cluster_parameter_group == "{{ new_db_parameter_group_name
-        }}"
-      - "'status' in _result_modify_db_parameter_group_name"
-      - _result_modify_db_parameter_group_name.status == "available"
-      - "'tags' in _result_modify_db_parameter_group_name"
-      - "'vpc_security_groups' in _result_modify_db_parameter_group_name"
+    - ansible.builtin.assert:
+        that:
+          - _result_modify_db_parameter_group_name.changed
+          - "'allocated_storage' in _result_modify_db_parameter_group_name"
+          - _result_modify_db_parameter_group_name.allocated_storage == 1
+          - "'cluster_create_time' in _result_modify_db_parameter_group_name"
+          - _result_modify_db_parameter_group_name.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_modify_db_parameter_group_name"
+          - _result_modify_db_parameter_group_name.db_cluster_identifier == '{{ new_cluster_id }}'
+          - "'db_cluster_parameter_group' in _result_modify_db_parameter_group_name"
+          - "'db_cluster_resource_id' in _result_modify_db_parameter_group_name"
+          - "'endpoint' in _result_modify_db_parameter_group_name"
+          - "'engine' in _result_modify_db_parameter_group_name"
+          - _result_modify_db_parameter_group_name.engine == "aurora-mysql"
+          - "'engine_mode' in _result_modify_db_parameter_group_name"
+          - _result_modify_db_parameter_group_name.engine_mode == "provisioned"
+          - "'engine_version' in _result_modify_db_parameter_group_name"
+          - "'master_username' in _result_modify_db_parameter_group_name"
+          - _result_modify_db_parameter_group_name.master_username == username
+          - "'port' in _result_modify_db_parameter_group_name"
+          - _result_modify_db_parameter_group_name.db_cluster_parameter_group == "{{ new_db_parameter_group_name }}"
+          - "'status' in _result_modify_db_parameter_group_name"
+          - _result_modify_db_parameter_group_name.status == "available"
+          - "'tags' in _result_modify_db_parameter_group_name"
+          - "'vpc_security_groups' in _result_modify_db_parameter_group_name"
 
-  - name: Delete DB cluster without creating a final snapshot (CHECK MODE)
-    rds_cluster:
-      state: absent
-      cluster_id: '{{ new_cluster_id }}'
-      skip_final_snapshot: true
-    register: _result_delete_cluster
-    check_mode: true
+    - name: Delete DB cluster without creating a final snapshot (CHECK MODE)
+      rds_cluster:
+        state: absent
+        cluster_id: "{{ new_cluster_id }}"
+        skip_final_snapshot: true
+      register: _result_delete_cluster
+      check_mode: true
 
-  - assert:
-      that:
-      - _result_delete_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_delete_cluster.changed
 
-  - name: Delete DB cluster without creating a final snapshot
-    rds_cluster:
-      state: absent
-      cluster_id: '{{ new_cluster_id }}'
-      skip_final_snapshot: true
-    register: _result_delete_cluster
+    - name: Delete DB cluster without creating a final snapshot
+      rds_cluster:
+        state: absent
+        cluster_id: "{{ new_cluster_id }}"
+        skip_final_snapshot: true
+      register: _result_delete_cluster
 
-  - assert:
-      that:
-      - _result_delete_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_delete_cluster.changed
 
-  - name: Delete DB cluster without creating a final snapshot (idempotence)
-    rds_cluster:
-      state: absent
-      cluster_id: '{{ new_cluster_id }}'
-      skip_final_snapshot: true
-    register: _result_delete_cluster
+    - name: Delete DB cluster without creating a final snapshot (idempotence)
+      rds_cluster:
+        state: absent
+        cluster_id: "{{ new_cluster_id }}"
+        skip_final_snapshot: true
+      register: _result_delete_cluster
 
-  - assert:
-      that:
-      - not _result_delete_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_delete_cluster.changed
 
   always:
-  - name: Delete DB cluster without creating a final snapshot
-    rds_cluster:
-      state: absent
-      cluster_id: '{{ cluster_id }}'
-      skip_final_snapshot: true
-    ignore_errors: true
+    - name: Delete DB cluster without creating a final snapshot
+      rds_cluster:
+        state: absent
+        cluster_id: "{{ cluster_id }}"
+        skip_final_snapshot: true
+      ignore_errors: true
 
-  - name: Delete cluster parameter group
-    command: aws rds delete-db-cluster-parameter-group --db-cluster-parameter-group-name
-      {{ new_db_parameter_group_name }}
-    environment:
-      AWS_ACCESS_KEY_ID: '{{ aws_access_key }}'
-      AWS_SECRET_ACCESS_KEY: '{{ aws_secret_key }}'
-      AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
-      AWS_DEFAULT_REGION: '{{ aws_region }}'
-    ignore_errors: true
+    - name: Delete cluster parameter group
+      ansible.builtin.command: aws rds delete-db-cluster-parameter-group --db-cluster-parameter-group-name {{ new_db_parameter_group_name }}
+      environment:
+        AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
+        AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
+        AWS_SESSION_TOKEN: "{{ security_token | default('') }}"
+        AWS_DEFAULT_REGION: "{{ aws_region }}"
+      ignore_errors: true

--- a/tests/integration/targets/rds_cluster_modify/tasks/remove_from_global_db.yaml
+++ b/tests/integration/targets/rds_cluster_modify/tasks/remove_from_global_db.yaml
@@ -1,7 +1,6 @@
 ---
 - name: Run tests for testing remove cluster from global db
   block:
-
     # Create global db -------------------------------------------------------------------------------
 
     - name: Create rds global database
@@ -9,7 +8,7 @@
         global_cluster_identifier: "{{ test_global_cluster_name }}"
         engine: "{{ test_engine }}"
         engine_version: "{{ test_engine_version }}"
-        region:  "{{ test_primary_cluster_region }}"
+        region: "{{ test_primary_cluster_region }}"
         state: present
       register: create_global_result
 
@@ -41,7 +40,7 @@
       register: primary_cluster_info_result
 
     - name: Get global db info
-      command: 'aws rds describe-global-clusters --global-cluster-identifier {{ test_global_cluster_name }}'
+      ansible.builtin.command: aws rds describe-global-clusters --global-cluster-identifier {{ test_global_cluster_name }}
       environment:
         AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
         AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
@@ -50,11 +49,11 @@
       register: global_cluster_info_result
 
     - name: convert it to an object
-      set_fact:
+      ansible.builtin.set_fact:
         global_cluster_info: "{{ global_cluster_info_result.stdout | from_json }}"
 
     - name: Assert that primary cluster is a part of global db
-      assert:
+      ansible.builtin.assert:
         that:
           - global_cluster_info.GlobalClusters[0].GlobalClusterMembers[0].DBClusterArn == primary_cluster_info_result.clusters[0].db_cluster_arn
 
@@ -76,7 +75,7 @@
       register: replica_cluster_info_result
 
     - name: Get global db info
-      command: 'aws rds describe-global-clusters --global-cluster-identifier {{ test_global_cluster_name }}'
+      ansible.builtin.command: aws rds describe-global-clusters --global-cluster-identifier {{ test_global_cluster_name }}
       environment:
         AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
         AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
@@ -85,11 +84,11 @@
       register: global_cluster_info_result
 
     - name: convert it to an object
-      set_fact:
+      ansible.builtin.set_fact:
         global_cluster_info: "{{ global_cluster_info_result.stdout | from_json }}"
 
     - name: Assert that replica cluster is a part of global db
-      assert:
+      ansible.builtin.assert:
         that:
           - global_cluster_info.GlobalClusters[0].GlobalClusterMembers[1].DBClusterArn == replica_cluster_info_result.clusters[0].db_cluster_arn
 
@@ -106,7 +105,7 @@
       ignore_errors: true
 
     - name: Assert that deletion failed due to cluster being part of global db
-      assert:
+      ansible.builtin.assert:
         that:
           - delete_replica_cluster_result is failed
           - delete_replica_cluster_result is not changed
@@ -130,14 +129,14 @@
         region: "{{ test_replica_cluster_region }}"
       register: replica_cluster_info_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - modify_port_result is not failed
           - modify_port_result is changed
           - replica_cluster_info_result.clusters[0].port == 3389
 
     - name: Get global db info
-      command: 'aws rds describe-global-clusters --global-cluster-identifier {{ test_global_cluster_name }}'
+      ansible.builtin.command: aws rds describe-global-clusters --global-cluster-identifier {{ test_global_cluster_name }}
       environment:
         AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
         AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
@@ -146,11 +145,11 @@
       register: global_cluster_info_result
 
     - name: convert it to an object
-      set_fact:
+      ansible.builtin.set_fact:
         global_cluster_info: "{{ global_cluster_info_result.stdout | from_json }}"
 
     - name: Assert that replica cluster is NOT a part of global db
-      assert:
+      ansible.builtin.assert:
         that:
           - global_cluster_info.GlobalClusters[0].GlobalClusterMembers | length == 1
           - global_cluster_info.GlobalClusters[0].GlobalClusterMembers[0].DBClusterArn != replica_cluster_info_result.clusters[0].db_cluster_arn
@@ -167,7 +166,7 @@
       register: delete_replica_cluster_result
 
     - name: Assert that replica cluster deletion succeeded
-      assert:
+      ansible.builtin.assert:
         that:
           - delete_replica_cluster_result is not failed
           - delete_replica_cluster_result is changed
@@ -175,13 +174,13 @@
     # Test remove primary cluster from global db------------------------------------------------------------
     - name: Remove primary cluster from global db
       amazon.aws.rds_cluster:
-        global_cluster_identifier: '{{ test_global_cluster_name }}'
-        db_cluster_identifier: '{{ test_primary_cluster_name }}'
+        global_cluster_identifier: "{{ test_global_cluster_name }}"
+        db_cluster_identifier: "{{ test_primary_cluster_name }}"
         region: "{{ test_primary_cluster_region }}"
         remove_from_global_db: true
 
     - name: Get global db info
-      command: 'aws rds describe-global-clusters --global-cluster-identifier {{ test_global_cluster_name }}'
+      ansible.builtin.command: aws rds describe-global-clusters --global-cluster-identifier {{ test_global_cluster_name }}
       environment:
         AWS_ACCESS_KEY_ID: "{{ aws_access_key }}"
         AWS_SECRET_ACCESS_KEY: "{{ aws_secret_key }}"
@@ -190,13 +189,13 @@
       register: global_cluster_info_result
 
     - name: convert it to an object
-      set_fact:
+      ansible.builtin.set_fact:
         global_cluster_info: "{{ global_cluster_info_result.stdout | from_json }}"
 
     - name: Assert that primary cluster is NOT a part of global db
-      assert:
+      ansible.builtin.assert:
         that:
-           - global_cluster_info.GlobalClusters[0].GlobalClusterMembers | length == 0
+          - global_cluster_info.GlobalClusters[0].GlobalClusterMembers | length == 0
 
   # Cleanup starts------------------------------------------------------------
 
@@ -230,7 +229,7 @@
         username: "{{ username }}"
         password: "{{ password }}"
         skip_final_snapshot: true
-        region:  "{{ test_primary_cluster_region }}"
+        region: "{{ test_primary_cluster_region }}"
         state: absent
       ignore_errors: true
 

--- a/tests/integration/targets/rds_cluster_multi_az/defaults/main.yml
+++ b/tests/integration/targets/rds_cluster_multi_az/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 # Create cluster
 cluster_id: ansible-test-{{ tiny_prefix }}
 username: testrdsusername

--- a/tests/integration/targets/rds_cluster_multi_az/tasks/main.yml
+++ b/tests/integration/targets/rds_cluster_multi_az/tasks/main.yml
@@ -9,67 +9,66 @@
     - amazon.aws
 
   block:
-  - name: Ensure the resource doesn't exist
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: absent
-      engine: 'mysql'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      skip_final_snapshot: true
-    register: _result_delete_db_cluster
+    - name: Ensure the resource doesn't exist
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: absent
+        engine: mysql
+        username: "{{ username }}"
+        password: "{{ password }}"
+        skip_final_snapshot: true
+      register: _result_delete_db_cluster
 
-  - assert:
-      that:
-      - not _result_delete_db_cluster.changed
-    ignore_errors: true
+    - ansible.builtin.assert:
+        that:
+          - not _result_delete_db_cluster.changed
+      ignore_errors: true
 
-  - name: Create a source DB cluster (CHECK_MODE)
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: present
-      engine: 'mysql'
-      engine_version: 8.0.28
-      allocated_storage: 100
-      iops: 5000
-      db_cluster_instance_class: db.r6gd.xlarge
-      username: '{{ username }}'
-      password: '{{ password }}'
-      wait: true
-      tags: '{{ tags_create }}'
-    register: _result_create_source_db_cluster
-    check_mode: True
+    - name: Create a source DB cluster (CHECK_MODE)
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: present
+        engine: mysql
+        engine_version: 8.0.28
+        allocated_storage: 100
+        iops: 5000
+        db_cluster_instance_class: db.r6gd.xlarge
+        username: "{{ username }}"
+        password: "{{ password }}"
+        wait: true
+        tags: "{{ tags_create }}"
+      register: _result_create_source_db_cluster
+      check_mode: true
 
-  - assert:
-      that:
-      - _result_create_source_db_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_create_source_db_cluster.changed
 
-  - name: Create a source DB cluster
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: present
-      engine: 'mysql'
-      engine_version: 8.0.28
-      allocated_storage: 100
-      iops: 5000
-      db_cluster_instance_class: db.r6gd.xlarge
-      username: '{{ username }}'
-      password: '{{ password }}'
-      wait: true
-      tags: '{{ tags_create }}'
-    register: _result_create_source_db_cluster
+    - name: Create a source DB cluster
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: present
+        engine: mysql
+        engine_version: 8.0.28
+        allocated_storage: 100
+        iops: 5000
+        db_cluster_instance_class: db.r6gd.xlarge
+        username: "{{ username }}"
+        password: "{{ password }}"
+        wait: true
+        tags: "{{ tags_create }}"
+      register: _result_create_source_db_cluster
 
-  - assert:
-      that:
-      - _result_create_source_db_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_create_source_db_cluster.changed
 
   always:
-
-  - name: Delete DB cluster without creating a final snapshot
-    rds_cluster:
-      state: absent
-      cluster_id: '{{ item }}'
-      skip_final_snapshot: true
-    ignore_errors: true
-    loop:
-    - '{{ cluster_id }}'
+    - name: Delete DB cluster without creating a final snapshot
+      rds_cluster:
+        state: absent
+        cluster_id: "{{ item }}"
+        skip_final_snapshot: true
+      ignore_errors: true
+      loop:
+        - "{{ cluster_id }}"

--- a/tests/integration/targets/rds_cluster_promote/defaults/main.yml
+++ b/tests/integration/targets/rds_cluster_promote/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 # defaults file for rds_cluster
 
 # Create cluster

--- a/tests/integration/targets/rds_cluster_promote/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_promote/tasks/main.yaml
@@ -1,193 +1,192 @@
+---
 - module_defaults:
     group/aws:
-      region: '{{ aws_region }}'
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   block:
-  - name: Ensure the resource doesn't exist
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: absent
-      engine: '{{ engine}}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      skip_final_snapshot: true
-    register: _result_delete_db_cluster
+    - name: Ensure the resource doesn't exist
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: absent
+        engine: "{{ engine}}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        skip_final_snapshot: true
+      register: _result_delete_db_cluster
 
-  - assert:
-      that:
-      - not _result_delete_db_cluster.changed
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - not _result_delete_db_cluster.changed
+      ignore_errors: true
 
-  - name: Set the two regions for the source DB and the read replica
-    set_fact:
-      region_src: '{{ aws_region }}'
-      region_dest: '{{ aws_region }}'
+    - name: Set the two regions for the source DB and the read replica
+      ansible.builtin.set_fact:
+        region_src: "{{ aws_region }}"
+        region_dest: "{{ aws_region }}"
 
-  - name: Create a source DB cluster
-    rds_cluster:
-      cluster_id: '{{ cluster_id }}'
-      state: present
-      engine: '{{ engine}}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      region: '{{ region_src }}'
-      tags:
-        Name: '{{ cluster_id }}'
-        Created_by: Ansible rds_cluster tests
-    register: _result_create_src_db_cluster
+    - name: Create a source DB cluster
+      rds_cluster:
+        cluster_id: "{{ cluster_id }}"
+        state: present
+        engine: "{{ engine}}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        region: "{{ region_src }}"
+        tags:
+          Name: "{{ cluster_id }}"
+          Created_by: Ansible rds_cluster tests
+      register: _result_create_src_db_cluster
 
-  - assert:
-      that:
-      - _result_create_src_db_cluster.changed
-      - "'allocated_storage' in _result_create_src_db_cluster"
-      - _result_create_src_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_create_src_db_cluster"
-      - _result_create_src_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_create_src_db_cluster"
-      - _result_create_src_db_cluster.db_cluster_identifier == '{{ cluster_id }}'
-      - "'db_cluster_parameter_group' in _result_create_src_db_cluster"
-      - "'db_cluster_resource_id' in _result_create_src_db_cluster"
-      - "'endpoint' in _result_create_src_db_cluster"
-      - "'engine' in _result_create_src_db_cluster"
-      - _result_create_src_db_cluster.engine == engine
-      - "'engine_mode' in _result_create_src_db_cluster"
-      - _result_create_src_db_cluster.engine_mode == "serverless"
-      - "'engine_version' in _result_create_src_db_cluster"
-      - "'master_username' in _result_create_src_db_cluster"
-      - _result_create_src_db_cluster.master_username == username
-      - "'port' in _result_create_src_db_cluster"
-      - _result_create_src_db_cluster.port == {{ port }}
-      - "'status' in _result_create_src_db_cluster"
-      - _result_create_src_db_cluster.status == "available"
-      - "'tags' in _result_create_src_db_cluster"
-      - _result_create_src_db_cluster.tags | length == 2
-      - _result_create_src_db_cluster.tags.Name == '{{ cluster_id }}'
-      - _result_create_src_db_cluster.tags.Created_by == 'Ansible rds_cluster tests'
-      - "'vpc_security_groups' in _result_create_src_db_cluster"
+    - ansible.builtin.assert:
+        that:
+          - _result_create_src_db_cluster.changed
+          - "'allocated_storage' in _result_create_src_db_cluster"
+          - _result_create_src_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_create_src_db_cluster"
+          - _result_create_src_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_create_src_db_cluster"
+          - _result_create_src_db_cluster.db_cluster_identifier == '{{ cluster_id }}'
+          - "'db_cluster_parameter_group' in _result_create_src_db_cluster"
+          - "'db_cluster_resource_id' in _result_create_src_db_cluster"
+          - "'endpoint' in _result_create_src_db_cluster"
+          - "'engine' in _result_create_src_db_cluster"
+          - _result_create_src_db_cluster.engine == engine
+          - "'engine_mode' in _result_create_src_db_cluster"
+          - _result_create_src_db_cluster.engine_mode == "serverless"
+          - "'engine_version' in _result_create_src_db_cluster"
+          - "'master_username' in _result_create_src_db_cluster"
+          - _result_create_src_db_cluster.master_username == username
+          - "'port' in _result_create_src_db_cluster"
+          - _result_create_src_db_cluster.port == {{ port }}
+          - "'status' in _result_create_src_db_cluster"
+          - _result_create_src_db_cluster.status == "available"
+          - "'tags' in _result_create_src_db_cluster"
+          - _result_create_src_db_cluster.tags | length == 2
+          - _result_create_src_db_cluster.tags.Name == '{{ cluster_id }}'
+          - _result_create_src_db_cluster.tags.Created_by == 'Ansible rds_cluster tests'
+          - "'vpc_security_groups' in _result_create_src_db_cluster"
 
-  - name: Get info on DB cluster
-    rds_cluster_info:
-      db_cluster_identifier: '{{ cluster_id }}'
-    register: _result_cluster_info
+    - name: Get info on DB cluster
+      rds_cluster_info:
+        db_cluster_identifier: "{{ cluster_id }}"
+      register: _result_cluster_info
 
-  - assert:
-      that:
-      - _result_cluster_info is successful
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_info is successful
 
-  - name: Set the ARN of the source DB cluster
-    set_fact:
-      src_db_cluster_arn: '{{ _result_cluster_info.clusters[0].db_cluster_arn}}'
+    - name: Set the ARN of the source DB cluster
+      ansible.builtin.set_fact:
+        src_db_cluster_arn: "{{ _result_cluster_info.clusters[0].db_cluster_arn}}"
 
-  - name: Create a DB cluster read replica in a different region
-    rds_cluster:
-      id: '{{ cluster_id }}-replica'
-      state: present
-      replication_source_identifier: '{{ src_db_cluster_arn }}'
-      engine: '{{ engine}}'
-      region: '{{ region_dest }}'
-      tags:
-        Name: '{{ cluster_id }}'
-        Created_by: Ansible rds_cluster tests
-      wait: yes
-    register: _result_create_replica_db_cluster
+    - name: Create a DB cluster read replica in a different region
+      rds_cluster:
+        id: "{{ cluster_id }}-replica"
+        state: present
+        replication_source_identifier: "{{ src_db_cluster_arn }}"
+        engine: "{{ engine}}"
+        region: "{{ region_dest }}"
+        tags:
+          Name: "{{ cluster_id }}"
+          Created_by: Ansible rds_cluster tests
+        wait: true
+      register: _result_create_replica_db_cluster
 
-  - assert:
-      that:
-      - _result_create_replica_db_cluster.changed
-      - "'allocated_storage' in _result_create_replica_db_cluster"
-      - _result_create_replica_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_create_replica_db_cluster"
-      - _result_create_replica_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_create_replica_db_cluster"
-      - _result_create_replica_db_cluster.db_cluster_identifier == '{{ cluster_id
-        }}'
-      - "'db_cluster_parameter_group' in _result_create_replica_db_cluster"
-      - "'db_cluster_resource_id' in _result_create_replica_db_cluster"
-      - "'endpoint' in _result_create_replica_db_cluster"
-      - "'engine' in _result_create_replica_db_cluster"
-      - _result_create_replica_db_cluster.engine == engine
-      - "'engine_mode' in _result_create_replica_db_cluster"
-      - _result_create_replica_db_cluster.engine_mode == "serverless"
-      - "'engine_version' in _result_create_replica_db_cluster"
-      - "'master_username' in _result_create_replica_db_cluster"
-      - _result_create_replica_db_cluster.master_username == username
-      - "'port' in _result_create_replica_db_cluster"
-      - _result_create_replica_db_cluster.port == {{ port }}
-      - "'status' in _result_create_replica_db_cluster"
-      - _result_create_replica_db_cluster.status == "available"
-      - "'tags' in _result_create_replica_db_cluster"
-      - _result_create_replica_db_cluster.tags | length == 2
-      - _result_create_replica_db_cluster.tags.Name == '{{ cluster_id }}'
-      - _result_create_replica_db_cluster.tags.Created_by == 'Ansible rds_cluster
-        tests'
-      - "'vpc_security_groups' in _result_create_replica_db_cluster"
+    - ansible.builtin.assert:
+        that:
+          - _result_create_replica_db_cluster.changed
+          - "'allocated_storage' in _result_create_replica_db_cluster"
+          - _result_create_replica_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_create_replica_db_cluster"
+          - _result_create_replica_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_create_replica_db_cluster"
+          - _result_create_replica_db_cluster.db_cluster_identifier == '{{ cluster_id }}'
+          - "'db_cluster_parameter_group' in _result_create_replica_db_cluster"
+          - "'db_cluster_resource_id' in _result_create_replica_db_cluster"
+          - "'endpoint' in _result_create_replica_db_cluster"
+          - "'engine' in _result_create_replica_db_cluster"
+          - _result_create_replica_db_cluster.engine == engine
+          - "'engine_mode' in _result_create_replica_db_cluster"
+          - _result_create_replica_db_cluster.engine_mode == "serverless"
+          - "'engine_version' in _result_create_replica_db_cluster"
+          - "'master_username' in _result_create_replica_db_cluster"
+          - _result_create_replica_db_cluster.master_username == username
+          - "'port' in _result_create_replica_db_cluster"
+          - _result_create_replica_db_cluster.port == {{ port }}
+          - "'status' in _result_create_replica_db_cluster"
+          - _result_create_replica_db_cluster.status == "available"
+          - "'tags' in _result_create_replica_db_cluster"
+          - _result_create_replica_db_cluster.tags | length == 2
+          - _result_create_replica_db_cluster.tags.Name == '{{ cluster_id }}'
+          - _result_create_replica_db_cluster.tags.Created_by == 'Ansible rds_cluster tests'
+          - "'vpc_security_groups' in _result_create_replica_db_cluster"
 
-  - name: Test idempotence with a DB cluster read replica
-    rds_cluster:
-      id: '{{ cluster_id }}-replica'
-      state: present
-      replication_source_identifier: '{{ src_db_cluster_arn }}'
-      engine: '{{ engine}}'
-      region: '{{ region_dest }}'
-      tags:
-        Name: '{{ cluster_id }}'
-        Created_by: Ansible rds_cluster tests
-    register: _result_create_replica_db_cluster
+    - name: Test idempotence with a DB cluster read replica
+      rds_cluster:
+        id: "{{ cluster_id }}-replica"
+        state: present
+        replication_source_identifier: "{{ src_db_cluster_arn }}"
+        engine: "{{ engine}}"
+        region: "{{ region_dest }}"
+        tags:
+          Name: "{{ cluster_id }}"
+          Created_by: Ansible rds_cluster tests
+      register: _result_create_replica_db_cluster
 
-  - assert:
-      that:
-      - not _result_create_replica_db_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_create_replica_db_cluster.changed
 
-  - name: Get info of existing DB cluster
-    rds_cluster_info:
-      db_cluster_identifier: '{{ cluster_id }}-replica'
-      region: '{{ region_dest }}'
-    register: _result_cluster_info
+    - name: Get info of existing DB cluster
+      rds_cluster_info:
+        db_cluster_identifier: "{{ cluster_id }}-replica"
+        region: "{{ region_dest }}"
+      register: _result_cluster_info
 
-  - assert:
-      that:
-      - _result_cluster_info is successful
-      # - _result_cluster_info.clusters | length == 0
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_info is successful
+    # - _result_cluster_info.clusters | length == 0
 
-  - name: Promote the DB cluster read replica
-    rds_cluster:
-      cluster_id: '{{ cluster_id }}-replica'
-      state: present
-      promote: true
-      region: '{{ region_dest }}'
-    register: _result_promote_replica_db_cluster
+    - name: Promote the DB cluster read replica
+      rds_cluster:
+        cluster_id: "{{ cluster_id }}-replica"
+        state: present
+        promote: true
+        region: "{{ region_dest }}"
+      register: _result_promote_replica_db_cluster
 
-  - assert:
-      that:
-      - _result_promote_replica_db_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_promote_replica_db_cluster.changed
 
-  - name: Promote the DB cluster read replica (idempotence)
-    rds_cluster:
-      cluster_id: '{{ cluster_id }}-replica'
-      state: present
-      promote: true
-      region: '{{ region_dest }}'
-    register: _result_promote_replica_db_cluster
+    - name: Promote the DB cluster read replica (idempotence)
+      rds_cluster:
+        cluster_id: "{{ cluster_id }}-replica"
+        state: present
+        promote: true
+        region: "{{ region_dest }}"
+      register: _result_promote_replica_db_cluster
 
-  - assert:
-      that:
-      - not _result_promote_replica_db_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_promote_replica_db_cluster.changed
 
   always:
-  - name: Remove the DB cluster
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: absent
-      skip_final_snapshot: true
-      region: '{{ region_src }}'
-    ignore_errors: yes
+    - name: Remove the DB cluster
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: absent
+        skip_final_snapshot: true
+        region: "{{ region_src }}"
+      ignore_errors: true
 
-  - name: Remove the DB cluster read replica
-    rds_cluster:
-      id: '{{ cluster_id }}-replica'
-      state: absent
-      skip_final_snapshot: true
-      region: '{{ region_dest }}'
-    ignore_errors: yes
+    - name: Remove the DB cluster read replica
+      rds_cluster:
+        id: "{{ cluster_id }}-replica"
+        state: absent
+        skip_final_snapshot: true
+        region: "{{ region_dest }}"
+      ignore_errors: true

--- a/tests/integration/targets/rds_cluster_restore/defaults/main.yml
+++ b/tests/integration/targets/rds_cluster_restore/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 # defaults file for rds_cluster
 
 # Create cluster

--- a/tests/integration/targets/rds_cluster_restore/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_restore/tasks/main.yaml
@@ -1,191 +1,192 @@
+---
 - module_defaults:
     group/aws:
-      region: '{{ aws_region }}'
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   block:
-  - name: Ensure the resource doesn't exist
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: absent
-      engine: '{{ engine}}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      skip_final_snapshot: true
-    register: _result_delete_db_cluster
+    - name: Ensure the resource doesn't exist
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: absent
+        engine: "{{ engine}}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        skip_final_snapshot: true
+      register: _result_delete_db_cluster
 
-  - assert:
-      that:
-      - not _result_delete_db_cluster.changed
-    ignore_errors: true
+    - ansible.builtin.assert:
+        that:
+          - not _result_delete_db_cluster.changed
+      ignore_errors: true
 
-  - name: Create a source DB cluster
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: present
-      engine: '{{ engine}}'
-      backup_retention_period: 1
-      username: '{{ username }}'
-      password: '{{ password }}'
-      wait: true
-    register: _result_create_source_db_cluster
+    - name: Create a source DB cluster
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: present
+        engine: "{{ engine}}"
+        backup_retention_period: 1
+        username: "{{ username }}"
+        password: "{{ password }}"
+        wait: true
+      register: _result_create_source_db_cluster
 
-  - assert:
-      that:
-      - _result_create_source_db_cluster.changed
-      - "'allocated_storage' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_create_source_db_cluster"
-      - "'db_cluster_identifier' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.db_cluster_identifier == cluster_id
-      - "'db_cluster_parameter_group' in _result_create_source_db_cluster"
-      - "'db_cluster_resource_id' in _result_create_source_db_cluster"
-      - "'endpoint' in _result_create_source_db_cluster"
-      - "'engine' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.engine == engine
-      - "'engine_mode' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_create_source_db_cluster"
-      - "'master_username' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.master_username == username
-      - "'port' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.port == {{ port }}
-      - "'status' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.status == 'available'
-      - _result_create_source_db_cluster.storage_encrypted == false
-      - "'tags' in _result_create_source_db_cluster"
-      - "'vpc_security_groups' in _result_create_source_db_cluster"
+    - ansible.builtin.assert:
+        that:
+          - _result_create_source_db_cluster.changed
+          - "'allocated_storage' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_create_source_db_cluster"
+          - "'db_cluster_identifier' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.db_cluster_identifier == cluster_id
+          - "'db_cluster_parameter_group' in _result_create_source_db_cluster"
+          - "'db_cluster_resource_id' in _result_create_source_db_cluster"
+          - "'endpoint' in _result_create_source_db_cluster"
+          - "'engine' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.engine == engine
+          - "'engine_mode' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_create_source_db_cluster"
+          - "'master_username' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.master_username == username
+          - "'port' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.port == {{ port }}
+          - "'status' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.status == 'available'
+          - _result_create_source_db_cluster.storage_encrypted == false
+          - "'tags' in _result_create_source_db_cluster"
+          - "'vpc_security_groups' in _result_create_source_db_cluster"
 
-  - name: Create a point in time DB cluster
-    rds_cluster:
-      state: present
-      id: '{{ cluster_id }}-point-in-time'
-      source_db_cluster_identifier: '{{ cluster_id }}'
-      creation_source: cluster
-      engine: '{{ engine}}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      use_latest_restorable_time: true
-      tags:
-        Name: '{{ cluster_id }}'
-        Created_by: Ansible rds_cluster tests
-    register: _result_restored_db_cluster
+    - name: Create a point in time DB cluster
+      rds_cluster:
+        state: present
+        id: "{{ cluster_id }}-point-in-time"
+        source_db_cluster_identifier: "{{ cluster_id }}"
+        creation_source: cluster
+        engine: "{{ engine}}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        use_latest_restorable_time: true
+        tags:
+          Name: "{{ cluster_id }}"
+          Created_by: Ansible rds_cluster tests
+      register: _result_restored_db_cluster
 
-  - assert:
-      that:
-      - _result_restored_db_cluster.changed
-      - "'allocated_storage' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.db_cluster_identifier == '{{ cluster_id }}-point-in-time'
-      - "'db_cluster_parameter_group' in _result_restored_db_cluster"
-      - "'db_cluster_resource_id' in _result_restored_db_cluster"
-      - "'endpoint' in _result_restored_db_cluster"
-      - "'engine' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.engine == engine
-      - "'engine_mode' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_restored_db_cluster"
-      - "'master_username' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.master_username == username
-      - "'port' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.port == {{ port }}
-      - "'status' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.status == "available"
-      - "'tags' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.tags | length == 2
-      - _result_restored_db_cluster.tags.Name == '{{ cluster_id }}'
-      - _result_restored_db_cluster.tags.Created_by == 'Ansible rds_cluster tests'
-      - "'vpc_security_groups' in _result_restored_db_cluster"
+    - ansible.builtin.assert:
+        that:
+          - _result_restored_db_cluster.changed
+          - "'allocated_storage' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.db_cluster_identifier == '{{ cluster_id }}-point-in-time'
+          - "'db_cluster_parameter_group' in _result_restored_db_cluster"
+          - "'db_cluster_resource_id' in _result_restored_db_cluster"
+          - "'endpoint' in _result_restored_db_cluster"
+          - "'engine' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.engine == engine
+          - "'engine_mode' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_restored_db_cluster"
+          - "'master_username' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.master_username == username
+          - "'port' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.port == {{ port }}
+          - "'status' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.status == "available"
+          - "'tags' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.tags | length == 2
+          - _result_restored_db_cluster.tags.Name == '{{ cluster_id }}'
+          - _result_restored_db_cluster.tags.Created_by == 'Ansible rds_cluster tests'
+          - "'vpc_security_groups' in _result_restored_db_cluster"
 
-  - name: Create a point in time DB cluster (idempotence)
-    rds_cluster:
-      state: present
-      id: '{{ cluster_id }}-point-in-time'
-      source_db_cluster_identifier: '{{ cluster_id }}'
-      creation_source: cluster
-      engine: '{{ engine}}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      restore_to_time: '{{ _result_restored_db_cluster.latest_restorable_time }}'
-      tags:
-        Name: '{{ cluster_id }}'
-        Created_by: Ansible rds_cluster tests
-    register: _result_restored_db_cluster
+    - name: Create a point in time DB cluster (idempotence)
+      rds_cluster:
+        state: present
+        id: "{{ cluster_id }}-point-in-time"
+        source_db_cluster_identifier: "{{ cluster_id }}"
+        creation_source: cluster
+        engine: "{{ engine}}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        restore_to_time: "{{ _result_restored_db_cluster.latest_restorable_time }}"
+        tags:
+          Name: "{{ cluster_id }}"
+          Created_by: Ansible rds_cluster tests
+      register: _result_restored_db_cluster
 
-  - assert:
-      that:
-      - not _result_restored_db_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_restored_db_cluster.changed
 
-  - name: Take a snapshot of the DB cluster
-    rds_cluster_snapshot:
-      state: present
-      db_cluster_identifier: '{{ cluster_id }}'
-      db_cluster_snapshot_identifier: '{{ cluster_id }}-snapshot'
-      wait: true
-    register: _result_cluster_snapshot
+    - name: Take a snapshot of the DB cluster
+      rds_cluster_snapshot:
+        state: present
+        db_cluster_identifier: "{{ cluster_id }}"
+        db_cluster_snapshot_identifier: "{{ cluster_id }}-snapshot"
+        wait: true
+      register: _result_cluster_snapshot
 
-  - assert:
-      that:
-      - _result_cluster_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_snapshot.changed
 
-  - name: Restore DB cluster from source (snapshot)
-    rds_cluster:
-      creation_source: snapshot
-      engine: '{{ engine }}'
-      cluster_id: '{{ cluster_id }}-restored-snapshot'
-      snapshot_identifier: '{{ cluster_id }}-snapshot'
-      wait: true
-    register: _result_restored_db_cluster
+    - name: Restore DB cluster from source (snapshot)
+      rds_cluster:
+        creation_source: snapshot
+        engine: "{{ engine }}"
+        cluster_id: "{{ cluster_id }}-restored-snapshot"
+        snapshot_identifier: "{{ cluster_id }}-snapshot"
+        wait: true
+      register: _result_restored_db_cluster
 
-  - assert:
-      that:
-      - _result_restored_db_cluster.changed
-      - "'allocated_storage' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.db_cluster_identifier == '{{ cluster_id }}-restored-snapshot'
-      - "'db_cluster_parameter_group' in _result_restored_db_cluster"
-      - "'db_cluster_resource_id' in _result_restored_db_cluster"
-      - "'endpoint' in _result_restored_db_cluster"
-      - "'engine' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.engine == engine
-      - "'engine_mode' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_restored_db_cluster"
-      - "'master_username' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.master_username == username
-      - "'port' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.port == {{ port }}
-      - "'status' in _result_restored_db_cluster"
-      - _result_restored_db_cluster.status == "available"
-      - "'tags' in _result_restored_db_cluster"
-      - "'vpc_security_groups' in _result_restored_db_cluster"
+    - ansible.builtin.assert:
+        that:
+          - _result_restored_db_cluster.changed
+          - "'allocated_storage' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.db_cluster_identifier == '{{ cluster_id }}-restored-snapshot'
+          - "'db_cluster_parameter_group' in _result_restored_db_cluster"
+          - "'db_cluster_resource_id' in _result_restored_db_cluster"
+          - "'endpoint' in _result_restored_db_cluster"
+          - "'engine' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.engine == engine
+          - "'engine_mode' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_restored_db_cluster"
+          - "'master_username' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.master_username == username
+          - "'port' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.port == {{ port }}
+          - "'status' in _result_restored_db_cluster"
+          - _result_restored_db_cluster.status == "available"
+          - "'tags' in _result_restored_db_cluster"
+          - "'vpc_security_groups' in _result_restored_db_cluster"
 
   # TODO: export a snapshot to an S3 bucket and restore cluster from it
   # Requires rds_export_task module
   always:
-  - name: Delete the snapshot
-    rds_cluster_snapshot:
-      db_cluster_snapshot_identifier: '{{ cluster_id }}-snapshot'
-      state: absent
-    register: _result_delete_snapshot
-    ignore_errors: true
+    - name: Delete the snapshot
+      rds_cluster_snapshot:
+        db_cluster_snapshot_identifier: "{{ cluster_id }}-snapshot"
+        state: absent
+      register: _result_delete_snapshot
+      ignore_errors: true
 
-  - name: Delete DB cluster without creating a final snapshot
-    rds_cluster:
-      state: absent
-      cluster_id: '{{ item }}'
-      skip_final_snapshot: true
-    ignore_errors: true
-    loop:
-    - '{{ cluster_id }}'
-    - '{{ cluster_id }}-point-in-time'
-    - '{{ cluster_id }}-restored-snapshot'
+    - name: Delete DB cluster without creating a final snapshot
+      rds_cluster:
+        state: absent
+        cluster_id: "{{ item }}"
+        skip_final_snapshot: true
+      ignore_errors: true
+      loop:
+        - "{{ cluster_id }}"
+        - "{{ cluster_id }}-point-in-time"
+        - "{{ cluster_id }}-restored-snapshot"

--- a/tests/integration/targets/rds_cluster_snapshot/defaults/main.yml
+++ b/tests/integration/targets/rds_cluster_snapshot/defaults/main.yml
@@ -1,13 +1,13 @@
 ---
 # defaults file for rds_cluster_snapshot
-_resource_prefix: 'ansible-test-{{ tiny_prefix }}'
+_resource_prefix: ansible-test-{{ tiny_prefix }}
 
 # Create RDS cluster
-cluster_id: '{{ _resource_prefix }}-rds-cluster'
-username: 'testrdsusername'
+cluster_id: "{{ _resource_prefix }}-rds-cluster"
+username: testrdsusername
 password: "{{ lookup('password', 'dev/null length=12 chars=ascii_letters,digits') }}"
 engine: aurora-mysql
 port: 3306
 
 # Create snapshot
-snapshot_id: '{{ _resource_prefix }}-rds-cluster-snapshot'
+snapshot_id: "{{ _resource_prefix }}-rds-cluster-snapshot"

--- a/tests/integration/targets/rds_cluster_snapshot/tasks/main.yml
+++ b/tests/integration/targets/rds_cluster_snapshot/tasks/main.yml
@@ -8,472 +8,472 @@
   collections:
     - amazon.aws
   block:
-  - name: Create a source DB cluster
-    rds_cluster:
-      id: "{{ cluster_id }}"
-      state: present
-      engine: "{{ engine}}"
-      backup_retention_period: 1
-      username: "{{ username }}"
-      password: "{{ password }}"
-      preferred_backup_window: "01:15-01:45"
-    register: _result_create_source_db_cluster
+    - name: Create a source DB cluster
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: present
+        engine: "{{ engine}}"
+        backup_retention_period: 1
+        username: "{{ username }}"
+        password: "{{ password }}"
+        preferred_backup_window: "01:15-01:45"
+      register: _result_create_source_db_cluster
 
-  - assert:
-      that:
-      - _result_create_source_db_cluster.changed
-      - "'allocated_storage' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.db_cluster_identifier == cluster_id
-      - "'db_cluster_parameter_group' in _result_create_source_db_cluster"
-      - "'db_cluster_resource_id' in _result_create_source_db_cluster"
-      - "'endpoint' in _result_create_source_db_cluster"
-      - "'engine' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.engine == engine
-      - "'engine_mode' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_create_source_db_cluster"
-      - "'master_username' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.master_username == username
-      - "'port' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.port == port
-      - "'status' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.status == "available"
-      - "'tags' in _result_create_source_db_cluster"
-      - "'vpc_security_groups' in _result_create_source_db_cluster"
+    - ansible.builtin.assert:
+        that:
+          - _result_create_source_db_cluster.changed
+          - "'allocated_storage' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.db_cluster_identifier == cluster_id
+          - "'db_cluster_parameter_group' in _result_create_source_db_cluster"
+          - "'db_cluster_resource_id' in _result_create_source_db_cluster"
+          - "'endpoint' in _result_create_source_db_cluster"
+          - "'engine' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.engine == engine
+          - "'engine_mode' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_create_source_db_cluster"
+          - "'master_username' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.master_username == username
+          - "'port' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.port == port
+          - "'status' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.status == "available"
+          - "'tags' in _result_create_source_db_cluster"
+          - "'vpc_security_groups' in _result_create_source_db_cluster"
 
-  - name: Get all RDS snapshots for the existing DB cluster
-    rds_snapshot_info:
-      db_cluster_identifier: "{{ cluster_id }}"
-    register: _result_cluster_snapshot_info
+    - name: Get all RDS snapshots for the existing DB cluster
+      amazon.aws.rds_snapshot_info:
+        db_cluster_identifier: "{{ cluster_id }}"
+      register: _result_cluster_snapshot_info
 
-  - assert:
-      that:
-      - _result_cluster_snapshot_info is successful
-      - _result_cluster_snapshot_info.cluster_snapshots | length == 0
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_snapshot_info is successful
+          - _result_cluster_snapshot_info.cluster_snapshots | length == 0
 
-  - name: Take a snapshot of the existing DB cluster (CHECK_MODE)
-    rds_cluster_snapshot:
-      state: present
-      db_cluster_identifier: "{{ cluster_id }}"
-      db_cluster_snapshot_identifier: "{{ snapshot_id }}"
-    check_mode: true
-    register: _result_cluster_snapshot
+    - name: Take a snapshot of the existing DB cluster (CHECK_MODE)
+      rds_cluster_snapshot:
+        state: present
+        db_cluster_identifier: "{{ cluster_id }}"
+        db_cluster_snapshot_identifier: "{{ snapshot_id }}"
+      check_mode: true
+      register: _result_cluster_snapshot
 
-  - assert:
-      that:
-      - _result_cluster_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_snapshot.changed
 
-  - name: Take a snapshot of the existing DB cluster
-    rds_cluster_snapshot:
-      state: present
-      db_cluster_identifier: "{{ cluster_id }}"
-      db_cluster_snapshot_identifier: "{{ snapshot_id }}"
-      wait: true
-    register: _result_cluster_snapshot
+    - name: Take a snapshot of the existing DB cluster
+      rds_cluster_snapshot:
+        state: present
+        db_cluster_identifier: "{{ cluster_id }}"
+        db_cluster_snapshot_identifier: "{{ snapshot_id }}"
+        wait: true
+      register: _result_cluster_snapshot
 
-  - assert:
-      that:
-      - _result_cluster_snapshot.changed
-      - "'allocated_storage' in _result_cluster_snapshot"
-      - "'cluster_create_time' in _result_cluster_snapshot"
-      - "'db_cluster_identifier' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.db_cluster_identifier == cluster_id
-      - "'db_cluster_snapshot_identifier' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.db_cluster_snapshot_identifier == snapshot_id
-      - "'db_cluster_snapshot_arn' in _result_cluster_snapshot"
-      - "'engine' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.engine == engine
-      # - "'engine_mode' in _result_cluster_snapshot"
-      # - _result_cluster_snapshot.engine_mode == "serverless"
-      - "'engine_version' in _result_cluster_snapshot"
-      - "'iam_database_authentication_enabled' in _result_cluster_snapshot"
-      - "'license_model' in _result_cluster_snapshot"
-      - "'master_username' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.master_username == username
-      - "'snapshot_create_time' in _result_cluster_snapshot"
-      - "'snapshot_type' in _result_cluster_snapshot"
-      - "'status' in _result_cluster_snapshot"
-      - _result_create_source_db_cluster.status == "available"
-      - "'storage_encrypted' in _result_cluster_snapshot"
-      - "'tags' in _result_cluster_snapshot"
-      - "'vpc_id' in _result_cluster_snapshot"
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_snapshot.changed
+          - "'allocated_storage' in _result_cluster_snapshot"
+          - "'cluster_create_time' in _result_cluster_snapshot"
+          - "'db_cluster_identifier' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.db_cluster_identifier == cluster_id
+          - "'db_cluster_snapshot_identifier' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.db_cluster_snapshot_identifier == snapshot_id
+          - "'db_cluster_snapshot_arn' in _result_cluster_snapshot"
+          - "'engine' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.engine == engine
+          # - "'engine_mode' in _result_cluster_snapshot"
+          # - _result_cluster_snapshot.engine_mode == "serverless"
+          - "'engine_version' in _result_cluster_snapshot"
+          - "'iam_database_authentication_enabled' in _result_cluster_snapshot"
+          - "'license_model' in _result_cluster_snapshot"
+          - "'master_username' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.master_username == username
+          - "'snapshot_create_time' in _result_cluster_snapshot"
+          - "'snapshot_type' in _result_cluster_snapshot"
+          - "'status' in _result_cluster_snapshot"
+          - _result_create_source_db_cluster.status == "available"
+          - "'storage_encrypted' in _result_cluster_snapshot"
+          - "'tags' in _result_cluster_snapshot"
+          - "'vpc_id' in _result_cluster_snapshot"
 
-  - name: Get information about the existing DB snapshot
-    rds_snapshot_info:
-      db_cluster_snapshot_identifier: "{{ snapshot_id }}"
-    register: _result_cluster_snapshot_info
+    - name: Get information about the existing DB snapshot
+      amazon.aws.rds_snapshot_info:
+        db_cluster_snapshot_identifier: "{{ snapshot_id }}"
+      register: _result_cluster_snapshot_info
 
-  - assert:
-      that:
-      - _result_cluster_snapshot_info is successful
-      - _result_cluster_snapshot_info.cluster_snapshots[0].db_cluster_identifier == cluster_id
-      - _result_cluster_snapshot_info.cluster_snapshots[0].db_cluster_snapshot_identifier == snapshot_id
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_snapshot_info is successful
+          - _result_cluster_snapshot_info.cluster_snapshots[0].db_cluster_identifier == cluster_id
+          - _result_cluster_snapshot_info.cluster_snapshots[0].db_cluster_snapshot_identifier == snapshot_id
 
-  - name: Get info of the existing DB cluster
-    rds_cluster_info:
-      cluster_id: "{{ cluster_id }}"
-    register: result_cluster_info
+    - name: Get info of the existing DB cluster
+      rds_cluster_info:
+        cluster_id: "{{ cluster_id }}"
+      register: result_cluster_info
 
-  - assert:
-      that:
-      - result_cluster_info is successful
+    - ansible.builtin.assert:
+        that:
+          - result_cluster_info is successful
 
-  - name: Create another source DB cluster
-    rds_cluster:
-      id: "{{ cluster_id }}-b"
-      state: present
-      engine: "{{ engine}}"
-      backup_retention_period: 1
-      username: "{{ username }}"
-      password: "{{ password }}"
-      preferred_backup_window: "01:15-01:45"
-    register: _result_create_source_db_cluster
+    - name: Create another source DB cluster
+      rds_cluster:
+        id: "{{ cluster_id }}-b"
+        state: present
+        engine: "{{ engine}}"
+        backup_retention_period: 1
+        username: "{{ username }}"
+        password: "{{ password }}"
+        preferred_backup_window: "01:15-01:45"
+      register: _result_create_source_db_cluster
 
-  - assert:
-      that:
-      - _result_create_source_db_cluster.changed
-      - "'allocated_storage' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.db_cluster_identifier == "{{ cluster_id }}-b"
-      - "'db_cluster_parameter_group' in _result_create_source_db_cluster"
-      - "'db_cluster_resource_id' in _result_create_source_db_cluster"
-      - "'endpoint' in _result_create_source_db_cluster"
-      - "'engine' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.engine == engine
-      - "'engine_mode' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_create_source_db_cluster"
-      - "'master_username' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.master_username == username
-      - "'port' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.port == port
-      - "'status' in _result_create_source_db_cluster"
-      - _result_create_source_db_cluster.status == "available"
-      - "'tags' in _result_create_source_db_cluster"
-      - "'vpc_security_groups' in _result_create_source_db_cluster"
+    - ansible.builtin.assert:
+        that:
+          - _result_create_source_db_cluster.changed
+          - "'allocated_storage' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.db_cluster_identifier == "{{ cluster_id }}-b"
+          - "'db_cluster_parameter_group' in _result_create_source_db_cluster"
+          - "'db_cluster_resource_id' in _result_create_source_db_cluster"
+          - "'endpoint' in _result_create_source_db_cluster"
+          - "'engine' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.engine == engine
+          - "'engine_mode' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_create_source_db_cluster"
+          - "'master_username' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.master_username == username
+          - "'port' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.port == port
+          - "'status' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.status == "available"
+          - "'tags' in _result_create_source_db_cluster"
+          - "'vpc_security_groups' in _result_create_source_db_cluster"
 
-  - name: Take another snapshot of the existing DB cluster
-    rds_cluster_snapshot:
-      state: present
-      db_cluster_identifier: "{{ cluster_id }}-b"
-      db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
-      wait: true
-    register: _result_cluster_snapshot
+    - name: Take another snapshot of the existing DB cluster
+      rds_cluster_snapshot:
+        state: present
+        db_cluster_identifier: "{{ cluster_id }}-b"
+        db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
+        wait: true
+      register: _result_cluster_snapshot
 
-  - assert:
-      that:
-      - _result_cluster_snapshot.changed
-      - "'allocated_storage' in _result_cluster_snapshot"
-      - "'cluster_create_time' in _result_cluster_snapshot"
-      - "'db_cluster_identifier' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.db_cluster_identifier == "{{ cluster_id }}-b"
-      - "'db_cluster_snapshot_identifier' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.db_cluster_snapshot_identifier == "{{ snapshot_id }}-b"
-      - "'db_cluster_snapshot_arn' in _result_cluster_snapshot"
-      - "'engine' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.engine == engine
-      # - "'engine_mode' in _result_cluster_snapshot"
-      # - _result_cluster_snapshot.engine_mode == "serverless"
-      - "'engine_version' in _result_cluster_snapshot"
-      - "'iam_database_authentication_enabled' in _result_cluster_snapshot"
-      - "'license_model' in _result_cluster_snapshot"
-      - "'master_username' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.master_username == username
-      - "'snapshot_create_time' in _result_cluster_snapshot"
-      - "'snapshot_type' in _result_cluster_snapshot"
-      - "'status' in _result_cluster_snapshot"
-      - _result_create_source_db_cluster.status == "available"
-      - "'storage_encrypted' in _result_cluster_snapshot"
-      - "'tags' in _result_cluster_snapshot"
-      - "'vpc_id' in _result_cluster_snapshot"
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_snapshot.changed
+          - "'allocated_storage' in _result_cluster_snapshot"
+          - "'cluster_create_time' in _result_cluster_snapshot"
+          - "'db_cluster_identifier' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.db_cluster_identifier == "{{ cluster_id }}-b"
+          - "'db_cluster_snapshot_identifier' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.db_cluster_snapshot_identifier == "{{ snapshot_id }}-b"
+          - "'db_cluster_snapshot_arn' in _result_cluster_snapshot"
+          - "'engine' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.engine == engine
+          # - "'engine_mode' in _result_cluster_snapshot"
+          # - _result_cluster_snapshot.engine_mode == "serverless"
+          - "'engine_version' in _result_cluster_snapshot"
+          - "'iam_database_authentication_enabled' in _result_cluster_snapshot"
+          - "'license_model' in _result_cluster_snapshot"
+          - "'master_username' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.master_username == username
+          - "'snapshot_create_time' in _result_cluster_snapshot"
+          - "'snapshot_type' in _result_cluster_snapshot"
+          - "'status' in _result_cluster_snapshot"
+          - _result_create_source_db_cluster.status == "available"
+          - "'storage_encrypted' in _result_cluster_snapshot"
+          - "'tags' in _result_cluster_snapshot"
+          - "'vpc_id' in _result_cluster_snapshot"
 
-  - name: Get all RDS snapshots for the existing DB cluster
-    rds_snapshot_info:
-      db_cluster_identifier: "{{ cluster_id }}-b"
-    register: _result_cluster_snapshot_info
+    - name: Get all RDS snapshots for the existing DB cluster
+      amazon.aws.rds_snapshot_info:
+        db_cluster_identifier: "{{ cluster_id }}-b"
+      register: _result_cluster_snapshot_info
 
-  - assert:
-      that:
-      - _result_cluster_snapshot_info is successful
-      - _result_cluster_snapshot_info.cluster_snapshots | length == 1
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_snapshot_info is successful
+          - _result_cluster_snapshot_info.cluster_snapshots | length == 1
 
-  - name: Delete existing DB cluster snapshot (CHECK_MODE)
-    rds_cluster_snapshot:
-      state: absent
-      db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
-    register: _result_delete_snapshot
-    check_mode: true
+    - name: Delete existing DB cluster snapshot (CHECK_MODE)
+      rds_cluster_snapshot:
+        state: absent
+        db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
+      register: _result_delete_snapshot
+      check_mode: true
 
-  - assert:
-      that:
-      - _result_delete_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_delete_snapshot.changed
 
-  - name: Delete the existing DB cluster snapshot
-    rds_cluster_snapshot:
-      state: absent
-      db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
-    register: _result_delete_snapshot
+    - name: Delete the existing DB cluster snapshot
+      rds_cluster_snapshot:
+        state: absent
+        db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
+      register: _result_delete_snapshot
 
-  - assert:
-      that:
-      - _result_delete_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_delete_snapshot.changed
 
-  - name: Get info of the existing DB cluster
-    rds_cluster_info:
-      cluster_id: "{{ cluster_id }}"
-    register: _result_cluster_info
+    - name: Get info of the existing DB cluster
+      rds_cluster_info:
+        cluster_id: "{{ cluster_id }}"
+      register: _result_cluster_info
 
-  - assert:
-      that:
-      - result_cluster_info is successful
+    - ansible.builtin.assert:
+        that:
+          - result_cluster_info is successful
 
-  - name: Take another snapshot of the existing DB cluster and assign tags
-    rds_cluster_snapshot:
-      state: present
-      db_cluster_identifier: "{{ cluster_id }}"
-      db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
-      wait: true
-      tags:
-        tag_one: '{{ snapshot_id }}-b One'
-        "Tag Two": 'two {{ snapshot_id }}-b'
-    register: _result_cluster_snapshot
+    - name: Take another snapshot of the existing DB cluster and assign tags
+      rds_cluster_snapshot:
+        state: present
+        db_cluster_identifier: "{{ cluster_id }}"
+        db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
+        wait: true
+        tags:
+          tag_one: "{{ snapshot_id }}-b One"
+          Tag Two: two {{ snapshot_id }}-b
+      register: _result_cluster_snapshot
 
-  - assert:
-      that:
-      - _result_cluster_snapshot.changed
-      - "'allocated_storage' in _result_cluster_snapshot"
-      - "'cluster_create_time' in _result_cluster_snapshot"
-      - "'db_cluster_identifier' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.db_cluster_identifier == cluster_id
-      - "'db_cluster_snapshot_identifier' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.db_cluster_snapshot_identifier == "{{ snapshot_id }}-b"
-      - "'db_cluster_snapshot_arn' in _result_cluster_snapshot"
-      - "'engine' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.engine == engine
-      # - "'engine_mode' in _result_cluster_snapshot"
-      # - _result_cluster_snapshot.engine_mode == "serverless"
-      - "'engine_version' in _result_cluster_snapshot"
-      - "'iam_database_authentication_enabled' in _result_cluster_snapshot"
-      - "'license_model' in _result_cluster_snapshot"
-      - "'master_username' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.master_username == username
-      - "'snapshot_create_time' in _result_cluster_snapshot"
-      - "'snapshot_type' in _result_cluster_snapshot"
-      - "'status' in _result_cluster_snapshot"
-      - _result_create_source_db_cluster.status == "available"
-      - "'storage_encrypted' in _result_cluster_snapshot"
-      - "'tags' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.tags | length == 2
-      - _result_cluster_snapshot.tags["tag_one"] == "{{ snapshot_id }}-b One"
-      - _result_cluster_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
-      - "'vpc_id' in _result_cluster_snapshot"
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_snapshot.changed
+          - "'allocated_storage' in _result_cluster_snapshot"
+          - "'cluster_create_time' in _result_cluster_snapshot"
+          - "'db_cluster_identifier' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.db_cluster_identifier == cluster_id
+          - "'db_cluster_snapshot_identifier' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.db_cluster_snapshot_identifier == "{{ snapshot_id }}-b"
+          - "'db_cluster_snapshot_arn' in _result_cluster_snapshot"
+          - "'engine' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.engine == engine
+          # - "'engine_mode' in _result_cluster_snapshot"
+          # - _result_cluster_snapshot.engine_mode == "serverless"
+          - "'engine_version' in _result_cluster_snapshot"
+          - "'iam_database_authentication_enabled' in _result_cluster_snapshot"
+          - "'license_model' in _result_cluster_snapshot"
+          - "'master_username' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.master_username == username
+          - "'snapshot_create_time' in _result_cluster_snapshot"
+          - "'snapshot_type' in _result_cluster_snapshot"
+          - "'status' in _result_cluster_snapshot"
+          - _result_create_source_db_cluster.status == "available"
+          - "'storage_encrypted' in _result_cluster_snapshot"
+          - "'tags' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.tags | length == 2
+          - _result_cluster_snapshot.tags["tag_one"] == "{{ snapshot_id }}-b One"
+          - _result_cluster_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
+          - "'vpc_id' in _result_cluster_snapshot"
 
-  - name: Attempt to take another snapshot of the existing DB cluster and assign tags (idempotence)
-    rds_cluster_snapshot:
-      state: present
-      db_cluster_identifier: "{{ cluster_id }}"
-      db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
-      wait: true
-      tags:
-        tag_one: '{{ snapshot_id }}-b One'
-        "Tag Two": 'two {{ snapshot_id }}-b'
-    register: _result_cluster_snapshot
+    - name: Attempt to take another snapshot of the existing DB cluster and assign tags (idempotence)
+      rds_cluster_snapshot:
+        state: present
+        db_cluster_identifier: "{{ cluster_id }}"
+        db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
+        wait: true
+        tags:
+          tag_one: "{{ snapshot_id }}-b One"
+          Tag Two: two {{ snapshot_id }}-b
+      register: _result_cluster_snapshot
 
-  - assert:
-      that:
-      - not _result_cluster_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_cluster_snapshot.changed
 
-  - name: Take another snapshot of the existing DB cluster and update tags
-    rds_cluster_snapshot:
-      state: present
-      db_cluster_identifier: "{{ cluster_id }}"
-      db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
-      tags:
-        tag_three: '{{ snapshot_id }}-b Three'
-        "Tag Two": 'two {{ snapshot_id }}-b'
-    register: _result_cluster_snapshot
+    - name: Take another snapshot of the existing DB cluster and update tags
+      rds_cluster_snapshot:
+        state: present
+        db_cluster_identifier: "{{ cluster_id }}"
+        db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
+        tags:
+          tag_three: "{{ snapshot_id }}-b Three"
+          Tag Two: two {{ snapshot_id }}-b
+      register: _result_cluster_snapshot
 
-  - assert:
-      that:
-      - _result_cluster_snapshot.changed
-      - "'allocated_storage' in _result_cluster_snapshot"
-      - "'cluster_create_time' in _result_cluster_snapshot"
-      - "'db_cluster_identifier' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.db_cluster_identifier == cluster_id
-      - "'db_cluster_snapshot_identifier' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.db_cluster_snapshot_identifier == "{{ snapshot_id }}-b"
-      - "'db_cluster_snapshot_arn' in _result_cluster_snapshot"
-      - "'engine' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.engine == engine
-      # - "'engine_mode' in _result_cluster_snapshot"
-      # - _result_cluster_snapshot.engine_mode == "serverless"
-      - "'engine_version' in _result_cluster_snapshot"
-      - "'iam_database_authentication_enabled' in _result_cluster_snapshot"
-      - "'license_model' in _result_cluster_snapshot"
-      - "'master_username' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.master_username == username
-      - "'snapshot_create_time' in _result_cluster_snapshot"
-      - "'snapshot_type' in _result_cluster_snapshot"
-      - "'status' in _result_cluster_snapshot"
-      - _result_create_source_db_cluster.status == "available"
-      - "'storage_encrypted' in _result_cluster_snapshot"
-      - "'tags' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.tags | length == 2
-      - _result_cluster_snapshot.tags["tag_three"] == "{{ snapshot_id }}-b Three"
-      - _result_cluster_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
-      - "'vpc_id' in _result_cluster_snapshot"
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_snapshot.changed
+          - "'allocated_storage' in _result_cluster_snapshot"
+          - "'cluster_create_time' in _result_cluster_snapshot"
+          - "'db_cluster_identifier' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.db_cluster_identifier == cluster_id
+          - "'db_cluster_snapshot_identifier' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.db_cluster_snapshot_identifier == "{{ snapshot_id }}-b"
+          - "'db_cluster_snapshot_arn' in _result_cluster_snapshot"
+          - "'engine' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.engine == engine
+          # - "'engine_mode' in _result_cluster_snapshot"
+          # - _result_cluster_snapshot.engine_mode == "serverless"
+          - "'engine_version' in _result_cluster_snapshot"
+          - "'iam_database_authentication_enabled' in _result_cluster_snapshot"
+          - "'license_model' in _result_cluster_snapshot"
+          - "'master_username' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.master_username == username
+          - "'snapshot_create_time' in _result_cluster_snapshot"
+          - "'snapshot_type' in _result_cluster_snapshot"
+          - "'status' in _result_cluster_snapshot"
+          - _result_create_source_db_cluster.status == "available"
+          - "'storage_encrypted' in _result_cluster_snapshot"
+          - "'tags' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.tags | length == 2
+          - _result_cluster_snapshot.tags["tag_three"] == "{{ snapshot_id }}-b Three"
+          - _result_cluster_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
+          - "'vpc_id' in _result_cluster_snapshot"
 
-  - name: Take another snapshot of the existing DB cluster and update tags without purge
-    rds_cluster_snapshot:
-      state: present
-      db_cluster_identifier: "{{ cluster_id }}"
-      db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
-      purge_tags: false
-      tags:
-        tag_one: '{{ snapshot_id }}-b One'
-    register: _result_cluster_snapshot
+    - name: Take another snapshot of the existing DB cluster and update tags without purge
+      rds_cluster_snapshot:
+        state: present
+        db_cluster_identifier: "{{ cluster_id }}"
+        db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
+        purge_tags: false
+        tags:
+          tag_one: "{{ snapshot_id }}-b One"
+      register: _result_cluster_snapshot
 
-  - assert:
-      that:
-      - _result_cluster_snapshot.changed
-      - "'allocated_storage' in _result_cluster_snapshot"
-      - "'cluster_create_time' in _result_cluster_snapshot"
-      - "'db_cluster_identifier' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.db_cluster_identifier == cluster_id
-      - "'db_cluster_snapshot_identifier' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.db_cluster_snapshot_identifier == "{{ snapshot_id }}-b"
-      - "'db_cluster_snapshot_arn' in _result_cluster_snapshot"
-      - "'engine' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.engine == engine
-      # - "'engine_mode' in _result_cluster_snapshot"
-      # - _result_cluster_snapshot.engine_mode == "serverless"
-      - "'engine_version' in _result_cluster_snapshot"
-      - "'iam_database_authentication_enabled' in _result_cluster_snapshot"
-      - "'license_model' in _result_cluster_snapshot"
-      - "'master_username' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.master_username == username
-      - "'snapshot_create_time' in _result_cluster_snapshot"
-      - "'snapshot_type' in _result_cluster_snapshot"
-      - "'status' in _result_cluster_snapshot"
-      - _result_create_source_db_cluster.status == "available"
-      - "'storage_encrypted' in _result_cluster_snapshot"
-      - "'tags' in _result_cluster_snapshot"
-      - _result_cluster_snapshot.tags | length == 3
-      - _result_cluster_snapshot.tags["tag_one"] == "{{ snapshot_id }}-b One"
-      - _result_cluster_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
-      - _result_cluster_snapshot.tags["tag_three"] == "{{ snapshot_id }}-b Three"
-      - "'vpc_id' in _result_cluster_snapshot"
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_snapshot.changed
+          - "'allocated_storage' in _result_cluster_snapshot"
+          - "'cluster_create_time' in _result_cluster_snapshot"
+          - "'db_cluster_identifier' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.db_cluster_identifier == cluster_id
+          - "'db_cluster_snapshot_identifier' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.db_cluster_snapshot_identifier == "{{ snapshot_id }}-b"
+          - "'db_cluster_snapshot_arn' in _result_cluster_snapshot"
+          - "'engine' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.engine == engine
+          # - "'engine_mode' in _result_cluster_snapshot"
+          # - _result_cluster_snapshot.engine_mode == "serverless"
+          - "'engine_version' in _result_cluster_snapshot"
+          - "'iam_database_authentication_enabled' in _result_cluster_snapshot"
+          - "'license_model' in _result_cluster_snapshot"
+          - "'master_username' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.master_username == username
+          - "'snapshot_create_time' in _result_cluster_snapshot"
+          - "'snapshot_type' in _result_cluster_snapshot"
+          - "'status' in _result_cluster_snapshot"
+          - _result_create_source_db_cluster.status == "available"
+          - "'storage_encrypted' in _result_cluster_snapshot"
+          - "'tags' in _result_cluster_snapshot"
+          - _result_cluster_snapshot.tags | length == 3
+          - _result_cluster_snapshot.tags["tag_one"] == "{{ snapshot_id }}-b One"
+          - _result_cluster_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
+          - _result_cluster_snapshot.tags["tag_three"] == "{{ snapshot_id }}-b Three"
+          - "'vpc_id' in _result_cluster_snapshot"
 
-  - name: Take another snapshot of the existing DB cluster and do not specify any tag to ensure previous tags are not removed
-    rds_cluster_snapshot:
-      state: present
-      db_cluster_identifier: "{{ cluster_id }}"
-      db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
-    register: _result_cluster_snapshot
+    - name: Take another snapshot of the existing DB cluster and do not specify any tag to ensure previous tags are not removed
+      rds_cluster_snapshot:
+        state: present
+        db_cluster_identifier: "{{ cluster_id }}"
+        db_cluster_snapshot_identifier: "{{ snapshot_id }}-b"
+      register: _result_cluster_snapshot
 
-  - assert:
-      that:
-      - not _result_cluster_snapshot.changed
-  
-  # ------------------------------------------------------------------------------------------
-   # Test copying a snapshot
-   ### Copying a DB cluster snapshot from a different region is supported, but not in CI,
-   ### because the aws-terminator only terminates resources in one region.
-  - set_fact:
-      _snapshot_arn: "{{ _result_cluster_snapshot.db_cluster_snapshot_arn }}"
+    - ansible.builtin.assert:
+        that:
+          - not _result_cluster_snapshot.changed
 
-  - name: Copy a DB cluster snapshot (check mode)
-    rds_cluster_snapshot:
-      id: "{{ snapshot_id }}-copy"
-      source_id: "{{ snapshot_id }}-b"
-      copy_tags: yes
-      wait: true
-    register: _result_cluster_copy_snapshot
-    check_mode: yes
+    # ------------------------------------------------------------------------------------------
+    # Test copying a snapshot
+    ### Copying a DB cluster snapshot from a different region is supported, but not in CI,
+    ### because the aws-terminator only terminates resources in one region.
+    - ansible.builtin.set_fact:
+        _snapshot_arn: "{{ _result_cluster_snapshot.db_cluster_snapshot_arn }}"
 
-  - assert:
-      that:
-        - _result_cluster_copy_snapshot.changed
+    - name: Copy a DB cluster snapshot (check mode)
+      rds_cluster_snapshot:
+        id: "{{ snapshot_id }}-copy"
+        source_id: "{{ snapshot_id }}-b"
+        copy_tags: true
+        wait: true
+      register: _result_cluster_copy_snapshot
+      check_mode: true
 
-  - name: Copy a DB cluster snapshot
-    rds_cluster_snapshot:
-      id: "{{ snapshot_id }}-copy"
-      source_id: "{{ snapshot_id }}-b"
-      copy_tags: yes
-      wait: true
-    register: _result_cluster_copy_snapshot
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_copy_snapshot.changed
 
-  - assert:
-      that:
-        - _result_cluster_copy_snapshot.changed
-        - _result_cluster_copy_snapshot.db_cluster_identifier == cluster_id
-        - _result_cluster_copy_snapshot.source_db_cluster_snapshot_arn == _snapshot_arn
-        - _result_cluster_copy_snapshot.db_cluster_snapshot_identifier == "{{ snapshot_id }}-copy"
-        - "'tags' in _result_cluster_copy_snapshot"
-        - _result_cluster_copy_snapshot.tags | length == 3
-        - _result_cluster_copy_snapshot.tags["tag_one"] == "{{ snapshot_id }}-b One"
-        - _result_cluster_copy_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
-        - _result_cluster_copy_snapshot.tags["tag_three"] == "{{ snapshot_id }}-b Three"
+    - name: Copy a DB cluster snapshot
+      rds_cluster_snapshot:
+        id: "{{ snapshot_id }}-copy"
+        source_id: "{{ snapshot_id }}-b"
+        copy_tags: true
+        wait: true
+      register: _result_cluster_copy_snapshot
 
-  - name: Copy a DB cluster snapshot (idempotence - check mode)
-    rds_cluster_snapshot:
-      id: "{{ snapshot_id }}-copy"
-      source_id: "{{ snapshot_id }}-b"
-      copy_tags: yes
-      wait: true
-    register: _result_cluster_copy_snapshot
-    check_mode: yes
+    - ansible.builtin.assert:
+        that:
+          - _result_cluster_copy_snapshot.changed
+          - _result_cluster_copy_snapshot.db_cluster_identifier == cluster_id
+          - _result_cluster_copy_snapshot.source_db_cluster_snapshot_arn == _snapshot_arn
+          - _result_cluster_copy_snapshot.db_cluster_snapshot_identifier == "{{ snapshot_id }}-copy"
+          - "'tags' in _result_cluster_copy_snapshot"
+          - _result_cluster_copy_snapshot.tags | length == 3
+          - _result_cluster_copy_snapshot.tags["tag_one"] == "{{ snapshot_id }}-b One"
+          - _result_cluster_copy_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
+          - _result_cluster_copy_snapshot.tags["tag_three"] == "{{ snapshot_id }}-b Three"
 
-  - assert:
-      that:
-        - not _result_cluster_copy_snapshot.changed
+    - name: Copy a DB cluster snapshot (idempotence - check mode)
+      rds_cluster_snapshot:
+        id: "{{ snapshot_id }}-copy"
+        source_id: "{{ snapshot_id }}-b"
+        copy_tags: true
+        wait: true
+      register: _result_cluster_copy_snapshot
+      check_mode: true
 
-  - name: Copy a DB cluster snapshot (idempotence)
-    rds_cluster_snapshot:
-      id: "{{ snapshot_id }}-copy"
-      source_id: "{{ snapshot_id }}-b"
-      copy_tags: yes
-      wait: true
-    register: _result_cluster_copy_snapshot
+    - ansible.builtin.assert:
+        that:
+          - not _result_cluster_copy_snapshot.changed
 
-  - assert:
-      that:
-        - not _result_cluster_copy_snapshot.changed
-        - _result_cluster_copy_snapshot.db_cluster_identifier == cluster_id
-        - _result_cluster_copy_snapshot.source_db_cluster_snapshot_arn == _snapshot_arn
-        - _result_cluster_copy_snapshot.db_cluster_snapshot_identifier == "{{ snapshot_id }}-copy"
-        - "'tags' in _result_cluster_copy_snapshot"
-        - _result_cluster_copy_snapshot.tags | length == 3
-        - _result_cluster_copy_snapshot.tags["tag_one"] == "{{ snapshot_id }}-b One"
-        - _result_cluster_copy_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
-        - _result_cluster_copy_snapshot.tags["tag_three"] == "{{ snapshot_id }}-b Three"
+    - name: Copy a DB cluster snapshot (idempotence)
+      rds_cluster_snapshot:
+        id: "{{ snapshot_id }}-copy"
+        source_id: "{{ snapshot_id }}-b"
+        copy_tags: true
+        wait: true
+      register: _result_cluster_copy_snapshot
+
+    - ansible.builtin.assert:
+        that:
+          - not _result_cluster_copy_snapshot.changed
+          - _result_cluster_copy_snapshot.db_cluster_identifier == cluster_id
+          - _result_cluster_copy_snapshot.source_db_cluster_snapshot_arn == _snapshot_arn
+          - _result_cluster_copy_snapshot.db_cluster_snapshot_identifier == "{{ snapshot_id }}-copy"
+          - "'tags' in _result_cluster_copy_snapshot"
+          - _result_cluster_copy_snapshot.tags | length == 3
+          - _result_cluster_copy_snapshot.tags["tag_one"] == "{{ snapshot_id }}-b One"
+          - _result_cluster_copy_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
+          - _result_cluster_copy_snapshot.tags["tag_three"] == "{{ snapshot_id }}-b Three"
 
   always:
-  - name: Delete the existing DB cluster snapshots
-    rds_cluster_snapshot:
-      state: absent
-      db_cluster_snapshot_identifier: "{{ item }}"
-    register: _result_delete_snapshot
-    ignore_errors: true
-    loop:
-    - "{{ snapshot_id }}"
-    - "{{ snapshot_id }}-b"
-    - "{{ snapshot_id }}-copy"
+    - name: Delete the existing DB cluster snapshots
+      rds_cluster_snapshot:
+        state: absent
+        db_cluster_snapshot_identifier: "{{ item }}"
+      register: _result_delete_snapshot
+      ignore_errors: true
+      loop:
+        - "{{ snapshot_id }}"
+        - "{{ snapshot_id }}-b"
+        - "{{ snapshot_id }}-copy"
 
-  - name: Delete the existing DB cluster without creating a final snapshot
-    rds_cluster:
-      state: absent
-      cluster_id: "{{ item }}"
-      skip_final_snapshot: true
-    register: _result_delete_cluster
-    ignore_errors: true
-    loop:
-    - "{{ cluster_id }}"
-    - "{{ cluster_id }}-b"
+    - name: Delete the existing DB cluster without creating a final snapshot
+      rds_cluster:
+        state: absent
+        cluster_id: "{{ item }}"
+        skip_final_snapshot: true
+      register: _result_delete_cluster
+      ignore_errors: true
+      loop:
+        - "{{ cluster_id }}"
+        - "{{ cluster_id }}-b"

--- a/tests/integration/targets/rds_cluster_states/defaults/main.yml
+++ b/tests/integration/targets/rds_cluster_states/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 cluster_id: ansible-test-cluster-{{ tiny_prefix }}
 username: testrdsusername
 password: test-rds_password

--- a/tests/integration/targets/rds_cluster_states/tasks/main.yml
+++ b/tests/integration/targets/rds_cluster_states/tasks/main.yml
@@ -1,88 +1,89 @@
+---
 - module_defaults:
     group/aws:
-      region: '{{ aws_region }}'
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   block:
     # ------------------------------------------------------------------------------------------
     # Create DB cluster
     - name: Ensure the resource doesn't exist
       rds_cluster:
-        id: '{{ cluster_id }}'
+        id: "{{ cluster_id }}"
         state: absent
-        engine: '{{ engine}}'
-        username: '{{ username }}'
-        password: '{{ password }}'
+        engine: "{{ engine}}"
+        username: "{{ username }}"
+        password: "{{ password }}"
         skip_final_snapshot: true
       register: _result_delete_db_cluster
 
-    - assert:
+    - ansible.builtin.assert:
         that:
-        - not _result_delete_db_cluster.changed
-      ignore_errors: yes
+          - not _result_delete_db_cluster.changed
+      ignore_errors: true
 
     - name: Create an Aurora-PostgreSQL DB cluster
       rds_cluster:
-        id: '{{ cluster_id }}'
+        id: "{{ cluster_id }}"
         state: present
         engine: aurora-postgresql
         engine_mode: provisioned
-        username: '{{ username }}'
-        password: '{{ password }}'
+        username: "{{ username }}"
+        password: "{{ password }}"
       register: _result_create_source_db_cluster
 
-    - assert:
+    - ansible.builtin.assert:
         that:
-        - _result_create_source_db_cluster.changed
-        - "'allocated_storage' in _result_create_source_db_cluster"
-        - _result_create_source_db_cluster.allocated_storage == 1
-        - "'cluster_create_time' in _result_create_source_db_cluster"
-        - _result_create_source_db_cluster.copy_tags_to_snapshot == false
-        - "'db_cluster_arn' in _result_create_source_db_cluster"
-        - _result_create_source_db_cluster.db_cluster_identifier == '{{ cluster_id }}'
-        - "'db_cluster_parameter_group' in _result_create_source_db_cluster"
-        - "'db_cluster_resource_id' in _result_create_source_db_cluster"
-        - "'endpoint' in _result_create_source_db_cluster"
-        - "'engine' in _result_create_source_db_cluster"
-        - _result_create_source_db_cluster.engine == "aurora-postgresql"
-        - "'engine_mode' in _result_create_source_db_cluster"
-        - _result_create_source_db_cluster.engine_mode == "provisioned"
-        - "'engine_version' in _result_create_source_db_cluster"
-        - "'master_username' in _result_create_source_db_cluster"
-        - _result_create_source_db_cluster.master_username == username
-        - "'port' in _result_create_source_db_cluster"
-        - "'status' in _result_create_source_db_cluster"
-        - _result_create_source_db_cluster.status == "available"
-        - "'tags' in _result_create_source_db_cluster"
-        - "'vpc_security_groups' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.changed
+          - "'allocated_storage' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.db_cluster_identifier == '{{ cluster_id }}'
+          - "'db_cluster_parameter_group' in _result_create_source_db_cluster"
+          - "'db_cluster_resource_id' in _result_create_source_db_cluster"
+          - "'endpoint' in _result_create_source_db_cluster"
+          - "'engine' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.engine == "aurora-postgresql"
+          - "'engine_mode' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_create_source_db_cluster"
+          - "'master_username' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.master_username == username
+          - "'port' in _result_create_source_db_cluster"
+          - "'status' in _result_create_source_db_cluster"
+          - _result_create_source_db_cluster.status == "available"
+          - "'tags' in _result_create_source_db_cluster"
+          - "'vpc_security_groups' in _result_create_source_db_cluster"
 
     # ------------------------------------------------------------------------------------------
     # Test stopping db clusters
     - name: Stop db clusters - checkmode
       amazon.aws.rds_cluster:
-        cluster_id: '{{ cluster_id }}'
+        cluster_id: "{{ cluster_id }}"
         state: stopped
       register: check_stopped_cluster
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
-        - check_stopped_cluster.changed
+          - check_stopped_cluster.changed
 
     - name: Stop db clusters
       amazon.aws.rds_cluster:
-        cluster_id: '{{ cluster_id }}'
+        cluster_id: "{{ cluster_id }}"
         state: stopped
       register: stopped_cluster
 
-    - assert:
+    - ansible.builtin.assert:
         that:
-        - stopped_cluster.changed
-    
+          - stopped_cluster.changed
+
     - name: Wait until db clusters state is stopped
       amazon.aws.rds_cluster_info:
-        cluster_id: '{{ cluster_id }}'
+        cluster_id: "{{ cluster_id }}"
       register: stopped_cluster_info
       retries: 30
       delay: 60
@@ -90,137 +91,136 @@
 
     - name: Stop db clusters (idempotence) - checkmode
       amazon.aws.rds_cluster:
-        cluster_id: '{{ cluster_id }}'
+        cluster_id: "{{ cluster_id }}"
         state: stopped
       register: check_stopped_cluster_idem
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
-        - not check_stopped_cluster_idem.changed
+          - not check_stopped_cluster_idem.changed
 
     - name: Stop db clusters (idempotence)
       amazon.aws.rds_cluster:
-        cluster_id: '{{ cluster_id }}'
+        cluster_id: "{{ cluster_id }}"
         state: stopped
       register: stopped_cluster_idem
 
-    - assert:
+    - ansible.builtin.assert:
         that:
-        - not stopped_cluster_idem.changed
+          - not stopped_cluster_idem.changed
 
     # ------------------------------------------------------------------------------------------
     # Test starting DB clusters
     - name: Start db clusters - checkmode
       amazon.aws.rds_cluster:
-        cluster_id: '{{ cluster_id }}'
+        cluster_id: "{{ cluster_id }}"
         state: started
       register: check_started_cluster
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
-        - check_started_cluster.changed
-    
+          - check_started_cluster.changed
+
     - name: Start db clusters
       amazon.aws.rds_cluster:
-        cluster_id: '{{ cluster_id }}'
+        cluster_id: "{{ cluster_id }}"
         state: started
       register: started_cluster
 
-    - assert:
+    - ansible.builtin.assert:
         that:
-        - started_cluster.changed
-    
+          - started_cluster.changed
+
     - name: Start db clusters (idempotence) - checkmode
       amazon.aws.rds_cluster:
-        cluster_id: '{{ cluster_id }}'
+        cluster_id: "{{ cluster_id }}"
         state: started
       register: check_started_cluster
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
-        - not check_started_cluster.changed
+          - not check_started_cluster.changed
 
     - name: Start db clusters
       amazon.aws.rds_cluster:
-        cluster_id: '{{ cluster_id }}'
+        cluster_id: "{{ cluster_id }}"
         state: started
       register: started_cluster
 
-    - assert:
+    - ansible.builtin.assert:
         that:
-        - not started_cluster.changed
+          - not started_cluster.changed
 
     # ------------------------------------------------------------------------------------------
     # Give errors for MySql DB cluster
     - name: Ensure the resource doesn't exist
       rds_cluster:
-        id: '{{ mysql_cluster_id }}'
+        id: "{{ mysql_cluster_id }}"
         state: absent
-        engine: '{{ mysql_engine }}'
-        username: '{{ username }}'
-        password: '{{ password }}'
+        engine: "{{ mysql_engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
         skip_final_snapshot: true
       register: _result_delete_mysql_db_cluster
-  
-    - assert:
+
+    - ansible.builtin.assert:
         that:
-        - not _result_delete_mysql_db_cluster.changed
-      ignore_errors: yes
-    
+          - not _result_delete_mysql_db_cluster.changed
+      ignore_errors: true
+
     - name: Create an MySql DB cluster
       rds_cluster:
-        id: '{{ mysql_cluster_id }}'
+        id: "{{ mysql_cluster_id }}"
         state: present
-        engine: '{{ mysql_engine }}'
+        engine: "{{ mysql_engine }}"
         engine_mode: provisioned
-        allocated_storage: '{{ mysql_allocated_storage }}'
-        iops: '{{ mysql_iops }}'
-        db_cluster_instance_class: '{{ mysql_db_cluster_instance_class }}'
-        username: '{{ username }}'
-        password: '{{ password }}'
-      ignore_errors: yes
+        allocated_storage: "{{ mysql_allocated_storage }}"
+        iops: "{{ mysql_iops }}"
+        db_cluster_instance_class: "{{ mysql_db_cluster_instance_class }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+      ignore_errors: true
       register: mysql_cluster
 
-    - assert:
+    - ansible.builtin.assert:
         that:
-        - mysql_cluster.changed
-        - "'allocated_storage' in mysql_cluster"
-        - mysql_cluster.allocated_storage == 100
-        - "'cluster_create_time' in mysql_cluster"
-        - mysql_cluster.copy_tags_to_snapshot == false
-        - "'db_cluster_arn' in mysql_cluster"
-        - mysql_cluster.db_cluster_identifier == mysql_cluster_id
-        - "'db_cluster_parameter_group' in mysql_cluster"
-        - "'db_cluster_resource_id' in mysql_cluster"
-        - "'endpoint' in mysql_cluster"
-        - "'engine' in mysql_cluster"
-        - mysql_cluster.engine == mysql_engine
-        - "'engine_mode' in mysql_cluster"
-        - mysql_cluster.engine_mode == "provisioned"
-        - "'engine_version' in mysql_cluster"
-        - "'master_username' in mysql_cluster"
-        - mysql_cluster.master_username == username
-        - "'port' in mysql_cluster"
-        - "'status' in mysql_cluster"
-        - mysql_cluster.status == "available"
-        - "'tags' in mysql_cluster"
-        - "'vpc_security_groups' in mysql_cluster"
-      
+          - mysql_cluster.changed
+          - "'allocated_storage' in mysql_cluster"
+          - mysql_cluster.allocated_storage == 100
+          - "'cluster_create_time' in mysql_cluster"
+          - mysql_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in mysql_cluster"
+          - mysql_cluster.db_cluster_identifier == mysql_cluster_id
+          - "'db_cluster_parameter_group' in mysql_cluster"
+          - "'db_cluster_resource_id' in mysql_cluster"
+          - "'endpoint' in mysql_cluster"
+          - "'engine' in mysql_cluster"
+          - mysql_cluster.engine == mysql_engine
+          - "'engine_mode' in mysql_cluster"
+          - mysql_cluster.engine_mode == "provisioned"
+          - "'engine_version' in mysql_cluster"
+          - "'master_username' in mysql_cluster"
+          - mysql_cluster.master_username == username
+          - "'port' in mysql_cluster"
+          - "'status' in mysql_cluster"
+          - mysql_cluster.status == "available"
+          - "'tags' in mysql_cluster"
+          - "'vpc_security_groups' in mysql_cluster"
 
     - name: Stop MySql DB cluster
       amazon.aws.rds_cluster:
-        cluster_id: '{{ mysql_cluster_id }}'
+        cluster_id: "{{ mysql_cluster_id }}"
         state: stopped
       register: mysql_cluster
       ignore_errors: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
-        - mysql_cluster is failed
-        - mysql_cluster.msg == "Only aurora clusters can use the state stopped"
+          - mysql_cluster is failed
+          - mysql_cluster.msg == "Only aurora clusters can use the state stopped"
 
   always:
     # ------------------------------------------------------------------------------------------
@@ -228,13 +228,13 @@
     - name: Delete MySql db cluster without creating a final snapshot
       rds_cluster:
         state: absent
-        cluster_id: '{{ mysql_cluster_id }}'
+        cluster_id: "{{ mysql_cluster_id }}"
         skip_final_snapshot: true
       ignore_errors: true
 
     - name: Delete Aurora-PostgreSql db cluster without creating a final snapshot
       rds_cluster:
         state: absent
-        cluster_id: '{{ cluster_id }}'
+        cluster_id: "{{ cluster_id }}"
         skip_final_snapshot: true
       ignore_errors: true

--- a/tests/integration/targets/rds_cluster_tag/defaults/main.yml
+++ b/tests/integration/targets/rds_cluster_tag/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 # defaults file for rds_cluster
 
 # Create cluster
@@ -13,5 +14,5 @@ new_password: test-rds_password-new
 
 # Tag cluster
 tags_patch:
-  Name: '{{ tiny_prefix }}-new'
+  Name: "{{ tiny_prefix }}-new"
   Created_by: Ansible rds_cluster integration tests

--- a/tests/integration/targets/rds_cluster_tag/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_tag/tasks/main.yaml
@@ -1,296 +1,295 @@
+---
 - module_defaults:
     group/aws:
-      region: '{{ aws_region }}'
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   block:
-  - name: Ensure the resource doesn't exist
-    rds_cluster:
-      id: '{{ cluster_id }}'
-      state: absent
-      engine: '{{ engine}}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      skip_final_snapshot: true
-    register: _result_delete_db_cluster
+    - name: Ensure the resource doesn't exist
+      rds_cluster:
+        id: "{{ cluster_id }}"
+        state: absent
+        engine: "{{ engine}}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        skip_final_snapshot: true
+      register: _result_delete_db_cluster
 
-  - assert:
-      that:
-      - not _result_delete_db_cluster.changed
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - not _result_delete_db_cluster.changed
+      ignore_errors: true
 
-  - name: Create a DB cluster
-    rds_cluster:
-      engine: '{{ engine }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      cluster_id: '{{ cluster_id }}'
-      tags: '{{ tags_create }}'
-    register: _result_create_db_cluster
+    - name: Create a DB cluster
+      rds_cluster:
+        engine: "{{ engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        cluster_id: "{{ cluster_id }}"
+        tags: "{{ tags_create }}"
+      register: _result_create_db_cluster
 
-  - assert:
-      that:
-      - _result_create_db_cluster.changed
-      - "'allocated_storage' in _result_create_db_cluster"
-      - _result_create_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_create_db_cluster"
-      - _result_create_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_create_db_cluster"
-      - "'db_cluster_identifier' in _result_create_db_cluster"
-      - _result_create_db_cluster.db_cluster_identifier == cluster_id
-      - "'db_cluster_parameter_group' in _result_create_db_cluster"
-      - "'db_cluster_resource_id' in _result_create_db_cluster"
-      - "'endpoint' in _result_create_db_cluster"
-      - "'engine' in _result_create_db_cluster"
-      - _result_create_db_cluster.engine == engine
-      - "'engine_mode' in _result_create_db_cluster"
-      - _result_create_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_create_db_cluster"
-      - "'master_username' in _result_create_db_cluster"
-      - _result_create_db_cluster.master_username == username
-      - "'port' in _result_create_db_cluster"
-      - _result_create_db_cluster.port == {{ port }}
-      - "'status' in _result_create_db_cluster"
-      - _result_create_db_cluster.status == 'available'
-      - _result_create_db_cluster.storage_encrypted == false
-      - "'tags' in _result_create_db_cluster"
-      - _result_create_db_cluster.tags | length == 2
-      - _result_create_db_cluster.tags["Created_By"] == "{{ tags_create["Created_By"]
-        }}"
-      - _result_create_db_cluster.tags["Name"] == "{{ tags_create["Name"]}}"
-      - "'vpc_security_groups' in _result_create_db_cluster"
+    - ansible.builtin.assert:
+        that:
+          - _result_create_db_cluster.changed
+          - "'allocated_storage' in _result_create_db_cluster"
+          - _result_create_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_create_db_cluster"
+          - _result_create_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_create_db_cluster"
+          - "'db_cluster_identifier' in _result_create_db_cluster"
+          - _result_create_db_cluster.db_cluster_identifier == cluster_id
+          - "'db_cluster_parameter_group' in _result_create_db_cluster"
+          - "'db_cluster_resource_id' in _result_create_db_cluster"
+          - "'endpoint' in _result_create_db_cluster"
+          - "'engine' in _result_create_db_cluster"
+          - _result_create_db_cluster.engine == engine
+          - "'engine_mode' in _result_create_db_cluster"
+          - _result_create_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_create_db_cluster"
+          - "'master_username' in _result_create_db_cluster"
+          - _result_create_db_cluster.master_username == username
+          - "'port' in _result_create_db_cluster"
+          - _result_create_db_cluster.port == {{ port }}
+          - "'status' in _result_create_db_cluster"
+          - _result_create_db_cluster.status == 'available'
+          - _result_create_db_cluster.storage_encrypted == false
+          - "'tags' in _result_create_db_cluster"
+          - _result_create_db_cluster.tags | length == 2
+          - _result_create_db_cluster.tags["Created_By"] == "{{ tags_create["Created_By"] }}"
+          - _result_create_db_cluster.tags["Name"] == "{{ tags_create["Name"]}}"
+          - "'vpc_security_groups' in _result_create_db_cluster"
 
-  - name: Test tags are not purged if purge_tags is False
-    rds_cluster:
-      engine: '{{ engine }}'
-      username: '{{ username }}'
-      password: '{{ new_password }}'
-      cluster_id: '{{ cluster_id }}'
-      tags: {}
-      purge_tags: false
-    register: _result_tag_db_cluster
+    - name: Test tags are not purged if purge_tags is False
+      rds_cluster:
+        engine: "{{ engine }}"
+        username: "{{ username }}"
+        password: "{{ new_password }}"
+        cluster_id: "{{ cluster_id }}"
+        tags: {}
+        purge_tags: false
+      register: _result_tag_db_cluster
 
-  - assert:
-      that:
-      - not _result_tag_db_cluster.changed
-      - "'allocated_storage' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_tag_db_cluster"
-      - "'db_cluster_identifier' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.db_cluster_identifier == cluster_id
-      - "'db_cluster_parameter_group' in _result_tag_db_cluster"
-      - "'db_cluster_resource_id' in _result_tag_db_cluster"
-      - "'endpoint' in _result_tag_db_cluster"
-      - "'engine' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.engine == engine
-      - "'engine_mode' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_tag_db_cluster"
-      - "'master_username' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.master_username == username
-      - "'port' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.port == {{ port }}
-      - "'status' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.status == 'available'
-      - _result_tag_db_cluster.storage_encrypted == false
-      - "'tags' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.tags | length == 2
-      - _result_tag_db_cluster.tags["Created_By"] == "{{ tags_create["Created_By"]
-        }}"
-      - _result_tag_db_cluster.tags["Name"] == tags_create["Name"]
-      - "'vpc_security_groups' in _result_tag_db_cluster"
+    - ansible.builtin.assert:
+        that:
+          - not _result_tag_db_cluster.changed
+          - "'allocated_storage' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_tag_db_cluster"
+          - "'db_cluster_identifier' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.db_cluster_identifier == cluster_id
+          - "'db_cluster_parameter_group' in _result_tag_db_cluster"
+          - "'db_cluster_resource_id' in _result_tag_db_cluster"
+          - "'endpoint' in _result_tag_db_cluster"
+          - "'engine' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.engine == engine
+          - "'engine_mode' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_tag_db_cluster"
+          - "'master_username' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.master_username == username
+          - "'port' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.port == {{ port }}
+          - "'status' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.status == 'available'
+          - _result_tag_db_cluster.storage_encrypted == false
+          - "'tags' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.tags | length == 2
+          - _result_tag_db_cluster.tags["Created_By"] == "{{ tags_create["Created_By"] }}"
+          - _result_tag_db_cluster.tags["Name"] == tags_create["Name"]
+          - "'vpc_security_groups' in _result_tag_db_cluster"
 
-  - name: Add a tag and remove a tag (purge_tags is True)
-    rds_cluster:
-      cluster_id: '{{ cluster_id }}'
-      state: present
-      tags: '{{ tags_patch }}'
-    register: _result_tag_db_cluster
+    - name: Add a tag and remove a tag (purge_tags is True)
+      rds_cluster:
+        cluster_id: "{{ cluster_id }}"
+        state: present
+        tags: "{{ tags_patch }}"
+      register: _result_tag_db_cluster
 
-  - assert:
-      that:
-      - _result_tag_db_cluster.changed
-      - "'allocated_storage' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_tag_db_cluster"
-      - "'db_cluster_identifier' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.db_cluster_identifier == cluster_id
-      - "'db_cluster_parameter_group' in _result_tag_db_cluster"
-      - "'db_cluster_resource_id' in _result_tag_db_cluster"
-      - "'endpoint' in _result_tag_db_cluster"
-      - "'engine' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.engine == engine
-      - "'engine_mode' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_tag_db_cluster"
-      - "'master_username' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.master_username == username
-      - "'port' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.port == {{ port }}
-      - "'status' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.status == 'available'
-      - _result_tag_db_cluster.storage_encrypted == false
-      - "'tags' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.tags | length == 2
-      - _result_tag_db_cluster.tags["Name"] == tags_patch['Name']
-      - "'vpc_security_groups' in _result_tag_db_cluster"
+    - ansible.builtin.assert:
+        that:
+          - _result_tag_db_cluster.changed
+          - "'allocated_storage' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_tag_db_cluster"
+          - "'db_cluster_identifier' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.db_cluster_identifier == cluster_id
+          - "'db_cluster_parameter_group' in _result_tag_db_cluster"
+          - "'db_cluster_resource_id' in _result_tag_db_cluster"
+          - "'endpoint' in _result_tag_db_cluster"
+          - "'engine' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.engine == engine
+          - "'engine_mode' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_tag_db_cluster"
+          - "'master_username' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.master_username == username
+          - "'port' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.port == {{ port }}
+          - "'status' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.status == 'available'
+          - _result_tag_db_cluster.storage_encrypted == false
+          - "'tags' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.tags | length == 2
+          - _result_tag_db_cluster.tags["Name"] == tags_patch['Name']
+          - "'vpc_security_groups' in _result_tag_db_cluster"
 
-  - name: Purge a tag from the cluster (CHECK MODE)
-    rds_cluster:
-      engine: '{{ engine }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      cluster_id: '{{ cluster_id }}'
-      tags:
-        Created_By: Ansible_rds_cluster_integration_test
-    register: _result_tag_db_cluster
-    check_mode: true
+    - name: Purge a tag from the cluster (CHECK MODE)
+      rds_cluster:
+        engine: "{{ engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        cluster_id: "{{ cluster_id }}"
+        tags:
+          Created_By: Ansible_rds_cluster_integration_test
+      register: _result_tag_db_cluster
+      check_mode: true
 
-  - assert:
-      that:
-      - _result_tag_db_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_tag_db_cluster.changed
 
-  - name: Purge a tag from the cluster
-    rds_cluster:
-      engine: '{{ engine }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      cluster_id: '{{ cluster_id }}'
-      tags:
-        Created_By: Ansible_rds_cluster_integration_test
-    register: _result_tag_db_cluster
+    - name: Purge a tag from the cluster
+      rds_cluster:
+        engine: "{{ engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        cluster_id: "{{ cluster_id }}"
+        tags:
+          Created_By: Ansible_rds_cluster_integration_test
+      register: _result_tag_db_cluster
 
-  - assert:
-      that:
-      - _result_tag_db_cluster.changed
-      - "'allocated_storage' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_tag_db_cluster"
-      - "'db_cluster_identifier' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.db_cluster_identifier == cluster_id
-      - "'db_cluster_parameter_group' in _result_tag_db_cluster"
-      - "'db_cluster_resource_id' in _result_tag_db_cluster"
-      - "'endpoint' in _result_tag_db_cluster"
-      - "'engine' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.engine == engine
-      - "'engine_mode' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_tag_db_cluster"
-      - "'master_username' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.master_username == username
-      - "'port' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.port == {{ port }}
-      - "'status' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.status == 'available'
-      - _result_tag_db_cluster.storage_encrypted == false
-      - "'tags' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.tags | length == 1
-      - _result_tag_db_cluster.tags["Created_By"] == "Ansible_rds_cluster_integration_test"
-      - "'vpc_security_groups' in _result_tag_db_cluster"
+    - ansible.builtin.assert:
+        that:
+          - _result_tag_db_cluster.changed
+          - "'allocated_storage' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_tag_db_cluster"
+          - "'db_cluster_identifier' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.db_cluster_identifier == cluster_id
+          - "'db_cluster_parameter_group' in _result_tag_db_cluster"
+          - "'db_cluster_resource_id' in _result_tag_db_cluster"
+          - "'endpoint' in _result_tag_db_cluster"
+          - "'engine' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.engine == engine
+          - "'engine_mode' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_tag_db_cluster"
+          - "'master_username' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.master_username == username
+          - "'port' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.port == {{ port }}
+          - "'status' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.status == 'available'
+          - _result_tag_db_cluster.storage_encrypted == false
+          - "'tags' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.tags | length == 1
+          - _result_tag_db_cluster.tags["Created_By"] == "Ansible_rds_cluster_integration_test"
+          - "'vpc_security_groups' in _result_tag_db_cluster"
 
-  - name: Add a tag to the cluster (CHECK MODE)
-    rds_cluster:
-      engine: '{{ engine }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      cluster_id: '{{ cluster_id }}'
-      tags:
-        Name: cluster-{{ resource_prefix }}
-        Created_By: Ansible_rds_cluster_integration_test
-    register: _result_tag_db_cluster
-    check_mode: true
+    - name: Add a tag to the cluster (CHECK MODE)
+      rds_cluster:
+        engine: "{{ engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        cluster_id: "{{ cluster_id }}"
+        tags:
+          Name: cluster-{{ resource_prefix }}
+          Created_By: Ansible_rds_cluster_integration_test
+      register: _result_tag_db_cluster
+      check_mode: true
 
-  - assert:
-      that:
-      - _result_tag_db_cluster.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_tag_db_cluster.changed
 
-  - name: Add a tag to the cluster
-    rds_cluster:
-      engine: '{{ engine }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      cluster_id: '{{ cluster_id }}'
-      tags: '{{ tags_create }}'
-    register: _result_tag_db_cluster
+    - name: Add a tag to the cluster
+      rds_cluster:
+        engine: "{{ engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        cluster_id: "{{ cluster_id }}"
+        tags: "{{ tags_create }}"
+      register: _result_tag_db_cluster
 
-  - assert:
-      that:
-      - _result_tag_db_cluster.changed
-      - "'allocated_storage' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_tag_db_cluster"
-      - "'db_cluster_identifier' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.db_cluster_identifier == cluster_id
-      - "'db_cluster_parameter_group' in _result_tag_db_cluster"
-      - "'db_cluster_resource_id' in _result_tag_db_cluster"
-      - "'endpoint' in _result_tag_db_cluster"
-      - "'engine' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.engine == engine
-      - "'engine_mode' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_tag_db_cluster"
-      - "'master_username' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.master_username == username
-      - "'port' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.port == {{ port }}
-      - "'status' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.status == 'available'
-      - _result_tag_db_cluster.storage_encrypted == false
-      - "'tags' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.tags | length == 2
-      - _result_tag_db_cluster.tags["Created_By"] == "{{ tags_create["Created_By"]}}"
-      - _result_tag_db_cluster.tags["Name"] == "{{ tags_create["Name"]}}"
-      - "'vpc_security_groups' in _result_tag_db_cluster"
-  - name: Remove all tags
-    rds_cluster:
-      engine: '{{ engine }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      cluster_id: '{{ cluster_id }}'
-      tags: {}
-    register: _result_tag_db_cluster
+    - ansible.builtin.assert:
+        that:
+          - _result_tag_db_cluster.changed
+          - "'allocated_storage' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_tag_db_cluster"
+          - "'db_cluster_identifier' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.db_cluster_identifier == cluster_id
+          - "'db_cluster_parameter_group' in _result_tag_db_cluster"
+          - "'db_cluster_resource_id' in _result_tag_db_cluster"
+          - "'endpoint' in _result_tag_db_cluster"
+          - "'engine' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.engine == engine
+          - "'engine_mode' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_tag_db_cluster"
+          - "'master_username' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.master_username == username
+          - "'port' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.port == {{ port }}
+          - "'status' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.status == 'available'
+          - _result_tag_db_cluster.storage_encrypted == false
+          - "'tags' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.tags | length == 2
+          - _result_tag_db_cluster.tags["Created_By"] == "{{ tags_create["Created_By"]}}"
+          - _result_tag_db_cluster.tags["Name"] == "{{ tags_create["Name"]}}"
+          - "'vpc_security_groups' in _result_tag_db_cluster"
+    - name: Remove all tags
+      rds_cluster:
+        engine: "{{ engine }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        cluster_id: "{{ cluster_id }}"
+        tags: {}
+      register: _result_tag_db_cluster
 
-  - assert:
-      that:
-      - _result_tag_db_cluster.changed
-      - "'allocated_storage' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.allocated_storage == 1
-      - "'cluster_create_time' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.copy_tags_to_snapshot == false
-      - "'db_cluster_arn' in _result_tag_db_cluster"
-      - "'db_cluster_identifier' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.db_cluster_identifier == cluster_id
-      - "'db_cluster_parameter_group' in _result_tag_db_cluster"
-      - "'db_cluster_resource_id' in _result_tag_db_cluster"
-      - "'endpoint' in _result_tag_db_cluster"
-      - "'engine' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.engine == engine
-      - "'engine_mode' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.engine_mode == "provisioned"
-      - "'engine_version' in _result_tag_db_cluster"
-      - "'master_username' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.master_username == username
-      - "'port' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.port == {{ port }}
-      - "'status' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.status == 'available'
-      - _result_tag_db_cluster.storage_encrypted == false
-      - "'tags' in _result_tag_db_cluster"
-      - _result_tag_db_cluster.tags | length == 0
-      - "'vpc_security_groups' in _result_tag_db_cluster"
+    - ansible.builtin.assert:
+        that:
+          - _result_tag_db_cluster.changed
+          - "'allocated_storage' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.allocated_storage == 1
+          - "'cluster_create_time' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.copy_tags_to_snapshot == false
+          - "'db_cluster_arn' in _result_tag_db_cluster"
+          - "'db_cluster_identifier' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.db_cluster_identifier == cluster_id
+          - "'db_cluster_parameter_group' in _result_tag_db_cluster"
+          - "'db_cluster_resource_id' in _result_tag_db_cluster"
+          - "'endpoint' in _result_tag_db_cluster"
+          - "'engine' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.engine == engine
+          - "'engine_mode' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.engine_mode == "provisioned"
+          - "'engine_version' in _result_tag_db_cluster"
+          - "'master_username' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.master_username == username
+          - "'port' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.port == {{ port }}
+          - "'status' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.status == 'available'
+          - _result_tag_db_cluster.storage_encrypted == false
+          - "'tags' in _result_tag_db_cluster"
+          - _result_tag_db_cluster.tags | length == 0
+          - "'vpc_security_groups' in _result_tag_db_cluster"
   always:
-  - name: Delete DB cluster without creating a final snapshot
-    rds_cluster:
-      state: absent
-      cluster_id: '{{ cluster_id }}'
-      skip_final_snapshot: true
-    ignore_errors: true
+    - name: Delete DB cluster without creating a final snapshot
+      rds_cluster:
+        state: absent
+        cluster_id: "{{ cluster_id }}"
+        skip_final_snapshot: true
+      ignore_errors: true

--- a/tests/integration/targets/rds_global_cluster_create/defaults/main.yml
+++ b/tests/integration/targets/rds_global_cluster_create/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 # defaults file for rds_global_cluster_create
 
 # Create cluster

--- a/tests/integration/targets/rds_global_cluster_create/tasks/main.yaml
+++ b/tests/integration/targets/rds_global_cluster_create/tasks/main.yaml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       region: "{{ aws_region }}"
@@ -40,7 +41,7 @@
     - name: Create a read replica cluster for global database
       amazon.aws.rds_cluster:
         db_cluster_identifier: "{{ secondary_cluster_id }}"
-        region: "eu-north-1"
+        region: eu-north-1
         engine: "{{ engine }}"
         engine_version: "{{ engine_version }}"
         global_cluster_identifier: "{{ global_cluster_id }}"
@@ -61,7 +62,7 @@
     - name: Get secondary cluster info
       amazon.aws.rds_cluster_info:
         db_cluster_identifier: "{{ secondary_cluster_id }}"
-        region: "eu-north-1"
+        region: eu-north-1
       register: secondary_cluster_info_result
 
     - name: Assert that the primary and secondary clusters are members of the global cluster
@@ -75,10 +76,10 @@
     - name: Delete secondary cluster without creating a final snapshot
       amazon.aws.rds_cluster:
         cluster_id: "{{ secondary_cluster_id }}"
-        region: "eu-north-1"
+        region: eu-north-1
         global_cluster_identifier: "{{  global_cluster_id }}"
         remove_from_global_db: true
-        skip_final_snapshot: True
+        skip_final_snapshot: true
         state: absent
       ignore_errors: true
 
@@ -95,7 +96,7 @@
       amazon.aws.rds_cluster:
         cluster_id: "{{ primary_cluster_id }}"
         global_cluster_identifier: "{{  global_cluster_id }}"
-        skip_final_snapshot: True
+        skip_final_snapshot: true
         region: "{{ aws_region }}"
         state: absent
       ignore_errors: true

--- a/tests/integration/targets/rds_instance_aurora/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_aurora/defaults/main.yml
@@ -1,9 +1,10 @@
+---
 instance_id: ansible-test-{{ tiny_prefix }}
-modified_instance_id: '{{ instance_id }}-updated'
+modified_instance_id: "{{ instance_id }}-updated"
 username: test
 password: test12345678
 db_instance_class: db.t3.micro
 
 # For aurora tests
-cluster_id: '{{ instance_id }}-cluster'
+cluster_id: "{{ instance_id }}-cluster"
 aurora_db_instance_class: db.t3.medium

--- a/tests/integration/targets/rds_instance_aurora/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_aurora/tasks/main.yml
@@ -1,122 +1,119 @@
+---
 - name: rds_instance / aurora integration tests
   collections:
-  - community.aws
+    - community.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
+    - name: Ensure the resource doesn't exist
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - name: Ensure the resource doesn't exist
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
+    - name: Create minimal aurora cluster in default VPC and default subnet group
+      rds_cluster:
+        state: present
+        engine: aurora-postgresql
+        engine_mode: provisioned
+        cluster_id: "{{ cluster_id }}"
+        username: "{{ username }}"
+        password: "{{ password }}"
+        tags:
+          CreatedBy: rds_instance integration tests
+      register: my_cluster
 
-  - name: Create minimal aurora cluster in default VPC and default subnet group
-    rds_cluster:
-      state: present
-      engine: aurora-postgresql
-      engine_mode: provisioned
-      cluster_id: '{{ cluster_id }}'
-      username: '{{ username }}'
-      password: '{{ password }}'
-      tags:
-        CreatedBy: rds_instance integration tests
-    register: my_cluster
+    - ansible.builtin.assert:
+        that:
+          - my_cluster.engine_mode == "provisioned"
 
-  - assert:
-      that:
-        - my_cluster.engine_mode == "provisioned"
+    - name: Create an Aurora instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        cluster_id: "{{ cluster_id }}"
+        engine: aurora-postgresql
+        state: present
+        db_instance_class: "{{ aurora_db_instance_class }}"
+        tags:
+          CreatedBy: rds_instance integration tests
+      register: result
 
-  - name: Create an Aurora instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      cluster_id: '{{ cluster_id }}'
-      engine: aurora-postgresql
-      state: present
-      db_instance_class: '{{ aurora_db_instance_class }}'
-      tags:
-        CreatedBy: rds_instance integration tests
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
+          - result.tags | length == 1
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
-      - result.tags | length == 1
+    - name: Create an Aurora instance with both username/password and id - invalid
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}-new"
+        cluster_id: "{{ cluster_id }}"
+        engine: aurora-postgresql
+        state: present
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ aurora_db_instance_class }}"
+        tags:
+          CreatedBy: rds_instance integration tests
+      register: result
+      ignore_errors: true
 
-  - name: Create an Aurora instance with both username/password and id - invalid
-    rds_instance:
-      id: '{{ instance_id }}-new'
-      cluster_id: '{{ cluster_id }}'
-      engine: aurora-postgresql
-      state: present
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ aurora_db_instance_class }}'
-      tags:
-        CreatedBy: rds_instance integration tests
-    register: result
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - result.failed
+          - "'Set master user password for the DB Cluster' in result.msg"
 
-  - assert:
-      that:
-      - result.failed
-      - "'Set master user password for the DB Cluster' in result.msg"
+    - name: Attempt to modify password (a cluster-managed attribute)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        password: "{{ password }}"
+        force_update_password: true
+        apply_immediately: true
+      register: result
+      ignore_errors: true
 
-  - name: Attempt to modify password (a cluster-managed attribute)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      password: '{{ password }}'
-      force_update_password: true
-      apply_immediately: true
-    register: result
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - result.failed
+          - "'Modify master user password for the DB Cluster using the ModifyDbCluster API' in result.msg"
+          - "'Please see rds_cluster' in result.msg"
 
-  - assert:
-      that:
-      - result.failed
-      - "'Modify master user password for the DB Cluster using the ModifyDbCluster\
-        \ API' in result.msg"
-      - "'Please see rds_cluster' in result.msg"
+    - name: Modify aurora instance port (a cluster-managed attribute)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        port: 1150
+      register: result
+      ignore_errors: true
 
-  - name: Modify aurora instance port (a cluster-managed attribute)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      port: 1150
-    register: result
-    ignore_errors: yes
-
-  - assert:
-      that:
-      - not result.changed
-      - "'Modify database endpoint port number for the DB Cluster using the ModifyDbCluster\
-        \ API' in result.msg"
-      - "'Please see rds_cluster' in result.msg"
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - "'Modify database endpoint port number for the DB Cluster using the ModifyDbCluster API' in result.msg"
+          - "'Please see rds_cluster' in result.msg"
 
   always:
+    - name: Delete the instance
+      amazon.aws.rds_instance:
+        id: "{{ item }}"
+        state: absent
+        skip_final_snapshot: true
+        wait: false
+      loop:
+        - "{{ instance_id }}"
+        - "{{ modified_instance_id }}"
+      ignore_errors: true
 
-  - name: Delete the instance
-    rds_instance:
-      id: '{{ item }}'
-      state: absent
-      skip_final_snapshot: true
-      wait: false
-    loop:
-    - '{{ instance_id }}'
-    - '{{ modified_instance_id }}'
-    ignore_errors: yes
-
-  - name: Delete the cluster
-    rds_cluster:
-      cluster_id: '{{ cluster_id }}'
-      state: absent
-      skip_final_snapshot: true
-      wait: false
-    ignore_errors: yes
+    - name: Delete the cluster
+      rds_cluster:
+        cluster_id: "{{ cluster_id }}"
+        state: absent
+        skip_final_snapshot: true
+        wait: false
+      ignore_errors: true

--- a/tests/integration/targets/rds_instance_complex/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_complex/defaults/main.yml
@@ -1,5 +1,6 @@
+---
 instance_id: ansible-test-{{ tiny_prefix }}
-modified_instance_id: '{{ instance_id }}-updated'
+modified_instance_id: "{{ instance_id }}-updated"
 username: test
 password: test12345678
 db_instance_class: db.t3.micro

--- a/tests/integration/targets/rds_instance_complex/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_complex/tasks/main.yml
@@ -1,205 +1,197 @@
+---
 - name: rds_instance / complex integration tests
   collections:
-  - community.aws
+    - community.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
   #TODO: test availability_zone and multi_az
-  - name: Ensure the resource doesn't exist
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
+    - name: Ensure the resource doesn't exist
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+      ignore_errors: true
 
-  - name: Create an enhanced monitoring role
-    iam_role:
-      assume_role_policy_document: "{{ lookup('file','files/enhanced_monitoring_assume_policy.json')\
-        \ }}"
-      name: '{{ instance_id }}-role'
-      state: present
-      managed_policy: arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole
-    register: enhanced_monitoring_role
+    - name: Create an enhanced monitoring role
+      community.aws.iam_role:
+        assume_role_policy_document: "{{ lookup('file','files/enhanced_monitoring_assume_policy.json') }}"
+        name: "{{ instance_id }}-role"
+        state: present
+        managed_policy: arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole
+      register: enhanced_monitoring_role
 
-  - name: Create a mariadb instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      engine_version: '{{ mariadb_engine_version }}'
-      allow_major_version_upgrade: true
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ io1_allocated_storage }}'
-      storage_type: '{{ storage_type }}'
-      iops: '{{ iops }}'
-    register: result
+    - name: Create a mariadb instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        engine_version: "{{ mariadb_engine_version }}"
+        allow_major_version_upgrade: true
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ io1_allocated_storage }}"
+        storage_type: "{{ storage_type }}"
+        iops: "{{ iops }}"
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
 
-  - name: Add IAM roles to mariab (should fail - iam roles not supported for mariadb)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      engine_version: '{{ mariadb_engine_version }}'
-      allow_major_version_upgrade: true
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ io1_allocated_storage }}'
-      storage_type: '{{ storage_type }}'
-      iops: '{{ iops }}'
-      iam_roles:
-      - role_arn: my_role
-        feature_name: my_feature
-    register: result
-    ignore_errors: true
+    - name: Add IAM roles to mariab (should fail - iam roles not supported for mariadb)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        engine_version: "{{ mariadb_engine_version }}"
+        allow_major_version_upgrade: true
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ io1_allocated_storage }}"
+        storage_type: "{{ storage_type }}"
+        iops: "{{ iops }}"
+        iam_roles:
+          - role_arn: my_role
+            feature_name: my_feature
+      register: result
+      ignore_errors: true
 
-  - assert:
-      that:
-      - result.failed
-      - '"is not valid for adding IAM roles" in result.msg'
+    - ansible.builtin.assert:
+        that:
+          - result.failed
+          - '"is not valid for adding IAM roles" in result.msg'
 
     # TODO: test modifying db_subnet_group_name, db_security_groups, db_parameter_group_name, option_group_name,
     # monitoring_role_arn, monitoring_interval, domain, domain_iam_role_name, cloudwatch_logs_export_configuration
 
     # Test multiple modifications including enabling enhanced monitoring
 
-  - name: Modify several attributes - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      allocated_storage: '{{ io1_modified_allocated_storage }}'
-      storage_type: '{{ storage_type }}'
-      db_instance_class: '{{ modified_db_instance_class }}'
-      backup_retention_period: 2
-      preferred_backup_window: 05:00-06:00
-      preferred_maintenance_window: '{{ preferred_maintenance_window }}'
-      auto_minor_version_upgrade: false
-      monitoring_interval: '{{ monitoring_interval }}'
-      monitoring_role_arn: '{{ enhanced_monitoring_role.arn }}'
-      iops: '{{ iops }}'
-      port: 1150
-      max_allocated_storage: 150
-      apply_immediately: true
-    register: result
-    check_mode: yes
+    - name: Modify several attributes - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        allocated_storage: "{{ io1_modified_allocated_storage }}"
+        storage_type: "{{ storage_type }}"
+        db_instance_class: "{{ modified_db_instance_class }}"
+        backup_retention_period: 2
+        preferred_backup_window: "05:00-06:00"
+        preferred_maintenance_window: "{{ preferred_maintenance_window }}"
+        auto_minor_version_upgrade: false
+        monitoring_interval: "{{ monitoring_interval }}"
+        monitoring_role_arn: "{{ enhanced_monitoring_role.arn }}"
+        iops: "{{ iops }}"
+        port: 1150
+        max_allocated_storage: 150
+        apply_immediately: true
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Modify several attributes
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      allocated_storage: '{{ io1_modified_allocated_storage }}'
-      storage_type: '{{ storage_type }}'
-      db_instance_class: '{{ modified_db_instance_class }}'
-      backup_retention_period: 2
-      preferred_backup_window: 05:00-06:00
-      preferred_maintenance_window: '{{ preferred_maintenance_window }}'
-      auto_minor_version_upgrade: false
-      monitoring_interval: '{{ monitoring_interval }}'
-      monitoring_role_arn: '{{ enhanced_monitoring_role.arn }}'
-      iops: '{{ iops }}'
-      port: 1150
-      max_allocated_storage: 150
-      apply_immediately: true
-    register: result
+    - name: Modify several attributes
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        allocated_storage: "{{ io1_modified_allocated_storage }}"
+        storage_type: "{{ storage_type }}"
+        db_instance_class: "{{ modified_db_instance_class }}"
+        backup_retention_period: 2
+        preferred_backup_window: "05:00-06:00"
+        preferred_maintenance_window: "{{ preferred_maintenance_window }}"
+        auto_minor_version_upgrade: false
+        monitoring_interval: "{{ monitoring_interval }}"
+        monitoring_role_arn: "{{ enhanced_monitoring_role.arn }}"
+        iops: "{{ iops }}"
+        port: 1150
+        max_allocated_storage: 150
+        apply_immediately: true
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - '"allocated_storage" in result.pending_modified_values or result.allocated_storage
-        == io1_modified_allocated_storage'
-      - '"max_allocated_storage" in result.pending_modified_values or result.max_allocated_storage
-        == 150'
-      - '"port" in result.pending_modified_values or result.endpoint.port == 1150'
-      - '"db_instance_class" in result.pending_modified_values or result.db_instance_class
-        == modified_db_instance_class'
-      - '"monitoring_interval" in result.pending_modified_values or result.monitoring_interval
-        == monitoring_interval'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - '"allocated_storage" in result.pending_modified_values or result.allocated_storage == io1_modified_allocated_storage'
+          - '"max_allocated_storage" in result.pending_modified_values or result.max_allocated_storage == 150'
+          - '"port" in result.pending_modified_values or result.endpoint.port == 1150'
+          - '"db_instance_class" in result.pending_modified_values or result.db_instance_class == modified_db_instance_class'
+          - '"monitoring_interval" in result.pending_modified_values or result.monitoring_interval == monitoring_interval'
 
-  - name: Idempotence modifying several pending attributes - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      allocated_storage: '{{ io1_modified_allocated_storage }}'
-      storage_type: '{{ storage_type }}'
-      db_instance_class: '{{ modified_db_instance_class }}'
-      backup_retention_period: 2
-      preferred_backup_window: 05:00-06:00
-      preferred_maintenance_window: '{{ preferred_maintenance_window }}'
-      auto_minor_version_upgrade: false
-      monitoring_interval: '{{ monitoring_interval }}'
-      monitoring_role_arn: '{{ enhanced_monitoring_role.arn }}'
-      iops: '{{ iops }}'
-      port: 1150
-      max_allocated_storage: 150
-    register: result
-    check_mode: yes
+    - name: Idempotence modifying several pending attributes - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        allocated_storage: "{{ io1_modified_allocated_storage }}"
+        storage_type: "{{ storage_type }}"
+        db_instance_class: "{{ modified_db_instance_class }}"
+        backup_retention_period: 2
+        preferred_backup_window: "05:00-06:00"
+        preferred_maintenance_window: "{{ preferred_maintenance_window }}"
+        auto_minor_version_upgrade: false
+        monitoring_interval: "{{ monitoring_interval }}"
+        monitoring_role_arn: "{{ enhanced_monitoring_role.arn }}"
+        iops: "{{ iops }}"
+        port: 1150
+        max_allocated_storage: 150
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: Idempotence modifying several pending attributes
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      allocated_storage: '{{ io1_modified_allocated_storage }}'
-      storage_type: '{{ storage_type }}'
-      db_instance_class: '{{ modified_db_instance_class }}'
-      backup_retention_period: 2
-      preferred_backup_window: 05:00-06:00
-      preferred_maintenance_window: '{{ preferred_maintenance_window }}'
-      auto_minor_version_upgrade: false
-      monitoring_interval: '{{ monitoring_interval }}'
-      monitoring_role_arn: '{{ enhanced_monitoring_role.arn }}'
-      iops: '{{ iops }}'
-      port: 1150
-      max_allocated_storage: 150
-    register: result
+    - name: Idempotence modifying several pending attributes
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        allocated_storage: "{{ io1_modified_allocated_storage }}"
+        storage_type: "{{ storage_type }}"
+        db_instance_class: "{{ modified_db_instance_class }}"
+        backup_retention_period: 2
+        preferred_backup_window: "05:00-06:00"
+        preferred_maintenance_window: "{{ preferred_maintenance_window }}"
+        auto_minor_version_upgrade: false
+        monitoring_interval: "{{ monitoring_interval }}"
+        monitoring_role_arn: "{{ enhanced_monitoring_role.arn }}"
+        iops: "{{ iops }}"
+        port: 1150
+        max_allocated_storage: 150
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - '"allocated_storage" in result.pending_modified_values or result.allocated_storage
-        == io1_modified_allocated_storage'
-      - '"max_allocated_storage" in result.pending_modified_values or result.max_allocated_storage
-        == 150'
-      - '"port" in result.pending_modified_values or result.endpoint.port == 1150'
-      - '"db_instance_class" in result.pending_modified_values or result.db_instance_class
-        == modified_db_instance_class'
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - '"allocated_storage" in result.pending_modified_values or result.allocated_storage == io1_modified_allocated_storage'
+          - '"max_allocated_storage" in result.pending_modified_values or result.max_allocated_storage == 150'
+          - '"port" in result.pending_modified_values or result.endpoint.port == 1150'
+          - '"db_instance_class" in result.pending_modified_values or result.db_instance_class == modified_db_instance_class'
 
   always:
-  - name: Delete the instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-      wait: false
-    ignore_errors: yes
+    - name: Delete the instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+        wait: false
+      ignore_errors: true
 
-  - name: Remove enhanced monitoring role
-    iam_role:
-      assume_role_policy_document: "{{ lookup('file','files/enhanced_monitoring_assume_policy.json')\
-        \ }}"
-      name: '{{ instance_id }}-role'
-      state: absent
-    ignore_errors: yes
+    - name: Remove enhanced monitoring role
+      community.aws.iam_role:
+        assume_role_policy_document: "{{ lookup('file','files/enhanced_monitoring_assume_policy.json') }}"
+        name: "{{ instance_id }}-role"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/rds_instance_modify/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_modify/defaults/main.yml
@@ -1,5 +1,6 @@
+---
 instance_id: ansible-test-{{ tiny_prefix }}
-modified_instance_id: '{{ instance_id }}-updated'
+modified_instance_id: "{{ instance_id }}-updated"
 username: test
 password: test12345678
 db_instance_class: db.t3.micro

--- a/tests/integration/targets/rds_instance_modify/meta/main.yml
+++ b/tests/integration/targets/rds_instance_modify/meta/main.yml
@@ -1,5 +1,5 @@
 ---
 dependencies:
-   - role: setup_botocore_pip
-     vars:
-        botocore_version: "1.29.44"
+  - role: setup_botocore_pip
+    vars:
+      botocore_version: 1.29.44

--- a/tests/integration/targets/rds_instance_modify/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_modify/tasks/main.yml
@@ -1,319 +1,319 @@
+---
 - name: rds_instance / modify integration tests
   collections:
-  - community.aws
+    - community.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-  - name: Ensure the resource doesn't exist
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
+    - name: Ensure the resource doesn't exist
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+      ignore_errors: true
 
-  - name: Create a mariadb instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      engine_version: '{{ mariadb_engine_version }}'
-      allow_major_version_upgrade: true
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      tags:
-        Name: '{{ instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
+    - name: Create a mariadb instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        engine_version: "{{ mariadb_engine_version }}"
+        allow_major_version_upgrade: true
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        tags:
+          Name: "{{ instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
 
-  - name: Create a DB instance with an invalid engine
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: thisisnotavalidengine
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-    register: result
-    ignore_errors: true
+    - name: Create a DB instance with an invalid engine
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: thisisnotavalidengine
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+      register: result
+      ignore_errors: true
 
-  - assert:
-      that:
-      - result.failed
-      - '"value of engine must be one of" in result.msg'
+    - ansible.builtin.assert:
+        that:
+          - result.failed
+          - '"value of engine must be one of" in result.msg'
 
-  - name: Add IAM roles to mariadb (should fail - iam roles not supported for mariadb)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      engine_version: '{{ mariadb_engine_version }}'
-      allow_major_version_upgrade: true
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      iam_roles:
-      - role_arn: my_role
-        feature_name: my_feature
-    register: result
-    ignore_errors: true
+    - name: Add IAM roles to mariadb (should fail - iam roles not supported for mariadb)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        engine_version: "{{ mariadb_engine_version }}"
+        allow_major_version_upgrade: true
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        iam_roles:
+          - role_arn: my_role
+            feature_name: my_feature
+      register: result
+      ignore_errors: true
 
-  - assert:
-      that:
-      - result.failed
-      - '"is not valid for adding IAM roles" in result.msg'
+    - ansible.builtin.assert:
+        that:
+          - result.failed
+          - '"is not valid for adding IAM roles" in result.msg'
 
     # TODO: test modifying db_subnet_group_name, db_security_groups, db_parameter_group_name, option_group_name,
     # monitoring_role_arn, monitoring_interval, domain, domain_iam_role_name, cloudwatch_logs_export_configuration
 
     # ------------------------------------------------------------------------------------------
-  - name: Modify the storage type without immediate application - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      storage_type: gp3
-      apply_immediately: false
-    register: result
-    check_mode: yes
+    - name: Modify the storage type without immediate application - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        storage_type: gp3
+        apply_immediately: false
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
-      - 'result.storage_type == "gp2"'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.storage_type == "gp2"
 
-  - name: Modify the storage type without immediate application
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      storage_type: gp3
-      apply_immediately: false
-    register: result
+    - name: Modify the storage type without immediate application
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        storage_type: gp3
+        apply_immediately: false
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - 'result.pending_modified_values.storage_type == "gp3"'
-      - 'result.storage_type == "gp2"'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.pending_modified_values.storage_type == "gp3"
+          - result.storage_type == "gp2"
 
-  - name: Modify the storage type without immediate application - idempotent
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      storage_type: gp3
-      apply_immediately: false
-    register: result
-    check_mode: yes
+    - name: Modify the storage type without immediate application - idempotent
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        storage_type: gp3
+        apply_immediately: false
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
-      - 'result.pending_modified_values.storage_type == "gp3"'
-      - 'result.storage_type == "gp2"'
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.pending_modified_values.storage_type == "gp3"
+          - result.storage_type == "gp2"
 
-  - name: Modify the storage type back to gp2 without immediate application
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      storage_type: gp2
-      apply_immediately: false
-    register: result
+    - name: Modify the storage type back to gp2 without immediate application
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        storage_type: gp2
+        apply_immediately: false
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - 'result.pending_modified_values == {}'
-      - 'result.storage_type == "gp2"'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.pending_modified_values == {}
+          - result.storage_type == "gp2"
 
-  - name: Modify the instance name without immediate application - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      new_id: '{{ modified_instance_id }}'
-      apply_immediately: false
-    register: result
-    check_mode: yes
+    - name: Modify the instance name without immediate application - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        new_id: "{{ modified_instance_id }}"
+        apply_immediately: false
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Modify the instance name without immediate application
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      new_id: '{{ modified_instance_id }}'
-      apply_immediately: false
-    register: result
+    - name: Modify the instance name without immediate application
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        new_id: "{{ modified_instance_id }}"
+        apply_immediately: false
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == instance_id
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == instance_id
 
-  - name: Immediately apply the pending update - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      new_id: '{{ modified_instance_id }}'
-      apply_immediately: true
-    register: result
-    check_mode: yes
+    - name: Immediately apply the pending update - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        new_id: "{{ modified_instance_id }}"
+        apply_immediately: true
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Immediately apply the pending update
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      new_id: '{{ modified_instance_id }}'
-      apply_immediately: true
-    register: result
+    - name: Immediately apply the pending update
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        new_id: "{{ modified_instance_id }}"
+        apply_immediately: true
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == modified_instance_id
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == modified_instance_id
 
+    # Test modifying CA certificate identifier -------------------------------------------
 
-  # Test modifying CA certificate identifier -------------------------------------------
+    - name: Modify the CA certificate identifier to rds-ca-ecc384-g1 - check_mode
+      amazon.aws.rds_instance:
+        state: present
+        db_instance_identifier: "{{ modified_instance_id }}"
+        allow_major_version_upgrade: true
+        ca_certificate_identifier: rds-ca-ecc384-g1
+        apply_immediately: true
+        tags:
+          Name: "{{ modified_instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
+      check_mode: true
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
-  - name: Modify the CA certificate identifier to rds-ca-ecc384-g1 - check_mode
-    rds_instance:
-      state: present
-      db_instance_identifier: '{{ modified_instance_id }}'
-      allow_major_version_upgrade: true
-      ca_certificate_identifier: rds-ca-ecc384-g1
-      apply_immediately: true
-      tags:
-        Name: '{{ modified_instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
-    check_mode: true
-    vars:
-      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+    - name: Get curent CA certificate identifier
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ modified_instance_id }}"
+      register: db_info
+    - name: Assert that CA certificate identifier has been modified - check_mode
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result is not failed
+          - db_info.instances[0].ca_certificate_identifier != "rds-ca-ecc384-g1"
 
-  - name: Get curent CA certificate identifier
-    rds_instance_info:
-      db_instance_identifier: '{{ modified_instance_id }}'
-    register: db_info
-  - name: Assert that CA certificate identifier has been modified - check_mode
-    assert:
-      that:
-        - result is changed
-        - result is not failed
-        - db_info.instances[0].ca_certificate_identifier != "rds-ca-ecc384-g1"
+    - name: Modify the CA certificate identifier to rds-ca-ecc384-g1
+      amazon.aws.rds_instance:
+        state: present
+        db_instance_identifier: "{{ modified_instance_id }}"
+        allow_major_version_upgrade: true
+        ca_certificate_identifier: rds-ca-ecc384-g1
+        apply_immediately: true
+        tags:
+          Name: "{{ modified_instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
-  - name: Modify the CA certificate identifier to rds-ca-ecc384-g1
-    rds_instance:
-      state: present
-      db_instance_identifier: '{{ modified_instance_id }}'
-      allow_major_version_upgrade: true
-      ca_certificate_identifier: rds-ca-ecc384-g1
-      apply_immediately: true
-      tags:
-        Name: '{{ modified_instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
-    vars:
-      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+    - name: Get curent CA certificate identifier
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ modified_instance_id }}"
+      register: db_info
+      retries: 20
+      delay: 10
+      until: db_info.instances[0].ca_certificate_identifier == "rds-ca-ecc384-g1"
+    - name: Assert that CA certificate identifier has been modified
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result is not failed
+          - db_info.instances[0].ca_certificate_identifier == "rds-ca-ecc384-g1"
 
-  - name: Get curent CA certificate identifier
-    rds_instance_info:
-      db_instance_identifier: '{{ modified_instance_id }}'
-    register: db_info
-    retries: 20
-    delay: 10
-    until: db_info.instances[0].ca_certificate_identifier == "rds-ca-ecc384-g1"
-  - name: Assert that CA certificate identifier has been modified
-    assert:
-      that:
-        - result is changed
-        - result is not failed
-        - db_info.instances[0].ca_certificate_identifier == "rds-ca-ecc384-g1"
+    - name: Modify the CA certificate identifier to rds-ca-ecc384-g1 - idempotent
+      amazon.aws.rds_instance:
+        state: present
+        db_instance_identifier: "{{ modified_instance_id }}"
+        ca_certificate_identifier: rds-ca-ecc384-g1
+        apply_immediately: true
+        tags:
+          Name: "{{ modified_instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
-  - name: Modify the CA certificate identifier to rds-ca-ecc384-g1 - idempotent
-    rds_instance:
-      state: present
-      db_instance_identifier: '{{ modified_instance_id }}'
-      ca_certificate_identifier: rds-ca-ecc384-g1
-      apply_immediately: true
-      tags:
-        Name: '{{ modified_instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
-    vars:
-      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+    - name: Get curent CA certificate identifier
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ modified_instance_id }}"
+      register: db_info
+      retries: 20
+      delay: 10
+      until: db_info.instances[0].ca_certificate_identifier == "rds-ca-ecc384-g1"
+    - name: Assert that CA certificate identifier has been modified
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result is not failed
+          - db_info.instances[0].ca_certificate_identifier == "rds-ca-ecc384-g1"
 
-  - name: Get curent CA certificate identifier
-    rds_instance_info:
-      db_instance_identifier: '{{ modified_instance_id }}'
-    register: db_info
-    retries: 20
-    delay: 10
-    until: db_info.instances[0].ca_certificate_identifier == "rds-ca-ecc384-g1"
-  - name: Assert that CA certificate identifier has been modified
-    assert:
-      that:
-        - result is not changed
-        - result is not failed
-        - db_info.instances[0].ca_certificate_identifier == "rds-ca-ecc384-g1"
+    - name: Modify the CA certificate identifier to rds-ca-ecc384-g1 - idempotent - check_mode
+      amazon.aws.rds_instance:
+        state: present
+        db_instance_identifier: "{{ modified_instance_id }}"
+        ca_certificate_identifier: rds-ca-ecc384-g1
+        apply_immediately: true
+        tags:
+          Name: "{{ modified_instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
+      check_mode: true
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
-  - name: Modify the CA certificate identifier to rds-ca-ecc384-g1 - idempotent - check_mode
-    rds_instance:
-      state: present
-      db_instance_identifier: '{{ modified_instance_id }}'
-      ca_certificate_identifier: rds-ca-ecc384-g1
-      apply_immediately: true
-      tags:
-        Name: '{{ modified_instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
-    check_mode: true
-    vars:
-      ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
-
-  - name: Get curent CA certificate identifier
-    rds_instance_info:
-      db_instance_identifier: '{{ modified_instance_id }}'
-    register: db_info
-    retries: 20
-    delay: 10
-    until: db_info.instances[0].ca_certificate_identifier == "rds-ca-ecc384-g1"
-  - name: Assert that CA certificate identifier has been modified
-    assert:
-      that:
-        - result is not changed
-        - result is not failed
-        - db_info.instances[0].ca_certificate_identifier == "rds-ca-ecc384-g1"
+    - name: Get curent CA certificate identifier
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ modified_instance_id }}"
+      register: db_info
+      retries: 20
+      delay: 10
+      until: db_info.instances[0].ca_certificate_identifier == "rds-ca-ecc384-g1"
+    - name: Assert that CA certificate identifier has been modified
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result is not failed
+          - db_info.instances[0].ca_certificate_identifier == "rds-ca-ecc384-g1"
   # Test modifying CA certificate identifier Complete-------------------------------------------
 
   always:
-  - name: Delete the instance
-    rds_instance:
-      id: '{{ item }}'
-      state: absent
-      skip_final_snapshot: true
-      wait: false
-    ignore_errors: yes
-    loop:
-    - '{{ instance_id }}'
-    - '{{ modified_instance_id }}'
+    - name: Delete the instance
+      amazon.aws.rds_instance:
+        id: "{{ item }}"
+        state: absent
+        skip_final_snapshot: true
+        wait: false
+      ignore_errors: true
+      loop:
+        - "{{ instance_id }}"
+        - "{{ modified_instance_id }}"

--- a/tests/integration/targets/rds_instance_processor/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_processor/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 instance_id: ansible-test-{{ tiny_prefix }}
 username: test
 password: test12345678

--- a/tests/integration/targets/rds_instance_processor/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_processor/tasks/main.yml
@@ -1,141 +1,134 @@
+---
 - name: rds_instance / processor integration tests
   collections:
-  - community.aws
+    - community.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
+    - name: Ensure the resource doesn't exist
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - name: Ensure the resource doesn't exist
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+      ignore_errors: true
 
-  - assert:
-      that:
-      - not result.changed
-    ignore_errors: yes
+    - name: Create an oracle-ee DB instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: oracle-ee
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ oracle_ee_db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        storage_encrypted: true
+        processor_features: {}
+      register: result
 
-  - name: Create an oracle-ee DB instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: oracle-ee
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ oracle_ee_db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      storage_encrypted: true
-      processor_features: {}
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - assert:
-      that:
-      - result.changed
+    - name: Modify the processor features - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: oracle-ee
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ oracle_ee_db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        storage_encrypted: true
+        processor_features: "{{ modified_processor_features }}"
+        apply_immediately: true
+      register: result
+      check_mode: true
 
-  - name: Modify the processor features - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: oracle-ee
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ oracle_ee_db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      storage_encrypted: true
-      processor_features: '{{ modified_processor_features }}'
-      apply_immediately: true
-    register: result
-    check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - assert:
-      that:
-      - result.changed
+    - name: Modify the processor features
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: oracle-ee
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ oracle_ee_db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        storage_encrypted: true
+        processor_features: "{{ modified_processor_features }}"
+        apply_immediately: true
+      register: result
 
-  - name: Modify the processor features
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: oracle-ee
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ oracle_ee_db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      storage_encrypted: true
-      processor_features: '{{ modified_processor_features }}'
-      apply_immediately: true
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.pending_modified_values.processor_features.coreCount == "{{ modified_processor_features.coreCount }}"
+          - result.pending_modified_values.processor_features.threadsPerCore == "{{ modified_processor_features.threadsPerCore }}"
 
-  - assert:
-      that:
-      - result.changed
-      - result.pending_modified_values.processor_features.coreCount == "{{ modified_processor_features.coreCount
-        }}"
-      - result.pending_modified_values.processor_features.threadsPerCore == "{{ modified_processor_features.threadsPerCore
-        }}"
+    - name: Modify the processor features (idempotence) - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: oracle-ee
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ oracle_ee_db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        storage_encrypted: true
+        processor_features: "{{ modified_processor_features }}"
+        apply_immediately: true
+      register: result
+      check_mode: true
 
-  - name: Modify the processor features (idempotence) - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: oracle-ee
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ oracle_ee_db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      storage_encrypted: true
-      processor_features: '{{ modified_processor_features }}'
-      apply_immediately: true
-    register: result
-    check_mode: true
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - assert:
-      that:
-      - not result.changed
+    - name: Modify the processor features (idempotence)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: oracle-ee
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ oracle_ee_db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        storage_encrypted: true
+        processor_features: "{{ modified_processor_features }}"
+        apply_immediately: true
+      register: result
 
-  - name: Modify the processor features (idempotence)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: oracle-ee
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ oracle_ee_db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      storage_encrypted: true
-      processor_features: '{{ modified_processor_features }}'
-      apply_immediately: true
-    register: result
-
-      # Check if processor features either are pending or already changed
-  - assert:
-      that:
-      - not result.changed
-      - (result.pending_modified_values.processor_features.coreCount is defined and
-        result.pending_modified_values.processor_features.coreCount == "{{ modified_processor_features.coreCount
-        }}") or (result.processor_features.coreCount is defined and result.processor_features.coreCount
-        == "{{ modified_processor_features.coreCount }}")
-      - (result.pending_modified_values.processor_features.threadsPerCore is defined
-        and result.pending_modified_values.processor_features.threadsPerCore == "{{
-        modified_processor_features.threadsPerCore }}") or (result.processor_features.threadsPerCore
-        is defined and result.processor_features.threadsPerCore == "{{ modified_processor_features.threadsPerCore
-        }}")
+    # Check if processor features either are pending or already changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - (result.pending_modified_values.processor_features.coreCount is defined and result.pending_modified_values.processor_features.coreCount == "{{ modified_processor_features.coreCount
+            }}") or (result.processor_features.coreCount is defined and result.processor_features.coreCount == "{{ modified_processor_features.coreCount }}")
+          - (result.pending_modified_values.processor_features.threadsPerCore is defined and result.pending_modified_values.processor_features.threadsPerCore == "{{
+            modified_processor_features.threadsPerCore }}") or (result.processor_features.threadsPerCore is defined and result.processor_features.threadsPerCore ==
+            "{{ modified_processor_features.threadsPerCore }}")
 
   always:
+    - name: Delete the DB instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+        wait: false
+      register: result
 
-  - name: Delete the DB instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-      wait: false
-    register: result
-
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed

--- a/tests/integration/targets/rds_instance_replica/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_replica/defaults/main.yml
@@ -1,5 +1,6 @@
+---
 instance_id: ansible-test-{{ tiny_prefix }}
-modified_instance_id: '{{ instance_id }}-updated'
+modified_instance_id: "{{ instance_id }}-updated"
 username: test
 password: test12345678
 db_instance_class: db.t3.micro

--- a/tests/integration/targets/rds_instance_replica/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_replica/tasks/main.yml
@@ -1,234 +1,233 @@
+---
 - name: rds_instance / replica integration tests
   collections:
-  - community.aws
+    - community.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
+    - name: set the two regions for the source DB and the replica
+      ansible.builtin.set_fact:
+        region_src: "{{ aws_region }}"
+        region_dest: "{{ aws_region }}"
 
-  - name: set the two regions for the source DB and the replica
-    set_fact:
-      region_src: '{{ aws_region }}'
-      region_dest: '{{ aws_region }}'
+    - name: Ensure the resource doesn't exist
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+        region: "{{ region_src }}"
+      register: result
 
-  - name: Ensure the resource doesn't exist
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-      region: '{{ region_src }}'
-    register: result
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+      ignore_errors: true
 
-  - assert:
-      that:
-      - not result.changed
-    ignore_errors: yes
+    - name: Create a source DB instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mysql
+        backup_retention_period: 1
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        region: "{{ region_src }}"
+        tags:
+          Name: "{{ instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: source_db
 
-  - name: Create a source DB instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mysql
-      backup_retention_period: 1
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      region: '{{ region_src }}'
-      tags:
-        Name: '{{ instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: source_db
-
-  - assert:
-      that:
-      - source_db.changed
-      - source_db.db_instance_identifier == '{{ instance_id }}'
-
-    # ------------------------------------------------------------------------------------------
-
-  - name: Create a read replica in a different region - check_mode
-    rds_instance:
-      id: '{{ instance_id }}-replica'
-      state: present
-      source_db_instance_identifier: '{{ instance_id }}'
-      engine: mysql
-      username: '{{ username }}'
-      password: '{{ password }}'
-      read_replica: true
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      region: '{{ region_dest }}'
-      tags:
-        Name: '{{ instance_id }}'
-        Created_by: Ansible rds_instance tests
-      wait: yes
-    register: result
-    check_mode: yes
-
-  - assert:
-      that:
-      - result.changed
-
-  - name: Create a read replica in a different region
-    rds_instance:
-      id: '{{ instance_id }}-replica'
-      state: present
-      source_db_instance_identifier: '{{ instance_id }}'
-      engine: mysql
-      username: '{{ username }}'
-      password: '{{ password }}'
-      read_replica: true
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      region: '{{ region_dest }}'
-      tags:
-        Name: '{{ instance_id }}'
-        Created_by: Ansible rds_instance tests
-      wait: yes
-    register: result
-
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == '{{ instance_id }}-replica'
-      - result.tags | length == 2
-      - result.tags.Name == '{{ instance_id }}'
-      - result.tags.Created_by == 'Ansible rds_instance tests'
-
-  - name: Test idempotence with a read replica - check_mode
-    rds_instance:
-      id: '{{ instance_id }}-replica'
-      state: present
-      source_db_instance_identifier: '{{ instance_id }}'
-      engine: mysql
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      region: '{{ region_dest }}'
-      tags:
-        Name: '{{ instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
-    check_mode: yes
-
-  - assert:
-      that:
-      - not result.changed
-
-  - name: Test idempotence with a read replica
-    rds_instance:
-      id: '{{ instance_id }}-replica'
-      state: present
-      source_db_instance_identifier: '{{ instance_id }}'
-      engine: mysql
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      region: '{{ region_dest }}'
-      tags:
-        Name: '{{ instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
-
-  - assert:
-      that:
-      - not result.changed
-
-  - name: Test idempotence with read_replica=True
-    rds_instance:
-      id: '{{ instance_id }}-replica'
-      state: present
-      read_replica: true
-      source_db_instance_identifier: '{{ instance_id }}'
-      engine: mysql
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      region: '{{ region_dest }}'
-      tags:
-        Name: '{{ instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
-
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - source_db.changed
+          - source_db.db_instance_identifier == '{{ instance_id }}'
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Promote the read replica - check_mode
-    rds_instance:
-      id: '{{ instance_id }}-replica'
-      state: present
-      read_replica: false
-      region: '{{ region_dest }}'
-    register: result
-    check_mode: yes
+    - name: Create a read replica in a different region - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}-replica"
+        state: present
+        source_db_instance_identifier: "{{ instance_id }}"
+        engine: mysql
+        username: "{{ username }}"
+        password: "{{ password }}"
+        read_replica: true
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        region: "{{ region_dest }}"
+        tags:
+          Name: "{{ instance_id }}"
+          Created_by: Ansible rds_instance tests
+        wait: true
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Promote the read replica
-    rds_instance:
-      id: '{{ instance_id }}-replica'
-      state: present
-      read_replica: false
-      region: '{{ region_dest }}'
-    register: result
+    - name: Create a read replica in a different region
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}-replica"
+        state: present
+        source_db_instance_identifier: "{{ instance_id }}"
+        engine: mysql
+        username: "{{ username }}"
+        password: "{{ password }}"
+        read_replica: true
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        region: "{{ region_dest }}"
+        tags:
+          Name: "{{ instance_id }}"
+          Created_by: Ansible rds_instance tests
+        wait: true
+      register: result
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == '{{ instance_id }}-replica'
+          - result.tags | length == 2
+          - result.tags.Name == '{{ instance_id }}'
+          - result.tags.Created_by == 'Ansible rds_instance tests'
 
-  - name: Test idempotence - check_mode
-    rds_instance:
-      id: '{{ instance_id }}-replica'
-      state: present
-      read_replica: false
-      region: '{{ region_dest }}'
-    register: result
-    check_mode: yes
+    - name: Test idempotence with a read replica - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}-replica"
+        state: present
+        source_db_instance_identifier: "{{ instance_id }}"
+        engine: mysql
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        region: "{{ region_dest }}"
+        tags:
+          Name: "{{ instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: Test idempotence
-    rds_instance:
-      id: '{{ instance_id }}-replica'
-      state: present
-      read_replica: false
-      region: '{{ region_dest }}'
-    register: result
+    - name: Test idempotence with a read replica
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}-replica"
+        state: present
+        source_db_instance_identifier: "{{ instance_id }}"
+        engine: mysql
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        region: "{{ region_dest }}"
+        tags:
+          Name: "{{ instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+
+    - name: Test idempotence with read_replica=True
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}-replica"
+        state: present
+        read_replica: true
+        source_db_instance_identifier: "{{ instance_id }}"
+        engine: mysql
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        region: "{{ region_dest }}"
+        tags:
+          Name: "{{ instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Promote the read replica - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}-replica"
+        state: present
+        read_replica: false
+        region: "{{ region_dest }}"
+      register: result
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+
+    - name: Promote the read replica
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}-replica"
+        state: present
+        read_replica: false
+        region: "{{ region_dest }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+
+    - name: Test idempotence - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}-replica"
+        state: present
+        read_replica: false
+        region: "{{ region_dest }}"
+      register: result
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+
+    - name: Test idempotence
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}-replica"
+        state: present
+        read_replica: false
+        region: "{{ region_dest }}"
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
   always:
+    - name: Remove the DB instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+        region: "{{ region_src }}"
+        wait: false
+      ignore_errors: true
 
-  - name: Remove the DB instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-      region: '{{ region_src }}'
-      wait: false
-    ignore_errors: yes
-
-  - name: Remove the DB replica
-    rds_instance:
-      id: '{{ instance_id }}-replica'
-      state: absent
-      skip_final_snapshot: true
-      region: '{{ region_dest }}'
-      wait: false
-    ignore_errors: yes
+    - name: Remove the DB replica
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}-replica"
+        state: absent
+        skip_final_snapshot: true
+        region: "{{ region_dest }}"
+        wait: false
+      ignore_errors: true

--- a/tests/integration/targets/rds_instance_restore/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_restore/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 instance_id: ansible-test-{{ tiny_prefix }}
 username: test
 password: test12345678

--- a/tests/integration/targets/rds_instance_restore/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_restore/tasks/main.yml
@@ -1,131 +1,131 @@
+---
 - name: rds_instance / restore integration tests
   collections:
-  - community.aws
+    - community.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-     # TODO: snapshot, s3
+    # TODO: snapshot, s3
 
-  - name: Ensure the resource doesn't exist
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
+    - name: Ensure the resource doesn't exist
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+      ignore_errors: true
 
-  - name: Create a source DB instance
-    rds_instance:
-      id: '{{ instance_id }}-s'
-      state: present
-      engine: mysql
-      backup_retention_period: 1
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-    register: source_db
+    - name: Create a source DB instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}-s"
+        state: present
+        engine: mysql
+        backup_retention_period: 1
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+      register: source_db
 
-  - assert:
-      that:
-      - source_db.changed
-      - source_db.db_instance_identifier == '{{ instance_id }}-s'
+    - ansible.builtin.assert:
+        that:
+          - source_db.changed
+          - source_db.db_instance_identifier == '{{ instance_id }}-s'
 
-  - name: Create a point in time DB instance - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      source_db_instance_identifier: '{{ instance_id }}-s'
-      creation_source: instance
-      engine: mysql
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      use_latest_restorable_time: true
-    register: result
-    check_mode: yes
+    - name: Create a point in time DB instance - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        source_db_instance_identifier: "{{ instance_id }}-s"
+        creation_source: instance
+        engine: mysql
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        use_latest_restorable_time: true
+      register: result
+      check_mode: true
 
-  - assert:
-      that: result.changed
+    - ansible.builtin.assert:
+        that: result.changed
 
-  - name: Create a point in time DB instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      source_db_instance_identifier: '{{ instance_id }}-s'
-      creation_source: instance
-      engine: mysql
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      use_latest_restorable_time: true
-    register: result
+    - name: Create a point in time DB instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        source_db_instance_identifier: "{{ instance_id }}-s"
+        creation_source: instance
+        engine: mysql
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        use_latest_restorable_time: true
+      register: result
 
-  - assert:
-      that: result.changed
+    - ansible.builtin.assert:
+        that: result.changed
 
-  - name: Create a point in time DB instance (idempotence) - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      source_db_instance_identifier: '{{ instance_id }}-s'
-      creation_source: instance
-      engine: mysql
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      restore_time: '{{ result.latest_restorable_time }}'
-    register: result
-    check_mode: yes
+    - name: Create a point in time DB instance (idempotence) - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        source_db_instance_identifier: "{{ instance_id }}-s"
+        creation_source: instance
+        engine: mysql
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        restore_time: "{{ result.latest_restorable_time }}"
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: Create a point in time DB instance (idempotence)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      source_db_instance_identifier: '{{ instance_id }}-s'
-      creation_source: instance
-      engine: mysql
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      restore_time: '{{ result.latest_restorable_time }}'
-    register: result
+    - name: Create a point in time DB instance (idempotence)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        source_db_instance_identifier: "{{ instance_id }}-s"
+        creation_source: instance
+        engine: mysql
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        restore_time: "{{ result.latest_restorable_time }}"
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
 
   always:
+    - name: Remove the DB instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}-s"
+        state: absent
+        skip_final_snapshot: true
+        wait: false
+      ignore_errors: true
 
-  - name: Remove the DB instance
-    rds_instance:
-      id: '{{ instance_id }}-s'
-      state: absent
-      skip_final_snapshot: true
-      wait: false
-    ignore_errors: yes
-
-  - name: Remove the point in time restored DB
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-      wait: false
-    ignore_errors: yes
+    - name: Remove the point in time restored DB
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+        wait: false
+      ignore_errors: true

--- a/tests/integration/targets/rds_instance_sgroups/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_sgroups/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 instance_id: ansible-test-{{ tiny_prefix }}
 username: test
 password: test12345678

--- a/tests/integration/targets/rds_instance_sgroups/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_sgroups/tasks/main.yml
@@ -1,332 +1,323 @@
+---
 - name: rds_instance / sgroups integration tests
   collections:
-  - community.aws
+    - community.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
+    - name: create a VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        state: present
+        cidr_block: 10.122.122.128/26
+        tags:
+          Name: "{{ resource_prefix }}-vpc"
+          Description: created by rds_instance integration tests
+      register: vpc_result
 
-  - name: create a VPC
-    ec2_vpc_net:
-      name: '{{ resource_prefix }}-vpc'
-      state: present
-      cidr_block: 10.122.122.128/26
-      tags:
-        Name: '{{ resource_prefix }}-vpc'
-        Description: created by rds_instance integration tests
-    register: vpc_result
+    - name: create subnets
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ item.cidr }}"
+        az: "{{ item.zone }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          Name: "{{ resource_prefix }}-subnet"
+          Description: created by rds_instance integration tests
+        state: present
+      register: subnets_result
+      loop:
+        - { cidr: 10.122.122.128/28, zone: "{{ aws_region }}a" }
+        - { cidr: 10.122.122.144/28, zone: "{{ aws_region }}b" }
+        - { cidr: 10.122.122.160/28, zone: "{{ aws_region }}c" }
 
-  - name: create subnets
-    ec2_vpc_subnet:
-      cidr: '{{ item.cidr }}'
-      az: '{{ item.zone }}'
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      tags:
-        Name: '{{ resource_prefix }}-subnet'
-        Description: created by rds_instance integration tests
-      state: present
-    register: subnets_result
-    loop:
-    - {cidr: 10.122.122.128/28, zone: '{{ aws_region }}a'}
-    - {cidr: 10.122.122.144/28, zone: '{{ aws_region }}b'}
-    - {cidr: 10.122.122.160/28, zone: '{{ aws_region }}c'}
+    - name: Create security groups
+      ec2_security_group:
+        name: "{{ item }}"
+        description: created by rds_instance integration tests
+        state: present
+      register: sgs_result
+      loop:
+        - "{{ resource_prefix }}-sg-1"
+        - "{{ resource_prefix }}-sg-2"
+        - "{{ resource_prefix }}-sg-3"
 
-  - name: Create security groups
-    ec2_security_group:
-      name: '{{ item }}'
-      description: created by rds_instance integration tests
-      state: present
-    register: sgs_result
-    loop:
-    - '{{ resource_prefix }}-sg-1'
-    - '{{ resource_prefix }}-sg-2'
-    - '{{ resource_prefix }}-sg-3'
+    - name: Ensure the resource doesn't exist
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - name: Ensure the resource doesn't exist
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
-
-  - assert:
-      that:
-      - not result.changed
-    ignore_errors: yes
-
-    # ------------------------------------------------------------------------------------------
-
-  - name: Create a DB instance in the VPC with two security groups - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      vpc_security_group_ids:
-      - '{{ sgs_result.results.0.group_id }}'
-      - '{{ sgs_result.results.1.group_id }}'
-    register: result
-    check_mode: yes
-
-  - assert:
-      that:
-      - result.changed
-
-  - name: Create a DB instance in the VPC with two security groups
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      vpc_security_group_ids:
-      - '{{ sgs_result.results.0.group_id }}'
-      - '{{ sgs_result.results.1.group_id }}'
-    register: result
-
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
-      - result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding'])
-        | list | length == 2
-
-  - name: Create a DB instance in the VPC with two security groups (idempotence) -
-      check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      vpc_security_group_ids:
-      - '{{ sgs_result.results.0.group_id }}'
-      - '{{ sgs_result.results.1.group_id }}'
-    register: result
-    check_mode: yes
-
-  - assert:
-      that:
-      - not result.changed
-
-  - name: Create a DB instance in the VPC with two security groups (idempotence)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      vpc_security_group_ids:
-      - '{{ sgs_result.results.0.group_id }}'
-      - '{{ sgs_result.results.1.group_id }}'
-    register: result
-
-  - assert:
-      that:
-      - not result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
-      - result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding'])
-        | list | length == 2
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+      ignore_errors: true
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Add a new security group without purge - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      vpc_security_group_ids:
-      - '{{ sgs_result.results.2.group_id }}'
-      apply_immediately: true
-      purge_security_groups: false
-    check_mode: true
-    register: result
+    - name: Create a DB instance in the VPC with two security groups - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        vpc_security_group_ids:
+          - "{{ sgs_result.results.0.group_id }}"
+          - "{{ sgs_result.results.1.group_id }}"
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Add a new security group without purge
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      vpc_security_group_ids:
-      - '{{ sgs_result.results.2.group_id }}'
-      apply_immediately: true
-      purge_security_groups: false
-    register: result
+    - name: Create a DB instance in the VPC with two security groups
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        vpc_security_group_ids:
+          - "{{ sgs_result.results.0.group_id }}"
+          - "{{ sgs_result.results.1.group_id }}"
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
-      - result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding'])
-        | list | length == 3
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
+          - result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 2
 
-  - name: Add a new security group without purge (idempotence) - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      vpc_security_group_ids:
-      - '{{ sgs_result.results.2.group_id }}'
-      apply_immediately: true
-      purge_security_groups: false
-    register: result
-    check_mode: yes
+    - name: Create a DB instance in the VPC with two security groups (idempotence) - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        vpc_security_group_ids:
+          - "{{ sgs_result.results.0.group_id }}"
+          - "{{ sgs_result.results.1.group_id }}"
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: Add a new security group without purge (idempotence)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      vpc_security_group_ids:
-      - '{{ sgs_result.results.2.group_id }}'
-      apply_immediately: true
-      purge_security_groups: false
-    register: result
+    - name: Create a DB instance in the VPC with two security groups (idempotence)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        vpc_security_group_ids:
+          - "{{ sgs_result.results.0.group_id }}"
+          - "{{ sgs_result.results.1.group_id }}"
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
-      - result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding'])
-        | list | length == 3
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
+          - result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 2
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Add a security group with purge - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      vpc_security_group_ids:
-      - '{{ sgs_result.results.2.group_id }}'
-      apply_immediately: true
-    register: result
-    check_mode: yes
+    - name: Add a new security group without purge - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        vpc_security_group_ids:
+          - "{{ sgs_result.results.2.group_id }}"
+        apply_immediately: true
+        purge_security_groups: false
+      check_mode: true
+      register: result
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
 
-  - name: Add a security group with purge
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      vpc_security_group_ids:
-      - '{{ sgs_result.results.2.group_id }}'
-      apply_immediately: true
-    register: result
+    - name: Add a new security group without purge
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        vpc_security_group_ids:
+          - "{{ sgs_result.results.2.group_id }}"
+        apply_immediately: true
+        purge_security_groups: false
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
-      - result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding'])
-        | list | length == 1
-      - result.vpc_security_groups | selectattr('status', 'equalto', 'removing') |
-        list | length == 2
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
+          - result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 3
 
-  - name: Add a security group with purge (idempotence) - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      vpc_security_group_ids:
-      - '{{ sgs_result.results.2.group_id }}'
-      apply_immediately: true
-    register: result
-    check_mode: yes
+    - name: Add a new security group without purge (idempotence) - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        vpc_security_group_ids:
+          - "{{ sgs_result.results.2.group_id }}"
+        apply_immediately: true
+        purge_security_groups: false
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
 
-  - name: Add a security group with purge (idempotence)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      vpc_security_group_ids:
-      - '{{ sgs_result.results.2.group_id }}'
-      apply_immediately: true
-    register: result
+    - name: Add a new security group without purge (idempotence)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        vpc_security_group_ids:
+          - "{{ sgs_result.results.2.group_id }}"
+        apply_immediately: true
+        purge_security_groups: false
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
-      - result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding'])
-        | list | length == 1
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
+          - result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 3
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Add a security group with purge - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        vpc_security_group_ids:
+          - "{{ sgs_result.results.2.group_id }}"
+        apply_immediately: true
+      register: result
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+
+    - name: Add a security group with purge
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        vpc_security_group_ids:
+          - "{{ sgs_result.results.2.group_id }}"
+        apply_immediately: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
+          - result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 1
+          - result.vpc_security_groups | selectattr('status', 'equalto', 'removing') | list | length == 2
+
+    - name: Add a security group with purge (idempotence) - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        vpc_security_group_ids:
+          - "{{ sgs_result.results.2.group_id }}"
+        apply_immediately: true
+      register: result
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+
+    - name: Add a security group with purge (idempotence)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        vpc_security_group_ids:
+          - "{{ sgs_result.results.2.group_id }}"
+        apply_immediately: true
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
+          - result.vpc_security_groups | selectattr('status', 'in', ['active', 'adding']) | list | length == 1
 
   always:
+    - name: Ensure the resource doesn't exist
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
+      ignore_errors: true
 
-  - name: Ensure the resource doesn't exist
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
-    ignore_errors: yes
+    - name: Remove security groups
+      ec2_security_group:
+        name: "{{ item }}"
+        description: created by rds_instance integration tests
+        state: absent
+      register: sgs_result
+      loop:
+        - "{{ resource_prefix }}-sg-1"
+        - "{{ resource_prefix }}-sg-2"
+        - "{{ resource_prefix }}-sg-3"
+      ignore_errors: true
+      retries: 30
+      until: sgs_result is not failed
+      delay: 10
 
-  - name: Remove security groups
-    ec2_security_group:
-      name: '{{ item }}'
-      description: created by rds_instance integration tests
-      state: absent
-    register: sgs_result
-    loop:
-    - '{{ resource_prefix }}-sg-1'
-    - '{{ resource_prefix }}-sg-2'
-    - '{{ resource_prefix }}-sg-3'
-    ignore_errors: yes
-    retries: 30
-    until: sgs_result is not failed
-    delay: 10
+    - name: remove subnets
+      amazon.aws.ec2_vpc_subnet:
+        cidr: "{{ item.cidr }}"
+        az: "{{ item.zone }}"
+        vpc_id: "{{ vpc_result.vpc.id }}"
+        tags:
+          Name: "{{ resource_prefix }}-subnet"
+          Description: created by rds_instance integration tests
+        state: absent
+      register: subnets
+      ignore_errors: true
+      retries: 30
+      until: subnets is not failed
+      delay: 10
+      loop:
+        - { cidr: 10.122.122.128/28, zone: "{{ aws_region }}a" }
+        - { cidr: 10.122.122.144/28, zone: "{{ aws_region }}b" }
+        - { cidr: 10.122.122.160/28, zone: "{{ aws_region }}c" }
+        - { cidr: 10.122.122.176/28, zone: "{{ aws_region }}d" }
 
-  - name: remove subnets
-    ec2_vpc_subnet:
-      cidr: '{{ item.cidr }}'
-      az: '{{ item.zone }}'
-      vpc_id: '{{ vpc_result.vpc.id }}'
-      tags:
-        Name: '{{ resource_prefix }}-subnet'
-        Description: created by rds_instance integration tests
-      state: absent
-    register: subnets
-    ignore_errors: yes
-    retries: 30
-    until: subnets is not failed
-    delay: 10
-    loop:
-    - {cidr: 10.122.122.128/28, zone: '{{ aws_region }}a'}
-    - {cidr: 10.122.122.144/28, zone: '{{ aws_region }}b'}
-    - {cidr: 10.122.122.160/28, zone: '{{ aws_region }}c'}
-    - {cidr: 10.122.122.176/28, zone: '{{ aws_region }}d'}
-
-  - name: Delete VPC
-    ec2_vpc_net:
-      name: '{{ resource_prefix }}-vpc'
-      state: absent
-      cidr_block: 10.122.122.128/26
-      tags:
-        Name: '{{ resource_prefix }}-vpc'
-        Description: created by rds_instance integration tests
-    register: vpc_result
-    ignore_errors: yes
-    retries: 30
-    until: vpc_result is not failed
-    delay: 10
+    - name: Delete VPC
+      amazon.aws.ec2_vpc_net:
+        name: "{{ resource_prefix }}-vpc"
+        state: absent
+        cidr_block: 10.122.122.128/26
+        tags:
+          Name: "{{ resource_prefix }}-vpc"
+          Description: created by rds_instance integration tests
+      register: vpc_result
+      ignore_errors: true
+      retries: 30
+      until: vpc_result is not failed
+      delay: 10

--- a/tests/integration/targets/rds_instance_snapshot/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_snapshot/defaults/main.yml
@@ -2,13 +2,13 @@
 # defaults file for rds_instance_snapshot
 
 # Create RDS instance
-instance_id: '{{ resource_prefix }}-instance'
-username: 'testrdsusername'
+instance_id: "{{ resource_prefix }}-instance"
+username: testrdsusername
 password: "{{ lookup('password', '/dev/null') }}"
 db_instance_class: db.t3.micro
 allocated_storage: 10
-engine: 'mariadb'
+engine: mariadb
 mariadb_engine_version: 10.6.10
 
 # Create snapshot
-snapshot_id: '{{ instance_id }}-snapshot'
+snapshot_id: "{{ instance_id }}-snapshot"

--- a/tests/integration/targets/rds_instance_snapshot/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_snapshot/tasks/main.yml
@@ -10,496 +10,496 @@
     - amazon.aws
 
   block:
-  - name: Create a source mariadb instance
-    rds_instance:
-      id: "{{ instance_id }}"
-      state: present
-      engine: "{{ engine}}"
-      engine_version: "{{ mariadb_engine_version }}"
-      allow_major_version_upgrade: true
-      username: "{{ username }}"
-      password: "{{ password }}"
-      db_instance_class: "{{ db_instance_class }}"
-      allocated_storage: "{{ allocated_storage }}"
-    register: _result_create_instance
+    - name: Create a source mariadb instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: "{{ engine}}"
+        engine_version: "{{ mariadb_engine_version }}"
+        allow_major_version_upgrade: true
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+      register: _result_create_instance
 
-  - assert:
-      that:
-      - _result_create_instance.changed
-      - _result_create_instance.db_instance_identifier == instance_id
+    - ansible.builtin.assert:
+        that:
+          - _result_create_instance.changed
+          - _result_create_instance.db_instance_identifier == instance_id
 
-  - name: Get all RDS snapshots for the existing instance
-    rds_snapshot_info:
-      db_instance_identifier: "{{ instance_id }}"
-    register: _result_instance_snapshot_info
+    - name: Get all RDS snapshots for the existing instance
+      amazon.aws.rds_snapshot_info:
+        db_instance_identifier: "{{ instance_id }}"
+      register: _result_instance_snapshot_info
 
-  - assert:
-      that:
-      - _result_instance_snapshot_info is successful
-      - _result_instance_snapshot_info.snapshots | length == 1
+    - ansible.builtin.assert:
+        that:
+          - _result_instance_snapshot_info is successful
+          - _result_instance_snapshot_info.snapshots | length == 1
 
-  - name: Take a snapshot of the existing RDS instance (CHECK_MODE)
-    rds_instance_snapshot:
-      state: present
-      db_instance_identifier: "{{ instance_id }}"
-      db_snapshot_identifier: "{{ snapshot_id }}"
-    check_mode: yes
-    register: _result_instance_snapshot
+    - name: Take a snapshot of the existing RDS instance (CHECK_MODE)
+      rds_instance_snapshot:
+        state: present
+        db_instance_identifier: "{{ instance_id }}"
+        db_snapshot_identifier: "{{ snapshot_id }}"
+      check_mode: true
+      register: _result_instance_snapshot
 
-  - assert:
-      that:
-      - _result_instance_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_instance_snapshot.changed
 
-  - name: Take a snapshot of the existing RDS instance
-    rds_instance_snapshot:
-      state: present
-      db_instance_identifier: "{{ instance_id }}"
-      db_snapshot_identifier: "{{ snapshot_id }}"
-      wait: true
-    register: _result_instance_snapshot
+    - name: Take a snapshot of the existing RDS instance
+      rds_instance_snapshot:
+        state: present
+        db_instance_identifier: "{{ instance_id }}"
+        db_snapshot_identifier: "{{ snapshot_id }}"
+        wait: true
+      register: _result_instance_snapshot
 
-  - assert:
-      that:
-      - _result_instance_snapshot.changed
-      - "'availability_zone' in _result_instance_snapshot"
-      - "'instance_create_time' in _result_instance_snapshot"
-      - "'db_instance_identifier' in _result_instance_snapshot"
-      - _result_instance_snapshot.db_instance_identifier == instance_id
-      - "'db_snapshot_identifier' in _result_instance_snapshot"
-      - _result_instance_snapshot.db_snapshot_identifier == snapshot_id
-      - "'db_snapshot_arn' in _result_instance_snapshot"
-      - "'dbi_resource_id' in _result_instance_snapshot"
-      - "'encrypted' in _result_instance_snapshot"
-      - "'engine' in _result_instance_snapshot"
-      - _result_instance_snapshot.engine == engine
-      - "'engine_version' in _result_instance_snapshot"
-      - _result_instance_snapshot.engine_version == mariadb_engine_version
-      - "'iam_database_authentication_enabled' in _result_instance_snapshot"
-      - "'license_model' in _result_instance_snapshot"
-      - "'master_username' in _result_instance_snapshot"
-      - _result_instance_snapshot.master_username == username
-      - "'snapshot_create_time' in _result_instance_snapshot"
-      - "'snapshot_type' in _result_instance_snapshot"
-      - "'status' in _result_instance_snapshot"
-      - _result_instance_snapshot.status == "available"
-      - "'snapshot_type' in _result_instance_snapshot"
-      - _result_instance_snapshot.snapshot_type == "manual"
-      - "'status' in _result_instance_snapshot"
-      - "'storage_type' in _result_instance_snapshot"
-      - _result_instance_snapshot.storage_type == "gp2"
-      - "'tags' in _result_instance_snapshot"
-      - "'vpc_id' in _result_instance_snapshot"
+    - ansible.builtin.assert:
+        that:
+          - _result_instance_snapshot.changed
+          - "'availability_zone' in _result_instance_snapshot"
+          - "'instance_create_time' in _result_instance_snapshot"
+          - "'db_instance_identifier' in _result_instance_snapshot"
+          - _result_instance_snapshot.db_instance_identifier == instance_id
+          - "'db_snapshot_identifier' in _result_instance_snapshot"
+          - _result_instance_snapshot.db_snapshot_identifier == snapshot_id
+          - "'db_snapshot_arn' in _result_instance_snapshot"
+          - "'dbi_resource_id' in _result_instance_snapshot"
+          - "'encrypted' in _result_instance_snapshot"
+          - "'engine' in _result_instance_snapshot"
+          - _result_instance_snapshot.engine == engine
+          - "'engine_version' in _result_instance_snapshot"
+          - _result_instance_snapshot.engine_version == mariadb_engine_version
+          - "'iam_database_authentication_enabled' in _result_instance_snapshot"
+          - "'license_model' in _result_instance_snapshot"
+          - "'master_username' in _result_instance_snapshot"
+          - _result_instance_snapshot.master_username == username
+          - "'snapshot_create_time' in _result_instance_snapshot"
+          - "'snapshot_type' in _result_instance_snapshot"
+          - "'status' in _result_instance_snapshot"
+          - _result_instance_snapshot.status == "available"
+          - "'snapshot_type' in _result_instance_snapshot"
+          - _result_instance_snapshot.snapshot_type == "manual"
+          - "'status' in _result_instance_snapshot"
+          - "'storage_type' in _result_instance_snapshot"
+          - _result_instance_snapshot.storage_type == "gp2"
+          - "'tags' in _result_instance_snapshot"
+          - "'vpc_id' in _result_instance_snapshot"
 
-  - name: Take a snapshot of the existing RDS instance (CHECK_MODE - IDEMPOTENCE)
-    rds_instance_snapshot:
-      state: present
-      db_instance_identifier: "{{ instance_id }}"
-      db_snapshot_identifier: "{{ snapshot_id }}"
-    check_mode: yes
-    register: _result_instance_snapshot
+    - name: Take a snapshot of the existing RDS instance (CHECK_MODE - IDEMPOTENCE)
+      rds_instance_snapshot:
+        state: present
+        db_instance_identifier: "{{ instance_id }}"
+        db_snapshot_identifier: "{{ snapshot_id }}"
+      check_mode: true
+      register: _result_instance_snapshot
 
-  - assert:
-      that:
-      - not _result_instance_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_instance_snapshot.changed
 
-  - name: Take a snapshot of the existing RDS instance (IDEMPOTENCE)
-    rds_instance_snapshot:
-      state: present
-      db_instance_identifier: "{{ instance_id }}"
-      db_snapshot_identifier: "{{ snapshot_id }}"
-      wait: true
-    register: _result_instance_snapshot
+    - name: Take a snapshot of the existing RDS instance (IDEMPOTENCE)
+      rds_instance_snapshot:
+        state: present
+        db_instance_identifier: "{{ instance_id }}"
+        db_snapshot_identifier: "{{ snapshot_id }}"
+        wait: true
+      register: _result_instance_snapshot
 
-  - assert:
-      that:
-      - not _result_instance_snapshot.changed
-      - "'availability_zone' in _result_instance_snapshot"
-      - "'instance_create_time' in _result_instance_snapshot"
-      - "'db_instance_identifier' in _result_instance_snapshot"
-      - _result_instance_snapshot.db_instance_identifier == instance_id
-      - "'db_snapshot_identifier' in _result_instance_snapshot"
-      - _result_instance_snapshot.db_snapshot_identifier == snapshot_id
-      - "'db_snapshot_arn' in _result_instance_snapshot"
-      - "'dbi_resource_id' in _result_instance_snapshot"
-      - "'encrypted' in _result_instance_snapshot"
-      - "'engine' in _result_instance_snapshot"
-      - _result_instance_snapshot.engine == engine
-      - "'engine_version' in _result_instance_snapshot"
-      - _result_instance_snapshot.engine_version == mariadb_engine_version
-      - "'iam_database_authentication_enabled' in _result_instance_snapshot"
-      - "'license_model' in _result_instance_snapshot"
-      - "'master_username' in _result_instance_snapshot"
-      - _result_instance_snapshot.master_username == username
-      - "'snapshot_create_time' in _result_instance_snapshot"
-      - "'snapshot_type' in _result_instance_snapshot"
-      - "'status' in _result_instance_snapshot"
-      - _result_instance_snapshot.status == "available"
-      - "'snapshot_type' in _result_instance_snapshot"
-      - _result_instance_snapshot.snapshot_type == "manual"
-      - "'status' in _result_instance_snapshot"
-      - "'storage_type' in _result_instance_snapshot"
-      - _result_instance_snapshot.storage_type == "gp2"
-      - "'tags' in _result_instance_snapshot"
-      - "'vpc_id' in _result_instance_snapshot"
+    - ansible.builtin.assert:
+        that:
+          - not _result_instance_snapshot.changed
+          - "'availability_zone' in _result_instance_snapshot"
+          - "'instance_create_time' in _result_instance_snapshot"
+          - "'db_instance_identifier' in _result_instance_snapshot"
+          - _result_instance_snapshot.db_instance_identifier == instance_id
+          - "'db_snapshot_identifier' in _result_instance_snapshot"
+          - _result_instance_snapshot.db_snapshot_identifier == snapshot_id
+          - "'db_snapshot_arn' in _result_instance_snapshot"
+          - "'dbi_resource_id' in _result_instance_snapshot"
+          - "'encrypted' in _result_instance_snapshot"
+          - "'engine' in _result_instance_snapshot"
+          - _result_instance_snapshot.engine == engine
+          - "'engine_version' in _result_instance_snapshot"
+          - _result_instance_snapshot.engine_version == mariadb_engine_version
+          - "'iam_database_authentication_enabled' in _result_instance_snapshot"
+          - "'license_model' in _result_instance_snapshot"
+          - "'master_username' in _result_instance_snapshot"
+          - _result_instance_snapshot.master_username == username
+          - "'snapshot_create_time' in _result_instance_snapshot"
+          - "'snapshot_type' in _result_instance_snapshot"
+          - "'status' in _result_instance_snapshot"
+          - _result_instance_snapshot.status == "available"
+          - "'snapshot_type' in _result_instance_snapshot"
+          - _result_instance_snapshot.snapshot_type == "manual"
+          - "'status' in _result_instance_snapshot"
+          - "'storage_type' in _result_instance_snapshot"
+          - _result_instance_snapshot.storage_type == "gp2"
+          - "'tags' in _result_instance_snapshot"
+          - "'vpc_id' in _result_instance_snapshot"
 
-  - name: Get information about the existing DB snapshot
-    rds_snapshot_info:
-      db_snapshot_identifier: "{{ snapshot_id }}"
-    register: _result_instance_snapshot_info
+    - name: Get information about the existing DB snapshot
+      amazon.aws.rds_snapshot_info:
+        db_snapshot_identifier: "{{ snapshot_id }}"
+      register: _result_instance_snapshot_info
 
-  - assert:
-      that:
-      - _result_instance_snapshot_info is successful
-      - _result_instance_snapshot_info.snapshots[0].db_instance_identifier == instance_id
-      - _result_instance_snapshot_info.snapshots[0].db_snapshot_identifier == snapshot_id
+    - ansible.builtin.assert:
+        that:
+          - _result_instance_snapshot_info is successful
+          - _result_instance_snapshot_info.snapshots[0].db_instance_identifier == instance_id
+          - _result_instance_snapshot_info.snapshots[0].db_snapshot_identifier == snapshot_id
 
-  - name: Take another snapshot of the existing RDS instance
-    rds_instance_snapshot:
-      state: present
-      db_instance_identifier: "{{ instance_id }}"
-      db_snapshot_identifier: "{{ snapshot_id }}-b"
-      wait: true
-    register: _result_instance_snapshot
+    - name: Take another snapshot of the existing RDS instance
+      rds_instance_snapshot:
+        state: present
+        db_instance_identifier: "{{ instance_id }}"
+        db_snapshot_identifier: "{{ snapshot_id }}-b"
+        wait: true
+      register: _result_instance_snapshot
 
-  - assert:
-      that:
-      - _result_instance_snapshot.changed
-      - "'availability_zone' in _result_instance_snapshot"
-      - "'instance_create_time' in _result_instance_snapshot"
-      - "'db_instance_identifier' in _result_instance_snapshot"
-      - _result_instance_snapshot.db_instance_identifier == instance_id
-      - "'db_snapshot_identifier' in _result_instance_snapshot"
-      - _result_instance_snapshot.db_snapshot_identifier == snapshot_id+"-b"
-      - "'db_snapshot_arn' in _result_instance_snapshot"
-      - "'dbi_resource_id' in _result_instance_snapshot"
-      - "'encrypted' in _result_instance_snapshot"
-      - "'engine' in _result_instance_snapshot"
-      - _result_instance_snapshot.engine == engine
-      - "'engine_version' in _result_instance_snapshot"
-      - _result_instance_snapshot.engine_version == mariadb_engine_version
-      - "'iam_database_authentication_enabled' in _result_instance_snapshot"
-      - "'license_model' in _result_instance_snapshot"
-      - "'master_username' in _result_instance_snapshot"
-      - _result_instance_snapshot.master_username == username
-      - "'snapshot_create_time' in _result_instance_snapshot"
-      - "'snapshot_type' in _result_instance_snapshot"
-      - "'status' in _result_instance_snapshot"
-      - _result_instance_snapshot.status == "available"
-      - "'snapshot_type' in _result_instance_snapshot"
-      - _result_instance_snapshot.snapshot_type == "manual"
-      - "'status' in _result_instance_snapshot"
-      - "'storage_type' in _result_instance_snapshot"
-      - _result_instance_snapshot.storage_type == "gp2"
-      - "'tags' in _result_instance_snapshot"
-      - "'vpc_id' in _result_instance_snapshot"
+    - ansible.builtin.assert:
+        that:
+          - _result_instance_snapshot.changed
+          - "'availability_zone' in _result_instance_snapshot"
+          - "'instance_create_time' in _result_instance_snapshot"
+          - "'db_instance_identifier' in _result_instance_snapshot"
+          - _result_instance_snapshot.db_instance_identifier == instance_id
+          - "'db_snapshot_identifier' in _result_instance_snapshot"
+          - _result_instance_snapshot.db_snapshot_identifier == snapshot_id+"-b"
+          - "'db_snapshot_arn' in _result_instance_snapshot"
+          - "'dbi_resource_id' in _result_instance_snapshot"
+          - "'encrypted' in _result_instance_snapshot"
+          - "'engine' in _result_instance_snapshot"
+          - _result_instance_snapshot.engine == engine
+          - "'engine_version' in _result_instance_snapshot"
+          - _result_instance_snapshot.engine_version == mariadb_engine_version
+          - "'iam_database_authentication_enabled' in _result_instance_snapshot"
+          - "'license_model' in _result_instance_snapshot"
+          - "'master_username' in _result_instance_snapshot"
+          - _result_instance_snapshot.master_username == username
+          - "'snapshot_create_time' in _result_instance_snapshot"
+          - "'snapshot_type' in _result_instance_snapshot"
+          - "'status' in _result_instance_snapshot"
+          - _result_instance_snapshot.status == "available"
+          - "'snapshot_type' in _result_instance_snapshot"
+          - _result_instance_snapshot.snapshot_type == "manual"
+          - "'status' in _result_instance_snapshot"
+          - "'storage_type' in _result_instance_snapshot"
+          - _result_instance_snapshot.storage_type == "gp2"
+          - "'tags' in _result_instance_snapshot"
+          - "'vpc_id' in _result_instance_snapshot"
 
-  - name: Get all snapshots for the existing RDS instance
-    rds_snapshot_info:
-      db_instance_identifier: "{{ instance_id }}"
-    register: _result_instance_snapshot_info
+    - name: Get all snapshots for the existing RDS instance
+      amazon.aws.rds_snapshot_info:
+        db_instance_identifier: "{{ instance_id }}"
+      register: _result_instance_snapshot_info
 
-  - assert:
-      that:
-      - _result_instance_snapshot_info is successful
-      #- _result_instance_snapshot_info.cluster_snapshots | length == 3
+    - ansible.builtin.assert:
+        that:
+          - _result_instance_snapshot_info is successful
+    #- _result_instance_snapshot_info.cluster_snapshots | length == 3
 
-  - name: Delete existing DB instance snapshot (CHECK_MODE)
-    rds_instance_snapshot:
-      state: absent
-      db_snapshot_identifier: "{{ snapshot_id }}-b"
-    register: _result_delete_snapshot
-    check_mode: yes
+    - name: Delete existing DB instance snapshot (CHECK_MODE)
+      rds_instance_snapshot:
+        state: absent
+        db_snapshot_identifier: "{{ snapshot_id }}-b"
+      register: _result_delete_snapshot
+      check_mode: true
 
-  - assert:
-      that:
-      - _result_delete_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_delete_snapshot.changed
 
-  - name: Delete the existing DB instance snapshot
-    rds_instance_snapshot:
-      state: absent
-      db_snapshot_identifier: "{{ snapshot_id }}-b"
-    register: _result_delete_snapshot
+    - name: Delete the existing DB instance snapshot
+      rds_instance_snapshot:
+        state: absent
+        db_snapshot_identifier: "{{ snapshot_id }}-b"
+      register: _result_delete_snapshot
 
-  - assert:
-      that:
-      - _result_delete_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_delete_snapshot.changed
 
-  - name: Delete existing DB instance snapshot (CHECK_MODE - IDEMPOTENCE)
-    rds_instance_snapshot:
-      state: absent
-      db_snapshot_identifier: "{{ snapshot_id }}-b"
-    register: _result_delete_snapshot
-    check_mode: yes
+    - name: Delete existing DB instance snapshot (CHECK_MODE - IDEMPOTENCE)
+      rds_instance_snapshot:
+        state: absent
+        db_snapshot_identifier: "{{ snapshot_id }}-b"
+      register: _result_delete_snapshot
+      check_mode: true
 
-  - assert:
-      that:
-      - not _result_delete_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_delete_snapshot.changed
 
-  - name: Delete the existing DB instance snapshot (IDEMPOTENCE)
-    rds_instance_snapshot:
-      state: absent
-      db_snapshot_identifier: "{{ snapshot_id }}-b"
-    register: _result_delete_snapshot
+    - name: Delete the existing DB instance snapshot (IDEMPOTENCE)
+      rds_instance_snapshot:
+        state: absent
+        db_snapshot_identifier: "{{ snapshot_id }}-b"
+      register: _result_delete_snapshot
 
-  - assert:
-      that:
-      - not _result_delete_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_delete_snapshot.changed
 
-  - name: Take another snapshot of the existing RDS instance and assign tags
-    rds_instance_snapshot:
-      state: present
-      db_instance_identifier: "{{ instance_id }}"
-      db_snapshot_identifier: "{{ snapshot_id }}-b"
-      wait: true
-      tags:
-        tag_one: '{{ snapshot_id }}-b One'
-        "Tag Two": 'two {{ snapshot_id }}-b'
-    register: _result_instance_snapshot
+    - name: Take another snapshot of the existing RDS instance and assign tags
+      rds_instance_snapshot:
+        state: present
+        db_instance_identifier: "{{ instance_id }}"
+        db_snapshot_identifier: "{{ snapshot_id }}-b"
+        wait: true
+        tags:
+          tag_one: "{{ snapshot_id }}-b One"
+          Tag Two: two {{ snapshot_id }}-b
+      register: _result_instance_snapshot
 
-  - assert:
-      that:
-      - _result_instance_snapshot.changed
-      - "'availability_zone' in _result_instance_snapshot"
-      - "'instance_create_time' in _result_instance_snapshot"
-      - "'db_instance_identifier' in _result_instance_snapshot"
-      - _result_instance_snapshot.db_instance_identifier == instance_id
-      - "'db_snapshot_identifier' in _result_instance_snapshot"
-      - _result_instance_snapshot.db_snapshot_identifier == snapshot_id+"-b"
-      - "'db_snapshot_arn' in _result_instance_snapshot"
-      - "'dbi_resource_id' in _result_instance_snapshot"
-      - "'encrypted' in _result_instance_snapshot"
-      - "'engine' in _result_instance_snapshot"
-      - _result_instance_snapshot.engine == engine
-      - "'engine_version' in _result_instance_snapshot"
-      - _result_instance_snapshot.engine_version == mariadb_engine_version
-      - "'iam_database_authentication_enabled' in _result_instance_snapshot"
-      - "'license_model' in _result_instance_snapshot"
-      - "'master_username' in _result_instance_snapshot"
-      - _result_instance_snapshot.master_username == username
-      - "'snapshot_create_time' in _result_instance_snapshot"
-      - "'snapshot_type' in _result_instance_snapshot"
-      - "'status' in _result_instance_snapshot"
-      - _result_instance_snapshot.status == "available"
-      - "'snapshot_type' in _result_instance_snapshot"
-      - _result_instance_snapshot.snapshot_type == "manual"
-      - "'status' in _result_instance_snapshot"
-      - "'storage_type' in _result_instance_snapshot"
-      - _result_instance_snapshot.storage_type == "gp2"
-      - "'tags' in _result_instance_snapshot"
-      - _result_instance_snapshot.tags | length == 2
-      - _result_instance_snapshot.tags["tag_one"] == snapshot_id+"-b One"
-      - _result_instance_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
-      - "'vpc_id' in _result_instance_snapshot"
+    - ansible.builtin.assert:
+        that:
+          - _result_instance_snapshot.changed
+          - "'availability_zone' in _result_instance_snapshot"
+          - "'instance_create_time' in _result_instance_snapshot"
+          - "'db_instance_identifier' in _result_instance_snapshot"
+          - _result_instance_snapshot.db_instance_identifier == instance_id
+          - "'db_snapshot_identifier' in _result_instance_snapshot"
+          - _result_instance_snapshot.db_snapshot_identifier == snapshot_id+"-b"
+          - "'db_snapshot_arn' in _result_instance_snapshot"
+          - "'dbi_resource_id' in _result_instance_snapshot"
+          - "'encrypted' in _result_instance_snapshot"
+          - "'engine' in _result_instance_snapshot"
+          - _result_instance_snapshot.engine == engine
+          - "'engine_version' in _result_instance_snapshot"
+          - _result_instance_snapshot.engine_version == mariadb_engine_version
+          - "'iam_database_authentication_enabled' in _result_instance_snapshot"
+          - "'license_model' in _result_instance_snapshot"
+          - "'master_username' in _result_instance_snapshot"
+          - _result_instance_snapshot.master_username == username
+          - "'snapshot_create_time' in _result_instance_snapshot"
+          - "'snapshot_type' in _result_instance_snapshot"
+          - "'status' in _result_instance_snapshot"
+          - _result_instance_snapshot.status == "available"
+          - "'snapshot_type' in _result_instance_snapshot"
+          - _result_instance_snapshot.snapshot_type == "manual"
+          - "'status' in _result_instance_snapshot"
+          - "'storage_type' in _result_instance_snapshot"
+          - _result_instance_snapshot.storage_type == "gp2"
+          - "'tags' in _result_instance_snapshot"
+          - _result_instance_snapshot.tags | length == 2
+          - _result_instance_snapshot.tags["tag_one"] == snapshot_id+"-b One"
+          - _result_instance_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
+          - "'vpc_id' in _result_instance_snapshot"
 
-  - name: Attempt to take another snapshot of the existing RDS instance and assign tags (idempotence)
-    rds_instance_snapshot:
-      state: present
-      db_instance_identifier: "{{ instance_id }}"
-      db_snapshot_identifier: "{{ snapshot_id }}-b"
-      wait: true
-      tags:
-        tag_one: '{{ snapshot_id }}-b One'
-        "Tag Two": 'two {{ snapshot_id }}-b'
-    register: _result_instance_snapshot
+    - name: Attempt to take another snapshot of the existing RDS instance and assign tags (idempotence)
+      rds_instance_snapshot:
+        state: present
+        db_instance_identifier: "{{ instance_id }}"
+        db_snapshot_identifier: "{{ snapshot_id }}-b"
+        wait: true
+        tags:
+          tag_one: "{{ snapshot_id }}-b One"
+          Tag Two: two {{ snapshot_id }}-b
+      register: _result_instance_snapshot
 
-  - assert:
-      that:
-      - not _result_instance_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_instance_snapshot.changed
 
-  - name: Take another snapshot of the existing RDS instance and update tags
-    rds_instance_snapshot:
-      state: present
-      db_instance_identifier: "{{ instance_id }}"
-      db_snapshot_identifier: "{{ snapshot_id }}-b"
-      tags:
-        tag_three: '{{ snapshot_id }}-b Three'
-        "Tag Two": 'two {{ snapshot_id }}-b'
-    register: _result_instance_snapshot
+    - name: Take another snapshot of the existing RDS instance and update tags
+      rds_instance_snapshot:
+        state: present
+        db_instance_identifier: "{{ instance_id }}"
+        db_snapshot_identifier: "{{ snapshot_id }}-b"
+        tags:
+          tag_three: "{{ snapshot_id }}-b Three"
+          Tag Two: two {{ snapshot_id }}-b
+      register: _result_instance_snapshot
 
-  - assert:
-      that:
-      - _result_instance_snapshot.changed
-      - "'availability_zone' in _result_instance_snapshot"
-      - "'instance_create_time' in _result_instance_snapshot"
-      - "'db_instance_identifier' in _result_instance_snapshot"
-      - _result_instance_snapshot.db_instance_identifier == instance_id
-      - "'db_snapshot_identifier' in _result_instance_snapshot"
-      - _result_instance_snapshot.db_snapshot_identifier == snapshot_id+"-b"
-      - "'db_snapshot_arn' in _result_instance_snapshot"
-      - "'dbi_resource_id' in _result_instance_snapshot"
-      - "'encrypted' in _result_instance_snapshot"
-      - "'engine' in _result_instance_snapshot"
-      - _result_instance_snapshot.engine == engine
-      - "'engine_version' in _result_instance_snapshot"
-      - _result_instance_snapshot.engine_version == mariadb_engine_version
-      - "'iam_database_authentication_enabled' in _result_instance_snapshot"
-      - "'license_model' in _result_instance_snapshot"
-      - "'master_username' in _result_instance_snapshot"
-      - _result_instance_snapshot.master_username == username
-      - "'snapshot_create_time' in _result_instance_snapshot"
-      - "'snapshot_type' in _result_instance_snapshot"
-      - "'status' in _result_instance_snapshot"
-      - _result_instance_snapshot.status == "available"
-      - "'snapshot_type' in _result_instance_snapshot"
-      - _result_instance_snapshot.snapshot_type == "manual"
-      - "'status' in _result_instance_snapshot"
-      - "'storage_type' in _result_instance_snapshot"
-      - _result_instance_snapshot.storage_type == "gp2"
-      - "'tags' in _result_instance_snapshot"
-      - _result_instance_snapshot.tags | length == 2
-      - _result_instance_snapshot.tags["tag_three"] == snapshot_id+"-b Three"
-      - _result_instance_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
-      - "'vpc_id' in _result_instance_snapshot"
+    - ansible.builtin.assert:
+        that:
+          - _result_instance_snapshot.changed
+          - "'availability_zone' in _result_instance_snapshot"
+          - "'instance_create_time' in _result_instance_snapshot"
+          - "'db_instance_identifier' in _result_instance_snapshot"
+          - _result_instance_snapshot.db_instance_identifier == instance_id
+          - "'db_snapshot_identifier' in _result_instance_snapshot"
+          - _result_instance_snapshot.db_snapshot_identifier == snapshot_id+"-b"
+          - "'db_snapshot_arn' in _result_instance_snapshot"
+          - "'dbi_resource_id' in _result_instance_snapshot"
+          - "'encrypted' in _result_instance_snapshot"
+          - "'engine' in _result_instance_snapshot"
+          - _result_instance_snapshot.engine == engine
+          - "'engine_version' in _result_instance_snapshot"
+          - _result_instance_snapshot.engine_version == mariadb_engine_version
+          - "'iam_database_authentication_enabled' in _result_instance_snapshot"
+          - "'license_model' in _result_instance_snapshot"
+          - "'master_username' in _result_instance_snapshot"
+          - _result_instance_snapshot.master_username == username
+          - "'snapshot_create_time' in _result_instance_snapshot"
+          - "'snapshot_type' in _result_instance_snapshot"
+          - "'status' in _result_instance_snapshot"
+          - _result_instance_snapshot.status == "available"
+          - "'snapshot_type' in _result_instance_snapshot"
+          - _result_instance_snapshot.snapshot_type == "manual"
+          - "'status' in _result_instance_snapshot"
+          - "'storage_type' in _result_instance_snapshot"
+          - _result_instance_snapshot.storage_type == "gp2"
+          - "'tags' in _result_instance_snapshot"
+          - _result_instance_snapshot.tags | length == 2
+          - _result_instance_snapshot.tags["tag_three"] == snapshot_id+"-b Three"
+          - _result_instance_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
+          - "'vpc_id' in _result_instance_snapshot"
 
-  - name: Take another snapshot of the existing RDS instance and update tags without purge
-    rds_instance_snapshot:
-      state: present
-      db_instance_identifier: "{{ instance_id }}"
-      db_snapshot_identifier: "{{ snapshot_id }}-b"
-      purge_tags: no
-      tags:
-        tag_one: '{{ snapshot_id }}-b One'
-    register: _result_instance_snapshot
+    - name: Take another snapshot of the existing RDS instance and update tags without purge
+      rds_instance_snapshot:
+        state: present
+        db_instance_identifier: "{{ instance_id }}"
+        db_snapshot_identifier: "{{ snapshot_id }}-b"
+        purge_tags: false
+        tags:
+          tag_one: "{{ snapshot_id }}-b One"
+      register: _result_instance_snapshot
 
-  - assert:
-      that:
-      - _result_instance_snapshot.changed
-      - "'availability_zone' in _result_instance_snapshot"
-      - "'instance_create_time' in _result_instance_snapshot"
-      - "'db_instance_identifier' in _result_instance_snapshot"
-      - _result_instance_snapshot.db_instance_identifier == instance_id
-      - "'db_snapshot_identifier' in _result_instance_snapshot"
-      - _result_instance_snapshot.db_snapshot_identifier == snapshot_id+"-b"
-      - "'db_snapshot_arn' in _result_instance_snapshot"
-      - "'dbi_resource_id' in _result_instance_snapshot"
-      - "'encrypted' in _result_instance_snapshot"
-      - "'engine' in _result_instance_snapshot"
-      - _result_instance_snapshot.engine == engine
-      - "'engine_version' in _result_instance_snapshot"
-      - _result_instance_snapshot.engine_version == mariadb_engine_version
-      - "'iam_database_authentication_enabled' in _result_instance_snapshot"
-      - "'license_model' in _result_instance_snapshot"
-      - "'master_username' in _result_instance_snapshot"
-      - _result_instance_snapshot.master_username == username
-      - "'snapshot_create_time' in _result_instance_snapshot"
-      - "'snapshot_type' in _result_instance_snapshot"
-      - "'status' in _result_instance_snapshot"
-      - _result_instance_snapshot.status == "available"
-      - "'snapshot_type' in _result_instance_snapshot"
-      - _result_instance_snapshot.snapshot_type == "manual"
-      - "'status' in _result_instance_snapshot"
-      - "'storage_type' in _result_instance_snapshot"
-      - _result_instance_snapshot.storage_type == "gp2"
-      - "'tags' in _result_instance_snapshot"
-      - _result_instance_snapshot.tags | length == 3
-      - _result_instance_snapshot.tags["tag_one"] == snapshot_id+"-b One"
-      - _result_instance_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
-      - _result_instance_snapshot.tags["tag_three"] == snapshot_id+"-b Three"
-      - "'vpc_id' in _result_instance_snapshot"
+    - ansible.builtin.assert:
+        that:
+          - _result_instance_snapshot.changed
+          - "'availability_zone' in _result_instance_snapshot"
+          - "'instance_create_time' in _result_instance_snapshot"
+          - "'db_instance_identifier' in _result_instance_snapshot"
+          - _result_instance_snapshot.db_instance_identifier == instance_id
+          - "'db_snapshot_identifier' in _result_instance_snapshot"
+          - _result_instance_snapshot.db_snapshot_identifier == snapshot_id+"-b"
+          - "'db_snapshot_arn' in _result_instance_snapshot"
+          - "'dbi_resource_id' in _result_instance_snapshot"
+          - "'encrypted' in _result_instance_snapshot"
+          - "'engine' in _result_instance_snapshot"
+          - _result_instance_snapshot.engine == engine
+          - "'engine_version' in _result_instance_snapshot"
+          - _result_instance_snapshot.engine_version == mariadb_engine_version
+          - "'iam_database_authentication_enabled' in _result_instance_snapshot"
+          - "'license_model' in _result_instance_snapshot"
+          - "'master_username' in _result_instance_snapshot"
+          - _result_instance_snapshot.master_username == username
+          - "'snapshot_create_time' in _result_instance_snapshot"
+          - "'snapshot_type' in _result_instance_snapshot"
+          - "'status' in _result_instance_snapshot"
+          - _result_instance_snapshot.status == "available"
+          - "'snapshot_type' in _result_instance_snapshot"
+          - _result_instance_snapshot.snapshot_type == "manual"
+          - "'status' in _result_instance_snapshot"
+          - "'storage_type' in _result_instance_snapshot"
+          - _result_instance_snapshot.storage_type == "gp2"
+          - "'tags' in _result_instance_snapshot"
+          - _result_instance_snapshot.tags | length == 3
+          - _result_instance_snapshot.tags["tag_one"] == snapshot_id+"-b One"
+          - _result_instance_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
+          - _result_instance_snapshot.tags["tag_three"] == snapshot_id+"-b Three"
+          - "'vpc_id' in _result_instance_snapshot"
 
-  - name: Take another snapshot of the existing RDS instance and do not specify any tag to ensure previous tags are not removed
-    rds_instance_snapshot:
-      state: present
-      db_instance_identifier: "{{ instance_id }}"
-      db_snapshot_identifier: "{{ snapshot_id }}-b"
-    register: _result_instance_snapshot
+    - name: Take another snapshot of the existing RDS instance and do not specify any tag to ensure previous tags are not removed
+      rds_instance_snapshot:
+        state: present
+        db_instance_identifier: "{{ instance_id }}"
+        db_snapshot_identifier: "{{ snapshot_id }}-b"
+      register: _result_instance_snapshot
 
-  - assert:
-      that:
-      - not _result_instance_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_instance_snapshot.changed
 
-  # ------------------------------------------------------------------------------------------
-  # Test copying a snapshot
-  ### Note - copying a snapshot from a different region is supported, but not in CI runs,
-  ### because the aws-terminator only terminates resources in one region.
+    # ------------------------------------------------------------------------------------------
+    # Test copying a snapshot
+    ### Note - copying a snapshot from a different region is supported, but not in CI runs,
+    ### because the aws-terminator only terminates resources in one region.
 
-  - set_fact:
-      _snapshot_arn: "{{ _result_instance_snapshot.db_snapshot_arn }}"
+    - ansible.builtin.set_fact:
+        _snapshot_arn: "{{ _result_instance_snapshot.db_snapshot_arn }}"
 
-  - name: Copy a snapshot (check mode)
-    rds_instance_snapshot:
-      id: "{{ snapshot_id }}-copy"
-      source_id: "{{ snapshot_id }}-b"
-      copy_tags: yes
-      wait: true
-    register: _result_instance_snapshot
-    check_mode: yes
+    - name: Copy a snapshot (check mode)
+      rds_instance_snapshot:
+        id: "{{ snapshot_id }}-copy"
+        source_id: "{{ snapshot_id }}-b"
+        copy_tags: true
+        wait: true
+      register: _result_instance_snapshot
+      check_mode: true
 
-  - assert:
-      that:
-        - _result_instance_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - _result_instance_snapshot.changed
 
-  - name: Copy a snapshot
-    rds_instance_snapshot:
-      id: "{{ snapshot_id }}-copy"
-      source_id: "{{ snapshot_id }}-b"
-      copy_tags: yes
-      wait: true
-    register: _result_instance_snapshot
+    - name: Copy a snapshot
+      rds_instance_snapshot:
+        id: "{{ snapshot_id }}-copy"
+        source_id: "{{ snapshot_id }}-b"
+        copy_tags: true
+        wait: true
+      register: _result_instance_snapshot
 
-  - assert:
-      that:
-        - _result_instance_snapshot.changed
-        - _result_instance_snapshot.db_instance_identifier == instance_id
-        - _result_instance_snapshot.source_db_snapshot_identifier == _snapshot_arn
-        - _result_instance_snapshot.db_snapshot_identifier == snapshot_id+"-copy"
-        - "'tags' in _result_instance_snapshot"
-        - _result_instance_snapshot.tags | length == 3
-        - _result_instance_snapshot.tags["tag_one"] == snapshot_id+"-b One"
-        - _result_instance_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
-        - _result_instance_snapshot.tags["tag_three"] == snapshot_id+"-b Three"
+    - ansible.builtin.assert:
+        that:
+          - _result_instance_snapshot.changed
+          - _result_instance_snapshot.db_instance_identifier == instance_id
+          - _result_instance_snapshot.source_db_snapshot_identifier == _snapshot_arn
+          - _result_instance_snapshot.db_snapshot_identifier == snapshot_id+"-copy"
+          - "'tags' in _result_instance_snapshot"
+          - _result_instance_snapshot.tags | length == 3
+          - _result_instance_snapshot.tags["tag_one"] == snapshot_id+"-b One"
+          - _result_instance_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
+          - _result_instance_snapshot.tags["tag_three"] == snapshot_id+"-b Three"
 
-  - name: Copy a snapshot (idempotence - check mode)
-    rds_instance_snapshot:
-      id: "{{ snapshot_id }}-copy"
-      source_id: "{{ snapshot_id }}-b"
-      copy_tags: yes
-      wait: true
-    register: _result_instance_snapshot
-    check_mode: yes
+    - name: Copy a snapshot (idempotence - check mode)
+      rds_instance_snapshot:
+        id: "{{ snapshot_id }}-copy"
+        source_id: "{{ snapshot_id }}-b"
+        copy_tags: true
+        wait: true
+      register: _result_instance_snapshot
+      check_mode: true
 
-  - assert:
-      that:
-        - not _result_instance_snapshot.changed
+    - ansible.builtin.assert:
+        that:
+          - not _result_instance_snapshot.changed
 
-  - name: Copy a snapshot (idempotence)
-    rds_instance_snapshot:
-      id: "{{ snapshot_id }}-copy"
-      source_id: "{{ snapshot_id }}-b"
-      copy_tags: yes
-      wait: true
-    register: _result_instance_snapshot
+    - name: Copy a snapshot (idempotence)
+      rds_instance_snapshot:
+        id: "{{ snapshot_id }}-copy"
+        source_id: "{{ snapshot_id }}-b"
+        copy_tags: true
+        wait: true
+      register: _result_instance_snapshot
 
-  - assert:
-      that:
-        - not _result_instance_snapshot.changed
-        - _result_instance_snapshot.db_instance_identifier == instance_id
-        - _result_instance_snapshot.source_db_snapshot_identifier == _snapshot_arn
-        - _result_instance_snapshot.db_snapshot_identifier == snapshot_id+"-copy"
-        - "'tags' in _result_instance_snapshot"
-        - _result_instance_snapshot.tags | length == 3
-        - _result_instance_snapshot.tags["tag_one"] == snapshot_id+"-b One"
-        - _result_instance_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
-        - _result_instance_snapshot.tags["tag_three"] == snapshot_id+"-b Three"
+    - ansible.builtin.assert:
+        that:
+          - not _result_instance_snapshot.changed
+          - _result_instance_snapshot.db_instance_identifier == instance_id
+          - _result_instance_snapshot.source_db_snapshot_identifier == _snapshot_arn
+          - _result_instance_snapshot.db_snapshot_identifier == snapshot_id+"-copy"
+          - "'tags' in _result_instance_snapshot"
+          - _result_instance_snapshot.tags | length == 3
+          - _result_instance_snapshot.tags["tag_one"] == snapshot_id+"-b One"
+          - _result_instance_snapshot.tags["Tag Two"] == "two {{ snapshot_id }}-b"
+          - _result_instance_snapshot.tags["tag_three"] == snapshot_id+"-b Three"
 
   always:
-  - name: Delete the existing DB instance snapshots
-    rds_instance_snapshot:
-      state: absent
-      db_snapshot_identifier: "{{ item }}"
-      wait: false
-    register: _result_delete_snapshot
-    ignore_errors: true
-    loop:
-    - "{{ snapshot_id }}"
-    - "{{ snapshot_id }}-b"
-    - "{{ snapshot_id }}-copy"
+    - name: Delete the existing DB instance snapshots
+      rds_instance_snapshot:
+        state: absent
+        db_snapshot_identifier: "{{ item }}"
+        wait: false
+      register: _result_delete_snapshot
+      ignore_errors: true
+      loop:
+        - "{{ snapshot_id }}"
+        - "{{ snapshot_id }}-b"
+        - "{{ snapshot_id }}-copy"
 
-  - name: Delete the existing RDS instance without creating a final snapshot
-    rds_instance:
-      state: absent
-      instance_id: "{{ instance_id }}"
-      skip_final_snapshot: True
-      wait: false
-    register: _result_delete_instance
-    ignore_errors: true
+    - name: Delete the existing RDS instance without creating a final snapshot
+      amazon.aws.rds_instance:
+        state: absent
+        instance_id: "{{ instance_id }}"
+        skip_final_snapshot: true
+        wait: false
+      register: _result_delete_instance
+      ignore_errors: true

--- a/tests/integration/targets/rds_instance_snapshot_mgmt/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_snapshot_mgmt/defaults/main.yml
@@ -1,9 +1,10 @@
+---
 instance_id: ansible-test-{{ tiny_prefix }}
-modified_instance_id: '{{ instance_id }}-updated'
+modified_instance_id: "{{ instance_id }}-updated"
 username: test
 password: test12345678
 db_instance_class: db.t3.micro
 allocated_storage: 20
 
 # For snapshot tests
-snapshot_id: '{{ instance_id }}-ss'
+snapshot_id: "{{ instance_id }}-ss"

--- a/tests/integration/targets/rds_instance_snapshot_mgmt/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_snapshot_mgmt/tasks/main.yml
@@ -1,224 +1,225 @@
+---
 - name: rds_instance / snapshot_mgmt integration tests
   collections:
-  - community.aws
+    - community.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-  - name: Ensure the resource doesn't exist
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
+    - name: Ensure the resource doesn't exist
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+      ignore_errors: true
 
-  - name: Create a mariadb instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      tags:
-        Name: '{{ instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
+    - name: Create a mariadb instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        tags:
+          Name: "{{ instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
-      - result.tags | length == 2
-      - result.tags.Name == '{{ instance_id }}'
-      - result.tags.Created_by == 'Ansible rds_instance tests'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
+          - result.tags | length == 2
+          - result.tags.Name == '{{ instance_id }}'
+          - result.tags.Created_by == 'Ansible rds_instance tests'
 
-  - name: Create a snapshot
-    rds_instance_snapshot:
-      instance_id: '{{ instance_id }}'
-      snapshot_id: '{{ snapshot_id }}'
-      state: present
-      wait: yes
-    register: result
+    - name: Create a snapshot
+      rds_instance_snapshot:
+        instance_id: "{{ instance_id }}"
+        snapshot_id: "{{ snapshot_id }}"
+        state: present
+        wait: true
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == instance_id
-      - result.db_snapshot_identifier == snapshot_id
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == instance_id
+          - result.db_snapshot_identifier == snapshot_id
 
     # ------------------------------------------------------------------------------------------
     # Test restoring db from snapshot
 
-  - name: Restore DB from snapshot - check_mode
-    rds_instance:
-      id: '{{ snapshot_id }}'
-      creation_source: snapshot
-      snapshot_identifier: '{{ snapshot_id }}'
-      engine: mariadb
-      state: present
-    register: result
-    check_mode: yes
+    - name: Restore DB from snapshot - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ snapshot_id }}"
+        creation_source: snapshot
+        snapshot_identifier: "{{ snapshot_id }}"
+        engine: mariadb
+        state: present
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Restore DB from snapshot
-    rds_instance:
-      id: '{{ snapshot_id }}'
-      creation_source: snapshot
-      snapshot_identifier: '{{ snapshot_id }}'
-      engine: mariadb
-      state: present
-    register: result
+    - name: Restore DB from snapshot
+      amazon.aws.rds_instance:
+        id: "{{ snapshot_id }}"
+        creation_source: snapshot
+        snapshot_identifier: "{{ snapshot_id }}"
+        engine: mariadb
+        state: present
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == snapshot_id
-      - result.tags | length == 2
-      - result.tags.Name == instance_id
-      - result.tags.Created_by == 'Ansible rds_instance tests'
-      - result.db_instance_status == 'available'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == snapshot_id
+          - result.tags | length == 2
+          - result.tags.Name == instance_id
+          - result.tags.Created_by == 'Ansible rds_instance tests'
+          - result.db_instance_status == 'available'
 
-  - name: Restore DB from snapshot (idempotence) - check_mode
-    rds_instance:
-      id: '{{ snapshot_id }}'
-      creation_source: snapshot
-      snapshot_identifier: '{{ snapshot_id }}'
-      engine: mariadb
-      state: present
-    register: result
-    check_mode: yes
+    - name: Restore DB from snapshot (idempotence) - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ snapshot_id }}"
+        creation_source: snapshot
+        snapshot_identifier: "{{ snapshot_id }}"
+        engine: mariadb
+        state: present
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: Restore DB from snapshot (idempotence)
-    rds_instance:
-      id: '{{ snapshot_id }}'
-      creation_source: snapshot
-      snapshot_identifier: '{{ snapshot_id }}'
-      engine: mariadb
-      state: present
-    register: result
+    - name: Restore DB from snapshot (idempotence)
+      amazon.aws.rds_instance:
+        id: "{{ snapshot_id }}"
+        creation_source: snapshot
+        snapshot_identifier: "{{ snapshot_id }}"
+        engine: mariadb
+        state: present
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - result.db_instance_identifier == snapshot_id
-      - result.tags | length == 2
-      - result.tags.Name == instance_id
-      - result.tags.Created_by == 'Ansible rds_instance tests'
-      - result.db_instance_status == 'available'
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.db_instance_identifier == snapshot_id
+          - result.tags | length == 2
+          - result.tags.Name == instance_id
+          - result.tags.Created_by == 'Ansible rds_instance tests'
+          - result.db_instance_status == 'available'
 
     # ------------------------------------------------------------------------------------------
     # Test final snapshot on deletion
 
-  - name: Ensure instance exists prior to deleting
-    rds_instance_info:
-      db_instance_identifier: '{{ instance_id }}'
-    register: db_info
+    - name: Ensure instance exists prior to deleting
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ instance_id }}"
+      register: db_info
 
-  - assert:
-      that:
-      - db_info.instances | length == 1
+    - ansible.builtin.assert:
+        that:
+          - db_info.instances | length == 1
 
-  - name: Delete the instance keeping snapshot - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      final_snapshot_identifier: '{{ instance_id }}'
-    register: result
-    check_mode: yes
+    - name: Delete the instance keeping snapshot - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        final_snapshot_identifier: "{{ instance_id }}"
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Delete the instance keeping snapshot
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      final_snapshot_identifier: '{{ instance_id }}'
-    register: result
+    - name: Delete the instance keeping snapshot
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        final_snapshot_identifier: "{{ instance_id }}"
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.final_snapshot.db_instance_identifier == '{{ instance_id }}'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.final_snapshot.db_instance_identifier == '{{ instance_id }}'
 
-  - name: Check that snapshot exists
-    rds_snapshot_info:
-      db_snapshot_identifier: '{{ instance_id }}'
-    register: result
+    - name: Check that snapshot exists
+      amazon.aws.rds_snapshot_info:
+        db_snapshot_identifier: "{{ instance_id }}"
+      register: result
 
-  - assert:
-      that:
-      - result.snapshots | length == 1
-      - result.snapshots.0.engine == 'mariadb'
+    - ansible.builtin.assert:
+        that:
+          - result.snapshots | length == 1
+          - result.snapshots.0.engine == 'mariadb'
 
-  - name: Ensure instance was deleted
-    rds_instance_info:
-      db_instance_identifier: '{{ instance_id }}'
-    register: db_info
+    - name: Ensure instance was deleted
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ instance_id }}"
+      register: db_info
 
-  - assert:
-      that:
-      - db_info.instances | length == 0
+    - ansible.builtin.assert:
+        that:
+          - db_info.instances | length == 0
 
-  - name: Delete the instance (idempotence) - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
-    check_mode: yes
+    - name: Delete the instance (idempotence) - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: Delete the instance (idempotence)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
+    - name: Delete the instance (idempotence)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
   always:
-  - name: Remove snapshots
-    rds_instance_snapshot:
-      db_snapshot_identifier: '{{ item }}'
-      state: absent
-      wait: false
-    ignore_errors: yes
-    with_items:
-    - '{{ instance_id }}'
-    - '{{ snapshot_id }}'
+    - name: Remove snapshots
+      rds_instance_snapshot:
+        db_snapshot_identifier: "{{ item }}"
+        state: absent
+        wait: false
+      ignore_errors: true
+      with_items:
+        - "{{ instance_id }}"
+        - "{{ snapshot_id }}"
 
-  - name: Remove DB instances
-    rds_instance:
-      id: '{{ item }}'
-      state: absent
-      skip_final_snapshot: true
-      wait: false
-    ignore_errors: yes
-    with_items:
-    - '{{ instance_id }}'
-    - '{{ snapshot_id }}'
+    - name: Remove DB instances
+      amazon.aws.rds_instance:
+        id: "{{ item }}"
+        state: absent
+        skip_final_snapshot: true
+        wait: false
+      ignore_errors: true
+      with_items:
+        - "{{ instance_id }}"
+        - "{{ snapshot_id }}"

--- a/tests/integration/targets/rds_instance_states/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_states/defaults/main.yml
@@ -1,3 +1,4 @@
+---
 instance_id: ansible-test-{{ tiny_prefix }}
 username: test
 password: test12345678

--- a/tests/integration/targets/rds_instance_states/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_states/tasks/main.yml
@@ -1,320 +1,321 @@
+---
 - name: rds_instance / states integration tests
   collections:
-  - community.aws
+    - community.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-  - name: Ensure the resource doesn't exist
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
+    - name: Ensure the resource doesn't exist
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+      ignore_errors: true
 
-  - name: Create a mariadb instance - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      deletion_protection: true
-      tags:
-        Name: '{{ instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
-    check_mode: yes
+    - name: Create a mariadb instance - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        deletion_protection: true
+        tags:
+          Name: "{{ instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Create a mariadb instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      deletion_protection: true
-      tags:
-        Name: '{{ instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
+    - name: Create a mariadb instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        deletion_protection: true
+        tags:
+          Name: "{{ instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
-      - result.tags | length == 2
-      - result.tags.Name == '{{ instance_id }}'
-      - result.tags.Created_by == 'Ansible rds_instance tests'
-      - result.deletion_protection == True
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
+          - result.tags | length == 2
+          - result.tags.Name == '{{ instance_id }}'
+          - result.tags.Created_by == 'Ansible rds_instance tests'
+          - result.deletion_protection == True
 
-  - name: Create a mariadb instance (idempotence) - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      deletion_protection: true
-      tags:
-        Name: '{{ instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
-    check_mode: yes
+    - name: Create a mariadb instance (idempotence) - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        deletion_protection: true
+        tags:
+          Name: "{{ instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: Create a mariadb instance (idempotence)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      deletion_protection: true
-      tags:
-        Name: '{{ instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
+    - name: Create a mariadb instance (idempotence)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        deletion_protection: true
+        tags:
+          Name: "{{ instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
-      - result.tags | length == 2
-      - result.tags.Name == '{{ instance_id }}'
-      - result.tags.Created_by == 'Ansible rds_instance tests'
-      - result.deletion_protection == True
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
+          - result.tags | length == 2
+          - result.tags.Name == '{{ instance_id }}'
+          - result.tags.Created_by == 'Ansible rds_instance tests'
+          - result.deletion_protection == True
 
     # ------------------------------------------------------------------------------------------
     # Test stopping / rebooting instances
 
-  - name: Reboot a stopped instance - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: rebooted
-    register: result
-    check_mode: yes
+    - name: Reboot a stopped instance - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: rebooted
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Reboot a stopped instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: rebooted
-    register: result
+    - name: Reboot a stopped instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: rebooted
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-
-    # ------------------------------------------------------------------------------------------
-
-  - name: Stop the instance - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: stopped
-    register: result
-    check_mode: yes
-
-  - assert:
-      that:
-      - result.changed
-
-  - name: Stop the instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: stopped
-    register: result
-
-  - assert:
-      that:
-      - result.changed
-
-  - name: Stop the instance (idempotence) - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: stopped
-    register: result
-    check_mode: yes
-
-  - assert:
-      that:
-      - not result.changed
-
-  - name: Stop the instance (idempotence)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: stopped
-    register: result
-
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
     # ------------------------------------------------------------------------------------------
 
-  - name: Start the instance - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: started
-    register: result
-    check_mode: yes
+    - name: Stop the instance - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: stopped
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Start the instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: started
-    register: result
+    - name: Stop the instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: stopped
+      register: result
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Start the instance (idempotence) - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: started
-    register: result
-    check_mode: yes
+    - name: Stop the instance (idempotence) - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: stopped
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: Start the instance (idempotence)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: started
-    register: result
+    - name: Stop the instance (idempotence)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: stopped
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+
+    # ------------------------------------------------------------------------------------------
+
+    - name: Start the instance - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: started
+      register: result
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+
+    - name: Start the instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: started
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+
+    - name: Start the instance (idempotence) - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: started
+      register: result
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+
+    - name: Start the instance (idempotence)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: started
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
     # ------------------------------------------------------------------------------------------
     # Test deletion protection / deletion
 
-  - name: Ensure instance exists prior to deleting
-    rds_instance_info:
-      db_instance_identifier: '{{ instance_id }}'
-    register: db_info
+    - name: Ensure instance exists prior to deleting
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ instance_id }}"
+      register: db_info
 
-  - assert:
-      that:
-      - db_info.instances | length == 1
+    - ansible.builtin.assert:
+        that:
+          - db_info.instances | length == 1
 
-  - name: Attempt to delete DB instance with deletion protection (should fail)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
-    ignore_errors: yes
+    - name: Attempt to delete DB instance with deletion protection (should fail)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
+      ignore_errors: true
 
-  - assert:
-      that:
-      - result.failed
+    - ansible.builtin.assert:
+        that:
+          - result.failed
 
-  - name: Turn off deletion protection
-    rds_instance:
-      id: '{{ instance_id }}'
-      deletion_protection: false
-    register: result
+    - name: Turn off deletion protection
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        deletion_protection: false
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.deletion_protection == False
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.deletion_protection == False
 
-  - name: Delete the instance - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
-    check_mode: yes
+    - name: Delete the instance - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Delete the instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
+    - name: Delete the instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Ensure instance was deleted
-    rds_instance_info:
-      db_instance_identifier: '{{ instance_id }}'
-    register: db_info
+    - name: Ensure instance was deleted
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ instance_id }}"
+      register: db_info
 
-  - assert:
-      that:
-      - db_info.instances | length == 0
+    - ansible.builtin.assert:
+        that:
+          - db_info.instances | length == 0
 
-  - name: Delete the instance (idempotence) - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
-    check_mode: yes
+    - name: Delete the instance (idempotence) - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: Delete the instance (idempotence)
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
+    - name: Delete the instance (idempotence)
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
   always:
-  - name: Remove DB instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-      wait: false
-    ignore_errors: yes
+    - name: Remove DB instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+        wait: false
+      ignore_errors: true

--- a/tests/integration/targets/rds_instance_tagging/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_tagging/defaults/main.yml
@@ -1,6 +1,7 @@
+---
 instance_id: ansible-test-{{ tiny_prefix }}
 instance_id_gp3: ansible-test-{{ tiny_prefix }}-gp3
-modified_instance_id: '{{ instance_id }}-updated'
+modified_instance_id: "{{ instance_id }}-updated"
 username: test
 password: test12345678
 db_instance_class: db.t3.micro

--- a/tests/integration/targets/rds_instance_tagging/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_tagging/tasks/main.yml
@@ -1,202 +1,202 @@
+---
 - name: rds_instance / tagging integration tests
   collections:
-  - community.aws
+    - community.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-  - name: Test tagging db with storage type gp3
-    import_tasks: test_tagging_gp3.yml
+    - name: Test tagging db with storage type gp3
+      ansible.builtin.import_tasks: test_tagging_gp3.yml
+    - name: Ensure the resource doesn't exist
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - name: Ensure the resource doesn't exist
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
-
-  - assert:
-      that:
-      - not result.changed
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+      ignore_errors: true
 
     # Test invalid bad options
-  - name: Create a DB instance with an invalid engine
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: thisisnotavalidengine
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-    register: result
-    ignore_errors: true
+    - name: Create a DB instance with an invalid engine
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: thisisnotavalidengine
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+      register: result
+      ignore_errors: true
 
-  - assert:
-      that:
-      - result.failed
-      - '"value of engine must be one of" in result.msg'
+    - ansible.builtin.assert:
+        that:
+          - result.failed
+          - '"value of engine must be one of" in result.msg'
 
     # Test creation, adding tags and enabling encryption
-  - name: Create a mariadb instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      storage_encrypted: true
-      tags:
-        Name: '{{ instance_id }}'
-        Created_by: Ansible rds_instance tests
-    register: result
+    - name: Create a mariadb instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        storage_encrypted: true
+        tags:
+          Name: "{{ instance_id }}"
+          Created_by: Ansible rds_instance tests
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
-      - result.tags | length == 2
-      - result.tags.Name == '{{ instance_id }}'
-      - result.tags.Created_by == 'Ansible rds_instance tests'
-      - result.kms_key_id
-      - result.storage_encrypted == true
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
+          - result.tags | length == 2
+          - result.tags.Name == '{{ instance_id }}'
+          - result.tags.Created_by == 'Ansible rds_instance tests'
+          - result.kms_key_id
+          - result.storage_encrypted == true
 
-  - name: Test impotency omitting tags - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-    register: result
-    check_mode: yes
+    - name: Test impotency omitting tags - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: Test impotency omitting tags
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-    register: result
+    - name: Test impotency omitting tags
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - result.db_instance_identifier
-      - result.tags | length == 2
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.db_instance_identifier
+          - result.tags | length == 2
 
-  - name: Idempotence with minimal options
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-    register: result
+    - name: Idempotence with minimal options
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - result.db_instance_identifier
-      - result.tags | length == 2
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.db_instance_identifier
+          - result.tags | length == 2
 
-  - name: Test tags are not purged if purge_tags is False
-    rds_instance:
-      db_instance_identifier: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      tags: {}
-      purge_tags: false
-    register: result
+    - name: Test tags are not purged if purge_tags is False
+      amazon.aws.rds_instance:
+        db_instance_identifier: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        tags: {}
+        purge_tags: false
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - result.tags | length == 2
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.tags | length == 2
 
-  - name: Add a tag and remove a tag - check_mode
-    rds_instance:
-      db_instance_identifier: '{{ instance_id }}'
-      state: present
-      tags:
-        Name: '{{ instance_id }}-new'
-        Created_by: Ansible rds_instance tests
-      purge_tags: true
-    register: result
-    check_mode: yes
+    - name: Add a tag and remove a tag - check_mode
+      amazon.aws.rds_instance:
+        db_instance_identifier: "{{ instance_id }}"
+        state: present
+        tags:
+          Name: "{{ instance_id }}-new"
+          Created_by: Ansible rds_instance tests
+        purge_tags: true
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Add a tag and remove a tag
-    rds_instance:
-      db_instance_identifier: '{{ instance_id }}'
-      state: present
-      tags:
-        Name: '{{ instance_id }}-new'
-        Created_by: Ansible rds_instance tests
-      purge_tags: true
-    register: result
+    - name: Add a tag and remove a tag
+      amazon.aws.rds_instance:
+        db_instance_identifier: "{{ instance_id }}"
+        state: present
+        tags:
+          Name: "{{ instance_id }}-new"
+          Created_by: Ansible rds_instance tests
+        purge_tags: true
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.tags | length == 2
-      - result.tags.Name == '{{ instance_id }}-new'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.tags | length == 2
+          - result.tags.Name == '{{ instance_id }}-new'
 
-  - name: Add a tag and remove a tag (idempotence) - check_mode
-    rds_instance:
-      db_instance_identifier: '{{ instance_id }}'
-      state: present
-      tags:
-        Name: '{{ instance_id }}-new'
-        Created_by: Ansible rds_instance tests
-      purge_tags: true
-    register: result
-    check_mode: yes
+    - name: Add a tag and remove a tag (idempotence) - check_mode
+      amazon.aws.rds_instance:
+        db_instance_identifier: "{{ instance_id }}"
+        state: present
+        tags:
+          Name: "{{ instance_id }}-new"
+          Created_by: Ansible rds_instance tests
+        purge_tags: true
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: Add a tag and remove a tag (idempotence)
-    rds_instance:
-      db_instance_identifier: '{{ instance_id }}'
-      state: present
-      tags:
-        Name: '{{ instance_id }}-new'
-        Created_by: Ansible rds_instance tests
-      purge_tags: true
-    register: result
+    - name: Add a tag and remove a tag (idempotence)
+      amazon.aws.rds_instance:
+        db_instance_identifier: "{{ instance_id }}"
+        state: present
+        tags:
+          Name: "{{ instance_id }}-new"
+          Created_by: Ansible rds_instance tests
+        purge_tags: true
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - result.tags | length == 2
-      - result.tags.Name == '{{ instance_id }}-new'
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.tags | length == 2
+          - result.tags.Name == '{{ instance_id }}-new'
 
   always:
-  - name: Remove DB instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-      wait: false
-    ignore_errors: yes
+    - name: Remove DB instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+        wait: false
+      ignore_errors: true

--- a/tests/integration/targets/rds_instance_tagging/tasks/test_tagging_gp3.yml
+++ b/tests/integration/targets/rds_instance_tagging/tasks/test_tagging_gp3.yml
@@ -1,190 +1,191 @@
+---
 - block:
-  - name: Ensure the resource doesn't exist
-    rds_instance:
-      id: '{{ instance_id_gp3 }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
+    - name: Ensure the resource doesn't exist
+      amazon.aws.rds_instance:
+        id: "{{ instance_id_gp3 }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+      ignore_errors: true
 
     # Test invalid bad options
-  - name: Create a DB instance with an invalid engine
-    rds_instance:
-      id: '{{ instance_id_gp3 }}'
-      state: present
-      engine: thisisnotavalidengine
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-    register: result
-    ignore_errors: true
+    - name: Create a DB instance with an invalid engine
+      amazon.aws.rds_instance:
+        id: "{{ instance_id_gp3 }}"
+        state: present
+        engine: thisisnotavalidengine
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+      register: result
+      ignore_errors: true
 
-  - assert:
-      that:
-      - result.failed
-      - '"value of engine must be one of" in result.msg'
+    - ansible.builtin.assert:
+        that:
+          - result.failed
+          - '"value of engine must be one of" in result.msg'
 
     # Test creation, adding tags and enabling encryption
-  - name: Create a mariadb instance
-    rds_instance:
-      id: '{{ instance_id_gp3 }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      storage_encrypted: true
-      tags:
-        Name: '{{ instance_id_gp3 }}'
-        Created_by: Ansible rds_instance tests
-    register: result
+    - name: Create a mariadb instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id_gp3 }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        storage_encrypted: true
+        tags:
+          Name: "{{ instance_id_gp3 }}"
+          Created_by: Ansible rds_instance tests
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == '{{ instance_id_gp3 }}'
-      - result.tags | length == 2
-      - result.tags.Name == '{{ instance_id_gp3 }}'
-      - result.tags.Created_by == 'Ansible rds_instance tests'
-      - result.kms_key_id
-      - result.storage_encrypted == true
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == '{{ instance_id_gp3 }}'
+          - result.tags | length == 2
+          - result.tags.Name == '{{ instance_id_gp3 }}'
+          - result.tags.Created_by == 'Ansible rds_instance tests'
+          - result.kms_key_id
+          - result.storage_encrypted == true
 
-  - name: Test idempotency omitting tags - check_mode
-    rds_instance:
-      id: '{{ instance_id_gp3 }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-    register: result
-    check_mode: yes
+    - name: Test idempotency omitting tags - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id_gp3 }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: Test idempotency omitting tags
-    rds_instance:
-      id: '{{ instance_id_gp3 }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-    register: result
+    - name: Test idempotency omitting tags
+      amazon.aws.rds_instance:
+        id: "{{ instance_id_gp3 }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - result.db_instance_identifier == '{{ instance_id_gp3 }}'
-      - result.tags | length == 2
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.db_instance_identifier == '{{ instance_id_gp3 }}'
+          - result.tags | length == 2
 
-  - name: Idempotence with minimal options
-    rds_instance:
-      id: '{{ instance_id_gp3 }}'
-      state: present
-    register: result
+    - name: Idempotence with minimal options
+      amazon.aws.rds_instance:
+        id: "{{ instance_id_gp3 }}"
+        state: present
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - result.db_instance_identifier == '{{ instance_id_gp3 }}'
-      - result.tags | length == 2
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.db_instance_identifier == '{{ instance_id_gp3 }}'
+          - result.tags | length == 2
 
-  - name: Test tags are not purged if purge_tags is False
-    rds_instance:
-      db_instance_identifier: '{{ instance_id_gp3 }}'
-      state: present
-      engine: mariadb
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      tags: {}
-      purge_tags: false
-    register: result
+    - name: Test tags are not purged if purge_tags is False
+      amazon.aws.rds_instance:
+        db_instance_identifier: "{{ instance_id_gp3 }}"
+        state: present
+        engine: mariadb
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        tags: {}
+        purge_tags: false
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - result.tags | length == 2
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.tags | length == 2
 
-  - name: Add a tag and remove a tag - check_mode
-    rds_instance:
-      db_instance_identifier: '{{ instance_id_gp3 }}'
-      state: present
-      tags:
-        Name: '{{ instance_id_gp3 }}-new'
-        Created_by: Ansible rds_instance tests
-      purge_tags: true
-    register: result
-    check_mode: yes
+    - name: Add a tag and remove a tag - check_mode
+      amazon.aws.rds_instance:
+        db_instance_identifier: "{{ instance_id_gp3 }}"
+        state: present
+        tags:
+          Name: "{{ instance_id_gp3 }}-new"
+          Created_by: Ansible rds_instance tests
+        purge_tags: true
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Add a tag and remove a tag
-    rds_instance:
-      db_instance_identifier: '{{ instance_id_gp3 }}'
-      state: present
-      tags:
-        Name: '{{ instance_id_gp3 }}-new'
-        Created_by: Ansible rds_instance tests
-      purge_tags: true
-    register: result
+    - name: Add a tag and remove a tag
+      amazon.aws.rds_instance:
+        db_instance_identifier: "{{ instance_id_gp3 }}"
+        state: present
+        tags:
+          Name: "{{ instance_id_gp3 }}-new"
+          Created_by: Ansible rds_instance tests
+        purge_tags: true
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.tags | length == 2
-      - result.tags.Name == '{{ instance_id_gp3 }}-new'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.tags | length == 2
+          - result.tags.Name == '{{ instance_id_gp3 }}-new'
 
-  - name: Add a tag and remove a tag (idempotence) - check_mode
-    rds_instance:
-      db_instance_identifier: '{{ instance_id_gp3 }}'
-      state: present
-      tags:
-        Name: '{{ instance_id_gp3 }}-new'
-        Created_by: Ansible rds_instance tests
-      purge_tags: true
-    register: result
-    check_mode: yes
+    - name: Add a tag and remove a tag (idempotence) - check_mode
+      amazon.aws.rds_instance:
+        db_instance_identifier: "{{ instance_id_gp3 }}"
+        state: present
+        tags:
+          Name: "{{ instance_id_gp3 }}-new"
+          Created_by: Ansible rds_instance tests
+        purge_tags: true
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - not result.changed
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: Add a tag and remove a tag (idempotence)
-    rds_instance:
-      db_instance_identifier: '{{ instance_id_gp3 }}'
-      state: present
-      tags:
-        Name: '{{ instance_id_gp3 }}-new'
-        Created_by: Ansible rds_instance tests
-      purge_tags: true
-    register: result
+    - name: Add a tag and remove a tag (idempotence)
+      amazon.aws.rds_instance:
+        db_instance_identifier: "{{ instance_id_gp3 }}"
+        state: present
+        tags:
+          Name: "{{ instance_id_gp3 }}-new"
+          Created_by: Ansible rds_instance tests
+        purge_tags: true
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - result.tags | length == 2
-      - result.tags.Name == '{{ instance_id_gp3 }}-new'
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - result.tags | length == 2
+          - result.tags.Name == '{{ instance_id_gp3 }}-new'
 
   always:
-  - name: Remove DB instance
-    rds_instance:
-      id: '{{ instance_id_gp3 }}'
-      state: absent
-      skip_final_snapshot: true
-      wait: false
-    ignore_errors: yes
+    - name: Remove DB instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id_gp3 }}"
+        state: absent
+        skip_final_snapshot: true
+        wait: false
+      ignore_errors: true

--- a/tests/integration/targets/rds_instance_upgrade/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_upgrade/defaults/main.yml
@@ -1,5 +1,6 @@
+---
 instance_id: ansible-test-{{ tiny_prefix }}
-modified_instance_id: '{{ instance_id }}-updated'
+modified_instance_id: "{{ instance_id }}-updated"
 username: test
 password: test12345678
 db_instance_class: db.t3.micro

--- a/tests/integration/targets/rds_instance_upgrade/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_upgrade/tasks/main.yml
@@ -1,97 +1,97 @@
+---
 - name: rds_instance / upgrade integration tests
   collections:
-  - community.aws
+    - community.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-  - name: Ensure the resource doesn't exist
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-    register: result
+    - name: Ensure the resource doesn't exist
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-    ignore_errors: yes
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+      ignore_errors: true
 
-  - name: Create a mariadb instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      engine_version: '{{ mariadb_engine_version }}'
-      allow_major_version_upgrade: true
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-    register: result
+    - name: Create a mariadb instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        engine_version: "{{ mariadb_engine_version }}"
+        allow_major_version_upgrade: true
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - result.db_instance_identifier == '{{ instance_id }}'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - result.db_instance_identifier == '{{ instance_id }}'
 
     # Test upgrade of DB instance
 
-  - name: Upgrade a mariadb instance - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      engine_version: '{{ mariadb_engine_version_2 }}'
-      allow_major_version_upgrade: true
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      apply_immediately: true
-    register: result
-    check_mode: yes
+    - name: Upgrade a mariadb instance - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        engine_version: "{{ mariadb_engine_version_2 }}"
+        allow_major_version_upgrade: true
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        apply_immediately: true
+      register: result
+      check_mode: true
 
-  - assert:
-      that:
-      - result.changed
+    - ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: Upgrade a mariadb instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      engine_version: '{{ mariadb_engine_version_2 }}'
-      allow_major_version_upgrade: true
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-      apply_immediately: true
-    register: result
+    - name: Upgrade a mariadb instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        engine_version: "{{ mariadb_engine_version_2 }}"
+        allow_major_version_upgrade: true
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+        apply_immediately: true
+      register: result
 
-  - assert:
-      that:
-      - result.changed
-      - '"engine_version" in result.pending_modified_values or result.engine_version
-        == mariadb_engine_version_2'
+    - ansible.builtin.assert:
+        that:
+          - result.changed
+          - '"engine_version" in result.pending_modified_values or result.engine_version == mariadb_engine_version_2'
 
-  - name: Idempotence upgrading a mariadb instance - check_mode
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      engine_version: '{{ mariadb_engine_version_2 }}'
-      allow_major_version_upgrade: true
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-    register: result
-    check_mode: yes
+    - name: Idempotence upgrading a mariadb instance - check_mode
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        engine_version: "{{ mariadb_engine_version_2 }}"
+        allow_major_version_upgrade: true
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+      register: result
+      check_mode: true
 
     ### Specifying allow_major_version_upgrade with check_mode will always result in changed=True
     ### since it's not returned in describe_db_instances api call
@@ -99,30 +99,29 @@
     #     that:
     #       - not result.changed
 
-  - name: Idempotence upgrading a mariadb instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: present
-      engine: mariadb
-      engine_version: '{{ mariadb_engine_version_2 }}'
-      allow_major_version_upgrade: true
-      username: '{{ username }}'
-      password: '{{ password }}'
-      db_instance_class: '{{ db_instance_class }}'
-      allocated_storage: '{{ allocated_storage }}'
-    register: result
+    - name: Idempotence upgrading a mariadb instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: present
+        engine: mariadb
+        engine_version: "{{ mariadb_engine_version_2 }}"
+        allow_major_version_upgrade: true
+        username: "{{ username }}"
+        password: "{{ password }}"
+        db_instance_class: "{{ db_instance_class }}"
+        allocated_storage: "{{ allocated_storage }}"
+      register: result
 
-  - assert:
-      that:
-      - not result.changed
-      - '"engine_version" in result.pending_modified_values or result.engine_version
-        == mariadb_engine_version_2'
+    - ansible.builtin.assert:
+        that:
+          - not result.changed
+          - '"engine_version" in result.pending_modified_values or result.engine_version == mariadb_engine_version_2'
 
   always:
-  - name: Delete the instance
-    rds_instance:
-      id: '{{ instance_id }}'
-      state: absent
-      skip_final_snapshot: true
-      wait: false
-    ignore_errors: yes
+    - name: Delete the instance
+      amazon.aws.rds_instance:
+        id: "{{ instance_id }}"
+        state: absent
+        skip_final_snapshot: true
+        wait: false
+      ignore_errors: true

--- a/tests/integration/targets/rds_option_group/tasks/main.yml
+++ b/tests/integration/targets/rds_option_group/tasks/main.yml
@@ -879,7 +879,7 @@
         state: absent
         option_group_name: "{{ option_group_name }}"
       register: deleted_rds_mysql_option_group
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
 
     - name: Remove security groups
       amazon.aws.ec2_security_group:
@@ -891,14 +891,14 @@
         - "{{ sg_1_name }}"
         - "{{ sg_2_name }}"
         - "{{ sg_3_name }}"
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
 
     - name: Remove subnet
       amazon.aws.ec2_vpc_subnet:
         cidr: "{{ subnet_cidr }}"
         vpc_id: "{{ vpc_id }}"
         state: absent
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors
 
     - name: Delete VPC
       amazon.aws.ec2_vpc_net:
@@ -906,4 +906,4 @@
         cidr_block: "{{ vpc_cidr }}"
         state: absent
         purge_cidrs: true
-      ignore_errors: true  # noqa: ignore-errors
+      ignore_errors: true # noqa: ignore-errors

--- a/tests/integration/targets/rds_param_group/defaults/main.yml
+++ b/tests/integration/targets/rds_param_group/defaults/main.yml
@@ -1,30 +1,31 @@
+---
 rds_param_group:
-  name: '{{ resource_prefix}}rds-param-group'
+  name: "{{ resource_prefix}}rds-param-group"
   description: Test group for rds_param_group Ansible module
   engine: postgres9.6
   engine_to_modify_to: postgres10
 
 rds_long_param_list:
   application_name: Test
-  logging_collector: on
+  logging_collector: true
   log_directory: /var/log/postgresql
   log_filename: postgresql.log.%Y-%m-%d-%H
-  log_file_mode: 0600
+  log_file_mode: "0600"
   event_source: RDS
   log_min_messages: INFO
   log_min_duration_statement: 500
   log_rotation_age: 60
-  debug_print_parse: on
-  debug_print_rewritten: on
-  debug_print_plan: on
-  debug_pretty_print: on
-  log_checkpoints: on
-  log_connections: on
-  log_disconnections: on
-  log_duration: on
+  debug_print_parse: true
+  debug_print_rewritten: true
+  debug_print_plan: true
+  debug_pretty_print: true
+  log_checkpoints: true
+  log_connections: true
+  log_disconnections: true
+  log_duration: true
   log_error_verbosity: VERBOSE
-  log_lock_waits: on
+  log_lock_waits: true
   log_temp_files: 10K
   log_timezone: UTC
   log_statement: all
-  log_replication_commands: on
+  log_replication_commands: true

--- a/tests/integration/targets/rds_param_group/meta/main.yml
+++ b/tests/integration/targets/rds_param_group/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/rds_param_group/tasks/main.yml
+++ b/tests/integration/targets/rds_param_group/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 # A Note about ec2 environment variable name preference:
 #  - EC2_URL -> AWS_URL
 #  - EC2_ACCESS_KEY -> AWS_ACCESS_KEY_ID -> AWS_ACCESS_KEY
@@ -14,525 +15,516 @@
 - name: rds_option_group tests
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
+    # ============================================================
+    - name: test empty parameter group - CHECK_MODE
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+      check_mode: true
+      register: result
+
+    - name: assert rds parameter group changed - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - result.changed
+
+    - name: test empty parameter group
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+      register: result
+
+    - name: assert rds parameter group changed
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - '"db_parameter_group_arn" in result'
+          - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name | lower }}'"
+          - '"description" in result'
+          - result.tags == {}
 
     # ============================================================
-  - name: test empty parameter group - CHECK_MODE
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-    check_mode: true
-    register: result
+    - name: test empty parameter group with no arguments changes nothing - CHECK_MODE
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+      check_mode: true
+      register: result
 
-  - name: assert rds parameter group changed - CHECK_MODE
-    assert:
-      that:
-      - result.changed
+    - name: assert no change when running empty parameter group a second time - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: test empty parameter group
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-    register: result
+    - name: test empty parameter group with no arguments changes nothing
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+      register: result
 
-  - name: assert rds parameter group changed
-    assert:
-      that:
-      - result.changed
-      - '"db_parameter_group_arn" in result'
-      - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name\
-        \ | lower }}'"
-      - '"description" in result'
-      - result.tags == {}
+    - name: assert no change when running empty parameter group a second time
+      ansible.builtin.assert:
+        that:
+          - not result.changed
 
     # ============================================================
-  - name: test empty parameter group with no arguments changes nothing - CHECK_MODE
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-    check_mode: true
-    register: result
+    - name: test adding numeric tag - CHECK_MODE
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+        tags:
+          Environment: test
+          Test: 123
+      check_mode: true
+      register: result
 
-  - name: assert no change when running empty parameter group a second time - CHECK_MODE
-    assert:
-      that:
-      - not result.changed
+    - name: adding numeric tag just silently converts - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - result.changed
+    - name: test adding numeric tag
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+        tags:
+          Environment: test
+          Test: 123
+      register: result
 
-  - name: test empty parameter group with no arguments changes nothing
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-    register: result
-
-  - name: assert no change when running empty parameter group a second time
-    assert:
-      that:
-      - not result.changed
-
-    # ============================================================
-  - name: test adding numeric tag - CHECK_MODE
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-      tags:
-        Environment: test
-        Test: 123
-    check_mode: true
-    register: result
-
-  - name: adding numeric tag just silently converts - CHECK_MODE
-    assert:
-      that:
-      - result.changed
-  - name: test adding numeric tag
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-      tags:
-        Environment: test
-        Test: 123
-    register: result
-
-  - name: adding numeric tag just silently converts
-    assert:
-      that:
-      - result.changed
-      - '"db_parameter_group_arn" in result'
-      - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name\
-        \ | lower }}'"
-      - '"description" in result'
-      - '"tags" in result'
-      - result.tags | length == 2
-      - result.tags["Environment"] == 'test'
-      - result.tags["Test"] == '123'
+    - name: adding numeric tag just silently converts
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - '"db_parameter_group_arn" in result'
+          - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name | lower }}'"
+          - '"description" in result'
+          - '"tags" in result'
+          - result.tags | length == 2
+          - result.tags["Environment"] == 'test'
+          - result.tags["Test"] == '123'
 
     # ============================================================
 
-  - name: test modifying rds parameter group engine/family (warning displayed)
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine_to_modify_to }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-      tags:
-        Environment: test
-        Test: 123
-    register: result
+    - name: test modifying rds parameter group engine/family (warning displayed)
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine_to_modify_to }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+        tags:
+          Environment: test
+          Test: 123
+      register: result
 
-  - name: verify that modifying rds param group engine/family displays warning
-    assert:
-      that:
-      - not result.changed
-      - not result.failed
-      - result.warnings is defined
-      - result.warnings | length > 0
-
-    # ============================================================
-  - name: test tagging existing group - CHECK_MODE
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-      tags:
-        Environment: test
-        Test: '123'
-        NewTag: hello
-    check_mode: true
-    register: result
-
-  - name: assert tagging existing group changes it and adds tags - CHECK_MODE
-    assert:
-      that:
-      - result.changed
-  - name: test tagging existing group
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-      tags:
-        Environment: test
-        Test: '123'
-        NewTag: hello
-    register: result
-
-  - name: assert tagging existing group changes it and adds tags
-    assert:
-      that:
-      - result.changed
-      - '"db_parameter_group_arn" in result'
-      - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name\
-        \ | lower }}'"
-      - '"description" in result'
-      - '"tags" in result'
-      - result.tags | length == 3
-      - result.tags["Environment"] == 'test'
-      - result.tags["Test"] == '123'
-      - result.tags["NewTag"] == 'hello'
+    - name: verify that modifying rds param group engine/family displays warning
+      ansible.builtin.assert:
+        that:
+          - not result.changed
+          - not result.failed
+          - result.warnings is defined
+          - result.warnings | length > 0
 
     # ============================================================
-  - name: test repeating tagging existing group - CHECK_MODE
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-      tags:
-        Environment: test
-        Test: '123'
-        NewTag: hello
-    check_mode: true
-    register: result
+    - name: test tagging existing group - CHECK_MODE
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+        tags:
+          Environment: test
+          Test: "123"
+          NewTag: hello
+      check_mode: true
+      register: result
 
-  - name: assert tagging existing group changes it and adds tags - CHECK_MODE
-    assert:
-      that:
-      - not result.changed
-      - '"db_parameter_group_arn" in result'
-      - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name\
-        \ | lower }}'"
-      - '"description" in result'
-      - '"tags" in result'
-      - result.tags | length == 3
-      - result.tags["Environment"] == 'test'
-      - result.tags["Test"] == '123'
-      - result.tags["NewTag"] == 'hello'
+    - name: assert tagging existing group changes it and adds tags - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - result.changed
+    - name: test tagging existing group
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+        tags:
+          Environment: test
+          Test: "123"
+          NewTag: hello
+      register: result
 
-  - name: test repeating tagging existing group
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-      tags:
-        Environment: test
-        Test: '123'
-        NewTag: hello
-    register: result
-
-  - name: assert tagging existing group changes it and adds tags
-    assert:
-      that:
-      - not result.changed
-      - '"db_parameter_group_arn" in result'
-      - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name\
-        \ | lower }}'"
-      - '"description" in result'
-      - '"tags" in result'
-      - result.tags | length == 3
-      - result.tags["Environment"] == 'test'
-      - result.tags["Test"] == '123'
-      - result.tags["NewTag"] == 'hello'
+    - name: assert tagging existing group changes it and adds tags
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - '"db_parameter_group_arn" in result'
+          - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name | lower }}'"
+          - '"description" in result'
+          - '"tags" in result'
+          - result.tags | length == 3
+          - result.tags["Environment"] == 'test'
+          - result.tags["Test"] == '123'
+          - result.tags["NewTag"] == 'hello'
 
     # ============================================================
-  - name: test deleting tags from existing group - CHECK_MODE
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-      tags:
-        Environment: test
-      purge_tags: yes
-    check_mode: true
-    register: result
+    - name: test repeating tagging existing group - CHECK_MODE
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+        tags:
+          Environment: test
+          Test: "123"
+          NewTag: hello
+      check_mode: true
+      register: result
 
-  - name: assert removing tags from existing group changes it - CHECK_MODE
-    assert:
-      that:
-      - result.changed
-  - name: test deleting tags from existing group
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-      tags:
-        Environment: test
-      purge_tags: yes
-    register: result
+    - name: assert tagging existing group changes it and adds tags - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - not result.changed
+          - '"db_parameter_group_arn" in result'
+          - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name | lower }}'"
+          - '"description" in result'
+          - '"tags" in result'
+          - result.tags | length == 3
+          - result.tags["Environment"] == 'test'
+          - result.tags["Test"] == '123'
+          - result.tags["NewTag"] == 'hello'
 
-  - name: assert removing tags from existing group changes it
-    assert:
-      that:
-      - result.changed
-      - '"db_parameter_group_arn" in result'
-      - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name\
-        \ | lower }}'"
-      - '"description" in result'
-      - '"tags" in result'
-      - result.tags | length == 1
-      - result.tags["Environment"] == 'test'
+    - name: test repeating tagging existing group
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+        tags:
+          Environment: test
+          Test: "123"
+          NewTag: hello
+      register: result
 
-    # ============================================================
-  - name: test state=absent with engine defined (expect changed=true) - CHECK_MODE
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      state: absent
-    check_mode: true
-    register: result
-
-  - name: assert state=absent with engine defined (expect changed=true) - CHECK_MODE
-    assert:
-      that:
-      - result.changed
-
-  - name: test state=absent with engine defined (expect changed=true)
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      state: absent
-    register: result
-
-  - name: assert state=absent with engine defined (expect changed=true)
-    assert:
-      that:
-      - result.changed
+    - name: assert tagging existing group changes it and adds tags
+      ansible.builtin.assert:
+        that:
+          - not result.changed
+          - '"db_parameter_group_arn" in result'
+          - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name | lower }}'"
+          - '"description" in result'
+          - '"tags" in result'
+          - result.tags | length == 3
+          - result.tags["Environment"] == 'test'
+          - result.tags["Test"] == '123'
+          - result.tags["NewTag"] == 'hello'
 
     # ============================================================
-  - name: test creating group with parameters - CHECK_MODE
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-      params:
-        log_directory: /var/log/postgresql
-        log_statement: all
-        log_duration: on
-        this_param_does_not_exist: oh_no
-      tags:
-        Environment: test
-        Test: '123'
-    check_mode: true
-    register: result
+    - name: test deleting tags from existing group - CHECK_MODE
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+        tags:
+          Environment: test
+        purge_tags: true
+      check_mode: true
+      register: result
 
-  - name: assert creating a new group with parameter changes it - CHECK_MODE
-    assert:
-      that:
-      - result.changed
+    - name: assert removing tags from existing group changes it - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - result.changed
+    - name: test deleting tags from existing group
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+        tags:
+          Environment: test
+        purge_tags: true
+      register: result
 
-  - name: test creating group with parameters
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-      params:
-        log_directory: /var/log/postgresql
-        log_statement: all
-        log_duration: on
-        this_param_does_not_exist: oh_no
-      tags:
-        Environment: test
-        Test: '123'
-    register: result
-
-  - name: assert creating a new group with parameter changes it
-    assert:
-      that:
-      - result.changed
-      - '"db_parameter_group_arn" in result'
-      - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name\
-        \ | lower }}'"
-      - '"description" in result'
-      - '"tags" in result'
-      - result.tags | length == 2
-      - result.tags["Environment"] == 'test'
-      - result.tags["Test"] == '123'
-      - result.errors|length == 2
+    - name: assert removing tags from existing group changes it
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - '"db_parameter_group_arn" in result'
+          - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name | lower }}'"
+          - '"description" in result'
+          - '"tags" in result'
+          - result.tags | length == 1
+          - result.tags["Environment"] == 'test'
 
     # ============================================================
-  - name: test repeating group with parameters - CHECK_MODE
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-      params:
-        log_directory: /var/log/postgresql
-        log_statement: all
-        log_duration: on
-        this_param_does_not_exist: oh_no
-      tags:
-        Environment: test
-        Test: '123'
-    check_mode: true
-    register: result
+    - name: test state=absent with engine defined (expect changed=true) - CHECK_MODE
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        state: absent
+      check_mode: true
+      register: result
 
-  - name: assert repeating group with parameters does not change it - CHECK_MODE
-    assert:
-      that:
-      - not result.changed
+    - name: assert state=absent with engine defined (expect changed=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: test repeating group with parameters
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      state: present
-      params:
-        log_directory: /var/log/postgresql
-        log_statement: all
-        log_duration: on
-        this_param_does_not_exist: oh_no
-      tags:
-        Environment: test
-        Test: '123'
-    register: result
+    - name: test state=absent with engine defined (expect changed=true)
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        state: absent
+      register: result
 
-  - name: assert repeating group with parameters does not change it
-    assert:
-      that:
-      - not result.changed
-      - '"db_parameter_group_arn" in result'
-      - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name\
-        \ | lower }}'"
-      - '"description" in result'
-      - '"tags" in result'
-      - result.tags | length == 2
-      - result.tags["Environment"] == 'test'
-      - result.tags["Test"] == '123'
-      - result.errors|length == 2
+    - name: assert state=absent with engine defined (expect changed=true)
+      ansible.builtin.assert:
+        that:
+          - result.changed
 
     # ============================================================
-  - name: test state=absent with engine defined (expect changed=true) - CHECK_MODE
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      state: absent
-    check_mode: true
-    register: result
+    - name: test creating group with parameters - CHECK_MODE
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+        params:
+          log_directory: /var/log/postgresql
+          log_statement: all
+          log_duration: true
+          this_param_does_not_exist: oh_no
+        tags:
+          Environment: test
+          Test: "123"
+      check_mode: true
+      register: result
 
-  - name: assert state=absent with engine defined (expect changed=true) - CHECK_MODE
-    assert:
-      that:
-      - result.changed
-  - name: test state=absent with engine defined (expect changed=true)
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      state: absent
-    register: result
+    - name: assert creating a new group with parameter changes it - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - result.changed
 
-  - name: assert state=absent with engine defined (expect changed=true)
-    assert:
-      that:
-      - result.changed
+    - name: test creating group with parameters
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+        params:
+          log_directory: /var/log/postgresql
+          log_statement: all
+          log_duration: true
+          this_param_does_not_exist: oh_no
+        tags:
+          Environment: test
+          Test: "123"
+      register: result
 
-    # ============================================================
-  - name: test repeating state=absent (expect changed=false) - CHECK_MODE
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      state: absent
-    register: result
-    check_mode: true
-    ignore_errors: true
-
-  - name: assert repeating state=absent (expect changed=false) - CHECK_MODE
-    assert:
-      that:
-      - not result.changed
-  - name: test repeating state=absent (expect changed=false)
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      state: absent
-    register: result
-    ignore_errors: true
-
-  - name: assert repeating state=absent (expect changed=false)
-    assert:
-      that:
-      - not result.changed
-
-    # ============================================================
-  - name: test creating group with more than 20 parameters - CHECK_MODE
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      params: '{{ rds_long_param_list }}'
-      state: present
-    check_mode: true
-    register: result
-
-  - name: assert creating a new group with lots of parameter changes it - CHECK_MODE
-    assert:
-      that:
-      - result.changed
-  - name: test creating group with more than 20 parameters
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      params: '{{ rds_long_param_list }}'
-      state: present
-    register: result
-
-  - name: assert creating a new group with lots of parameter changes it
-    assert:
-      that:
-      - result.changed
+    - name: assert creating a new group with parameter changes it
+      ansible.builtin.assert:
+        that:
+          - result.changed
+          - '"db_parameter_group_arn" in result'
+          - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name | lower }}'"
+          - '"description" in result'
+          - '"tags" in result'
+          - result.tags | length == 2
+          - result.tags["Environment"] == 'test'
+          - result.tags["Test"] == '123'
+          - result.errors|length == 2
 
     # ============================================================
-  - name: test creating group with more than 20 parameters - CHECK_MODE
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      params: '{{ rds_long_param_list }}'
-      state: present
-    check_mode: true
-    register: result
+    - name: test repeating group with parameters - CHECK_MODE
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+        params:
+          log_directory: /var/log/postgresql
+          log_statement: all
+          log_duration: true
+          this_param_does_not_exist: oh_no
+        tags:
+          Environment: test
+          Test: "123"
+      check_mode: true
+      register: result
 
-  - name: assert repeating a group with lots of parameter does not change it - CHECK_MODE
-    assert:
-      that:
-      - not result.changed
-  - name: test creating group with more than 20 parameters
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      engine: '{{ rds_param_group.engine }}'
-      description: '{{ rds_param_group.description }}'
-      params: '{{ rds_long_param_list }}'
-      state: present
-    register: result
+    - name: assert repeating group with parameters does not change it - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - not result.changed
 
-  - name: assert repeating a group with lots of parameter does not change it
-    assert:
-      that:
-      - not result.changed
+    - name: test repeating group with parameters
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        state: present
+        params:
+          log_directory: /var/log/postgresql
+          log_statement: all
+          log_duration: true
+          this_param_does_not_exist: oh_no
+        tags:
+          Environment: test
+          Test: "123"
+      register: result
+
+    - name: assert repeating group with parameters does not change it
+      ansible.builtin.assert:
+        that:
+          - not result.changed
+          - '"db_parameter_group_arn" in result'
+          - "'{{ result.db_parameter_group_name | lower }}' == '{{ rds_param_group.name | lower }}'"
+          - '"description" in result'
+          - '"tags" in result'
+          - result.tags | length == 2
+          - result.tags["Environment"] == 'test'
+          - result.tags["Test"] == '123'
+          - result.errors|length == 2
+
+    # ============================================================
+    - name: test state=absent with engine defined (expect changed=true) - CHECK_MODE
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        state: absent
+      check_mode: true
+      register: result
+
+    - name: assert state=absent with engine defined (expect changed=true) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - result.changed
+    - name: test state=absent with engine defined (expect changed=true)
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        state: absent
+      register: result
+
+    - name: assert state=absent with engine defined (expect changed=true)
+      ansible.builtin.assert:
+        that:
+          - result.changed
+
+    # ============================================================
+    - name: test repeating state=absent (expect changed=false) - CHECK_MODE
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        state: absent
+      register: result
+      check_mode: true
+      ignore_errors: true
+
+    - name: assert repeating state=absent (expect changed=false) - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - not result.changed
+    - name: test repeating state=absent (expect changed=false)
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        state: absent
+      register: result
+      ignore_errors: true
+
+    - name: assert repeating state=absent (expect changed=false)
+      ansible.builtin.assert:
+        that:
+          - not result.changed
+
+    # ============================================================
+    - name: test creating group with more than 20 parameters - CHECK_MODE
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        params: "{{ rds_long_param_list }}"
+        state: present
+      check_mode: true
+      register: result
+
+    - name: assert creating a new group with lots of parameter changes it - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - result.changed
+    - name: test creating group with more than 20 parameters
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        params: "{{ rds_long_param_list }}"
+        state: present
+      register: result
+
+    - name: assert creating a new group with lots of parameter changes it
+      ansible.builtin.assert:
+        that:
+          - result.changed
+
+    # ============================================================
+    - name: test creating group with more than 20 parameters - CHECK_MODE
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        params: "{{ rds_long_param_list }}"
+        state: present
+      check_mode: true
+      register: result
+
+    - name: assert repeating a group with lots of parameter does not change it - CHECK_MODE
+      ansible.builtin.assert:
+        that:
+          - not result.changed
+    - name: test creating group with more than 20 parameters
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        engine: "{{ rds_param_group.engine }}"
+        description: "{{ rds_param_group.description }}"
+        params: "{{ rds_long_param_list }}"
+        state: present
+      register: result
+
+    - name: assert repeating a group with lots of parameter does not change it
+      ansible.builtin.assert:
+        that:
+          - not result.changed
 
   always:
     # ============================================================
-  - name: test state=absent (expect changed=false)
-    rds_param_group:
-      name: '{{ rds_param_group.name }}'
-      state: absent
-    register: result
-    ignore_errors: true
+    - name: test state=absent (expect changed=false)
+      amazon.aws.rds_param_group:
+        name: "{{ rds_param_group.name }}"
+        state: absent
+      register: result
+      ignore_errors: true
 
-  - name: assert state=absent (expect changed=false)
-    assert:
-      that:
-      - result.changed
+    - name: assert state=absent (expect changed=false)
+      ansible.builtin.assert:
+        that:
+          - result.changed

--- a/tests/integration/targets/rds_subnet_group/defaults/main.yml
+++ b/tests/integration/targets/rds_subnet_group/defaults/main.yml
@@ -1,9 +1,9 @@
+---
 vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/16
 subnet_a: 10.{{ 256 | random(seed=resource_prefix) }}.10.0/24
 subnet_b: 10.{{ 256 | random(seed=resource_prefix) }}.11.0/24
 subnet_c: 10.{{ 256 | random(seed=resource_prefix) }}.12.0/24
 subnet_d: 10.{{ 256 | random(seed=resource_prefix) }}.13.0/24
 
-group_description: 'Created by integration test : {{ resource_prefix }}'
-group_description_changed: 'Created by integration test : {{ resource_prefix }} -
-  changed'
+group_description: "Created by integration test : {{ resource_prefix }}"
+group_description_changed: "Created by integration test : {{ resource_prefix }} - changed"

--- a/tests/integration/targets/rds_subnet_group/meta/main.yml
+++ b/tests/integration/targets/rds_subnet_group/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/rds_subnet_group/tasks/main.yml
+++ b/tests/integration/targets/rds_subnet_group/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 # Tests for rds_subnet_group
 #
 # Note: (From Amazon's documentation)
@@ -7,106 +8,101 @@
 
 - module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-
   # ============================================================
 
-  - name: Fetch AZ availability
-    aws_az_info:
-    register: az_info
+    - name: Fetch AZ availability
+      amazon.aws.aws_az_info:
+      register: az_info
 
-  - name: Assert that we have multiple AZs available to us
-    assert:
-      that: az_info.availability_zones | length >= 2
+    - name: Assert that we have multiple AZs available to us
+      ansible.builtin.assert:
+        that: az_info.availability_zones | length >= 2
 
-  - name: Pick AZs
-    set_fact:
-      az_one: '{{ az_info.availability_zones[0].zone_name }}'
-      az_two: '{{ az_info.availability_zones[1].zone_name }}'
+    - name: Pick AZs
+      ansible.builtin.set_fact:
+        az_one: "{{ az_info.availability_zones[0].zone_name }}"
+        az_two: "{{ az_info.availability_zones[1].zone_name }}"
 
-  # ============================================================
+    # ============================================================
 
-  - name: Create a VPC
-    ec2_vpc_net:
-      state: present
-      cidr_block: '{{ vpc_cidr }}'
-      name: '{{ resource_prefix }}'
-    register: vpc
+    - name: Create a VPC
+      amazon.aws.ec2_vpc_net:
+        state: present
+        cidr_block: "{{ vpc_cidr }}"
+        name: "{{ resource_prefix }}"
+      register: vpc
 
-  - name: Create subnets
-    ec2_vpc_subnet:
-      state: present
-      cidr: '{{ item.cidr }}'
-      az: '{{ item.az }}'
-      vpc_id: '{{ vpc.vpc.id }}'
-      tags:
-        Name: '{{ item.name }}'
-    with_items:
-    - cidr: '{{ subnet_a }}'
-      az: '{{ az_one }}'
-      name: '{{ resource_prefix }}-subnet-a'
-    - cidr: '{{ subnet_b }}'
-      az: '{{ az_two }}'
-      name: '{{ resource_prefix }}-subnet-b'
-    - cidr: '{{ subnet_c }}'
-      az: '{{ az_one }}'
-      name: '{{ resource_prefix }}-subnet-c'
-    - cidr: '{{ subnet_d }}'
-      az: '{{ az_two }}'
-      name: '{{ resource_prefix }}-subnet-d'
-    register: subnets
+    - name: Create subnets
+      amazon.aws.ec2_vpc_subnet:
+        state: present
+        cidr: "{{ item.cidr }}"
+        az: "{{ item.az }}"
+        vpc_id: "{{ vpc.vpc.id }}"
+        tags:
+          Name: "{{ item.name }}"
+      with_items:
+        - cidr: "{{ subnet_a }}"
+          az: "{{ az_one }}"
+          name: "{{ resource_prefix }}-subnet-a"
+        - cidr: "{{ subnet_b }}"
+          az: "{{ az_two }}"
+          name: "{{ resource_prefix }}-subnet-b"
+        - cidr: "{{ subnet_c }}"
+          az: "{{ az_one }}"
+          name: "{{ resource_prefix }}-subnet-c"
+        - cidr: "{{ subnet_d }}"
+          az: "{{ az_two }}"
+          name: "{{ resource_prefix }}-subnet-d"
+      register: subnets
 
-  - set_fact:
-      subnet_ids: '{{ subnets.results | map(attribute="subnet.id") | list }}'
+    - ansible.builtin.set_fact:
+        subnet_ids: '{{ subnets.results | map(attribute="subnet.id") | list }}'
 
-  # ============================================================
+    # ============================================================
 
-  - include_tasks: params.yml
-
-  - include_tasks: tests.yml
-
-  # ============================================================
-
+    - ansible.builtin.include_tasks: params.yml
+    - ansible.builtin.include_tasks: tests.yml
   always:
-  - name: Remove subnet group
-    rds_subnet_group:
-      state: absent
-      name: '{{ resource_prefix }}'
-    ignore_errors: yes
+    - name: Remove subnet group
+      amazon.aws.rds_subnet_group:
+        state: absent
+        name: "{{ resource_prefix }}"
+      ignore_errors: true
 
-  - name: Remove subnets
-    ec2_vpc_subnet:
-      state: absent
-      cidr: '{{ item.cidr }}'
-      vpc_id: '{{ vpc.vpc.id }}'
-    with_items:
-    - cidr: '{{ subnet_a }}'
-      name: '{{ resource_prefix }}-subnet-a'
-    - cidr: '{{ subnet_b }}'
-      name: '{{ resource_prefix }}-subnet-b'
-    - cidr: '{{ subnet_c }}'
-      name: '{{ resource_prefix }}-subnet-c'
-    - cidr: '{{ subnet_d }}'
-      name: '{{ resource_prefix }}-subnet-d'
-    ignore_errors: yes
-    register: removed_subnets
-    until: removed_subnets is succeeded
-    retries: 5
-    delay: 5
+    - name: Remove subnets
+      amazon.aws.ec2_vpc_subnet:
+        state: absent
+        cidr: "{{ item.cidr }}"
+        vpc_id: "{{ vpc.vpc.id }}"
+      with_items:
+        - cidr: "{{ subnet_a }}"
+          name: "{{ resource_prefix }}-subnet-a"
+        - cidr: "{{ subnet_b }}"
+          name: "{{ resource_prefix }}-subnet-b"
+        - cidr: "{{ subnet_c }}"
+          name: "{{ resource_prefix }}-subnet-c"
+        - cidr: "{{ subnet_d }}"
+          name: "{{ resource_prefix }}-subnet-d"
+      ignore_errors: true
+      register: removed_subnets
+      until: removed_subnets is succeeded
+      retries: 5
+      delay: 5
 
-  - name: Remove the VPC
-    ec2_vpc_net:
-      state: absent
-      cidr_block: '{{ vpc_cidr }}'
-      name: '{{ resource_prefix }}'
-    ignore_errors: yes
-    register: removed_vpc
-    until: removed_vpc is success
-    retries: 5
-    delay: 5
+    - name: Remove the VPC
+      amazon.aws.ec2_vpc_net:
+        state: absent
+        cidr_block: "{{ vpc_cidr }}"
+        name: "{{ resource_prefix }}"
+      ignore_errors: true
+      register: removed_vpc
+      until: removed_vpc is success
+      retries: 5
+      delay: 5
 
   # ============================================================

--- a/tests/integration/targets/rds_subnet_group/tasks/params.yml
+++ b/tests/integration/targets/rds_subnet_group/tasks/params.yml
@@ -1,29 +1,30 @@
+---
 # Try creating without a description
 - name: Create a subnet group (no description)
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
+    name: "{{ resource_prefix }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
-  ignore_errors: yes
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
+  ignore_errors: true
   register: create_missing_param
-- assert:
+- ansible.builtin.assert:
     that:
-    - create_missing_param is failed
-    - "'description' in create_missing_param.msg"
-    - "'state is present but all of the following are missing' in create_missing_param.msg"
+      - create_missing_param is failed
+      - "'description' in create_missing_param.msg"
+      - "'state is present but all of the following are missing' in create_missing_param.msg"
 
 # Try creating without subnets
 - name: Create a subnet group (no subnets)
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
-  ignore_errors: yes
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
+  ignore_errors: true
   register: create_missing_param
-- assert:
+- ansible.builtin.assert:
     that:
-    - create_missing_param is failed
-    - "'subnets' in create_missing_param.msg"
-    - "'state is present but all of the following are missing' in create_missing_param.msg"
+      - create_missing_param is failed
+      - "'subnets' in create_missing_param.msg"
+      - "'state is present but all of the following are missing' in create_missing_param.msg"

--- a/tests/integration/targets/rds_subnet_group/tasks/tests.yml
+++ b/tests/integration/targets/rds_subnet_group/tasks/tests.yml
@@ -1,565 +1,566 @@
+---
 # ============================================================
 # Basic creation
 - name: Create a subnet group - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
+      - result is changed
 
 - name: Create a subnet group
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
-    - result.subnet_group.description == group_description
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
+      - result is changed
+      - result.subnet_group.description == group_description
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
 
 - name: Create a subnet group (idempotency) - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is not changed
+      - result is not changed
 
 - name: Create a subnet group (idempotency)
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is not changed
-    - result.subnet_group.description == group_description
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
+      - result is not changed
+      - result.subnet_group.description == group_description
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
 
 # ============================================================
 # Update description
 - name: Update subnet group description - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
+      - result is changed
 
 - name: Update subnet group description
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
-    - result.subnet_group.description == group_description_changed
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
+      - result is changed
+      - result.subnet_group.description == group_description_changed
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
 
 - name: Update subnet group description (idempotency) - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is not changed
+      - result is not changed
 
 - name: Update subnet group description (idempotency)
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is not changed
-    - result.subnet_group.description == group_description_changed
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
+      - result is not changed
+      - result.subnet_group.description == group_description_changed
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
 
 - name: Restore subnet group description - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
+      - result is changed
 
 - name: Restore subnet group description
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
-    - result.subnet_group.description == group_description
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
+      - result is changed
+      - result.subnet_group.description == group_description
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
 
 # ============================================================
 # Update subnets
 - name: Update subnet group list - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[2] }}'
-    - '{{ subnet_ids[3] }}'
+      - "{{ subnet_ids[2] }}"
+      - "{{ subnet_ids[3] }}"
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
+      - result is changed
 
 - name: Update subnet group list
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[2] }}'
-    - '{{ subnet_ids[3] }}'
+      - "{{ subnet_ids[2] }}"
+      - "{{ subnet_ids[3] }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
-    - result.subnet_group.description == group_description
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[2] in result.subnet_group.subnet_ids
-    - subnet_ids[3] in result.subnet_group.subnet_ids
+      - result is changed
+      - result.subnet_group.description == group_description
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[2] in result.subnet_group.subnet_ids
+      - subnet_ids[3] in result.subnet_group.subnet_ids
 
 - name: Update subnet group list (idempotency) - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[2] }}'
-    - '{{ subnet_ids[3] }}'
+      - "{{ subnet_ids[2] }}"
+      - "{{ subnet_ids[3] }}"
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is not changed
+      - result is not changed
 
 - name: Update subnet group list (idempotency)
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[2] }}'
-    - '{{ subnet_ids[3] }}'
+      - "{{ subnet_ids[2] }}"
+      - "{{ subnet_ids[3] }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is not changed
-    - result.subnet_group.description == group_description
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[2] in result.subnet_group.subnet_ids
-    - subnet_ids[3] in result.subnet_group.subnet_ids
+      - result is not changed
+      - result.subnet_group.description == group_description
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[2] in result.subnet_group.subnet_ids
+      - subnet_ids[3] in result.subnet_group.subnet_ids
 
 - name: Add more subnets subnet group list - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
-    - '{{ subnet_ids[2] }}'
-    - '{{ subnet_ids[3] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
+      - "{{ subnet_ids[2] }}"
+      - "{{ subnet_ids[3] }}"
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
+      - result is changed
 
 - name: Add more subnets subnet group list
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
-    - '{{ subnet_ids[2] }}'
-    - '{{ subnet_ids[3] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
+      - "{{ subnet_ids[2] }}"
+      - "{{ subnet_ids[3] }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
-    - result.subnet_group.description == group_description
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 4
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
-    - subnet_ids[2] in result.subnet_group.subnet_ids
-    - subnet_ids[3] in result.subnet_group.subnet_ids
+      - result is changed
+      - result.subnet_group.description == group_description
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 4
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
+      - subnet_ids[2] in result.subnet_group.subnet_ids
+      - subnet_ids[3] in result.subnet_group.subnet_ids
 
 - name: Add more members to subnet group list (idempotency) - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
-    - '{{ subnet_ids[2] }}'
-    - '{{ subnet_ids[3] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
+      - "{{ subnet_ids[2] }}"
+      - "{{ subnet_ids[3] }}"
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is not changed
+      - result is not changed
 
 - name: Add more members to subnet group list (idempotency)
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
-    - '{{ subnet_ids[2] }}'
-    - '{{ subnet_ids[3] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
+      - "{{ subnet_ids[2] }}"
+      - "{{ subnet_ids[3] }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is not changed
-    - result.subnet_group.description == group_description
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 4
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
-    - subnet_ids[2] in result.subnet_group.subnet_ids
-    - subnet_ids[3] in result.subnet_group.subnet_ids
+      - result is not changed
+      - result.subnet_group.description == group_description
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 4
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
+      - subnet_ids[2] in result.subnet_group.subnet_ids
+      - subnet_ids[3] in result.subnet_group.subnet_ids
 
 # ============================================================
 # Add tags to subnets
 - name: Update subnet with tags - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
     tags:
-      tag_one: '{{ resource_prefix }} One'
+      tag_one: "{{ resource_prefix }} One"
       Tag Two: two {{ resource_prefix }}
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
+      - result is changed
 
 - name: Update subnet with tags
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
     tags:
-      tag_one: '{{ resource_prefix }} One'
+      tag_one: "{{ resource_prefix }} One"
       Tag Two: two {{ resource_prefix }}
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
-    - result.subnet_group.description == group_description_changed
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
-    - '"tags" in result.subnet_group'
-    - result.subnet_group.tags | length == 2
-    - result.subnet_group.tags["tag_one"] == '{{ resource_prefix }} One'
-    - result.subnet_group.tags["Tag Two"] == 'two {{ resource_prefix }}'
+      - result is changed
+      - result.subnet_group.description == group_description_changed
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
+      - '"tags" in result.subnet_group'
+      - result.subnet_group.tags | length == 2
+      - result.subnet_group.tags["tag_one"] == '{{ resource_prefix }} One'
+      - result.subnet_group.tags["Tag Two"] == 'two {{ resource_prefix }}'
 
 - name: Update subnet with tags (idempotency) - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
     tags:
-      tag_one: '{{ resource_prefix }} One'
+      tag_one: "{{ resource_prefix }} One"
       Tag Two: two {{ resource_prefix }}
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is not changed
+      - result is not changed
 
 - name: Update subnet with tags (idempotency)
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
     tags:
-      tag_one: '{{ resource_prefix }} One'
+      tag_one: "{{ resource_prefix }} One"
       Tag Two: two {{ resource_prefix }}
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is not changed
-    - result.subnet_group.description == group_description_changed
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
-    - '"tags" in result.subnet_group'
-    - result.subnet_group.tags | length == 2
-    - result.subnet_group.tags["tag_one"] == '{{ resource_prefix }} One'
-    - result.subnet_group.tags["Tag Two"] == 'two {{ resource_prefix }}'
+      - result is not changed
+      - result.subnet_group.description == group_description_changed
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
+      - '"tags" in result.subnet_group'
+      - result.subnet_group.tags | length == 2
+      - result.subnet_group.tags["tag_one"] == '{{ resource_prefix }} One'
+      - result.subnet_group.tags["Tag Two"] == 'two {{ resource_prefix }}'
 
 - name: Update (add/remove) tags - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
     tags:
-      tag_three: '{{ resource_prefix }} Three'
+      tag_three: "{{ resource_prefix }} Three"
       Tag Two: two {{ resource_prefix }}
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
+      - result is changed
 
 - name: Update (add/remove) tags
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
     tags:
-      tag_three: '{{ resource_prefix }} Three'
+      tag_three: "{{ resource_prefix }} Three"
       Tag Two: two {{ resource_prefix }}
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
-    - result.subnet_group.description == group_description_changed
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
-    - '"tags" in result.subnet_group'
-    - result.subnet_group.tags | length == 2
-    - result.subnet_group.tags["tag_three"] == '{{ resource_prefix }} Three'
-    - result.subnet_group.tags["Tag Two"] == 'two {{ resource_prefix }}'
+      - result is changed
+      - result.subnet_group.description == group_description_changed
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
+      - '"tags" in result.subnet_group'
+      - result.subnet_group.tags | length == 2
+      - result.subnet_group.tags["tag_three"] == '{{ resource_prefix }} Three'
+      - result.subnet_group.tags["Tag Two"] == 'two {{ resource_prefix }}'
 
 - name: Update tags without purge - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
-    purge_tags: no
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
+    purge_tags: false
     tags:
-      tag_one: '{{ resource_prefix }} One'
+      tag_one: "{{ resource_prefix }} One"
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
+      - result is changed
 
 - name: Update tags without purge
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
-    purge_tags: no
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
+    purge_tags: false
     tags:
-      tag_one: '{{ resource_prefix }} One'
+      tag_one: "{{ resource_prefix }} One"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
-    - result.subnet_group.description == group_description_changed
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
-    - '"tags" in result.subnet_group'
-    - result.subnet_group.tags | length == 3
-    - result.subnet_group.tags["tag_three"] == '{{ resource_prefix }} Three'
-    - result.subnet_group.tags["Tag Two"] == 'two {{ resource_prefix }}'
-    - result.subnet_group.tags["tag_one"] == '{{ resource_prefix }} One'
+      - result is changed
+      - result.subnet_group.description == group_description_changed
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
+      - '"tags" in result.subnet_group'
+      - result.subnet_group.tags | length == 3
+      - result.subnet_group.tags["tag_three"] == '{{ resource_prefix }} Three'
+      - result.subnet_group.tags["Tag Two"] == 'two {{ resource_prefix }}'
+      - result.subnet_group.tags["tag_one"] == '{{ resource_prefix }} One'
 
 - name: Remove all the tags - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
     tags: {}
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
+      - result is changed
 
 - name: Remove all the tags
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
     tags: {}
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
-    - result.subnet_group.description == group_description_changed
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
-    - '"tags" in result.subnet_group'
+      - result is changed
+      - result.subnet_group.description == group_description_changed
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
+      - '"tags" in result.subnet_group'
 
 - name: Update with CamelCase tags - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
     tags:
       lowercase spaced: hello cruel world
       Title Case: Hello Cruel World
@@ -568,18 +569,18 @@
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
+      - result is changed
 
 - name: Update with CamelCase tags
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
     tags:
       lowercase spaced: hello cruel world
       Title Case: Hello Cruel World
@@ -587,89 +588,88 @@
       snake_case: simple_snake_case
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
-    - result.subnet_group.description == group_description_changed
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
-    - '"tags" in result.subnet_group'
-    - result.subnet_group.tags | length == 4
-    - result.subnet_group.tags["lowercase spaced"] == 'hello cruel world'
-    - result.subnet_group.tags["Title Case"] == 'Hello Cruel World'
-    - result.subnet_group.tags["CamelCase"] == 'SimpleCamelCase'
-    - result.subnet_group.tags["snake_case"] == 'simple_snake_case'
+      - result is changed
+      - result.subnet_group.description == group_description_changed
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
+      - '"tags" in result.subnet_group'
+      - result.subnet_group.tags | length == 4
+      - result.subnet_group.tags["lowercase spaced"] == 'hello cruel world'
+      - result.subnet_group.tags["Title Case"] == 'Hello Cruel World'
+      - result.subnet_group.tags["CamelCase"] == 'SimpleCamelCase'
+      - result.subnet_group.tags["snake_case"] == 'simple_snake_case'
 
 - name: Do not specify any tag to ensure previous tags are not removed
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: present
-    name: '{{ resource_prefix }}'
-    description: '{{ group_description_changed }}'
+    name: "{{ resource_prefix }}"
+    description: "{{ group_description_changed }}"
     subnets:
-    - '{{ subnet_ids[0] }}'
-    - '{{ subnet_ids[1] }}'
+      - "{{ subnet_ids[0] }}"
+      - "{{ subnet_ids[1] }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is not changed
-    - result.subnet_group.description == group_description_changed
-    - result.subnet_group.name == resource_prefix
-    - result.subnet_group.vpc_id == vpc.vpc.id
-    - result.subnet_group.subnet_ids | length == 2
-    - subnet_ids[0] in result.subnet_group.subnet_ids
-    - subnet_ids[1] in result.subnet_group.subnet_ids
-    - '"tags" in result.subnet_group'
-    - result.subnet_group.tags | length == 4
-    - result.subnet_group.tags["lowercase spaced"] == 'hello cruel world'
-    - result.subnet_group.tags["Title Case"] == 'Hello Cruel World'
-    - result.subnet_group.tags["CamelCase"] == 'SimpleCamelCase'
-    - result.subnet_group.tags["snake_case"] == 'simple_snake_case'
-
+      - result is not changed
+      - result.subnet_group.description == group_description_changed
+      - result.subnet_group.name == resource_prefix
+      - result.subnet_group.vpc_id == vpc.vpc.id
+      - result.subnet_group.subnet_ids | length == 2
+      - subnet_ids[0] in result.subnet_group.subnet_ids
+      - subnet_ids[1] in result.subnet_group.subnet_ids
+      - '"tags" in result.subnet_group'
+      - result.subnet_group.tags | length == 4
+      - result.subnet_group.tags["lowercase spaced"] == 'hello cruel world'
+      - result.subnet_group.tags["Title Case"] == 'Hello Cruel World'
+      - result.subnet_group.tags["CamelCase"] == 'SimpleCamelCase'
+      - result.subnet_group.tags["snake_case"] == 'simple_snake_case'
 
 # ============================================================
 # Deletion
 - name: Delete a subnet group - CHECK_MODE
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: absent
-    name: '{{ resource_prefix }}'
+    name: "{{ resource_prefix }}"
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
+      - result is changed
 
 - name: Delete a subnet group
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: absent
-    name: '{{ resource_prefix }}'
+    name: "{{ resource_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is changed
+      - result is changed
 
 - name: Delete a subnet group - CHECK_MODE (idempotency)
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: absent
-    name: '{{ resource_prefix }}'
+    name: "{{ resource_prefix }}"
   check_mode: true
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is not changed
+      - result is not changed
 
 - name: Delete a subnet group (idempotency)
-  rds_subnet_group:
+  amazon.aws.rds_subnet_group:
     state: absent
-    name: '{{ resource_prefix }}'
+    name: "{{ resource_prefix }}"
   register: result
 
-- assert:
+- ansible.builtin.assert:
     that:
-    - result is not changed
+      - result is not changed

--- a/tests/integration/targets/route53/meta/main.yml
+++ b/tests/integration/targets/route53/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -1,1131 +1,1124 @@
+---
 # tasks file for Route53 integration tests
 
-- set_fact:
+- ansible.builtin.set_fact:
     zone_one: '{{ resource_prefix | replace("-", "") }}.one.ansible.test.'
     zone_two: '{{ resource_prefix | replace("-", "") }}.two.ansible.test.'
-- debug:
+- ansible.builtin.debug:
     msg: Set zones {{ zone_one }} and {{ zone_two }}
 
 - name: Test basics (new zone, A and AAAA records)
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
     amazon.aws.route53:
       # Route53 is explicitly a global service
       region:
   block:
-  - name: create VPC
-    ec2_vpc_net:
-      cidr_block: 192.0.2.0/24
-      name: '{{ resource_prefix }}_vpc'
-      state: present
-    register: vpc
-
-  - name: Create a zone
-    route53_zone:
-      zone: '{{ zone_one }}'
-      comment: Created in Ansible test {{ resource_prefix }}
-      tags:
-        TestTag: '{{ resource_prefix }}.z1'
-    register: z1
-  - assert:
-      that:
-      - z1 is success
-      - z1 is changed
-      - z1.comment == 'Created in Ansible test {{ resource_prefix }}'
-      - z1.tags.TestTag == '{{ resource_prefix }}.z1'
-
-  - name: Get zone details
-    route53_info:
-      query: hosted_zone
-      hosted_zone_id: '{{ z1.zone_id }}'
-      hosted_zone_method: details
-    register: hosted_zones
-  - name: Assert newly created hosted zone only has NS and SOA records
-    assert:
-      that:
-      - hosted_zones.HostedZone.ResourceRecordSetCount == 2
-
-  - name: Create a second zone
-    route53_zone:
-      zone: '{{ zone_two }}'
-      vpc_id: '{{ vpc.vpc.id }}'
-      vpc_region: '{{ aws_region }}'
-      comment: Created in Ansible test {{ resource_prefix }}
-      tags:
-        TestTag: '{{ resource_prefix }}.z2'
-    register: z2
-  - assert:
-      that:
-      - z2 is success
-      - z2 is changed
-      - z2.comment == 'Created in Ansible test {{ resource_prefix }}'
-      - z2.tags.TestTag == '{{ resource_prefix }}.z2'
-
-  - name: Get zone details
-    route53_info:
-      query: hosted_zone
-      hosted_zone_id: '{{ z2.zone_id }}'
-      hosted_zone_method: details
-    register: hosted_zones
-
-  - name: Assert newly created hosted zone only has NS and SOA records
-    assert:
-      that:
-      - hosted_zones.HostedZone.ResourceRecordSetCount == 2
-      - hosted_zones.HostedZone.Config.PrivateZone
-
-  # Ensure that we can use the non-paginated list_by_name method with max_items
-  - name: Get zone 1 details only
-    route53_info:
-      query: hosted_zone
-      hosted_zone_method: list_by_name
-      dns_name: '{{ zone_one }}'
-      max_items: 1
-    register: list_by_name_result
-
-  - name: Assert that we found exactly one zone when querying by name
-    assert:
-      that:
-      - list_by_name_result.HostedZones | length == 1
-      - list_by_name_result.HostedZones[0].Name == '{{ zone_one }}'
-
-  - name: Create A record using zone fqdn
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: qdn_test.{{ zone_one }}
-      type: A
-      value: 192.0.2.1
-    register: qdn
-  - assert:
-      that:
-      - qdn is not failed
-      - qdn is changed
-      - "'wait_id' in qdn"
-      - qdn.wait_id is string
-
-  - name: Get A record using "get" method of route53 module
-    route53:
-      state: get
-      zone: '{{ zone_one }}'
-      record: qdn_test.{{ zone_one }}
-      type: A
-    register: get_result
-  - name: Check boto3 type get data
-    assert:
-      that:
-      - get_result.nameservers | length > 0
-      - get_result.resource_record_sets | length == 1
-      - '"name" in record_set'
-      - record_set.name == qdn_record
-      - '"resource_records" in record_set'
-      - record_set.resource_records | length == 1
-      - '"value" in record_set.resource_records[0]'
-      - record_set.resource_records[0].value == '192.0.2.1'
-      - '"ttl" in record_set'
-      - record_set.ttl == 3600
-      - '"type" in record_set'
-      - record_set.type == 'A'
-    vars:
-      record_set: '{{ get_result.resource_record_sets[0] }}'
-      qdn_record: qdn_test.{{ zone_one }}
-
-  - name: Check boto3 compat get data
-    assert:
-      that:
-      - '"set" in get_result'
-      - '"Name" in record_set'
-      - record_set.Name == qdn_record
-      - '"ResourceRecords" in record_set'
-      - record_set.ResourceRecords | length == 1
-      - '"Value" in record_set.ResourceRecords[0]'
-      - record_set.ResourceRecords[0].Value == '192.0.2.1'
-      - '"TTL" in record_set'
-      - record_set.TTL == 3600
-      - record_set.Type == 'A'
-    vars:
-      record_set: '{{ get_result.set }}'
-      qdn_record: qdn_test.{{ zone_one }}
-
-  - name: Check boto2 compat get data
-    assert:
-      that:
-      - '"set" in get_result'
-      - '"alias" in record_set'
-      - record_set.alias == False
-      - '"failover" in record_set'
-      - '"health_check" in record_set'
-      - '"hosted_zone_id" in record_set'
-      - record_set.hosted_zone_id == z1.zone_id
-      - '"identifier" in record_set'
-      - '"record" in record_set'
-      - record_set.record == qdn_record
-      - '"ttl" in record_set'
-      - record_set.ttl == "3600"
-      - '"type" in record_set'
-      - record_set.type == 'A'
-      - '"value" in record_set'
-      - record_set.value == '192.0.2.1'
-      - '"values" in record_set'
-      - record_set['values'] | length == 1
-      - record_set['values'][0] == '192.0.2.1'
-      - '"weight" in record_set'
-      - '"zone" in record_set'
-      - record_set.zone == zone_one
-    vars:
-      record_set: '{{ get_result.set }}'
-      qdn_record: qdn_test.{{ zone_one }}
-
-  ## test A recordset creation and order adjustments
-  - name: Create same A record using zone non-qualified domain
-    route53:
-      state: present
-      zone: '{{ zone_one[:-1] }}'
-      record: qdn_test.{{ zone_one[:-1] }}
-      type: A
-      value: 192.0.2.1
-    register: non_qdn
-  - assert:
-      that:
-      - non_qdn is not failed
-      - non_qdn is not changed
-      - "'wait_id' not in non_qdn"
-
-  - name: Create A record using zone ID
-    route53:
-      state: present
-      hosted_zone_id: '{{ z1.zone_id }}'
-      record: zid_test.{{ zone_one }}
-      type: A
-      value: 192.0.2.1
-    register: zid
-  - assert:
-      that:
-      - zid is not failed
-      - zid is changed
-
-  - name: Create a multi-value A record with values in different order
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: order_test.{{ zone_one }}
-      type: A
-      value:
-      - 192.0.2.2
-      - 192.0.2.1
-    register: mv_a_record
-  - assert:
-      that:
-      - mv_a_record is not failed
-      - mv_a_record is changed
-
-  - name: Create same multi-value A record with values in different order
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: order_test.{{ zone_one }}
-      type: A
-      value:
-      - 192.0.2.2
-      - 192.0.2.1
-    register: mv_a_record
-  - assert:
-      that:
-      - mv_a_record is not failed
-      - mv_a_record is not changed
-
-  # Get resulting A record and ensure max_items is applied
-  - name: get Route53 A record information
-    route53_info:
-      type: A
-      query: record_sets
-      hosted_zone_id: '{{ z1.zone_id }}'
-      start_record_name: order_test.{{ zone_one }}
-      max_items: 1
-    register: records
-
-  - assert:
-      that:
-      - records.ResourceRecordSets|length == 1
-      - records.ResourceRecordSets[0].ResourceRecords|length == 2
-      - records.ResourceRecordSets[0].ResourceRecords[0].Value == '192.0.2.2'
-      - records.ResourceRecordSets[0].ResourceRecords[1].Value == '192.0.2.1'
-
-  - name: Remove a member from multi-value A record with values in different order
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: order_test.{{ zone_one }}
-      type: A
-      value:
-      - 192.0.2.2
-    register: del_a_record
-    ignore_errors: true
-  - name: This should fail, because `overwrite` is false
-    assert:
-      that:
-      - del_a_record is failed
-
-  - name: Remove a member from multi-value A record with values in different order
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: order_test.{{ zone_one }}
-      overwrite: true
-      type: A
-      value:
-      - 192.0.2.2
-    register: del_a_record
-    ignore_errors: true
-
-  - name: This should not fail, because `overwrite` is true
-    assert:
-      that:
-      - del_a_record is not failed
-      - del_a_record is changed
-
-  - name: get Route53 zone A record information
-    route53_info:
-      type: A
-      query: record_sets
-      hosted_zone_id: '{{ z1.zone_id }}'
-      start_record_name: order_test.{{ zone_one }}
-      max_items: 50
-    register: records
-
-  - assert:
-      that:
-      - records.ResourceRecordSets|length == 3
-      - records.ResourceRecordSets[0].ResourceRecords|length == 1
-      - records.ResourceRecordSets[0].ResourceRecords[0].Value == '192.0.2.2'
-
-  ## Test CNAME record creation and retrive info
-  - name: Create CNAME record
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      type: CNAME
-      record: cname_test.{{ zone_one }}
-      value: order_test.{{ zone_one }}
-    register: cname_record
-
-  - assert:
-      that:
-      - cname_record is not failed
-      - cname_record is changed
-
-  - name: Get Route53 CNAME record information
-    route53_info:
-      type: CNAME
-      query: record_sets
-      hosted_zone_id: '{{ z1.zone_id }}'
-      start_record_name: cname_test.{{ zone_one }}
-      max_items: 1
-    register: cname_records
-
-  - assert:
-      that:
-      - cname_records.ResourceRecordSets|length == 1
-      - cname_records.ResourceRecordSets[0].ResourceRecords|length == 1
-      - cname_records.ResourceRecordSets[0].ResourceRecords[0].Value == "order_test.{{
-        zone_one }}"
-
-  ## Test CAA record creation
-  - name: Create a LetsEncrypt CAA record
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: '{{ zone_one }}'
-      type: CAA
-      value:
-      - 0 issue "letsencrypt.org;"
-      - 0 issuewild "letsencrypt.org;"
-      overwrite: true
-    register: caa
-  - assert:
-      that:
-      - caa is not failed
-      - caa is changed
-
-  - name: Re-create the same LetsEncrypt CAA record
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: '{{ zone_one }}'
-      type: CAA
-      value:
-      - 0 issue "letsencrypt.org;"
-      - 0 issuewild "letsencrypt.org;"
-      overwrite: true
-    register: caa
-  - assert:
-      that:
-      - caa is not failed
-      - caa is not changed
-
-  - name: Re-create the same LetsEncrypt CAA record in opposite-order
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: '{{ zone_one }}'
-      type: CAA
-      value:
-      - 0 issuewild "letsencrypt.org;"
-      - 0 issue "letsencrypt.org;"
-      overwrite: true
-    register: caa
-  - name: This should not be changed, as CAA records are not order sensitive
-    assert:
-      that:
-      - caa is not failed
-      - caa is not changed
-
-  - name: Create an A record for a wildcard prefix
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: '*.wildcard_test.{{ zone_one }}'
-      type: A
-      value:
-      - 192.0.2.1
-    register: wc_a_record
-  - assert:
-      that:
-      - wc_a_record is not failed
-      - wc_a_record is changed
-
-  - name: Create an A record for a wildcard prefix (idempotency)
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: '*.wildcard_test.{{ zone_one }}'
-      type: A
-      value:
-      - 192.0.2.1
-    register: wc_a_record
-  - assert:
-      that:
-      - wc_a_record is not failed
-      - wc_a_record is not changed
-
-  - name: Create an A record for a wildcard prefix (change)
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: '*.wildcard_test.{{ zone_one }}'
-      type: A
-      value:
-      - 192.0.2.2
-      overwrite: true
-    register: wc_a_record
-  - assert:
-      that:
-      - wc_a_record is not failed
-      - wc_a_record is changed
-
-  - name: Delete an A record for a wildcard prefix
-    route53:
-      state: absent
-      zone: '{{ zone_one }}'
-      record: '*.wildcard_test.{{ zone_one }}'
-      type: A
-      value:
-      - 192.0.2.2
-    register: wc_a_record
-  - assert:
-      that:
-      - wc_a_record is not failed
-      - wc_a_record is changed
-      - wc_a_record.diff.after == {}
-
-  - name: create a record with different TTL
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: localhost.{{ zone_one }}
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-    register: ttl30
-  - name: check return values
-    assert:
-      that:
-      - ttl30.diff.resource_record_sets[0].ttl == 30
-      - ttl30 is changed
-
-  - name: delete previous record without mention ttl and value
-    route53:
-      state: absent
-      zone: '{{ zone_one }}'
-      record: localhost.{{ zone_one }}
-      type: A
-    register: ttl30
-  - name: check if record is deleted
-    assert:
-      that:
-      - ttl30 is changed
-
-  - name: immutable delete previous record without mention ttl and value
-    route53:
-      state: absent
-      zone: '{{ zone_one }}'
-      record: localhost.{{ zone_one }}
-      type: A
-    register: ttl30
-  - name: check if record was deleted
-    assert:
-      that:
-      - ttl30 is not changed
-
-  # Tests on zone two (private zone)
-  - name: Create A record using zone fqdn
-    route53:
-      state: present
-      zone: '{{ zone_two }}'
-      record: qdn_test.{{ zone_two }}
-      type: A
-      value: 192.0.2.1
-      private_zone: true
-    register: qdn
-  - assert:
-      that:
-      - qdn is not failed
-      - qdn is changed
-
-  - name: Get A record using 'get' method of route53 module
-    route53:
-      state: get
-      zone: '{{ zone_two }}'
-      record: qdn_test.{{ zone_two }}
-      type: A
-      private_zone: true
-    register: get_result
-  - assert:
-      that:
-      - get_result.nameservers|length > 0
-      - get_result.set.Name == "qdn_test."+zone_two
-      - get_result.set.ResourceRecords[0].Value == "192.0.2.1"
-      - get_result.set.Type == "A"
-
-  - name: Get a record that does not exist
-    route53:
-      state: get
-      zone: '{{ zone_two }}'
-      record: notfound.{{ zone_two }}
-      type: A
-      private_zone: true
-    register: get_result
-  - assert:
-      that:
-      - get_result.nameservers|length > 0
-      - get_result.set|length == 0
-      - get_result.resource_record_sets|length == 0
-
-  - name: Create same A record using zone non-qualified domain
-    route53:
-      state: present
-      zone: '{{ zone_two[:-1] }}'
-      record: qdn_test.{{ zone_two[:-1] }}
-      type: A
-      value: 192.0.2.1
-      private_zone: true
-    register: non_qdn
-  - assert:
-      that:
-      - non_qdn is not failed
-      - non_qdn is not changed
-
-  - name: Create A record using zone ID
-    route53:
-      state: present
-      hosted_zone_id: '{{ z2.zone_id }}'
-      record: zid_test.{{ zone_two }}
-      type: A
-      value: 192.0.2.2
-      private_zone: true
-    register: zid
-  - assert:
-      that:
-      - zid is not failed
-      - zid is changed
-
-  - name: Create A record using zone fqdn and vpc_id
-    route53:
-      state: present
-      zone: '{{ zone_two }}'
-      record: qdn_test_vpc.{{ zone_two }}
-      type: A
-      value: 192.0.2.3
-      private_zone: true
-      vpc_id: '{{ vpc.vpc.id }}'
-    register: qdn
-  - assert:
-      that:
-      - qdn is not failed
-      - qdn is changed
-
-  - name: Create A record using zone ID and vpc_id
-    route53:
-      state: present
-      hosted_zone_id: '{{ z2.zone_id }}'
-      record: zid_test_vpc.{{ zone_two }}
-      type: A
-      value: 192.0.2.4
-      private_zone: true
-      vpc_id: '{{ vpc.vpc.id }}'
-    register: zid
-  - assert:
-      that:
-      - zid is not failed
-      - zid is changed
-
-  - name: Create an Alias record
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: alias.{{ zone_one }}
-      type: A
-      alias: true
-      alias_hosted_zone_id: '{{ z1.zone_id }}'
-      value: zid_test.{{ zone_one }}
-      overwrite: true
-    register: alias_record
-  - name: This should be changed
-    assert:
-      that:
-      - alias_record is not failed
-      - alias_record is changed
-
-  - name: Re-Create an Alias record
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: alias.{{ zone_one }}
-      type: A
-      alias: true
-      alias_hosted_zone_id: '{{ z1.zone_id }}'
-      value: zid_test.{{ zone_one }}
-      overwrite: true
-    register: alias_record
-  - name: This should not be changed
-    assert:
-      that:
-      - alias_record is not failed
-      - alias_record is not changed
-
-  - name: Create a weighted record
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: weighted.{{ zone_one }}
-      type: CNAME
-      value: zid_test.{{ zone_one }}
-      overwrite: true
-      identifier: host1@www
-      weight: 100
-      region: '{{ omit }}'
-    register: weighted_record
-  - name: This should be changed
-    assert:
-      that:
-      - weighted_record is not failed
-      - weighted_record is changed
-
-  - name: Re-Create a weighted record
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: weighted.{{ zone_one }}
-      type: CNAME
-      value: zid_test.{{ zone_one }}
-      overwrite: true
-      identifier: host1@www
-      weight: 100
-      region: '{{ omit }}'
-    register: weighted_record
-  - name: This should not be changed
-    assert:
-      that:
-      - weighted_record is not failed
-      - weighted_record is not changed
-
-  - name: Create a zero weighted record
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: zero_weighted.{{ zone_one }}
-      type: CNAME
-      value: zid_test.{{ zone_one }}
-      overwrite: true
-      identifier: host1@www
-      weight: 0
-      region: '{{ omit }}'
-    register: weighted_record
-  - name: This should be changed
-    assert:
-      that:
-      - weighted_record is not failed
-      - weighted_record is changed
-
-  - name: Re-Create a zero weighted record
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: zero_weighted.{{ zone_one }}
-      type: CNAME
-      value: zid_test.{{ zone_one }}
-      overwrite: true
-      identifier: host1@www
-      weight: 0
-      region: '{{ omit }}'
-    register: weighted_record
-  - name: This should not be changed
-    assert:
-      that:
-      - weighted_record is not failed
-      - weighted_record is not changed
-
-#Test Geo Location - Continent Code
-  - name: Create a record with geo_location - continent_code (check_mode)
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: geo-test-1.{{ zone_one }}
-      identifier: geohost1@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        continent_code: NA
-    check_mode: true
-    register: create_geo_continent_check_mode
-  - assert:
-      that:
-      - create_geo_continent_check_mode is changed
-      - create_geo_continent_check_mode is not failed
-      - '"route53:ChangeResourceRecordSets" not in create_geo_continent_check_mode.resource_actions'
-      - '"wait_id" in create_geo_continent_check_mode'
-      - create_geo_continent_check_mode.wait_id is none
-
-  - name: Create a record with geo_location - continent_code
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: geo-test-1.{{ zone_one }}
-      identifier: geohost1@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        continent_code: NA
-    register: create_geo_continent
-  # Get resulting A record and geo_location parameters are applied
-  - name: get Route53 A record information
-    route53_info:
-      type: A
-      query: record_sets
-      hosted_zone_id: '{{ z1.zone_id }}'
-      start_record_name: geo-test-1.{{ zone_one }}
-      max_items: 1
-    register: result
-
-  - assert:
-      that:
-      - create_geo_continent is changed
-      - create_geo_continent is not failed
-      - '"route53:ChangeResourceRecordSets" in create_geo_continent.resource_actions'
-      - result.ResourceRecordSets[0].GeoLocation.ContinentCode == "NA"
-
-  - name: Create a record with geo_location - continent_code (idempotency)
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: geo-test-1.{{ zone_one }}
-      identifier: geohost1@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        continent_code: NA
-    register: create_geo_continent_idem
-  - assert:
-      that:
-      - create_geo_continent_idem is not changed
-      - create_geo_continent_idem is not failed
-      - '"route53:ChangeResourceRecordSets" not in create_geo_continent_idem.resource_actions'
-
-  - name: Create a record with geo_location - continent_code (idempotency - check_mode)
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: geo-test-1.{{ zone_one }}
-      identifier: geohost1@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        continent_code: NA
-    check_mode: true
-    register: create_geo_continent_idem_check
-
-  - assert:
-      that:
-      - create_geo_continent_idem_check is not changed
-      - create_geo_continent_idem_check is not failed
-      - '"route53:ChangeResourceRecordSets" not in create_geo_continent_idem_check.resource_actions'
-
-#Test Geo Location - Country Code
-  - name: Create a record with geo_location - country_code (check_mode)
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: geo-test-2.{{ zone_one }}
-      identifier: geohost2@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        country_code: US
-    check_mode: true
-    register: create_geo_country_check_mode
-  - assert:
-      that:
-      - create_geo_country_check_mode is changed
-      - create_geo_country_check_mode is not failed
-      - '"route53:ChangeResourceRecordSets" not in create_geo_country_check_mode.resource_actions'
-
-  - name: Create a record with geo_location - country_code
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: geo-test-2.{{ zone_one }}
-      identifier: geohost2@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        country_code: US
-    register: create_geo_country
-  # Get resulting A record and geo_location parameters are applied
-  - name: get Route53 A record information
-    route53_info:
-      type: A
-      query: record_sets
-      hosted_zone_id: '{{ z1.zone_id }}'
-      start_record_name: geo-test-2.{{ zone_one }}
-      max_items: 1
-    register: result
-  - assert:
-      that:
-      - create_geo_country is changed
-      - create_geo_country is not failed
-      - '"route53:ChangeResourceRecordSets" in create_geo_country.resource_actions'
-      - result.ResourceRecordSets[0].GeoLocation.CountryCode == "US"
-
-  - name: Create a record with geo_location - country_code (idempotency)
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: geo-test-2.{{ zone_one }}
-      identifier: geohost2@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        country_code: US
-    register: create_geo_country_idem
-  - assert:
-      that:
-      - create_geo_country_idem is not changed
-      - create_geo_country_idem is not failed
-      - '"route53:ChangeResourceRecordSets" not in create_geo_country_idem.resource_actions'
-
-  - name: Create a record with geo_location - country_code (idempotency - check_mode)
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: geo-test-2.{{ zone_one }}
-      identifier: geohost2@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        country_code: US
-    check_mode: true
-    register: create_geo_country_idem_check
-
-  - assert:
-      that:
-      - create_geo_country_idem_check is not changed
-      - create_geo_country_idem_check is not failed
-      - '"route53:ChangeResourceRecordSets" not in create_geo_country_idem_check.resource_actions'
-
-#Test Geo Location - Subdivision Code
-  - name: Create a record with geo_location - subdivision_code (check_mode)
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: geo-test-3.{{ zone_one }}
-      identifier: geohost3@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        country_code: US
-        subdivision_code: TX
-    check_mode: true
-    register: create_geo_subdivision_check_mode
-  - assert:
-      that:
-      - create_geo_subdivision_check_mode is changed
-      - create_geo_subdivision_check_mode is not failed
-      - '"route53:ChangeResourceRecordSets" not in create_geo_subdivision_check_mode.resource_actions'
-
-  - name: Create a record with geo_location - subdivision_code
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: geo-test-3.{{ zone_one }}
-      identifier: geohost3@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        country_code: US
-        subdivision_code: TX
-    register: create_geo_subdivision
-  # Get resulting A record and geo_location parameters are applied
-  - name: get Route53 A record information
-    route53_info:
-      type: A
-      query: record_sets
-      hosted_zone_id: '{{ z1.zone_id }}'
-      start_record_name: geo-test-3.{{ zone_one }}
-      max_items: 1
-    register: result
-  - assert:
-      that:
-      - create_geo_subdivision is changed
-      - create_geo_subdivision is not failed
-      - '"route53:ChangeResourceRecordSets" in create_geo_subdivision.resource_actions'
-      - result.ResourceRecordSets[0].GeoLocation.CountryCode == "US"
-      - result.ResourceRecordSets[0].GeoLocation.SubdivisionCode == "TX"
-
-  - name: Create a record with geo_location - subdivision_code (idempotency)
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: geo-test-3.{{ zone_one }}
-      identifier: geohost3@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        country_code: US
-        subdivision_code: TX
-    register: create_geo_subdivision_idem
-  - assert:
-      that:
-      - create_geo_subdivision_idem is not changed
-      - create_geo_subdivision_idem is not failed
-      - '"route53:ChangeResourceRecordSets" not in create_geo_subdivision_idem.resource_actions'
-
-  - name: Create a record with geo_location - subdivision_code (idempotency - check_mode)
-    route53:
-      state: present
-      zone: '{{ zone_one }}'
-      record: geo-test-3.{{ zone_one }}
-      identifier: geohost3@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        country_code: US
-        subdivision_code: TX
-    check_mode: true
-    register: create_geo_subdivision_idem_check
-
-  - assert:
-      that:
-      - create_geo_subdivision_idem_check is not changed
-      - create_geo_subdivision_idem_check is not failed
-      - '"route53:ChangeResourceRecordSets" not in create_geo_subdivision_idem_check.resource_actions'
-
-#Cleanup------------------------------------------------------
+    - name: create VPC
+      amazon.aws.ec2_vpc_net:
+        cidr_block: 192.0.2.0/24
+        name: "{{ resource_prefix }}_vpc"
+        state: present
+      register: vpc
+
+    - name: Create a zone
+      amazon.aws.route53_zone:
+        zone: "{{ zone_one }}"
+        comment: Created in Ansible test {{ resource_prefix }}
+        tags:
+          TestTag: "{{ resource_prefix }}.z1"
+      register: z1
+    - ansible.builtin.assert:
+        that:
+          - z1 is success
+          - z1 is changed
+          - z1.comment == 'Created in Ansible test {{ resource_prefix }}'
+          - z1.tags.TestTag == '{{ resource_prefix }}.z1'
+
+    - name: Get zone details
+      amazon.aws.route53_info:
+        query: hosted_zone
+        hosted_zone_id: "{{ z1.zone_id }}"
+        hosted_zone_method: details
+      register: hosted_zones
+    - name: Assert newly created hosted zone only has NS and SOA records
+      ansible.builtin.assert:
+        that:
+          - hosted_zones.HostedZone.ResourceRecordSetCount == 2
+
+    - name: Create a second zone
+      amazon.aws.route53_zone:
+        zone: "{{ zone_two }}"
+        vpc_id: "{{ vpc.vpc.id }}"
+        vpc_region: "{{ aws_region }}"
+        comment: Created in Ansible test {{ resource_prefix }}
+        tags:
+          TestTag: "{{ resource_prefix }}.z2"
+      register: z2
+    - ansible.builtin.assert:
+        that:
+          - z2 is success
+          - z2 is changed
+          - z2.comment == 'Created in Ansible test {{ resource_prefix }}'
+          - z2.tags.TestTag == '{{ resource_prefix }}.z2'
+
+    - name: Get zone details
+      amazon.aws.route53_info:
+        query: hosted_zone
+        hosted_zone_id: "{{ z2.zone_id }}"
+        hosted_zone_method: details
+      register: hosted_zones
+
+    - name: Assert newly created hosted zone only has NS and SOA records
+      ansible.builtin.assert:
+        that:
+          - hosted_zones.HostedZone.ResourceRecordSetCount == 2
+          - hosted_zones.HostedZone.Config.PrivateZone
+
+    # Ensure that we can use the non-paginated list_by_name method with max_items
+    - name: Get zone 1 details only
+      amazon.aws.route53_info:
+        query: hosted_zone
+        hosted_zone_method: list_by_name
+        dns_name: "{{ zone_one }}"
+        max_items: 1
+      register: list_by_name_result
+
+    - name: Assert that we found exactly one zone when querying by name
+      ansible.builtin.assert:
+        that:
+          - list_by_name_result.HostedZones | length == 1
+          - list_by_name_result.HostedZones[0].Name == '{{ zone_one }}'
+
+    - name: Create A record using zone fqdn
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: qdn_test.{{ zone_one }}
+        type: A
+        value: 192.0.2.1
+      register: qdn
+    - ansible.builtin.assert:
+        that:
+          - qdn is not failed
+          - qdn is changed
+          - "'wait_id' in qdn"
+          - qdn.wait_id is string
+
+    - name: Get A record using "get" method of route53 module
+      amazon.aws.route53:
+        state: get
+        zone: "{{ zone_one }}"
+        record: qdn_test.{{ zone_one }}
+        type: A
+      register: get_result
+    - name: Check boto3 type get data
+      ansible.builtin.assert:
+        that:
+          - get_result.nameservers | length > 0
+          - get_result.resource_record_sets | length == 1
+          - '"name" in record_set'
+          - record_set.name == qdn_record
+          - '"resource_records" in record_set'
+          - record_set.resource_records | length == 1
+          - '"value" in record_set.resource_records[0]'
+          - record_set.resource_records[0].value == '192.0.2.1'
+          - '"ttl" in record_set'
+          - record_set.ttl == 3600
+          - '"type" in record_set'
+          - record_set.type == 'A'
+      vars:
+        record_set: "{{ get_result.resource_record_sets[0] }}"
+        qdn_record: qdn_test.{{ zone_one }}
+
+    - name: Check boto3 compat get data
+      ansible.builtin.assert:
+        that:
+          - '"set" in get_result'
+          - '"Name" in record_set'
+          - record_set.Name == qdn_record
+          - '"ResourceRecords" in record_set'
+          - record_set.ResourceRecords | length == 1
+          - '"Value" in record_set.ResourceRecords[0]'
+          - record_set.ResourceRecords[0].Value == '192.0.2.1'
+          - '"TTL" in record_set'
+          - record_set.TTL == 3600
+          - record_set.Type == 'A'
+      vars:
+        record_set: "{{ get_result.set }}"
+        qdn_record: qdn_test.{{ zone_one }}
+
+    - name: Check boto2 compat get data
+      ansible.builtin.assert:
+        that:
+          - '"set" in get_result'
+          - '"alias" in record_set'
+          - record_set.alias == False
+          - '"failover" in record_set'
+          - '"health_check" in record_set'
+          - '"hosted_zone_id" in record_set'
+          - record_set.hosted_zone_id == z1.zone_id
+          - '"identifier" in record_set'
+          - '"record" in record_set'
+          - record_set.record == qdn_record
+          - '"ttl" in record_set'
+          - record_set.ttl == "3600"
+          - '"type" in record_set'
+          - record_set.type == 'A'
+          - '"value" in record_set'
+          - record_set.value == '192.0.2.1'
+          - '"values" in record_set'
+          - record_set['values'] | length == 1
+          - record_set['values'][0] == '192.0.2.1'
+          - '"weight" in record_set'
+          - '"zone" in record_set'
+          - record_set.zone == zone_one
+      vars:
+        record_set: "{{ get_result.set }}"
+        qdn_record: qdn_test.{{ zone_one }}
+
+    ## test A recordset creation and order adjustments
+    - name: Create same A record using zone non-qualified domain
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one[:-1] }}"
+        record: qdn_test.{{ zone_one[:-1] }}
+        type: A
+        value: 192.0.2.1
+      register: non_qdn
+    - ansible.builtin.assert:
+        that:
+          - non_qdn is not failed
+          - non_qdn is not changed
+          - "'wait_id' not in non_qdn"
+
+    - name: Create A record using zone ID
+      amazon.aws.route53:
+        state: present
+        hosted_zone_id: "{{ z1.zone_id }}"
+        record: zid_test.{{ zone_one }}
+        type: A
+        value: 192.0.2.1
+      register: zid
+    - ansible.builtin.assert:
+        that:
+          - zid is not failed
+          - zid is changed
+
+    - name: Create a multi-value A record with values in different order
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: order_test.{{ zone_one }}
+        type: A
+        value:
+          - 192.0.2.2
+          - 192.0.2.1
+      register: mv_a_record
+    - ansible.builtin.assert:
+        that:
+          - mv_a_record is not failed
+          - mv_a_record is changed
+
+    - name: Create same multi-value A record with values in different order
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: order_test.{{ zone_one }}
+        type: A
+        value:
+          - 192.0.2.2
+          - 192.0.2.1
+      register: mv_a_record
+    - ansible.builtin.assert:
+        that:
+          - mv_a_record is not failed
+          - mv_a_record is not changed
+
+    # Get resulting A record and ensure max_items is applied
+    - name: get Route53 A record information
+      amazon.aws.route53_info:
+        type: A
+        query: record_sets
+        hosted_zone_id: "{{ z1.zone_id }}"
+        start_record_name: order_test.{{ zone_one }}
+        max_items: 1
+      register: records
+
+    - ansible.builtin.assert:
+        that:
+          - records.ResourceRecordSets|length == 1
+          - records.ResourceRecordSets[0].ResourceRecords|length == 2
+          - records.ResourceRecordSets[0].ResourceRecords[0].Value == '192.0.2.2'
+          - records.ResourceRecordSets[0].ResourceRecords[1].Value == '192.0.2.1'
+
+    - name: Remove a member from multi-value A record with values in different order
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: order_test.{{ zone_one }}
+        type: A
+        value:
+          - 192.0.2.2
+      register: del_a_record
+      ignore_errors: true
+    - name: This should fail, because `overwrite` is false
+      ansible.builtin.assert:
+        that:
+          - del_a_record is failed
+
+    - name: Remove a member from multi-value A record with values in different order
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: order_test.{{ zone_one }}
+        overwrite: true
+        type: A
+        value:
+          - 192.0.2.2
+      register: del_a_record
+      ignore_errors: true
+
+    - name: This should not fail, because `overwrite` is true
+      ansible.builtin.assert:
+        that:
+          - del_a_record is not failed
+          - del_a_record is changed
+
+    - name: get Route53 zone A record information
+      amazon.aws.route53_info:
+        type: A
+        query: record_sets
+        hosted_zone_id: "{{ z1.zone_id }}"
+        start_record_name: order_test.{{ zone_one }}
+        max_items: 50
+      register: records
+
+    - ansible.builtin.assert:
+        that:
+          - records.ResourceRecordSets|length == 3
+          - records.ResourceRecordSets[0].ResourceRecords|length == 1
+          - records.ResourceRecordSets[0].ResourceRecords[0].Value == '192.0.2.2'
+
+    ## Test CNAME record creation and retrive info
+    - name: Create CNAME record
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        type: CNAME
+        record: cname_test.{{ zone_one }}
+        value: order_test.{{ zone_one }}
+      register: cname_record
+
+    - ansible.builtin.assert:
+        that:
+          - cname_record is not failed
+          - cname_record is changed
+
+    - name: Get Route53 CNAME record information
+      amazon.aws.route53_info:
+        type: CNAME
+        query: record_sets
+        hosted_zone_id: "{{ z1.zone_id }}"
+        start_record_name: cname_test.{{ zone_one }}
+        max_items: 1
+      register: cname_records
+
+    - ansible.builtin.assert:
+        that:
+          - cname_records.ResourceRecordSets|length == 1
+          - cname_records.ResourceRecordSets[0].ResourceRecords|length == 1
+          - cname_records.ResourceRecordSets[0].ResourceRecords[0].Value == "order_test.{{ zone_one }}"
+
+    ## Test CAA record creation
+    - name: Create a LetsEncrypt CAA record
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: "{{ zone_one }}"
+        type: CAA
+        value:
+          - "0 issue \"letsencrypt.org;\""
+          - "0 issuewild \"letsencrypt.org;\""
+        overwrite: true
+      register: caa
+    - ansible.builtin.assert:
+        that:
+          - caa is not failed
+          - caa is changed
+
+    - name: Re-create the same LetsEncrypt CAA record
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: "{{ zone_one }}"
+        type: CAA
+        value:
+          - "0 issue \"letsencrypt.org;\""
+          - "0 issuewild \"letsencrypt.org;\""
+        overwrite: true
+      register: caa
+    - ansible.builtin.assert:
+        that:
+          - caa is not failed
+          - caa is not changed
+
+    - name: Re-create the same LetsEncrypt CAA record in opposite-order
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: "{{ zone_one }}"
+        type: CAA
+        value:
+          - "0 issuewild \"letsencrypt.org;\""
+          - "0 issue \"letsencrypt.org;\""
+        overwrite: true
+      register: caa
+    - name: This should not be changed, as CAA records are not order sensitive
+      ansible.builtin.assert:
+        that:
+          - caa is not failed
+          - caa is not changed
+
+    - name: Create an A record for a wildcard prefix
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: "*.wildcard_test.{{ zone_one }}"
+        type: A
+        value:
+          - 192.0.2.1
+      register: wc_a_record
+    - ansible.builtin.assert:
+        that:
+          - wc_a_record is not failed
+          - wc_a_record is changed
+
+    - name: Create an A record for a wildcard prefix (idempotency)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: "*.wildcard_test.{{ zone_one }}"
+        type: A
+        value:
+          - 192.0.2.1
+      register: wc_a_record
+    - ansible.builtin.assert:
+        that:
+          - wc_a_record is not failed
+          - wc_a_record is not changed
+
+    - name: Create an A record for a wildcard prefix (change)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: "*.wildcard_test.{{ zone_one }}"
+        type: A
+        value:
+          - 192.0.2.2
+        overwrite: true
+      register: wc_a_record
+    - ansible.builtin.assert:
+        that:
+          - wc_a_record is not failed
+          - wc_a_record is changed
+
+    - name: Delete an A record for a wildcard prefix
+      amazon.aws.route53:
+        state: absent
+        zone: "{{ zone_one }}"
+        record: "*.wildcard_test.{{ zone_one }}"
+        type: A
+        value:
+          - 192.0.2.2
+      register: wc_a_record
+    - ansible.builtin.assert:
+        that:
+          - wc_a_record is not failed
+          - wc_a_record is changed
+          - wc_a_record.diff.after == {}
+
+    - name: create a record with different TTL
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: localhost.{{ zone_one }}
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+      register: ttl30
+    - name: check return values
+      ansible.builtin.assert:
+        that:
+          - ttl30.diff.resource_record_sets[0].ttl == 30
+          - ttl30 is changed
+
+    - name: delete previous record without mention ttl and value
+      amazon.aws.route53:
+        state: absent
+        zone: "{{ zone_one }}"
+        record: localhost.{{ zone_one }}
+        type: A
+      register: ttl30
+    - name: check if record is deleted
+      ansible.builtin.assert:
+        that:
+          - ttl30 is changed
+
+    - name: immutable delete previous record without mention ttl and value
+      amazon.aws.route53:
+        state: absent
+        zone: "{{ zone_one }}"
+        record: localhost.{{ zone_one }}
+        type: A
+      register: ttl30
+    - name: check if record was deleted
+      ansible.builtin.assert:
+        that:
+          - ttl30 is not changed
+
+    # Tests on zone two (private zone)
+    - name: Create A record using zone fqdn
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_two }}"
+        record: qdn_test.{{ zone_two }}
+        type: A
+        value: 192.0.2.1
+        private_zone: true
+      register: qdn
+    - ansible.builtin.assert:
+        that:
+          - qdn is not failed
+          - qdn is changed
+
+    - name: Get A record using 'get' method of route53 module
+      amazon.aws.route53:
+        state: get
+        zone: "{{ zone_two }}"
+        record: qdn_test.{{ zone_two }}
+        type: A
+        private_zone: true
+      register: get_result
+    - ansible.builtin.assert:
+        that:
+          - get_result.nameservers|length > 0
+          - get_result.set.Name == "qdn_test."+zone_two
+          - get_result.set.ResourceRecords[0].Value == "192.0.2.1"
+          - get_result.set.Type == "A"
+
+    - name: Get a record that does not exist
+      amazon.aws.route53:
+        state: get
+        zone: "{{ zone_two }}"
+        record: notfound.{{ zone_two }}
+        type: A
+        private_zone: true
+      register: get_result
+    - ansible.builtin.assert:
+        that:
+          - get_result.nameservers|length > 0
+          - get_result.set|length == 0
+          - get_result.resource_record_sets|length == 0
+
+    - name: Create same A record using zone non-qualified domain
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_two[:-1] }}"
+        record: qdn_test.{{ zone_two[:-1] }}
+        type: A
+        value: 192.0.2.1
+        private_zone: true
+      register: non_qdn
+    - ansible.builtin.assert:
+        that:
+          - non_qdn is not failed
+          - non_qdn is not changed
+
+    - name: Create A record using zone ID
+      amazon.aws.route53:
+        state: present
+        hosted_zone_id: "{{ z2.zone_id }}"
+        record: zid_test.{{ zone_two }}
+        type: A
+        value: 192.0.2.2
+        private_zone: true
+      register: zid
+    - ansible.builtin.assert:
+        that:
+          - zid is not failed
+          - zid is changed
+
+    - name: Create A record using zone fqdn and vpc_id
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_two }}"
+        record: qdn_test_vpc.{{ zone_two }}
+        type: A
+        value: 192.0.2.3
+        private_zone: true
+        vpc_id: "{{ vpc.vpc.id }}"
+      register: qdn
+    - ansible.builtin.assert:
+        that:
+          - qdn is not failed
+          - qdn is changed
+
+    - name: Create A record using zone ID and vpc_id
+      amazon.aws.route53:
+        state: present
+        hosted_zone_id: "{{ z2.zone_id }}"
+        record: zid_test_vpc.{{ zone_two }}
+        type: A
+        value: 192.0.2.4
+        private_zone: true
+        vpc_id: "{{ vpc.vpc.id }}"
+      register: zid
+    - ansible.builtin.assert:
+        that:
+          - zid is not failed
+          - zid is changed
+
+    - name: Create an Alias record
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: alias.{{ zone_one }}
+        type: A
+        alias: true
+        alias_hosted_zone_id: "{{ z1.zone_id }}"
+        value: zid_test.{{ zone_one }}
+        overwrite: true
+      register: alias_record
+    - name: This should be changed
+      ansible.builtin.assert:
+        that:
+          - alias_record is not failed
+          - alias_record is changed
+
+    - name: Re-Create an Alias record
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: alias.{{ zone_one }}
+        type: A
+        alias: true
+        alias_hosted_zone_id: "{{ z1.zone_id }}"
+        value: zid_test.{{ zone_one }}
+        overwrite: true
+      register: alias_record
+    - name: This should not be changed
+      ansible.builtin.assert:
+        that:
+          - alias_record is not failed
+          - alias_record is not changed
+
+    - name: Create a weighted record
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: weighted.{{ zone_one }}
+        type: CNAME
+        value: zid_test.{{ zone_one }}
+        overwrite: true
+        identifier: host1@www
+        weight: 100
+        region: "{{ omit }}"
+      register: weighted_record
+    - name: This should be changed
+      ansible.builtin.assert:
+        that:
+          - weighted_record is not failed
+          - weighted_record is changed
+
+    - name: Re-Create a weighted record
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: weighted.{{ zone_one }}
+        type: CNAME
+        value: zid_test.{{ zone_one }}
+        overwrite: true
+        identifier: host1@www
+        weight: 100
+        region: "{{ omit }}"
+      register: weighted_record
+    - name: This should not be changed
+      ansible.builtin.assert:
+        that:
+          - weighted_record is not failed
+          - weighted_record is not changed
+
+    - name: Create a zero weighted record
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: zero_weighted.{{ zone_one }}
+        type: CNAME
+        value: zid_test.{{ zone_one }}
+        overwrite: true
+        identifier: host1@www
+        weight: 0
+        region: "{{ omit }}"
+      register: weighted_record
+    - name: This should be changed
+      ansible.builtin.assert:
+        that:
+          - weighted_record is not failed
+          - weighted_record is changed
+
+    - name: Re-Create a zero weighted record
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: zero_weighted.{{ zone_one }}
+        type: CNAME
+        value: zid_test.{{ zone_one }}
+        overwrite: true
+        identifier: host1@www
+        weight: 0
+        region: "{{ omit }}"
+      register: weighted_record
+    - name: This should not be changed
+      ansible.builtin.assert:
+        that:
+          - weighted_record is not failed
+          - weighted_record is not changed
+
+    #Test Geo Location - Continent Code
+    - name: Create a record with geo_location - continent_code (check_mode)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: geo-test-1.{{ zone_one }}
+        identifier: geohost1@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          continent_code: NA
+      check_mode: true
+      register: create_geo_continent_check_mode
+    - ansible.builtin.assert:
+        that:
+          - create_geo_continent_check_mode is changed
+          - create_geo_continent_check_mode is not failed
+          - '"route53:ChangeResourceRecordSets" not in create_geo_continent_check_mode.resource_actions'
+          - '"wait_id" in create_geo_continent_check_mode'
+          - create_geo_continent_check_mode.wait_id is none
+
+    - name: Create a record with geo_location - continent_code
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: geo-test-1.{{ zone_one }}
+        identifier: geohost1@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          continent_code: NA
+      register: create_geo_continent
+    # Get resulting A record and geo_location parameters are applied
+    - name: get Route53 A record information
+      amazon.aws.route53_info:
+        type: A
+        query: record_sets
+        hosted_zone_id: "{{ z1.zone_id }}"
+        start_record_name: geo-test-1.{{ zone_one }}
+        max_items: 1
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - create_geo_continent is changed
+          - create_geo_continent is not failed
+          - '"route53:ChangeResourceRecordSets" in create_geo_continent.resource_actions'
+          - result.ResourceRecordSets[0].GeoLocation.ContinentCode == "NA"
+
+    - name: Create a record with geo_location - continent_code (idempotency)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: geo-test-1.{{ zone_one }}
+        identifier: geohost1@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          continent_code: NA
+      register: create_geo_continent_idem
+    - ansible.builtin.assert:
+        that:
+          - create_geo_continent_idem is not changed
+          - create_geo_continent_idem is not failed
+          - '"route53:ChangeResourceRecordSets" not in create_geo_continent_idem.resource_actions'
+
+    - name: Create a record with geo_location - continent_code (idempotency - check_mode)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: geo-test-1.{{ zone_one }}
+        identifier: geohost1@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          continent_code: NA
+      check_mode: true
+      register: create_geo_continent_idem_check
+
+    - ansible.builtin.assert:
+        that:
+          - create_geo_continent_idem_check is not changed
+          - create_geo_continent_idem_check is not failed
+          - '"route53:ChangeResourceRecordSets" not in create_geo_continent_idem_check.resource_actions'
+
+    #Test Geo Location - Country Code
+    - name: Create a record with geo_location - country_code (check_mode)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: geo-test-2.{{ zone_one }}
+        identifier: geohost2@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          country_code: US
+      check_mode: true
+      register: create_geo_country_check_mode
+    - ansible.builtin.assert:
+        that:
+          - create_geo_country_check_mode is changed
+          - create_geo_country_check_mode is not failed
+          - '"route53:ChangeResourceRecordSets" not in create_geo_country_check_mode.resource_actions'
+
+    - name: Create a record with geo_location - country_code
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: geo-test-2.{{ zone_one }}
+        identifier: geohost2@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          country_code: US
+      register: create_geo_country
+    # Get resulting A record and geo_location parameters are applied
+    - name: get Route53 A record information
+      amazon.aws.route53_info:
+        type: A
+        query: record_sets
+        hosted_zone_id: "{{ z1.zone_id }}"
+        start_record_name: geo-test-2.{{ zone_one }}
+        max_items: 1
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - create_geo_country is changed
+          - create_geo_country is not failed
+          - '"route53:ChangeResourceRecordSets" in create_geo_country.resource_actions'
+          - result.ResourceRecordSets[0].GeoLocation.CountryCode == "US"
+
+    - name: Create a record with geo_location - country_code (idempotency)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: geo-test-2.{{ zone_one }}
+        identifier: geohost2@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          country_code: US
+      register: create_geo_country_idem
+    - ansible.builtin.assert:
+        that:
+          - create_geo_country_idem is not changed
+          - create_geo_country_idem is not failed
+          - '"route53:ChangeResourceRecordSets" not in create_geo_country_idem.resource_actions'
+
+    - name: Create a record with geo_location - country_code (idempotency - check_mode)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: geo-test-2.{{ zone_one }}
+        identifier: geohost2@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          country_code: US
+      check_mode: true
+      register: create_geo_country_idem_check
+
+    - ansible.builtin.assert:
+        that:
+          - create_geo_country_idem_check is not changed
+          - create_geo_country_idem_check is not failed
+          - '"route53:ChangeResourceRecordSets" not in create_geo_country_idem_check.resource_actions'
+
+    #Test Geo Location - Subdivision Code
+    - name: Create a record with geo_location - subdivision_code (check_mode)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: geo-test-3.{{ zone_one }}
+        identifier: geohost3@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          country_code: US
+          subdivision_code: TX
+      check_mode: true
+      register: create_geo_subdivision_check_mode
+    - ansible.builtin.assert:
+        that:
+          - create_geo_subdivision_check_mode is changed
+          - create_geo_subdivision_check_mode is not failed
+          - '"route53:ChangeResourceRecordSets" not in create_geo_subdivision_check_mode.resource_actions'
+
+    - name: Create a record with geo_location - subdivision_code
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: geo-test-3.{{ zone_one }}
+        identifier: geohost3@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          country_code: US
+          subdivision_code: TX
+      register: create_geo_subdivision
+    # Get resulting A record and geo_location parameters are applied
+    - name: get Route53 A record information
+      amazon.aws.route53_info:
+        type: A
+        query: record_sets
+        hosted_zone_id: "{{ z1.zone_id }}"
+        start_record_name: geo-test-3.{{ zone_one }}
+        max_items: 1
+      register: result
+    - ansible.builtin.assert:
+        that:
+          - create_geo_subdivision is changed
+          - create_geo_subdivision is not failed
+          - '"route53:ChangeResourceRecordSets" in create_geo_subdivision.resource_actions'
+          - result.ResourceRecordSets[0].GeoLocation.CountryCode == "US"
+          - result.ResourceRecordSets[0].GeoLocation.SubdivisionCode == "TX"
+
+    - name: Create a record with geo_location - subdivision_code (idempotency)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: geo-test-3.{{ zone_one }}
+        identifier: geohost3@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          country_code: US
+          subdivision_code: TX
+      register: create_geo_subdivision_idem
+    - ansible.builtin.assert:
+        that:
+          - create_geo_subdivision_idem is not changed
+          - create_geo_subdivision_idem is not failed
+          - '"route53:ChangeResourceRecordSets" not in create_geo_subdivision_idem.resource_actions'
+
+    - name: Create a record with geo_location - subdivision_code (idempotency - check_mode)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: geo-test-3.{{ zone_one }}
+        identifier: geohost3@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          country_code: US
+          subdivision_code: TX
+      check_mode: true
+      register: create_geo_subdivision_idem_check
+
+    - ansible.builtin.assert:
+        that:
+          - create_geo_subdivision_idem_check is not changed
+          - create_geo_subdivision_idem_check is not failed
+          - '"route53:ChangeResourceRecordSets" not in create_geo_subdivision_idem_check.resource_actions'
+
+  #Cleanup------------------------------------------------------
 
   always:
+    - name: delete a record with geo_location - continent_code
+      amazon.aws.route53:
+        state: absent
+        zone: "{{ zone_one }}"
+        record: geo-test-1.{{ zone_one }}
+        identifier: geohost1@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          continent_code: NA
+      ignore_errors: true
 
-  - name: delete a record with geo_location - continent_code
-    route53:
-      state: absent
-      zone: '{{ zone_one }}'
-      record: geo-test-1.{{ zone_one }}
-      identifier: geohost1@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        continent_code: NA
-    ignore_errors: true
+    - name: delete a record with geo_location - country_code
+      amazon.aws.route53:
+        state: absent
+        zone: "{{ zone_one }}"
+        record: geo-test-2.{{ zone_one }}
+        identifier: geohost2@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          country_code: US
+      ignore_errors: true
 
-  - name: delete a record with geo_location - country_code
-    route53:
-      state: absent
-      zone: '{{ zone_one }}'
-      record: geo-test-2.{{ zone_one }}
-      identifier: geohost2@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        country_code: US
-    ignore_errors: true
+    - name: delete a record with geo_location - subdivision_code
+      amazon.aws.route53:
+        state: absent
+        zone: "{{ zone_one }}"
+        record: geo-test-3.{{ zone_one }}
+        identifier: geohost3@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        geo_location:
+          country_code: US
+          subdivision_code: TX
+      ignore_errors: true
 
-  - name: delete a record with geo_location - subdivision_code
-    route53:
-      state: absent
-      zone: '{{ zone_one }}'
-      record: geo-test-3.{{ zone_one }}
-      identifier: geohost3@www
-      type: A
-      value: 127.0.0.1
-      ttl: 30
-      geo_location:
-        country_code: US
-        subdivision_code: TX
-    ignore_errors: true
+    - amazon.aws.route53_info:
+        query: record_sets
+        hosted_zone_id: "{{ z1.zone_id }}"
+      register: z1_records
 
-  - route53_info:
-      query: record_sets
-      hosted_zone_id: '{{ z1.zone_id }}'
-    register: z1_records
+    - name: Loop over A/AAAA/CNAME Alias records and delete them
+      amazon.aws.route53:
+        state: absent
+        alias: true
+        alias_hosted_zone_id: "{{ item.AliasTarget.HostedZoneId }}"
+        zone: "{{ zone_one }}"
+        record: "{{ item.Name }}"
+        type: "{{ item.Type }}"
+        value: "{{ item.AliasTarget.DNSName }}"
+      ignore_errors: true
+      loop: '{{ z1_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA", "CNAME", "CAA"]) | list }}'
+      when:
+        - '"AliasTarget" in item'
 
-  - name: Loop over A/AAAA/CNAME Alias records and delete them
-    route53:
-      state: absent
-      alias: true
-      alias_hosted_zone_id: '{{ item.AliasTarget.HostedZoneId }}'
-      zone: '{{ zone_one }}'
-      record: '{{ item.Name }}'
-      type: '{{ item.Type }}'
-      value: '{{ item.AliasTarget.DNSName }}'
-    ignore_errors: true
-    loop: '{{ z1_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA",
-      "CNAME", "CAA"]) | list }}'
-    when:
-    - '"AliasTarget" in item'
+    - name: Loop over A/AAAA/CNAME records and delete them
+      amazon.aws.route53:
+        state: absent
+        zone: "{{ zone_one }}"
+        record: "{{ item.Name }}"
+        type: "{{ item.Type }}"
+        value: '{{ item.ResourceRecords | map(attribute="Value") | join(",") }}'
+        weight: "{{ item.Weight | default(omit) }}"
+        identifier: "{{ item.SetIdentifier }}"
+        region: "{{ omit }}"
+      ignore_errors: true
+      loop: '{{ z1_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA", "CNAME", "CAA"]) | list }}'
+      when:
+        - '"ResourceRecords" in item'
+        - '"SetIdentifier" in item'
 
-  - name: Loop over A/AAAA/CNAME records and delete them
-    route53:
-      state: absent
-      zone: '{{ zone_one }}'
-      record: '{{ item.Name }}'
-      type: '{{ item.Type }}'
-      value: '{{ item.ResourceRecords | map(attribute="Value") | join(",") }}'
-      weight: '{{ item.Weight | default(omit) }}'
-      identifier: '{{ item.SetIdentifier }}'
-      region: '{{ omit }}'
-    ignore_errors: true
-    loop: '{{ z1_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA",
-      "CNAME", "CAA"]) | list }}'
-    when:
-    - '"ResourceRecords" in item'
-    - '"SetIdentifier" in item'
+    - name: Loop over A/AAAA/CNAME records and delete them
+      amazon.aws.route53:
+        state: absent
+        zone: "{{ zone_one }}"
+        record: "{{ item.Name }}"
+        type: "{{ item.Type }}"
+        value: '{{ item.ResourceRecords | map(attribute="Value") | join(",") }}'
+      ignore_errors: true
+      loop: '{{ z1_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA", "CNAME", "CAA"]) | list }}'
+      when:
+        - '"ResourceRecords" in item'
 
-  - name: Loop over A/AAAA/CNAME records and delete them
-    route53:
-      state: absent
-      zone: '{{ zone_one }}'
-      record: '{{ item.Name }}'
-      type: '{{ item.Type }}'
-      value: '{{ item.ResourceRecords | map(attribute="Value") | join(",") }}'
-    ignore_errors: true
-    loop: '{{ z1_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA",
-      "CNAME", "CAA"]) | list }}'
-    when:
-    - '"ResourceRecords" in item'
+    - amazon.aws.route53_info:
+        query: record_sets
+        hosted_zone_id: "{{ z2.zone_id }}"
+      register: z2_records
 
-  - route53_info:
-      query: record_sets
-      hosted_zone_id: '{{ z2.zone_id }}'
-    register: z2_records
+    - name: Loop over A/AAAA/CNAME Alias records and delete them
+      amazon.aws.route53:
+        state: absent
+        alias: true
+        alias_hosted_zone_id: "{{ item.AliasTarget.HostedZoneId }}"
+        zone: "{{ zone_two }}"
+        record: "{{ item.Name }}"
+        type: "{{ item.Type }}"
+        value: "{{ item.AliasTarget.DNSName }}"
+        private_zone: true
+      ignore_errors: true
+      loop: '{{ z2_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA", "CNAME", "CAA"]) | list }}'
+      when:
+        - '"AliasTarget" in item'
 
-  - name: Loop over A/AAAA/CNAME Alias records and delete them
-    route53:
-      state: absent
-      alias: true
-      alias_hosted_zone_id: '{{ item.AliasTarget.HostedZoneId }}'
-      zone: '{{ zone_two }}'
-      record: '{{ item.Name }}'
-      type: '{{ item.Type }}'
-      value: '{{ item.AliasTarget.DNSName }}'
-      private_zone: true
-    ignore_errors: true
-    loop: '{{ z2_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA",
-      "CNAME", "CAA"]) | list }}'
-    when:
-    - '"AliasTarget" in item'
+    - name: Loop over A/AAAA/CNAME records and delete them
+      amazon.aws.route53:
+        state: absent
+        zone: "{{ zone_two }}"
+        record: "{{ item.Name }}"
+        type: "{{ item.Type }}"
+        value: '{{ item.ResourceRecords | map(attribute="Value") | join(",") }}'
+        identifier: "{{ item.SetIdentifier }}"
+        region: "{{ omit }}"
+        private_zone: true
+      ignore_errors: true
+      loop: '{{ z2_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA", "CNAME", "CAA"]) | list }}'
+      when:
+        - '"ResourceRecords" in item'
+        - '"SetIdentifier" in item'
 
-  - name: Loop over A/AAAA/CNAME records and delete them
-    route53:
-      state: absent
-      zone: '{{ zone_two }}'
-      record: '{{ item.Name }}'
-      type: '{{ item.Type }}'
-      value: '{{ item.ResourceRecords | map(attribute="Value") | join(",") }}'
-      identifier: '{{ item.SetIdentifier }}'
-      region: '{{ omit }}'
-      private_zone: true
-    ignore_errors: true
-    loop: '{{ z2_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA",
-      "CNAME", "CAA"]) | list }}'
-    when:
-    - '"ResourceRecords" in item'
-    - '"SetIdentifier" in item'
+    - name: Loop over A/AAAA/CNAME records and delete them
+      amazon.aws.route53:
+        state: absent
+        zone: "{{ zone_two }}"
+        record: "{{ item.Name }}"
+        type: "{{ item.Type }}"
+        value: '{{ item.ResourceRecords | map(attribute="Value") | join(",") }}'
+        private_zone: true
+      ignore_errors: true
+      loop: '{{ z2_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA", "CNAME", "CAA"]) | list }}'
+      when:
+        - '"ResourceRecords" in item'
 
-  - name: Loop over A/AAAA/CNAME records and delete them
-    route53:
-      state: absent
-      zone: '{{ zone_two }}'
-      record: '{{ item.Name }}'
-      type: '{{ item.Type }}'
-      value: '{{ item.ResourceRecords | map(attribute="Value") | join(",") }}'
-      private_zone: true
-    ignore_errors: true
-    loop: '{{ z2_records.ResourceRecordSets | selectattr("Type", "in", ["A", "AAAA",
-      "CNAME", "CAA"]) | list }}'
-    when:
-    - '"ResourceRecords" in item'
+    - name: Delete test zone one {{ zone_one }}
+      amazon.aws.route53_zone:
+        state: absent
+        zone: "{{ zone_one }}"
+      register: delete_one
+      ignore_errors: true
+      retries: 10
+      until: delete_one is not failed
 
-  - name: Delete test zone one {{ zone_one }}
-    route53_zone:
-      state: absent
-      zone: '{{ zone_one }}'
-    register: delete_one
-    ignore_errors: true
-    retries: 10
-    until: delete_one is not failed
+    - name: Delete test zone two {{ zone_two }}
+      amazon.aws.route53_zone:
+        state: absent
+        zone: "{{ zone_two }}"
+      register: delete_two
+      ignore_errors: true
+      retries: 10
+      until: delete_two is not failed
 
-  - name: Delete test zone two {{ zone_two }}
-    route53_zone:
-      state: absent
-      zone: '{{ zone_two }}'
-    register: delete_two
-    ignore_errors: true
-    retries: 10
-    until: delete_two is not failed
-
-  - name: destroy VPC
-    ec2_vpc_net:
-      cidr_block: 192.0.2.0/24
-      name: '{{ resource_prefix }}_vpc'
-      state: absent
-    register: remove_vpc
-    retries: 10
-    delay: 5
-    until: remove_vpc is success
-    ignore_errors: true
+    - name: destroy VPC
+      amazon.aws.ec2_vpc_net:
+        cidr_block: 192.0.2.0/24
+        name: "{{ resource_prefix }}_vpc"
+        state: absent
+      register: remove_vpc
+      retries: 10
+      delay: 5
+      until: remove_vpc is success
+      ignore_errors: true

--- a/tests/integration/targets/route53_health_check/defaults/main.yml
+++ b/tests/integration/targets/route53_health_check/defaults/main.yml
@@ -10,11 +10,11 @@
 # - request_interval
 
 #ip_address: We allocate an EIP due to route53 restrictions
-fqdn: '{{ tiny_prefix }}.route53-health.ansible.test'
-fqdn_1: '{{ tiny_prefix }}-1.route53-health.ansible.test'
+fqdn: "{{ tiny_prefix }}.route53-health.ansible.test"
+fqdn_1: "{{ tiny_prefix }}-1.route53-health.ansible.test"
 port: 8080
 updated_port: 8181
-type: 'TCP'
+type: TCP
 request_interval: 30
 
 # modifiable
@@ -27,11 +27,11 @@ failure_threshold_updated: 1
 
 # For resource_path we need an HTTP/HTTPS type check
 # for string_match we need an _STR_MATCH type
-type_https_match: 'HTTPS_STR_MATCH'
-type_http_match: 'HTTP_STR_MATCH'
-type_http: 'HTTP'
-resource_path: '/health.php'
-resource_path_1: '/new-health.php'
-resource_path_updated: '/healthz'
-string_match: 'Hello'
-string_match_updated: 'Hello World'
+type_https_match: HTTPS_STR_MATCH
+type_http_match: HTTP_STR_MATCH
+type_http: HTTP
+resource_path: /health.php
+resource_path_1: /new-health.php
+resource_path_updated: /healthz
+string_match: Hello
+string_match_updated: Hello World

--- a/tests/integration/targets/route53_health_check/meta/main.yml
+++ b/tests/integration/targets/route53_health_check/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
   - setup_ec2_facts

--- a/tests/integration/targets/route53_health_check/tasks/calculate_health_check.yml
+++ b/tests/integration/targets/route53_health_check/tasks/calculate_health_check.yml
@@ -1,141 +1,141 @@
 ---
 - block:
     # Create Health Check =================================================================
-    - name: 'Create Health Check with name'
+    - name: Create Health Check with name
       amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ resource_path }}'
+        name: "{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ resource_path }}"
         use_unique_names: true
-        fqdn: '{{ fqdn }}'
+        fqdn: "{{ fqdn }}"
       register: create_result
 
     # Create and Update  ===================================================================
-    - name: 'Create Invalid Parameter Calculated Health Check'
-      route53_health_check:
-        health_check_name: "calculated_health_check"
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
+    - name: Create Invalid Parameter Calculated Health Check
+      amazon.aws.route53_health_check:
+        health_check_name: calculated_health_check
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
         type: CALCULATED
         use_unique_names: true
-        fqdn: '{{ fqdn }}'
+        fqdn: "{{ fqdn }}"
         health_threshold: 1
-        child_health_checks: '{{ create_result.health_check.id }}'
+        child_health_checks: "{{ create_result.health_check.id }}"
       ignore_errors: true
       register: error_create_calculated
 
-    - name: 'Check result - Create Invalid Parameter Calculated Health Check'
+    - name: Check result - Create Invalid Parameter Calculated Health Check
       ansible.builtin.assert:
         that:
-        - error_create_calculated is failed
-        - "error_create_calculated.msg == 'parameters are mutually exclusive: child_health_checks|ip_address, child_health_checks|port, child_health_checks|fqdn'"
+          - error_create_calculated is failed
+          - "error_create_calculated.msg == 'parameters are mutually exclusive: child_health_checks|ip_address, child_health_checks|port, child_health_checks|fqdn'"
 
-    - name: 'Create Calculated Health Check - check_mode'
-      route53_health_check:
-        health_check_name: "calculated_health_check"
+    - name: Create Calculated Health Check - check_mode
+      amazon.aws.route53_health_check:
+        health_check_name: calculated_health_check
         use_unique_names: true
         type: CALCULATED
         health_threshold: 1
-        child_health_checks: '{{ create_result.health_check.id }}'
+        child_health_checks: "{{ create_result.health_check.id }}"
       register: check_create_calculated
       check_mode: true
 
-    - name: 'Check result - Calculated Health Check'
+    - name: Check result - Calculated Health Check
       ansible.builtin.assert:
         that:
-        - check_create_calculated is not failed
-        - check_create_calculated is changed
+          - check_create_calculated is not failed
+          - check_create_calculated is changed
 
-    - name: 'Create Calculated Health Check'
-      route53_health_check:
-        health_check_name: "calculated_health_check"
+    - name: Create Calculated Health Check
+      amazon.aws.route53_health_check:
+        health_check_name: calculated_health_check
         use_unique_names: true
         type: CALCULATED
         health_threshold: 1
-        child_health_checks: '{{ create_result.health_check.id }}'
+        child_health_checks: "{{ create_result.health_check.id }}"
       register: create_calculated
 
-    - name: 'Check result - Calculated Health Check'
+    - name: Check result - Calculated Health Check
       ansible.builtin.assert:
         that:
-        - create_calculated is not failed
-        - create_calculated is changed
+          - create_calculated is not failed
+          - create_calculated is changed
 
-    - name: 'Check result - Create Calculated Health Check - idempotency'
-      route53_health_check:
-        health_check_name: "calculated_health_check"
+    - name: Check result - Create Calculated Health Check - idempotency
+      amazon.aws.route53_health_check:
+        health_check_name: calculated_health_check
         use_unique_names: true
         type: CALCULATED
         health_threshold: 1
-        child_health_checks: '{{ create_result.health_check.id }}'
+        child_health_checks: "{{ create_result.health_check.id }}"
       register: create_idem
 
-    - name: 'Check result - Calculated Health Check - idempotency'
+    - name: Check result - Calculated Health Check - idempotency
       ansible.builtin.assert:
         that:
-        - create_idem is not failed
-        - create_idem is not changed
+          - create_idem is not failed
+          - create_idem is not changed
 
-    - name: 'Update Calculated Health Check'
-      route53_health_check:
-        health_check_name: "calculated_health_check"
+    - name: Update Calculated Health Check
+      amazon.aws.route53_health_check:
+        health_check_name: calculated_health_check
         use_unique_names: true
         type: CALCULATED
         health_threshold: 2
-        child_health_checks: '{{ create_result.health_check.id }}'
+        child_health_checks: "{{ create_result.health_check.id }}"
       register: check_updated_calculated
       check_mode: true
 
-    - name: 'Check result - Update Calculated Health Check - check_mode'
+    - name: Check result - Update Calculated Health Check - check_mode
       ansible.builtin.assert:
         that:
-        - check_updated_calculated is not failed
-        - check_updated_calculated is changed
+          - check_updated_calculated is not failed
+          - check_updated_calculated is changed
 
-    - name: 'Update Calculated Health Check'
-      route53_health_check:
-        health_check_name: "calculated_health_check"
+    - name: Update Calculated Health Check
+      amazon.aws.route53_health_check:
+        health_check_name: calculated_health_check
         use_unique_names: true
         type: CALCULATED
         health_threshold: 2
-        child_health_checks: '{{ create_result.health_check.id }}'
+        child_health_checks: "{{ create_result.health_check.id }}"
       register: updated_calculated
 
-    - name: 'Check result - Update Calculated Health Check'
+    - name: Check result - Update Calculated Health Check
       ansible.builtin.assert:
         that:
-        - updated_calculated is not failed
-        - updated_calculated is changed
+          - updated_calculated is not failed
+          - updated_calculated is changed
 
-  # Deleting Calculated Health Check ======================================================
-    - name: 'Delete Calculated Health Check'
+    # Deleting Calculated Health Check ======================================================
+    - name: Delete Calculated Health Check
       amazon.aws.route53_health_check:
         state: absent
-        health_check_id: '{{ create_calculated.health_check.id }}'
+        health_check_id: "{{ create_calculated.health_check.id }}"
       register: deleted_calculated
 
-    - name: 'Check if Calculated Health Check can be deleted'
+    - name: Check if Calculated Health Check can be deleted
       ansible.builtin.assert:
         that:
-        - deleted_calculated is not failed
-        - deleted_calculated is changed
+          - deleted_calculated is not failed
+          - deleted_calculated is changed
 
-    - name: 'Delete HTTP health check with use_unique_names'
+    - name: Delete HTTP health check with use_unique_names
       amazon.aws.route53_health_check:
         state: absent
-        name: '{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ resource_path }}'
+        name: "{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ resource_path }}"
         use_unique_names: true
-        fqdn: '{{ fqdn }}'
+        fqdn: "{{ fqdn }}"
       register: delete_result
 
-    - name: 'Check if HTTP health check with use_unique_names can be deleted'
+    - name: Check if HTTP health check with use_unique_names can be deleted
       ansible.builtin.assert:
         that:
           - delete_result is changed
@@ -143,14 +143,14 @@
 
   always:
   # Cleanup starts here =================================================================
-    - name: 'Delete Calculated Health Check'
+    - name: Delete Calculated Health Check
       amazon.aws.route53_health_check:
         state: absent
-        health_check_id: '{{ create_calculated.health_check.id }}'
+        health_check_id: "{{ create_calculated.health_check.id }}"
       ignore_errors: true
 
-    - name: 'Delete HTTP health check with use_unique_names'
+    - name: Delete HTTP health check with use_unique_names
       amazon.aws.route53_health_check:
         state: absent
-        name: '{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations'
+        name: "{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations"
       ignore_errors: true

--- a/tests/integration/targets/route53_health_check/tasks/create_multiple_health_checks.yml
+++ b/tests/integration/targets/route53_health_check/tasks/create_multiple_health_checks.yml
@@ -1,44 +1,44 @@
 ---
 - block:
-    - name: 'Create multiple HTTP health checks with different resource_path - check_mode'
-      route53_health_check:
+    - name: Create multiple HTTP health checks with different resource_path - check_mode
+      amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ item }}'
+        name: "{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ item }}"
         use_unique_names: true
       register: create_check
       check_mode: true
       with_items:
-        - '{{ resource_path }}'
-        - '{{ resource_path_1 }}'
+        - "{{ resource_path }}"
+        - "{{ resource_path_1 }}"
 
-    - name: 'Check result - Create a HTTP health check - check_mode'
-      assert:
+    - name: Check result - Create a HTTP health check - check_mode
+      ansible.builtin.assert:
         that:
-        - create_check is not failed
-        - create_check is changed
-        - '"route53:CreateHealthCheck" not in create_check.results[0].resource_actions'
-        - '"route53:CreateHealthCheck" not in create_check.results[1].resource_actions'
+          - create_check is not failed
+          - create_check is changed
+          - '"route53:CreateHealthCheck" not in create_check.results[0].resource_actions'
+          - '"route53:CreateHealthCheck" not in create_check.results[1].resource_actions'
 
-    - name: 'Create multiple HTTP health checks with different resource_path'
-      route53_health_check:
+    - name: Create multiple HTTP health checks with different resource_path
+      amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ item }}'
+        name: "{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ item }}"
         use_unique_names: true
       register: create_result
       with_items:
-        - '{{ resource_path }}'
-        - '{{ resource_path_1 }}'
+        - "{{ resource_path }}"
+        - "{{ resource_path_1 }}"
 
     - name: Get ID's for health_checks created in above task
-      set_fact:
+      ansible.builtin.set_fact:
         health_check_1_id: "{{ create_result.results[0].health_check.id }}"
         health_check_2_id: "{{ create_result.results[1].health_check.id }}"
 
@@ -56,130 +56,130 @@
         health_check_method: details
       register: health_check_2_info
 
-    - name: 'Check result - Create multiple HTTP health check'
-      assert:
+    - name: Check result - Create multiple HTTP health check
+      ansible.builtin.assert:
         that:
-        - create_result is not failed
-        - create_result is changed
-        - '"route53:UpdateHealthCheck" not in create_result.results[0].resource_actions'
-        - '"route53:UpdateHealthCheck" not in create_result.results[1].resource_actions'
-        - health_check_1_id != health_check_2_id
-        - health_check_1_info.HealthCheck.HealthCheckConfig.ResourcePath == '{{ resource_path }}'
-        - health_check_2_info.HealthCheck.HealthCheckConfig.ResourcePath == '{{ resource_path_1 }}'
+          - create_result is not failed
+          - create_result is changed
+          - '"route53:UpdateHealthCheck" not in create_result.results[0].resource_actions'
+          - '"route53:UpdateHealthCheck" not in create_result.results[1].resource_actions'
+          - health_check_1_id != health_check_2_id
+          - health_check_1_info.HealthCheck.HealthCheckConfig.ResourcePath == '{{ resource_path }}'
+          - health_check_2_info.HealthCheck.HealthCheckConfig.ResourcePath == '{{ resource_path_1 }}'
 
-    - name: 'Create multiple HTTP health checks with different resource_path - idempotency - check_mode'
-      route53_health_check:
+    - name: Create multiple HTTP health checks with different resource_path - idempotency - check_mode
+      amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ item }}'
+        name: "{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ item }}"
         use_unique_names: true
       register: create_idem_check
       check_mode: true
       with_items:
-        - '{{ resource_path }}'
-        - '{{ resource_path_1 }}'
+        - "{{ resource_path }}"
+        - "{{ resource_path_1 }}"
 
-    - name: 'Check result - Create multiple HTTP health check - idempotency - check_mode'
-      assert:
+    - name: Check result - Create multiple HTTP health check - idempotency - check_mode
+      ansible.builtin.assert:
         that:
-        - create_idem_check is not failed
-        - create_idem_check is not changed
-        - '"route53:CreateHealthCheck" not in create_idem_check.results[0].resource_actions'
-        - '"route53:CreateHealthCheck" not in create_idem_check.results[1].resource_actions'
-        - '"route53:UpdateHealthCheck" not in create_idem_check.results[0].resource_actions'
-        - '"route53:UpdateHealthCheck" not in create_idem_check.results[1].resource_actions'
+          - create_idem_check is not failed
+          - create_idem_check is not changed
+          - '"route53:CreateHealthCheck" not in create_idem_check.results[0].resource_actions'
+          - '"route53:CreateHealthCheck" not in create_idem_check.results[1].resource_actions'
+          - '"route53:UpdateHealthCheck" not in create_idem_check.results[0].resource_actions'
+          - '"route53:UpdateHealthCheck" not in create_idem_check.results[1].resource_actions'
 
-    - name: 'Create multiple HTTP health checks with different resource_path - idempotency'
-      route53_health_check:
+    - name: Create multiple HTTP health checks with different resource_path - idempotency
+      amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ item }}'
+        name: "{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ item }}"
         use_unique_names: true
       register: create_idem
       with_items:
-        - '{{ resource_path }}'
-        - '{{ resource_path_1 }}'
+        - "{{ resource_path }}"
+        - "{{ resource_path_1 }}"
 
-    - name: 'Check result - Create multiple HTTP health check - idempotency'
-      assert:
+    - name: Check result - Create multiple HTTP health check - idempotency
+      ansible.builtin.assert:
         that:
-        - create_idem is not failed
-        - create_idem is not changed
-        - '"route53:CreateHealthCheck" not in create_idem.results[0].resource_actions'
-        - '"route53:CreateHealthCheck" not in create_idem.results[1].resource_actions'
-        - '"route53:UpdateHealthCheck" not in create_idem.results[0].resource_actions'
-        - '"route53:UpdateHealthCheck" not in create_idem.results[1].resource_actions'
+          - create_idem is not failed
+          - create_idem is not changed
+          - '"route53:CreateHealthCheck" not in create_idem.results[0].resource_actions'
+          - '"route53:CreateHealthCheck" not in create_idem.results[1].resource_actions'
+          - '"route53:UpdateHealthCheck" not in create_idem.results[0].resource_actions'
+          - '"route53:UpdateHealthCheck" not in create_idem.results[1].resource_actions'
 
-    - name: 'Update HTTP health check - update port'
-      route53_health_check:
+    - name: Update HTTP health check - update port
+      amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found'
-        ip_address: '{{ ip_address }}'
-        port: '{{ updated_port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ item }}'
+        name: "{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found"
+        ip_address: "{{ ip_address }}"
+        port: "{{ updated_port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ item }}"
         use_unique_names: true
       register: update_health_check
       with_items:
-        - '{{ resource_path }}'
+        - "{{ resource_path }}"
 
-    - name: 'Check result - Update TCP health check - update port'
-      assert:
+    - name: Check result - Update TCP health check - update port
+      ansible.builtin.assert:
         that:
-        - update_health_check is successful
-        - update_health_check is changed
-        - '"id" in _health_check'
-        - _health_check.id == health_check_1_id
-        - '"health_check_version" in _health_check'
-        - '"tags" in _health_check'
-        - '"health_check_config" in _health_check'
-        - '"type" in _check_config'
-        - '"disabled" in _check_config'
-        - '"failure_threshold" in _check_config'
-        - '"request_interval" in _check_config'
-        - '"fully_qualified_domain_name" not in _check_config'
-        - '"ip_address" in _check_config'
-        - '"port" in _check_config'
-        - '"search_string" not in _check_config'
-        - _check_config.disabled == false
-        - _check_config.type == 'HTTP'
-        - _check_config.request_interval == 30
-        - _check_config.ip_address == ip_address
-        - _check_config.port == updated_port
+          - update_health_check is successful
+          - update_health_check is changed
+          - '"id" in _health_check'
+          - _health_check.id == health_check_1_id
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - '"health_check_config" in _health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" not in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"search_string" not in _check_config'
+          - _check_config.disabled == false
+          - _check_config.type == 'HTTP'
+          - _check_config.request_interval == 30
+          - _check_config.ip_address == ip_address
+          - _check_config.port == updated_port
       vars:
-        _health_check: '{{ update_health_check.results[0].health_check }}'
-        _check_config: '{{ update_health_check.results[0].health_check.health_check_config }}'
+        _health_check: "{{ update_health_check.results[0].health_check }}"
+        _check_config: "{{ update_health_check.results[0].health_check.health_check_config }}"
 
   always:
     # Cleanup starts here
-      - name: 'Delete HTTP health check'
-        route53_health_check:
-          state: absent
-          name: '{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found'
-          ip_address: '{{ ip_address }}'
-          port: '{{ updated_port }}'
-          type: '{{ type_http }}'
-          resource_path: '{{ item }}'
-          use_unique_names: true
-        register: delete_result
-        with_items:
-          - '{{ resource_path }}'
+    - name: Delete HTTP health check
+      amazon.aws.route53_health_check:
+        state: absent
+        name: "{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found"
+        ip_address: "{{ ip_address }}"
+        port: "{{ updated_port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ item }}"
+        use_unique_names: true
+      register: delete_result
+      with_items:
+        - "{{ resource_path }}"
 
-      - name: 'Delete HTTP health check'
-        route53_health_check:
-          state: absent
-          name: '{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found'
-          ip_address: '{{ ip_address }}'
-          port: '{{ port }}'
-          type: '{{ type_http }}'
-          resource_path: '{{ item }}'
-          use_unique_names: true
-        register: delete_result
-        with_items:
-          - '{{ resource_path_1 }}'
+    - name: Delete HTTP health check
+      amazon.aws.route53_health_check:
+        state: absent
+        name: "{{ tiny_prefix }}-{{ item }}-test-hc-delete-if-found"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ item }}"
+        use_unique_names: true
+      register: delete_result
+      with_items:
+        - "{{ resource_path_1 }}"

--- a/tests/integration/targets/route53_health_check/tasks/main.yml
+++ b/tests/integration/targets/route53_health_check/tasks/main.yml
@@ -17,1812 +17,1805 @@
 #
 - module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
   # Route53 can only test against routable IPs.  Request an EIP so some poor
   # soul doesn't get randomly hit by our testing.
-  - name: Allocate an EIP we can test against
-    ec2_eip:
-      state: present
-    register: eip
-
-  - set_fact:
-      ip_address: '{{ eip.public_ip }}'
-
-  - name: Run tests for create and delete health check with tags and name as unique identifier
-    include_tasks: named_health_check_tag_operations.yml
-
-  - name: Run tests for creating multiple health checks with name as unique identifier
-    include_tasks: create_multiple_health_checks.yml
-
-  - name: Run tests for update and delete health check by ID
-    include_tasks: update_delete_by_id.yml
-
-  - name: Run tests for create, update, and delete calculated health check
-    include_tasks: calculate_health_check.yml
-
-  # Minimum possible definition
-  - name: 'Create a TCP health check - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-    register: create_check
-    check_mode: true
-
-  - name: 'Check result - Create a TCP health check - check_mode'
-    assert:
-      that:
-      - create_check is successful
-      - create_check is changed
-
-  - name: 'Create a TCP health check'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-    register: create_check
-
-  - name: 'Check result - Create a TCP health check'
-    assert:
-      that:
-      - create_check is successful
-      - create_check is changed
-      - '"health_check" in create_check'
-      - '"id" in _health_check'
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - create_check.health_check.action == 'create'
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" not in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" not in _check_config'
-      - _check_config.disabled == false
-      - _check_config.type == 'TCP'
-      - _check_config.failure_threshold == 3
-      - _check_config.request_interval == 30
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-    vars:
-      _health_check: '{{ create_check.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - set_fact:
-      tcp_check_id: '{{ create_check.health_check.id }}'
-
-  - name: 'Create a TCP health check - idempotency - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-    register: create_check
-    check_mode: true
-
-  - name: 'Check result - Create a TCP health check - idempotency - check_mode'
-    assert:
-      that:
-      - create_check is successful
-      - create_check is not changed
-
-  - name: 'Create a TCP health check - idempotency'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-    register: create_check
-
-  - name: 'Check result - Create a TCP health check - idempotency'
-    assert:
-      that:
-      - create_check is successful
-      - create_check is not changed
-      - '"health_check" in create_check'
-      - '"id" in create_check.health_check'
-      - _health_check.id == tcp_check_id
-      - '"id" in _health_check'
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" not in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" not in _check_config'
-      - _check_config.disabled == false
-      - _check_config.type == 'TCP'
-      - _check_config.request_interval == 30
-      - _check_config.failure_threshold == 3
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-    vars:
-      _health_check: '{{ create_check.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  # Update an attribute
-  - name: 'Update TCP health check - set threshold - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      failure_threshold: '{{ failure_threshold_updated }}'
-    register: update_threshold
-    check_mode: true
-
-  - name: 'Check result - Update TCP health check - set threshold - check_mode'
-    assert:
-      that:
-      - update_threshold is successful
-      - update_threshold is changed
-
-  - name: 'Update TCP health check - set threshold'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      failure_threshold: '{{ failure_threshold_updated }}'
-    register: update_threshold
-
-  - name: 'Check result - Update TCP health check - set threshold'
-    assert:
-      that:
-      - update_threshold is successful
-      - update_threshold is changed
-      - '"health_check" in update_threshold'
-      - '"id" in _health_check'
-      - _health_check.id == tcp_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" not in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" not in _check_config'
-      - _check_config.disabled == false
-      - _check_config.type == 'TCP'
-      - _check_config.request_interval == 30
-      - _check_config.failure_threshold == failure_threshold_updated
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-    vars:
-      _health_check: '{{ update_threshold.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update TCP health check - set threshold - idempotency - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      failure_threshold: '{{ failure_threshold_updated }}'
-    register: update_threshold
-    check_mode: true
-
-  - name: 'Check result - Update TCP health check - set threshold - idempotency - check_mode'
-    assert:
-      that:
-      - update_threshold is successful
-      - update_threshold is not changed
-
-  - name: 'Update TCP health check - set threshold - idempotency'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      failure_threshold: '{{ failure_threshold_updated }}'
-    register: update_threshold
-
-  - name: 'Check result - Update TCP health check - set threshold - idempotency'
-    assert:
-      that:
-      - update_threshold is successful
-      - update_threshold is not changed
-      - '"health_check" in update_threshold'
-      - '"id" in _health_check'
-      - _health_check.id == tcp_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" not in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" not in _check_config'
-      - _check_config.disabled == false
-      - _check_config.type == 'TCP'
-      - _check_config.request_interval == 30
-      - _check_config.failure_threshold == failure_threshold_updated
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-    vars:
-      _health_check: '{{ update_threshold.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update TCP health check - set disabled - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      disabled: true
-    register: update_disabled
-    check_mode: true
-
-  - name: 'Check result - Update TCP health check - set disabled - check_mode'
-    assert:
-      that:
-      - update_disabled is successful
-      - update_disabled is changed
-
-  - name: 'Update TCP health check - set disabled'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      disabled: true
-    register: update_disabled
-
-  - name: 'Check result - Update TCP health check - set disabled'
-    assert:
-      that:
-      - update_disabled is successful
-      - update_disabled is changed
-      - '"health_check" in update_disabled'
-      - '"id" in _health_check'
-      - _health_check.id == tcp_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" not in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" not in _check_config'
-      - _check_config.disabled == true
-      - _check_config.type == 'TCP'
-      - _check_config.request_interval == 30
-      - _check_config.failure_threshold == failure_threshold_updated
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-    vars:
-      _health_check: '{{ update_disabled.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update TCP health check - set disabled - idempotency - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      disabled: true
-    register: update_disabled
-    check_mode: true
-
-  - name: 'Check result - Update TCP health check - set disabled - idempotency - check_mode'
-    assert:
-      that:
-      - update_disabled is successful
-      - update_disabled is not changed
-
-  - name: 'Update TCP health check - set disabled - idempotency'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      disabled: true
-    register: update_disabled
-
-  - name: 'Check result - Update TCP health check - set disabled - idempotency'
-    assert:
-      that:
-      - update_disabled is successful
-      - update_disabled is not changed
-      - '"health_check" in update_disabled'
-      - '"id" in _health_check'
-      - _health_check.id == tcp_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" not in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" not in _check_config'
-      - _check_config.disabled == true
-      - _check_config.type == 'TCP'
-      - _check_config.request_interval == 30
-      - _check_config.failure_threshold == failure_threshold_updated
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-    vars:
-      _health_check: '{{ update_disabled.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update TCP health check - set tags - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      tags:
-        CamelCase: CamelCaseValue
-        snake_case: snake_case_value
-        "with space": Some value
-      purge_tags: false
-    register: update_tags
-    check_mode: true
-
-  - name: 'Check result - Update TCP health check - set tags - check_mode'
-    assert:
-      that:
-      - update_tags is successful
-      - update_tags is changed
-
-  - name: 'Update TCP health check - set tags'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      tags:
-        CamelCase: CamelCaseValue
-        snake_case: snake_case_value
-        "with space": Some value
-      purge_tags: false
-    register: update_tags
-
-  - name: 'Check result - Update TCP health check - set tags'
-    assert:
-      that:
-      - update_tags is successful
-      - update_tags is changed
-      - '"health_check" in update_tags'
-      - '"id" in _health_check'
-      - _health_check.id == tcp_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - '"CamelCase" in _health_check.tags'
-      - _health_check.tags['CamelCase'] == 'CamelCaseValue'
-      - '"snake_case" in _health_check.tags'
-      - _health_check.tags['snake_case'] == 'snake_case_value'
-      - '"with space" in _health_check.tags'
-      - _health_check.tags['with space'] == 'Some value'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" not in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" not in _check_config'
-      - _check_config.disabled == true
-      - _check_config.type == 'TCP'
-      - _check_config.request_interval == 30
-      - _check_config.failure_threshold == failure_threshold_updated
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-    vars:
-      _health_check: '{{ update_tags.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update TCP health check - set tags - idempotency - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      tags:
-        CamelCase: CamelCaseValue
-        snake_case: snake_case_value
-        "with space": Some value
-      purge_tags: false
-    register: update_tags
-    check_mode: true
-
-  - name: 'Check result - Update TCP health check - set tags - idempotency - check_mode'
-    assert:
-      that:
-      - update_tags is successful
-      - update_tags is not changed
-
-  - name: 'Update TCP health check - set tags - idempotency'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      tags:
-        CamelCase: CamelCaseValue
-        snake_case: snake_case_value
-        "with space": Some value
-      purge_tags: false
-    register: update_tags
-
-  - name: 'Check result - Update TCP health check - set tags - idempotency'
-    assert:
-      that:
-      - update_tags is successful
-      - update_tags is not changed
-      - '"health_check" in update_tags'
-      - '"id" in _health_check'
-      - _health_check.id == tcp_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - '"CamelCase" in _health_check.tags'
-      - _health_check.tags['CamelCase'] == 'CamelCaseValue'
-      - '"snake_case" in _health_check.tags'
-      - _health_check.tags['snake_case'] == 'snake_case_value'
-      - '"with space" in _health_check.tags'
-      - _health_check.tags['with space'] == 'Some value'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" not in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" not in _check_config'
-      - _check_config.disabled == true
-      - _check_config.type == 'TCP'
-      - _check_config.request_interval == 30
-      - _check_config.failure_threshold == failure_threshold_updated
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-    vars:
-      _health_check: '{{ update_tags.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update TCP health check - add tags - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      tags:
-        anotherTag: anotherValue
-      purge_tags: false
-    register: add_tags
-    check_mode: true
-
-  - name: 'Check result - Update TCP health check - add tags - check_mode'
-    assert:
-      that:
-      - add_tags is successful
-      - add_tags is changed
-
-  - name: 'Update TCP health check - add tags'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      tags:
-        anotherTag: anotherValue
-      purge_tags: false
-    register: add_tags
-
-  - name: 'Check result - Update TCP health check - add tags'
-    assert:
-      that:
-      - add_tags is successful
-      - add_tags is changed
-      - '"health_check" in add_tags'
-      - '"id" in _health_check'
-      - _health_check.id == tcp_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - '"CamelCase" in _health_check.tags'
-      - _health_check.tags['CamelCase'] == 'CamelCaseValue'
-      - '"snake_case" in _health_check.tags'
-      - _health_check.tags['snake_case'] == 'snake_case_value'
-      - '"with space" in _health_check.tags'
-      - _health_check.tags['with space'] == 'Some value'
-      - '"anotherTag" in _health_check.tags'
-      - _health_check.tags['anotherTag'] == 'anotherValue'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" not in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" not in _check_config'
-      - _check_config.disabled == true
-      - _check_config.type == 'TCP'
-      - _check_config.request_interval == 30
-      - _check_config.failure_threshold == failure_threshold_updated
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-    vars:
-      _health_check: '{{ add_tags.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update TCP health check - add tags - idempotency - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      tags:
-        anotherTag: anotherValue
-      purge_tags: false
-    register: add_tags
-    check_mode: true
-
-  - name: 'Check result - Update TCP health check - add tags - idempotency - check_mode'
-    assert:
-      that:
-      - add_tags is successful
-      - add_tags is not changed
-
-  - name: 'Update TCP health check - add tags - idempotency'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      tags:
-        anotherTag: anotherValue
-      purge_tags: false
-    register: add_tags
-
-  - name: 'Check result - Update TCP health check - add tags - idempotency'
-    assert:
-      that:
-      - add_tags is successful
-      - add_tags is not changed
-      - '"health_check" in add_tags'
-      - '"id" in _health_check'
-      - _health_check.id == tcp_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - '"CamelCase" in _health_check.tags'
-      - _health_check.tags['CamelCase'] == 'CamelCaseValue'
-      - '"snake_case" in _health_check.tags'
-      - _health_check.tags['snake_case'] == 'snake_case_value'
-      - '"with space" in _health_check.tags'
-      - _health_check.tags['with space'] == 'Some value'
-      - '"anotherTag" in _health_check.tags'
-      - _health_check.tags['anotherTag'] == 'anotherValue'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" not in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" not in _check_config'
-      - _check_config.disabled == true
-      - _check_config.type == 'TCP'
-      - _check_config.request_interval == 30
-      - _check_config.failure_threshold == failure_threshold_updated
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-    vars:
-      _health_check: '{{ add_tags.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update TCP health check - purge tags - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      tags:
-        anotherTag: anotherValue
-      purge_tags: true
-    register: purge_tags
-    check_mode: true
-
-  - name: 'Check result - Update TCP health check - purge tags - check_mode'
-    assert:
-      that:
-      - purge_tags is successful
-      - purge_tags is changed
-
-  - name: 'Update TCP health check - purge tags'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      tags:
-        anotherTag: anotherValue
-      purge_tags: true
-    register: purge_tags
-
-  - name: 'Check result - Update TCP health check - purge tags'
-    assert:
-      that:
-      - purge_tags is successful
-      - purge_tags is changed
-      - '"health_check" in purge_tags'
-      - '"id" in _health_check'
-      - _health_check.id == tcp_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - '"CamelCase" not in _health_check.tags'
-      - '"snake_case" not in _health_check.tags'
-      - '"with space" not in _health_check.tags'
-      - '"anotherTag" in _health_check.tags'
-      - _health_check.tags['anotherTag'] == 'anotherValue'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" not in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" not in _check_config'
-      - _check_config.disabled == true
-      - _check_config.type == 'TCP'
-      - _check_config.request_interval == 30
-      - _check_config.failure_threshold == failure_threshold_updated
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-    vars:
-      _health_check: '{{ purge_tags.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update TCP health check - purge tags - idempotency - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      tags:
-        anotherTag: anotherValue
-      purge_tags: true
-    register: purge_tags
-    check_mode: true
-
-  - name: 'Check result - Update TCP health check - purge tags - idempotency - check_mode'
-    assert:
-      that:
-      - purge_tags is successful
-      - purge_tags is not changed
-
-  - name: 'Update TCP health check - purge tags - idempotency'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      tags:
-        anotherTag: anotherValue
-      purge_tags: true
-    register: purge_tags
-
-  - name: 'Check result - Update TCP health check - purge tags - idempotency'
-    assert:
-      that:
-      - purge_tags is successful
-      - purge_tags is not changed
-      - '"health_check" in purge_tags'
-      - '"id" in _health_check'
-      - _health_check.id == tcp_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - '"CamelCase" not in _health_check.tags'
-      - '"snake_case" not in _health_check.tags'
-      - '"with space" not in _health_check.tags'
-      - '"anotherTag" in _health_check.tags'
-      - _health_check.tags['anotherTag'] == 'anotherValue'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" not in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" not in _check_config'
-      - _check_config.disabled == true
-      - _check_config.type == 'TCP'
-      - _check_config.request_interval == 30
-      - _check_config.failure_threshold == failure_threshold_updated
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-    vars:
-      _health_check: '{{ purge_tags.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  # Delete the check
-  - name: 'Delete TCP health check - check_mode'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-    register: delete_tcp
-    check_mode: True
-
-  - name: 'Check result - Delete TCP health check - check_mode'
-    assert:
-      that:
-      - delete_tcp is successful
-      - delete_tcp is changed
-
-  - name: 'Delete TCP health check'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-    register: delete_tcp
-
-  - name: 'Check result - Delete TCP health check'
-    assert:
-      that:
-      - delete_tcp is successful
-      - delete_tcp is changed
-
-  - name: 'Delete TCP health check - idempotency - check_mode'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-    register: delete_tcp
-    check_mode: True
-
-  - name: 'Check result - Delete TCP health check - idempotency - check_mode'
-    assert:
-      that:
-      - delete_tcp is successful
-      - delete_tcp is not changed
-
-  - name: 'Delete TCP health check - idempotency'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-    register: delete_tcp
-
-  - name: 'Check result - Delete TCP health check - idempotency'
-    assert:
-      that:
-      - delete_tcp is successful
-      - delete_tcp is not changed
-
-  # Create an HTTPS_STR_MATCH healthcheck so we can try out more settings
-  - name: 'Create a HTTPS_STR_MATCH health check - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match }}'
-    register: create_match
-    check_mode: true
-
-  - name: 'Check result - Create a HTTPS_STR_MATCH health check - check_mode'
-    assert:
-      that:
-      - create_match is successful
-      - create_match is changed
-
-  - name: 'Create a HTTPS_STR_MATCH health check'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match }}'
-    register: create_match
-
-  - name: 'Check result - Create a HTTPS_STR_MATCH health check'
-    assert:
-      that:
-      - create_match is successful
-      - create_match is changed
-      - '"health_check" in create_match'
-      - '"id" in _health_check'
-      - _health_check.id != tcp_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" in _check_config'
-      - _check_config.disabled == false
-      - _check_config.type == 'HTTPS_STR_MATCH'
-      - _check_config.request_interval == request_interval
-      - _check_config.failure_threshold == 3
-      - _check_config.fully_qualified_domain_name == fqdn
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-      - _check_config.search_string == string_match
-    vars:
-      _health_check: '{{ create_match.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - set_fact:
-      match_check_id: '{{ create_match.health_check.id }}'
-
-  - name: 'Create a HTTPS_STR_MATCH health check - idempotency - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match }}'
-    register: create_match
-    check_mode: true
-
-  - name: 'Check result - Create a HTTPS_STR_MATCH health check - idempotency - check_mode'
-    assert:
-      that:
-      - create_match is successful
-      - create_match is not changed
-
-  - name: 'Create a HTTPS_STR_MATCH health check - idempotency'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match }}'
-    register: create_match
-
-  - name: 'Check result - Create a HTTPS_STR_MATCH health check - idempotency'
-    assert:
-      that:
-      - create_match is successful
-      - create_match is not changed
-      - '"health_check" in create_match'
-      - '"id" in _health_check'
-      - _health_check.id == match_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" not in _check_config'
-      - '"search_string" in _check_config'
-      - _check_config.disabled == false
-      - _check_config.type == type_https_match
-      - _check_config.request_interval == request_interval
-      - _check_config.failure_threshold == 3
-      - _check_config.fully_qualified_domain_name == fqdn
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-      - _check_config.search_string == string_match
-    vars:
-      _health_check: '{{ create_match.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update HTTPS health check - set resource_path - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      resource_path: '{{ resource_path }}'
-    register: update_resource_path
-    check_mode: true
-
-  - name: 'Check result - Update HTTPS health check - set resource_path - check_mode'
-    assert:
-      that:
-      - update_resource_path is successful
-      - update_resource_path is changed
-
-  - name: 'Update HTTPS health check - set resource_path'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      resource_path: '{{ resource_path }}'
-    register: update_resource_path
-
-  - name: 'Check result - Update HTTPS health check - set resource_path'
-    assert:
-      that:
-      - update_resource_path is successful
-      - update_resource_path is changed
-      - '"health_check" in update_resource_path'
-      - '"id" in _health_check'
-      - _health_check.id == match_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" in _check_config'
-      - '"search_string" in _check_config'
-      - _check_config.disabled == false
-      - _check_config.type == type_https_match
-      - _check_config.request_interval == request_interval
-      - _check_config.failure_threshold == 3
-      - _check_config.fully_qualified_domain_name == fqdn
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-      - _check_config.resource_path == resource_path
-      - _check_config.search_string == string_match
-    vars:
-      _health_check: '{{ update_resource_path.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update HTTPS health check - set resource_path - idempotency - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      resource_path: '{{ resource_path }}'
-    register: update_resource_path
-    check_mode: true
-
-  - name: 'Check result - Update HTTPS health check - set resource_path - idempotency - check_mode'
-    assert:
-      that:
-      - update_resource_path is successful
-      - update_resource_path is not changed
-
-  - name: 'Update HTTPS health check - set resource_path - idempotency'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      resource_path: '{{ resource_path }}'
-    register: update_resource_path
-
-  - name: 'Check result - Update HTTPS health check - set resource_path - idempotency'
-    assert:
-      that:
-      - update_resource_path is successful
-      - update_resource_path is not changed
-      - '"health_check" in update_resource_path'
-      - '"id" in _health_check'
-      - _health_check.id == match_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" in _check_config'
-      - '"search_string" in _check_config'
-      - _check_config.disabled == false
-      - _check_config.type == type_https_match
-      - _check_config.request_interval == request_interval
-      - _check_config.failure_threshold == 3
-      - _check_config.fully_qualified_domain_name == fqdn
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-      - _check_config.resource_path == resource_path
-      - _check_config.search_string == string_match
-    vars:
-      _health_check: '{{ update_resource_path.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update HTTPS health check - set string_match - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match_updated }}'
-    register: update_string_match
-    check_mode: true
-
-  - name: 'Check result - Update HTTPS health check - set string_match - check_mode'
-    assert:
-      that:
-      - update_string_match is successful
-      - update_string_match is changed
-
-  - name: 'Update HTTPS health check - set string_match'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match_updated }}'
-    register: update_string_match
-
-  - name: 'Check result - Update HTTPS health check - set string_match'
-    assert:
-      that:
-      - update_string_match is successful
-      - update_string_match is changed
-      - '"health_check" in update_string_match'
-      - '"id" in _health_check'
-      - _health_check.id == match_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" in _check_config'
-      - '"search_string" in _check_config'
-      - _check_config.disabled == false
-      - _check_config.type == type_https_match
-      - _check_config.request_interval == request_interval
-      - _check_config.failure_threshold == 3
-      - _check_config.fully_qualified_domain_name == fqdn
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-      - _check_config.resource_path == resource_path
-      - _check_config.search_string == string_match_updated
-    vars:
-      _health_check: '{{ update_string_match.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update HTTPS health check - set string_match - idempotency - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match_updated }}'
-    register: update_string_match
-    check_mode: true
-
-  - name: 'Check result - Update HTTPS health check - set string_match - idempotency - check_mode'
-    assert:
-      that:
-      - update_string_match is successful
-      - update_string_match is not changed
-
-  - name: 'Update HTTPS health check - set string_match - idempotency'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match_updated }}'
-    register: update_string_match
-
-  - name: 'Check result - Update HTTPS health check - set string_match - idempotency'
-    assert:
-      that:
-      - update_string_match is successful
-      - update_string_match is not changed
-      - '"health_check" in update_string_match'
-      - '"id" in _health_check'
-      - _health_check.id == match_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" in _check_config'
-      - '"search_string" in _check_config'
-      - _check_config.disabled == false
-      - _check_config.type == type_https_match
-      - _check_config.request_interval == request_interval
-      - _check_config.failure_threshold == 3
-      - _check_config.fully_qualified_domain_name == fqdn
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-      - _check_config.resource_path == resource_path
-      - _check_config.search_string == string_match_updated
-    vars:
-      _health_check: '{{ update_string_match.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  # Test deletion
-  - name: 'Delete HTTPS health check - check_mode'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-    register: delete_match
-    check_mode: true
-
-  - name: 'Check result - Delete HTTPS health check - check_mode'
-    assert:
-      that:
-      - delete_match is successful
-      - delete_match is changed
-
-  - name: 'Delete HTTPS health check'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-    register: delete_match
-
-  - name: 'Check result - Delete HTTPS health check'
-    assert:
-      that:
-      - delete_match is successful
-      - delete_match is changed
-
-  - name: 'Delete HTTPS health check - idempotency - check_mode'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-    register: delete_match
-    check_mode: true
-
-  - name: 'Check result - Delete HTTPS health check - idempotency - check_mode'
-    assert:
-      that:
-      - delete_match is successful
-      - delete_match is not changed
-
-  - name: 'Delete HTTPS health check - idempotency'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-    register: delete_match
-
-  - name: 'Check result - Delete HTTPS health check - idempotency'
-    assert:
-      that:
-      - delete_match is successful
-      - delete_match is not changed
-
-  # Create an HTTP health check with lots of settings we can update
-  - name: 'Create Complex health check - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_http_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match }}'
-      resource_path: '{{ resource_path }}'
-      failure_threshold: '{{ failure_threshold }}'
-      disabled: true
-      tags:
-        CamelCase: CamelCaseValue
-        snake_case: snake_case_value
-        "with space": Some value
-      purge_tags: false
-    register: create_complex
-    check_mode: true
-
-  - name: 'Check result - Create Complex health check - check_mode'
-    assert:
-      that:
-      - create_complex is successful
-      - create_complex is changed
-
-  - name: 'Create Complex health check'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_http_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match }}'
-      resource_path: '{{ resource_path }}'
-      failure_threshold: '{{ failure_threshold }}'
-      disabled: true
-      tags:
-        CamelCase: CamelCaseValue
-        snake_case: snake_case_value
-        "with space": Some value
-      purge_tags: false
-    register: create_complex
-
-  - name: 'Check result - Create Complex health check'
-    assert:
-      that:
-      - create_complex is successful
-      - create_complex is changed
-      - '"health_check" in create_complex'
-      - '"id" in _health_check'
-      - _health_check.id != tcp_check_id
-      - _health_check.id != match_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - '"CamelCase" in _health_check.tags'
-      - _health_check.tags['CamelCase'] == 'CamelCaseValue'
-      - '"snake_case" in _health_check.tags'
-      - _health_check.tags['snake_case'] == 'snake_case_value'
-      - '"with space" in _health_check.tags'
-      - _health_check.tags['with space'] == 'Some value'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" in _check_config'
-      - '"search_string" in _check_config'
-      - _check_config.disabled == true
-      - _check_config.type == type_http_match
-      - _check_config.request_interval == request_interval
-      - _check_config.failure_threshold == failure_threshold
-      - _check_config.fully_qualified_domain_name == fqdn
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-      - _check_config.resource_path == resource_path
-      - _check_config.search_string == string_match
-    vars:
-      _health_check: '{{ create_complex.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - set_fact:
-      complex_check_id: '{{ create_complex.health_check.id }}'
-
-  - name: 'Create Complex health check - idempotency - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_http_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match }}'
-      resource_path: '{{ resource_path }}'
-      failure_threshold: '{{ failure_threshold }}'
-      disabled: true
-      tags:
-        CamelCase: CamelCaseValue
-        snake_case: snake_case_value
-        "with space": Some value
-      purge_tags: false
-    register: create_complex
-    check_mode: true
-
-  - name: 'Check result - Create Complex health check - idempotency - check_mode'
-    assert:
-      that:
-      - create_complex is successful
-      - create_complex is not changed
-
-  - name: 'Create Complex health check - idempotency'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_http_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match }}'
-      resource_path: '{{ resource_path }}'
-      failure_threshold: '{{ failure_threshold }}'
-      disabled: true
-      tags:
-        CamelCase: CamelCaseValue
-        snake_case: snake_case_value
-        "with space": Some value
-      purge_tags: false
-    register: create_complex
-
-  - name: 'Check result - Create Complex health check - idempotency'
-    assert:
-      that:
-      - create_complex is successful
-      - create_complex is not changed
-      - '"health_check" in create_complex'
-      - '"id" in _health_check'
-      - _health_check.id == complex_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - '"CamelCase" in _health_check.tags'
-      - _health_check.tags['CamelCase'] == 'CamelCaseValue'
-      - '"snake_case" in _health_check.tags'
-      - _health_check.tags['snake_case'] == 'snake_case_value'
-      - '"with space" in _health_check.tags'
-      - _health_check.tags['with space'] == 'Some value'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" in _check_config'
-      - '"search_string" in _check_config'
-      - _check_config.disabled == true
-      - _check_config.type == type_http_match
-      - _check_config.request_interval == request_interval
-      - _check_config.failure_threshold == failure_threshold
-      - _check_config.fully_qualified_domain_name == fqdn
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-      - _check_config.resource_path == resource_path
-      - _check_config.search_string == string_match
-    vars:
-      _health_check: '{{ create_complex.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update Complex health check - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_http_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match_updated }}'
-      resource_path: '{{ resource_path_updated }}'
-      failure_threshold: '{{ failure_threshold_updated }}'
-    register: update_complex
-    check_mode: true
-
-  - name: 'Check result - Update Complex health check - check_mode'
-    assert:
-      that:
-      - update_complex is successful
-      - update_complex is changed
-
-  - name: 'Update Complex health check'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_http_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match_updated }}'
-      resource_path: '{{ resource_path_updated }}'
-      failure_threshold: '{{ failure_threshold_updated }}'
-    register: update_complex
-
-  - name: 'Check result - Update Complex health check'
-    assert:
-      that:
-      - update_complex is successful
-      - update_complex is changed
-      - '"health_check" in update_complex'
-      - '"id" in _health_check'
-      - _health_check.id == complex_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - '"CamelCase" in _health_check.tags'
-      - _health_check.tags['CamelCase'] == 'CamelCaseValue'
-      - '"snake_case" in _health_check.tags'
-      - _health_check.tags['snake_case'] == 'snake_case_value'
-      - '"with space" in _health_check.tags'
-      - _health_check.tags['with space'] == 'Some value'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" in _check_config'
-      - '"search_string" in _check_config'
-      - _check_config.disabled == true
-      - _check_config.type == type_http_match
-      - _check_config.request_interval == request_interval
-      - _check_config.failure_threshold == failure_threshold_updated
-      - _check_config.fully_qualified_domain_name == fqdn
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-      - _check_config.resource_path == resource_path_updated
-      - _check_config.search_string == string_match_updated
-    vars:
-      _health_check: '{{ update_complex.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Update Complex health check - idempotency - check_mode'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_http_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match_updated }}'
-      resource_path: '{{ resource_path_updated }}'
-      failure_threshold: '{{ failure_threshold_updated }}'
-    register: update_complex
-    check_mode: true
-
-  - name: 'Check result - Update Complex health check - idempotency - check_mode'
-    assert:
-      that:
-      - update_complex is successful
-      - update_complex is not changed
-
-  - name: 'Update Complex health check - idempotency'
-    route53_health_check:
-      state: present
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_http_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-      string_match: '{{ string_match_updated }}'
-      resource_path: '{{ resource_path_updated }}'
-      failure_threshold: '{{ failure_threshold_updated }}'
-    register: update_complex
-
-  - name: 'Check result - Update Complex health check - idempotency'
-    assert:
-      that:
-      - update_complex is successful
-      - update_complex is not changed
-      - '"health_check" in update_complex'
-      - '"id" in _health_check'
-      - _health_check.id == complex_check_id
-      - '"action" in _health_check'
-      - '"health_check_version" in _health_check'
-      - '"tags" in _health_check'
-      - '"CamelCase" in _health_check.tags'
-      - _health_check.tags['CamelCase'] == 'CamelCaseValue'
-      - '"snake_case" in _health_check.tags'
-      - _health_check.tags['snake_case'] == 'snake_case_value'
-      - '"with space" in _health_check.tags'
-      - _health_check.tags['with space'] == 'Some value'
-      - create_check.health_check.action is none
-      - '"health_check_config" in create_check.health_check'
-      - '"type" in _check_config'
-      - '"disabled" in _check_config'
-      - '"failure_threshold" in _check_config'
-      - '"request_interval" in _check_config'
-      - '"fully_qualified_domain_name" in _check_config'
-      - '"ip_address" in _check_config'
-      - '"port" in _check_config'
-      - '"resource_path" in _check_config'
-      - '"search_string" in _check_config'
-      - _check_config.disabled == true
-      - _check_config.type == type_http_match
-      - _check_config.request_interval == request_interval
-      - _check_config.failure_threshold == failure_threshold_updated
-      - _check_config.fully_qualified_domain_name == fqdn
-      - _check_config.ip_address == ip_address
-      - _check_config.port == port
-      - _check_config.resource_path == resource_path_updated
-      - _check_config.search_string == string_match_updated
-    vars:
-      _health_check: '{{ update_complex.health_check }}'
-      _check_config: '{{ _health_check.health_check_config }}'
-
-  - name: 'Delete Complex health check - check_mode'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_http_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-    register: delete_complex
-    check_mode: true
-
-  - name: 'Check result - Delete Complex health check - check_mode'
-    assert:
-      that:
-      - delete_complex is successful
-      - delete_complex is changed
-
-  - name: 'Delete Complex health check'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_http_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-    register: delete_complex
-
-  - name: 'Check result - Delete Complex health check'
-    assert:
-      that:
-      - delete_complex is successful
-      - delete_complex is changed
-
-  - name: 'Delete Complex health check - idempotency - check_mode'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_http_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-    register: delete_complex
-    check_mode: true
-
-  - name: 'Check result - Delete Complex health check - idempotency - check_mode'
-    assert:
-      that:
-      - delete_complex is successful
-      - delete_complex is not changed
-
-  - name: 'Delete Complex health check - idempotency'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_http_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-    register: delete_complex
-
-  - name: 'Check result - Delete Complex health check - idempotency'
-    assert:
-      that:
-      - delete_complex is successful
-      - delete_complex is not changed
-
-  # Minimum possible definition
-  - name: 'Create a TCP health check with latency graphs enabled'
-    route53_health_check:
-      state: present
-      health_check_name: '{{ tiny_prefix }}-hc-latency-graph'
-      use_unique_names: true
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      measure_latency: true
-    register: create_check
-
-  - name: Get health check info
-    amazon.aws.route53_info:
-      query: health_check
-      health_check_id: "{{ create_check.health_check.id }}"
-      health_check_method: details
-    register: health_check_info
-
-  - name: 'Check result - Create a TCP health check with latency graphs enabled'
-    assert:
-      that:
-      - create_check is successful
-      - create_check is changed
-      - health_check_info.health_check.health_check_config.measure_latency == true
-
-  - pause:
-      seconds: 20
-
-  # test route53_info for health_check_method=status
-  - name: Get health check status
-    amazon.aws.route53_info:
-      query: health_check
-      health_check_id: "{{ create_check.health_check.id }}"
-      health_check_method: status
-    register: health_check_status_info
-
-  - assert:
-      that:
-      - health_check_status_info is not failed
-      - '"health_check_observations" in health_check_status_info'
-
-  # test route53_info for health_check_method=failure_reason
-  - name: Get health check failure_reason
-    amazon.aws.route53_info:
-      query: health_check
-      health_check_id: "{{ create_check.health_check.id }}"
-      health_check_method: failure_reason
-    register: health_check_failure_reason_info
-
-  - assert:
-      that:
-      - health_check_failure_reason_info is not failed
-      - '"health_check_observations" in health_check_failure_reason_info'
-
-
-  - name: 'Update above health check to disable latency graphs - immutable, no change'
-    route53_health_check:
-      state: present
-      health_check_name: '{{ tiny_prefix }}-hc-latency-graph'
-      use_unique_names: true
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      measure_latency: false
-    register: update_check
-
-  - name: 'Check result - Update TCP health check to disable latency graphs'
-    assert:
-      that:
-      - update_check is successful
-      - update_check is not changed
-      - health_check_info.health_check.health_check_config.measure_latency == true
+    - name: Allocate an EIP we can test against
+      amazon.aws.ec2_eip:
+        state: present
+      register: eip
+
+    - ansible.builtin.set_fact:
+        ip_address: "{{ eip.public_ip }}"
+
+    - name: Run tests for create and delete health check with tags and name as unique identifier
+      ansible.builtin.include_tasks: named_health_check_tag_operations.yml
+    - name: Run tests for creating multiple health checks with name as unique identifier
+      ansible.builtin.include_tasks: create_multiple_health_checks.yml
+    - name: Run tests for update and delete health check by ID
+      ansible.builtin.include_tasks: update_delete_by_id.yml
+    - name: Run tests for create, update, and delete calculated health check
+      ansible.builtin.include_tasks: calculate_health_check.yml
+    - name: Create a TCP health check - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+      register: create_check
+      check_mode: true
+
+    - name: Check result - Create a TCP health check - check_mode
+      ansible.builtin.assert:
+        that:
+          - create_check is successful
+          - create_check is changed
+
+    - name: Create a TCP health check
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+      register: create_check
+
+    - name: Check result - Create a TCP health check
+      ansible.builtin.assert:
+        that:
+          - create_check is successful
+          - create_check is changed
+          - '"health_check" in create_check'
+          - '"id" in _health_check'
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - create_check.health_check.action == 'create'
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" not in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" not in _check_config'
+          - _check_config.disabled == false
+          - _check_config.type == 'TCP'
+          - _check_config.failure_threshold == 3
+          - _check_config.request_interval == 30
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+      vars:
+        _health_check: "{{ create_check.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - ansible.builtin.set_fact:
+        tcp_check_id: "{{ create_check.health_check.id }}"
+
+    - name: Create a TCP health check - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+      register: create_check
+      check_mode: true
+
+    - name: Check result - Create a TCP health check - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - create_check is successful
+          - create_check is not changed
+
+    - name: Create a TCP health check - idempotency
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+      register: create_check
+
+    - name: Check result - Create a TCP health check - idempotency
+      ansible.builtin.assert:
+        that:
+          - create_check is successful
+          - create_check is not changed
+          - '"health_check" in create_check'
+          - '"id" in create_check.health_check'
+          - _health_check.id == tcp_check_id
+          - '"id" in _health_check'
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" not in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" not in _check_config'
+          - _check_config.disabled == false
+          - _check_config.type == 'TCP'
+          - _check_config.request_interval == 30
+          - _check_config.failure_threshold == 3
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+      vars:
+        _health_check: "{{ create_check.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    # Update an attribute
+    - name: Update TCP health check - set threshold - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        failure_threshold: "{{ failure_threshold_updated }}"
+      register: update_threshold
+      check_mode: true
+
+    - name: Check result - Update TCP health check - set threshold - check_mode
+      ansible.builtin.assert:
+        that:
+          - update_threshold is successful
+          - update_threshold is changed
+
+    - name: Update TCP health check - set threshold
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        failure_threshold: "{{ failure_threshold_updated }}"
+      register: update_threshold
+
+    - name: Check result - Update TCP health check - set threshold
+      ansible.builtin.assert:
+        that:
+          - update_threshold is successful
+          - update_threshold is changed
+          - '"health_check" in update_threshold'
+          - '"id" in _health_check'
+          - _health_check.id == tcp_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" not in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" not in _check_config'
+          - _check_config.disabled == false
+          - _check_config.type == 'TCP'
+          - _check_config.request_interval == 30
+          - _check_config.failure_threshold == failure_threshold_updated
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+      vars:
+        _health_check: "{{ update_threshold.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update TCP health check - set threshold - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        failure_threshold: "{{ failure_threshold_updated }}"
+      register: update_threshold
+      check_mode: true
+
+    - name: Check result - Update TCP health check - set threshold - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - update_threshold is successful
+          - update_threshold is not changed
+
+    - name: Update TCP health check - set threshold - idempotency
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        failure_threshold: "{{ failure_threshold_updated }}"
+      register: update_threshold
+
+    - name: Check result - Update TCP health check - set threshold - idempotency
+      ansible.builtin.assert:
+        that:
+          - update_threshold is successful
+          - update_threshold is not changed
+          - '"health_check" in update_threshold'
+          - '"id" in _health_check'
+          - _health_check.id == tcp_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" not in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" not in _check_config'
+          - _check_config.disabled == false
+          - _check_config.type == 'TCP'
+          - _check_config.request_interval == 30
+          - _check_config.failure_threshold == failure_threshold_updated
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+      vars:
+        _health_check: "{{ update_threshold.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update TCP health check - set disabled - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        disabled: true
+      register: update_disabled
+      check_mode: true
+
+    - name: Check result - Update TCP health check - set disabled - check_mode
+      ansible.builtin.assert:
+        that:
+          - update_disabled is successful
+          - update_disabled is changed
+
+    - name: Update TCP health check - set disabled
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        disabled: true
+      register: update_disabled
+
+    - name: Check result - Update TCP health check - set disabled
+      ansible.builtin.assert:
+        that:
+          - update_disabled is successful
+          - update_disabled is changed
+          - '"health_check" in update_disabled'
+          - '"id" in _health_check'
+          - _health_check.id == tcp_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" not in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" not in _check_config'
+          - _check_config.disabled == true
+          - _check_config.type == 'TCP'
+          - _check_config.request_interval == 30
+          - _check_config.failure_threshold == failure_threshold_updated
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+      vars:
+        _health_check: "{{ update_disabled.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update TCP health check - set disabled - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        disabled: true
+      register: update_disabled
+      check_mode: true
+
+    - name: Check result - Update TCP health check - set disabled - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - update_disabled is successful
+          - update_disabled is not changed
+
+    - name: Update TCP health check - set disabled - idempotency
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        disabled: true
+      register: update_disabled
+
+    - name: Check result - Update TCP health check - set disabled - idempotency
+      ansible.builtin.assert:
+        that:
+          - update_disabled is successful
+          - update_disabled is not changed
+          - '"health_check" in update_disabled'
+          - '"id" in _health_check'
+          - _health_check.id == tcp_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" not in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" not in _check_config'
+          - _check_config.disabled == true
+          - _check_config.type == 'TCP'
+          - _check_config.request_interval == 30
+          - _check_config.failure_threshold == failure_threshold_updated
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+      vars:
+        _health_check: "{{ update_disabled.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update TCP health check - set tags - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        tags:
+          CamelCase: CamelCaseValue
+          snake_case: snake_case_value
+          with space: Some value
+        purge_tags: false
+      register: update_tags
+      check_mode: true
+
+    - name: Check result - Update TCP health check - set tags - check_mode
+      ansible.builtin.assert:
+        that:
+          - update_tags is successful
+          - update_tags is changed
+
+    - name: Update TCP health check - set tags
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        tags:
+          CamelCase: CamelCaseValue
+          snake_case: snake_case_value
+          with space: Some value
+        purge_tags: false
+      register: update_tags
+
+    - name: Check result - Update TCP health check - set tags
+      ansible.builtin.assert:
+        that:
+          - update_tags is successful
+          - update_tags is changed
+          - '"health_check" in update_tags'
+          - '"id" in _health_check'
+          - _health_check.id == tcp_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - '"CamelCase" in _health_check.tags'
+          - _health_check.tags['CamelCase'] == 'CamelCaseValue'
+          - '"snake_case" in _health_check.tags'
+          - _health_check.tags['snake_case'] == 'snake_case_value'
+          - '"with space" in _health_check.tags'
+          - _health_check.tags['with space'] == 'Some value'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" not in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" not in _check_config'
+          - _check_config.disabled == true
+          - _check_config.type == 'TCP'
+          - _check_config.request_interval == 30
+          - _check_config.failure_threshold == failure_threshold_updated
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+      vars:
+        _health_check: "{{ update_tags.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update TCP health check - set tags - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        tags:
+          CamelCase: CamelCaseValue
+          snake_case: snake_case_value
+          with space: Some value
+        purge_tags: false
+      register: update_tags
+      check_mode: true
+
+    - name: Check result - Update TCP health check - set tags - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - update_tags is successful
+          - update_tags is not changed
+
+    - name: Update TCP health check - set tags - idempotency
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        tags:
+          CamelCase: CamelCaseValue
+          snake_case: snake_case_value
+          with space: Some value
+        purge_tags: false
+      register: update_tags
+
+    - name: Check result - Update TCP health check - set tags - idempotency
+      ansible.builtin.assert:
+        that:
+          - update_tags is successful
+          - update_tags is not changed
+          - '"health_check" in update_tags'
+          - '"id" in _health_check'
+          - _health_check.id == tcp_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - '"CamelCase" in _health_check.tags'
+          - _health_check.tags['CamelCase'] == 'CamelCaseValue'
+          - '"snake_case" in _health_check.tags'
+          - _health_check.tags['snake_case'] == 'snake_case_value'
+          - '"with space" in _health_check.tags'
+          - _health_check.tags['with space'] == 'Some value'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" not in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" not in _check_config'
+          - _check_config.disabled == true
+          - _check_config.type == 'TCP'
+          - _check_config.request_interval == 30
+          - _check_config.failure_threshold == failure_threshold_updated
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+      vars:
+        _health_check: "{{ update_tags.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update TCP health check - add tags - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        tags:
+          anotherTag: anotherValue
+        purge_tags: false
+      register: add_tags
+      check_mode: true
+
+    - name: Check result - Update TCP health check - add tags - check_mode
+      ansible.builtin.assert:
+        that:
+          - add_tags is successful
+          - add_tags is changed
+
+    - name: Update TCP health check - add tags
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        tags:
+          anotherTag: anotherValue
+        purge_tags: false
+      register: add_tags
+
+    - name: Check result - Update TCP health check - add tags
+      ansible.builtin.assert:
+        that:
+          - add_tags is successful
+          - add_tags is changed
+          - '"health_check" in add_tags'
+          - '"id" in _health_check'
+          - _health_check.id == tcp_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - '"CamelCase" in _health_check.tags'
+          - _health_check.tags['CamelCase'] == 'CamelCaseValue'
+          - '"snake_case" in _health_check.tags'
+          - _health_check.tags['snake_case'] == 'snake_case_value'
+          - '"with space" in _health_check.tags'
+          - _health_check.tags['with space'] == 'Some value'
+          - '"anotherTag" in _health_check.tags'
+          - _health_check.tags['anotherTag'] == 'anotherValue'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" not in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" not in _check_config'
+          - _check_config.disabled == true
+          - _check_config.type == 'TCP'
+          - _check_config.request_interval == 30
+          - _check_config.failure_threshold == failure_threshold_updated
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+      vars:
+        _health_check: "{{ add_tags.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update TCP health check - add tags - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        tags:
+          anotherTag: anotherValue
+        purge_tags: false
+      register: add_tags
+      check_mode: true
+
+    - name: Check result - Update TCP health check - add tags - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - add_tags is successful
+          - add_tags is not changed
+
+    - name: Update TCP health check - add tags - idempotency
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        tags:
+          anotherTag: anotherValue
+        purge_tags: false
+      register: add_tags
+
+    - name: Check result - Update TCP health check - add tags - idempotency
+      ansible.builtin.assert:
+        that:
+          - add_tags is successful
+          - add_tags is not changed
+          - '"health_check" in add_tags'
+          - '"id" in _health_check'
+          - _health_check.id == tcp_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - '"CamelCase" in _health_check.tags'
+          - _health_check.tags['CamelCase'] == 'CamelCaseValue'
+          - '"snake_case" in _health_check.tags'
+          - _health_check.tags['snake_case'] == 'snake_case_value'
+          - '"with space" in _health_check.tags'
+          - _health_check.tags['with space'] == 'Some value'
+          - '"anotherTag" in _health_check.tags'
+          - _health_check.tags['anotherTag'] == 'anotherValue'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" not in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" not in _check_config'
+          - _check_config.disabled == true
+          - _check_config.type == 'TCP'
+          - _check_config.request_interval == 30
+          - _check_config.failure_threshold == failure_threshold_updated
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+      vars:
+        _health_check: "{{ add_tags.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update TCP health check - purge tags - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        tags:
+          anotherTag: anotherValue
+        purge_tags: true
+      register: purge_tags
+      check_mode: true
+
+    - name: Check result - Update TCP health check - purge tags - check_mode
+      ansible.builtin.assert:
+        that:
+          - purge_tags is successful
+          - purge_tags is changed
+
+    - name: Update TCP health check - purge tags
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        tags:
+          anotherTag: anotherValue
+        purge_tags: true
+      register: purge_tags
+
+    - name: Check result - Update TCP health check - purge tags
+      ansible.builtin.assert:
+        that:
+          - purge_tags is successful
+          - purge_tags is changed
+          - '"health_check" in purge_tags'
+          - '"id" in _health_check'
+          - _health_check.id == tcp_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - '"CamelCase" not in _health_check.tags'
+          - '"snake_case" not in _health_check.tags'
+          - '"with space" not in _health_check.tags'
+          - '"anotherTag" in _health_check.tags'
+          - _health_check.tags['anotherTag'] == 'anotherValue'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" not in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" not in _check_config'
+          - _check_config.disabled == true
+          - _check_config.type == 'TCP'
+          - _check_config.request_interval == 30
+          - _check_config.failure_threshold == failure_threshold_updated
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+      vars:
+        _health_check: "{{ purge_tags.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update TCP health check - purge tags - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        tags:
+          anotherTag: anotherValue
+        purge_tags: true
+      register: purge_tags
+      check_mode: true
+
+    - name: Check result - Update TCP health check - purge tags - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - purge_tags is successful
+          - purge_tags is not changed
+
+    - name: Update TCP health check - purge tags - idempotency
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        tags:
+          anotherTag: anotherValue
+        purge_tags: true
+      register: purge_tags
+
+    - name: Check result - Update TCP health check - purge tags - idempotency
+      ansible.builtin.assert:
+        that:
+          - purge_tags is successful
+          - purge_tags is not changed
+          - '"health_check" in purge_tags'
+          - '"id" in _health_check'
+          - _health_check.id == tcp_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - '"CamelCase" not in _health_check.tags'
+          - '"snake_case" not in _health_check.tags'
+          - '"with space" not in _health_check.tags'
+          - '"anotherTag" in _health_check.tags'
+          - _health_check.tags['anotherTag'] == 'anotherValue'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" not in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" not in _check_config'
+          - _check_config.disabled == true
+          - _check_config.type == 'TCP'
+          - _check_config.request_interval == 30
+          - _check_config.failure_threshold == failure_threshold_updated
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+      vars:
+        _health_check: "{{ purge_tags.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    # Delete the check
+    - name: Delete TCP health check - check_mode
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+      register: delete_tcp
+      check_mode: true
+
+    - name: Check result - Delete TCP health check - check_mode
+      ansible.builtin.assert:
+        that:
+          - delete_tcp is successful
+          - delete_tcp is changed
+
+    - name: Delete TCP health check
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+      register: delete_tcp
+
+    - name: Check result - Delete TCP health check
+      ansible.builtin.assert:
+        that:
+          - delete_tcp is successful
+          - delete_tcp is changed
+
+    - name: Delete TCP health check - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+      register: delete_tcp
+      check_mode: true
+
+    - name: Check result - Delete TCP health check - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - delete_tcp is successful
+          - delete_tcp is not changed
+
+    - name: Delete TCP health check - idempotency
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+      register: delete_tcp
+
+    - name: Check result - Delete TCP health check - idempotency
+      ansible.builtin.assert:
+        that:
+          - delete_tcp is successful
+          - delete_tcp is not changed
+
+    # Create an HTTPS_STR_MATCH healthcheck so we can try out more settings
+    - name: Create a HTTPS_STR_MATCH health check - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match }}"
+      register: create_match
+      check_mode: true
+
+    - name: Check result - Create a HTTPS_STR_MATCH health check - check_mode
+      ansible.builtin.assert:
+        that:
+          - create_match is successful
+          - create_match is changed
+
+    - name: Create a HTTPS_STR_MATCH health check
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match }}"
+      register: create_match
+
+    - name: Check result - Create a HTTPS_STR_MATCH health check
+      ansible.builtin.assert:
+        that:
+          - create_match is successful
+          - create_match is changed
+          - '"health_check" in create_match'
+          - '"id" in _health_check'
+          - _health_check.id != tcp_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" in _check_config'
+          - _check_config.disabled == false
+          - _check_config.type == 'HTTPS_STR_MATCH'
+          - _check_config.request_interval == request_interval
+          - _check_config.failure_threshold == 3
+          - _check_config.fully_qualified_domain_name == fqdn
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+          - _check_config.search_string == string_match
+      vars:
+        _health_check: "{{ create_match.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - ansible.builtin.set_fact:
+        match_check_id: "{{ create_match.health_check.id }}"
+
+    - name: Create a HTTPS_STR_MATCH health check - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match }}"
+      register: create_match
+      check_mode: true
+
+    - name: Check result - Create a HTTPS_STR_MATCH health check - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - create_match is successful
+          - create_match is not changed
+
+    - name: Create a HTTPS_STR_MATCH health check - idempotency
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match }}"
+      register: create_match
+
+    - name: Check result - Create a HTTPS_STR_MATCH health check - idempotency
+      ansible.builtin.assert:
+        that:
+          - create_match is successful
+          - create_match is not changed
+          - '"health_check" in create_match'
+          - '"id" in _health_check'
+          - _health_check.id == match_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" not in _check_config'
+          - '"search_string" in _check_config'
+          - _check_config.disabled == false
+          - _check_config.type == type_https_match
+          - _check_config.request_interval == request_interval
+          - _check_config.failure_threshold == 3
+          - _check_config.fully_qualified_domain_name == fqdn
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+          - _check_config.search_string == string_match
+      vars:
+        _health_check: "{{ create_match.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update HTTPS health check - set resource_path - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        resource_path: "{{ resource_path }}"
+      register: update_resource_path
+      check_mode: true
+
+    - name: Check result - Update HTTPS health check - set resource_path - check_mode
+      ansible.builtin.assert:
+        that:
+          - update_resource_path is successful
+          - update_resource_path is changed
+
+    - name: Update HTTPS health check - set resource_path
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        resource_path: "{{ resource_path }}"
+      register: update_resource_path
+
+    - name: Check result - Update HTTPS health check - set resource_path
+      ansible.builtin.assert:
+        that:
+          - update_resource_path is successful
+          - update_resource_path is changed
+          - '"health_check" in update_resource_path'
+          - '"id" in _health_check'
+          - _health_check.id == match_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" in _check_config'
+          - '"search_string" in _check_config'
+          - _check_config.disabled == false
+          - _check_config.type == type_https_match
+          - _check_config.request_interval == request_interval
+          - _check_config.failure_threshold == 3
+          - _check_config.fully_qualified_domain_name == fqdn
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+          - _check_config.resource_path == resource_path
+          - _check_config.search_string == string_match
+      vars:
+        _health_check: "{{ update_resource_path.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update HTTPS health check - set resource_path - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        resource_path: "{{ resource_path }}"
+      register: update_resource_path
+      check_mode: true
+
+    - name: Check result - Update HTTPS health check - set resource_path - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - update_resource_path is successful
+          - update_resource_path is not changed
+
+    - name: Update HTTPS health check - set resource_path - idempotency
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        resource_path: "{{ resource_path }}"
+      register: update_resource_path
+
+    - name: Check result - Update HTTPS health check - set resource_path - idempotency
+      ansible.builtin.assert:
+        that:
+          - update_resource_path is successful
+          - update_resource_path is not changed
+          - '"health_check" in update_resource_path'
+          - '"id" in _health_check'
+          - _health_check.id == match_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" in _check_config'
+          - '"search_string" in _check_config'
+          - _check_config.disabled == false
+          - _check_config.type == type_https_match
+          - _check_config.request_interval == request_interval
+          - _check_config.failure_threshold == 3
+          - _check_config.fully_qualified_domain_name == fqdn
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+          - _check_config.resource_path == resource_path
+          - _check_config.search_string == string_match
+      vars:
+        _health_check: "{{ update_resource_path.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update HTTPS health check - set string_match - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match_updated }}"
+      register: update_string_match
+      check_mode: true
+
+    - name: Check result - Update HTTPS health check - set string_match - check_mode
+      ansible.builtin.assert:
+        that:
+          - update_string_match is successful
+          - update_string_match is changed
+
+    - name: Update HTTPS health check - set string_match
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match_updated }}"
+      register: update_string_match
+
+    - name: Check result - Update HTTPS health check - set string_match
+      ansible.builtin.assert:
+        that:
+          - update_string_match is successful
+          - update_string_match is changed
+          - '"health_check" in update_string_match'
+          - '"id" in _health_check'
+          - _health_check.id == match_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" in _check_config'
+          - '"search_string" in _check_config'
+          - _check_config.disabled == false
+          - _check_config.type == type_https_match
+          - _check_config.request_interval == request_interval
+          - _check_config.failure_threshold == 3
+          - _check_config.fully_qualified_domain_name == fqdn
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+          - _check_config.resource_path == resource_path
+          - _check_config.search_string == string_match_updated
+      vars:
+        _health_check: "{{ update_string_match.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update HTTPS health check - set string_match - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match_updated }}"
+      register: update_string_match
+      check_mode: true
+
+    - name: Check result - Update HTTPS health check - set string_match - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - update_string_match is successful
+          - update_string_match is not changed
+
+    - name: Update HTTPS health check - set string_match - idempotency
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match_updated }}"
+      register: update_string_match
+
+    - name: Check result - Update HTTPS health check - set string_match - idempotency
+      ansible.builtin.assert:
+        that:
+          - update_string_match is successful
+          - update_string_match is not changed
+          - '"health_check" in update_string_match'
+          - '"id" in _health_check'
+          - _health_check.id == match_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" in _check_config'
+          - '"search_string" in _check_config'
+          - _check_config.disabled == false
+          - _check_config.type == type_https_match
+          - _check_config.request_interval == request_interval
+          - _check_config.failure_threshold == 3
+          - _check_config.fully_qualified_domain_name == fqdn
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+          - _check_config.resource_path == resource_path
+          - _check_config.search_string == string_match_updated
+      vars:
+        _health_check: "{{ update_string_match.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    # Test deletion
+    - name: Delete HTTPS health check - check_mode
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+      register: delete_match
+      check_mode: true
+
+    - name: Check result - Delete HTTPS health check - check_mode
+      ansible.builtin.assert:
+        that:
+          - delete_match is successful
+          - delete_match is changed
+
+    - name: Delete HTTPS health check
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+      register: delete_match
+
+    - name: Check result - Delete HTTPS health check
+      ansible.builtin.assert:
+        that:
+          - delete_match is successful
+          - delete_match is changed
+
+    - name: Delete HTTPS health check - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+      register: delete_match
+      check_mode: true
+
+    - name: Check result - Delete HTTPS health check - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - delete_match is successful
+          - delete_match is not changed
+
+    - name: Delete HTTPS health check - idempotency
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+      register: delete_match
+
+    - name: Check result - Delete HTTPS health check - idempotency
+      ansible.builtin.assert:
+        that:
+          - delete_match is successful
+          - delete_match is not changed
+
+    # Create an HTTP health check with lots of settings we can update
+    - name: Create Complex health check - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match }}"
+        resource_path: "{{ resource_path }}"
+        failure_threshold: "{{ failure_threshold }}"
+        disabled: true
+        tags:
+          CamelCase: CamelCaseValue
+          snake_case: snake_case_value
+          with space: Some value
+        purge_tags: false
+      register: create_complex
+      check_mode: true
+
+    - name: Check result - Create Complex health check - check_mode
+      ansible.builtin.assert:
+        that:
+          - create_complex is successful
+          - create_complex is changed
+
+    - name: Create Complex health check
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match }}"
+        resource_path: "{{ resource_path }}"
+        failure_threshold: "{{ failure_threshold }}"
+        disabled: true
+        tags:
+          CamelCase: CamelCaseValue
+          snake_case: snake_case_value
+          with space: Some value
+        purge_tags: false
+      register: create_complex
+
+    - name: Check result - Create Complex health check
+      ansible.builtin.assert:
+        that:
+          - create_complex is successful
+          - create_complex is changed
+          - '"health_check" in create_complex'
+          - '"id" in _health_check'
+          - _health_check.id != tcp_check_id
+          - _health_check.id != match_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - '"CamelCase" in _health_check.tags'
+          - _health_check.tags['CamelCase'] == 'CamelCaseValue'
+          - '"snake_case" in _health_check.tags'
+          - _health_check.tags['snake_case'] == 'snake_case_value'
+          - '"with space" in _health_check.tags'
+          - _health_check.tags['with space'] == 'Some value'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" in _check_config'
+          - '"search_string" in _check_config'
+          - _check_config.disabled == true
+          - _check_config.type == type_http_match
+          - _check_config.request_interval == request_interval
+          - _check_config.failure_threshold == failure_threshold
+          - _check_config.fully_qualified_domain_name == fqdn
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+          - _check_config.resource_path == resource_path
+          - _check_config.search_string == string_match
+      vars:
+        _health_check: "{{ create_complex.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - ansible.builtin.set_fact:
+        complex_check_id: "{{ create_complex.health_check.id }}"
+
+    - name: Create Complex health check - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match }}"
+        resource_path: "{{ resource_path }}"
+        failure_threshold: "{{ failure_threshold }}"
+        disabled: true
+        tags:
+          CamelCase: CamelCaseValue
+          snake_case: snake_case_value
+          with space: Some value
+        purge_tags: false
+      register: create_complex
+      check_mode: true
+
+    - name: Check result - Create Complex health check - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - create_complex is successful
+          - create_complex is not changed
+
+    - name: Create Complex health check - idempotency
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match }}"
+        resource_path: "{{ resource_path }}"
+        failure_threshold: "{{ failure_threshold }}"
+        disabled: true
+        tags:
+          CamelCase: CamelCaseValue
+          snake_case: snake_case_value
+          with space: Some value
+        purge_tags: false
+      register: create_complex
+
+    - name: Check result - Create Complex health check - idempotency
+      ansible.builtin.assert:
+        that:
+          - create_complex is successful
+          - create_complex is not changed
+          - '"health_check" in create_complex'
+          - '"id" in _health_check'
+          - _health_check.id == complex_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - '"CamelCase" in _health_check.tags'
+          - _health_check.tags['CamelCase'] == 'CamelCaseValue'
+          - '"snake_case" in _health_check.tags'
+          - _health_check.tags['snake_case'] == 'snake_case_value'
+          - '"with space" in _health_check.tags'
+          - _health_check.tags['with space'] == 'Some value'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" in _check_config'
+          - '"search_string" in _check_config'
+          - _check_config.disabled == true
+          - _check_config.type == type_http_match
+          - _check_config.request_interval == request_interval
+          - _check_config.failure_threshold == failure_threshold
+          - _check_config.fully_qualified_domain_name == fqdn
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+          - _check_config.resource_path == resource_path
+          - _check_config.search_string == string_match
+      vars:
+        _health_check: "{{ create_complex.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update Complex health check - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match_updated }}"
+        resource_path: "{{ resource_path_updated }}"
+        failure_threshold: "{{ failure_threshold_updated }}"
+      register: update_complex
+      check_mode: true
+
+    - name: Check result - Update Complex health check - check_mode
+      ansible.builtin.assert:
+        that:
+          - update_complex is successful
+          - update_complex is changed
+
+    - name: Update Complex health check
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match_updated }}"
+        resource_path: "{{ resource_path_updated }}"
+        failure_threshold: "{{ failure_threshold_updated }}"
+      register: update_complex
+
+    - name: Check result - Update Complex health check
+      ansible.builtin.assert:
+        that:
+          - update_complex is successful
+          - update_complex is changed
+          - '"health_check" in update_complex'
+          - '"id" in _health_check'
+          - _health_check.id == complex_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - '"CamelCase" in _health_check.tags'
+          - _health_check.tags['CamelCase'] == 'CamelCaseValue'
+          - '"snake_case" in _health_check.tags'
+          - _health_check.tags['snake_case'] == 'snake_case_value'
+          - '"with space" in _health_check.tags'
+          - _health_check.tags['with space'] == 'Some value'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" in _check_config'
+          - '"search_string" in _check_config'
+          - _check_config.disabled == true
+          - _check_config.type == type_http_match
+          - _check_config.request_interval == request_interval
+          - _check_config.failure_threshold == failure_threshold_updated
+          - _check_config.fully_qualified_domain_name == fqdn
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+          - _check_config.resource_path == resource_path_updated
+          - _check_config.search_string == string_match_updated
+      vars:
+        _health_check: "{{ update_complex.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Update Complex health check - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match_updated }}"
+        resource_path: "{{ resource_path_updated }}"
+        failure_threshold: "{{ failure_threshold_updated }}"
+      register: update_complex
+      check_mode: true
+
+    - name: Check result - Update Complex health check - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - update_complex is successful
+          - update_complex is not changed
+
+    - name: Update Complex health check - idempotency
+      amazon.aws.route53_health_check:
+        state: present
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+        string_match: "{{ string_match_updated }}"
+        resource_path: "{{ resource_path_updated }}"
+        failure_threshold: "{{ failure_threshold_updated }}"
+      register: update_complex
+
+    - name: Check result - Update Complex health check - idempotency
+      ansible.builtin.assert:
+        that:
+          - update_complex is successful
+          - update_complex is not changed
+          - '"health_check" in update_complex'
+          - '"id" in _health_check'
+          - _health_check.id == complex_check_id
+          - '"action" in _health_check'
+          - '"health_check_version" in _health_check'
+          - '"tags" in _health_check'
+          - '"CamelCase" in _health_check.tags'
+          - _health_check.tags['CamelCase'] == 'CamelCaseValue'
+          - '"snake_case" in _health_check.tags'
+          - _health_check.tags['snake_case'] == 'snake_case_value'
+          - '"with space" in _health_check.tags'
+          - _health_check.tags['with space'] == 'Some value'
+          - create_check.health_check.action is none
+          - '"health_check_config" in create_check.health_check'
+          - '"type" in _check_config'
+          - '"disabled" in _check_config'
+          - '"failure_threshold" in _check_config'
+          - '"request_interval" in _check_config'
+          - '"fully_qualified_domain_name" in _check_config'
+          - '"ip_address" in _check_config'
+          - '"port" in _check_config'
+          - '"resource_path" in _check_config'
+          - '"search_string" in _check_config'
+          - _check_config.disabled == true
+          - _check_config.type == type_http_match
+          - _check_config.request_interval == request_interval
+          - _check_config.failure_threshold == failure_threshold_updated
+          - _check_config.fully_qualified_domain_name == fqdn
+          - _check_config.ip_address == ip_address
+          - _check_config.port == port
+          - _check_config.resource_path == resource_path_updated
+          - _check_config.search_string == string_match_updated
+      vars:
+        _health_check: "{{ update_complex.health_check }}"
+        _check_config: "{{ _health_check.health_check_config }}"
+
+    - name: Delete Complex health check - check_mode
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+      register: delete_complex
+      check_mode: true
+
+    - name: Check result - Delete Complex health check - check_mode
+      ansible.builtin.assert:
+        that:
+          - delete_complex is successful
+          - delete_complex is changed
+
+    - name: Delete Complex health check
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+      register: delete_complex
+
+    - name: Check result - Delete Complex health check
+      ansible.builtin.assert:
+        that:
+          - delete_complex is successful
+          - delete_complex is changed
+
+    - name: Delete Complex health check - idempotency - check_mode
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+      register: delete_complex
+      check_mode: true
+
+    - name: Check result - Delete Complex health check - idempotency - check_mode
+      ansible.builtin.assert:
+        that:
+          - delete_complex is successful
+          - delete_complex is not changed
+
+    - name: Delete Complex health check - idempotency
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+      register: delete_complex
+
+    - name: Check result - Delete Complex health check - idempotency
+      ansible.builtin.assert:
+        that:
+          - delete_complex is successful
+          - delete_complex is not changed
+
+    # Minimum possible definition
+    - name: Create a TCP health check with latency graphs enabled
+      amazon.aws.route53_health_check:
+        state: present
+        health_check_name: "{{ tiny_prefix }}-hc-latency-graph"
+        use_unique_names: true
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        measure_latency: true
+      register: create_check
+
+    - name: Get health check info
+      amazon.aws.route53_info:
+        query: health_check
+        health_check_id: "{{ create_check.health_check.id }}"
+        health_check_method: details
+      register: health_check_info
+
+    - name: Check result - Create a TCP health check with latency graphs enabled
+      ansible.builtin.assert:
+        that:
+          - create_check is successful
+          - create_check is changed
+          - health_check_info.health_check.health_check_config.measure_latency == true
+
+    - ansible.builtin.pause:
+        seconds: 20
+
+    # test route53_info for health_check_method=status
+    - name: Get health check status
+      amazon.aws.route53_info:
+        query: health_check
+        health_check_id: "{{ create_check.health_check.id }}"
+        health_check_method: status
+      register: health_check_status_info
+
+    - ansible.builtin.assert:
+        that:
+          - health_check_status_info is not failed
+          - '"health_check_observations" in health_check_status_info'
+
+    # test route53_info for health_check_method=failure_reason
+    - name: Get health check failure_reason
+      amazon.aws.route53_info:
+        query: health_check
+        health_check_id: "{{ create_check.health_check.id }}"
+        health_check_method: failure_reason
+      register: health_check_failure_reason_info
+
+    - ansible.builtin.assert:
+        that:
+          - health_check_failure_reason_info is not failed
+          - '"health_check_observations" in health_check_failure_reason_info'
+
+    - name: Update above health check to disable latency graphs - immutable, no change
+      amazon.aws.route53_health_check:
+        state: present
+        health_check_name: "{{ tiny_prefix }}-hc-latency-graph"
+        use_unique_names: true
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        measure_latency: false
+      register: update_check
+
+    - name: Check result - Update TCP health check to disable latency graphs
+      ansible.builtin.assert:
+        that:
+          - update_check is successful
+          - update_check is not changed
+          - health_check_info.health_check.health_check_config.measure_latency == true
 
   always:
-
     ################################################
     # TEARDOWN STARTS HERE
     ################################################
 
-  - name: 'Delete TCP health check with latency graphs enabled'
-    route53_health_check:
-      state: absent
-      health_check_name: '{{ tiny_prefix }}-hc-latency-graph'
-      use_unique_names: true
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-      measure_latency: true
-    ignore_errors: true
+    - name: Delete TCP health check with latency graphs enabled
+      amazon.aws.route53_health_check:
+        state: absent
+        health_check_name: "{{ tiny_prefix }}-hc-latency-graph"
+        use_unique_names: true
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+        measure_latency: true
+      ignore_errors: true
 
-  - name: 'Delete TCP health check'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type }}'
-    ignore_errors: true
+    - name: Delete TCP health check
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type }}"
+      ignore_errors: true
 
-  - name: 'Delete HTTPS health check'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_https_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-    ignore_errors: true
+    - name: Delete HTTPS health check
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_https_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+      ignore_errors: true
 
-  - name: 'Delete Complex health check'
-    route53_health_check:
-      state: absent
-      ip_address: '{{ ip_address }}'
-      port: '{{ port }}'
-      type: '{{ type_http_match }}'
-      fqdn: '{{ fqdn }}'
-      request_interval: '{{ request_interval }}'
-    ignore_errors: true
+    - name: Delete Complex health check
+      amazon.aws.route53_health_check:
+        state: absent
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http_match }}"
+        fqdn: "{{ fqdn }}"
+        request_interval: "{{ request_interval }}"
+      ignore_errors: true
 
-  - name: release EIP
-    ec2_eip:
-      state: absent
-      public_ip: '{{ ip_address }}'
-    ignore_errors: true
+    - name: release EIP
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ ip_address }}"
+      ignore_errors: true

--- a/tests/integration/targets/route53_health_check/tasks/named_health_check_tag_operations.yml
+++ b/tests/integration/targets/route53_health_check/tasks/named_health_check_tag_operations.yml
@@ -1,16 +1,16 @@
 ---
 - block:
     # Create Health Check =================================================================
-    - name: 'Create Health Check with name and tags'
+    - name: Create Health Check with name and tags
       amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ resource_path }}'
+        name: "{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ resource_path }}"
         use_unique_names: true
-        fqdn: '{{ fqdn }}'
+        fqdn: "{{ fqdn }}"
         tags:
           Service: my-service
           Owner: my-test-xyz
@@ -20,146 +20,146 @@
     - name: Get Health Check tags
       amazon.aws.route53_info:
         query: health_check
-        resource_id:  "{{ create_result.health_check.id }}"
+        resource_id: "{{ create_result.health_check.id }}"
         health_check_method: tags
       register: health_check_tags
-    - set_fact:
+    - ansible.builtin.set_fact:
         tags_keys_list: "{{ health_check_tags.ResourceTagSets[0].Tags | map(attribute='Key') | list }}"
 
-    - name: 'Check result - Create HTTP health check'
-      assert:
+    - name: Check result - Create HTTP health check
+      ansible.builtin.assert:
         that:
-        - create_result is not failed
-        - create_result is changed
-        - tags_keys_list | length == 4
-        - '"Service" in tags_keys_list'
-        - '"Owner" in tags_keys_list'
-        - '"Lifecycle" in tags_keys_list'
-        - '"Name" in tags_keys_list'
+          - create_result is not failed
+          - create_result is changed
+          - tags_keys_list | length == 4
+          - '"Service" in tags_keys_list'
+          - '"Owner" in tags_keys_list'
+          - '"Lifecycle" in tags_keys_list'
+          - '"Name" in tags_keys_list'
 
     # Create Health Check - check Idempotenty =================================================================
-    - name: 'Create Health Check with name and tags - idempotency'
+    - name: Create Health Check with name and tags - idempotency
       amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ resource_path }}'
+        name: "{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ resource_path }}"
         use_unique_names: true
         tags:
           Service: my-service
           Owner: my-test-xyz
           Lifecycle: dev
-        fqdn: '{{ fqdn }}'
+        fqdn: "{{ fqdn }}"
       register: create_idem
 
     - name: Get Health Check tags
       amazon.aws.route53_info:
         query: health_check
-        resource_id:  "{{ create_idem.health_check.id }}"
+        resource_id: "{{ create_idem.health_check.id }}"
         health_check_method: tags
       register: health_check_tags
-    - set_fact:
+    - ansible.builtin.set_fact:
         tags_keys_list: "{{ health_check_tags.ResourceTagSets[0].Tags | map(attribute='Key') | list }}"
 
-    - name: 'Check result - Create HTTP health check - idempotency'
-      assert:
+    - name: Check result - Create HTTP health check - idempotency
+      ansible.builtin.assert:
         that:
-        - create_idem is not failed
-        - create_idem is not changed
-        - tags_keys_list | length == 4
-        - '"Service" in tags_keys_list'
-        - '"Owner" in tags_keys_list'
-        - '"Lifecycle" in tags_keys_list'
-        - '"Name" in tags_keys_list'
+          - create_idem is not failed
+          - create_idem is not changed
+          - tags_keys_list | length == 4
+          - '"Service" in tags_keys_list'
+          - '"Owner" in tags_keys_list'
+          - '"Lifecycle" in tags_keys_list'
+          - '"Name" in tags_keys_list'
 
     # Create Health Check - Update Tags =================================================================
-    - name: 'Create Health Check with name and tags'
+    - name: Create Health Check with name and tags
       amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ resource_path }}'
+        name: "{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ resource_path }}"
         use_unique_names: true
         tags:
           Service: my-service
           NewOwner: my-test-abcd
-        fqdn: '{{ fqdn }}'
+        fqdn: "{{ fqdn }}"
       register: create_hc_update_tags
 
     - name: Get Health Check tags
       amazon.aws.route53_info:
         query: health_check
-        resource_id:  "{{ create_hc_update_tags.health_check.id }}"
+        resource_id: "{{ create_hc_update_tags.health_check.id }}"
         health_check_method: tags
       register: health_check_tags
-    - set_fact:
+    - ansible.builtin.set_fact:
         tags_keys_list: "{{ health_check_tags.ResourceTagSets[0].Tags | map(attribute='Key') | list }}"
 
-    - name: 'Check result - Create HTTP health check'
-      assert:
+    - name: Check result - Create HTTP health check
+      ansible.builtin.assert:
         that:
-        - create_hc_update_tags is not failed
-        - create_hc_update_tags is changed
-        - tags_keys_list | length == 3
-        - '"Service" in tags_keys_list'
-        - '"NewOwner" in tags_keys_list'
-        - '"Owner" not in tags_keys_list'
-        - '"Lifecycle" not in tags_keys_list'
-        - '"Name" in tags_keys_list'
+          - create_hc_update_tags is not failed
+          - create_hc_update_tags is changed
+          - tags_keys_list | length == 3
+          - '"Service" in tags_keys_list'
+          - '"NewOwner" in tags_keys_list'
+          - '"Owner" not in tags_keys_list'
+          - '"Lifecycle" not in tags_keys_list'
+          - '"Name" in tags_keys_list'
 
     # Create Health Check - Update Tags - Idempotency =================================================================
-    - name: 'Create Health Check with name and tags - Idempotency'
+    - name: Create Health Check with name and tags - Idempotency
       amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ resource_path }}'
+        name: "{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ resource_path }}"
         use_unique_names: true
         tags:
           Service: my-service
           NewOwner: my-test-abcd
-        fqdn: '{{ fqdn }}'
+        fqdn: "{{ fqdn }}"
       register: create_hc_update_tags_idem
 
     - name: Get Health Check tags
       amazon.aws.route53_info:
         query: health_check
-        resource_id:  "{{ create_hc_update_tags_idem.health_check.id }}"
+        resource_id: "{{ create_hc_update_tags_idem.health_check.id }}"
         health_check_method: tags
       register: health_check_tags
-    - set_fact:
+    - ansible.builtin.set_fact:
         tags_keys_list: "{{ health_check_tags.ResourceTagSets[0].Tags | map(attribute='Key') | list }}"
 
-    - name: 'Check result - Create HTTP health check'
-      assert:
+    - name: Check result - Create HTTP health check
+      ansible.builtin.assert:
         that:
-        - create_hc_update_tags_idem is not failed
-        - create_hc_update_tags_idem is not changed
-        - tags_keys_list | length == 3
-        - '"Service" in tags_keys_list'
-        - '"NewOwner" in tags_keys_list'
-        - '"Owner" not in tags_keys_list'
-        - '"Lifecycle" not in tags_keys_list'
-        - '"Name" in tags_keys_list'
+          - create_hc_update_tags_idem is not failed
+          - create_hc_update_tags_idem is not changed
+          - tags_keys_list | length == 3
+          - '"Service" in tags_keys_list'
+          - '"NewOwner" in tags_keys_list'
+          - '"Owner" not in tags_keys_list'
+          - '"Lifecycle" not in tags_keys_list'
+          - '"Name" in tags_keys_list'
 
     # Create Health Check - test purge_tags behavior =================================================================
 
-    - name: 'Create Health Check with name with tags={} and purge_tags=false (should not remove existing tags)'
+    - name: Create Health Check with name with tags={} and purge_tags=false (should not remove existing tags)
       amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ resource_path }}'
+        name: "{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ resource_path }}"
         use_unique_names: true
-        fqdn: '{{ fqdn }}'
+        fqdn: "{{ fqdn }}"
         tags: {}
         purge_tags: false
       register: create_hc_update_tags
@@ -167,64 +167,64 @@
     - name: Get Health Check tags
       amazon.aws.route53_info:
         query: health_check
-        resource_id:  "{{ create_hc_update_tags.health_check.id }}"
+        resource_id: "{{ create_hc_update_tags.health_check.id }}"
         health_check_method: tags
       register: health_check_tags
-    - set_fact:
+    - ansible.builtin.set_fact:
         tags_keys_list: "{{ health_check_tags.ResourceTagSets[0].Tags | map(attribute='Key') | list }}"
 
-    - name: 'Check result - Create HTTP health check'
-      assert:
+    - name: Check result - Create HTTP health check
+      ansible.builtin.assert:
         that:
-        - create_hc_update_tags is not failed
-        - create_hc_update_tags is not changed
-        - tags_keys_list | length == 3
-        - '"Service" in tags_keys_list'
-        - '"NewOwner" in tags_keys_list'
-        - '"Name" in tags_keys_list'
+          - create_hc_update_tags is not failed
+          - create_hc_update_tags is not changed
+          - tags_keys_list | length == 3
+          - '"Service" in tags_keys_list'
+          - '"NewOwner" in tags_keys_list'
+          - '"Name" in tags_keys_list'
 
-    - name: 'Create Health Check with name with tags=None with purge_tags=true (should not remove existing tags)'
+    - name: Create Health Check with name with tags=None with purge_tags=true (should not remove existing tags)
       amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ resource_path }}'
+        name: "{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ resource_path }}"
         use_unique_names: true
-        fqdn: '{{ fqdn }}'
+        fqdn: "{{ fqdn }}"
         purge_tags: true
       register: create_hc_update_tags
 
     - name: Get Health Check tags
       amazon.aws.route53_info:
         query: health_check
-        resource_id:  "{{ create_hc_update_tags.health_check.id }}"
+        resource_id: "{{ create_hc_update_tags.health_check.id }}"
         health_check_method: tags
       register: health_check_tags
-    - set_fact:
+    - ansible.builtin.set_fact:
         tags_keys_list: "{{ health_check_tags.ResourceTagSets[0].Tags | map(attribute='Key') | list }}"
 
-    - name: 'Check result - Create HTTP health check'
-      assert:
+    - name: Check result - Create HTTP health check
+      ansible.builtin.assert:
         that:
-        - create_hc_update_tags is not failed
-        - create_hc_update_tags is not changed
-        - tags_keys_list | length == 3
-        - '"Service" in tags_keys_list'
-        - '"NewOwner" in tags_keys_list'
-        - '"Name" in tags_keys_list'
+          - create_hc_update_tags is not failed
+          - create_hc_update_tags is not changed
+          - tags_keys_list | length == 3
+          - '"Service" in tags_keys_list'
+          - '"NewOwner" in tags_keys_list'
+          - '"Name" in tags_keys_list'
 
-    - name: 'Create Health Check with name with tags={} with purge_tags=true (should remove existing tags except Name)'
+    - name: Create Health Check with name with tags={} with purge_tags=true (should remove existing tags except Name)
       amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ resource_path }}'
+        name: "{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ resource_path }}"
         use_unique_names: true
-        fqdn: '{{ fqdn }}'
+        fqdn: "{{ fqdn }}"
         tags: {}
         purge_tags: true
       register: create_hc_update_tags
@@ -232,40 +232,40 @@
     - name: Get Health Check tags
       amazon.aws.route53_info:
         query: health_check
-        resource_id:  "{{ create_hc_update_tags.health_check.id }}"
+        resource_id: "{{ create_hc_update_tags.health_check.id }}"
         health_check_method: tags
       register: health_check_tags
-    - set_fact:
+    - ansible.builtin.set_fact:
         tags_keys_list: "{{ health_check_tags.ResourceTagSets[0].Tags | map(attribute='Key') | list }}"
 
-    - name: 'Check result - Create HTTP health check'
-      assert:
+    - name: Check result - Create HTTP health check
+      ansible.builtin.assert:
         that:
-        - create_hc_update_tags is not failed
-        - create_hc_update_tags is changed
-        - tags_keys_list | length == 1
-        - '"Service" not in tags_keys_list'
-        - '"NewOwner" not in tags_keys_list'
-        - '"Name" in tags_keys_list'
+          - create_hc_update_tags is not failed
+          - create_hc_update_tags is changed
+          - tags_keys_list | length == 1
+          - '"Service" not in tags_keys_list'
+          - '"NewOwner" not in tags_keys_list'
+          - '"Name" in tags_keys_list'
 
   # Cleanup starts here =================================================================
   always:
-      - name: 'Delete HTTP health check with use_unique_names'
-        amazon.aws.route53_health_check:
-          state: absent
-          name: '{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations'
-          ip_address: '{{ ip_address }}'
-          port: '{{ port }}'
-          type: '{{ type_http }}'
-          resource_path: '{{ resource_path }}'
-          use_unique_names: true
-          fqdn: '{{ fqdn }}'
-          tags: {}
-        register: delete_result
-        with_items:
-          - '{{ resource_path }}'
+    - name: Delete HTTP health check with use_unique_names
+      amazon.aws.route53_health_check:
+        state: absent
+        name: "{{ tiny_prefix }}-{{ resource_path }}-test-hc-tag-operations"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ resource_path }}"
+        use_unique_names: true
+        fqdn: "{{ fqdn }}"
+        tags: {}
+      register: delete_result
+      with_items:
+        - "{{ resource_path }}"
 
-      - assert:
-          that:
-            - delete_result is changed
-            - delete_result is not failed
+    - ansible.builtin.assert:
+        that:
+          - delete_result is changed
+          - delete_result is not failed

--- a/tests/integration/targets/route53_health_check/tasks/update_delete_by_id.yml
+++ b/tests/integration/targets/route53_health_check/tasks/update_delete_by_id.yml
@@ -1,26 +1,26 @@
 ---
 - block:
-    - name: 'Create HTTP health check for use in this test'
-      route53_health_check:
+    - name: Create HTTP health check for use in this test
+      amazon.aws.route53_health_check:
         state: present
-        name: '{{ tiny_prefix }}-test-update-delete-by-id'
-        ip_address: '{{ ip_address }}'
-        port: '{{ port }}'
-        type: '{{ type_http }}'
-        resource_path: '{{ resource_path }}'
-        fqdn: '{{ fqdn }}'
+        name: "{{ tiny_prefix }}-test-update-delete-by-id"
+        ip_address: "{{ ip_address }}"
+        port: "{{ port }}"
+        type: "{{ type_http }}"
+        resource_path: "{{ resource_path }}"
+        fqdn: "{{ fqdn }}"
         use_unique_names: true
       register: create_result
 
-    - name: 'Check result - Create HTTP health check'
-      assert:
+    - name: Check result - Create HTTP health check
+      ansible.builtin.assert:
         that:
-        - create_result is not failed
-        - create_result is changed
-        - '"route53:CreateHealthCheck" in create_result.resource_actions'
+          - create_result is not failed
+          - create_result is changed
+          - '"route53:CreateHealthCheck" in create_result.resource_actions'
 
     - name: Get ID for health_checks created in above task
-      set_fact:
+      ansible.builtin.set_fact:
         health_check_id: "{{ create_result.health_check.id }}"
 
     - name: Get health_check info
@@ -31,22 +31,22 @@
       register: health_check_info
 
     # Update Health Check by ID Tests
-    - name: 'Update Health Check by ID - Update Port - check_mode'
-      route53_health_check:
+    - name: Update Health Check by ID - Update Port - check_mode
+      amazon.aws.route53_health_check:
         id: "{{ health_check_id }}"
         port: 8888
       register: update_result
       check_mode: true
-    
-    - name: 'Check result - Update Health Check Port - check_mode'
-      assert:
+
+    - name: Check result - Update Health Check Port - check_mode
+      ansible.builtin.assert:
         that:
           - update_result is not failed
           - update_result is changed
           - '"route53:UpdateHealthCheck" not in update_result.resource_actions'
-    
-    - name: 'Update Health Check by ID - Update Port'
-      route53_health_check:
+
+    - name: Update Health Check by ID - Update Port
+      amazon.aws.route53_health_check:
         id: "{{ health_check_id }}"
         port: 8888
       register: update_result
@@ -58,62 +58,61 @@
         health_check_method: details
       register: health_check_info
 
-    - name: 'Check result - Update Health Check Port'
-      assert:
+    - name: Check result - Update Health Check Port
+      ansible.builtin.assert:
         that:
           - update_result is not failed
           - update_result is changed
           - health_check_info.HealthCheck.HealthCheckConfig.Port == 8888
 
-
-    - name: 'Update Health Check by ID - Update Port - idempotency - check_mode'
-      route53_health_check:
+    - name: Update Health Check by ID - Update Port - idempotency - check_mode
+      amazon.aws.route53_health_check:
         id: "{{ health_check_id }}"
         port: 8888
       register: update_result
       check_mode: true
 
-    - name: 'Check result - Update Health Check Port - idempotency - check_mode'
-      assert:
+    - name: Check result - Update Health Check Port - idempotency - check_mode
+      ansible.builtin.assert:
         that:
           - update_result is not failed
           - update_result is not changed
           - '"route53:UpdateHealthCheck" not in update_result.resource_actions'
 
-    - name: 'Update Health Check by ID - Update Port - idempotency'
-      route53_health_check:
+    - name: Update Health Check by ID - Update Port - idempotency
+      amazon.aws.route53_health_check:
         id: "{{ health_check_id }}"
         port: 8888
       register: update_result
-    
-    - name: 'Check result - Update Health Check Port - idempotency'
-      assert:
+
+    - name: Check result - Update Health Check Port - idempotency
+      ansible.builtin.assert:
         that:
           - update_result is not failed
           - update_result is not changed
           - '"route53:UpdateHealthCheck" not in update_result.resource_actions'
 
     ##
-    - name: 'Update Health Check by ID - Update IP address and FQDN - check_mode'
-      route53_health_check:
+    - name: Update Health Check by ID - Update IP address and FQDN - check_mode
+      amazon.aws.route53_health_check:
         id: "{{ health_check_id }}"
         ip_address: 1.2.3.4
-        fqdn: '{{ fqdn_1 }}'
+        fqdn: "{{ fqdn_1 }}"
       register: update_result
       check_mode: true
-    
-    - name: 'Check result - Update Health Check IP address and FQDN - check_mode'
-      assert:
+
+    - name: Check result - Update Health Check IP address and FQDN - check_mode
+      ansible.builtin.assert:
         that:
           - update_result is not failed
           - update_result is changed
           - '"route53:UpdateHealthCheck" not in update_result.resource_actions'
-    
-    - name: 'Update Health Check by ID - Update IP address and FQDN'
-      route53_health_check:
+
+    - name: Update Health Check by ID - Update IP address and FQDN
+      amazon.aws.route53_health_check:
         id: "{{ health_check_id }}"
         ip_address: 1.2.3.4
-        fqdn: '{{ fqdn_1 }}'
+        fqdn: "{{ fqdn_1 }}"
       register: update_result
 
     - name: Get health_check info
@@ -123,39 +122,38 @@
         health_check_method: details
       register: health_check_info
 
-    - name: 'Check result - Update Health Check IP address and FQDN'
-      assert:
+    - name: Check result - Update Health Check IP address and FQDN
+      ansible.builtin.assert:
         that:
           - update_result is not failed
           - update_result is changed
           - health_check_info.HealthCheck.HealthCheckConfig.IPAddress == '1.2.3.4'
           - health_check_info.HealthCheck.HealthCheckConfig.FullyQualifiedDomainName == fqdn_1
 
-
-    - name: 'Update Health Check by ID - Update IP address and FQDN - idempotency - check_mode'
-      route53_health_check:
+    - name: Update Health Check by ID - Update IP address and FQDN - idempotency - check_mode
+      amazon.aws.route53_health_check:
         id: "{{ health_check_id }}"
         ip_address: 1.2.3.4
-        fqdn: '{{ fqdn_1 }}'
+        fqdn: "{{ fqdn_1 }}"
       register: update_result
       check_mode: true
 
-    - name: 'Check result - Update Health Check IP address and FQDN - idempotency - check_mode'
-      assert:
+    - name: Check result - Update Health Check IP address and FQDN - idempotency - check_mode
+      ansible.builtin.assert:
         that:
           - update_result is not failed
           - update_result is not changed
           - '"route53:UpdateHealthCheck" not in update_result.resource_actions'
 
-    - name: 'Update Health Check by ID - Update IP address and FQDN - idempotency'
-      route53_health_check:
+    - name: Update Health Check by ID - Update IP address and FQDN - idempotency
+      amazon.aws.route53_health_check:
         id: "{{ health_check_id }}"
         ip_address: 1.2.3.4
-        fqdn: '{{ fqdn_1 }}'
+        fqdn: "{{ fqdn_1 }}"
       register: update_result
-    
-    - name: 'Check result - Update Health Check IP address and FQDN - idempotency'
-      assert:
+
+    - name: Check result - Update Health Check IP address and FQDN - idempotency
+      ansible.builtin.assert:
         that:
           - update_result is not failed
           - update_result is not changed
@@ -163,31 +161,31 @@
 
     # Update Health Check (Port) by name
 
-    - name: 'Update Health Check by name - Update Port - check_mode'
-      route53_health_check:
+    - name: Update Health Check by name - Update Port - check_mode
+      amazon.aws.route53_health_check:
         state: present
         port: 8080
-        type: '{{ type_http }}'
-        fqdn: '{{ fqdn }}'
-        health_check_name: '{{ tiny_prefix }}-test-update-delete-by-id'
+        type: "{{ type_http }}"
+        fqdn: "{{ fqdn }}"
+        health_check_name: "{{ tiny_prefix }}-test-update-delete-by-id"
         use_unique_names: true
       register: update_result
       check_mode: true
 
-    - name: 'Check result - Update Health Check Port - check_mode'
-      assert:
+    - name: Check result - Update Health Check Port - check_mode
+      ansible.builtin.assert:
         that:
           - update_result is not failed
           - update_result is changed
           - '"route53:UpdateHealthCheck" not in update_result.resource_actions'
 
-    - name: 'Update Health Check by name - Update Port'
-      route53_health_check:
+    - name: Update Health Check by name - Update Port
+      amazon.aws.route53_health_check:
         state: present
         port: 8080
-        type: '{{ type_http }}'
-        fqdn: '{{ fqdn }}'
-        health_check_name: '{{ tiny_prefix }}-test-update-delete-by-id'
+        type: "{{ type_http }}"
+        fqdn: "{{ fqdn }}"
+        health_check_name: "{{ tiny_prefix }}-test-update-delete-by-id"
         use_unique_names: true
       register: update_result
 
@@ -198,43 +196,43 @@
         health_check_method: details
       register: health_check_info
 
-    - name: 'Check result - Update Health Check Port'
-      assert:
+    - name: Check result - Update Health Check Port
+      ansible.builtin.assert:
         that:
           - update_result is not failed
           - update_result is changed
           - health_check_info.HealthCheck.HealthCheckConfig.Port == 8080
 
-    - name: 'Update Health Check by name - Update Port - idempotency - check_mode'
-      route53_health_check:
+    - name: Update Health Check by name - Update Port - idempotency - check_mode
+      amazon.aws.route53_health_check:
         state: present
         port: 8080
-        type: '{{ type_http }}'
-        fqdn: '{{ fqdn }}'
-        health_check_name: '{{ tiny_prefix }}-test-update-delete-by-id'
+        type: "{{ type_http }}"
+        fqdn: "{{ fqdn }}"
+        health_check_name: "{{ tiny_prefix }}-test-update-delete-by-id"
         use_unique_names: true
       register: update_result
       check_mode: true
 
-    - name: 'Check result - Update Health Check Port - idempotency - check_mode'
-      assert:
+    - name: Check result - Update Health Check Port - idempotency - check_mode
+      ansible.builtin.assert:
         that:
           - update_result is not failed
           - update_result is not changed
           - '"route53:UpdateHealthCheck" not in update_result.resource_actions'
 
-    - name: 'Update Health Check by name - Update Port - idempotency'
-      route53_health_check:
+    - name: Update Health Check by name - Update Port - idempotency
+      amazon.aws.route53_health_check:
         state: present
         port: 8080
-        type: '{{ type_http }}'
-        fqdn: '{{ fqdn }}'
-        health_check_name: '{{ tiny_prefix }}-test-update-delete-by-id'
+        type: "{{ type_http }}"
+        fqdn: "{{ fqdn }}"
+        health_check_name: "{{ tiny_prefix }}-test-update-delete-by-id"
         use_unique_names: true
       register: update_result
 
-    - name: 'Check result - Update Health Check Port - idempotency'
-      assert:
+    - name: Check result - Update Health Check Port - idempotency
+      ansible.builtin.assert:
         that:
           - update_result is not failed
           - update_result is not changed
@@ -242,54 +240,54 @@
 
     # Delete Health Check by ID Tests
     - name: Delete Health check by ID - check_mode
-      route53_health_check:
+      amazon.aws.route53_health_check:
         state: absent
         id: "{{ health_check_id }}"
       register: delete_result
       check_mode: true
 
-    - name: 'Check result - Delete Health Check by ID -check_mode'
-      assert:
+    - name: Check result - Delete Health Check by ID -check_mode
+      ansible.builtin.assert:
         that:
           - delete_result is not failed
           - delete_result is changed
           - '"route53:DeleteHealthCheck" not in delete_result.resource_actions'
 
     - name: Delete Health check by ID
-      route53_health_check:
+      amazon.aws.route53_health_check:
         state: absent
         id: "{{ health_check_id }}"
       register: delete_result
 
-    - name: 'Check result - Delete Health Check by ID'
-      assert:
+    - name: Check result - Delete Health Check by ID
+      ansible.builtin.assert:
         that:
           - delete_result is not failed
           - delete_result is changed
           - '"route53:DeleteHealthCheck" in delete_result.resource_actions'
 
     - name: Delete Health check by ID - idempotency - check_mode
-      route53_health_check:
+      amazon.aws.route53_health_check:
         state: absent
         id: "{{ health_check_id }}"
       register: delete_result
       check_mode: true
 
-    - name: 'Check result - Delete Health Check by ID -idempotency -check_mode'
-      assert:
+    - name: Check result - Delete Health Check by ID -idempotency -check_mode
+      ansible.builtin.assert:
         that:
           - delete_result is not failed
           - delete_result is not changed
           - '"route53:DeleteHealthCheck" not in delete_result.resource_actions'
 
     - name: Delete Health check by ID - idempotency
-      route53_health_check:
+      amazon.aws.route53_health_check:
         state: absent
         id: "{{ health_check_id }}"
       register: delete_result
 
-    - name: 'Check result - Delete Health Check by ID -idempotency'
-      assert:
+    - name: Check result - Delete Health Check by ID -idempotency
+      ansible.builtin.assert:
         that:
           - delete_result is not failed
           - delete_result is not changed
@@ -298,6 +296,6 @@
   # cleanup
   always:
     - name: Delete Health check by ID
-      route53_health_check:
+      amazon.aws.route53_health_check:
         state: absent
         id: "{{ health_check_id }}"

--- a/tests/integration/targets/route53_zone/meta/main.yml
+++ b/tests/integration/targets/route53_zone/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/route53_zone/tasks/main.yml
+++ b/tests/integration/targets/route53_zone/tasks/main.yml
@@ -1,19 +1,18 @@
 ---
-- name: 'route53_zone integration tests'
+- name: route53_zone integration tests
   collections:
     - amazon.aws
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-
     # ============================================================
 
     - name: Create VPC for use in testing
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         name: "{{ resource_prefix }}-vpc"
         cidr_block: 10.22.32.0/23
         tags:
@@ -23,7 +22,7 @@
 
     # ============================================================
     - name: Create a public zone
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.public"
         comment: original comment
         state: present
@@ -32,7 +31,7 @@
           another_tag: "{{ resource_prefix }} again"
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.comment == 'original comment'
@@ -43,7 +42,7 @@
 
     # ============================================================
     - name: Create a public zone (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.check.public"
         comment: original comment
         state: present
@@ -51,9 +50,9 @@
           TestTag: "{{ resource_prefix }}"
           another_tag: "{{ resource_prefix }} again"
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.comment == 'original comment'
@@ -64,7 +63,7 @@
 
     # ============================================================
     - name: Do an idemptotent update of a public zone
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.public"
         comment: original comment
         state: present
@@ -73,7 +72,7 @@
           another_tag: "{{ resource_prefix }} again"
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
           - output.comment == 'original comment'
@@ -83,7 +82,7 @@
           - not output.private_zone
 
     - name: Do an idemptotent update of a public zone (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.public"
         comment: original comment
         state: present
@@ -91,9 +90,9 @@
           TestTag: "{{ resource_prefix }}"
           another_tag: "{{ resource_prefix }} again"
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
           - output.comment == 'original comment'
@@ -104,7 +103,7 @@
 
     # ============================================================
     - name: Modify tags on a public zone
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.public"
         comment: original comment
         state: present
@@ -113,7 +112,7 @@
         purge_tags: true
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - "'TestTag' not in output.tags"
@@ -121,7 +120,7 @@
 
     # ============================================================
     - name: Update comment and remove tags of a public zone
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.public"
         comment: updated comment
         state: present
@@ -129,23 +128,23 @@
         tags: {}
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.result.comment == "updated comment"
           - not output.tags
 
     - name: Update comment and remove tags of a public zone (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.public"
         comment: updated comment for check
         state: present
         purge_tags: true
         tags: {}
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.result.comment == "updated comment for check"
@@ -153,45 +152,45 @@
 
     # ============================================================
     - name: Delete public zone (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.public"
         state: absent
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - "'Successfully deleted' in output.result"
 
     - name: Delete public zone
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.public"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - "'Successfully deleted' in output.result"
 
     # ============================================================
     - name: Create a private zone (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         vpc_region: "{{ aws_region }}"
         zone: "{{ resource_prefix }}.private"
         comment: original comment
         state: present
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
 
     - name: Create a private zone
-      route53_zone:
+      amazon.aws.route53_zone:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         vpc_region: "{{ aws_region }}"
         zone: "{{ resource_prefix }}.private"
@@ -199,12 +198,12 @@
         state: present
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
     # ============================================================
     - name: Idemptotent update a private zone
-      route53_zone:
+      amazon.aws.route53_zone:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         vpc_region: "{{ aws_region }}"
         zone: "{{ resource_prefix }}.private"
@@ -212,29 +211,29 @@
         state: present
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
           - "'There is already a private hosted zone in the same region with the same VPC' in output.msg"
 
     - name: Idemptotent update a private zone (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         vpc_region: "{{ aws_region }}"
         zone: "{{ resource_prefix }}.private"
         comment: original comment
         state: present
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
           - "'There is already a private hosted zone in the same region with the same VPC' in output.msg"
 
     # ============================================================
     - name: Update private zone comment
-      route53_zone:
+      amazon.aws.route53_zone:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         vpc_region: "{{ aws_region }}"
         zone: "{{ resource_prefix }}.private"
@@ -242,107 +241,107 @@
         state: present
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.result.comment == "updated_comment"
 
     - name: Update private zone comment (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         vpc_region: "{{ aws_region }}"
         zone: "{{ resource_prefix }}.private"
         comment: updated_comment check
         state: present
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.result.comment == "updated_comment check"
 
     # ============================================================
     - name: Try to delete private zone without setting vpc_id and vpc_region
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.private"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
-          - "output.result == 'No zone to delete.'"
+          - output.result == 'No zone to delete.'
 
     - name: Try to delete private zone without setting vpc_id and vpc_region (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.private"
         state: absent
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
-          - "output.result == 'No zone to delete.'"
+          - output.result == 'No zone to delete.'
 
     # ============================================================
     - name: Try to delete a public zone that does not exists
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.publicfake"
         comment: original comment
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
-          - "output.result == 'No zone to delete.'"
+          - output.result == 'No zone to delete.'
 
     - name: Try to delete a public zone that does not exists (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.publicfake"
         comment: original comment
         state: absent
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
-          - "output.result == 'No zone to delete.'"
+          - output.result == 'No zone to delete.'
 
     # ============================================================
     - name: Delete private zone (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         vpc_region: "{{ aws_region }}"
         zone: "{{ resource_prefix }}.private"
         state: absent
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - "'Successfully deleted' in output.result"
 
     - name: Delete private zone
-      route53_zone:
+      amazon.aws.route53_zone:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         vpc_region: "{{ aws_region }}"
         zone: "{{ resource_prefix }}.private"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - "'Successfully deleted' in output.result"
 
     # ============================================================
     - name: Create a private zone (new format) (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         vpcs:
           - id: "{{ testing_vpc.vpc.id }}"
             region: "{{ aws_region }}"
@@ -350,14 +349,14 @@
         comment: original comment
         state: present
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
 
     - name: Create a private zone (new format)
-      route53_zone:
+      amazon.aws.route53_zone:
         vpcs:
           - id: "{{ testing_vpc.vpc.id }}"
             region: "{{ aws_region }}"
@@ -366,13 +365,13 @@
         state: present
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
 
     # ============================================================
     - name: Idemptotent update a private zone (new format) (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         vpcs:
           - id: "{{ testing_vpc.vpc.id }}"
             region: "{{ aws_region }}"
@@ -380,15 +379,15 @@
         comment: original comment
         state: present
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
           - "'There is already a private hosted zone in the same region with the same VPC' in output.msg"
 
     - name: Idemptotent update a private zone (new format)
-      route53_zone:
+      amazon.aws.route53_zone:
         vpcs:
           - id: "{{ testing_vpc.vpc.id }}"
             region: "{{ aws_region }}"
@@ -397,14 +396,14 @@
         state: present
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
           - "'There is already a private hosted zone in the same region with the same VPC' in output.msg"
 
     # ============================================================
     - name: Update a private zone comment (new format) (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         vpcs:
           - id: "{{ testing_vpc.vpc.id }}"
             region: "{{ aws_region }}"
@@ -412,14 +411,14 @@
         comment: new comment
         state: present
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
 
     - name: Update a private zone comment (new format)
-      route53_zone:
+      amazon.aws.route53_zone:
         vpcs:
           - id: "{{ testing_vpc.vpc.id }}"
             region: "{{ aws_region }}"
@@ -428,28 +427,28 @@
         state: present
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
 
     # ============================================================
     - name: Delete private zone (new format) (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         vpcs:
           - id: "{{ testing_vpc.vpc.id }}"
             region: "{{ aws_region }}"
         zone: "{{ resource_prefix }}.private"
         state: absent
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - "'Successfully deleted' in output.result"
 
     - name: Delete private zone (new format)
-      route53_zone:
+      amazon.aws.route53_zone:
         vpcs:
           - id: "{{ testing_vpc.vpc.id }}"
             region: "{{ aws_region }}"
@@ -460,7 +459,7 @@
     # ============================================================
     - block:
         - name: Create second VPC for use in testing
-          ec2_vpc_net:
+          amazon.aws.ec2_vpc_net:
             name: "{{ resource_prefix }}-vpc2"
             cidr_block: 10.22.34.0/23
             tags:
@@ -469,7 +468,7 @@
           register: second_testing_vpc
 
         - name: Create a private zone with multiple VPCs (CHECK MODE)
-          route53_zone:
+          amazon.aws.route53_zone:
             vpcs:
               - id: "{{ testing_vpc.vpc.id }}"
                 region: "{{ aws_region }}"
@@ -479,14 +478,14 @@
             comment: original comment
             state: present
           register: output
-          check_mode: yes
+          check_mode: true
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - output.changed
 
         - name: Create a private zone with multiple VPCs
-          route53_zone:
+          amazon.aws.route53_zone:
             vpcs:
               - id: "{{ testing_vpc.vpc.id }}"
                 region: "{{ aws_region }}"
@@ -497,10 +496,10 @@
             state: present
           register: output
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - output.changed
-              - output.vpc_id == testing_vpc.vpc.id  # The first one for backwards compatibility
+              - output.vpc_id == testing_vpc.vpc.id # The first one for backwards compatibility
               - output.vpc_region == aws_region
               - (output.vpcs | length) == 2
               - output.vpcs.1.id == second_testing_vpc.vpc.id
@@ -508,7 +507,7 @@
 
         # ============================================================
         - name: Delete private zone with multiple VPCs (CHECK MODE)
-          route53_zone:
+          amazon.aws.route53_zone:
             vpcs:
               - id: "{{ testing_vpc.vpc.id }}"
                 region: "{{ aws_region }}"
@@ -517,15 +516,15 @@
             zone: "{{ resource_prefix }}.private"
             state: absent
           register: output
-          check_mode: yes
+          check_mode: true
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - output.changed
               - "'Successfully deleted' in output.result"
 
         - name: Delete private zone with multiple VPCs
-          route53_zone:
+          amazon.aws.route53_zone:
             vpcs:
               - id: "{{ testing_vpc.vpc.id }}"
                 region: "{{ aws_region }}"
@@ -535,21 +534,21 @@
             state: absent
           register: output
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - output.changed
               - "'Successfully deleted' in output.result"
 
       always:
         - name: Delete second VPC for use in testing
-          ec2_vpc_net:
+          amazon.aws.ec2_vpc_net:
             name: "{{ resource_prefix }}-vpc2"
             cidr_block: 10.22.34.0/23
             state: absent
 
     # ============================================================
     - name: Create a public zone
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.public2"
         comment: this is an example
         state: present
@@ -557,26 +556,26 @@
 
     # Delete zone using its id
     - name: Delete zone using attribute hosted_zone_id (CHECK MODE)
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.public2"
         hosted_zone_id: "{{new_zone.zone_id}}"
         state: absent
       register: output
-      check_mode: yes
+      check_mode: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - "'Successfully deleted' in output.result"
 
     - name: Delete zone using attribute hosted_zone_id
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.public2"
         hosted_zone_id: "{{new_zone.zone_id}}"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - "'Successfully deleted' in output.result"
@@ -584,34 +583,34 @@
   # ============================================================
   always:
     - name: Ensure public zone is deleted
-      route53_zone:
+      amazon.aws.route53_zone:
         zone: "{{ item }}"
         state: absent
       register: removed
       until: removed is not failed
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10
       with_items:
         - "{{ resource_prefix }}.public"
         - "{{ resource_prefix }}.public2"
 
     - name: Ensure private zone is deleted
-      route53_zone:
+      amazon.aws.route53_zone:
         vpc_id: "{{ testing_vpc.vpc.id }}"
         vpc_region: "{{ aws_region }}"
         zone: "{{ resource_prefix }}.private"
         state: absent
       register: removed
       until: removed is not failed
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10
 
     - name: remove the VPC
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         name: "{{ resource_prefix }}-vpc"
         cidr_block: 10.22.32.0/23
         state: absent
       register: removed
       until: removed is not failed
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10

--- a/tests/integration/targets/s3_bucket/main.yml
+++ b/tests/integration/targets/s3_bucket/main.yml
@@ -5,7 +5,7 @@
 
 # VPC should get cleaned up once all hosts have run
 - hosts: all
-  gather_facts: no
+  gather_facts: false
   strategy: free
   #serial: 10
   roles:

--- a/tests/integration/targets/s3_bucket/meta/main.yml
+++ b/tests/integration/targets/s3_bucket/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/defaults/main.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/defaults/main.yml
@@ -1,2 +1,2 @@
 ---
-bucket_name: '{{ resource_prefix }}'
+bucket_name: "{{ resource_prefix }}"

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/meta/main.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/acl.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/acl.yml
@@ -6,12 +6,12 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - set_fact:
+    - ansible.builtin.set_fact:
         local_bucket_name: "{{ bucket_name | hash('md5')}}acl"
 
-    - name: 'Create a simple bucket'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Create a simple bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         object_ownership: BucketOwnerPreferred
         public_access:
           block_public_acls: true
@@ -19,32 +19,32 @@
           ignore_public_acls: true
           restrict_public_buckets: true
 
-    - name: 'Update bucket ACL, new value = private'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Update bucket ACL, new value = private
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         acl: private
         state: present
       register: private_acl
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - private_acl.changed
 
-    - name: 'Update bucket ACL, new value = public-read'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Update bucket ACL, new value = public-read
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         acl: public-read
         state: present
       ignore_errors: true
       register: public_read_acl
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - public_read_acl is failed
 
-    - name: 'Update bucket ACL, new value = public-read'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Update bucket ACL, new value = public-read
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         acl: public-read
         state: present
         public_access:
@@ -55,14 +55,14 @@
       ignore_errors: true
       register: public_read_acl
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - public_read_acl.changed
 
   # ============================================================
   always:
     - name: Ensure all buckets are deleted
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/complex.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/complex.yml
@@ -1,14 +1,14 @@
 ---
 - block:
-    - set_fact:
+    - ansible.builtin.set_fact:
         local_bucket_name: "{{ bucket_name | hash('md5')}}complex"
-    - name: 'Create more complex s3_bucket'
-      s3_bucket:
+    - name: Create more complex s3_bucket
+      amazon.aws.s3_bucket:
         name: "{{ local_bucket_name }}"
         state: present
         policy: "{{ lookup('template','policy.json') }}"
-        requester_pays: yes
-        versioning: yes
+        requester_pays: true
+        versioning: true
         public_access:
           block_public_acls: false
         tags:
@@ -16,7 +16,7 @@
           another: tag2
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is changed
           - output.name == '{{ local_bucket_name }}'
@@ -33,24 +33,24 @@
 
     # ============================================================
 
-    - name: 'Pause to help with s3 bucket eventual consistency'
-      wait_for:
+    - name: Pause to help with s3 bucket eventual consistency
+      ansible.builtin.wait_for:
         timeout: 10
       delegate_to: localhost
 
-    - name: 'Try to update the same complex s3_bucket'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Try to update the same complex s3_bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         policy: "{{ lookup('template','policy.json') }}"
-        requester_pays: yes
-        versioning: yes
+        requester_pays: true
+        versioning: true
         tags:
           example: tag1
           another: tag2
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is not changed
           - output.name == '{{ local_bucket_name }}'
@@ -66,19 +66,19 @@
           - output.policy.Statement[0].Sid == 'AddPerm'
 
     # ============================================================
-    - name: 'Update bucket policy on complex bucket'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Update bucket policy on complex bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         policy: "{{ lookup('template','policy-updated.json') }}"
-        requester_pays: yes
-        versioning: yes
+        requester_pays: true
+        versioning: true
         tags:
           example: tag1
           another: tag2
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is changed
           - output.policy.Statement[0].Action == 's3:GetObject'
@@ -89,24 +89,24 @@
 
     # ============================================================
 
-    - name: 'Pause to help with s3 bucket eventual consistency'
-      wait_for:
+    - name: Pause to help with s3 bucket eventual consistency
+      ansible.builtin.wait_for:
         timeout: 10
       delegate_to: localhost
 
     - name: Update attributes for s3_bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         policy: "{{ lookup('template','policy.json') }}"
-        requester_pays: no
-        versioning: no
+        requester_pays: false
+        versioning: false
         tags:
           example: tag1-udpated
           another: tag2
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is changed
           - output.name == '{{ local_bucket_name }}'
@@ -121,30 +121,30 @@
           - output.policy.Statement[0].Resource == 'arn:aws:s3:::{{ local_bucket_name }}/*'
           - output.policy.Statement[0].Sid == 'AddPerm'
 
-    - name: 'Delete complex test bucket'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Delete complex test bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is changed
 
-    - name: 'Re-delete complex test bucket'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Re-delete complex test bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is not changed
 
   # ============================================================
   always:
-    - name: 'Ensure all buckets are deleted'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Ensure all buckets are deleted
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/dotted.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/dotted.yml
@@ -1,55 +1,53 @@
 ---
 - block:
-    - name: 'Ensure bucket_name contains a .'
-      set_fact:
+    - name: Ensure bucket_name contains a .
+      ansible.builtin.set_fact:
         local_bucket_name: "{{ bucket_name | hash('md5')}}.dotted"
-
 
     # ============================================================
     #
-    - name: 'Create bucket with dot in name'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Create bucket with dot in name
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is changed
           - output.name == '{{ local_bucket_name }}'
 
-
     # ============================================================
 
-    - name: 'Pause to help with s3 bucket eventual consistency'
-      wait_for:
+    - name: Pause to help with s3 bucket eventual consistency
+      ansible.builtin.wait_for:
         timeout: 10
       delegate_to: localhost
 
-    - name: 'Delete s3_bucket with dot in name'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Delete s3_bucket with dot in name
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is changed
 
-    - name: 'Re-delete s3_bucket with dot in name'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Re-delete s3_bucket with dot in name
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is not changed
 
   # ============================================================
   always:
-    - name: 'Ensure all buckets are deleted'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Ensure all buckets are deleted
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_bucket_key.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_bucket_key.yml
@@ -7,46 +7,46 @@
       region: "{{ aws_region }}"
   block:
     - name: Set facts for encryption_bucket_key test
-      set_fact:
+      ansible.builtin.set_fact:
         local_bucket_name: "{{ bucket_name | hash('md5') }}-bucket-key"
     # ============================================================
 
-    - name: "Create a simple bucket"
-      s3_bucket:
+    - name: Create a simple bucket
+      amazon.aws.s3_bucket:
         name: "{{ local_bucket_name }}"
         state: present
       register: output
 
-    - name: "Enable aws:kms encryption with KMS master key"
-      s3_bucket:
+    - name: Enable aws:kms encryption with KMS master key
+      amazon.aws.s3_bucket:
         name: "{{ local_bucket_name }}"
         state: present
-        encryption: "aws:kms"
+        encryption: aws:kms
       register: output
 
-    - name: "Enable bucket key for bucket with aws:kms encryption"
-      s3_bucket:
+    - name: Enable bucket key for bucket with aws:kms encryption
+      amazon.aws.s3_bucket:
         name: "{{ local_bucket_name }}"
         state: present
-        encryption: "aws:kms"
+        encryption: aws:kms
         bucket_key_enabled: true
       register: output
 
-    - name: "Assert for 'Enable bucket key for bucket with aws:kms encryption'"
-      assert:
+    - name: Assert for 'Enable bucket key for bucket with aws:kms encryption'
+      ansible.builtin.assert:
         that:
           - output.changed
           - output.encryption
 
-    - name: "Re-enable bucket key for bucket with aws:kms encryption (idempotent)"
-      s3_bucket:
+    - name: Re-enable bucket key for bucket with aws:kms encryption (idempotent)
+      amazon.aws.s3_bucket:
         name: "{{ local_bucket_name }}"
-        encryption: "aws:kms"
+        encryption: aws:kms
         bucket_key_enabled: true
       register: output
 
-    - name: "Assert for 'Re-enable bucket key for bucket with aws:kms encryption (idempotent)'"
-      assert:
+    - name: Assert for 'Re-enable bucket key for bucket with aws:kms encryption (idempotent)'
+      ansible.builtin.assert:
         that:
           - not output.changed
           - output.encryption
@@ -84,20 +84,20 @@
     ## # ============================================================
 
     - name: Delete encryption test s3 bucket
-      s3_bucket:
+      amazon.aws.s3_bucket:
         name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
     - name: Assert for 'Delete encryption test s3 bucket'
-      assert:
+      ansible.builtin.assert:
         that:
           - output.changed
 
   # ============================================================
   always:
     - name: Ensure all buckets are deleted
-      s3_bucket:
+      amazon.aws.s3_bucket:
         name: "{{ local_bucket_name }}"
         state: absent
       failed_when: false

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_kms.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_kms.yml
@@ -6,37 +6,37 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - set_fact:
+    - ansible.builtin.set_fact:
         local_bucket_name: "{{ bucket_name | hash('md5')}}e-kms"
     # ============================================================
 
-    - name: 'Create a simple bucket'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Create a simple bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
       register: output
 
-    - name: 'Enable aws:kms encryption with KMS master key'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Enable aws:kms encryption with KMS master key
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
-        encryption: "aws:kms"
+        encryption: aws:kms
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.encryption
           - output.encryption.SSEAlgorithm == 'aws:kms'
 
-    - name: 'Re-enable aws:kms encryption with KMS master key (idempotent)'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Re-enable aws:kms encryption with KMS master key (idempotent)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
-        encryption: "aws:kms"
+        encryption: aws:kms
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
           - output.encryption
@@ -74,19 +74,19 @@
     ## # ============================================================
 
     - name: Delete encryption test s3 bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
 
   # ============================================================
   always:
     - name: Ensure all buckets are deleted
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_sse.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_sse.yml
@@ -6,38 +6,38 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - set_fact:
+    - ansible.builtin.set_fact:
         local_bucket_name: "{{ bucket_name | hash('md5')}}e-sse"
     # ============================================================
 
-    - name: 'Create a simple bucket'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Create a simple bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
       register: output
 
-    - name: 'Enable AES256 encryption'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Enable AES256 encryption
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
-        encryption: 'AES256'
+        encryption: AES256
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           # SSE is now enabled by default
           # - output.changed
           - output.encryption
           - output.encryption.SSEAlgorithm == 'AES256'
 
-    - name: 'Re-enable AES256 encryption (idempotency)'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Re-enable AES256 encryption (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
-        encryption: 'AES256'
+        encryption: AES256
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
           - output.encryption
@@ -75,19 +75,19 @@
     ## # ============================================================
 
     - name: Delete encryption test s3 bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
 
   # ============================================================
   always:
     - name: Ensure all buckets are deleted
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/main.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/main.yml
@@ -5,7 +5,7 @@
 #
 # ###############################################################################
 
-- name: "Wrap up all tests and setup AWS credentials"
+- name: Wrap up all tests and setup AWS credentials
   module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -13,8 +13,8 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - debug:
+    - ansible.builtin.debug:
         msg: "{{ inventory_hostname }} start: {{ lookup('pipe','date') }}"
-    - include_tasks: '{{ inventory_hostname }}.yml'
-    - debug:
+    - ansible.builtin.include_tasks: "{{ inventory_hostname }}.yml"
+    - ansible.builtin.debug:
         msg: "{{ inventory_hostname }} finish: {{ lookup('pipe','date') }}"

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/missing.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/missing.yml
@@ -1,28 +1,28 @@
 ---
-- name: 'Attempt to delete non-existent buckets'
+- name: Attempt to delete non-existent buckets
   block:
-    - set_fact:
+    - ansible.builtin.set_fact:
         local_bucket_name: "{{ bucket_name | hash('md5')}}-missing"
     # ============================================================
     #
     # While in theory the 'simple' test case covers this there are
     # ways in which eventual-consistency could catch us out.
     #
-    - name: 'Delete non-existstent s3_bucket (never created)'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Delete non-existstent s3_bucket (never created)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is success
           - output is not changed
 
   # ============================================================
   always:
-    - name: 'Ensure all buckets are deleted'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Ensure all buckets are deleted
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/object_lock.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/object_lock.yml
@@ -6,126 +6,126 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - set_fact:
+    - ansible.builtin.set_fact:
         local_bucket_name: "{{ bucket_name | hash('md5')}}-objectlock"
 
     # ============================================================
 
-    - name: 'Create a simple bucket'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Create a simple bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - not output.object_lock_enabled
 
-    - name: 'Re-disable object lock (idempotency)'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Re-disable object lock (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         object_lock_enabled: false
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
           - not output.object_lock_enabled
 
-    - name: 'Enable object lock'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Enable object lock
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         object_lock_enabled: true
       register: output
       ignore_errors: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is failed
 
     - name: Delete test s3 bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
 
     # ============================================================
 
-    - name: 'Create a bucket with object lock enabled'
-      s3_bucket:
-        name: '{{ local_bucket_name }}-2'
+    - name: Create a bucket with object lock enabled
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
         state: present
         object_lock_enabled: true
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.object_lock_enabled
 
-    - name: 'Disable object lock'
-      s3_bucket:
-        name: '{{ local_bucket_name }}-2'
+    - name: Disable object lock
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
         state: present
         object_lock_enabled: false
       register: output
       ignore_errors: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is failed
 
-    - name: 'Re-Enable object lock (idempotency)'
-      s3_bucket:
-        name: '{{ local_bucket_name }}-2'
+    - name: Re-Enable object lock (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
         state: present
         object_lock_enabled: true
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
           - output.object_lock_enabled
 
-    - name: 'Touch bucket with object lock enabled (idempotency)'
-      s3_bucket:
-        name: '{{ local_bucket_name }}-2'
+    - name: Touch bucket with object lock enabled (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
         state: present
         object_lock_enabled: true
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
           - output.object_lock_enabled
 
     - name: Delete test s3 bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}-2'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
 
   # ============================================================
   always:
     - name: Ensure all buckets are deleted
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Ensure all buckets are deleted
-      s3_bucket:
-        name: '{{ local_bucket_name }}-2'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/ownership_controls.yml
@@ -6,123 +6,123 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - set_fact:
+    - ansible.builtin.set_fact:
         local_bucket_name: "{{ bucket_name | hash('md5')}}ownership"
 
-    - name: 'Create a simple bucket bad value for ownership controls'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Create a simple bucket bad value for ownership controls
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         object_ownership: default
       ignore_errors: true
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.failed
 
-    - name: 'Create bucket with object_ownership set to object_writer'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Create bucket with object_ownership set to object_writer
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
       ignore_errors: true
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - not output.object_ownership|bool
 
     - name: delete s3 bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
 
-    - name: 'create s3 bucket with object ownership controls'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: create s3 bucket with object ownership controls
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         object_ownership: ObjectWriter
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.object_ownership
           - output.object_ownership == 'ObjectWriter'
 
-    - name: 'update s3 bucket ownership preferred controls'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: update s3 bucket ownership preferred controls
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         object_ownership: BucketOwnerPreferred
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.object_ownership
           - output.object_ownership == 'BucketOwnerPreferred'
 
-    - name: 'test idempotency update s3 bucket ownership preferred controls'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: test idempotency update s3 bucket ownership preferred controls
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         object_ownership: BucketOwnerPreferred
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed is false
           - output.object_ownership
           - output.object_ownership == 'BucketOwnerPreferred'
 
-    - name: 'update s3 bucket ownership enforced controls'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: update s3 bucket ownership enforced controls
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         object_ownership: BucketOwnerEnforced
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.object_ownership
           - output.object_ownership == 'BucketOwnerEnforced'
 
-    - name: 'test idempotency update s3 bucket ownership preferred controls'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: test idempotency update s3 bucket ownership preferred controls
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         object_ownership: BucketOwnerEnforced
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed is false
           - output.object_ownership
           - output.object_ownership == 'BucketOwnerEnforced'
 
-    - name: 'delete s3 bucket ownership controls'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: delete s3 bucket ownership controls
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         delete_object_ownership: true
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - not output.object_ownership|bool
 
-    - name: 'delete s3 bucket ownership controls once again (idempotency)'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: delete s3 bucket ownership controls once again (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         delete_object_ownership: true
       register: idempotency
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not idempotency.changed
           - not idempotency.object_ownership|bool
@@ -130,14 +130,14 @@
   # ============================================================
   always:
     - name: delete s3 bucket ownership controls
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         delete_object_ownership: true
-      ignore_errors: yes
+      ignore_errors: true
 
     - name: Ensure all buckets are deleted
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/public_access.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/public_access.yml
@@ -6,13 +6,13 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - set_fact:
+    - ansible.builtin.set_fact:
         local_bucket_name: "{{ bucket_name | hash('md5')}}-public"
     # ============================================================
 
-    - name: 'Create a simple bucket with public access block configuration'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Create a simple bucket with public access block configuration
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         public_access:
           block_public_acls: true
@@ -21,7 +21,7 @@
           restrict_public_buckets: true
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.public_access_block
@@ -30,9 +30,9 @@
           - output.public_access_block.IgnorePublicAcls
           - output.public_access_block.RestrictPublicBuckets
 
-    - name: 'Re-configure public access block configuration'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Re-configure public access block configuration
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         public_access:
           block_public_acls: true
@@ -41,7 +41,7 @@
           restrict_public_buckets: false
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.public_access_block
@@ -50,9 +50,9 @@
           - output.public_access_block.IgnorePublicAcls
           - not output.public_access_block.RestrictPublicBuckets
 
-    - name: 'Re-configure public access block configuration (idempotency)'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Re-configure public access block configuration (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         public_access:
           block_public_acls: true
@@ -61,7 +61,7 @@
           restrict_public_buckets: false
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is not changed
           - output.public_access_block
@@ -70,26 +70,26 @@
           - output.public_access_block.IgnorePublicAcls
           - not output.public_access_block.RestrictPublicBuckets
 
-    - name: 'Delete public access block configuration'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Delete public access block configuration
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         delete_public_access: true
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is changed
           - not output.public_access_block|bool
 
-    - name: 'Delete public access block configuration (idempotency)'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Delete public access block configuration (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         delete_public_access: true
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is not changed
           - not output.public_access_block|bool
@@ -97,19 +97,19 @@
     # ============================================================
 
     - name: Delete testing s3 bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
 
   # ============================================================
   always:
     - name: Ensure all buckets are deleted
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/simple.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/simple.yml
@@ -1,18 +1,18 @@
 ---
-- name: 'Run simple tests'
+- name: Run simple tests
   block:
-    - set_fact:
+    - ansible.builtin.set_fact:
         local_bucket_name: "{{ bucket_name | hash('md5')}}-simple"
     # Note: s3_bucket doesn't support check_mode
 
     # ============================================================
-    - name: 'Create a simple s3_bucket'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Create a simple s3_bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is success
           - output is changed
@@ -21,13 +21,13 @@
           - output.public_access is undefined
 
     # ============================================================
-    - name: 'Try to update the simple bucket with the same values'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Try to update the simple bucket with the same values
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is success
           - output is not changed
@@ -35,33 +35,33 @@
           - not output.requester_pays
 
     # ============================================================
-    - name: 'Delete the simple s3_bucket'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Delete the simple s3_bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is success
           - output is changed
 
     # ============================================================
-    - name: 'Re-delete the simple s3_bucket (idempotency)'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Re-delete the simple s3_bucket (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is success
           - output is not changed
 
   # ============================================================
   always:
-    - name: 'Ensure all buckets are deleted'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Ensure all buckets are deleted
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/tags.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/tags.yml
@@ -1,48 +1,48 @@
 ---
-- name: 'Run tagging tests'
+- name: Run tagging tests
   block:
-    - set_fact:
+    - ansible.builtin.set_fact:
         local_bucket_name: "{{ bucket_name | hash('md5')}}-tags"
     # ============================================================
-    - name: 'Create simple s3_bucket for testing tagging'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Create simple s3_bucket for testing tagging
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.name == '{{ local_bucket_name }}'
 
     # ============================================================
 
-    - name: 'Add tags to s3 bucket'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Add tags to s3 bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         tags:
           example: tag1
           another: tag2
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.name == '{{ local_bucket_name }}'
           - output.tags.example == 'tag1'
           - output.tags.another == 'tag2'
 
-    - name: 'Re-Add tags to s3 bucket'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Re-Add tags to s3 bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         tags:
           example: tag1
           another: tag2
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is not changed
           - output.name == '{{ local_bucket_name }}'
@@ -52,14 +52,14 @@
     # ============================================================
 
     - name: Remove a tag from an s3_bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         tags:
           example: tag1
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.name == '{{ local_bucket_name }}'
@@ -67,14 +67,14 @@
           - "'another' not in output.tags"
 
     - name: Re-remove the tag from an s3_bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         tags:
           example: tag1
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is not changed
           - output.name == '{{ local_bucket_name }}'
@@ -90,32 +90,32 @@
 
     ## ============================================================
 
-    - name: 'Add a tag for s3_bucket with purge_tags False'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Add a tag for s3_bucket with purge_tags False
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
-        purge_tags: no
+        purge_tags: false
         tags:
           anewtag: here
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.name == '{{ local_bucket_name }}'
           - output.tags.example == 'tag1'
           - output.tags.anewtag == 'here'
 
-    - name: 'Re-add a tag for s3_bucket with purge_tags False'
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+    - name: Re-add a tag for s3_bucket with purge_tags False
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
-        purge_tags: no
+        purge_tags: false
         tags:
           anewtag: here
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is not changed
           - output.name == '{{ local_bucket_name }}'
@@ -132,15 +132,15 @@
     ## ============================================================
 
     - name: Update a tag for s3_bucket with purge_tags False
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
-        purge_tags: no
+        purge_tags: false
         tags:
           anewtag: next
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.name == '{{ local_bucket_name }}'
@@ -148,15 +148,15 @@
           - output.tags.anewtag == 'next'
 
     - name: Re-update a tag for s3_bucket with purge_tags False
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
-        purge_tags: no
+        purge_tags: false
         tags:
           anewtag: next
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is not changed
           - output.name == '{{ local_bucket_name }}'
@@ -173,14 +173,14 @@
     ## ============================================================
 
     - name: Pass empty tags dict for s3_bucket with purge_tags False
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
-        purge_tags: no
+        purge_tags: false
         tags: {}
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is not changed
           - output.name == '{{ local_bucket_name }}'
@@ -197,12 +197,12 @@
     ## ============================================================
 
     - name: Do not specify any tag to ensure previous tags are not removed
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - not output.changed
           - output.name == '{{ local_bucket_name }}'
@@ -211,26 +211,26 @@
     # ============================================================
 
     - name: Remove all tags
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         tags: {}
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
           - output.name == '{{ local_bucket_name }}'
           - output.tags == {}
 
     - name: Re-remove all tags
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: present
         tags: {}
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output is not changed
           - output.name == '{{ local_bucket_name }}'
@@ -239,19 +239,19 @@
     # ============================================================
 
     - name: Delete bucket
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
       register: output
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - output.changed
 
   # ============================================================
   always:
     - name: Ensure all buckets are deleted
-      s3_bucket:
-        name: '{{ local_bucket_name }}'
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
         state: absent
-      ignore_errors: yes
+      ignore_errors: true

--- a/tests/integration/targets/s3_bucket_info/defaults/main.yml
+++ b/tests/integration/targets/s3_bucket_info/defaults/main.yml
@@ -1,4 +1,5 @@
+---
 name_pattern: testbucket-ansible-integration
 testing_buckets:
-- '{{ tiny_prefix }}-{{ name_pattern }}-1'
-- '{{ tiny_prefix }}-{{ name_pattern }}-2'
+  - "{{ tiny_prefix }}-{{ name_pattern }}-1"
+  - "{{ tiny_prefix }}-{{ name_pattern }}-2"

--- a/tests/integration/targets/s3_bucket_info/meta/main.yml
+++ b/tests/integration/targets/s3_bucket_info/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/s3_bucket_info/tasks/basic.yml
+++ b/tests/integration/targets/s3_bucket_info/tasks/basic.yml
@@ -1,15 +1,16 @@
+---
 - name: Get simple S3 bucket list
   s3_bucket_info:
   register: bucket_list
 - name: Assert result.changed == False and bucket list was retrieved
-  assert:
+  ansible.builtin.assert:
     that:
-    - bucket_list.changed == False
-    - bucket_list.buckets
+      - bucket_list.changed == False
+      - bucket_list.buckets
 
 - name: Get complex S3 bucket list
   s3_bucket_info:
-    name_filter: '{{ name_pattern }}'
+    name_filter: "{{ name_pattern }}"
     bucket_facts:
       bucket_accelerate_configuration: true
       bucket_acl: true
@@ -29,40 +30,40 @@
     transform_location: true
   register: bucket_list
 - name: Assert that buckets list contains requested bucket facts
-  assert:
+  ansible.builtin.assert:
     that:
-    - item.name is search(name_pattern)
-    - item.bucket_accelerate_configuration is defined
-    - item.bucket_acl is defined
-    - item.bucket_cors is defined
-    - item.bucket_encryption is defined
-    - item.bucket_lifecycle_configuration is defined
-    - item.bucket_location is defined
-    - item.bucket_logging is defined
-    - item.bucket_notification_configuration is defined
-    - item.bucket_policy is defined
-    - item.bucket_policy_status is defined
-    - item.bucket_replication is defined
-    - item.bucket_request_payment is defined
-    - item.bucket_tagging is defined
-    - item.bucket_website is defined
-    - item.public_access_block is defined
-  loop: '{{ bucket_list.buckets }}'
+      - item.name is search(name_pattern)
+      - item.bucket_accelerate_configuration is defined
+      - item.bucket_acl is defined
+      - item.bucket_cors is defined
+      - item.bucket_encryption is defined
+      - item.bucket_lifecycle_configuration is defined
+      - item.bucket_location is defined
+      - item.bucket_logging is defined
+      - item.bucket_notification_configuration is defined
+      - item.bucket_policy is defined
+      - item.bucket_policy_status is defined
+      - item.bucket_replication is defined
+      - item.bucket_request_payment is defined
+      - item.bucket_tagging is defined
+      - item.bucket_website is defined
+      - item.public_access_block is defined
+  loop: "{{ bucket_list.buckets }}"
   loop_control:
-    label: '{{ item.name }}'
+    label: "{{ item.name }}"
 - name: Assert that retrieved bucket facts contains valid data
-  assert:
+  ansible.builtin.assert:
     that:
-    - item.bucket_acl.Owner is defined
-    - item.bucket_tagging.snake_case is defined
-    - item.bucket_tagging.CamelCase is defined
-    - item.bucket_tagging["lowercase spaced"] is defined
-    - item.bucket_tagging["Title Case"] is defined
-    - item.bucket_tagging.snake_case == 'simple_snake_case'
-    - item.bucket_tagging.CamelCase == 'SimpleCamelCase'
-    - item.bucket_tagging["lowercase spaced"] == 'hello cruel world'
-    - item.bucket_tagging["Title Case"] == 'Hello Cruel World'
-    - item.bucket_location.LocationConstraint == aws_region
-  loop: '{{ bucket_list.buckets }}'
+      - item.bucket_acl.Owner is defined
+      - item.bucket_tagging.snake_case is defined
+      - item.bucket_tagging.CamelCase is defined
+      - item.bucket_tagging["lowercase spaced"] is defined
+      - item.bucket_tagging["Title Case"] is defined
+      - item.bucket_tagging.snake_case == 'simple_snake_case'
+      - item.bucket_tagging.CamelCase == 'SimpleCamelCase'
+      - item.bucket_tagging["lowercase spaced"] == 'hello cruel world'
+      - item.bucket_tagging["Title Case"] == 'Hello Cruel World'
+      - item.bucket_location.LocationConstraint == aws_region
+  loop: "{{ bucket_list.buckets }}"
   loop_control:
-    label: '{{ item.name }}'
+    label: "{{ item.name }}"

--- a/tests/integration/targets/s3_bucket_info/tasks/bucket_ownership_controls.yml
+++ b/tests/integration/targets/s3_bucket_info/tasks/bucket_ownership_controls.yml
@@ -1,21 +1,22 @@
+---
 - name: Get S3 bucket ownership controls
   s3_bucket_info:
-    name_filter: '{{ name_pattern }}'
+    name_filter: "{{ name_pattern }}"
     bucket_facts:
       bucket_ownership_controls: true
     transform_location: true
   register: bucket_list
 - name: Assert that buckets list contains requested bucket facts
-  assert:
+  ansible.builtin.assert:
     that:
-    - item.name is search(name_pattern)
-    - item.bucket_ownership_controls is defined
-  loop: '{{ bucket_list.buckets }}'
+      - item.name is search(name_pattern)
+      - item.bucket_ownership_controls is defined
+  loop: "{{ bucket_list.buckets }}"
   loop_control:
-    label: '{{ item.name }}'
+    label: "{{ item.name }}"
 - name: Get complex S3 bucket list (including ownership controls)
   s3_bucket_info:
-    name_filter: '{{ name_pattern }}'
+    name_filter: "{{ name_pattern }}"
     bucket_facts:
       bucket_accelerate_configuration: true
       bucket_acl: true
@@ -36,41 +37,41 @@
     transform_location: true
   register: bucket_list
 - name: Assert that buckets list contains requested bucket facts
-  assert:
+  ansible.builtin.assert:
     that:
-    - item.name is search(name_pattern)
-    - item.bucket_accelerate_configuration is defined
-    - item.bucket_acl is defined
-    - item.bucket_cors is defined
-    - item.bucket_encryption is defined
-    - item.bucket_lifecycle_configuration is defined
-    - item.bucket_location is defined
-    - item.bucket_logging is defined
-    - item.bucket_notification_configuration is defined
-    - item.bucket_ownership_controls is defined
-    - item.bucket_policy is defined
-    - item.bucket_policy_status is defined
-    - item.bucket_replication is defined
-    - item.bucket_request_payment is defined
-    - item.bucket_tagging is defined
-    - item.bucket_website is defined
-    - item.public_access_block is defined
-  loop: '{{ bucket_list.buckets }}'
+      - item.name is search(name_pattern)
+      - item.bucket_accelerate_configuration is defined
+      - item.bucket_acl is defined
+      - item.bucket_cors is defined
+      - item.bucket_encryption is defined
+      - item.bucket_lifecycle_configuration is defined
+      - item.bucket_location is defined
+      - item.bucket_logging is defined
+      - item.bucket_notification_configuration is defined
+      - item.bucket_ownership_controls is defined
+      - item.bucket_policy is defined
+      - item.bucket_policy_status is defined
+      - item.bucket_replication is defined
+      - item.bucket_request_payment is defined
+      - item.bucket_tagging is defined
+      - item.bucket_website is defined
+      - item.public_access_block is defined
+  loop: "{{ bucket_list.buckets }}"
   loop_control:
-    label: '{{ item.name }}'
+    label: "{{ item.name }}"
 - name: Assert that retrieved bucket facts contains valid data
-  assert:
+  ansible.builtin.assert:
     that:
-    - item.bucket_acl.Owner is defined
-    - item.bucket_tagging.snake_case is defined
-    - item.bucket_tagging.CamelCase is defined
-    - item.bucket_tagging["lowercase spaced"] is defined
-    - item.bucket_tagging["Title Case"] is defined
-    - item.bucket_tagging.snake_case == 'simple_snake_case'
-    - item.bucket_tagging.CamelCase == 'SimpleCamelCase'
-    - item.bucket_tagging["lowercase spaced"] == 'hello cruel world'
-    - item.bucket_tagging["Title Case"] == 'Hello Cruel World'
-    - item.bucket_location.LocationConstraint == aws_region
-  loop: '{{ bucket_list.buckets }}'
+      - item.bucket_acl.Owner is defined
+      - item.bucket_tagging.snake_case is defined
+      - item.bucket_tagging.CamelCase is defined
+      - item.bucket_tagging["lowercase spaced"] is defined
+      - item.bucket_tagging["Title Case"] is defined
+      - item.bucket_tagging.snake_case == 'simple_snake_case'
+      - item.bucket_tagging.CamelCase == 'SimpleCamelCase'
+      - item.bucket_tagging["lowercase spaced"] == 'hello cruel world'
+      - item.bucket_tagging["Title Case"] == 'Hello Cruel World'
+      - item.bucket_location.LocationConstraint == aws_region
+  loop: "{{ bucket_list.buckets }}"
   loop_control:
-    label: '{{ item.name }}'
+    label: "{{ item.name }}"

--- a/tests/integration/targets/s3_bucket_info/tasks/main.yml
+++ b/tests/integration/targets/s3_bucket_info/tasks/main.yml
@@ -1,27 +1,28 @@
+---
 - name: Test community.aws.aws_s3_bucket_info
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
   block:
-  - name: Create a simple s3_bucket
-    s3_bucket:
-      name: '{{ item }}'
-      state: present
-      tags:
-        lowercase spaced: hello cruel world
-        Title Case: Hello Cruel World
-        CamelCase: SimpleCamelCase
-        snake_case: simple_snake_case
-    register: output
-    loop: '{{ testing_buckets }}'
-  - include_tasks: basic.yml
-  - include_tasks: bucket_ownership_controls.yml
+    - name: Create a simple s3_bucket
+      amazon.aws.s3_bucket:
+        name: "{{ item }}"
+        state: present
+        tags:
+          lowercase spaced: hello cruel world
+          Title Case: Hello Cruel World
+          CamelCase: SimpleCamelCase
+          snake_case: simple_snake_case
+      register: output
+      loop: "{{ testing_buckets }}"
+    - ansible.builtin.include_tasks: basic.yml
+    - ansible.builtin.include_tasks: bucket_ownership_controls.yml
   always:
-  - name: Delete simple s3_buckets
-    s3_bucket:
-      name: '{{ item }}'
-      state: absent
-    loop: '{{ testing_buckets }}'
+    - name: Delete simple s3_buckets
+      amazon.aws.s3_bucket:
+        name: "{{ item }}"
+        state: absent
+      loop: "{{ testing_buckets }}"

--- a/tests/integration/targets/s3_object/meta/main.yml
+++ b/tests/integration/targets/s3_object/meta/main.yml
@@ -1,2 +1,3 @@
+---
 dependencies:
   - setup_remote_tmp_dir

--- a/tests/integration/targets/s3_object/tasks/copy_object.yml
+++ b/tests/integration/targets/s3_object/tasks/copy_object.yml
@@ -1,148 +1,149 @@
+---
 - block:
-  - name: define bucket name used for tests
-    set_fact:
-      copy_bucket:
-        src: "{{ bucket_name }}-copysrc"
-        dst: "{{ bucket_name }}-copydst"
+    - name: define bucket name used for tests
+      ansible.builtin.set_fact:
+        copy_bucket:
+          src: "{{ bucket_name }}-copysrc"
+          dst: "{{ bucket_name }}-copydst"
 
-  - name: create bucket source
-    s3_bucket:
-      name: "{{ copy_bucket.src }}"
-      state: present
+    - name: create bucket source
+      amazon.aws.s3_bucket:
+        name: "{{ copy_bucket.src }}"
+        state: present
 
-  - name: create bucket destination
-    s3_bucket:
-      name: "{{ copy_bucket.dst }}"
-      state: present
+    - name: create bucket destination
+      amazon.aws.s3_bucket:
+        name: "{{ copy_bucket.dst }}"
+        state: present
 
-  - name: Create content
-    set_fact:
-      content: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits,punctuation') }}"
+    - name: Create content
+      ansible.builtin.set_fact:
+        content: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits,punctuation') }}"
 
-  - name: Put a content in the source bucket
-    s3_object:
-      bucket: "{{ copy_bucket.src }}"
-      mode: put
-      content: "{{ content }}"
-      object: source.txt
-      tags:
-        ansible_release: '2.0.0'
-        ansible_team: cloud
-    retries: 3
-    delay: 3
-    register: put_result
-    until:
-      - '"not found" not in put_result.msg'
-    ignore_errors: True
-
-  - name: Copy the content of the source bucket into dest bucket
-    s3_object:
-      bucket: "{{ copy_bucket.dst }}"
-      mode: copy
-      object: destination.txt
-      copy_src:
+    - name: Put a content in the source bucket
+      s3_object:
         bucket: "{{ copy_bucket.src }}"
+        mode: put
+        content: "{{ content }}"
         object: source.txt
-    retries: 3
-    delay: 3
-    register: put_result
-    until:
-      - '"not found" not in put_result.msg'
-    ignore_errors: True
+        tags:
+          ansible_release: 2.0.0
+          ansible_team: cloud
+      retries: 3
+      delay: 3
+      register: put_result
+      until:
+        - '"not found" not in put_result.msg'
+      ignore_errors: true
 
-  - name: Get the content copied into {{ copy_bucket.dst }}
-    s3_object:
-      bucket: "{{ copy_bucket.dst }}"
-      mode: getstr
-      object: destination.txt
-    register: copy_content
+    - name: Copy the content of the source bucket into dest bucket
+      s3_object:
+        bucket: "{{ copy_bucket.dst }}"
+        mode: copy
+        object: destination.txt
+        copy_src:
+          bucket: "{{ copy_bucket.src }}"
+          object: source.txt
+      retries: 3
+      delay: 3
+      register: put_result
+      until:
+        - '"not found" not in put_result.msg'
+      ignore_errors: true
 
-  - name: assert that the content is matching with the source
-    assert:
-      that:
-        - content == copy_content.contents
+    - name: Get the content copied into {{ copy_bucket.dst }}
+      s3_object:
+        bucket: "{{ copy_bucket.dst }}"
+        mode: getstr
+        object: destination.txt
+      register: copy_content
 
-  - name: Get the download url for object copied into {{ copy_bucket.dst }}
-    s3_object:
-      bucket: "{{ copy_bucket.dst }}"
-      mode: geturl
-      object: destination.txt
-    register: copy_url
+    - name: assert that the content is matching with the source
+      ansible.builtin.assert:
+        that:
+          - content == copy_content.contents
 
-  - name: assert that tags are the same in the destination bucket
-    assert:
-      that:
-        - put_result.tags == copy_url.tags
+    - name: Get the download url for object copied into {{ copy_bucket.dst }}
+      s3_object:
+        bucket: "{{ copy_bucket.dst }}"
+        mode: geturl
+        object: destination.txt
+      register: copy_url
 
-  - name: Copy the same content from the source bucket into dest bucket (idempotency)
-    s3_object:
-      bucket: "{{ copy_bucket.dst }}"
-      mode: copy
-      object: destination.txt
-      copy_src:
-        bucket: "{{ copy_bucket.src }}"
-        object: source.txt
-    register: copy_idempotency
+    - name: assert that tags are the same in the destination bucket
+      ansible.builtin.assert:
+        that:
+          - put_result.tags == copy_url.tags
 
-  - name: assert that no change was made
-    assert:
-      that:
-        - copy_idempotency is not changed
-        - "copy_idempotency.msg == 'ETag from source and destination are the same'"
+    - name: Copy the same content from the source bucket into dest bucket (idempotency)
+      s3_object:
+        bucket: "{{ copy_bucket.dst }}"
+        mode: copy
+        object: destination.txt
+        copy_src:
+          bucket: "{{ copy_bucket.src }}"
+          object: source.txt
+      register: copy_idempotency
 
-  - name: Copy object with tags
-    s3_object:
-      bucket: "{{ copy_bucket.dst }}"
-      mode: copy
-      object: destination.txt
-      tags:
-        ansible_release: "2.0.1"
-      copy_src:
-        bucket: "{{ copy_bucket.src }}"
-        object: source.txt
-    register: copy_result
+    - name: assert that no change was made
+      ansible.builtin.assert:
+        that:
+          - copy_idempotency is not changed
+          - copy_idempotency.msg == 'ETag from source and destination are the same'
 
-  - name: assert that tags were updated
-    assert:
-      that:
-        - copy_result is changed
-        - copy_result.tags['ansible_release'] == '2.0.1'
+    - name: Copy object with tags
+      s3_object:
+        bucket: "{{ copy_bucket.dst }}"
+        mode: copy
+        object: destination.txt
+        tags:
+          ansible_release: 2.0.1
+        copy_src:
+          bucket: "{{ copy_bucket.src }}"
+          object: source.txt
+      register: copy_result
 
-  - name: Copy object with tags (idempotency)
-    s3_object:
-      bucket: "{{ copy_bucket.dst }}"
-      mode: copy
-      object: destination.txt
-      tags:
-        ansible_release: "2.0.1"
-      copy_src:
-        bucket: "{{ copy_bucket.src }}"
-        object: source.txt
-    register: copy_result
+    - name: assert that tags were updated
+      ansible.builtin.assert:
+        that:
+          - copy_result is changed
+          - copy_result.tags['ansible_release'] == '2.0.1'
 
-  - name: assert that no change was made
-    assert:
-      that:
-        - copy_result is not changed
+    - name: Copy object with tags (idempotency)
+      s3_object:
+        bucket: "{{ copy_bucket.dst }}"
+        mode: copy
+        object: destination.txt
+        tags:
+          ansible_release: 2.0.1
+        copy_src:
+          bucket: "{{ copy_bucket.src }}"
+          object: source.txt
+      register: copy_result
 
-  - name: Copy from unexisting key should not succeed
-    s3_object:
-      bucket: "{{ copy_bucket.dst }}"
-      mode: copy
-      object: missing_key.txt
-      copy_src:
-        bucket: "{{ copy_bucket.src }}"
-        object: this_key_does_not_exist.txt
-    register: result
+    - name: assert that no change was made
+      ansible.builtin.assert:
+        that:
+          - copy_result is not changed
 
-  - name: Validate result when copying missing key
-    assert:
-      that:
-        - result is not changed
-        - 'result.msg == "Key this_key_does_not_exist.txt does not exist in bucket {{ copy_bucket.src }}."'
+    - name: Copy from unexisting key should not succeed
+      s3_object:
+        bucket: "{{ copy_bucket.dst }}"
+        mode: copy
+        object: missing_key.txt
+        copy_src:
+          bucket: "{{ copy_bucket.src }}"
+          object: this_key_does_not_exist.txt
+      register: result
+
+    - name: Validate result when copying missing key
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.msg == "Key this_key_does_not_exist.txt does not exist in bucket {{ copy_bucket.src }}."
 
   always:
-    - include_tasks: delete_bucket.yml
+    - ansible.builtin.include_tasks: delete_bucket.yml
       with_items:
         - "{{ copy_bucket.dst }}"
         - "{{ copy_bucket.src }}"

--- a/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
+++ b/tests/integration/targets/s3_object/tasks/copy_object_acl_disabled_bucket.yml
@@ -1,25 +1,26 @@
+---
 - name: test copying objects to bucket with ACL disabled
   block:
     - name: Create a bucket with ACL disabled for the test
-      s3_bucket:
+      amazon.aws.s3_bucket:
         name: "{{ bucket_name }}-acl-disabled"
         object_ownership: BucketOwnerEnforced
         state: present
       register: create_result
 
     - name: Ensure bucket creation
-      assert:
+      ansible.builtin.assert:
         that:
           - create_result is changed
           - create_result is not failed
           - create_result.object_ownership == "BucketOwnerEnforced"
 
     - name: Create content
-      set_fact:
-          content: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits,punctuation') }}"
+      ansible.builtin.set_fact:
+        content: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits,punctuation') }}"
 
     - name: Create local acl_disabled_upload_test.txt
-      copy:
+      ansible.builtin.copy:
         content: "{{ content }}"
         dest: "{{ remote_tmp_dir }}/acl_disabled_upload_test.txt"
 
@@ -27,12 +28,12 @@
       amazon.aws.s3_object:
         bucket: "{{ bucket_name }}-acl-disabled"
         src: "{{ remote_tmp_dir }}/acl_disabled_upload_test.txt"
-        object: "acl_disabled_upload_test.txt"
+        object: acl_disabled_upload_test.txt
         mode: put
       check_mode: true
       register: upload_file_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - upload_file_result is changed
           - upload_file_result is not failed
@@ -45,11 +46,11 @@
       amazon.aws.s3_object:
         bucket: "{{ bucket_name }}-acl-disabled"
         src: "{{ remote_tmp_dir }}/acl_disabled_upload_test.txt"
-        object: "acl_disabled_upload_test.txt"
+        object: acl_disabled_upload_test.txt
         mode: put
       register: upload_file_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - upload_file_result is changed
           - upload_file_result is not failed
@@ -62,12 +63,12 @@
       amazon.aws.s3_object:
         bucket: "{{ bucket_name }}-acl-disabled"
         src: "{{ remote_tmp_dir }}/acl_disabled_upload_test.txt"
-        object: "acl_disabled_upload_test.txt"
+        object: acl_disabled_upload_test.txt
         mode: put
       check_mode: true
       register: upload_file_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - upload_file_result is not changed
           - upload_file_result is not failed
@@ -80,11 +81,11 @@
       amazon.aws.s3_object:
         bucket: "{{ bucket_name }}-acl-disabled"
         src: "{{ remote_tmp_dir }}/acl_disabled_upload_test.txt"
-        object: "acl_disabled_upload_test.txt"
+        object: acl_disabled_upload_test.txt
         mode: put
       register: upload_file_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - upload_file_result is not changed
           - upload_file_result is not failed
@@ -96,12 +97,12 @@
     - name: Create an object in the bucket with permissions (permission not set)
       amazon.aws.s3_object:
         bucket: "{{ bucket_name }}-acl-disabled"
-        object: "/test_directory"
+        object: /test_directory
         permission: bucket-owner-full-control
         mode: create
       register: permission_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - permission_result is changed
           - upload_file_result is not failed
@@ -109,7 +110,6 @@
           - '"Virtual directory test_directory/ created" in permission_result.msg'
 
   always:
-
     - name: Delete the file in the bucket
       amazon.aws.s3_object:
         bucket: "{{ bucket_name }}-acl-disabled"
@@ -119,8 +119,8 @@
       delay: 3
       ignore_errors: true
       loop:
-        - "acl_disabled_upload_test.txt"
-        - "/test_directory/"
+        - acl_disabled_upload_test.txt
+        - /test_directory/
 
     - name: List keys simple
       amazon.aws.s3_object:
@@ -128,7 +128,7 @@
         mode: list
 
     - name: Delete bucket created in this test
-      s3_bucket:
+      amazon.aws.s3_bucket:
         name: "{{ bucket_name }}-acl-disabled"
         state: absent
       register: delete_result

--- a/tests/integration/targets/s3_object/tasks/copy_recursively.yml
+++ b/tests/integration/targets/s3_object/tasks/copy_recursively.yml
@@ -1,7 +1,8 @@
+---
 - name: Test copy recursively object from one bucket to another one.
   block:
     - name: Create S3 bucket
-      s3_bucket:
+      amazon.aws.s3_bucket:
         name: "{{ item }}"
         state: present
       with_items:
@@ -31,7 +32,7 @@
       register: _objects
 
     - name: Ensure no object were found into bucket
-      assert:
+      ansible.builtin.assert:
         that:
           - _objects.s3_keys | length == 0
 
@@ -42,7 +43,7 @@
         mode: copy
         copy_src:
           bucket: "{{ bucket_src }}"
-          prefix: "file"
+          prefix: file
       register: _copy_with_prefix
 
     - name: list objects from bucket
@@ -52,7 +53,7 @@
       register: _objects
 
     - name: Ensure objects with prefix 'file' were copied into bucket
-      assert:
+      ansible.builtin.assert:
         that:
           - _copy_with_prefix is changed
           - _objects.s3_keys | length == 3
@@ -67,7 +68,7 @@
         mode: copy
         copy_src:
           bucket: "{{ bucket_src }}"
-          prefix: "file"
+          prefix: file
       register: _copy_with_prefix_idempotency
 
     - name: list objects from bucket
@@ -77,7 +78,7 @@
       register: _objects
 
     - name: Ensure objects with prefix 'file' were copied into bucket
-      assert:
+      ansible.builtin.assert:
         that:
           - _copy_with_prefix_idempotency is not changed
           - _objects.s3_keys | length == 3
@@ -101,7 +102,7 @@
       register: _objects
 
     - name: Ensure all objects were copied into bucket
-      assert:
+      ansible.builtin.assert:
         that:
           - _copy_all is changed
           - _objects.s3_keys | length == 5
@@ -122,11 +123,11 @@
       register: _objects
 
     - name: Ensure number of copied objects remains the same.
-      assert:
+      ansible.builtin.assert:
         that:
           - _copy_all_idempotency is not changed
           - _objects.s3_keys | length == 5
-  
+
   vars:
     bucket_src: "{{ bucket_name }}-recursive-src"
     bucket_dst: "{{ bucket_name }}-recursive-dst"
@@ -141,12 +142,12 @@
         content: |
           some content for file3.txt
       - object: testfile.py
-        content: "This is a sample text file"
+        content: This is a sample text file
       - object: another.txt
-        content: "another file to create into bucket"
+        content: another file to create into bucket
 
   always:
-    - include_tasks: delete_bucket.yml
+    - ansible.builtin.include_tasks: delete_bucket.yml
       with_items:
         - "{{ bucket_src }}"
         - "{{ bucket_dst }}"

--- a/tests/integration/targets/s3_object/tasks/delete_bucket.yml
+++ b/tests/integration/targets/s3_object/tasks/delete_bucket.yml
@@ -1,3 +1,4 @@
+---
 - name: delete bucket at the end of Integration tests
   block:
     - name: list bucket object
@@ -18,7 +19,7 @@
       ignore_errors: true
 
     - name: delete the bucket
-      s3_bucket:
+      amazon.aws.s3_bucket:
         name: "{{ item }}"
         state: absent
       ignore_errors: true

--- a/tests/integration/targets/s3_object/tasks/main.yml
+++ b/tests/integration/targets/s3_object/tasks/main.yml
@@ -15,52 +15,52 @@
       when: (lookup('env', 'HOME'))
 
     - name: get ARN of calling user
-      aws_caller_info:
+      amazon.aws.aws_caller_info:
       register: aws_caller_info
 
     - name: register account id
-      set_fact:
+      ansible.builtin.set_fact:
         aws_account: "{{ aws_caller_info.account }}"
 
     - name: check that temp directory was made
-      assert:
+      ansible.builtin.assert:
         that:
-        - remote_tmp_dir is defined
+          - remote_tmp_dir is defined
 
     - name: Create content
-      set_fact:
+      ansible.builtin.set_fact:
         content: "{{ lookup('password', '/dev/null chars=ascii_letters,digits,hexdigits,punctuation') }}"
 
     - name: test create bucket
-      s3_bucket:
+      amazon.aws.s3_bucket:
         name: "{{ bucket_name }}"
         state: present
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
     - name: make a bucket with the bucket-owner-full-control ACL
-      s3_bucket:
+      amazon.aws.s3_bucket:
         name: "{{ bucket_name_acl }}"
         state: present
         policy: "{{ lookup('template', 'policy.json.j2') }}"
       register: bucket_with_policy
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - bucket_with_policy is changed
 
     - name: Create local upload.txt
-      copy:
+      ansible.builtin.copy:
         content: "{{ content }}"
         dest: "{{ remote_tmp_dir }}/upload.txt"
 
     - name: stat the file
-      stat:
+      ansible.builtin.stat:
         path: "{{ remote_tmp_dir }}/upload.txt"
-        get_checksum: yes
+        get_checksum: true
       register: upload_file
 
     - name: test putting an object in the bucket
@@ -70,13 +70,13 @@
         src: "{{ remote_tmp_dir }}/upload.txt"
         object: delete.txt
         tags:
-            "lowercase spaced": "hello cruel world"
-            "Title Case": "Hello Cruel World"
+          lowercase spaced: hello cruel world
+          Title Case: Hello Cruel World
       retries: 3
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.msg == "PUT operation complete"
@@ -92,7 +92,7 @@
         object_name: "{{ list_keys_result.s3_keys[0] }}"
       register: info_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - info_result is not failed
           - info_result is not changed
@@ -121,7 +121,7 @@
             - ObjectParts
       register: info_detail_result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - info_detail_result is not failed
           - info_detail_result is not changed
@@ -149,7 +149,7 @@
       poll: 0
 
     - name: ensure it completed
-      async_status:
+      ansible.builtin.async_status:
         jid: "{{ test_async.ansible_job_id }}"
       register: status
       until: status is finished
@@ -165,7 +165,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
@@ -179,7 +179,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.msg == "PUT operation complete"
@@ -198,7 +198,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.msg == "PUT operation complete"
@@ -214,7 +214,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
@@ -229,7 +229,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
@@ -244,7 +244,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
@@ -257,15 +257,15 @@
       retries: 3
       delay: 3
       register: result
-      until: "result.msg == 'GET operation complete'"
+      until: result.msg == 'GET operation complete'
 
     - name: stat the file so we can compare the checksums
-      stat:
+      ansible.builtin.stat:
         path: "{{ remote_tmp_dir }}/download.txt"
-        get_checksum: yes
+        get_checksum: true
       register: download_file
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - upload_file.stat.checksum == download_file.stat.checksum
 
@@ -278,15 +278,15 @@
       retries: 3
       delay: 3
       register: result
-      until: "result.msg == 'GET operation complete'"
+      until: result.msg == 'GET operation complete'
 
     - name: stat the file so we can compare the checksums
-      stat:
+      ansible.builtin.stat:
         path: "{{ remote_tmp_dir }}/download-2.txt"
-        get_checksum: yes
+        get_checksum: true
       register: download_file
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - upload_file.stat.checksum == download_file.stat.checksum
 
@@ -300,12 +300,12 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
     - name: modify destination
-      copy:
+      ansible.builtin.copy:
         dest: "{{ remote_tmp_dir }}/download.txt"
         src: hello.txt
 
@@ -320,7 +320,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
@@ -334,7 +334,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
@@ -349,7 +349,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
@@ -364,13 +364,12 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
     - name: modify mtime for local file to past
-      shell: touch -mt 197001010900.00 "{{ remote_tmp_dir }}/download.txt"
-
+      ansible.builtin.shell: touch -mt 197001010900.00 "{{ remote_tmp_dir }}/download.txt"
     - name: test get with overwrite=latest and files that mtimes are different
       s3_object:
         bucket: "{{ bucket_name }}"
@@ -382,7 +381,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
@@ -396,7 +395,7 @@
       register: result
       until: result is changed
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - "'Download url:' in result.msg"
           - result is changed
@@ -412,7 +411,7 @@
       register: result
       until: result is changed
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - "'Download url:' in result.msg"
           - result is changed
@@ -426,7 +425,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result.msg == "GET operation complete"
           - result.contents == content
@@ -439,7 +438,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - "'delete.txt' in result.s3_keys"
           - result.msg == "LIST operation complete"
@@ -453,7 +452,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - "'Object deleted from bucket' in result.msg"
           - result is changed
@@ -463,16 +462,16 @@
         bucket: "{{ bucket_name }}"
         mode: put
         src: "{{ remote_tmp_dir }}/upload.txt"
-        metadata: "Content-Type=text/plain"
+        metadata: Content-Type=text/plain
         object: delete_meta.txt
         tags:
-            "lowercase spaced": "hello cruel world"
-            "Title Case": "Hello Cruel World"
+          lowercase spaced: hello cruel world
+          Title Case: Hello Cruel World
       retries: 3
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.msg == "PUT operation complete"
@@ -491,13 +490,13 @@
         bucket: "{{ bucket_name }}"
         mode: put
         src: "{{ remote_tmp_dir }}/upload.txt"
-        encrypt: yes
+        encrypt: true
         object: delete_encrypt.txt
       retries: 3
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.msg == "PUT operation complete"
@@ -511,15 +510,15 @@
       retries: 3
       delay: 3
       register: result
-      until: "result.msg == 'GET operation complete'"
+      until: result.msg == 'GET operation complete'
 
     - name: stat the file so we can compare the checksums
-      stat:
+      ansible.builtin.stat:
         path: "{{ remote_tmp_dir }}/download_encrypted.txt"
-        get_checksum: yes
+        get_checksum: true
       register: download_file
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - upload_file.stat.checksum == download_file.stat.checksum
 
@@ -536,14 +535,14 @@
         bucket: "{{ bucket_name }}"
         mode: put
         src: "{{ remote_tmp_dir }}/upload.txt"
-        encrypt: yes
+        encrypt: true
         encryption_mode: aws:kms
         object: delete_encrypt_kms.txt
       retries: 3
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
           - result.msg == "PUT operation complete"
@@ -557,19 +556,19 @@
       retries: 3
       delay: 3
       register: result
-      until: "result.msg == 'GET operation complete'"
+      until: result.msg == 'GET operation complete'
 
     - name: get the stat of the file so we can compare the checksums
-      stat:
+      ansible.builtin.stat:
         path: "{{ remote_tmp_dir }}/download_kms.txt"
-        get_checksum: yes
+        get_checksum: true
       register: download_file
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - upload_file.stat.checksum == download_file.stat.checksum
 
-      # FIXME - could use a test that checks uploaded file is *actually* aws:kms encrypted
+    # FIXME - could use a test that checks uploaded file is *actually* aws:kms encrypted
 
     - name: delete KMS encrypted file
       s3_object:
@@ -592,7 +591,7 @@
       delay: 3
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - "'Virtual directory foo/bar/baz/ created' in result.msg"
           - result is changed
@@ -606,7 +605,7 @@
       delay: 3
 
     - name: test delete bucket
-      s3_bucket:
+      amazon.aws.s3_bucket:
         name: "{{ bucket_name }}"
         state: absent
       register: result
@@ -614,12 +613,12 @@
       delay: 3
       until: result is changed
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
     - name: Restore the bucket for later use
-      s3_bucket:
+      amazon.aws.s3_bucket:
         name: "{{ bucket_name }}"
         state: present
 
@@ -628,13 +627,13 @@
         - ansible_system == 'Linux' or ansible_distribution == 'MacOSX'
       block:
         - name: make tempfile 4 GB for OSX
-          command:
-            _raw_params: "dd if=/dev/zero of={{ remote_tmp_dir }}/largefile bs=1m count=4096"
+          ansible.builtin.command:
+            _raw_params: dd if=/dev/zero of={{ remote_tmp_dir }}/largefile bs=1m count=4096
           when: ansible_distribution == 'MacOSX'
 
         - name: make tempfile 4 GB for linux
-          command:
-            _raw_params: "dd if=/dev/zero of={{ remote_tmp_dir }}/largefile bs=1M count=4096"
+          ansible.builtin.command:
+            _raw_params: dd if=/dev/zero of={{ remote_tmp_dir }}/largefile bs=1M count=4096
           when: ansible_system == 'Linux'
 
         - name: upload the file to the bucket
@@ -653,10 +652,10 @@
             overwrite: different
           retries: 3
           delay: 3
-          until: "result.msg == 'GET operation complete'"
+          until: result.msg == 'GET operation complete'
           register: result
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is changed
 
@@ -669,7 +668,7 @@
             overwrite: different
           register: result
 
-        - assert:
+        - ansible.builtin.assert:
             that:
               - result is not changed
 
@@ -681,11 +680,11 @@
         src: "{{ remote_tmp_dir }}/upload.txt"
         object: file-with-permissions.txt
         permission: public-read
-        ignore_nonexistent_bucket: True
+        ignore_nonexistent_bucket: true
       register: upload_private
-      ignore_errors: True
+      ignore_errors: true
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - upload_private is failed
 
@@ -696,10 +695,10 @@
         src: "{{ remote_tmp_dir }}/upload.txt"
         object: file-with-permissions.txt
         permission: bucket-owner-full-control
-        ignore_nonexistent_bucket: True
+        ignore_nonexistent_bucket: true
       register: upload_owner
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - upload_owner is changed
 
@@ -712,7 +711,7 @@
           test content
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
@@ -725,7 +724,7 @@
           test content
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
@@ -736,11 +735,11 @@
         object: put-content.txt
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result.contents == "test content"
 
-    - set_fact:
+    - ansible.builtin.set_fact:
         put_template_text: test template
 
     - name: create an object from a template
@@ -751,7 +750,7 @@
         content: "{{ lookup('template', 'templates/put-template.txt.j2')|replace('\n', '') }}"
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
@@ -763,7 +762,7 @@
         content: "{{ lookup('template', 'templates/put-template.txt.j2')|replace('\n', '') }}"
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
@@ -774,12 +773,12 @@
         object: put-template.txt
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result.contents == "template:test template"
 
     # at present, there is no lookup that can process binary data, so we use slurp instead
-    - slurp:
+    - ansible.builtin.slurp:
         src: "{{ role_path }}/files/test.png"
       register: put_binary
 
@@ -791,7 +790,7 @@
         content_base64: "{{ put_binary.content }}"
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is changed
 
@@ -803,7 +802,7 @@
         content_base64: "{{ put_binary.content }}"
       register: result
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - result is not changed
 
@@ -816,261 +815,256 @@
       register: result
 
     - name: stat the files so we can compare the checksums
-      stat:
+      ansible.builtin.stat:
         path: "{{ item }}"
-        get_checksum: yes
+        get_checksum: true
       loop:
-      - "{{ role_path }}/files/test.png"
-      - "{{ remote_tmp_dir }}/download_binary.bin"
+        - "{{ role_path }}/files/test.png"
+        - "{{ remote_tmp_dir }}/download_binary.bin"
       register: binary_files
 
-    - assert:
+    - ansible.builtin.assert:
         that:
           - binary_files.results[0].stat.checksum == binary_files.results[1].stat.checksum
 
-    - include_tasks: copy_object.yml
-
-    - include_tasks: copy_object_acl_disabled_bucket.yml
-
-    # ============================================================
-    - name: 'Run tagging tests'
+    - ansible.builtin.include_tasks: copy_object.yml
+    - ansible.builtin.include_tasks: copy_object_acl_disabled_bucket.yml
+    - name: Run tagging tests
       block:
-    # ============================================================
-      - name: create an object from static content
-        s3_object:
-          bucket: "{{ bucket_name }}"
-          object: put-content.txt
-          mode: put
-          content: >-
-            test content
-          tags:
-            tag_one: '{{ resource_prefix }} One'
-            "Tag Two": 'two {{ resource_prefix }}'
-        register: result
+        # ============================================================
+        - name: create an object from static content
+          s3_object:
+            bucket: "{{ bucket_name }}"
+            object: put-content.txt
+            mode: put
+            content: >-
+              test content
+            tags:
+              tag_one: "{{ resource_prefix }} One"
+              Tag Two: two {{ resource_prefix }}
+          register: result
 
-      - assert:
-          that:
-            - result is changed
-            - "'tags' in result"
-            - (result.tags | length) == 2
-            - result.tags["tag_one"] == '{{ resource_prefix }} One'
-            - result.tags["Tag Two"] == 'two {{ resource_prefix }}'
+        - ansible.builtin.assert:
+            that:
+              - result is changed
+              - "'tags' in result"
+              - (result.tags | length) == 2
+              - result.tags["tag_one"] == '{{ resource_prefix }} One'
+              - result.tags["Tag Two"] == 'two {{ resource_prefix }}'
 
-      - name: ensure idempotency on static content
-        s3_object:
-          bucket: "{{ bucket_name }}"
-          object: put-content.txt
-          mode: put
-          content: >-
-            test content
-          tags:
-            tag_one: '{{ resource_prefix }} One'
-            "Tag Two": 'two {{ resource_prefix }}'
-        register: result
+        - name: ensure idempotency on static content
+          s3_object:
+            bucket: "{{ bucket_name }}"
+            object: put-content.txt
+            mode: put
+            content: >-
+              test content
+            tags:
+              tag_one: "{{ resource_prefix }} One"
+              Tag Two: two {{ resource_prefix }}
+          register: result
 
-      - assert:
-          that:
-            - result is not changed
-            - "'tags' in result"
-            - (result.tags | length) == 2
-            - result.tags["tag_one"] == '{{ resource_prefix }} One'
-            - result.tags["Tag Two"] == 'two {{ resource_prefix }}'
+        - ansible.builtin.assert:
+            that:
+              - result is not changed
+              - "'tags' in result"
+              - (result.tags | length) == 2
+              - result.tags["tag_one"] == '{{ resource_prefix }} One'
+              - result.tags["Tag Two"] == 'two {{ resource_prefix }}'
 
-      - name: Remove a tag from an S3 object
-        s3_object:
-          bucket: "{{ bucket_name }}"
-          object: put-content.txt
-          mode: put
-          content: >-
-            test content
-          tags:
-            tag_one: '{{ resource_prefix }} One'
-        register: result
+        - name: Remove a tag from an S3 object
+          s3_object:
+            bucket: "{{ bucket_name }}"
+            object: put-content.txt
+            mode: put
+            content: >-
+              test content
+            tags:
+              tag_one: "{{ resource_prefix }} One"
+          register: result
 
-      - assert:
-          that:
-            - result is changed
-            - "'tags' in result"
-            - (result.tags | length) == 1
-            - result.tags["tag_one"] == resource_prefix+" One"
-            - "'Tag Two' not in result.tags"
+        - ansible.builtin.assert:
+            that:
+              - result is changed
+              - "'tags' in result"
+              - (result.tags | length) == 1
+              - result.tags["tag_one"] == resource_prefix+" One"
+              - "'Tag Two' not in result.tags"
 
-      - name: Remove the tag from an S3 object (idempotency)
-        s3_object:
-          bucket: "{{ bucket_name }}"
-          object: put-content.txt
-          mode: put
-          content: >-
-            test content
-          tags:
-            tag_one: '{{ resource_prefix }} One'
-        register: result
+        - name: Remove the tag from an S3 object (idempotency)
+          s3_object:
+            bucket: "{{ bucket_name }}"
+            object: put-content.txt
+            mode: put
+            content: >-
+              test content
+            tags:
+              tag_one: "{{ resource_prefix }} One"
+          register: result
 
-      - assert:
-          that:
-            - result is not changed
-            - "'tags' in result"
-            - (result.tags | length) == 1
-            - result.tags["tag_one"] == resource_prefix+" One"
-            - "'Tag Two' not in result.tags"
+        - ansible.builtin.assert:
+            that:
+              - result is not changed
+              - "'tags' in result"
+              - (result.tags | length) == 1
+              - result.tags["tag_one"] == resource_prefix+" One"
+              - "'Tag Two' not in result.tags"
 
-      - name: Add a tag for an S3 object with purge_tags False
-        s3_object:
-          bucket: "{{ bucket_name }}"
-          object: put-content.txt
-          mode: put
-          content: >-
-            test content
-          tags:
-            tag_three: '{{ resource_prefix }} Three'
-          purge_tags: false
-        register: result
+        - name: Add a tag for an S3 object with purge_tags False
+          s3_object:
+            bucket: "{{ bucket_name }}"
+            object: put-content.txt
+            mode: put
+            content: >-
+              test content
+            tags:
+              tag_three: "{{ resource_prefix }} Three"
+            purge_tags: false
+          register: result
 
-      - assert:
-          that:
-            - result is changed
-            - "'tags' in result"
-            - (result.tags | length) == 2
-            - result.tags["tag_three"] == '{{ resource_prefix }} Three'
-            - result.tags["tag_one"] == '{{ resource_prefix }} One'
+        - ansible.builtin.assert:
+            that:
+              - result is changed
+              - "'tags' in result"
+              - (result.tags | length) == 2
+              - result.tags["tag_three"] == '{{ resource_prefix }} Three'
+              - result.tags["tag_one"] == '{{ resource_prefix }} One'
 
-      - name: Add a tag for an S3 object with purge_tags False (idempotency)
-        s3_object:
-          bucket: "{{ bucket_name }}"
-          object: put-content.txt
-          mode: put
-          content: >-
-            test content
-          tags:
-            tag_three: '{{ resource_prefix }} Three'
-          purge_tags: false
-        register: result
+        - name: Add a tag for an S3 object with purge_tags False (idempotency)
+          s3_object:
+            bucket: "{{ bucket_name }}"
+            object: put-content.txt
+            mode: put
+            content: >-
+              test content
+            tags:
+              tag_three: "{{ resource_prefix }} Three"
+            purge_tags: false
+          register: result
 
-      - assert:
-          that:
-            - result is not changed
-            - "'tags' in result"
-            - (result.tags | length) == 2
-            - result.tags["tag_three"] == '{{ resource_prefix }} Three'
-            - result.tags["tag_one"] == '{{ resource_prefix }} One'
+        - ansible.builtin.assert:
+            that:
+              - result is not changed
+              - "'tags' in result"
+              - (result.tags | length) == 2
+              - result.tags["tag_three"] == '{{ resource_prefix }} Three'
+              - result.tags["tag_one"] == '{{ resource_prefix }} One'
 
-      - name: Update tags for an S3 object with purge_tags False
-        s3_object:
-          bucket: "{{ bucket_name }}"
-          object: put-content.txt
-          mode: put
-          content: >-
-            test content
-          tags:
-            "TagFour": '{{ resource_prefix }} tag_four'
-          purge_tags: false
-        register: result
+        - name: Update tags for an S3 object with purge_tags False
+          s3_object:
+            bucket: "{{ bucket_name }}"
+            object: put-content.txt
+            mode: put
+            content: >-
+              test content
+            tags:
+              TagFour: "{{ resource_prefix }} tag_four"
+            purge_tags: false
+          register: result
 
-      - assert:
-          that:
-            - result is changed
-            - "'tags' in result"
-            - (result.tags | length) == 3
-            - result.tags["tag_one"] == '{{ resource_prefix }} One'
-            - result.tags["tag_three"] == '{{ resource_prefix }} Three'
-            - result.tags["TagFour"] == '{{ resource_prefix }} tag_four'
+        - ansible.builtin.assert:
+            that:
+              - result is changed
+              - "'tags' in result"
+              - (result.tags | length) == 3
+              - result.tags["tag_one"] == '{{ resource_prefix }} One'
+              - result.tags["tag_three"] == '{{ resource_prefix }} Three'
+              - result.tags["TagFour"] == '{{ resource_prefix }} tag_four'
 
-      - name:  Update tags for an S3 object with purge_tags False (idempotency)
-        s3_object:
-          bucket: "{{ bucket_name }}"
-          object: put-content.txt
-          mode: put
-          content: >-
-            test content
-          tags:
-            "TagFour": '{{ resource_prefix }} tag_four'
-          purge_tags: false
-        register: result
+        - name: Update tags for an S3 object with purge_tags False (idempotency)
+          s3_object:
+            bucket: "{{ bucket_name }}"
+            object: put-content.txt
+            mode: put
+            content: >-
+              test content
+            tags:
+              TagFour: "{{ resource_prefix }} tag_four"
+            purge_tags: false
+          register: result
 
-      - assert:
-          that:
-            - result is not changed
-            - "'tags' in result"
-            - (result.tags | length) == 3
-            - result.tags["tag_one"] == '{{ resource_prefix }} One'
-            - result.tags["tag_three"] == '{{ resource_prefix }} Three'
-            - result.tags["TagFour"] == '{{ resource_prefix }} tag_four'
+        - ansible.builtin.assert:
+            that:
+              - result is not changed
+              - "'tags' in result"
+              - (result.tags | length) == 3
+              - result.tags["tag_one"] == '{{ resource_prefix }} One'
+              - result.tags["tag_three"] == '{{ resource_prefix }} Three'
+              - result.tags["TagFour"] == '{{ resource_prefix }} tag_four'
 
-      - name: Specify empty tags for an S3 object with purge_tags False
-        s3_object:
-          bucket: "{{ bucket_name }}"
-          object: put-content.txt
-          mode: put
-          content: >-
-            test content
-          tags: {}
-          purge_tags: false
-        register: result
+        - name: Specify empty tags for an S3 object with purge_tags False
+          s3_object:
+            bucket: "{{ bucket_name }}"
+            object: put-content.txt
+            mode: put
+            content: >-
+              test content
+            tags: {}
+            purge_tags: false
+          register: result
 
-      - assert:
-          that:
-            - result is not changed
-            - "'tags' in result"
-            - (result.tags | length) == 3
-            - result.tags["tag_one"] == '{{ resource_prefix }} One'
-            - result.tags["tag_three"] == '{{ resource_prefix }} Three'
-            - result.tags["TagFour"] == '{{ resource_prefix }} tag_four'
+        - ansible.builtin.assert:
+            that:
+              - result is not changed
+              - "'tags' in result"
+              - (result.tags | length) == 3
+              - result.tags["tag_one"] == '{{ resource_prefix }} One'
+              - result.tags["tag_three"] == '{{ resource_prefix }} Three'
+              - result.tags["TagFour"] == '{{ resource_prefix }} tag_four'
 
-      - name: Do not specify any tag to ensure previous tags are not removed
-        s3_object:
-          bucket: "{{ bucket_name }}"
-          object: put-content.txt
-          mode: put
-          content: >-
-            test content
-        register: result
+        - name: Do not specify any tag to ensure previous tags are not removed
+          s3_object:
+            bucket: "{{ bucket_name }}"
+            object: put-content.txt
+            mode: put
+            content: >-
+              test content
+          register: result
 
-      - assert:
-          that:
-            - result is not changed
-            - "'tags' in result"
-            - (result.tags | length) == 3
-            - result.tags["tag_one"] == '{{ resource_prefix }} One'
-            - result.tags["tag_three"] == '{{ resource_prefix }} Three'
-            - result.tags["TagFour"] == '{{ resource_prefix }} tag_four'
+        - ansible.builtin.assert:
+            that:
+              - result is not changed
+              - "'tags' in result"
+              - (result.tags | length) == 3
+              - result.tags["tag_one"] == '{{ resource_prefix }} One'
+              - result.tags["tag_three"] == '{{ resource_prefix }} Three'
+              - result.tags["TagFour"] == '{{ resource_prefix }} tag_four'
 
-      - name: Remove all tags
-        s3_object:
-          bucket: "{{ bucket_name }}"
-          object: put-content.txt
-          mode: put
-          overwrite: different
-          content: >-
-            test content
-          tags: {}
-        register: result
+        - name: Remove all tags
+          s3_object:
+            bucket: "{{ bucket_name }}"
+            object: put-content.txt
+            mode: put
+            overwrite: different
+            content: >-
+              test content
+            tags: {}
+          register: result
 
-      - assert:
-          that:
-            - result is changed
-            - "'tags' in result"
-            - (result.tags | length) == 0
+        - ansible.builtin.assert:
+            that:
+              - result is changed
+              - "'tags' in result"
+              - (result.tags | length) == 0
 
-      - name: Remove all tags (idempotency)
-        s3_object:
-          bucket: "{{ bucket_name }}"
-          object: put-content.txt
-          mode: put
-          content: >-
-            test content
-          tags: {}
-        register: result
+        - name: Remove all tags (idempotency)
+          s3_object:
+            bucket: "{{ bucket_name }}"
+            object: put-content.txt
+            mode: put
+            content: >-
+              test content
+            tags: {}
+          register: result
 
-      - assert:
-          that:
-            - result is not changed
-            - "'tags' in result"
-            - (result.tags | length) == 0
+        - ansible.builtin.assert:
+            that:
+              - result is not changed
+              - "'tags' in result"
+              - (result.tags | length) == 0
 
-      - include_tasks: copy_recursively.yml
-
+        - ansible.builtin.include_tasks: copy_recursively.yml
   always:
-
     - name: delete temporary files
       file:
         state: absent

--- a/tests/integration/targets/setup_botocore_pip/defaults/main.yml
+++ b/tests/integration/targets/setup_botocore_pip/defaults/main.yml
@@ -1,2 +1,3 @@
+---
 default_botocore_version: "{{ lookup('amazon.aws.aws_collection_constants', 'MINIMUM_BOTOCORE_VERSION') }}"
 default_boto3_version: "{{ lookup('amazon.aws.aws_collection_constants', 'MINIMUM_BOTO3_VERSION') }}"

--- a/tests/integration/targets/setup_botocore_pip/handlers/main.yml
+++ b/tests/integration/targets/setup_botocore_pip/handlers/main.yml
@@ -1,2 +1,3 @@
-- name: 'Delete temporary pip environment'
-  include_tasks: cleanup.yml
+---
+- name: Delete temporary pip environment
+  ansible.builtin.include_tasks: cleanup.yml

--- a/tests/integration/targets/setup_botocore_pip/meta/main.yml
+++ b/tests/integration/targets/setup_botocore_pip/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/setup_botocore_pip/tasks/cleanup.yml
+++ b/tests/integration/targets/setup_botocore_pip/tasks/cleanup.yml
@@ -1,5 +1,6 @@
-- name: 'Delete temporary pip environment'
-  file:
+---
+- name: Delete temporary pip environment
+  ansible.builtin.file:
     path: "{{ botocore_pip_directory }}"
     state: absent
-  no_log: yes
+  no_log: true

--- a/tests/integration/targets/setup_botocore_pip/tasks/main.yml
+++ b/tests/integration/targets/setup_botocore_pip/tasks/main.yml
@@ -1,43 +1,44 @@
-- name: 'Ensure that we have virtualenv available to us'
-  pip:
+---
+- name: Ensure that we have virtualenv available to us
+  ansible.builtin.pip:
     name: virtualenv
 
-- name: 'Create temporary directory for pip environment'
-  tempfile:
+- name: Create temporary directory for pip environment
+  ansible.builtin.tempfile:
     path: /var/tmp
     state: directory
     prefix: botocore
     suffix: .test
   register: botocore_pip_directory
   notify:
-    - 'Delete temporary pip environment'
+    - Delete temporary pip environment
 
-- name: 'Record temporary directory'
-  set_fact:
+- name: Record temporary directory
+  ansible.builtin.set_fact:
     botocore_pip_directory: "{{ botocore_pip_directory.path }}"
 
-- set_fact:
+- ansible.builtin.set_fact:
     botocore_virtualenv: "{{ botocore_pip_directory }}/virtualenv"
     botocore_virtualenv_command: "{{ ansible_python_interpreter }} -m virtualenv"
 
-- set_fact:
+- ansible.builtin.set_fact:
     botocore_virtualenv_interpreter: "{{ botocore_virtualenv }}/bin/python"
 
-- pip:
+- ansible.builtin.pip:
     name:
-      - 'boto3{{ _boto3_comparison }}{{ _boto3_version }}'
-      - 'botocore{{ _botocore_comparison }}{{ _botocore_version }}'
-      - 'coverage<5'
+      - boto3{{ _boto3_comparison }}{{ _boto3_version }}
+      - botocore{{ _botocore_comparison }}{{ _botocore_version }}
+      - coverage<5
     virtualenv: "{{ botocore_virtualenv }}"
     virtualenv_command: "{{ botocore_virtualenv_command }}"
-    virtualenv_site_packages: no
+    virtualenv_site_packages: false
   vars:
-    _boto3_version: '{{ boto3_version | default(default_boto3_version) }}'
-    _botocore_version: '{{ botocore_version | default(default_botocore_version) }}'
-    _is_default_boto3: '{{ _boto3_version == default_boto3_version }}'
-    _is_default_botocore: '{{ _botocore_version == default_botocore_version }}'
+    _boto3_version: "{{ boto3_version | default(default_boto3_version) }}"
+    _botocore_version: "{{ botocore_version | default(default_botocore_version) }}"
+    _is_default_boto3: "{{ _boto3_version == default_boto3_version }}"
+    _is_default_botocore: "{{ _botocore_version == default_botocore_version }}"
     # Only set the default to >= if the other dep has been updated and the dep has not been set
-    _default_boto3_comparison: '{% if _is_default_boto3 and not _is_default_botocore %}>={% else %}=={% endif %}'
-    _default_botocore_comparison: '{% if _is_default_botocore and not _is_default_boto3 %}>={% else %}=={% endif %}'
-    _boto3_comparison: '{{ boto3_comparison | default(_default_boto3_comparison) }}'
-    _botocore_comparison: '{{ botocore_comparison | default(_default_botocore_comparison) }}'
+    _default_boto3_comparison: "{% if _is_default_boto3 and not _is_default_botocore %}>={% else %}=={% endif %}"
+    _default_botocore_comparison: "{% if _is_default_botocore and not _is_default_boto3 %}>={% else %}=={% endif %}"
+    _boto3_comparison: "{{ boto3_comparison | default(_default_boto3_comparison) }}"
+    _botocore_comparison: "{{ botocore_comparison | default(_default_botocore_comparison) }}"

--- a/tests/integration/targets/setup_ec2_facts/defaults/main.yml
+++ b/tests/integration/targets/setup_ec2_facts/defaults/main.yml
@@ -1,4 +1,5 @@
-ec2_ami_name: 'Fedora-Cloud-Base-*.x86_64*'
+---
+ec2_ami_name: Fedora-Cloud-Base-*.x86_64*
 # CentOS Community Platform Engineering (CPE)
-ec2_ami_owner_id: '125523088429'
-ec2_ami_ssh_user: 'fedora'
+ec2_ami_owner_id: "125523088429"
+ec2_ami_ssh_user: fedora

--- a/tests/integration/targets/setup_ec2_facts/meta/main.yml
+++ b/tests/integration/targets/setup_ec2_facts/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/setup_ec2_facts/tasks/main.yml
+++ b/tests/integration/targets/setup_ec2_facts/tasks/main.yml
@@ -10,44 +10,44 @@
 #
 - module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit) }}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
-  run_once: True
+  run_once: true
   block:
   # ============================================================
 
-  - name: Get available AZs
-    aws_az_info:
-      filters:
-        region-name: '{{ aws_region }}'
-    register: _az_info
+    - name: Get available AZs
+      amazon.aws.aws_az_info:
+        filters:
+          region-name: "{{ aws_region }}"
+      register: _az_info
 
-  - name: Pick an AZ
-    set_fact:
-      ec2_availability_zone_names: '{{ _az_info.availability_zones | selectattr("zone_name", "defined") | map(attribute="zone_name") | list }}'
+    - name: Pick an AZ
+      ansible.builtin.set_fact:
+        ec2_availability_zone_names: '{{ _az_info.availability_zones | selectattr("zone_name", "defined") | map(attribute="zone_name") | list }}'
 
-  # ============================================================
+    # ============================================================
 
-  - name: Get a list of images
-    ec2_ami_info:
-      filters:
-        name: '{{ ec2_ami_name }}'
-        owner-id: '{{ ec2_ami_owner_id }}'
-        architecture: x86_64
-        virtualization-type: hvm
-        root-device-type: ebs
-    register: _images_info
-    # Very spammy
-    no_log: True
+    - name: Get a list of images
+      amazon.aws.ec2_ami_info:
+        filters:
+          name: "{{ ec2_ami_name }}"
+          owner-id: "{{ ec2_ami_owner_id }}"
+          architecture: x86_64
+          virtualization-type: hvm
+          root-device-type: ebs
+      register: _images_info
+      # Very spammy
+      no_log: true
 
-  - name: Set Fact for latest AMI
-    vars:
-      latest_image: '{{ _images_info.images | sort(attribute="creation_date") | reverse | first }}'
-    set_fact:
-      ec2_ami_id: '{{ latest_image.image_id }}'
-      ec2_ami_details: '{{ latest_image }}'
-      ec2_ami_root_disk: '{{ latest_image.block_device_mappings[0].device_name }}'
-      ec2_ami_ssh_user: '{{ ec2_ami_ssh_user }}'
+    - name: Set Fact for latest AMI
+      vars:
+        latest_image: '{{ _images_info.images | sort(attribute="creation_date") | reverse | first }}'
+      ansible.builtin.set_fact:
+        ec2_ami_id: "{{ latest_image.image_id }}"
+        ec2_ami_details: "{{ latest_image }}"
+        ec2_ami_root_disk: "{{ latest_image.block_device_mappings[0].device_name }}"
+        ec2_ami_ssh_user: "{{ ec2_ami_ssh_user }}"

--- a/tests/integration/targets/setup_ec2_instance_env/defaults/main.yml
+++ b/tests/integration/targets/setup_ec2_instance_env/defaults/main.yml
@@ -1,24 +1,24 @@
 ---
 # defaults file for ec2_instance tests
-ec2_instance_test_name: 'ec2_instance'
+ec2_instance_test_name: ec2_instance
 
-ec2_instance_owner: 'integration-run-{{ ec2_instance_test_name }}'
-ec2_instance_type: 't3.micro'
-ec2_instance_tag_TestId: '{{ resource_prefix }}-{{ ec2_instance_test_name }}'
+ec2_instance_owner: integration-run-{{ ec2_instance_test_name }}
+ec2_instance_type: t3.micro
+ec2_instance_tag_TestId: "{{ resource_prefix }}-{{ ec2_instance_test_name }}"
 
-vpc_name: '{{ resource_prefix }}-{{ ec2_instance_test_name }}'
-vpc_seed: '{{ resource_prefix }}-{{ ec2_instance_test_name }}'
+vpc_name: "{{ resource_prefix }}-{{ ec2_instance_test_name }}"
+vpc_seed: "{{ resource_prefix }}-{{ ec2_instance_test_name }}"
 
-vpc_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.0.0/16'
+vpc_cidr: 10.{{ 256 | random(seed=vpc_seed) }}.0.0/16
 
-subnet_a_az: '{{ ec2_availability_zone_names[0] }}'
-subnet_a_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.32.0/24'
-subnet_a_startswith: '10.{{ 256 | random(seed=vpc_seed) }}.32.'
-subnet_a_name: '{{ resource_prefix }}-{{ ec2_instance_test_name }}-a'
-subnet_b_az: '{{ ec2_availability_zone_names[1] }}'
-subnet_b_cidr: '10.{{ 256 | random(seed=vpc_seed) }}.33.0/24'
-subnet_b_startswith: '10.{{ 256 | random(seed=vpc_seed) }}.33.'
-subnet_b_name: '{{ resource_prefix }}-{{ ec2_instance_test_name }}-b'
+subnet_a_az: "{{ ec2_availability_zone_names[0] }}"
+subnet_a_cidr: 10.{{ 256 | random(seed=vpc_seed) }}.32.0/24
+subnet_a_startswith: 10.{{ 256 | random(seed=vpc_seed) }}.32.
+subnet_a_name: "{{ resource_prefix }}-{{ ec2_instance_test_name }}-a"
+subnet_b_az: "{{ ec2_availability_zone_names[1] }}"
+subnet_b_cidr: 10.{{ 256 | random(seed=vpc_seed) }}.33.0/24
+subnet_b_startswith: 10.{{ 256 | random(seed=vpc_seed) }}.33.
+subnet_b_name: "{{ resource_prefix }}-{{ ec2_instance_test_name }}-b"
 
-security_group_name_1: '{{ resource_prefix }}-{{ ec2_instance_test_name }}-1'
-security_group_name_2: '{{ resource_prefix }}-{{ ec2_instance_test_name }}-2'
+security_group_name_1: "{{ resource_prefix }}-{{ ec2_instance_test_name }}-1"
+security_group_name_2: "{{ resource_prefix }}-{{ ec2_instance_test_name }}-2"

--- a/tests/integration/targets/setup_ec2_instance_env/handlers/main.yml
+++ b/tests/integration/targets/setup_ec2_instance_env/handlers/main.yml
@@ -1,2 +1,3 @@
-- name: 'Delete ec2_instance environment'
-  include_tasks: cleanup.yml
+---
+- name: Delete ec2_instance environment
+  ansible.builtin.include_tasks: cleanup.yml

--- a/tests/integration/targets/setup_ec2_instance_env/meta/main.yml
+++ b/tests/integration/targets/setup_ec2_instance_env/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/setup_ec2_instance_env/tasks/cleanup.yml
+++ b/tests/integration/targets/setup_ec2_instance_env/tasks/cleanup.yml
@@ -1,3 +1,4 @@
+---
 - module_defaults:
     group/aws:
       access_key: "{{ aws_access_key }}"
@@ -5,114 +6,114 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-  - name: Set termination protection to false (so we can terminate instance) (cleanup)
-    ec2_instance:
-      filters:
-        instance-state-name: ['pending', 'running', 'stopping', 'stopped']
-        vpc-id: '{{ testing_vpc.vpc.id }}'
-      termination_protection: false
-    ignore_errors: yes
+    - name: Set termination protection to false (so we can terminate instance) (cleanup)
+      amazon.aws.ec2_instance:
+        filters:
+          instance-state-name: [pending, running, stopping, stopped]
+          vpc-id: "{{ testing_vpc.vpc.id }}"
+        termination_protection: false
+      ignore_errors: true
 
-  - name: "(Cleanup) Find all remaining Instances"
-    ec2_instance_info:
-      filters:
-        vpc-id: '{{ testing_vpc.vpc.id }}'
-        instance-state-name: ['pending', 'running', 'shutting-down', 'stopping', 'stopped']
-    register: instances
+    - name: (Cleanup) Find all remaining Instances
+      amazon.aws.ec2_instance_info:
+        filters:
+          vpc-id: "{{ testing_vpc.vpc.id }}"
+          instance-state-name: [pending, running, shutting-down, stopping, stopped]
+      register: instances
 
-  - name: "(Cleanup) Remove Instances (start)"
-    ec2_instance:
-      state: absent
-      instance_ids: '{{ item.instance_id }}'
-      wait: no
-    ignore_errors: yes
-    loop: '{{ instances.instances }}'
+    - name: (Cleanup) Remove Instances (start)
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids: "{{ item.instance_id }}"
+        wait: false
+      ignore_errors: true
+      loop: "{{ instances.instances }}"
 
-  - name: "(Cleanup) Remove Instances (wait for completion)"
-    ec2_instance:
-      state: absent
-      instance_ids: '{{ item.instance_id }}'
-      filters:
-        instance-state-name: ['pending', 'running', 'shutting-down', 'stopping', 'stopped']
-        vpc-id: '{{ testing_vpc.vpc.id }}'
-      wait: yes
-    ignore_errors: yes
-    loop: '{{ instances.instances }}'
+    - name: (Cleanup) Remove Instances (wait for completion)
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids: "{{ item.instance_id }}"
+        filters:
+          instance-state-name: [pending, running, shutting-down, stopping, stopped]
+          vpc-id: "{{ testing_vpc.vpc.id }}"
+        wait: true
+      ignore_errors: true
+      loop: "{{ instances.instances }}"
 
-  - name: "(Cleanup) Find all remaining ENIs"
-    ec2_eni_info:
-      filters:
-        vpc-id: "{{ testing_vpc.vpc.id }}"
-    register: enis
+    - name: (Cleanup) Find all remaining ENIs
+      amazon.aws.ec2_eni_info:
+        filters:
+          vpc-id: "{{ testing_vpc.vpc.id }}"
+      register: enis
 
-  - name: "(Cleanup) delete all ENIs"
-    ec2_eni:
-      state: absent
-      eni_id: "{{ item.id }}"
-    register: eni_removed
-    until: eni_removed is not failed
-    with_items: "{{ enis.network_interfaces }}"
-    ignore_errors: yes
-    retries: 10
+    - name: (Cleanup) delete all ENIs
+      amazon.aws.ec2_eni:
+        state: absent
+        eni_id: "{{ item.id }}"
+      register: eni_removed
+      until: eni_removed is not failed
+      with_items: "{{ enis.network_interfaces }}"
+      ignore_errors: true
+      retries: 10
 
-  - name: "(Cleanup) Find all remaining Security Groups"
-    ec2_security_group_info:
-      filters:
-        vpc-id: '{{ testing_vpc.vpc.id }}'
-    register: security_groups
+    - name: (Cleanup) Find all remaining Security Groups
+      ec2_security_group_info:
+        filters:
+          vpc-id: "{{ testing_vpc.vpc.id }}"
+      register: security_groups
 
-  - name: "(Cleanup) Remove the security group rules"
-    ec2_security_group:
-      state: present
-      name: '{{ item.group_name }}'
-      description: '{{ item.description }}'
-      vpc_id: '{{ testing_vpc.vpc.id }}'
-      rules: []
-      egress_rules: []
-    loop: '{{ security_groups.security_groups }}'
-    register: sg_removed
-    until: sg_removed is not failed
-    ignore_errors: yes
-    retries: 10
+    - name: (Cleanup) Remove the security group rules
+      ec2_security_group:
+        state: present
+        name: "{{ item.group_name }}"
+        description: "{{ item.description }}"
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        rules: []
+        egress_rules: []
+      loop: "{{ security_groups.security_groups }}"
+      register: sg_removed
+      until: sg_removed is not failed
+      ignore_errors: true
+      retries: 10
 
-  - name: "(Cleanup) Remove the security groups"
-    ec2_security_group:
-      state: absent
-      group_id: '{{ item.group_id }}'
-    loop: '{{ security_groups.security_groups }}'
-    when:
-    - item.group_name != 'default'
-    register: sg_removed
-    until: sg_removed is not failed
-    ignore_errors: yes
-    retries: 10
+    - name: (Cleanup) Remove the security groups
+      ec2_security_group:
+        state: absent
+        group_id: "{{ item.group_id }}"
+      loop: "{{ security_groups.security_groups }}"
+      when:
+        - item.group_name != 'default'
+      register: sg_removed
+      until: sg_removed is not failed
+      ignore_errors: true
+      retries: 10
 
-  - name: "(Cleanup) Find all remaining Subnets"
-    ec2_vpc_subnet_info:
-      filters:
-        vpc-id: '{{ testing_vpc.vpc.id }}'
-    register: subnets
+    - name: (Cleanup) Find all remaining Subnets
+      amazon.aws.ec2_vpc_subnet_info:
+        filters:
+          vpc-id: "{{ testing_vpc.vpc.id }}"
+      register: subnets
 
-  - name: "(Cleanup) Remove subnets"
-    ec2_vpc_subnet:
-      state: absent
-      vpc_id: "{{ testing_vpc.vpc.id }}"
-      cidr: "{{ item.cidr_block }}"
-    register: removed
-    loop: '{{ subnets.subnets }}'
-    until: removed is not failed
-    ignore_errors: yes
-    retries: 10
+    - name: (Cleanup) Remove subnets
+      amazon.aws.ec2_vpc_subnet:
+        state: absent
+        vpc_id: "{{ testing_vpc.vpc.id }}"
+        cidr: "{{ item.cidr_block }}"
+      register: removed
+      loop: "{{ subnets.subnets }}"
+      until: removed is not failed
+      ignore_errors: true
+      retries: 10
 
-  - name: "(Cleanup) Remove the VPC"
-    ec2_vpc_net:
-      state: absent
-      name: "{{ vpc_name }}"
-      cidr_block: "{{ vpc_cidr }}"
-      tags:
-        Name: Ansible Testing VPC
-      tenancy: default
-    register: removed
-    until: removed is not failed
-    ignore_errors: yes
-    retries: 10
+    - name: (Cleanup) Remove the VPC
+      amazon.aws.ec2_vpc_net:
+        state: absent
+        name: "{{ vpc_name }}"
+        cidr_block: "{{ vpc_cidr }}"
+        tags:
+          Name: Ansible Testing VPC
+        tenancy: default
+      register: removed
+      until: removed is not failed
+      ignore_errors: true
+      retries: 10

--- a/tests/integration/targets/setup_ec2_instance_env/tasks/main.yml
+++ b/tests/integration/targets/setup_ec2_instance_env/tasks/main.yml
@@ -8,7 +8,7 @@
       region: "{{ aws_region }}"
   block:
     - name: Create VPC for use in testing
-      ec2_vpc_net:
+      amazon.aws.ec2_vpc_net:
         state: present
         name: "{{ vpc_name }}"
         cidr_block: "{{ vpc_cidr }}"
@@ -20,7 +20,7 @@
         - Delete ec2_instance environment
 
     - name: Create default subnet in zone A
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         state: present
         vpc_id: "{{ testing_vpc.vpc.id }}"
         cidr: "{{ subnet_a_cidr }}"
@@ -30,7 +30,7 @@
       register: testing_subnet_a
 
     - name: Create secondary subnet in zone B
-      ec2_vpc_subnet:
+      amazon.aws.ec2_vpc_subnet:
         state: present
         vpc_id: "{{ testing_vpc.vpc.id }}"
         cidr: "{{ subnet_b_cidr }}"
@@ -73,7 +73,7 @@
       register: sg2
 
     - name: Preserve defaults for other roles
-      set_fact:
+      ansible.builtin.set_fact:
       # Ensure variables are available outside of this role
         vpc_cidr: "{{ vpc_cidr }}"
         vpc_name: "{{ vpc_name }}"

--- a/tests/integration/targets/setup_ec2_vpc/meta/main.yml
+++ b/tests/integration/targets/setup_ec2_vpc/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/setup_ec2_vpc/tasks/cleanup.yml
+++ b/tests/integration/targets/setup_ec2_vpc/tasks/cleanup.yml
@@ -1,56 +1,56 @@
+---
 # ============================================================
 - name: Run all tests
   module_defaults:
     group/aws:
-      access_key: '{{ aws_access_key }}'
-      secret_key: '{{ aws_secret_key }}'
-      session_token: '{{ security_token | default(omit)}}'
-      region: '{{ aws_region }}'
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit)}}"
+      region: "{{ aws_region }}"
   block:
-
     # ============================================================
     # Describe state of remaining resources
 
-    - name: '(VPC Cleanup) Find all remaining ENIs'
-      ec2_eni_info:
+    - name: (VPC Cleanup) Find all remaining ENIs
+      amazon.aws.ec2_eni_info:
         filters:
-          vpc-id: '{{ vpc_id }}'
+          vpc-id: "{{ vpc_id }}"
       register: remaining_enis
 
-    - name: '(VPC Cleanup) Retrieve security group info based on VPC ID'
+    - name: (VPC Cleanup) Retrieve security group info based on VPC ID
       ec2_security_group_info:
         filters:
-          vpc-id: '{{ vpc_id }}'
+          vpc-id: "{{ vpc_id }}"
       register: remaining_groups
 
-    - name: '(VPC Cleanup) Retrieve subnet info based on VPC ID'
-      ec2_vpc_subnet_info:
+    - name: (VPC Cleanup) Retrieve subnet info based on VPC ID
+      amazon.aws.ec2_vpc_subnet_info:
         filters:
-          vpc-id: '{{ vpc_id }}'
+          vpc-id: "{{ vpc_id }}"
       register: remaining_subnets
 
-    - name: '(VPC Cleanup) Retrieve route table info based on VPC ID'
-      ec2_vpc_route_table_info:
+    - name: (VPC Cleanup) Retrieve route table info based on VPC ID
+      amazon.aws.ec2_vpc_route_table_info:
         filters:
-          vpc-id: '{{ vpc_id }}'
+          vpc-id: "{{ vpc_id }}"
       register: remaining_rtbs
 
-    - name: '(VPC Cleanup) Retrieve VPC info based on VPC ID'
-      ec2_vpc_net_info:
+    - name: (VPC Cleanup) Retrieve VPC info based on VPC ID
+      amazon.aws.ec2_vpc_net_info:
         vpc_ids:
-          - '{{ vpc_id }}'
+          - "{{ vpc_id }}"
       register: remaining_vpc
 
     # ============================================================
 
-    - name: '(Cleanup) Delete all ENIs'
-      ec2_eni:
+    - name: (Cleanup) Delete all ENIs
+      amazon.aws.ec2_eni:
         state: absent
-        eni_id: '{{ item.id }}'
+        eni_id: "{{ item.id }}"
       register: eni_removed
       until: eni_removed is not failed
-      loop: '{{ remaining_enis.network_interfaces }}'
-      ignore_errors: yes
+      loop: "{{ remaining_enis.network_interfaces }}"
+      ignore_errors: true
       retries: 10
 
     # ============================================================
@@ -58,71 +58,71 @@
 
     # Cross-dependencies between rules in the SGs can cause us problems if we don't clear the rules
     # first
-    - name: '(VPC Cleanup) Delete rules from remaining SGs'
+    - name: (VPC Cleanup) Delete rules from remaining SGs
       ec2_security_group:
-        name: '{{ item.group_name }}'
-        group_id: '{{ item.group_id }}'
-        description: '{{ item.description }}'
+        name: "{{ item.group_name }}"
+        group_id: "{{ item.group_id }}"
+        description: "{{ item.description }}"
         rules: []
         rules_egress: []
-      loop: '{{ remaining_groups.security_groups }}'
-      ignore_errors: yes
+      loop: "{{ remaining_groups.security_groups }}"
+      ignore_errors: true
 
-    - name: '(VPC Cleanup) Delete remaining SGs'
+    - name: (VPC Cleanup) Delete remaining SGs
       ec2_security_group:
         state: absent
-        group_id: '{{ item.group_id }}'
-      loop: '{{ remaining_groups.security_groups }}'
+        group_id: "{{ item.group_id }}"
+      loop: "{{ remaining_groups.security_groups }}"
       when:
-      - item.group_name != 'default'
-      ignore_errors: yes
+        - item.group_name != 'default'
+      ignore_errors: true
 
     # ============================================================
 
-    - name: '(VPC Cleanup) Delete remaining subnets'
-      ec2_vpc_subnet:
+    - name: (VPC Cleanup) Delete remaining subnets
+      amazon.aws.ec2_vpc_subnet:
         state: absent
-        vpc_id: '{{ vpc_id }}'
-        cidr: '{{ item.cidr_block }}'
+        vpc_id: "{{ vpc_id }}"
+        cidr: "{{ item.cidr_block }}"
       register: subnets_removed
-      loop: '{{ remaining_subnets.subnets }}'
+      loop: "{{ remaining_subnets.subnets }}"
       until: subnets_removed is not failed
       when:
         - item.name != 'default'
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10
 
     # ============================================================
 
-    - name: '(VPC Cleanup) Delete IGW'
-      ec2_vpc_igw:
+    - name: (VPC Cleanup) Delete IGW
+      amazon.aws.ec2_vpc_igw:
         state: absent
-        vpc_id: '{{ vpc_id }}'
+        vpc_id: "{{ vpc_id }}"
       register: igw_deletion
       retries: 10
       delay: 5
       until: igw_deletion is success
-      ignore_errors: yes
+      ignore_errors: true
 
     # ============================================================
 
-    - name: '(VPC Cleanup) Delete remaining route tables'
-      ec2_vpc_route_table:
+    - name: (VPC Cleanup) Delete remaining route tables
+      amazon.aws.ec2_vpc_route_table:
         state: absent
-        vpc_id: '{{ vpc_id }}'
-        route_table_id: '{{ item.id }}'
-        lookup: 'id'
+        vpc_id: "{{ vpc_id }}"
+        route_table_id: "{{ item.id }}"
+        lookup: id
       register: rtbs_removed
-      loop: '{{ remaining_rtbs.route_tables }}'
-      ignore_errors: yes
+      loop: "{{ remaining_rtbs.route_tables }}"
+      ignore_errors: true
 
     # ============================================================
 
-    - name: '(VPC Cleanup) Remove the VPC'
-      ec2_vpc_net:
+    - name: (VPC Cleanup) Remove the VPC
+      amazon.aws.ec2_vpc_net:
         state: absent
-        vpc_id: '{{ vpc_id }}'
+        vpc_id: "{{ vpc_id }}"
       register: vpc_removed
       until: vpc_removed is not failed
-      ignore_errors: yes
+      ignore_errors: true
       retries: 10

--- a/tests/integration/targets/setup_ec2_vpc/tasks/main.yml
+++ b/tests/integration/targets/setup_ec2_vpc/tasks/main.yml
@@ -1,2 +1,3 @@
-- debug:
-    msg: 'VPC Cleanup module loaded'
+---
+- ansible.builtin.debug:
+    msg: VPC Cleanup module loaded

--- a/tests/integration/targets/setup_remote_tmp_dir/handlers/main.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/handlers/main.yml
@@ -1,5 +1,5 @@
+---
 - name: delete temporary directory
-  include_tasks: default-cleanup.yml
-
+  ansible.builtin.include_tasks: default-cleanup.yml
 - name: delete temporary directory (windows)
-  include_tasks: windows-cleanup.yml
+  ansible.builtin.include_tasks: windows-cleanup.yml

--- a/tests/integration/targets/setup_remote_tmp_dir/meta/main.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/setup_remote_tmp_dir/tasks/default-cleanup.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/tasks/default-cleanup.yml
@@ -1,5 +1,6 @@
+---
 - name: delete temporary directory
-  file:
+  ansible.builtin.file:
     path: "{{ remote_tmp_dir }}"
     state: absent
-  no_log: yes
+  no_log: true

--- a/tests/integration/targets/setup_remote_tmp_dir/tasks/default.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/tasks/default.yml
@@ -1,5 +1,6 @@
+---
 - name: create temporary directory
-  tempfile:
+  ansible.builtin.tempfile:
     path: /var/tmp
     state: directory
     suffix: .test
@@ -8,5 +9,5 @@
     - delete temporary directory
 
 - name: record temporary directory
-  set_fact:
+  ansible.builtin.set_fact:
     remote_tmp_dir: "{{ remote_tmp_dir.path }}"

--- a/tests/integration/targets/setup_remote_tmp_dir/tasks/main.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/tasks/main.yml
@@ -1,10 +1,11 @@
+---
 - name: make sure we have the ansible_os_family and ansible_distribution_version facts
-  setup:
+  ansible.builtin.setup:
     gather_subset: distribution
   when: ansible_facts == {}
 
-- include_tasks: "{{ lookup('first_found', files)}}"
+- ansible.builtin.include_tasks: "{{ lookup('first_found', files)}}"
   vars:
     files:
       - "{{ ansible_os_family | lower }}.yml"
-      - "default.yml"
+      - default.yml

--- a/tests/integration/targets/setup_remote_tmp_dir/tasks/windows-cleanup.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/tasks/windows-cleanup.yml
@@ -1,4 +1,5 @@
+---
 - name: delete temporary directory (windows)
   ansible.windows.win_file:
-    path: '{{ remote_tmp_dir }}'
+    path: "{{ remote_tmp_dir }}"
     state: absent

--- a/tests/integration/targets/setup_remote_tmp_dir/tasks/windows.yml
+++ b/tests/integration/targets/setup_remote_tmp_dir/tasks/windows.yml
@@ -1,10 +1,11 @@
+---
 - name: create temporary directory
   register: remote_tmp_dir
   notify:
-  - delete temporary directory (windows)
+    - delete temporary directory (windows)
   ansible.windows.win_tempfile:
     state: directory
     suffix: .test
 - name: record temporary directory
-  set_fact:
-    remote_tmp_dir: '{{ remote_tmp_dir.path }}'
+  ansible.builtin.set_fact:
+    remote_tmp_dir: "{{ remote_tmp_dir.path }}"

--- a/tests/integration/targets/setup_sshkey/meta/main.yml
+++ b/tests/integration/targets/setup_sshkey/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/setup_sshkey/tasks/main.yml
+++ b/tests/integration/targets/setup_sshkey/tasks/main.yml
@@ -1,3 +1,4 @@
+---
 # (c) 2014, James Laska <jlaska@ansible.com>
 
 # This file is part of Ansible
@@ -16,56 +17,56 @@
 # along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
 
 - name: create a temp dir
-  tempfile:
+  ansible.builtin.tempfile:
     state: directory
   register: sshkey_dir
   tags:
     - prepare
 
 - name: ensure script is available
-  copy:
+  ansible.builtin.copy:
     src: ec2-fingerprint.py
-    dest: '{{ sshkey_dir.path }}/ec2-fingerprint.py'
-    mode: 0700
+    dest: "{{ sshkey_dir.path }}/ec2-fingerprint.py"
+    mode: "0700"
   tags:
     - prepare
 
 - name: Set location of SSH keys
-  set_fact:
-    sshkey: '{{ sshkey_dir.path }}/key_one'
-    another_sshkey: '{{ sshkey_dir.path }}/key_two'
-    sshkey_pub: '{{ sshkey_dir.path }}/key_one.pub'
-    another_sshkey_pub: '{{ sshkey_dir.path }}/key_two.pub'
+  ansible.builtin.set_fact:
+    sshkey: "{{ sshkey_dir.path }}/key_one"
+    another_sshkey: "{{ sshkey_dir.path }}/key_two"
+    sshkey_pub: "{{ sshkey_dir.path }}/key_one.pub"
+    another_sshkey_pub: "{{ sshkey_dir.path }}/key_two.pub"
 
 - name: generate sshkey
-  shell: echo 'y' | ssh-keygen -P '' -f '{{ sshkey }}'
+  ansible.builtin.shell: echo 'y' | ssh-keygen -P '' -f '{{ sshkey }}'
   tags:
     - prepare
 
 - name: record fingerprint
-  shell: '{{ sshkey_dir.path }}/ec2-fingerprint.py {{ sshkey_pub }}'
+  ansible.builtin.shell: "{{ sshkey_dir.path }}/ec2-fingerprint.py {{ sshkey_pub }}"
   register: fingerprint
   tags:
     - prepare
 
 - name: generate another_sshkey
-  shell: echo 'y' | ssh-keygen -P '' -f {{ another_sshkey }}
+  ansible.builtin.shell: echo 'y' | ssh-keygen -P '' -f {{ another_sshkey }}
   tags:
     - prepare
 
 - name: record another fingerprint
-  shell: '{{ sshkey_dir.path }}/ec2-fingerprint.py {{ another_sshkey_pub }}'
+  ansible.builtin.shell: "{{ sshkey_dir.path }}/ec2-fingerprint.py {{ another_sshkey_pub }}"
   register: another_fingerprint
   tags:
     - prepare
 
 - name: set facts for future roles
-  set_fact:
+  ansible.builtin.set_fact:
     # Public SSH keys (OpenSSH format)
     key_material: "{{ lookup('file', sshkey_pub) }}"
     another_key_material: "{{ lookup('file', another_sshkey_pub) }}"
     # AWS 'fingerprint' (md5digest)
-    fingerprint: '{{ fingerprint.stdout }}'
-    another_fingerprint: '{{ another_fingerprint.stdout }}'
+    fingerprint: "{{ fingerprint.stdout }}"
+    another_fingerprint: "{{ another_fingerprint.stdout }}"
   tags:
     - prepare

--- a/tests/integration/targets/sts_assume_role/defaults/main.yml
+++ b/tests/integration/targets/sts_assume_role/defaults/main.yml
@@ -1,1 +1,2 @@
-iam_role_name: "ansible-test-{{ tiny_prefix }}"
+---
+iam_role_name: ansible-test-{{ tiny_prefix }}

--- a/tests/integration/targets/sts_assume_role/meta/main.yml
+++ b/tests/integration/targets/sts_assume_role/meta/main.yml
@@ -1,1 +1,2 @@
+---
 dependencies: []

--- a/tests/integration/targets/sts_assume_role/tasks/main.yml
+++ b/tests/integration/targets/sts_assume_role/tasks/main.yml
@@ -3,29 +3,29 @@
 
 - module_defaults:
     group/aws:
-        region: "{{ aws_region }}"
-        access_key: "{{ aws_access_key }}"
-        secret_key: "{{ aws_secret_key }}"
-        session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   collections:
     - amazon.aws
   block:
     # Get some information about who we are before starting our tests
     # we'll need this as soon as we start working on the policies
     - name: get ARN of calling user
-      aws_caller_info:
+      amazon.aws.aws_caller_info:
       register: aws_caller_info
 
     - name: register account id
-      set_fact:
+      ansible.builtin.set_fact:
         aws_account: "{{ aws_caller_info.account }}"
 
     # ============================================================
     - name: create test iam role
-      iam_role:
+      community.aws.iam_role:
         name: "{{ iam_role_name }}"
-        assume_role_policy_document:  "{{ lookup('template','policy.json.j2') }}"
-        create_instance_profile: False
+        assume_role_policy_document: "{{ lookup('template','policy.json.j2') }}"
+        create_instance_profile: false
         managed_policy:
           - arn:aws:iam::aws:policy/IAMReadOnlyAccess
         state: present
@@ -33,76 +33,76 @@
 
     # ============================================================
     - name: pause to ensure role exists before using
-      pause:
+      ansible.builtin.pause:
         seconds: 30
 
     # ============================================================
     - name: test with no parameters
-      sts_assume_role:
-        access_key: '{{ omit }}'
-        secret_key: '{{ omit }}'
-        session_token: '{{ omit }}'
+      community.aws.sts_assume_role:
+        access_key: "{{ omit }}"
+        secret_key: "{{ omit }}"
+        session_token: "{{ omit }}"
       register: result
       ignore_errors: true
 
     - name: assert with no parameters
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.failed'
-           - "'missing required arguments:' in result.msg"
+          - result.failed
+          - "'missing required arguments:' in result.msg"
 
     # ============================================================
     - name: test with only 'role_arn' parameter
-      sts_assume_role:
+      community.aws.sts_assume_role:
         role_arn: "{{ test_role.iam_role.arn }}"
       register: result
       ignore_errors: true
 
     - name: assert with only 'role_arn' parameter
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.failed'
-           - "'missing required arguments: role_session_name' in result.msg"
+          - result.failed
+          - "'missing required arguments: role_session_name' in result.msg"
 
     # ============================================================
     - name: test with only 'role_session_name' parameter
-      sts_assume_role:
-        role_session_name: "AnsibleTest"
+      community.aws.sts_assume_role:
+        role_session_name: AnsibleTest
       register: result
       ignore_errors: true
 
     - name: assert with only 'role_session_name' parameter
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'result.failed'
-           - "'missing required arguments: role_arn' in result.msg"
+          - result.failed
+          - "'missing required arguments: role_arn' in result.msg"
 
     # ============================================================
     - name: test assume role with invalid policy
-      sts_assume_role:
+      community.aws.sts_assume_role:
         role_arn: "{{ test_role.iam_role.arn }}"
-        role_session_name: "AnsibleTest"
-        policy: "invalid policy"
+        role_session_name: AnsibleTest
+        policy: invalid policy
       register: result
       ignore_errors: true
 
     - name: assert assume role with invalid policy
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - "'The policy is not in the valid JSON format.' in result.msg"
       when: result.module_stderr is not defined
 
     - name: assert assume role with invalid policy
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - "'The policy is not in the valid JSON format.' in result.module_stderr"
       when: result.module_stderr is defined
 
     # ============================================================
     - name: test assume role with invalid duration seconds
-      sts_assume_role:
+      community.aws.sts_assume_role:
         role_arn: "{{ test_role.iam_role.arn }}"
         role_session_name: AnsibleTest
         duration_seconds: invalid duration
@@ -110,7 +110,7 @@
       ignore_errors: true
 
     - name: assert assume role with invalid duration seconds
-      assert:
+      ansible.builtin.assert:
         that:
           - result is failed
           - "'duration_seconds' in result.msg"
@@ -118,7 +118,7 @@
 
     # ============================================================
     - name: test assume role with invalid external id
-      sts_assume_role:
+      community.aws.sts_assume_role:
         role_arn: "{{ test_role.iam_role.arn }}"
         role_session_name: AnsibleTest
         external_id: invalid external id
@@ -126,22 +126,22 @@
       ignore_errors: true
 
     - name: assert assume role with invalid external id
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - "'Member must satisfy regular expression pattern:' in result.msg"
       when: result.module_stderr is not defined
 
     - name: assert assume role with invalid external id
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - "'Member must satisfy regular expression pattern:' in result.module_stderr"
       when: result.module_stderr is defined
 
     # ============================================================
     - name: test assume role with invalid mfa serial number
-      sts_assume_role:
+      community.aws.sts_assume_role:
         role_arn: "{{ test_role.iam_role.arn }}"
         role_session_name: AnsibleTest
         mfa_serial_number: invalid serial number
@@ -149,22 +149,22 @@
       ignore_errors: true
 
     - name: assert assume role with invalid mfa serial number
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - "'Member must satisfy regular expression pattern:' in result.msg"
       when: result.module_stderr is not defined
 
     - name: assert assume role with invalid mfa serial number
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - "'Member must satisfy regular expression pattern:' in result.module_stderr"
       when: result.module_stderr is defined
 
     # ============================================================
     - name: test assume role with invalid mfa token code
-      sts_assume_role:
+      community.aws.sts_assume_role:
         role_arn: "{{ test_role.iam_role.arn }}"
         role_session_name: AnsibleTest
         mfa_token: invalid token code
@@ -172,101 +172,101 @@
       ignore_errors: true
 
     - name: assert assume role with invalid mfa token code
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - "'Member must satisfy regular expression pattern:' in result.msg"
       when: result.module_stderr is not defined
 
     - name: assert assume role with invalid mfa token code
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - "'Member must satisfy regular expression pattern:' in result.module_stderr"
       when: result.module_stderr is defined
 
     # ============================================================
     - name: test assume role with invalid role_arn
-      sts_assume_role:
+      community.aws.sts_assume_role:
         role_arn: invalid role arn
         role_session_name: AnsibleTest
       register: result
       ignore_errors: true
 
     - name: assert assume role with invalid role_arn
-      assert:
+      ansible.builtin.assert:
         that:
           - result.failed
           - "'Invalid length for parameter RoleArn' in result.msg"
       when: result.module_stderr is not defined
 
     - name: assert assume role with invalid role_arn
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - "'Member must have length greater than or equal to 20' in result.module_stderr"
       when: result.module_stderr is defined
 
     # ============================================================
     - name: test assume not existing sts role
-      sts_assume_role:
-        role_arn: "arn:aws:iam::123456789:role/non-existing-role"
-        role_session_name: "AnsibleTest"
+      community.aws.sts_assume_role:
+        role_arn: arn:aws:iam::123456789:role/non-existing-role
+        role_session_name: AnsibleTest
       register: result
       ignore_errors: true
 
     - name: assert assume not existing sts role
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - "'is not authorized to perform: sts:AssumeRole' in result.msg"
       when: result.module_stderr is not defined
 
     - name: assert assume not existing sts role
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - "'is not authorized to perform: sts:AssumeRole' in result.msg"
       when: result.module_stderr is defined
 
     # ============================================================
     - name: test assume role
-      sts_assume_role:
+      community.aws.sts_assume_role:
         role_arn: "{{ test_role.iam_role.arn }}"
         role_session_name: AnsibleTest
       register: assumed_role
 
     - name: assert assume role
-      assert:
+      ansible.builtin.assert:
         that:
-           - 'not assumed_role.failed'
-           - "'sts_creds' in assumed_role"
-           - "'access_key' in assumed_role.sts_creds"
-           - "'secret_key' in assumed_role.sts_creds"
-           - "'session_token' in assumed_role.sts_creds"
+          - not assumed_role.failed
+          - "'sts_creds' in assumed_role"
+          - "'access_key' in assumed_role.sts_creds"
+          - "'secret_key' in assumed_role.sts_creds"
+          - "'session_token' in assumed_role.sts_creds"
 
     # ============================================================
     - name: test that assumed credentials have IAM read-only access
-      iam_role:
+      community.aws.iam_role:
         access_key: "{{ assumed_role.sts_creds.access_key }}"
         secret_key: "{{ assumed_role.sts_creds.secret_key }}"
         session_token: "{{ assumed_role.sts_creds.session_token }}"
         name: "{{ iam_role_name }}"
         assume_role_policy_document: "{{ lookup('template','policy.json.j2') }}"
-        create_instance_profile: False
+        create_instance_profile: false
         state: present
       register: result
 
     - name: assert assumed role with privileged action (expect changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'not result.failed'
-          - 'not result.changed'
+          - not result.failed
+          - not result.changed
           - "'iam_role' in result"
 
     # ============================================================
     - name: test assumed role with unprivileged action
-      iam_role:
+      community.aws.iam_role:
         access_key: "{{ assumed_role.sts_creds.access_key }}"
         secret_key: "{{ assumed_role.sts_creds.secret_key }}"
         session_token: "{{ assumed_role.sts_creds.session_token }}"
@@ -277,29 +277,28 @@
       ignore_errors: true
 
     - name: assert assumed role with unprivileged action (expect changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - "'is not authorized to perform: iam:CreateRole' in result.msg"
       # runs on Python2
       when: result.module_stderr is not defined
 
     - name: assert assumed role with unprivileged action (expect changed=false)
-      assert:
+      ansible.builtin.assert:
         that:
-          - 'result.failed'
+          - result.failed
           - "'is not authorized to perform: iam:CreateRole' in result.module_stderr"
       # runs on Python3
       when: result.module_stderr is defined
 
-    # ============================================================
+  # ============================================================
   always:
-
     - name: delete test iam role
-      iam_role:
+      community.aws.iam_role:
         name: "{{ iam_role_name }}"
-        assume_role_policy_document:  "{{ lookup('template','policy.json.j2') }}"
-        delete_instance_profile: True
+        assume_role_policy_document: "{{ lookup('template','policy.json.j2') }}"
+        delete_instance_profile: true
         managed_policy:
           - arn:aws:iam::aws:policy/IAMReadOnlyAccess
         state: absent


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes the integration tests to use FQCN throughout. Every change has been generated by running `ansible-lint --fix` with the `write_list` limited to `fqcn`. The one exception is the manual removal of the `tests/integration/targets/aws_region_info/main.yml` which ansible-lint was failing on. This seems to be unused? It attempts to include `tasks/tests.yml` which does not exist.

The ansible-lint config used to generate this changeset:

```yaml
---
exclude_paths:
  - plugins/
write_list:
  - fqcn
```

I had to exclude the `plugins/` directory because ansible-lint was crashing, I suspect because of docstrings. It did not provide enough information in debug or traceback to identify which file was causing the problem.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
