### PR TITLE
returns boolean if a user has access to console login

### DIFF
--- a/changelogs/fragments/20240321-iam-user-info.yml
+++ b/changelogs/fragments/20240321-iam-user-info.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - iam_user_info - Add console_access to return info that is get from a user, to know if they can login from AWS console (https://github.com/ansible-collections/amazon.aws/pull/2012).
+  - iam_user_info - Add ``login_profile`` to return info that is get from a user, to know if they can login from AWS console (https://github.com/ansible-collections/amazon.aws/pull/2012).

--- a/changelogs/fragments/20240321-iam-user-info.yml
+++ b/changelogs/fragments/20240321-iam-user-info.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - iam_user_info - Add console_access to return info that is get from a user, to know if they can login from AWS console (https://github.com/ansible-collections/amazon.aws/pull/2012).

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -115,15 +115,15 @@ from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_grou
 from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_user
 from ansible_collections.amazon.aws.plugins.module_utils.iam import list_iam_users
 from ansible_collections.amazon.aws.plugins.module_utils.iam import normalize_iam_user
-from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule, is_boto3_error_code
 
-##add function to check if a user has or not access to login via console
+#add function to check if a user has or not access to login via console
 def check_console_access(connection, user_name):
     try:
         return connection.get_login_profile(UserName=user_name)['LoginProfile']
     except is_boto3_error_code("NoSuchEntity"):
         return {}
-          
+
 def _list_users(connection, name, group, path):
     # name but not path or group
     if name and not (path or group):

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -117,8 +117,8 @@ from ansible_collections.amazon.aws.plugins.module_utils.iam import list_iam_use
 from ansible_collections.amazon.aws.plugins.module_utils.iam import normalize_iam_user
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule, is_boto3_error_code
 
-#add function to check if a user has or not access to login via console
 def check_console_access(connection, user_name):
+# add function to check if a user has or not access to login via console
     try:
         return connection.get_login_profile(UserName=user_name)['LoginProfile']
     except is_boto3_error_code("NoSuchEntity"):

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -145,7 +145,7 @@ def list_users(connection, name, group, path):
     users = _list_users(connection, name, group, path)
     users = [u for u in users if u is not None]
     for user in users:
-        user['console_access'] = check_console_access(connection, user['UserName'])
+        user['LoginProfile'] = check_console_access(connection, user['UserName'])
     return [normalize_iam_user(user) for user in users]
 
 

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -103,11 +103,11 @@ iam_users:
             type: dict
             returned: if user exists
             sample: '{"Env": "Prod"}'
-        console_access:
-            description: If user has access to log in from AWS default console.
+        login_profile:
+            description: Detailed login profile information if the user has access to log in from AWS default console. Returns an empty object {} if no access.
             returned: always
-            type: bool
-            sample: "true"
+            type: dict
+            sample: {"create_date": "2024-03-20T12:50:56+00:00", "password_reset_required": false, "user_name": "i_am_a_user"}
 """
 
 from ansible_collections.amazon.aws.plugins.module_utils.iam import AnsibleIAMError

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -119,12 +119,11 @@ from ansible_collections.amazon.aws.plugins.module_utils.iam import normalize_ia
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 
+
+@IAMErrorHandler.list_error_handler("get login profile", {}) 
+@AWSRetry.jittered_backoff()
 def check_console_access(connection, user_name):
-# add function to check if a user has or not access to login via console
-    try:
-        return connection.get_login_profile(UserName=user_name)['LoginProfile']
-    except is_boto3_error_code("NoSuchEntity"):
-        return {}
+    return connection.get_login_profile(UserName=user_name)['LoginProfile']
 
 def _list_users(connection, name, group, path):
     # name but not path or group

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -123,7 +123,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 @IAMErrorHandler.list_error_handler("get login profile", {})
 @AWSRetry.jittered_backoff()
 def check_console_access(connection, user_name):
-    return connection.get_login_profile(UserName=user_name)['LoginProfile']
+    return connection.get_login_profile(UserName=user_name)["LoginProfile"]
 
 
 def _list_users(connection, name, group, path):
@@ -150,7 +150,7 @@ def list_users(connection, name, group, path):
     users = _list_users(connection, name, group, path)
     users = [u for u in users if u is not None]
     for user in users:
-        user['LoginProfile'] = check_console_access(connection, user['UserName'])
+        user["LoginProfile"] = check_console_access(connection, user["UserName"])
     return [normalize_iam_user(user) for user in users]
 
 
@@ -162,7 +162,9 @@ def main():
     )
 
     module = AnsibleAWSModule(
-        argument_spec=argument_spec, mutually_exclusive=[["group", "path_prefix"]], supports_check_mode=True
+        argument_spec=argument_spec,
+        mutually_exclusive=[["group", "path_prefix"]],
+        supports_check_mode=True,
     )
 
     name = module.params.get("name")
@@ -171,7 +173,9 @@ def main():
 
     connection = module.client("iam")
     try:
-        module.exit_json(changed=False, iam_users=list_users(connection, name, group, path))
+        module.exit_json(
+            changed=False, iam_users=list_users(connection, name, group, path)
+        )
     except AnsibleIAMError as e:
         module.fail_json_aws_error(e)
 

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -103,6 +103,11 @@ iam_users:
             type: dict
             returned: if user exists
             sample: '{"Env": "Prod"}'
+        console_access:
+            description: If user has access to log in from AWS default console.
+            returned: always
+            type: bool
+            sample: "true"
 """
 
 from ansible_collections.amazon.aws.plugins.module_utils.iam import AnsibleIAMError
@@ -111,8 +116,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_user
 from ansible_collections.amazon.aws.plugins.module_utils.iam import list_iam_users
 from ansible_collections.amazon.aws.plugins.module_utils.iam import normalize_iam_user
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
-##import of botocore 
-from botocore.exceptions import ClientError
 
 ##add function to check if a user has or not access to login via console
 def check_console_access(connection, user_name):

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -111,6 +111,7 @@ iam_users:
 """
 
 from ansible_collections.amazon.aws.plugins.module_utils.iam import AnsibleIAMError
+from ansible_collections.amazon.aws.plugins.module_utils.iam import IAMErrorHandler
 from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_group
 from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_user
 from ansible_collections.amazon.aws.plugins.module_utils.iam import list_iam_users

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -118,11 +118,8 @@ from botocore.exceptions import ClientError
 def check_console_access(connection, user_name):
     try:
         return connection.get_login_profile(UserName=user_name)['LoginProfile']
-    except ClientError as e:
-        if e.response['Error']['Code'] == 'NoSuchEntity':
-            return False
-        else:
-            raise
+    except is_boto3_error_code("NoSuchEntity"):
+        return {}
           
 def _list_users(connection, name, group, path):
     # name but not path or group

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -115,7 +115,8 @@ from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_grou
 from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_user
 from ansible_collections.amazon.aws.plugins.module_utils.iam import list_iam_users
 from ansible_collections.amazon.aws.plugins.module_utils.iam import normalize_iam_user
-from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule, is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 
 def check_console_access(connection, user_name):
 # add function to check if a user has or not access to login via console

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -120,10 +120,11 @@ from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleA
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 
 
-@IAMErrorHandler.list_error_handler("get login profile", {}) 
+@IAMErrorHandler.list_error_handler("get login profile", {})
 @AWSRetry.jittered_backoff()
 def check_console_access(connection, user_name):
     return connection.get_login_profile(UserName=user_name)['LoginProfile']
+
 
 def _list_users(connection, name, group, path):
     # name but not path or group

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -117,8 +117,7 @@ from botocore.exceptions import ClientError
 ##add function to check if a user has or not access to login via console
 def check_console_access(connection, user_name):
     try:
-        connection.get_login_profile(UserName=user_name)
-        return True
+        return connection.get_login_profile(UserName=user_name)['LoginProfile']
     except ClientError as e:
         if e.response['Error']['Code'] == 'NoSuchEntity':
             return False

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -173,9 +173,7 @@ def main():
 
     connection = module.client("iam")
     try:
-        module.exit_json(
-            changed=False, iam_users=list_users(connection, name, group, path)
-        )
+        module.exit_json(changed=False, iam_users=list_users(connection, name, group, path))
     except AnsibleIAMError as e:
         module.fail_json_aws_error(e)
 


### PR DESCRIPTION
Summary
I've introduced a new feature that includes in the response a console_access parameter, which is a boolean indicating whether an iam user has the ability to log in through the AWS console. This addition is particularly useful for scenarios where administrative constraints require users to access AWS services exclusively via API keys or through controlled environments, such as landing zones, without using the AWS console login interface.

Issue Type
- Feature Pull Request
Component Name: botocore
includes the botocore interaction, specifically regarding the console_access information retrievals

Additional Information
With this update, the module now provides visibility into whether an IAM user is permitted console access. This could be pivotal for enforcing stricter security protocols, ensuring users do not bypass VPN requirements, API keys, or other access control measures by logging in through the AWS console

Before the change a normal response:
```
{
    "arn": "arn:aws:iam::11111111:user/terraform",
    "create_date": "2018-04-18T14:12:44+00:00",
    "path": "/",
    "tags": {},
    "user_id": "12345abcd",
    "user_name": "terraform"
}
```


After the change:
```
{
    "arn": "arn:aws:iam::11111111:user/terraform",
    "console_access": false,
    "create_date": "2018-04-18T14:12:44+00:00",
    "path": "/",
    "tags": {},
    "user_id": "12345abcd",
    "user_name": "terraform"
}
```
