### PR TITLE
Quote scalars with colons in flow style collection

### DIFF
--- a/tests/integration/targets/ec2_ami/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami/tasks/main.yml
@@ -708,8 +708,8 @@
         tags:
           Name: "{{ ec2_ami_name }}_permissions"
         launch_permissions:
-          org_arns: [arn:aws:organizations::123456789012:organization/o-123ab4cdef]
-          org_unit_arns: [arn:aws:organizations::123456789012:ou/o-123example/ou-1234-5exampld]
+          org_arns: ["arn:aws:organizations::123456789012:organization/o-123ab4cdef"]
+          org_unit_arns: ["arn:aws:organizations::123456789012:ou/o-123example/ou-1234-5exampld"]
       register: permissions_update_result
 
     - name: Get ami info

--- a/tests/integration/targets/ec2_security_group/tasks/multi_nested_target.yml
+++ b/tests/integration/targets/ec2_security_group/tasks/multi_nested_target.yml
@@ -12,7 +12,7 @@
         to_port: 8182
         cidr_ipv6:
           - 64:ff9b::/96
-          - [2620::/32]
+          - ["2620::/32"]
       - proto: tcp
         ports: 5665
         cidr_ip:
@@ -38,7 +38,7 @@
         to_port: 8182
         cidr_ipv6:
           - 64:ff9b::/96
-          - [2620::/32]
+          - ["2620::/32"]
       - proto: tcp
         ports: 5665
         cidr_ip:
@@ -66,7 +66,7 @@
         to_port: 8182
         cidr_ipv6:
           - 64:ff9b::/96
-          - [2620::/32]
+          - ["2620::/32"]
       - proto: tcp
         ports: 5665
         cidr_ip:
@@ -92,7 +92,7 @@
         to_port: 8182
         cidr_ipv6:
           - 64:ff9b::/96
-          - [2620::/32]
+          - ["2620::/32"]
       - proto: tcp
         ports: 5665
         cidr_ip:
@@ -117,7 +117,7 @@
         to_port: 8182
         cidr_ipv6:
           - 64:ff9b::/96
-          - [2620::/32]
+          - ["2620::/32"]
       - proto: tcp
         ports: 5665
         cidr_ip:
@@ -142,7 +142,7 @@
         to_port: 8182
         cidr_ipv6:
           - 64:ff9b::/96
-          - [2620::/32]
+          - ["2620::/32"]
       - proto: tcp
         ports: 5665
         cidr_ip:
@@ -167,7 +167,7 @@
         from_port: 8182
         to_port: 8182
         cidr_ipv6:
-          - [2620::/32, 64:ff9b::/96]
+          - ["2620::/32", "64:ff9b::/96"]
       - proto: tcp
         ports: 5665
         cidr_ip:
@@ -190,8 +190,8 @@
         from_port: 8182
         to_port: 8182
         cidr_ipv6:
-          - [2620::/32, 64:ff9b::/96]
-          - [2001:DB8:A0B:12F0::1/64]
+          - ["2620::/32", "64:ff9b::/96"]
+          - ["2001:DB8:A0B:12F0::1/64"]
       - proto: tcp
         ports: 5665
         cidr_ip:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Older versions of libyaml and pyyaml don't support colons in scalars that appear in flow style collections. This adds quotes to the handful of cases where they are used in the integration tests.

This was uncovered by downstream testing. I am only able to reproduce the problem on the supported ee-minimal-rhel8 image. I believe this is because even though pyyaml should be recent enough, it has likely been compiled against an older version of libyaml that does not have the fix.

See:
https://github.com/yaml/libyaml/pull/104
https://github.com/yaml/pyyaml/pull/45

It's worth noting that running `ansible-lint --fix` will undo these changes, which is how I think they were made in the first place.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
