### PR TITLE
Add the release_summary accidentally removed when prepping 7.3.0

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -2692,6 +2692,7 @@ releases:
       - iam_user_info - the ``path`` parameter has been renamed ``path_prefix`` for
         consistency with other IAM modules, ``path`` remains as an alias. No change
         to playbooks is required (https://github.com/ansible-collections/amazon.aws/pull/1933).
+    release_summary: This release includes new features and a bugfix.
     fragments:
     - 1918-ec2_instance-add-support-to-modify-metadata-options.yml
     - 20231206-iam_user_path.yml


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add the release_summary acctidentally removed when prepping 7.3.0
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
