### PR TITLE
Remove unneeded sanity ignore for ansible 2.17

### DIFF
--- a/tests/sanity/ignore-2.17.txt
+++ b/tests/sanity/ignore-2.17.txt
@@ -1,3 +1,2 @@
-plugins/inventory/aws_ec2.py yamllint:unparsable-with-libyaml # bug in ansible-test - https://github.com/ansible/ansible/issues/82353
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
 plugins/module_utils/policy.py pylint:collection-deprecated-version


### PR DESCRIPTION
##### SUMMARY
Now that https://github.com/ansible/ansible/pull/82355 has been merged into devel we can remove the sanity ignore for 2.17 that has been causing non-blocking sanity tests to fail in CI.