### PR TITLE
Add fail method that knows how to handle AnsibleAWSErrors

### DIFF
--- a/changelogs/fragments/20240227-fail_aws_error.yml
+++ b/changelogs/fragments/20240227-fail_aws_error.yml
@@ -1,0 +1,2 @@
+minor_changes:
+ - AnsibeAWSModule - added ``fail_json_aws_error()`` as a wrapper for ``fail_json()`` and ``fail_json_aws()`` when passed an ``AnsibleAWSError`` exception (https://github.com/ansible-collections/amazon.aws/pull/1997).

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -242,6 +242,12 @@ class AnsibleAWSModule:
 
         self.fail_json(**failure)
 
+    def fail_json_aws_error(self, exception):
+        """A helper to call the right failure mode after catching an AnsibleAWSError"""
+        if exception.exception:
+            self.fail_json_aws(exception.exception, msg=exception.message)
+        self.fail_json(msg=exception.message)
+
     def _gather_versions(self):
         """Gather AWS SDK (boto3 and botocore) dependency versions
 


### PR DESCRIPTION
##### SUMMARY

Adds fail_json_aws_error() to AnsibeAWSModule this is just a simple wrapper around fail_json() and fail_json_aws() that knows how to route AnsibleAWSError exceptions (with and without triggering exceptions)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

module_utils/modules

##### ADDITIONAL INFORMATION