### PR TITLE
adding new modules to manage RDS cluster parameter groups

### DIFF
--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -98,8 +98,11 @@ action_groups:
     - lambda_policy
     - rds_cluster
     - rds_cluster_info
-    - rds_global_cluster_info
+    - rds_cluster_param_group
+    - rds_cluster_param_group_info
     - rds_cluster_snapshot
+    - rds_engine_versions_info
+    - rds_global_cluster_info
     - rds_instance
     - rds_instance_info
     - rds_instance_param_group

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -451,7 +451,7 @@ def describe_db_cluster_parameter_groups(module, connection, group_name):
             params["DBClusterParameterGroupName"] = group_name
         paginator = connection.get_paginator("describe_db_cluster_parameter_groups")
         return paginator.paginate(**params).build_full_result()["DBClusterParameterGroups"]
-    except is_boto3_error_code("DBParameterGroupNotFoundFault"):
+    except is_boto3_error_code("DBParameterGroupNotFound"):
         return []
     except ClientError as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Couldn't access parameter groups information")
@@ -465,7 +465,7 @@ def describe_db_cluster_parameters(module, connection, group_name, source="all")
         if source != "all":
             params["Source"] = source
         return paginator.paginate(**params).build_full_result()["Parameters"]
-    except is_boto3_error_code("DBParameterGroupNotFoundFault"):
+    except is_boto3_error_code("DBParameterGroupNotFound"):
         return []
     except ClientError as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Couldn't access RDS cluster parameters information")

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -5,6 +5,9 @@
 
 from collections import namedtuple
 from time import sleep
+from typing import Any
+from typing import Dict
+from typing import List
 
 try:
     from botocore.exceptions import BotoCoreError
@@ -17,6 +20,7 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 
 from .botocore import is_boto3_error_code
+from .core import AnsibleAWSModule
 from .retries import AWSRetry
 from .tagging import ansible_dict_to_boto3_tag_list
 from .tagging import boto3_tag_list_to_ansible_dict
@@ -444,28 +448,36 @@ def update_iam_roles(client, module, instance_id, roles_to_add, roles_to_remove)
 
 
 @AWSRetry.jittered_backoff()
-def describe_db_cluster_parameter_groups(module, connection, group_name):
+def describe_db_cluster_parameter_groups(
+    module: AnsibleAWSModule, connection: Any, group_name: str
+) -> List[Dict[str, Any]]:
+    result = []
     try:
         params = {}
         if group_name is not None:
             params["DBClusterParameterGroupName"] = group_name
         paginator = connection.get_paginator("describe_db_cluster_parameter_groups")
-        return paginator.paginate(**params).build_full_result()["DBClusterParameterGroups"]
+        result = paginator.paginate(**params).build_full_result()["DBClusterParameterGroups"]
     except is_boto3_error_code("DBParameterGroupNotFound"):
-        return []
+        pass
     except ClientError as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Couldn't access parameter groups information")
+    return result
 
 
 @AWSRetry.jittered_backoff()
-def describe_db_cluster_parameters(module, connection, group_name, source="all"):
+def describe_db_cluster_parameters(
+    module: AnsibleAWSModule, connection: Any, group_name: str, source: str = "all"
+) -> List[Dict[str, Any]]:
+    result = []
     try:
         paginator = connection.get_paginator("describe_db_cluster_parameters")
         params = {"DBClusterParameterGroupName": group_name}
         if source != "all":
             params["Source"] = source
-        return paginator.paginate(**params).build_full_result()["Parameters"]
+        result = paginator.paginate(**params).build_full_result()["Parameters"]
     except is_boto3_error_code("DBParameterGroupNotFound"):
-        return []
+        pass
     except ClientError as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Couldn't access RDS cluster parameters information")
+    return result

--- a/plugins/modules/rds_cluster_param_group.py
+++ b/plugins/modules/rds_cluster_param_group.py
@@ -104,7 +104,7 @@ extends_documentation_fragment:
 """
 
 EXAMPLES = r"""
-- name: Add or change a parameter group, in this case setting auto_increment_increment to 42 * 1024
+- name: Add or change a parameter group, in this case setting authentication_timeout to 200
   amazon.aws.rds_cluster_param_group:
       state: present
       name: test-cluster-group
@@ -168,7 +168,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.rds import ensure_tags
 from ansible_collections.amazon.aws.plugins.module_utils.rds import get_tags
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
-from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 
 @AWSRetry.jittered_backoff()
@@ -265,9 +264,7 @@ def ensure_present(module, connection):
 
     response = _describe_db_cluster_parameter_group(module=module, connection=connection, group_name=group_name)
     group = camel_dict_to_snake_dict(response["DBClusterParameterGroups"][0])
-    group["tags"] = boto3_tag_list_to_ansible_dict(
-        get_tags(connection, module, group["db_cluster_parameter_group_arn"])
-    )
+    group["tags"] = get_tags(connection, module, group["db_cluster_parameter_group_arn"])
 
     module.exit_json(changed=changed, db_cluster_parameter_group=group)
 

--- a/plugins/modules/rds_cluster_param_group.py
+++ b/plugins/modules/rds_cluster_param_group.py
@@ -1,0 +1,369 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+---
+module: rds_cluster_param_group
+version_added: 7.5.0
+short_description: Manage RDS cluster parameter groups
+description:
+  - Creates, modifies, and deletes RDS cluster parameter groups.
+options:
+  state:
+    description:
+      - Specifies whether the RDS cluster parameter group should be present or absent.
+    default: present
+    choices: [ 'present' , 'absent' ]
+    type: str
+  name:
+    description:
+      - The name of the RDS cluster parameter group to create, modify or delete.
+    required: true
+    type: str
+  description:
+    description:
+      - The description for the RDS cluster parameter group.
+      - Required for O(state=present).
+    type: str
+  db_parameter_group_family:
+    description:
+      - The RDS cluster parameter group family name.
+      - An RDS cluster parameter group can be associated with one and only one RDS cluster parameter group family,
+        and can be applied only to a RDS cluster running a database engine and engine version compatible with that RDS cluster parameter group family.
+      - Please use M(amazon.aws.rds_engine_versions_info) module To list all of the available parameter group families for a DB engine.
+      - The RDS cluster parameter group family is immutable and can't be changed when updating a RDS cluster parameter group.
+        See U(https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbclusterparametergroup.html)
+      - Required for O(state=present).
+    type: str
+  immediate:
+    description:
+      - Whether to apply the changes immediately, or after the next reboot of any associated instances.
+      - Ignored when O(state=absent)
+    aliases:
+      - apply_immediately
+    type: bool
+  params:
+    description:
+      - Map of parameter names and values. Numeric values may be represented as K for kilo (1024), M for mega (1024^2), G for giga (1024^3),
+        or T for tera (1024^4), and these values will be expanded into the appropriate number before being set in the parameter group.
+    aliases: [parameters]
+    type: dict
+author:
+  - "Aubin Bikouo (@abikouo)"
+extends_documentation_fragment:
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
+  - amazon.aws.tags
+  - amazon.aws.boto3
+"""
+
+EXAMPLES = r"""
+- name: Add or change a parameter group, in this case setting auto_increment_increment to 42 * 1024
+  amazon.aws.rds_cluster_param_group:
+      state: present
+      name: test-cluster-group
+      description: 'My test RDS cluster group'
+      db_parameter_group_family: 'mysql5.6'
+      params:
+          auto_increment_increment: "42K"
+      tags:
+          Environment: production
+          Application: parrot
+
+- name: Remove a parameter group
+  amazon.aws.rds_param_group:
+      state: absent
+      name: test-cluster-group
+"""
+
+RETURN = r"""
+db_cluster_parameter_group:
+    description: dictionary containing all the RDS cluster parameter group information
+    returned: success
+    type: complex
+    contains:
+        db_cluster_parameter_group_arn:
+            description: The Amazon Resource Name (ARN) for the RDS cluster parameter group.
+            type: str
+            returned: when state is present
+        db_cluster_parameter_group_name:
+            description: The name of the RDS cluster parameter group.
+            type: str
+            returned: when state is present
+        db_parameter_group_family:
+            description: The name of the RDS parameter group family that this RDS cluster parameter group is compatible with.
+            type: str
+            returned: when state is present
+        description:
+            description: Provides the customer-specified description for this RDS cluster parameter group.
+            type: str
+            returned: when state is present
+        tags:
+            description: dictionary of tags
+            type: dict
+            returned: when state is present
+"""
+
+from itertools import zip_longest
+
+try:
+    import botocore
+except ImportError:
+    pass  # Handled by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE
+from ansible.module_utils.six import string_types
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import compare_aws_tags
+
+INT_MODIFIERS = {
+    "K": 1024,
+    "M": pow(1024, 2),
+    "G": pow(1024, 3),
+    "T": pow(1024, 4),
+}
+
+
+@AWSRetry.jittered_backoff()
+def _describe_db_cluster_parameters(module, connection, group_name):
+    try:
+        paginator = connection.get_paginator("describe_db_cluster_parameters")
+        return paginator.paginate(DBClusterParameterGroupName=group_name).build_full_result()
+    except is_boto3_error_code("DBParameterGroupNotFound"):
+        return None
+    except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Failed to describe existing RDS cluster parameter groups")
+
+
+def convert_parameter(param, value):
+    """
+    Allows setting parameters with 10M = 10* 1024 * 1024 and so on.
+    """
+    converted_value = value
+
+    if param["DataType"] == "integer":
+        if isinstance(value, string_types):
+            try:
+                for modifier in INT_MODIFIERS.keys():
+                    if value.endswith(modifier):
+                        converted_value = int(value[:-1]) * INT_MODIFIERS[modifier]
+            except ValueError:
+                # may be based on a variable (ie. {foo*3/4}) so
+                # just pass it on through to the AWS SDK
+                pass
+        elif isinstance(value, bool):
+            converted_value = 1 if value else 0
+
+    elif param["DataType"] == "boolean":
+        if isinstance(value, string_types):
+            converted_value = value in BOOLEANS_TRUE
+        # convert True/False to 1/0
+        converted_value = 1 if converted_value else 0
+    return str(converted_value)
+
+
+def update_parameters(module, connection):
+    group_name = module.params["name"]
+    db_parameter_group_family = module.params["db_parameter_group_family"]
+    user_params = module.params["params"]
+    apply_method = "immediate" if module.params["immediate"] else "pending-reboot"
+    modify_list = []
+    db_cluster_params = []
+    response = _describe_db_cluster_parameters(module, connection, group_name)
+    if response:
+        db_cluster_params = response["Parameters"]
+    invalids, not_modifiable = [], []
+    for param_key, param_value in user_params.items():
+        found = list(filter(lambda x: x["ParameterName"] == param_key, db_cluster_params))
+        if not found:
+            invalids.append(param_key)
+            continue
+        param_def = found[0]
+        converted_value = convert_parameter(param_def, param_value)
+        # engine-default parameters do not have a ParameterValue, so we'll always override those.
+        if converted_value != param_def.get("ParameterValue"):
+            if param_def["IsModifiable"]:
+                modify_list.append(
+                    dict(ParameterValue=converted_value, ParameterName=param_key, ApplyMethod=apply_method)
+                )
+            else:
+                not_modifiable.append(param_key)
+    if not_modifiable or invalids:
+        error = ""
+        if not_modifiable:
+            error += f"The following parameters are not modifiable: {','.join(not_modifiable)}. "
+        if invalids:
+            error += (
+                "The following parameters are not available parameters for the '%s' DB parameter group family: %s."
+                % (db_parameter_group_family, ",".join(invalids))
+            )
+        return False, error
+
+    # modify_db_parameters takes at most 20 parameters
+    if modify_list and not module.check_mode:
+        for modify_slice in zip_longest(*[iter(modify_list)] * 20, fillvalue=None):
+            non_empty_slice = [item for item in modify_slice if item]
+            try:
+                connection.modify_db_cluster_parameter_group(
+                    aws_retry=True, DBClusterParameterGroupName=group_name, Parameters=non_empty_slice
+                )
+            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+                module.fail_json_aws(e, msg="Couldn't update RDS cluster parameters")
+        return True, None
+    return False, None
+
+
+def _list_resource_tags(module, connection, resource_arn):
+    try:
+        return connection.list_tags_for_resource(aws_retry=True, ResourceName=resource_arn)["TagList"]
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Couldn't obtain RDS cluster parameter group tags")
+
+
+def update_tags(module, connection, group_arn, tags):
+    if tags is None:
+        return False
+    changed = False
+
+    existing_tags = _list_resource_tags(module, connection, group_arn)
+    to_update, to_delete = compare_aws_tags(
+        boto3_tag_list_to_ansible_dict(existing_tags), tags, module.params["purge_tags"]
+    )
+
+    if module.check_mode:
+        return to_delete or to_update
+
+    if to_update:
+        try:
+            connection.add_tags_to_resource(
+                aws_retry=True,
+                ResourceName=group_arn,
+                Tags=ansible_dict_to_boto3_tag_list(to_update),
+            )
+            changed = True
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't add tags to RDS cluster parameter group")
+    if to_delete:
+        try:
+            connection.remove_tags_from_resource(aws_retry=True, ResourceName=group_arn, TagKeys=to_delete)
+            changed = True
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't remove tags from RDS cluster parameter group")
+    return changed
+
+
+def _describe_db_cluster_parameter_group(module, connection, group_name):
+    try:
+        response = connection.describe_db_cluster_parameter_groups(
+            aws_retry=True, DBClusterParameterGroupName=group_name
+        )
+    except is_boto3_error_code("DBParameterGroupNotFound"):
+        response = None
+    except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Couldn't access parameter group information")
+    return response
+
+
+def ensure_present(module, connection):
+    group_name = module.params["name"]
+    db_parameter_group_family = module.params["db_parameter_group_family"]
+    tags = module.params.get("tags")
+    changed = False
+
+    response = _describe_db_cluster_parameter_group(module=module, connection=connection, group_name=group_name)
+    if not response:
+        # Create RDS cluster parameter group
+        params = dict(
+            DBClusterParameterGroupName=group_name,
+            DBParameterGroupFamily=db_parameter_group_family,
+            Description=module.params["description"],
+        )
+        if tags:
+            params["Tags"] = ansible_dict_to_boto3_tag_list(tags)
+        if module.check_mode:
+            module.exit_json(changed=True)
+        try:
+            response = connection.create_db_cluster_parameter_group(aws_retry=True, **params)
+            changed = True
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't create parameter group")
+    else:
+        group = response["DBClusterParameterGroups"][0]
+        if db_parameter_group_family != group["DBParameterGroupFamily"]:
+            module.warn(
+                "The RDS cluster parameter group family is immutable and can't be changed when updating a RDS cluster parameter group."
+            )
+
+        if tags:
+            changed = update_tags(module, connection, group["DBClusterParameterGroupArn"], tags)
+
+    if module.params.get("params"):
+        params_changed, err = update_parameters(module, connection)
+        if err:
+            module.fail_json(changed=changed, msg=err)
+        changed = changed or params_changed
+
+    response = _describe_db_cluster_parameter_group(module=module, connection=connection, group_name=group_name)
+    group = camel_dict_to_snake_dict(response["DBClusterParameterGroups"][0])
+    group["tags"] = boto3_tag_list_to_ansible_dict(
+        _list_resource_tags(module, connection, group["db_cluster_parameter_group_arn"])
+    )
+
+    module.exit_json(changed=changed, db_cluster_parameter_group=group)
+
+
+def ensure_absent(module, connection):
+    group = module.params["name"]
+    response = _describe_db_cluster_parameter_group(module=module, connection=connection, group_name=group)
+    if not response:
+        module.exit_json(changed=False, msg="The RDS cluster parameter group does not exist.")
+
+    if not module.check_mode:
+        try:
+            response = connection.delete_db_cluster_parameter_group(aws_retry=True, DBClusterParameterGroupName=group)
+        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+            module.fail_json_aws(e, msg="Couldn't delete RDS cluster parameter group")
+    module.exit_json(changed=True)
+
+
+def main():
+    argument_spec = dict(
+        state=dict(default="present", choices=["present", "absent"]),
+        name=dict(required=True),
+        db_parameter_group_family=dict(),
+        description=dict(),
+        params=dict(aliases=["parameters"], type="dict"),
+        immediate=dict(type="bool", aliases=["apply_immediately"]),
+        tags=dict(type="dict", aliases=["resource_tags"]),
+        purge_tags=dict(type="bool", default=True),
+    )
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        required_if=[["state", "present", ["description", "db_parameter_group_family"]]],
+        supports_check_mode=True,
+    )
+
+    try:
+        client = module.client("rds", retry_decorator=AWSRetry.jittered_backoff())
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to connect to AWS")
+
+    func_mapping = {
+        "present": ensure_present,
+        "absent": ensure_absent,
+    }
+    state = module.params.get("state")
+    func_mapping.get(state)(module, client)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/rds_cluster_param_group.py
+++ b/plugins/modules/rds_cluster_param_group.py
@@ -149,10 +149,10 @@ def modify_parameters(module, connection, group_name, parameters):
             if param.get("ParameterName") == current_p.get("ParameterName"):
                 found = True
                 if not current_p["IsModifiable"]:
-                    module.fail_json("The parameter %s cannot be modified" % param.get("ParameterName"))
+                    module.fail_json(f"The parameter {param.get('ParameterName')} cannot be modified")
                 changed |= any((current_p.get(k) != v for k, v in param.items()))
         if not found:
-            module.fail_json(msg="Could not find parameter with name: %s" % param.get("ParameterName"))
+            module.fail_json(msg=f"Could not find parameter with name: {param.get('ParameterName')}")
     if changed:
         if not module.check_mode:
             # When calling modify_db_cluster_parameter_group() function

--- a/plugins/modules/rds_cluster_param_group_info.py
+++ b/plugins/modules/rds_cluster_param_group_info.py
@@ -1,0 +1,119 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2024 Aubin Bikouo (@abikouo)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+module: rds_cluster_param_group_info
+version_added: 7.5.0
+short_description: Describes the properties of specific RDS cluster parameter group.
+description:
+  - Obtain information about one specific RDS cluster parameter group.
+options:
+    name:
+        description:
+          - The RDS cluster parameter group name.
+        type: str
+        required: true
+author:
+  - Aubin Bikouo (@abikouo)
+extends_documentation_fragment:
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
+  - amazon.aws.boto3
+"""
+
+EXAMPLES = r"""
+- name: Describe a specific RDS cluster parameter group
+  amazon.aws.rds_cluster_param_group_info:
+    name: myrdsclustergroup
+"""
+
+RETURN = r"""
+db_cluster_parameter_groups:
+  description: List of RDS cluster parameter groups.
+  returned: always
+  type: list
+  contains:
+    db_cluster_parameter_group_name:
+        description:
+        - The name of the RDS cluster parameter group.
+        type: str
+    db_parameter_group_family:
+        description:
+        - The name of the RDS parameter group family that this RDS cluster parameter group is compatible with.
+        type: str
+    description:
+        description:
+        - Provides the customer-specified description for this RDS cluster parameter group.
+        type: str
+    db_cluster_parameter_group_arn:
+        description:
+        - The Amazon Resource Name (ARN) for the RDS cluster parameter group.
+        type: str
+    tags:
+        description: A dictionary of key value pairs.
+        type: dict
+        sample: {
+            "Name": "rds-cluster-demo"
+        }
+"""
+
+
+try:
+    import botocore
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.rds import get_tags
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+
+
+def _describe_db_cluster_parameter_group(module, connection, group_name):
+    try:
+        response = connection.describe_db_cluster_parameter_groups(
+            aws_retry=True, DBClusterParameterGroupName=group_name
+        )
+    except is_boto3_error_code("DBParameterGroupNotFound"):
+        response = None
+    except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
+        module.fail_json_aws(e, msg="Couldn't access parameter group information")
+    return response
+
+
+def describe_db_engine_versions(connection, module):
+    group_name = module.params.get("name")
+    results = []
+    response = _describe_db_cluster_parameter_group(module, connection, group_name)
+    if response:
+        resource = response["DBClusterParameterGroups"][0]
+        resource["tags"] = get_tags(connection, module, resource["DBClusterParameterGroupArn"])
+        results.append(camel_dict_to_snake_dict(resource, ignore_list=["tags"]))
+    module.exit_json(changed=False, db_cluster_parameter_groups=results)
+
+
+def main():
+    argument_spec = dict(
+        name=dict(required=True),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    try:
+        client = module.client("rds", retry_decorator=AWSRetry.jittered_backoff(retries=10))
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to connect to AWS.")
+
+    describe_db_engine_versions(client, module)
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/rds_cluster_param_group_info.py
+++ b/plugins/modules/rds_cluster_param_group_info.py
@@ -102,6 +102,7 @@ db_cluster_parameter_groups:
         }
 """
 
+from typing import Any
 
 try:
     import botocore
@@ -117,7 +118,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.rds import get_tags
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 
 
-def describe_rds_cluster_parameter_group(connection, module):
+def describe_rds_cluster_parameter_group(connection: Any, module: AnsibleAWSModule) -> None:
     group_name = module.params.get("name")
     include_parameters = module.params.get("include_parameters")
     results = []
@@ -133,7 +134,7 @@ def describe_rds_cluster_parameter_group(connection, module):
     module.exit_json(changed=False, db_cluster_parameter_groups=results)
 
 
-def main():
+def main() -> None:
     argument_spec = dict(
         name=dict(),
         include_parameters=dict(choices=["user", "all", "system", "engine-default"]),

--- a/plugins/modules/rds_cluster_param_group_info.py
+++ b/plugins/modules/rds_cluster_param_group_info.py
@@ -123,7 +123,7 @@ def describe_rds_cluster_parameter_group(connection, module):
     results = []
     response = describe_db_cluster_parameter_groups(module, connection, group_name)
     if response:
-        for resource in response["DBClusterParameterGroups"]:
+        for resource in response:
             resource["tags"] = get_tags(connection, module, resource["DBClusterParameterGroupArn"])
             if include_parameters is not None:
                 resource["db_parameters"] = describe_db_cluster_parameters(

--- a/plugins/modules/rds_cluster_param_group_info.py
+++ b/plugins/modules/rds_cluster_param_group_info.py
@@ -119,7 +119,7 @@ def _describe_db_cluster_parameter_group(module, connection, group_name):
         response = connection.describe_db_cluster_parameter_groups(
             aws_retry=True, DBClusterParameterGroupName=group_name
         )
-    except is_boto3_error_code("DBParameterGroupNotFound"):
+    except is_boto3_error_code("DBParameterGroupNotFoundFault"):
         response = None
     except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
         module.fail_json_aws(e, msg="Couldn't access parameter group information")

--- a/plugins/modules/rds_engine_versions_info.py
+++ b/plugins/modules/rds_engine_versions_info.py
@@ -1,0 +1,377 @@
+#!/usr/bin/python
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2024 Aubin Bikouo (@abikouo)
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+DOCUMENTATION = r"""
+module: rds_engine_versions_info
+version_added: 7.5.0
+short_description: Describes the properties of specific versions of DB engines.
+description:
+  - Obtain information about a specific versions of DB engines.
+options:
+    engine:
+        description:
+          - The database engine to return version details for.
+        type: str
+        choices:
+          - aurora-mysql
+          - aurora-postgresql
+          - custom-oracle-ee
+          - db2-ae
+          - db2-se
+          - mariadb
+          - mysql
+          - oracle-ee
+          - oracle-ee-cdb
+          - oracle-se2
+          - oracle-se2-cdb
+          - postgres
+          - sqlserver-ee
+          - sqlserver-se
+          - sqlserver-ex
+          - sqlserver-web
+    engine_version:
+        description:
+          - A specific database engine version to return details for.
+        type: str
+    db_parameter_group_family:
+        description:
+          - The name of a specific RDS parameter group family to return details for.
+        type: str
+    default_only:
+        description:
+          - Specifies whether to return only the default version of the specified engine
+            or the engine and major version combination.
+        type: bool
+        default: False
+    filters:
+        description:
+            - A filter that specifies one or more DB engine versions to describe.
+              See U(https://docs.aws.amazon.com/AmazonRDS/latest/APIReference/API_DescribeDBEngineVersions.html).
+        type: dict
+author:
+  - Aubin Bikouo (@abikouo)
+extends_documentation_fragment:
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
+  - amazon.aws.boto3
+"""
+
+EXAMPLES = r"""
+- name: List all of the available parameter group families for the Aurora PostgreSQL DB engine
+  amazon.aws.rds_engine_versions_info:
+    engine: aurora-postgresql
+
+- name: List all of the available parameter group families for the Aurora PostgreSQL DB engine on a specific version
+  amazon.aws.rds_engine_versions_info:
+    engine: aurora-postgresql
+    engine_version: 16.1
+
+- name: Get default engine version for DB parameter group family postgres16
+  amazon.aws.rds_engine_versions_info:
+    engine: postgres
+    default_only: true
+    db_parameter_group_family: postgres16
+"""
+
+RETURN = r"""
+db_engine_versions:
+  description: List of RDS engine versions.
+  returned: always
+  type: list
+  contains:
+    engine:
+        description:
+        - The name of the database engine.
+        type: str
+    engine_version:
+        description:
+        - The version number of the database engine.
+        type: str
+    db_parameter_group_family:
+        description:
+        - The name of the DB parameter group family for the database engine.
+        type: str
+    db_engine_description:
+        description:
+        - The description of the database engine.
+        type: str
+    db_engine_version_description:
+        description:
+        - The description of the database engine version.
+        type: str
+    default_character_set:
+        description:
+        - The default character set for new instances of this engine version.
+        type: dict
+        sample: {
+            "character_set_description": "Unicode 5.0 UTF-8 Universal character set",
+            "character_set_name": "AL32UTF8"
+        }
+    image:
+        description:
+        - The EC2 image
+        type: complex
+        contains:
+            image_id:
+                description:
+                - A value that indicates the ID of the AMI.
+                type: str
+            status:
+                description:
+                - A value that indicates the status of a custom engine version (CEV).
+                type: str
+    db_engine_media_type:
+        description:
+        - A value that indicates the source media provider of the AMI based on the usage operation.
+        type: str
+    supported_character_sets:
+        description:
+        - A list of the character sets supported by this engine for the CharacterSetName parameter of the CreateDBInstance operation.
+        type: list
+        elements: dict
+        contains:
+            character_set_name:
+                description:
+                - The name of the character set.
+                type: str
+            character_set_description:
+                description:
+                - The description of the character set.
+                type: str
+    supported_nchar_character_sets:
+        description:
+        - A list of the character sets supported by the Oracle DB engine.
+        type: list
+        elements: dict
+        contains:
+            character_set_name:
+                description:
+                - The name of the character set.
+                type: str
+            character_set_description:
+                description:
+                - The description of the character set.
+                type: str
+    valid_upgrade_target:
+        description:
+        - A list of engine versions that this database engine version can be upgraded to.
+        type: list
+        elements: dict
+        sample: [
+            {
+                "auto_upgrade": false,
+                "description": "Aurora PostgreSQL (Compatible with PostgreSQL 15.5)",
+                "engine": "aurora-postgresql",
+                "engine_version": "15.5",
+                "is_major_version_upgrade": false,
+                "supported_engine_modes": [
+                    "provisioned"
+                ],
+                "supports_babelfish": true,
+                "supports_global_databases": true,
+                "supports_integrations": false,
+                "supports_local_write_forwarding": true,
+                "supports_parallel_query": false
+            }
+        ]
+    supported_timezones:
+        description:
+        - A list of the time zones supported by this engine for the Timezone parameter of the CreateDBInstance action.
+        type: list
+        elements: dict
+        sample: [
+            {"TimezoneName": "xxx"}
+        ]
+    exportable_log_types:
+        description:
+        - The types of logs that the database engine has available for export to CloudWatch Logs.
+        type: list
+        elements: str
+    supports_log_exports_to_cloudwatchLogs:
+        description:
+        - Indicates whether the engine version supports exporting the log types specified by ExportableLogTypes to CloudWatch Logs.
+        type: bool
+    supports_read_replica:
+        description:
+        - Indicates whether the database engine version supports read replicas.
+        type: bool
+    supported_engine_modes:
+        description:
+        - A list of the supported DB engine modes.
+        type: list
+        elements: str
+    supported_feature_names:
+        description:
+        - A list of features supported by the DB engine.
+        type: list
+        elements: str
+        sample: [
+            "Comprehend",
+            "Lambda",
+            "s3Export",
+            "s3Import",
+            "SageMaker"
+        ]
+    status:
+        description:
+        - The status of the DB engine version, either available or deprecated.
+        type: str
+    supports_parallel_query:
+        description:
+        - Indicates whether you can use Aurora parallel query with a specific DB engine version.
+        type: bool
+    supports_global_databases:
+        description:
+        - Indicates whether you can use Aurora global databases with a specific DB engine version.
+        type: bool
+    major_engine_version:
+        description:
+        - The major engine version of the CEV.
+        type: str
+    database_installation_files_s3_bucket_name:
+        description:
+        - The name of the Amazon S3 bucket that contains your database installation files.
+        type: str
+    database_installation_files_s3_prefix:
+        description:
+        - The Amazon S3 directory that contains the database installation files.
+        type: str
+    db_engine_version_arn:
+        description:
+        - The ARN of the custom engine version.
+        type: str
+    kms_key_id:
+        description:
+        - The Amazon Web Services KMS key identifier for an encrypted CEV.
+        type: str
+    create_time:
+        description:
+        - The creation time of the DB engine version.
+        type: str
+    tag_list:
+        description:
+        - A list of tags.
+        type: list
+        elements: dict
+    supports_babelfish:
+        description:
+        - Indicates whether the engine version supports Babelfish for Aurora PostgreSQL.
+        type: bool
+    custom_db_engine_version_manifest:
+        description:
+        - JSON string that lists the installation files and parameters that RDS Custom uses to create a custom engine version (CEV).
+        type: str
+    supports_certificate_rotation_without_restart:
+        description:
+        - Indicates whether the engine version supports rotating the server certificate without rebooting the DB instance.
+        type: bool
+    supported_ca_certificate_identifiers:
+        description:
+        - A list of the supported CA certificate identifiers.
+        type: list
+        elements: str
+        sample: [
+            "rds-ca-2019",
+            "rds-ca-ecc384-g1",
+            "rds-ca-rsa4096-g1",
+            "rds-ca-rsa2048-g1"
+        ]
+    supports_local_write_forwarding:
+        description:
+        - Indicates whether the DB engine version supports forwarding write operations from reader DB instances to the writer DB instance in the DB cluster.
+        type: bool
+    supports_integrations:
+        description:
+        - Indicates whether the DB engine version supports zero-ETL integrations with Amazon Redshift.
+        type: bool
+"""
+
+
+try:
+    import botocore
+except ImportError:
+    pass  # handled by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+
+
+@AWSRetry.jittered_backoff(retries=10)
+def _describe_db_engine_versions(client, **params):
+    paginator = client.get_paginator("describe_db_engine_versions")
+    return paginator.paginate(**params).build_full_result()["DBEngineVersions"]
+
+
+def describe_db_engine_versions(client, module):
+    engine = module.params.get("engine")
+    engine_version = module.params.get("engine_version")
+    db_parameter_group_family = module.params.get("db_parameter_group_family")
+    default_only = module.params.get("default_only")
+    filters = module.params.get("filters")
+
+    params = {"DefaultOnly": default_only}
+    if engine:
+        params["Engine"] = engine
+    if engine_version:
+        params["EngineVersion"] = engine_version
+    if db_parameter_group_family:
+        params["DBParameterGroupFamily"] = db_parameter_group_family
+    if filters:
+        params["Filters"] = filters
+
+    try:
+        result = _describe_db_engine_versions(client, **params)
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, "Couldn't get RDS engine versions.")
+
+    return dict(changed=False, db_engine_versions=[camel_dict_to_snake_dict(v) for v in result])
+
+
+def main():
+    argument_spec = dict(
+        engine=dict(
+            choices=[
+                "aurora-mysql",
+                "aurora-postgresql",
+                "custom-oracle-ee",
+                "db2-ae",
+                "db2-se",
+                "mariadb",
+                "mysql",
+                "oracle-ee",
+                "oracle-ee-cdb",
+                "oracle-se2",
+                "oracle-se2-cdb",
+                "postgres",
+                "sqlserver-ee",
+                "sqlserver-se",
+                "sqlserver-ex",
+                "sqlserver-web",
+            ]
+        ),
+        engine_version=dict(),
+        db_parameter_group_family=dict(),
+        default_only=dict(type="bool", default=False),
+        filters=dict(type="dict"),
+    )
+
+    module = AnsibleAWSModule(
+        argument_spec=argument_spec,
+        supports_check_mode=True,
+    )
+
+    try:
+        client = module.client("rds", retry_decorator=AWSRetry.jittered_backoff(retries=10))
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to connect to AWS.")
+
+    module.exit_json(**describe_db_engine_versions(client, module))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/modules/rds_engine_versions_info.py
+++ b/plugins/modules/rds_engine_versions_info.py
@@ -6,7 +6,7 @@
 
 DOCUMENTATION = r"""
 module: rds_engine_versions_info
-version_added: 7.5.0
+version_added: 7.6.0
 short_description: Describes the properties of specific versions of DB engines.
 description:
   - Obtain information about a specific versions of DB engines.

--- a/plugins/modules/rds_instance_param_group.py
+++ b/plugins/modules/rds_instance_param_group.py
@@ -31,8 +31,7 @@ options:
   engine:
     description:
       - The type of database for this group.
-      - Please use following command to get list of all supported db engines and their respective versions.
-      - '# aws rds describe-db-engine-versions --query "DBEngineVersions[].DBParameterGroupFamily"'
+      - Please use M(amazon.aws.rds_engine_versions_info) to get list of all supported db engines and their respective versions.
       - The DB parameter group family is immutable and can't be changed when updating a DB parameter group.
         See U(https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-rds-dbparametergroup.html)
       - Required for I(state=present).

--- a/tests/integration/targets/rds_cluster_param_group/aliases
+++ b/tests/integration/targets/rds_cluster_param_group/aliases
@@ -1,0 +1,3 @@
+cloud/aws
+rds_cluster_param_group_info
+rds_engine_versions_info

--- a/tests/integration/targets/rds_cluster_param_group/defaults/main.yaml
+++ b/tests/integration/targets/rds_cluster_param_group/defaults/main.yaml
@@ -1,0 +1,7 @@
+---
+rds_cluster_param_group_name: "{{ resource_prefix }}-cluster-param-group"
+rds_engine: postgres
+resource_tags:
+  resource_prefix: "{{ resource_prefix }}"
+  some: tag
+  another: tag

--- a/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
@@ -172,6 +172,40 @@
           - '"Could not find parameter with name: invalid_fake" in invalid_param.msg'
 
     # Test Modify parameters
+    - name: Describe RDS parameter group
+      amazon.aws.rds_cluster_param_group_info:
+        name: "{{ rds_cluster_param_group_name }}"
+        include_parameters: user
+      register: initial_params
+
+    - name: Modify RDS cluster parameter group with new parameters (check_mode)
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        db_parameter_group_family: "{{ dbparam_group_family }}"
+        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
+        parameters:
+          - parameter_name: array_nulls
+            parameter_value: "0"
+            apply_method: immediate
+          - parameter_name: authentication_timeout
+            parameter_value: "50"
+            apply_method: immediate
+      register: update_param_check_mode
+      check_mode: true
+
+    - name: Describe RDS parameter group
+      amazon.aws.rds_cluster_param_group_info:
+        name: "{{ rds_cluster_param_group_name }}"
+        include_parameters: user
+      register: cluster_params
+
+    - name: Assert that the task executed in check_mode reported change, while the parameters remain unchanged
+      ansible.builtin.assert:
+        that:
+          - update_param_check_mode is changed
+          - cluster_params.db_cluster_parameter_groups.0.db_parameters | selectattr('parameter_name', 'equalto', 'array_nulls') | first | community.general.json_query('parameter_value') == initial_params.db_cluster_parameter_groups.0.db_parameters | selectattr('parameter_name', 'equalto', 'array_nulls') | first | community.general.json_query('parameter_value')
+          - cluster_params.db_cluster_parameter_groups.0.db_parameters | selectattr('parameter_name', 'equalto', 'authentication_timeout') | first | community.general.json_query('parameter_value') == initial_params.db_cluster_parameter_groups.0.db_parameters | selectattr('parameter_name', 'equalto', 'authentication_timeout') | first | community.general.json_query('parameter_value')
+
     - name: Modify RDS cluster parameter group with new parameters
       amazon.aws.rds_cluster_param_group:
         name: "{{ rds_cluster_param_group_name }}"
@@ -200,6 +234,25 @@
           - cluster_params.db_cluster_parameter_groups.0.db_parameters | selectattr('parameter_name', 'equalto', 'authentication_timeout') | first | community.general.json_query('parameter_value') == "50"
 
     # Test Modify parameters (idempotency)
+    - name: Modify RDS cluster parameter group with new parameters (idempotency with check_mode)
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        db_parameter_group_family: "{{ dbparam_group_family }}"
+        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
+        parameters:
+          - parameter_name: array_nulls
+            parameter_value: "0"
+            apply_method: immediate
+          - parameter_name: authentication_timeout
+            parameter_value: "50"
+            apply_method: immediate
+      register: update_idempotency_check_mode
+
+    - name: Ensure task executed using check_mode did not reported change
+      ansible.builtin.assert:
+        that:
+          - update_idempotency_check_mode is not changed
+
     - name: Modify RDS cluster parameter group with new parameters (idempotency)
       amazon.aws.rds_cluster_param_group:
         name: "{{ rds_cluster_param_group_name }}"

--- a/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
@@ -54,6 +54,9 @@
       ansible.builtin.assert:
         that:
           - create_group is changed
+          - create_group.db_cluster_parameter_group.db_cluster_parameter_group_arn
+          - create_group.db_cluster_parameter_group.db_cluster_parameter_group_name == rds_cluster_param_group_name
+          - create_group.db_cluster_parameter_group.db_parameter_group_family == dbparam_group_family
           - cluster_params.db_cluster_parameter_groups | length == 1
 
     # Test create RDS cluster parameter group (idempotency)

--- a/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
@@ -1,0 +1,255 @@
+---
+- module_defaults:
+    group/aws:
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+
+  block:
+    - name: Gather information about RDS engine version
+      amazon.aws.rds_engine_versions_info:
+        engine: "{{ rds_engine }}"
+        default_only: true
+      register: engine_versions
+
+    - set_fact:
+        dbparam_group_family: "{{ engine_versions.db_engine_versions.0.db_parameter_group_family }}"
+
+    # Test create using check_mode=true
+    - name: Create RDS cluster parameter group (check_mode=true)
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        db_parameter_group_family: "{{ dbparam_group_family }}"
+        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
+      check_mode: true
+      register: create_checkmode
+
+    - name: Describe RDS parameter group
+      amazon.aws.rds_cluster_param_group_info:
+        name: "{{ rds_cluster_param_group_name }}"
+      register: cluster_params
+
+    - name: Assert that the RDS cluster parameter was not created (using check_mode=true)
+      assert:
+        that:
+          - create_checkmode is changed
+          - cluster_params.db_cluster_parameter_groups | length == 0
+
+    # Test create RDS cluster parameter group
+    - name: Create RDS cluster parameter group
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        db_parameter_group_family: "{{ dbparam_group_family }}"
+        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
+      register: create_group
+
+    - name: Describe RDS parameter group
+      amazon.aws.rds_cluster_param_group_info:
+        name: "{{ rds_cluster_param_group_name }}"
+      register: cluster_params
+
+    - name: Assert that the RDS cluster parameter was created
+      assert:
+        that:
+          - create_group is changed
+          - cluster_params.db_cluster_parameter_groups | length == 1
+
+    # Test create RDS cluster parameter group (idempotency)
+    - name: Create RDS cluster parameter group (idempotency)
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        db_parameter_group_family: "{{ dbparam_group_family }}"
+        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
+      register: create_idempotency
+
+    - name: Validate that module did not reported change
+      assert:
+        that:
+          - create_idempotency is not changed
+
+    # Test adding tag to existing RDS cluster parameter group (check_mode=true)
+    - name: Update existing RDS cluster parameter group with tags (check_mode=true)
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        db_parameter_group_family: "{{ dbparam_group_family }}"
+        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
+        tags: "{{ resource_tags }}"
+      register: create_tag
+      check_mode: true
+
+    - name: Describe RDS parameter group
+      amazon.aws.rds_cluster_param_group_info:
+        name: "{{ rds_cluster_param_group_name }}"
+      register: cluster_params
+
+    - name: Validate that the resource has been updated with tags
+      assert:
+        that:
+          - create_tag is changed
+          - cluster_params.db_cluster_parameter_groups.0.tags == {}
+
+    # Test adding tag to existing RDS cluster parameter group
+    - name: Update existing RDS cluster parameter group with tags
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        db_parameter_group_family: "{{ dbparam_group_family }}"
+        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
+        tags: "{{ resource_tags }}"
+      register: create_tag
+
+    - name: Describe RDS parameter group
+      amazon.aws.rds_cluster_param_group_info:
+        name: "{{ rds_cluster_param_group_name }}"
+      register: cluster_params
+
+    - name: Validate that the resource has been updated with tags
+      assert:
+        that:
+          - create_tag is changed
+          - cluster_params.db_cluster_parameter_groups.0.tags == resource_tags
+
+    # Test adding tag to existing RDS cluster parameter group (idempotency)
+    - name: Update existing RDS cluster parameter group with tags (idempotency)
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        db_parameter_group_family: "{{ dbparam_group_family }}"
+        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
+        tags: "{{ resource_tags }}"
+      register: create_tag_idempotency
+
+    - name: Describe RDS parameter group
+      amazon.aws.rds_cluster_param_group_info:
+        name: "{{ rds_cluster_param_group_name }}"
+      register: cluster_params
+
+    - name: Validate that the resource has been updated with tags
+      assert:
+        that:
+          - create_tag_idempotency is not changed
+          - cluster_params.db_cluster_parameter_groups.0.tags == resource_tags
+
+    # Test adding invalid or not modifiable parameters
+    - name: Update existing RDS cluster parameter group with tags (idempotency)
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        db_parameter_group_family: "{{ dbparam_group_family }}"
+        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
+        parameters:
+          archive_library: "testing_lib"  # This parameter is not modifiable
+          invalid_fake: true  # this parameter does not exist
+      register: update_parameters
+      ignore_errors: true
+
+    - name: Ensure module failed to update invalid/not modifiable parameters
+      assert:
+        that:
+          - update_parameters is failed
+          - update_parameters.msg == error_msg
+      vars:
+        error_msg: "The following parameters are not modifiable: archive_library. The following parameters are not available parameters for the 'postgres16' DB parameter group family: invalid_fake."
+
+    # Test adding parameters
+    - name: Modify RDS cluster parameter group with new parameters
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        db_parameter_group_family: "{{ dbparam_group_family }}"
+        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
+        parameters:
+          array_nulls: 0
+          authentication_timeout: 50
+      register: update_parameters
+
+    - name: Assert that the parameters are updated correctly
+      assert:
+        that:
+          - update_parameters is changed
+
+    # Test adding parameters (idempotency)
+    - name: Modify RDS cluster parameter group with new parameters (idempotency)
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        db_parameter_group_family: "{{ dbparam_group_family }}"
+        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
+        parameters:
+          array_nulls: 0
+          authentication_timeout: 50
+      register: update_idempotency
+
+    - name: Ensure module did not reported change
+      assert:
+        that:
+          - update_idempotency is not changed
+
+    # Test update existing parameter value
+    - name: Modify RDS cluster parameter group existing parameter value
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        db_parameter_group_family: "{{ dbparam_group_family }}"
+        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
+        parameters:
+          array_nulls: 0
+          authentication_timeout: 100
+      register: update_parameters
+
+    - name: Ensure module reported change
+      assert:
+        that:
+          - update_parameters is changed
+
+    # Test delete RDS cluster parameter group (check_mode=true)
+    - name: Delete existing RDS cluster parameter group (check_mode=true)
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        state: absent
+      register: delete_cluster_param_checkmode
+      check_mode: true
+
+    - name: Describe RDS parameter group
+      amazon.aws.rds_cluster_param_group_info:
+        name: "{{ rds_cluster_param_group_name }}"
+      register: cluster_params
+
+    - name: Validate that module execution reported change but the RDS cluster param group was not deleted
+      assert:
+        that:
+          - delete_cluster_param_checkmode is changed
+          - cluster_params.db_cluster_parameter_groups | length == 1
+
+    # Test delete RDS cluster parameter group
+    - name: Delete existing RDS cluster parameter group
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        state: absent
+      register: delete_cluster_param
+
+    - name: Describe RDS parameter group
+      amazon.aws.rds_cluster_param_group_info:
+        name: "{{ rds_cluster_param_group_name }}"
+      register: cluster_params
+
+    - name: Validate that module execution reported change but the RDS cluster param group was not deleted
+      assert:
+        that:
+          - delete_cluster_param is changed
+          - cluster_params.db_cluster_parameter_groups | length == 0
+
+    # Test delete RDS cluster parameter group (idempotency)
+    - name: Delete existing RDS cluster parameter group
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        state: absent
+      register: delete_cluster_param
+
+    - name: Ensure module did not reported change
+      assert:
+        that:
+          - delete_cluster_param is not changed
+
+  always:
+    - name: Delete existing RDS cluster parameter group
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        state: absent
+      register: delete_cluster_param
+      ignore_errors: true

--- a/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
@@ -87,7 +87,7 @@
         name: "{{ rds_cluster_param_group_name }}"
       register: cluster_params
 
-    - name: Validate that the resource has been updated with tags
+    - name: Validate that the resource has not been updated with tags (check_mode)
       ansible.builtin.assert:
         that:
           - create_tag is changed

--- a/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
@@ -172,12 +172,6 @@
           - '"Could not find parameter with name: invalid_fake" in invalid_param.msg'
 
     # Test Modify parameters
-    - name: Describe RDS parameter group
-      amazon.aws.rds_cluster_param_group_info:
-        name: "{{ rds_cluster_param_group_name }}"
-        include_parameters: user
-      register: initial_params
-
     - name: Modify RDS cluster parameter group with new parameters (check_mode)
       amazon.aws.rds_cluster_param_group:
         name: "{{ rds_cluster_param_group_name }}"
@@ -196,15 +190,19 @@
     - name: Describe RDS parameter group
       amazon.aws.rds_cluster_param_group_info:
         name: "{{ rds_cluster_param_group_name }}"
-        include_parameters: user
-      register: cluster_params
+        include_parameters: all
+      register: initial_params
+      no_log: true # very spammy
 
     - name: Assert that the task executed in check_mode reported change, while the parameters remain unchanged
       ansible.builtin.assert:
         that:
           - update_param_check_mode is changed
-          - cluster_params.db_cluster_parameter_groups.0.db_parameters | selectattr('parameter_name', 'equalto', 'array_nulls') | first | community.general.json_query('parameter_value') == initial_params.db_cluster_parameter_groups.0.db_parameters | selectattr('parameter_name', 'equalto', 'array_nulls') | first | community.general.json_query('parameter_value')
-          - cluster_params.db_cluster_parameter_groups.0.db_parameters | selectattr('parameter_name', 'equalto', 'authentication_timeout') | first | community.general.json_query('parameter_value') == initial_params.db_cluster_parameter_groups.0.db_parameters | selectattr('parameter_name', 'equalto', 'authentication_timeout') | first | community.general.json_query('parameter_value')
+          - "'parameter_value' not in array_nulls_param"
+          - "'parameter_value' not in auth_timeout_param"
+      vars:
+        array_nulls_param: "{{ initial_params.db_cluster_parameter_groups.0.db_parameters | selectattr('parameter_name', 'equalto', 'array_nulls') | first }}"
+        auth_timeout_param: "{{ initial_params.db_cluster_parameter_groups.0.db_parameters | selectattr('parameter_name', 'equalto', 'authentication_timeout') | first }}"
 
     - name: Modify RDS cluster parameter group with new parameters
       amazon.aws.rds_cluster_param_group:

--- a/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
@@ -13,7 +13,8 @@
         default_only: true
       register: engine_versions
 
-    - set_fact:
+    - name: Set variable for RDS param group family
+      ansible.builtin.set_fact:
         dbparam_group_family: "{{ engine_versions.db_engine_versions.0.db_parameter_group_family }}"
 
     # Test create using check_mode=true
@@ -31,7 +32,7 @@
       register: cluster_params
 
     - name: Assert that the RDS cluster parameter was not created (using check_mode=true)
-      assert:
+      ansible.builtin.assert:
         that:
           - create_checkmode is changed
           - cluster_params.db_cluster_parameter_groups | length == 0
@@ -50,7 +51,7 @@
       register: cluster_params
 
     - name: Assert that the RDS cluster parameter was created
-      assert:
+      ansible.builtin.assert:
         that:
           - create_group is changed
           - cluster_params.db_cluster_parameter_groups | length == 1
@@ -63,8 +64,8 @@
         description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
       register: create_idempotency
 
-    - name: Validate that module did not reported change
-      assert:
+    - name: Validate that module did not report change
+      ansible.builtin.assert:
         that:
           - create_idempotency is not changed
 
@@ -84,7 +85,7 @@
       register: cluster_params
 
     - name: Validate that the resource has been updated with tags
-      assert:
+      ansible.builtin.assert:
         that:
           - create_tag is changed
           - cluster_params.db_cluster_parameter_groups.0.tags == {}
@@ -104,7 +105,7 @@
       register: cluster_params
 
     - name: Validate that the resource has been updated with tags
-      assert:
+      ansible.builtin.assert:
         that:
           - create_tag is changed
           - cluster_params.db_cluster_parameter_groups.0.tags == resource_tags
@@ -123,79 +124,97 @@
         name: "{{ rds_cluster_param_group_name }}"
       register: cluster_params
 
-    - name: Validate that the resource has been updated with tags
-      assert:
+    - name: Validate that the module did not report change and the resource tag remain unchanged
+      ansible.builtin.assert:
         that:
           - create_tag_idempotency is not changed
           - cluster_params.db_cluster_parameter_groups.0.tags == resource_tags
 
-    # Test adding invalid or not modifiable parameters
-    - name: Update existing RDS cluster parameter group with tags (idempotency)
+    # Test adding not modifiable parameter
+    - name: Update RDS cluster param group with not modifiable parameter
       amazon.aws.rds_cluster_param_group:
         name: "{{ rds_cluster_param_group_name }}"
         db_parameter_group_family: "{{ dbparam_group_family }}"
         description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
         parameters:
-          archive_library: "testing_lib"  # This parameter is not modifiable
-          invalid_fake: true  # this parameter does not exist
-      register: update_parameters
+          - parameter_name: archive_library
+            parameter_value: test
+            apply_method: immediate
+      register: not_modifiable
       ignore_errors: true
 
-    - name: Ensure module failed to update invalid/not modifiable parameters
-      assert:
+    - name: Ensure module failed to update not modifiable parameter
+      ansible.builtin.assert:
         that:
-          - update_parameters is failed
-          - update_parameters.msg == error_msg
-      vars:
-        error_msg: "The following parameters are not modifiable: archive_library. The following parameters are not available parameters for the 'postgres16' DB parameter group family: invalid_fake."
+          - not_modifiable is failed
+          - '"The parameter archive_library cannot be modified" in not_modifiable.msg'
 
-    # Test adding parameters
+    # Test adding invalid parameter
+    - name: Update RDS cluster param group with invalid parameter
+      amazon.aws.rds_cluster_param_group:
+        name: "{{ rds_cluster_param_group_name }}"
+        db_parameter_group_family: "{{ dbparam_group_family }}"
+        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
+        parameters:
+          - parameter_name: invalid_fake
+            parameter_value: test
+            apply_method: immediate
+      register: invalid_param
+      ignore_errors: true
+
+    - name: Ensure module failed to update invalid parameter
+      ansible.builtin.assert:
+        that:
+          - invalid_param is failed
+          - '"Could not find parameter with name: invalid_fake" in invalid_param.msg'
+
+    # Test Modify parameters
     - name: Modify RDS cluster parameter group with new parameters
       amazon.aws.rds_cluster_param_group:
         name: "{{ rds_cluster_param_group_name }}"
         db_parameter_group_family: "{{ dbparam_group_family }}"
         description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
         parameters:
-          array_nulls: 0
-          authentication_timeout: 50
+          - parameter_name: array_nulls
+            parameter_value: "0"
+            apply_method: immediate
+          - parameter_name: authentication_timeout
+            parameter_value: "50"
+            apply_method: immediate
       register: update_parameters
 
+    - name: Describe RDS parameter group
+      amazon.aws.rds_cluster_param_group_info:
+        name: "{{ rds_cluster_param_group_name }}"
+        include_parameters: user
+      register: cluster_params
+
     - name: Assert that the parameters are updated correctly
-      assert:
+      ansible.builtin.assert:
         that:
           - update_parameters is changed
+          - cluster_params.db_cluster_parameter_groups.0.db_parameters | selectattr('parameter_name', 'equalto', 'array_nulls') | first | community.general.json_query('parameter_value') == "0"
+          - cluster_params.db_cluster_parameter_groups.0.db_parameters | selectattr('parameter_name', 'equalto', 'authentication_timeout') | first | community.general.json_query('parameter_value') == "50"
 
-    # Test adding parameters (idempotency)
+    # Test Modify parameters (idempotency)
     - name: Modify RDS cluster parameter group with new parameters (idempotency)
       amazon.aws.rds_cluster_param_group:
         name: "{{ rds_cluster_param_group_name }}"
         db_parameter_group_family: "{{ dbparam_group_family }}"
         description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
         parameters:
-          array_nulls: 0
-          authentication_timeout: 50
+          - parameter_name: array_nulls
+            parameter_value: "0"
+            apply_method: immediate
+          - parameter_name: authentication_timeout
+            parameter_value: "50"
+            apply_method: immediate
       register: update_idempotency
 
-    - name: Ensure module did not reported change
-      assert:
+    - name: Ensure module did not report change
+      ansible.builtin.assert:
         that:
           - update_idempotency is not changed
-
-    # Test update existing parameter value
-    - name: Modify RDS cluster parameter group existing parameter value
-      amazon.aws.rds_cluster_param_group:
-        name: "{{ rds_cluster_param_group_name }}"
-        db_parameter_group_family: "{{ dbparam_group_family }}"
-        description: "RDS cluster param group for Engine {{ engine_versions.db_engine_versions.0.engine_version }}"
-        parameters:
-          array_nulls: 0
-          authentication_timeout: 100
-      register: update_parameters
-
-    - name: Ensure module reported change
-      assert:
-        that:
-          - update_parameters is changed
 
     # Test delete RDS cluster parameter group (check_mode=true)
     - name: Delete existing RDS cluster parameter group (check_mode=true)
@@ -228,8 +247,8 @@
         name: "{{ rds_cluster_param_group_name }}"
       register: cluster_params
 
-    - name: Validate that module execution reported change but the RDS cluster param group was not deleted
-      assert:
+    - name: Validate that module execution reported change and the RDS cluster param group is deleted
+      ansible.builtin.assert:
         that:
           - delete_cluster_param is changed
           - cluster_params.db_cluster_parameter_groups | length == 0
@@ -241,8 +260,8 @@
         state: absent
       register: delete_cluster_param
 
-    - name: Ensure module did not reported change
-      assert:
+    - name: Ensure module did not report change
+      ansible.builtin.assert:
         that:
           - delete_cluster_param is not changed
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes #1075 
This pull request adds the following modules: 
- rds_parameter_group: to create, modify, delete RDS cluster parameter group
- rds_parameter_group_info: to gather information about a specific RDS cluster parameter group
- rds_engine_versions_info: to gather information about a specific version of DB engine, this will avoid using cli command `aws rds describe-db-engine-versions --query "DBEngineVersions[].DBParameterGroupFamily"` to perform this task
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`rds_parameter_group`
`rds_parameter_group_info`
`rds_engine_versions_info`