### PR TITLE
Copy 2.17 ignore to 2.18 - 2.17 has been branched

### DIFF
--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,0 +1,1 @@
+plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this


### PR DESCRIPTION
##### SUMMARY

With 2.17 now branched, devel has been bumped to "2.18", as a result we need to create ignore-2.18.txt

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

tests/sanity/ignore-2.18.txt

##### ADDITIONAL INFORMATION

While there is a devel/milestone error for "deprecated version", this will be fixed by #2040 (hint: please review).  Because #2040 touches module_utils it triggers a lot of tests, which I'd rather not do.  As such I'll leave the entry out of this PR and everything should be good again once 2040 merges.