### PR TITLE
Bump MariaDB versions for test - Amazon dropped old ones again

### DIFF
--- a/tests/integration/targets/rds_instance_upgrade/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_upgrade/defaults/main.yml
@@ -7,5 +7,5 @@ db_instance_class: db.t3.micro
 allocated_storage: 20
 
 # For mariadb tests
-mariadb_engine_version: 10.5.17
-mariadb_engine_version_2: 10.6.10
+mariadb_engine_version: 10.6.16
+mariadb_engine_version_2: 10.11.6


### PR DESCRIPTION
##### SUMMARY

Bump MariaDB versions for test - Amazon dropped old ones again

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

rds_instance_upgrade

##### ADDITIONAL INFORMATION
