### PR TITLE
rds_instance - Allow empty enable_cloudwatch_logs_exports

### DIFF
--- a/changelogs/fragments/20231211-rds_instance_cloudwatch.yml
+++ b/changelogs/fragments/20231211-rds_instance_cloudwatch.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - rds_instance - Allow passing empty list to ``enable_cloudwatch_logs_exports`` in order to remove all existing exports (https://github.com/ansible-collections/amazon.aws/issues/1879).
+  - rds_instance - Allow passing empty list to ``enable_cloudwatch_logs_exports`` in order to remove all existing exports (https://github.com/ansible-collections/amazon.aws/pull/1917).

--- a/changelogs/fragments/20231211-rds_instance_cloudwatch.yml
+++ b/changelogs/fragments/20231211-rds_instance_cloudwatch.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - rds_instance - Allow passing empty list to ``enable_cloudwatch_logs_exports`` in order to remove all existing exports (https://github.com/ansible-collections/amazon.aws/issues/1879).

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -45,7 +45,7 @@ options:
     purge_cloudwatch_logs_exports:
         description:
           - Set to C(false) to retain any enabled cloudwatch logs that aren't specified in the task and are associated with the instance.
-            Set I(enable_cloudwatch_logs_exports) to an empty list to disable all.
+          - Set I(enable_cloudwatch_logs_exports) to an empty list to disable all.
         type: bool
         default: true
     read_replica:

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1028,7 +1028,7 @@ def get_options_with_changing_values(client, module, parameters):
         parameters["DBPortNumber"] = port
     if not force_update_password:
         parameters.pop("MasterUserPassword", None)
-    if cloudwatch_logs_enabled:
+    if cloudwatch_logs_enabled is not None:
         parameters["CloudwatchLogsExportConfiguration"] = cloudwatch_logs_enabled
     if not module.params["storage_type"]:
         parameters.pop("Iops", None)

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -43,7 +43,9 @@ options:
         type: bool
         default: false
     purge_cloudwatch_logs_exports:
-        description: Set to C(false) to retain any enabled cloudwatch logs that aren't specified in the task and are associated with the instance.
+        description:
+          - Set to C(false) to retain any enabled cloudwatch logs that aren't specified in the task and are associated with the instance.
+            Set I(enable_cloudwatch_logs_exports) to an empty list to disable all.
         type: bool
         default: true
     read_replica:

--- a/tests/integration/targets/rds_instance_modify/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_modify/tasks/main.yml
@@ -82,7 +82,7 @@
           - '"is not valid for adding IAM roles" in result.msg'
 
     # TODO: test modifying db_subnet_group_name, db_security_groups, db_parameter_group_name, option_group_name,
-    # monitoring_role_arn, monitoring_interval, domain, domain_iam_role_name, cloudwatch_logs_export_configuration
+    # monitoring_role_arn, monitoring_interval, domain, domain_iam_role_name
 
     # ------------------------------------------------------------------------------------------
     - name: Modify the storage type without immediate application - check_mode
@@ -305,6 +305,171 @@
           - result is not failed
           - db_info.instances[0].ca_certificate_identifier == "rds-ca-ecc384-g1"
   # Test modifying CA certificate identifier Complete-------------------------------------------
+
+  # Test modifying cloudwatch log exports -------------------------------------------
+    - name: Enable all cloudwatch log exports - check_mode
+      amazon.aws.rds_instance:
+        state: present
+        db_instance_identifier: "{{ modified_instance_id }}"
+        enable_cloudwatch_logs_exports: ["audit", "error", "general", "slowquery"]
+      register: result
+      check_mode: true
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+
+    - name: Get current cloudwatch log exports
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ modified_instance_id }}"
+      register: db_info
+    - name: Assert that cloudwatch log exports has been modified - check_mode
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result is not failed
+          - db_info.instances[0].enabled_cloudwatch_logs_exports is not defined
+
+    - name: Enable all cloudwatch log exports
+      amazon.aws.rds_instance:
+        state: present
+        db_instance_identifier: "{{ modified_instance_id }}"
+        enable_cloudwatch_logs_exports: ["audit", "error", "general", "slowquery"]
+      register: result
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+
+    - name: Get current cloudwatch log exports
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ modified_instance_id }}"
+      register: db_info
+      # It applies immediately but takes a couple seconds
+      until:
+        - db_info.instances[0].db_instance_status == 'available'
+        - not db_info.instances[0].pending_modified_values
+      retries: 10
+      delay: 20
+
+    - name: Assert that cloudwatch log exports has been modified
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result is not failed
+          - db_info.instances[0].enabled_cloudwatch_logs_exports | length == 4
+
+    - name: Enable all cloudwatch log exports - idempotent
+      amazon.aws.rds_instance:
+        state: present
+        db_instance_identifier: "{{ modified_instance_id }}"
+        enable_cloudwatch_logs_exports: ["audit", "error", "general", "slowquery"]
+      register: result
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+
+    - name: Get current cloudwatch log exports
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ modified_instance_id }}"
+      register: db_info
+    - name: Assert that cloudwatch log exports has not been modified
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result is not failed
+          - not result.pending_modified_values
+          - db_info.instances[0].enabled_cloudwatch_logs_exports | length == 4
+
+    - name: Disable some cloudwatch log exports - check_mode
+      amazon.aws.rds_instance:
+        state: present
+        db_instance_identifier: "{{ modified_instance_id }}"
+        enable_cloudwatch_logs_exports: ["audit", "error"]
+      register: result
+      check_mode: true
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+
+    - name: Get current cloudwatch log exports
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ modified_instance_id }}"
+      register: db_info
+    - name: Assert that cloudwatch log exports has been modified - check_mode
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result is not failed
+          - db_info.instances[0].enabled_cloudwatch_logs_exports | length == 4
+
+    - name: Disable some cloudwatch log exports
+      amazon.aws.rds_instance:
+        state: present
+        db_instance_identifier: "{{ modified_instance_id }}"
+        enable_cloudwatch_logs_exports: ["audit", "error"]
+      register: result
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+
+    - name: Get current cloudwatch log exports
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ modified_instance_id }}"
+      register: db_info
+      until:
+        - db_info.instances[0].db_instance_status == 'available'
+        - not db_info.instances[0].pending_modified_values
+      retries: 10
+      delay: 20
+
+    - name: Assert that cloudwatch log exports has been modified
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result is not failed
+          - db_info.instances[0].enabled_cloudwatch_logs_exports | length == 2
+
+    - name: Disable all cloudwatch log exports - check_mode
+      amazon.aws.rds_instance:
+        state: present
+        db_instance_identifier: "{{ modified_instance_id }}"
+        enable_cloudwatch_logs_exports: []
+      register: result
+      check_mode: true
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+
+    - name: Get current cloudwatch log exports
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ modified_instance_id }}"
+      register: db_info
+    - name: Assert that cloudwatch log exports has been modified - check_mode
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result is not failed
+          - db_info.instances[0].enabled_cloudwatch_logs_exports | length == 2
+
+    - name: Disable all cloudwatch log exports
+      amazon.aws.rds_instance:
+        state: present
+        db_instance_identifier: "{{ modified_instance_id }}"
+        enable_cloudwatch_logs_exports: []
+      register: result
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+
+    - name: Get current cloudwatch log exports
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ modified_instance_id }}"
+      register: db_info
+      until:
+        - db_info.instances[0].db_instance_status == 'available'
+        - not db_info.instances[0].pending_modified_values
+      retries: 10
+      delay: 20
+
+    - name: Assert that cloudwatch log exports has been modified
+      ansible.builtin.assert:
+        that:
+          - result is changed
+          - result is not failed
+          - db_info.instances[0].enabled_cloudwatch_logs_exports is not defined
+  # Test modifying cloudwatch log exports Complete-------------------------------------------
 
   always:
     - name: Delete the instance

--- a/tests/integration/targets/rds_instance_modify/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_modify/tasks/main.yml
@@ -423,6 +423,28 @@
           - result is not failed
           - db_info.instances[0].enabled_cloudwatch_logs_exports | length == 2
 
+    - name: Disable all cloudwatch log exports - no purge
+      amazon.aws.rds_instance:
+        state: present
+        db_instance_identifier: "{{ modified_instance_id }}"
+        enable_cloudwatch_logs_exports: []
+        purge_cloudwatch_logs_exports: false
+      register: result
+      vars:
+        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
+
+    - name: Get current cloudwatch log exports
+      amazon.aws.rds_instance_info:
+        db_instance_identifier: "{{ modified_instance_id }}"
+      register: db_info
+    - name: Assert that cloudwatch log exports has not been modified
+      ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result is not failed
+          - not result.pending_modified_values
+          - db_info.instances[0].enabled_cloudwatch_logs_exports | length == 2
+
     - name: Disable all cloudwatch log exports - check_mode
       amazon.aws.rds_instance:
         state: present


### PR DESCRIPTION
##### SUMMARY

Fixes #1879 and adds some tests for the `enable_cloudwatch_logs_exports` parameter.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

`rds_instance`

##### ADDITIONAL INFORMATION

I had to add retries before the assertions, the reason is two fold:
1. It's very likely no changes at all are picked up by `rds_instance_info` if it runs right after modifying the RDS.
2. The API returns 400 if you attempt to modify something else before the previous modification was done, making the following non-check_mode test fail.

In my tests, it usually takes about a minute for the modifications to complete, so 200 total seconds should be more than enough. 
