### PR TITLE
fix - check stack is ready for cc to be created

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -898,6 +898,7 @@ Bugfixes
 - cloudwatchevent_rule - Fix to avoid adding quotes to JSON input for provided input_template (https://github.com/ansible-collections/amazon.aws/pull/1883).
 - lookup/secretsmanager_secret - fix the issue when the nested secret is missing and on_missing is set to warn, the lookup was raising an error instead of a warning message (https://github.com/ansible-collections/amazon.aws/issues/1781).
 - module_utils/elbv2 - Fix issue when creating or modifying Load balancer rule type authenticate-oidc using ``ClientSecret`` parameter and ``UseExistingClientSecret=true`` (https://github.com/ansible-collections/amazon.aws/issues/1877).
+- amazon.aws.cloudformation - Fixed an issue where creating a changeset in check mode would fail if the stack is not in a ready state (e.g., UPDATE_IN_PROGRESS). The module now waits for the stack to be in a ready state (UPDATE_COMPLETE) before creating the changeset (https://github.com/ansible-collections/amazon.aws/pull/1910)
 
 v7.3.0
 ======

--- a/changelogs/fragments/1910-check_stack_change_set.yml
+++ b/changelogs/fragments/1910-check_stack_change_set.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - amazon.aws.cloudformation - Fixed an issue where creating a changeset in check mode would fail if the stack is not in a ready state (e.g., UPDATE_IN_PROGRESS). The module now waits for the stack to be in a ready state (UPDATE_COMPLETE) before creating the changeset (https://github.com/ansible-collections/amazon.aws/pull/1910)

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -602,6 +602,12 @@ def check_mode_changeset(module, stack_params, cfn):
     stack_params.pop("ClientRequestToken", None)
 
     try:
+        for _i in range(60):  # total time 5 min
+            # check stack is ready to have a change set created
+            stack = get_stack_facts(module, cfn, stack_params["StackName"], raise_errors=True)
+            if stack["StackStatus"].endswith("_COMPLETE"):
+                break
+            time.sleep(5)
         change_set = cfn.create_change_set(aws_retry=True, **stack_params)
         for _i in range(60):  # total time 5 min
             description = cfn.describe_change_set(aws_retry=True, ChangeSetName=change_set["Id"])


### PR DESCRIPTION
Handling creating a change set when the check flag is set to true, and the stack is not in a state to be updated yet e.g `UPDATE_IN_PROGRESS`

##### SUMMARY
When creating a changeset in check_mode for cloudformation, unless the stack is in a ready state e.g `UPDATE_COMPLETE` the cmd will error out. 

This is particularly a problem in CI pipelines where stacks are being updated constantly and multiple branches with this check are run when the stacks are updating as part of pre deployment testing. 

This change waits for the stack to be in a ready state i.e `UPDATE_COMPLETE` prior to moving on to creating the changeset. 

I think this is more of a bug as I would think this case would be handled by the module but isn't. 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
amazon.aws.cloudformation

##### ADDITIONAL INFORMATION

As I think I've understood here, all I do is check the status of the stack. If its in `UPDATE_COMPLETE`, continue on to creating the changeset. Otherwise wait like the operation to wait for a create changeset below it. 

A step-by-step reproduction of the problem

1. Create a stack
2. Create an ansible playbook to create a changeset based off this stack.  
3. Get the stack into a status of `UPDATE_IN_PROGRESS` and immediately run the create changeset with the `--check` flag true. 
5. Error will indicate that a changeset cannot be created while `UPDATE_IN_PROGRESS` is the status of the stack. 


Please let me know if I can be of more support in explaining the issue. 

Thanks!