### PR TITLE
ec2_security_group -  Use yield from in order to fix sanity errors

### DIFF
--- a/changelogs/fragments/20240403-ec2_securty_group-sanity.yml
+++ b/changelogs/fragments/20240403-ec2_securty_group-sanity.yml
@@ -1,0 +1,2 @@
+trivial:
+  - ec2_securty_group - Use ``yield from`` in order to fix sanity errors.

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -1296,8 +1296,7 @@ def flatten_nested_targets(module, rules):
                     date="2024-12-01",
                     collection_name="amazon.aws",
                 )
-                for t in _flatten(target):
-                    yield t
+                yield from _flatten(target)
             elif isinstance(target, string_types):
                 yield target
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ec2_security_group -  Use `yield from` in order to fix sanity errors
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_security_group 

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
