### PR TITLE
add support for host option in placement.tenancy

### DIFF
--- a/changelogs/fragments/2026-ec2_instance-add-support-for-placement-tenancy-host.yml
+++ b/changelogs/fragments/2026-ec2_instance-add-support-for-placement-tenancy-host.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ec2_instance - add support for `host` option in placement.tenancy (https://github.com/ansible-collections/amazon.aws/pull/2026).

--- a/changelogs/fragments/2026-ec2_instance-add-support-for-placement-tenancy-host.yml
+++ b/changelogs/fragments/2026-ec2_instance-add-support-for-placement-tenancy-host.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - ec2_instance - add support for `host` option in placement.tenancy (https://github.com/ansible-collections/amazon.aws/pull/2026).
+  - ec2_instance - add support for ``host`` option in placement.tenancy (https://github.com/ansible-collections/amazon.aws/pull/2026).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -362,7 +362,7 @@ options:
         description: Type of tenancy to allow an instance to use. Default is shared tenancy. Dedicated tenancy will incur additional charges.
         type: str
         required: false
-        choices: ['dedicated', 'default']
+        choices: ['dedicated', 'default', 'host']
   license_specifications:
     description:
       - The license specifications to be used for the instance.
@@ -2304,7 +2304,7 @@ def main():
                 host_id=dict(type="str"),
                 host_resource_group_arn=dict(type="str"),
                 partition_number=dict(type="int"),
-                tenancy=dict(type="str", choices=["dedicated", "default"]),
+                tenancy=dict(type="str", choices=["dedicated", "default", "host"]),
             ),
         ),
         instance_initiated_shutdown_behavior=dict(type="str", choices=["stop", "terminate"]),

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -359,7 +359,9 @@ options:
         type: int
         required: false
       tenancy:
-        description: Type of tenancy to allow an instance to use. Default is shared tenancy. Dedicated tenancy will incur additional charges.
+        description:
+          - Type of tenancy to allow an instance to use. Default is shared tenancy. Dedicated tenancy will incur additional charges.
+          - Support for I(tenancy=host) was added in amazon.aws 7.6.0.
         type: str
         required: false
         choices: ['dedicated', 'default', 'host']


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add host option in tenancy under placement.

Resolves #1990 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_instance
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/run_instances.html

The host tenancy is not supported for [ImportInstance](https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_ImportInstance.html) or for T3 instances that are configured for the unlimited CPU credit option.
