### PR TITLE
Manual backport: Inventory plugins do not convert template parameters (#1980)

### DIFF
--- a/tests/integration/targets/inventory_aws_ec2/playbooks/create_inventory_config.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/create_inventory_config.yml
@@ -9,3 +9,8 @@
       copy:
         dest: ../test.aws_ec2.yml
         content: "{{ lookup('template', template_name) }}"
+
+    - name: write ini configuration
+      ansible.builtin.copy:
+        dest: ../config.ini
+        content: "{{ lookup('template', '../templates/config.ini.j2') }}"

--- a/tests/integration/targets/inventory_aws_ec2/templates/config.ini.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/config.ini.j2
@@ -1,0 +1,3 @@
+[ansible-test]
+
+region = {{ aws_region }}

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_template.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_template.yml.j2
@@ -5,7 +5,7 @@ secret_key: '{{ aws_secret_key }}'
 session_token: '{{ security_token }}'
 {% endif %}
 regions:
-- '{{ aws_region }}'
+- '{{ '{{ lookup("ansible.builtin.ini", "region", section="ansible-test", file="config.ini") }}' }}'
 filters:
   tag:Name:
   - '{{ resource_prefix }}'

--- a/tests/unit/plugin_utils/inventory/test_inventory_base.py
+++ b/tests/unit/plugin_utils/inventory/test_inventory_base.py
@@ -131,7 +131,9 @@ def test_inventory_get_options_without_templar(aws_inventory_base, mocker, optio
     }
     aws_inventory_base._options = inventory_options
 
-    super_get_options_patch = mocker.patch("ansible_collections.amazon.aws.plugins.plugin_utils.inventory.BaseInventoryPlugin.get_options")
+    super_get_options_patch = mocker.patch(
+        "ansible_collections.amazon.aws.plugins.plugin_utils.inventory.BaseInventoryPlugin.get_options"
+    )
     super_get_options_patch.return_value = aws_inventory_base._options
 
     options = aws_inventory_base.get_options()
@@ -166,10 +168,14 @@ def test_inventory_get_options_with_templar(aws_inventory_base, mocker, option, 
     }
     aws_inventory_base.templar = AwsUnitTestTemplar(templar_config)
 
-    super_get_options_patch = mocker.patch("ansible_collections.amazon.aws.plugins.plugin_utils.inventory.BaseInventoryPlugin.get_options")
+    super_get_options_patch = mocker.patch(
+        "ansible_collections.amazon.aws.plugins.plugin_utils.inventory.BaseInventoryPlugin.get_options"
+    )
     super_get_options_patch.return_value = aws_inventory_base._options
 
-    super_get_option_patch = mocker.patch("ansible_collections.amazon.aws.plugins.plugin_utils.inventory.BaseInventoryPlugin.get_option")
+    super_get_option_patch = mocker.patch(
+        "ansible_collections.amazon.aws.plugins.plugin_utils.inventory.BaseInventoryPlugin.get_option"
+    )
     super_get_option_patch.side_effect = lambda x, hostvars=None: aws_inventory_base._options.get(x)
 
     if error:

--- a/tests/unit/plugin_utils/inventory/test_inventory_base.py
+++ b/tests/unit/plugin_utils/inventory/test_inventory_base.py
@@ -3,13 +3,18 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import pytest
-from unittest.mock import call
+import re
 from unittest.mock import MagicMock
+from unittest.mock import call
 from unittest.mock import patch
 from unittest.mock import sentinel
 
+import pytest
+
 import ansible.plugins.inventory as base_inventory
+from ansible.errors import AnsibleError
+from ansible.module_utils.six import string_types
+
 import ansible_collections.amazon.aws.plugins.plugin_utils.inventory as utils_inventory
 
 
@@ -63,3 +68,125 @@ def test_inventory_verify_file(monkeypatch, filename, result):
     assert inventory_plugin.verify_file(filename) is result
     base_verify.return_value = False
     assert inventory_plugin.verify_file(filename) is False
+
+
+class AwsUnitTestTemplar:
+    def __init__(self, config):
+        self.config = config
+
+    def is_template_string(self, key):
+        m = re.findall("{{([ ]*[a-zA-Z0-9_]*[ ]*)}}", key)
+        return bool(m)
+
+    def is_template(self, data):
+        if isinstance(data, string_types):
+            return self.is_template_string(data)
+        elif isinstance(data, (list, tuple)):
+            for v in data:
+                if self.is_template(v):
+                    return True
+        elif isinstance(data, dict):
+            for k in data:
+                if self.is_template(k) or self.is_template(data[k]):
+                    return True
+        return False
+
+    def template(self, variable, disable_lookups):
+        for k, v in self.config.items():
+            variable = re.sub("{{([ ]*%s[ ]*)}}" % k, v, variable)
+        if self.is_template_string(variable):
+            m = re.findall("{{([ ]*[a-zA-Z0-9_]*[ ]*)}}", variable)
+            raise AnsibleError(f"Missing variables: {','.join([k.replace(' ', '') for k in m])}")
+        return variable
+
+
+@pytest.fixture
+def aws_inventory_base():
+    inventory = utils_inventory.AWSInventoryBase()
+    inventory._options = {}
+    inventory.templar = None
+    return inventory
+
+
+@pytest.mark.parametrize(
+    "option,value",
+    [
+        ("access_key", "amazon_ansible_access_key_001"),
+        ("secret_key", "amazon_ansible_secret_key_890"),
+        ("session_token", None),
+        ("use_ssm_inventory", False),
+        ("This_field_is_undefined", None),
+        ("assume_role_arn", "arn:aws:iam::123456789012:role/ansible-test-inventory"),
+        ("region", "us-east-2"),
+    ],
+)
+def test_inventory_get_options_without_templar(aws_inventory_base, mocker, option, value):
+    inventory_options = {
+        "access_key": "amazon_ansible_access_key_001",
+        "secret_key": "amazon_ansible_secret_key_890",
+        "endpoint": "http//ansible.amazon.com",
+        "assume_role_arn": "arn:aws:iam::123456789012:role/ansible-test-inventory",
+        "region": "us-east-2",
+        "use_ssm_inventory": False,
+    }
+    aws_inventory_base._options = inventory_options
+
+    super_get_options_patch = mocker.patch("ansible_collections.amazon.aws.plugins.plugin_utils.inventory.BaseInventoryPlugin.get_options")
+    super_get_options_patch.return_value = aws_inventory_base._options
+
+    options = aws_inventory_base.get_options()
+    assert value == options.get(option)
+
+
+@pytest.mark.parametrize(
+    "option,value,error",
+    [
+        ("access_key", "amazon_ansible_access_key_001", None),
+        ("session_token", None, None),
+        ("use_ssm_inventory", "{{ aws_inventory_use_ssm }}", None),
+        ("This_field_is_undefined", None, None),
+        ("region", "us-east-1", None),
+        ("profile", None, "Missing variables: ansible_version"),
+    ],
+)
+def test_inventory_get_options_with_templar(aws_inventory_base, mocker, option, value, error):
+    inventory_options = {
+        "access_key": "amazon_ansible_access_key_001",
+        "profile": "ansbile_{{ ansible_os }}_{{ ansible_version }}",
+        "endpoint": "{{ aws_endpoint }}",
+        "region": "{{ aws_region_country }}-east-{{ aws_region_id }}",
+        "use_ssm_inventory": "{{ aws_inventory_use_ssm }}",
+    }
+    aws_inventory_base._options = inventory_options
+    templar_config = {
+        "ansible_os": "RedHat",
+        "aws_region_country": "us",
+        "aws_region_id": "1",
+        "aws_endpoint": "http//ansible.amazon.com",
+    }
+    aws_inventory_base.templar = AwsUnitTestTemplar(templar_config)
+
+    super_get_options_patch = mocker.patch("ansible_collections.amazon.aws.plugins.plugin_utils.inventory.BaseInventoryPlugin.get_options")
+    super_get_options_patch.return_value = aws_inventory_base._options
+
+    super_get_option_patch = mocker.patch("ansible_collections.amazon.aws.plugins.plugin_utils.inventory.BaseInventoryPlugin.get_option")
+    super_get_option_patch.side_effect = lambda x, hostvars=None: aws_inventory_base._options.get(x)
+
+    if error:
+        # test using get_options()
+        with pytest.raises(AnsibleError) as exc:
+            options = aws_inventory_base.get_options()
+            options.get(option)
+        assert error == str(exc.value)
+
+        # test using get_option()
+        with pytest.raises(AnsibleError) as exc:
+            aws_inventory_base.get_option(option)
+        assert error == str(exc.value)
+    else:
+        # test using get_options()
+        options = aws_inventory_base.get_options()
+        assert value == options.get(option)
+
+        # test using get_option()
+        assert value == aws_inventory_base.get_option(option)

--- a/tests/unit/plugins/inventory/test_aws_ec2.py
+++ b/tests/unit/plugins/inventory/test_aws_ec2.py
@@ -238,6 +238,7 @@ def test_get_tag_hostname(preference, instance, expected):
 )
 def test_inventory_build_include_filters(inventory, _options, expected):
     inventory._options = _options
+    inventory.templar = None
     assert inventory.build_include_filters() == expected
 
 


### PR DESCRIPTION
Manual backport of #1980 