### PR TITLE
Big IAM code refactor

### DIFF
--- a/changelogs/fragments/20240227-iam-refactor.yml
+++ b/changelogs/fragments/20240227-iam-refactor.yml
@@ -1,0 +1,14 @@
+minor_changes:
+ - iam_access_key - refactored code to use ``AnsibleIAMError`` and ``IAMErrorHandler`` as well as moving shared code into module_utils.iam (https://github.com/ansible-collections/amazon.aws/pull/1998).
+ - iam_access_key_info - refactored code to use ``AnsibleIAMError`` and ``IAMErrorHandler`` as well as moving shared code into module_utils.iam (https://github.com/ansible-collections/amazon.aws/pull/1998).
+ - iam_group - refactored code to use ``AnsibleIAMError`` and ``IAMErrorHandler`` as well as moving shared code into module_utils.iam (https://github.com/ansible-collections/amazon.aws/pull/1998).
+ - iam_instance_profile - refactored code to use ``AnsibleIAMError`` and ``IAMErrorHandler`` as well as moving shared code into module_utils.iam (https://github.com/ansible-collections/amazon.aws/pull/1998).
+ - iam_instance_profile_info - refactored code to use ``AnsibleIAMError`` and ``IAMErrorHandler`` as well as moving shared code into module_utils.iam (https://github.com/ansible-collections/amazon.aws/pull/1998).
+ - iam_managed_policy - refactored code to use ``AnsibleIAMError`` and ``IAMErrorHandler`` as well as moving shared code into module_utils.iam (https://github.com/ansible-collections/amazon.aws/pull/1998).
+ - iam_mfa_device_info - refactored code to use ``AnsibleIAMError`` and ``IAMErrorHandler`` as well as moving shared code into module_utils.iam (https://github.com/ansible-collections/amazon.aws/pull/1998).
+ - iam_role - refactored code to use ``AnsibleIAMError`` and ``IAMErrorHandler`` as well as moving shared code into module_utils.iam (https://github.com/ansible-collections/amazon.aws/pull/1998).
+ - iam_role_info - refactored code to use ``AnsibleIAMError`` and ``IAMErrorHandler`` as well as moving shared code into module_utils.iam (https://github.com/ansible-collections/amazon.aws/pull/1998).
+ - iam_user - refactored code to use ``AnsibleIAMError`` and ``IAMErrorHandler`` as well as moving shared code into module_utils.iam (https://github.com/ansible-collections/amazon.aws/pull/1998).
+ - iam_user_info - refactored code to use ``AnsibleIAMError`` and ``IAMErrorHandler`` as well as moving shared code into module_utils.iam (https://github.com/ansible-collections/amazon.aws/pull/1998).
+deprecated_features:
+ - iam_role_info - in a release after 2026-05-01 paths must begin and end with ``/`` (https://github.com/ansible-collections/amazon.aws/pull/1998).

--- a/plugins/module_utils/iam.py
+++ b/plugins/module_utils/iam.py
@@ -202,9 +202,9 @@ def normalize_iam_mfa_device(device):
     """Converts IAM MFA Device from the CamelCase boto3 format to the snake_case Ansible format"""
     if not device:
         return device
-    camel_user = camel_dict_to_snake_dict(device)
-    camel_user["tags"] = boto3_tag_list_to_ansible_dict(device.pop("Tags", []))
-    return camel_user
+    camel_device = camel_dict_to_snake_dict(device)
+    camel_device["tags"] = boto3_tag_list_to_ansible_dict(device.pop("Tags", []))
+    return camel_device
 
 
 def normalize_iam_mfa_devices(devices):

--- a/plugins/module_utils/iam.py
+++ b/plugins/module_utils/iam.py
@@ -17,6 +17,7 @@ from ansible.module_utils.common.dict_transformations import camel_dict_to_snake
 from .arn import parse_aws_arn
 from .arn import validate_aws_arn
 from .botocore import is_boto3_error_code
+from .botocore import normalize_boto3_result
 from .errors import AWSErrorHandler
 from .exceptions import AnsibleAWSError
 from .retries import AWSRetry
@@ -36,14 +37,25 @@ class IAMErrorHandler(AWSErrorHandler):
         return is_boto3_error_code("NoSuchEntity")
 
 
+@IAMErrorHandler.deletion_error_handler("detach group policy")
 @AWSRetry.jittered_backoff()
-def _tag_iam_instance_profile(client, **kwargs):
-    client.tag_instance_profile(**kwargs)
+def detach_iam_group_policy(client, arn, group):
+    client.detach_group_policy(PolicyArn=arn, GroupName=group)
+    return True
 
 
+@IAMErrorHandler.deletion_error_handler("detach role policy")
 @AWSRetry.jittered_backoff()
-def _untag_iam_instance_profile(client, **kwargs):
-    client.untag_instance_profile(**kwargs)
+def detach_iam_role_policy(client, arn, role):
+    client.detach_group_policy(PolicyArn=arn, RoleName=role)
+    return True
+
+
+@IAMErrorHandler.deletion_error_handler("detach user policy")
+@AWSRetry.jittered_backoff()
+def detach_iam_user_policy(client, arn, user):
+    client.detach_group_policy(PolicyArn=arn, UserName=user)
+    return True
 
 
 @AWSRetry.jittered_backoff()
@@ -63,42 +75,194 @@ def _list_iam_instance_profiles_for_role(client, **kwargs):
     return paginator.paginate(**kwargs).build_full_result()["InstanceProfiles"]
 
 
+@IAMErrorHandler.list_error_handler("list policies for role", [])
 @AWSRetry.jittered_backoff()
-def _create_instance_profile(client, **kwargs):
-    return client.create_instance_profile(**kwargs)
+def list_iam_role_policies(client, role_name):
+    paginator = client.get_paginator("list_role_policies")
+    return paginator.paginate(RoleName=role_name).build_full_result()["PolicyNames"]
 
 
+@IAMErrorHandler.list_error_handler("list policies attached to role", [])
 @AWSRetry.jittered_backoff()
-def _delete_instance_profile(client, **kwargs):
-    client.delete_instance_profile(**kwargs)
+def list_iam_role_attached_policies(client, role_name):
+    paginator = client.get_paginator("list_attached_role_policies")
+    return paginator.paginate(RoleName=role_name).build_full_result()["AttachedPolicies"]
 
 
+@IAMErrorHandler.list_error_handler("list users", [])
 @AWSRetry.jittered_backoff()
-def _add_role_to_instance_profile(client, **kwargs):
-    client.add_role_to_instance_profile(**kwargs)
-
-
-@AWSRetry.jittered_backoff()
-def _remove_role_from_instance_profile(client, **kwargs):
-    client.remove_role_from_instance_profile(**kwargs)
-
-
-@AWSRetry.jittered_backoff()
-def _list_managed_policies(client, **kwargs):
-    paginator = client.get_paginator("list_policies")
-    return paginator.paginate(**kwargs).build_full_result()
+def list_iam_users(client, path=None):
+    args = {}
+    if path is None:
+        args = {"PathPrefix": path}
+    paginator = client.get_paginator("list_users")
+    return paginator.paginate(**args).build_full_result()["Users"]
 
 
 @IAMErrorHandler.common_error_handler("list all managed policies")
-def list_managed_policies(client):
-    return _list_managed_policies(client)["Policies"]
+@AWSRetry.jittered_backoff()
+def list_iam_managed_policies(client, **kwargs):
+    paginator = client.get_paginator("list_policies")
+    return paginator.paginate(**kwargs).build_full_result()["Policies"]
+
+
+list_managed_policies = list_iam_managed_policies
+
+
+@IAMErrorHandler.list_error_handler("list entities for policy", [])
+@AWSRetry.jittered_backoff()
+def list_iam_entities_for_policy(client, arn):
+    paginator = client.get_paginator("list_entities_for_policy")
+    return paginator.paginate(PolicyArn=arn).build_full_result()
+
+
+@IAMErrorHandler.list_error_handler("list roles", [])
+@AWSRetry.jittered_backoff()
+def list_iam_roles(client, path=None):
+    args = {}
+    if path:
+        args["PathPrefix"] = path
+    paginator = client.get_paginator("list_roles")
+    return paginator.paginate(**args).build_full_result()["Roles"]
+
+
+@IAMErrorHandler.list_error_handler("list mfa devices", [])
+@AWSRetry.jittered_backoff()
+def list_iam_mfa_devices(client, user=None):
+    args = {}
+    if user:
+        args["UserName"] = user
+    paginator = client.get_paginator("list_mfa_devices")
+    return paginator.paginate(**args).build_full_result()["MFADevices"]
+
+
+@IAMErrorHandler.list_error_handler("get role")
+@AWSRetry.jittered_backoff()
+def get_iam_role(client, name):
+    return client.get_role(RoleName=name)["Role"]
+
+
+@IAMErrorHandler.list_error_handler("get group")
+@AWSRetry.jittered_backoff()
+def get_iam_group(client, name):
+    paginator = client.get_paginator("get_group")
+    return paginator.paginate(GroupName=name).build_full_result()
+
+
+@IAMErrorHandler.list_error_handler("get access keys for user", [])
+@AWSRetry.jittered_backoff()
+def get_iam_access_keys(client, user):
+    results = client.list_access_keys(UserName=user)
+    return normalize_iam_access_keys(results.get("AccessKeyMetadata", []))
+
+
+@IAMErrorHandler.list_error_handler("get user")
+@AWSRetry.jittered_backoff()
+def get_iam_user(client, user):
+    results = client.get_user(UserName=user)
+    return normalize_iam_user(results.get("User", []))
+
+
+def find_iam_managed_policy_by_name(client, name):
+    policies = list_iam_managed_policies(client)
+    for policy in policies:
+        if policy["PolicyName"] == name:
+            return policy
+    return None
+
+
+def get_iam_managed_policy_by_name(client, name):
+    # get_policy() requires an ARN, and list_policies() doesn't return all fields, so we need to do both :(
+    policy = find_iam_managed_policy_by_name(client, name)
+    if policy is None:
+        return None
+    return get_iam_managed_policy_by_arn(client, policy["Arn"])
+
+
+@IAMErrorHandler.common_error_handler("get policy")
+@AWSRetry.jittered_backoff()
+def get_iam_managed_policy_by_arn(client, arn):
+    policy = client.get_policy(PolicyArn=arn)["Policy"]
+    return policy
+
+
+@IAMErrorHandler.common_error_handler("list policy versions")
+@AWSRetry.jittered_backoff()
+def list_iam_managed_policy_versions(client, arn):
+    return client.list_policy_versions(PolicyArn=arn)["Versions"]
+
+
+@IAMErrorHandler.common_error_handler("get policy version")
+@AWSRetry.jittered_backoff()
+def get_iam_managed_policy_version(client, arn, version):
+    return client.get_policy_version(PolicyArn=arn, VersionId=version)["PolicyVersion"]
+
+
+def normalize_iam_mfa_device(device):
+    """Converts IAM MFA Device from the CamelCase boto3 format to the snake_case Ansible format"""
+    if not device:
+        return device
+    camel_user = camel_dict_to_snake_dict(device)
+    camel_user["tags"] = boto3_tag_list_to_ansible_dict(device.pop("Tags", []))
+    return camel_user
+
+
+def normalize_iam_mfa_devices(devices):
+    """Converts a list of IAM MFA Devices from the CamelCase boto3 format to the snake_case Ansible format"""
+    if not devices:
+        return []
+    devices = [normalize_iam_mfa_device(d) for d in devices]
+    return devices
+
+
+def normalize_iam_user(user):
+    """Converts IAM users from the CamelCase boto3 format to the snake_case Ansible format"""
+    if not user:
+        return user
+    camel_user = camel_dict_to_snake_dict(user)
+    camel_user["tags"] = boto3_tag_list_to_ansible_dict(user.pop("Tags", []))
+    return camel_user
+
+
+def normalize_iam_policy(policy):
+    """Converts IAM policies from the CamelCase boto3 format to the snake_case Ansible format"""
+    if not policy:
+        return policy
+    camel_policy = camel_dict_to_snake_dict(policy)
+    camel_policy["tags"] = boto3_tag_list_to_ansible_dict(policy.get("Tags", []))
+    return camel_policy
+
+
+def normalize_iam_group(group):
+    """Converts IAM Groups from the CamelCase boto3 format to the snake_case Ansible format"""
+    if not group:
+        return group
+    camel_group = camel_dict_to_snake_dict(normalize_boto3_result(group))
+    return camel_group
+
+
+def normalize_iam_access_key(access_key):
+    """Converts IAM access keys from the CamelCase boto3 format to the snake_case Ansible format"""
+    if not access_key:
+        return access_key
+    camel_key = camel_dict_to_snake_dict(normalize_boto3_result(access_key))
+    return camel_key
+
+
+def normalize_iam_access_keys(access_keys):
+    """Converts a list of IAM access keys from the CamelCase boto3 format to the snake_case Ansible format"""
+    if not access_keys:
+        return []
+    access_keys = [normalize_iam_access_key(k) for k in access_keys]
+    sorted_keys = sorted(access_keys, key=lambda d: d.get("create_date", None))
+    return sorted_keys
 
 
 def convert_managed_policy_names_to_arns(client, policy_names):
     if all(validate_aws_arn(policy, service="iam") for policy in policy_names if policy is not None):
         return policy_names
     allpolicies = {}
-    policies = list_managed_policies(client)
+    policies = list_iam_managed_policies(client)
 
     for policy in policies:
         allpolicies[policy["PolicyName"]] = policy["Arn"]
@@ -173,29 +337,33 @@ def get_aws_account_info(module):
 
 
 @IAMErrorHandler.common_error_handler("create instance profile")
+@AWSRetry.jittered_backoff()
 def create_iam_instance_profile(client, name, path, tags):
     boto3_tags = ansible_dict_to_boto3_tag_list(tags or {})
     path = path or "/"
-    result = _create_instance_profile(client, InstanceProfileName=name, Path=path, Tags=boto3_tags)
+    result = client.create_instance_profile(InstanceProfileName=name, Path=path, Tags=boto3_tags)
     return result["InstanceProfile"]
 
 
 @IAMErrorHandler.deletion_error_handler("delete instance profile")
+@AWSRetry.jittered_backoff()
 def delete_iam_instance_profile(client, name):
-    _delete_instance_profile(client, InstanceProfileName=name)
+    client.delete_instance_profile(InstanceProfileName=name)
     # Error Handler will return False if the resource didn't exist
     return True
 
 
 @IAMErrorHandler.common_error_handler("add role to instance profile")
+@AWSRetry.jittered_backoff()
 def add_role_to_iam_instance_profile(client, profile_name, role_name):
-    _add_role_to_instance_profile(client, InstanceProfileName=profile_name, RoleName=role_name)
+    client.add_role_to_instance_profile(InstanceProfileName=profile_name, RoleName=role_name)
     return True
 
 
 @IAMErrorHandler.deletion_error_handler("remove role from instance profile")
+@AWSRetry.jittered_backoff()
 def remove_role_from_iam_instance_profile(client, profile_name, role_name):
-    _remove_role_from_instance_profile(client, InstanceProfileName=profile_name, RoleName=role_name)
+    client.remove_role_from_instance_profile(InstanceProfileName=profile_name, RoleName=role_name)
     # Error Handler will return False if the resource didn't exist
     return True
 
@@ -218,14 +386,16 @@ def list_iam_instance_profiles(client, name=None, prefix=None, role=None):
     return _list_iam_instance_profiles(client)
 
 
-def normalize_iam_instance_profile(profile):
+def normalize_iam_instance_profile(profile, _v7_compat=False):
     """
     Converts a boto3 format IAM instance profile into "Ansible" format
+
+    _v7_compat is deprecated and will be removed in release after 2025-05-01 DO NOT USE.
     """
 
     new_profile = camel_dict_to_snake_dict(deepcopy(profile))
     if profile.get("Roles"):
-        new_profile["roles"] = [normalize_iam_role(role) for role in profile.get("Roles")]
+        new_profile["roles"] = [normalize_iam_role(role, _v7_compat=_v7_compat) for role in profile.get("Roles")]
     if profile.get("Tags"):
         new_profile["tags"] = boto3_tag_list_to_ansible_dict(profile.get("Tags"))
     else:
@@ -234,39 +404,61 @@ def normalize_iam_instance_profile(profile):
     return new_profile
 
 
-def normalize_iam_role(role):
+def normalize_iam_role(role, _v7_compat=False):
     """
     Converts a boto3 format IAM instance role into "Ansible" format
+
+    _v7_compat is deprecated and will be removed in release after 2025-05-01 DO NOT USE.
     """
 
     new_role = camel_dict_to_snake_dict(deepcopy(role))
     if role.get("InstanceProfiles"):
         new_role["instance_profiles"] = [
-            normalize_iam_instance_profile(profile) for profile in role.get("InstanceProfiles")
+            normalize_iam_instance_profile(profile, _v7_compat=_v7_compat) for profile in role.get("InstanceProfiles")
         ]
     if role.get("AssumeRolePolicyDocument"):
-        new_role["assume_role_policy_document"] = role.get("AssumeRolePolicyDocument")
-    if role.get("Tags"):
-        new_role["tags"] = boto3_tag_list_to_ansible_dict(role.get("Tags"))
-    else:
-        new_role["tags"] = {}
-    new_role["original"] = role
+        if _v7_compat:
+            # new_role["assume_role_policy_document"] = role.get("AssumeRolePolicyDocument")
+            new_role["assume_role_policy_document_raw"] = role.get("AssumeRolePolicyDocument")
+        else:
+            new_role["assume_role_policy_document"] = role.get("AssumeRolePolicyDocument")
+
+    new_role["tags"] = boto3_tag_list_to_ansible_dict(role.get("Tags", []))
     return new_role
 
 
 @IAMErrorHandler.common_error_handler("tag instance profile")
+@AWSRetry.jittered_backoff()
 def tag_iam_instance_profile(client, name, tags):
     if not tags:
         return
     boto3_tags = ansible_dict_to_boto3_tag_list(tags or {})
-    result = _tag_iam_instance_profile(client, InstanceProfileName=name, Tags=boto3_tags)
+    result = client.tag_instance_profile(InstanceProfileName=name, Tags=boto3_tags)
 
 
 @IAMErrorHandler.common_error_handler("untag instance profile")
+@AWSRetry.jittered_backoff()
 def untag_iam_instance_profile(client, name, tags):
     if not tags:
         return
-    result = _untag_iam_instance_profile(client, InstanceProfileName=name, TagKeys=tags)
+    client.untag_instance_profile(InstanceProfileName=name, TagKeys=tags)
+
+
+@IAMErrorHandler.common_error_handler("tag managed policy")
+@AWSRetry.jittered_backoff()
+def tag_iam_policy(client, arn, tags):
+    if not tags:
+        return
+    boto3_tags = ansible_dict_to_boto3_tag_list(tags or {})
+    client.tag_policy(PolicyArn=arn, Tags=boto3_tags)
+
+
+@IAMErrorHandler.common_error_handler("untag managed policy")
+@AWSRetry.jittered_backoff()
+def untag_iam_policy(client, arn, tags):
+    if not tags:
+        return
+    client.untag_policy(PolicyArn=arn, TagKeys=tags)
 
 
 def _validate_iam_name(resource_type, name=None):

--- a/plugins/modules/iam_access_key_info.py
+++ b/plugins/modules/iam_access_key_info.py
@@ -69,40 +69,14 @@ access_key:
             sample: Inactive
 """
 
-try:
-    import botocore
-except ImportError:
-    pass  # caught by AnsibleAWSModule
-
-from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import normalize_boto3_result
+from ansible_collections.amazon.aws.plugins.module_utils.iam import AnsibleIAMError
+from ansible_collections.amazon.aws.plugins.module_utils.iam import IAMErrorHandler
+from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_access_keys
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 
 
-def get_access_keys(user):
-    try:
-        results = client.list_access_keys(aws_retry=True, UserName=user)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg=f'Failed to get access keys for user "{user}"')
-    if not results:
-        return None
-
-    results = camel_dict_to_snake_dict(results)
-    access_keys = results.get("access_key_metadata", [])
-    if not access_keys:
-        return []
-
-    access_keys = normalize_boto3_result(access_keys)
-    access_keys = sorted(access_keys, key=lambda d: d.get("create_date", None))
-    return access_keys
-
-
 def main():
-    global module
-    global client
-
     argument_spec = dict(
         user_name=dict(required=True, type="str", aliases=["username"]),
     )
@@ -111,11 +85,11 @@ def main():
 
     client = module.client("iam", retry_decorator=AWSRetry.jittered_backoff())
 
-    changed = False
-    user = module.params.get("user_name")
-    access_keys = get_access_keys(user)
-
-    module.exit_json(changed=changed, access_keys=access_keys)
+    try:
+        access_keys = get_iam_access_keys(client, module.params.get("user_name"))
+        module.exit_json(changed=False, access_keys=access_keys)
+    except AnsibleIAMError as e:
+        module.fail_json_aws_error(e)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iam_access_key_info.py
+++ b/plugins/modules/iam_access_key_info.py
@@ -70,7 +70,6 @@ access_key:
 """
 
 from ansible_collections.amazon.aws.plugins.module_utils.iam import AnsibleIAMError
-from ansible_collections.amazon.aws.plugins.module_utils.iam import IAMErrorHandler
 from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_access_keys
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry

--- a/plugins/modules/iam_group.py
+++ b/plugins/modules/iam_group.py
@@ -196,7 +196,6 @@ iam_group:
                     sample: test_policy
 """
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.iam import AnsibleIAMError
 from ansible_collections.amazon.aws.plugins.module_utils.iam import IAMErrorHandler
 from ansible_collections.amazon.aws.plugins.module_utils.iam import convert_managed_policy_names_to_arns

--- a/plugins/modules/iam_group.py
+++ b/plugins/modules/iam_group.py
@@ -196,21 +196,18 @@ iam_group:
                     sample: test_policy
 """
 
-try:
-    import botocore
-except ImportError:
-    pass  # caught by AnsibleAWSModule
-
-from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.iam import AnsibleIAMError
+from ansible_collections.amazon.aws.plugins.module_utils.iam import IAMErrorHandler
 from ansible_collections.amazon.aws.plugins.module_utils.iam import convert_managed_policy_names_to_arns
+from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_group
+from ansible_collections.amazon.aws.plugins.module_utils.iam import normalize_iam_group
 from ansible_collections.amazon.aws.plugins.module_utils.iam import validate_iam_identifiers
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 
 
+@IAMErrorHandler.common_error_handler("update group path")
 def ensure_path(connection, module, group_info, path):
     if path is None:
         return False
@@ -231,18 +228,16 @@ def ensure_path(connection, module, group_info, path):
 
 def detach_policies(connection, module, group_name, policies):
     for policy_arn in policies:
-        try:
-            connection.detach_group_policy(aws_retry=True, GroupName=group_name, PolicyArn=policy_arn)
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg=f"Couldn't detach policy {policy_arn} from group {group_name}")
+        IAMErrorHandler.deletion_error_handler(f"detach policy {policy_arn} from group")(
+            connection.detach_group_policy
+        )(aws_retry=True, GroupName=group_name, PolicyArn=policy_arn)
 
 
 def attach_policies(connection, module, group_name, policies):
     for policy_arn in policies:
-        try:
-            connection.attach_group_policy(aws_retry=True, GroupName=group_name, PolicyArn=policy_arn)
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg=f"Couldn't attach policy {policy_arn} to group {group_name}")
+        IAMErrorHandler.common_error_handler(f"attach policy {policy_arn} to group")(connection.attach_group_policy)(
+            aws_retry=True, GroupName=group_name, PolicyArn=policy_arn
+        )
 
 
 def ensure_managed_policies(connection, module, group_info, managed_policies, purge_policies):
@@ -276,18 +271,16 @@ def ensure_managed_policies(connection, module, group_info, managed_policies, pu
 
 def add_group_members(connection, module, group_name, members):
     for user in members:
-        try:
-            connection.add_user_to_group(GroupName=group_name, UserName=user)
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg=f"Couldn't add user {user} to group {group_name}")
+        IAMErrorHandler.common_error_handler(f"add user {user} to group")(connection.add_user_to_group)(
+            aws_retry=True, GroupName=group_name, UserName=user
+        )
 
 
 def remove_group_members(connection, module, group_name, members):
     for user in members:
-        try:
-            connection.remove_user_from_group(aws_retry=True, GroupName=group_name, UserName=user)
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg=f"Couldn't remove user {user} from group {group_name}")
+        IAMErrorHandler.deletion_error_handler(f"remove user {user} from group")(connection.remove_user_from_group)(
+            aws_retry=True, GroupName=group_name, UserName=user
+        )
 
 
 def ensure_group_members(connection, module, group_info, users, purge_users):
@@ -314,13 +307,9 @@ def ensure_group_members(connection, module, group_info, users, purge_users):
     return True
 
 
+@IAMErrorHandler.common_error_handler("create group")
 def get_or_create_group(connection, module, group_name, path):
-    # Get group
-    try:
-        group = get_group(connection, module, group_name)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Couldn't get group")
-
+    group = get_iam_group(connection, group_name)
     if group:
         return False, group
 
@@ -332,10 +321,7 @@ def get_or_create_group(connection, module, group_name, path):
     if module.check_mode:
         module.exit_json(changed=True, create_params=params)
 
-    try:
-        group = connection.create_group(aws_retry=True, **params)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Couldn't create group")
+    group = connection.create_group(aws_retry=True, **params)
 
     if "Users" not in group:
         group["Users"] = []
@@ -376,26 +362,18 @@ def create_or_update_group(connection, module):
         module.exit_json(changed=changed)
 
     # Get the group again
-    try:
-        group_info = get_group(connection, module, module.params["name"])
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, f"Couldn't get group {module.params['name']}")
-    try:
-        policies = get_attached_policy_list(connection, module, module.params["name"])
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, f"Couldn't get group policies {module.params['name']}")
+    group_info = get_iam_group(connection, module.params["name"])
+    policies = get_attached_policy_list(connection, module, module.params["name"])
     group_info["AttachedPolicies"] = policies
 
-    module.exit_json(changed=changed, iam_group=camel_dict_to_snake_dict(group_info))
+    module.exit_json(changed=changed, iam_group=normalize_iam_group(group_info))
 
 
+@IAMErrorHandler.deletion_error_handler("delete group")
 def destroy_group(connection, module):
     group_name = module.params.get("name")
 
-    try:
-        group = get_group(connection, module, group_name)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, f"Couldn't get group {group_name}")
+    group = get_iam_group(connection, group_name)
 
     if not group:
         module.exit_json(changed=False)
@@ -413,36 +391,16 @@ def destroy_group(connection, module):
     current_group_members = [user["UserName"] for user in group["Users"]]
     remove_group_members(connection, module, group_name, current_group_members)
 
-    try:
-        connection.delete_group(aws_retry=True, GroupName=group_name)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, f"Couldn't delete group {group_name}")
+    connection.delete_group(aws_retry=True, GroupName=group_name)
 
     module.exit_json(changed=True)
 
 
-@AWSRetry.jittered_backoff()
-def get_group(connection, module, name):
-    try:
-        paginator = connection.get_paginator("get_group")
-        return paginator.paginate(GroupName=name).build_full_result()
-    except is_boto3_error_code("NoSuchEntity"):
-        return None
-
-
+@IAMErrorHandler.list_error_handler("list policies attached to group")
 @AWSRetry.jittered_backoff()
 def get_attached_policy_list(connection, module, name):
-    try:
-        paginator = connection.get_paginator("list_attached_group_policies")
-        return paginator.paginate(GroupName=name).build_full_result()["AttachedPolicies"]
-    except is_boto3_error_code("NoSuchEntity"):
-        return None
-
-
-@AWSRetry.jittered_backoff()
-def list_all_policies(connection, module):
-    paginator = connection.get_paginator("list_policies")
-    return paginator.paginate().build_full_result()["Policies"]
+    paginator = connection.get_paginator("list_attached_group_policies")
+    return paginator.paginate(GroupName=name).build_full_result()["AttachedPolicies"]
 
 
 def main():
@@ -477,9 +435,7 @@ def main():
         else:
             destroy_group(connection, module)
     except AnsibleIAMError as e:
-        if e.exception:
-            module.fail_json_aws(e.exception, msg=e.message)
-        module.fail_json(msg=e.message)
+        module.fail_json_aws_error(e)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iam_instance_profile.py
+++ b/plugins/modules/iam_instance_profile.py
@@ -354,9 +354,7 @@ def main():
             final_profile = describe_iam_instance_profile(client, name, path)
 
     except AnsibleIAMError as e:
-        if e.exception:
-            module.fail_json_aws(e.exception, msg=e.message)
-        module.fail_json(msg=e.message)
+        module.fail_json_aws_error(e)
 
     results = {
         "changed": changed,

--- a/plugins/modules/iam_instance_profile_info.py
+++ b/plugins/modules/iam_instance_profile_info.py
@@ -99,12 +99,7 @@ def describe_iam_instance_profiles(module, client):
     name = module.params["name"]
     prefix = module.params["path_prefix"]
     profiles = []
-    try:
-        profiles = list_iam_instance_profiles(client, name=name, prefix=prefix)
-    except AnsibleIAMError as e:
-        if e.exception:
-            module.fail_json_aws(e.exception, msg=e.message)
-        module.fail_json(msg=e.message)
+    profiles = list_iam_instance_profiles(client, name=name, prefix=prefix)
 
     return [normalize_iam_instance_profile(p) for p in profiles]
 
@@ -125,7 +120,10 @@ def main():
     )
 
     client = module.client("iam", retry_decorator=AWSRetry.jittered_backoff())
-    module.exit_json(changed=False, iam_instance_profiles=describe_iam_instance_profiles(module, client))
+    try:
+        module.exit_json(changed=False, iam_instance_profiles=describe_iam_instance_profiles(module, client))
+    except AnsibleIAMError as e:
+        module.fail_json_aws_error(e)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/iam_role_info.py
+++ b/plugins/modules/iam_role_info.py
@@ -160,7 +160,6 @@ iam_roles:
 
 
 from ansible_collections.amazon.aws.plugins.module_utils.iam import AnsibleIAMError
-from ansible_collections.amazon.aws.plugins.module_utils.iam import IAMErrorHandler
 from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_role
 from ansible_collections.amazon.aws.plugins.module_utils.iam import list_iam_instance_profiles
 from ansible_collections.amazon.aws.plugins.module_utils.iam import list_iam_role_attached_policies
@@ -232,7 +231,7 @@ def main():
                 "In a release after 2026-05-01 paths must begin and end with /.  "
                 "path_prefix has been modified to '{path_prefix}'",
                 date="2026-05-01",
-                collection="amazon.aws",
+                collection_name="amazon.aws",
             )
 
     try:

--- a/plugins/modules/iam_user.py
+++ b/plugins/modules/iam_user.py
@@ -218,14 +218,8 @@ user:
                     sample: test_policy
 """
 
-try:
-    import botocore
-except ImportError:
-    pass  # caught by AnsibleAWSModule
-
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.iam import AnsibleIAMError
 from ansible_collections.amazon.aws.plugins.module_utils.iam import IAMErrorHandler
 from ansible_collections.amazon.aws.plugins.module_utils.iam import convert_managed_policy_names_to_arns
@@ -235,7 +229,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.iam import validate_iam
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
-from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import compare_aws_tags
 
 

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -105,21 +105,12 @@ iam_users:
             sample: '{"Env": "Prod"}'
 """
 
-try:
-    from botocore.exceptions import BotoCoreError
-    from botocore.exceptions import ClientError
-except ImportError:
-    pass  # caught by AnsibleAWSModule
-
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.iam import AnsibleIAMError
-from ansible_collections.amazon.aws.plugins.module_utils.iam import IAMErrorHandler
 from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_group
 from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_user
 from ansible_collections.amazon.aws.plugins.module_utils.iam import list_iam_users
 from ansible_collections.amazon.aws.plugins.module_utils.iam import normalize_iam_user
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 
 def _list_users(connection, name, group, path):

--- a/tests/integration/targets/iam_access_key/tasks/main.yml
+++ b/tests/integration/targets/iam_access_key/tasks/main.yml
@@ -54,7 +54,7 @@
       amazon.aws.iam_access_key:
         user_name: "{{ test_user }}"
         state: present
-        no_log: true
+      no_log: true
       register: create_key_1
     - ansible.builtin.assert:
         that:
@@ -104,7 +104,7 @@
       amazon.aws.iam_access_key:
         user_name: "{{ test_user }}"
         state: present
-        no_log: true
+      no_log: true
       register: create_key_2
     - ansible.builtin.assert:
         that:
@@ -152,7 +152,7 @@
       amazon.aws.iam_access_key:
         user_name: "{{ test_user }}"
         state: present
-        no_log: true
+      no_log: true
       register: create_key_3
       ignore_errors: true
     - ansible.builtin.assert:
@@ -207,7 +207,7 @@
         user_name: "{{ test_user }}"
         state: present
         rotate_keys: true
-        no_log: true
+      no_log: true
       register: create_key_3
     - ansible.builtin.assert:
         that:
@@ -650,7 +650,7 @@
         user_name: "{{ test_user }}"
         state: present
         enabled: false
-        no_log: true
+      no_log: true
       register: create_key_4
     - ansible.builtin.assert:
         that:

--- a/tests/integration/targets/iam_group/tasks/users.yml
+++ b/tests/integration/targets/iam_group/tasks/users.yml
@@ -13,7 +13,7 @@
   ansible.builtin.assert:
     that:
       - iam_group is failed
-      - iam_group.msg.startswith("Couldn't add user NonExistentUser to group " + test_group)
+      - iam_group.msg.startswith("Failed to add user NonExistentUser to group")
 
 - name: Remove a user
   amazon.aws.iam_group:


### PR DESCRIPTION
##### SUMMARY

Refactored code to use `AnsibleIAMError` and `IAMErrorHandler` as well as moving shared code into module_utils.iam

iam_role_info - Deprecate support for paths without leading and trailing `\`

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- iam_access_key
- iam_access_key_info
- iam_group
- iam_instance_profile
- iam_instance_profile_info
- iam_managed_policy
- iam_mfa_device_info
- iam_role
- iam_role_info
- iam_user
- iam_user_info

##### ADDITIONAL INFORMATION
