### PR TITLE
s3_bucket_info - add support for bucket versioning in bucket_facts

### DIFF
--- a/changelogs/fragments/20231211-s3_bucket_info-add-support-for-bucket_versioning.yml
+++ b/changelogs/fragments/20231211-s3_bucket_info-add-support-for-bucket_versioning.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - s3_bucket_info - add parameter ``bucket_versioning`` to return the versioning state of a bucket (https://github.com/ansible-collections/amazon.aws/pull/1919).

--- a/changelogs/fragments/20231211-s3_bucket_info-add-support-for-bucket_versioning.yml
+++ b/changelogs/fragments/20231211-s3_bucket_info-add-support-for-bucket_versioning.yml
@@ -1,3 +1,4 @@
 ---
 minor_changes:
   - s3_bucket_info - add parameter ``bucket_versioning`` to return the versioning state of a bucket (https://github.com/ansible-collections/amazon.aws/pull/1919).
+  - s3_object_info - fix exception raised when listing objects from empty bucket (https://github.com/ansible-collections/amazon.aws/pull/1919).

--- a/plugins/modules/s3_bucket_info.py
+++ b/plugins/modules/s3_bucket_info.py
@@ -36,70 +36,77 @@ options:
       - You can limit buckets by using the I(name) or I(name_filter) option.
     suboptions:
       bucket_accelerate_configuration:
-        description: Retrive S3 accelerate configuration.
+        description: Retrieve S3 accelerate configuration.
         type: bool
         default: False
       bucket_location:
-        description: Retrive S3 bucket location.
+        description: Retrieve S3 bucket location.
         type: bool
         default: False
       bucket_replication:
-        description: Retrive S3 bucket replication.
+        description: Retrieve S3 bucket replication.
         type: bool
         default: False
       bucket_acl:
-        description: Retrive S3 bucket ACLs.
+        description: Retrieve S3 bucket ACLs.
         type: bool
         default: False
       bucket_logging:
-        description: Retrive S3 bucket logging.
+        description: Retrieve S3 bucket logging.
         type: bool
         default: False
       bucket_request_payment:
-        description: Retrive S3 bucket request payment.
+        description: Retrieve S3 bucket request payment.
         type: bool
         default: False
       bucket_tagging:
-        description: Retrive S3 bucket tagging.
+        description: Retrieve S3 bucket tagging.
         type: bool
         default: False
       bucket_cors:
-        description: Retrive S3 bucket CORS configuration.
+        description: Retrieve S3 bucket CORS configuration.
         type: bool
         default: False
       bucket_notification_configuration:
-        description: Retrive S3 bucket notification configuration.
+        description: Retrieve S3 bucket notification configuration.
         type: bool
         default: False
       bucket_encryption:
-        description: Retrive S3 bucket encryption.
+        description: Retrieve S3 bucket encryption.
         type: bool
         default: False
       bucket_ownership_controls:
         description:
-        - Retrive S3 ownership controls.
+        - Retrieve S3 ownership controls.
         type: bool
         default: False
       bucket_website:
-        description: Retrive S3 bucket website.
+        description: Retrieve S3 bucket website.
         type: bool
         default: False
       bucket_policy:
-        description: Retrive S3 bucket policy.
+        description: Retrieve S3 bucket policy.
         type: bool
         default: False
       bucket_policy_status:
-        description: Retrive S3 bucket policy status.
+        description: Retrieve S3 bucket policy status.
         type: bool
         default: False
       bucket_lifecycle_configuration:
-        description: Retrive S3 bucket lifecycle configuration.
+        description: Retrieve S3 bucket lifecycle configuration.
         type: bool
         default: False
       public_access_block:
-        description: Retrive S3 bucket public access block.
+        description: Retrieve S3 bucket public access block.
         type: bool
         default: False
+      bucket_versioning:
+        description:
+          - Retrieve the versioning state of a bucket.
+          - To retrieve the versioning state of a bucket, you must be the bucket owner.
+        type: bool
+        default: False
+        version_added: 7.2.0
     type: dict
     version_added: 1.4.0
   transform_location:
@@ -396,6 +403,15 @@ bucket_list:
               returned: always
               type: str
               sample: https
+    bucket_versioning:
+      description:
+        - The versioning state of the bucket.
+        - This will also specifies whether MFA delete is enabled in the bucket versioning configuration.
+          if only the bucket has been configured with MFA delete.
+      returned: when I(bucket_facts=true) and I(bucket_versioning=true)
+      type: dict
+      sample: { 'Status': 'Enabled' }
+      version_added: 7.2.0
 """
 
 try:
@@ -448,10 +464,10 @@ def get_bucket_list(module, connection, name="", name_filter=""):
 
 def get_buckets_facts(connection, buckets, requested_facts, transform_location):
     """
-    Retrive additional information about S3 buckets
+    Retrieve additional information about S3 buckets
     """
     full_bucket_list = []
-    # Iterate over all buckets and append retrived facts to bucket
+    # Iterate over all buckets and append Retrieved facts to bucket
     for bucket in buckets:
         bucket.update(get_bucket_details(connection, bucket["name"], requested_facts, transform_location))
         full_bucket_list.append(bucket)
@@ -568,6 +584,7 @@ def main():
                 bucket_tagging=dict(type="bool", default=False),
                 bucket_website=dict(type="bool", default=False),
                 public_access_block=dict(type="bool", default=False),
+                bucket_versioning=dict(type="bool", default=False),
             ),
         ),
         transform_location=dict(type="bool", default=False),

--- a/plugins/modules/s3_bucket_info.py
+++ b/plugins/modules/s3_bucket_info.py
@@ -406,7 +406,7 @@ bucket_list:
     bucket_versioning:
       description:
         - The versioning state of the bucket.
-        - This will also specifies whether MFA delete is enabled in the bucket versioning configuration.
+        - This will also specify whether MFA delete is enabled in the bucket versioning configuration.
           if only the bucket has been configured with MFA delete.
       returned: when I(bucket_facts=true) and I(bucket_versioning=true)
       type: dict

--- a/plugins/modules/s3_object_info.py
+++ b/plugins/modules/s3_object_info.py
@@ -642,7 +642,7 @@ def list_bucket_objects(connection, module, bucket_name):
 
     if len(list_objects_response) != 0:
         # convert to snake_case
-        for response_list_item in list_objects_response["Contents"]:
+        for response_list_item in list_objects_response.get("Contents", []):
             result.append(response_list_item["Key"])
 
     return result

--- a/tests/integration/targets/s3_bucket_info/tasks/basic.yml
+++ b/tests/integration/targets/s3_bucket_info/tasks/basic.yml
@@ -27,6 +27,7 @@
       bucket_tagging: true
       bucket_website: true
       public_access_block: true
+      bucket_versioning: true
     transform_location: true
   register: bucket_list
 - name: Assert that buckets list contains requested bucket facts
@@ -48,6 +49,7 @@
       - item.bucket_tagging is defined
       - item.bucket_website is defined
       - item.public_access_block is defined
+      - item.bucket_versioning is defined
   loop: "{{ bucket_list.buckets }}"
   loop_control:
     label: "{{ item.name }}"
@@ -64,6 +66,8 @@
       - item.bucket_tagging["lowercase spaced"] == 'hello cruel world'
       - item.bucket_tagging["Title Case"] == 'Hello Cruel World'
       - item.bucket_location.LocationConstraint == aws_region
+      - item.bucket_versioning.Status is defined
+      - item.bucket_versioning.MFADelete is undefined
   loop: "{{ bucket_list.buckets }}"
   loop_control:
     label: "{{ item.name }}"

--- a/tests/integration/targets/s3_bucket_info/tasks/basic.yml
+++ b/tests/integration/targets/s3_bucket_info/tasks/basic.yml
@@ -67,6 +67,7 @@
       - item.bucket_tagging["Title Case"] == 'Hello Cruel World'
       - item.bucket_location.LocationConstraint == aws_region
       - item.bucket_versioning.Status is defined
+      - item.bucket_versioning.Status
       - item.bucket_versioning.MFADelete is undefined
   loop: "{{ bucket_list.buckets }}"
   loop_control:

--- a/tests/integration/targets/s3_bucket_info/tasks/main.yml
+++ b/tests/integration/targets/s3_bucket_info/tasks/main.yml
@@ -11,6 +11,7 @@
       amazon.aws.s3_bucket:
         name: "{{ item }}"
         state: present
+        versioning: true
         tags:
           lowercase spaced: hello cruel world
           Title Case: Hello Cruel World

--- a/tests/integration/targets/s3_object/tasks/main.yml
+++ b/tests/integration/targets/s3_object/tasks/main.yml
@@ -37,6 +37,16 @@
         state: present
       register: result
 
+    - name: list objects from empty bucket
+      amazon.aws.s3_object_info:
+        bucket_name: "{{ bucket_name }}"
+      register: objects
+
+    - name: Ensure the bucket is empty
+      ansible.builtin.assert:
+        that:
+          - objects.s3_keys | length == 0
+
     - ansible.builtin.assert:
         that:
           - result is changed


### PR DESCRIPTION
##### SUMMARY
Module `s3_bucket_info` should be able to return the bucket versioning into bucket_facts

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`s3_bucket_info`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```yaml
- amazon.aws.s3_bucket_info:
   name: mybucket
   bucket_facts:
    bucket_versioninig: true
```

expecting output

```json
{
    "bucket_name": "mybucket",
    "buckets": [
         {
            "bucket_versioning": {"Status": "Enabled"},    ## New information in output
           "creation_date": "2023-12-11T15:48:42+00:00",
           "name": "mybucket"
         }
    ],
   "changed": false,
   "msg": "Retrieved s3 info."
}
```
