### PR TITLE
ec2_instance: add support for modifying instance metadata options

### DIFF
--- a/changelogs/fragments/1918-ec2_instance-add-support-to-modify-metadata-options.yml
+++ b/changelogs/fragments/1918-ec2_instance-add-support-to-modify-metadata-options.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ec2_instance - Add support for modifying metadata options of an existing instance (https://github.com/ansible-collections/amazon.aws/pull/1918).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1095,7 +1095,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_ta
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_specifications
 from ansible_collections.amazon.aws.plugins.module_utils.tower import tower_callback_script
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
-from ansible_collections.amazon.aws.plugins.module_utils.transformation import scrub_none_parameters
 
 module = None
 

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1649,7 +1649,7 @@ def change_instance_metadata_options(instance, params):
             "HttpPutResponseHopLimit": changes_to_apply.get("http_put_response_hop_limit", ""),
             "HttpEndpoint": changes_to_apply.get("http_endpoint", ""),
             "HttpProtocolIpv6": changes_to_apply.get("http_protocol_ipv6", ""),
-            "InstanceMetadataTags": changes_to_apply.get("instance_metadata_tags", "")
+            "InstanceMetadataTags": changes_to_apply.get("instance_metadata_tags", ""),
         }
         request_args = {k: v for k, v in request_args.items() if v}
 

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1651,10 +1651,13 @@ def change_instance_metadata_options(instance, params):
     request_args = {
         "InstanceId": instance["InstanceId"],
         "HttpTokens": changes_to_apply.get("http_tokens") or existing_metadata_options.get("http_tokens"),
-        "HttpPutResponseHopLimit": changes_to_apply.get("http_put_response_hop_limit") or existing_metadata_options.get("http_put_response_hop_limit"),
+        "HttpPutResponseHopLimit": changes_to_apply.get("http_put_response_hop_limit")
+        or existing_metadata_options.get("http_put_response_hop_limit"),
         "HttpEndpoint": changes_to_apply.get("http_endpoint") or existing_metadata_options.get("http_endpoint"),
-        "HttpProtocolIpv6": changes_to_apply.get("http_protocol_ipv6") or existing_metadata_options.get("http_protocol_ipv6"),
-        "InstanceMetadataTags": changes_to_apply.get("instance_metadata_tags") or existing_metadata_options.get("instance_metadata_tags"),
+        "HttpProtocolIpv6": changes_to_apply.get("http_protocol_ipv6")
+        or existing_metadata_options.get("http_protocol_ipv6"),
+        "InstanceMetadataTags": changes_to_apply.get("instance_metadata_tags")
+        or existing_metadata_options.get("instance_metadata_tags"),
     }
 
     if module.check_mode:

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1650,11 +1650,11 @@ def change_instance_metadata_options(instance, params):
 
     request_args = {
         "InstanceId": instance["InstanceId"],
-        "HttpTokens": changes_to_apply.get("http_tokens", None),
-        "HttpPutResponseHopLimit": changes_to_apply.get("http_put_response_hop_limit", None),
-        "HttpEndpoint": changes_to_apply.get("http_endpoint", None),
-        "HttpProtocolIpv6": changes_to_apply.get("http_protocol_ipv6", None),
-        "InstanceMetadataTags": changes_to_apply.get("instance_metadata_tags", None),
+        "HttpTokens": changes_to_apply.get("http_tokens"),
+        "HttpPutResponseHopLimit": changes_to_apply.get("http_put_response_hop_limit"),
+        "HttpEndpoint": changes_to_apply.get("http_endpoint"),
+        "HttpProtocolIpv6": changes_to_apply.get("http_protocol_ipv6"),
+        "InstanceMetadataTags": changes_to_apply.get("instance_metadata_tags"),
     }
 
     request_args = scrub_none_parameters(request_args)

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1650,14 +1650,12 @@ def change_instance_metadata_options(instance, params):
 
     request_args = {
         "InstanceId": instance["InstanceId"],
-        "HttpTokens": changes_to_apply.get("http_tokens"),
-        "HttpPutResponseHopLimit": changes_to_apply.get("http_put_response_hop_limit"),
-        "HttpEndpoint": changes_to_apply.get("http_endpoint"),
-        "HttpProtocolIpv6": changes_to_apply.get("http_protocol_ipv6"),
-        "InstanceMetadataTags": changes_to_apply.get("instance_metadata_tags"),
+        "HttpTokens": changes_to_apply.get("http_tokens") or existing_metadata_options.get("http_tokens"),
+        "HttpPutResponseHopLimit": changes_to_apply.get("http_put_response_hop_limit") or existing_metadata_options.get("http_put_response_hop_limit"),
+        "HttpEndpoint": changes_to_apply.get("http_endpoint") or existing_metadata_options.get("http_endpoint"),
+        "HttpProtocolIpv6": changes_to_apply.get("http_protocol_ipv6") or existing_metadata_options.get("http_protocol_ipv6"),
+        "InstanceMetadataTags": changes_to_apply.get("instance_metadata_tags") or existing_metadata_options.get("instance_metadata_tags"),
     }
-
-    request_args = scrub_none_parameters(request_args)
 
     if module.check_mode:
         return True

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -2000,8 +2000,7 @@ def handle_existing(existing_matches, state, filters):
     for instance in existing_matches:
         changed |= ensure_ec2_tags(client, module, instance["InstanceId"], tags=tags, purge_tags=purge_tags)
 
-        if module.params.get("metadata_options"):
-            changed |= change_instance_metadata_options(instance, module.params)
+        changed |= change_instance_metadata_options(instance, module.params)
 
         changes = diff_instance_and_params(instance, module.params)
         for c in changes:

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1650,11 +1650,11 @@ def change_instance_metadata_options(instance, params):
 
     request_args = {
         "InstanceId": instance["InstanceId"],
-        "HttpTokens": changes_to_apply.get("http_tokens", ""),
-        "HttpPutResponseHopLimit": changes_to_apply.get("http_put_response_hop_limit", ""),
-        "HttpEndpoint": changes_to_apply.get("http_endpoint", ""),
-        "HttpProtocolIpv6": changes_to_apply.get("http_protocol_ipv6", ""),
-        "InstanceMetadataTags": changes_to_apply.get("instance_metadata_tags", ""),
+        "HttpTokens": changes_to_apply.get("http_tokens", None),
+        "HttpPutResponseHopLimit": changes_to_apply.get("http_put_response_hop_limit", None),
+        "HttpEndpoint": changes_to_apply.get("http_endpoint", None),
+        "HttpProtocolIpv6": changes_to_apply.get("http_protocol_ipv6", None),
+        "InstanceMetadataTags": changes_to_apply.get("instance_metadata_tags", None),
     }
 
     request_args = scrub_none_parameters(request_args)

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1636,7 +1636,11 @@ def change_instance_metadata_options(instance, params):
     existing_metadata_options = camel_dict_to_snake_dict(instance.get("MetadataOptions"))
     metadata_options_to_apply = params.get("metadata_options")
 
-    changes_to_apply = {key:  metadata_options_to_apply[key] for key in set(existing_metadata_options) & set(metadata_options_to_apply) if existing_metadata_options[key] != metadata_options_to_apply[key]}
+    changes_to_apply = {
+        key: metadata_options_to_apply[key]
+        for key in set(existing_metadata_options) & set(metadata_options_to_apply)
+        if existing_metadata_options[key] != metadata_options_to_apply[key]
+    }
 
     if changes_to_apply:
         request_args = {
@@ -1659,6 +1663,7 @@ def change_instance_metadata_options(instance, params):
                 )
 
     return changed
+
 
 def change_network_attachments(instance, params):
     if (params.get("network") or {}).get("interfaces") is not None:

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -32,7 +32,7 @@
           - instance_creation.spec.MetadataOptions.HttpEndpoint == 'enabled'
           - instance_creation.spec.MetadataOptions.HttpTokens == 'required'
           - instance_creation.spec.MetadataOptions.InstanceMetadataTags == 'enabled'
-          - instance_creation.spec.MetadataOptions.HttpPutResponseHopLimit == 2"
+          - instance_creation.spec.MetadataOptions.HttpPutResponseHopLimit == 2
 
     - name: modify metadata_options on existing instance
       amazon.aws.ec2_instance:

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -20,6 +20,7 @@
           http_endpoint: enabled
           http_tokens: required
           instance_metadata_tags: enabled
+          http_put_response_hop_limit: 2
         wait: false
       register: instance_creation
 
@@ -31,6 +32,7 @@
           - instance_creation.spec.MetadataOptions.HttpEndpoint == 'enabled'
           - instance_creation.spec.MetadataOptions.HttpTokens == 'required'
           - instance_creation.spec.MetadataOptions.InstanceMetadataTags == 'enabled'
+          - instance_creation.spec.MetadataOptions.HttpPutResponseHopLimit == 2"
 
     - name: modify metadata_options on existing instance
       amazon.aws.ec2_instance:
@@ -44,6 +46,7 @@
         metadata_options:
           http_endpoint: enabled
           http_tokens: optional
+          http_put_response_hop_limit: 4
         wait: false
       register: metadata_options_update
       ignore_errors: true
@@ -54,7 +57,7 @@
           tag:Name: "{{ resource_prefix }}-test-t3nano-enabled-required"
       register: presented_instance_fact
 
-    - name: modify metadata_options has no effect on existing instance
+    - name: Assert that instance metadata options have been modified successfully
       ansible.builtin.assert:
         that:
           - metadata_options_update is success
@@ -62,4 +65,5 @@
           - presented_instance_fact.instances | length > 0
           - presented_instance_fact.instances.0.state.name in ['running','pending']
           - presented_instance_fact.instances.0.metadata_options.http_endpoint == 'enabled'
-          - presented_instance_fact.instances.0.metadata_options.http_tokens == 'required'
+          - presented_instance_fact.instances.0.metadata_options.http_tokens == 'optional'
+          - presented_instance_fact.instances.0.metadata_options.http_put_response_hop_limit == 4s

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -22,6 +22,7 @@
           instance_metadata_tags: enabled
           http_put_response_hop_limit: 2
         wait: true
+        wait_timeout: 1200
       register: instance_creation
 
     - name: instance with metadata_options created with the right options

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -66,4 +66,4 @@
           - presented_instance_fact.instances.0.state.name in ['running','pending']
           - presented_instance_fact.instances.0.metadata_options.http_endpoint == 'enabled'
           - presented_instance_fact.instances.0.metadata_options.http_tokens == 'optional'
-          - presented_instance_fact.instances.0.metadata_options.http_put_response_hop_limit == 4s
+          - presented_instance_fact.instances.0.metadata_options.http_put_response_hop_limit == 4

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -24,6 +24,12 @@
         wait: false
       register: instance_creation
 
+    - name: Wait for instance to start
+      amazon.aws.ec2_instance:
+        state: running
+        instance_ids: "{{ instance_creation.instance_ids }}"
+        wait: true
+
     - name: instance with metadata_options created with the right options
       ansible.builtin.assert:
         that:

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -7,22 +7,21 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - name: create t3.nano instance with metadata_options
+
+    - name: Create a new instance
       amazon.aws.ec2_instance:
-        state: present
-        name: "{{ resource_prefix }}-test-t3nano-enabled-required"
+        state: running
+        name: "{{ resource_prefix }}-test-basic"
+        instance_type: "{{ ec2_instance_type }}"
         image_id: "{{ ec2_ami_id }}"
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
-        vpc_subnet_id: "{{ testing_subnet_a.subnet.id }}"
-        instance_type: t3.nano
         metadata_options:
           http_endpoint: enabled
           http_tokens: required
           instance_metadata_tags: enabled
           http_put_response_hop_limit: 2
         wait: true
-        wait_timeout: 1200
       register: instance_creation
 
     - name: instance with metadata_options created with the right options

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -21,14 +21,8 @@
           http_tokens: required
           instance_metadata_tags: enabled
           http_put_response_hop_limit: 2
-        wait: false
-      register: instance_creation
-
-    - name: Wait for instance to start
-      amazon.aws.ec2_instance:
-        state: running
-        instance_ids: "{{ instance_creation.instance_ids }}"
         wait: true
+      register: instance_creation
 
     - name: instance with metadata_options created with the right options
       ansible.builtin.assert:

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -61,7 +61,7 @@
       ansible.builtin.assert:
         that:
           - metadata_options_update is success
-          - metadata_options_update is not changed
+          - metadata_options_update is changed
           - presented_instance_fact.instances | length > 0
           - presented_instance_fact.instances.0.state.name in ['running','pending']
           - presented_instance_fact.instances.0.metadata_options.http_endpoint == 'enabled'

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -49,7 +49,6 @@
           http_put_response_hop_limit: 4
         wait: false
       register: metadata_options_update
-      ignore_errors: true
 
     - name: fact presented ec2 instance
       amazon.aws.ec2_instance_info:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #1864 
This PR add support for modifying instance metadata options.
Uses `client. modify_instance_metadata_options()`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
