### PR TITLE
[Manual backport] Update python runtime version in lambda tests (#1987)

### DIFF
--- a/tests/integration/targets/lambda_alias/tasks/main.yml
+++ b/tests/integration/targets/lambda_alias/tasks/main.yml
@@ -34,18 +34,18 @@
       path: '{{ output_dir }}/mini_lambda.py'
       dest: '{{ output_dir }}/mini_lambda.zip'
 
-  - name: Upload test lambda (version 1)
-    lambda:
-      name: '{{ lambda_function_name }}'
-      runtime: 'python3.7'
-      handler: 'mini_lambda.handler'
-      role: '{{ lambda_role_name }}'
-      zip_file: '{{ zip_res.dest }}'
-    register: lambda_a
-  - name: assert lambda upload succeeded
-    assert:
-      that:
-      - lambda_a is changed
+    - name: Upload test lambda (version 1)
+      amazon.aws.lambda:
+        name: "{{ lambda_function_name }}"
+        runtime: python3.12
+        handler: mini_lambda.handler
+        role: "{{ lambda_role_name }}"
+        zip_file: "{{ zip_res.dest }}"
+      register: lambda_a
+    - name: assert lambda upload succeeded
+      ansible.builtin.assert:
+        that:
+          - lambda_a is changed
 
   - name: Update lambda (version 2)
     lambda:

--- a/tests/integration/targets/lambda_alias/tasks/main.yml
+++ b/tests/integration/targets/lambda_alias/tasks/main.yml
@@ -34,18 +34,18 @@
       path: '{{ output_dir }}/mini_lambda.py'
       dest: '{{ output_dir }}/mini_lambda.zip'
 
-    - name: Upload test lambda (version 1)
-      amazon.aws.lambda:
-        name: "{{ lambda_function_name }}"
-        runtime: python3.12
-        handler: mini_lambda.handler
-        role: "{{ lambda_role_name }}"
-        zip_file: "{{ zip_res.dest }}"
-      register: lambda_a
-    - name: assert lambda upload succeeded
-      ansible.builtin.assert:
-        that:
-          - lambda_a is changed
+  - name: Upload test lambda (version 1)
+    amazon.aws.lambda:
+      name: "{{ lambda_function_name }}"
+      runtime: python3.12
+      handler: mini_lambda.handler
+      role: "{{ lambda_role_name }}"
+      zip_file: "{{ zip_res.dest }}"
+    register: lambda_a
+  - name: assert lambda upload succeeded
+    ansible.builtin.assert:
+      that:
+        - lambda_a is changed
 
   - name: Update lambda (version 2)
     lambda:

--- a/tests/integration/targets/lambda_layer/tasks/main.yml
+++ b/tests/integration/targets/lambda_layer/tasks/main.yml
@@ -55,7 +55,7 @@
         content:
           zip_file: "{{ zip_file_path }}"
         compatible_runtimes:
-          - python3.7
+          - python3.12
         license_info: GPL-3.0-only
       register: create_check_mode
       check_mode: true
@@ -79,7 +79,7 @@
         content:
           zip_file: "{{ zip_file_path }}"
         compatible_runtimes:
-          - python3.7
+          - python3.12
         license_info: GPL-3.0-only
       register: first_version
 
@@ -91,7 +91,7 @@
           s3_bucket: "{{ s3_bucket_name }}"
           s3_key: "{{ s3_bucket_object }}"
         compatible_runtimes:
-          - python3.7
+          - python3.12
         license_info: GPL-3.0-only
       register: last_version
 


### PR DESCRIPTION

SUMMARY

The lambda_alias target was failing due to the python3.7 runtime no longer being supported. I have updated this to python3.12. The lambda_layer target was still passing, but I went ahead and updated these to python3.12, as well.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

ADDITIONAL INFORMATION

Reviewed-by: Alina Buzachis
Reviewed-by: Mark Chappell
(cherry picked from commit 85efdadae51f7c523bc5da742cbd02e1055b869d)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
