### PR TITLE
Deprecate ignored boto3 parameters

### DIFF
--- a/changelogs/fragments/sanity-boto3.yml
+++ b/changelogs/fragments/sanity-boto3.yml
@@ -1,0 +1,7 @@
+deprecated_features:
+  - module_utils.botocore - the ``boto3`` parameter for ``get_aws_region()`` will be removed in a release after 2025-05-01.
+    The ``boto3`` parameter has been ignored since release 4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/2047).
+  - module_utils.botocore - the ``boto3`` parameter for ``get_aws_connection_info()`` will be removed in a release after 2025-05-01.
+    The ``boto3`` parameter has been ignored since release 4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/2047).
+  - module_utils.ec2 - the ``boto3`` parameter for ``get_ec2_security_group_ids_from_names()`` will be removed in a release after 2025-05-01.
+    The ``boto3`` parameter has been ignored since release 4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/2047).

--- a/plugins/module_utils/botocore.py
+++ b/plugins/module_utils/botocore.py
@@ -202,7 +202,14 @@ def _aws_region(params):
         return None
 
 
-def get_aws_region(module, boto3=None):
+def get_aws_region(module, boto3=None):  # pylint: disable=redefined-outer-name
+    if boto3 is not None:
+        module.deprecate(
+            "get_aws_region(): the boto3 parameter will be removed in a release after 2025-05-01. "
+            "The parameter has been ignored since release 4.0.0.",
+            date="2025-05-01",
+            collection_name="amazon.aws",
+        )
     try:
         return _aws_region(module.params)
     except AnsibleBotocoreError as e:
@@ -266,7 +273,14 @@ def _aws_connection_info(params):
     return region, endpoint_url, boto_params
 
 
-def get_aws_connection_info(module, boto3=None):
+def get_aws_connection_info(module, boto3=None):  # pylint: disable=redefined-outer-name
+    if boto3 is not None:
+        module.deprecate(
+            "get_aws_connection_info(): the boto3 parameter will be removed in a release after 2025-05-01. "
+            "The parameter has been ignored since release 4.0.0.",
+            date="2025-05-01",
+            collection_name="amazon.aws",
+        )
     try:
         return _aws_connection_info(module.params)
     except AnsibleBotocoreError as e:

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -39,6 +39,7 @@ up in this module because "that's where the AWS code was" (originally).
 
 import re
 
+import ansible.module_utils.common.warnings as ansible_warnings
 from ansible.module_utils.ansible_release import __version__
 
 # Used to live here, moved into ansible.module_utils.common.dict_transformations
@@ -103,6 +104,16 @@ def get_ec2_security_group_ids_from_names(sec_group_list, ec2_connection, vpc_id
 
     def get_sg_id(sg):
         return str(sg["GroupId"])
+
+    if boto3 is not None:
+        ansible_warnings.deprecate(
+            (
+                "The boto3 parameter for get_ec2_security_group_ids_from_names() has been deprecated."
+                "The parameter has been ignored since release 4.0.0."
+            ),
+            date="2025-05-01",
+            collection_name="amazon.aws",
+        )
 
     sec_group_id_list = []
 

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -98,10 +98,10 @@ def get_ec2_security_group_ids_from_names(sec_group_list, ec2_connection, vpc_id
     a try block
     """
 
-    def get_sg_name(sg, boto3=None):
+    def get_sg_name(sg):
         return str(sg["GroupName"])
 
-    def get_sg_id(sg, boto3=None):
+    def get_sg_id(sg):
         return str(sg["GroupId"])
 
     sec_group_id_list = []
@@ -123,7 +123,7 @@ def get_ec2_security_group_ids_from_names(sec_group_list, ec2_connection, vpc_id
     else:
         all_sec_groups = ec2_connection.describe_security_groups()["SecurityGroups"]
 
-    unmatched = set(sec_group_list).difference(str(get_sg_name(all_sg, boto3)) for all_sg in all_sec_groups)
+    unmatched = set(sec_group_list).difference(str(get_sg_name(all_sg)) for all_sg in all_sec_groups)
     sec_group_name_list = list(set(sec_group_list) - set(unmatched))
 
     if len(unmatched) > 0:

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -449,7 +449,7 @@ class ApplicationLoadBalancer(ElasticLoadBalancerV2):
         if module.params.get("security_groups") is not None:
             try:
                 self.security_groups = AWSRetry.jittered_backoff()(get_ec2_security_group_ids_from_names)(
-                    module.params.get("security_groups"), self.connection_ec2, boto3=True
+                    module.params.get("security_groups"), self.connection_ec2
                 )
             except ValueError as e:
                 self.module.fail_json(msg=str(e), exception=traceback.format_exc())

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -192,21 +192,21 @@ class AnsibleAWSModule:
         return self._module.md5(*args, **kwargs)
 
     def client(self, service, retry_decorator=None, **extra_params):
-        region, endpoint_url, aws_connect_kwargs = get_aws_connection_info(self, boto3=True)
+        region, endpoint_url, aws_connect_kwargs = get_aws_connection_info(self)
         kw_args = dict(region=region, endpoint=endpoint_url, **aws_connect_kwargs)
         kw_args.update(extra_params)
         conn = boto3_conn(self, conn_type="client", resource=service, **kw_args)
         return conn if retry_decorator is None else RetryingBotoClientWrapper(conn, retry_decorator)
 
     def resource(self, service, **extra_params):
-        region, endpoint_url, aws_connect_kwargs = get_aws_connection_info(self, boto3=True)
+        region, endpoint_url, aws_connect_kwargs = get_aws_connection_info(self)
         kw_args = dict(region=region, endpoint=endpoint_url, **aws_connect_kwargs)
         kw_args.update(extra_params)
         return boto3_conn(self, conn_type="resource", resource=service, **kw_args)
 
     @property
     def region(self):
-        return get_aws_region(self, True)
+        return get_aws_region(self)
 
     def fail_json_aws(self, exception, msg=None, **kwargs):
         """call fail_json with processed exception

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -395,7 +395,7 @@ def create_eni(connection, vpc_id, module):
     private_ip_address = module.params.get("private_ip_address")
     description = module.params.get("description")
     security_groups = get_ec2_security_group_ids_from_names(
-        module.params.get("security_groups"), connection, vpc_id=vpc_id, boto3=True
+        module.params.get("security_groups"), connection, vpc_id=vpc_id
     )
     secondary_private_ip_addresses = module.params.get("secondary_private_ip_addresses")
     secondary_private_ip_address_count = module.params.get("secondary_private_ip_address_count")
@@ -510,7 +510,7 @@ def modify_eni(connection, module, eni):
                     )
                 changed = True
         if len(security_groups) > 0:
-            groups = get_ec2_security_group_ids_from_names(security_groups, connection, vpc_id=eni["VpcId"], boto3=True)
+            groups = get_ec2_security_group_ids_from_names(security_groups, connection, vpc_id=eni["VpcId"])
             if sorted(get_sec_group_list(eni["Groups"])) != sorted(groups):
                 if not module.check_mode:
                     connection.modify_network_interface_attribute(

--- a/tests/unit/module_utils/modules/ansible_aws_module/test_passthrough.py
+++ b/tests/unit/module_utils/modules/ansible_aws_module/test_passthrough.py
@@ -70,7 +70,7 @@ def test_region(monkeypatch, stdin):
     aws_module = utils_module.AnsibleAWSModule(argument_spec=dict())
 
     assert aws_module.region is sentinel.RETURNED_REGION
-    assert get_aws_region.call_args == call(aws_module, True)
+    assert get_aws_region.call_args == call(aws_module)
 
 
 @pytest.mark.parametrize("stdin", [{}], indirect=["stdin"])
@@ -129,7 +129,7 @@ def test_client_no_wrapper(monkeypatch, stdin):
 
     aws_module = utils_module.AnsibleAWSModule(argument_spec=dict())
     assert aws_module.client(sentinel.PARAM_SERVICE) is sentinel.BOTO3_CONN
-    assert get_aws_connection_info.call_args == call(aws_module, boto3=True)
+    assert get_aws_connection_info.call_args == call(aws_module)
     assert boto3_conn.call_args == call(
         aws_module,
         conn_type="client",
@@ -153,7 +153,7 @@ def test_client_wrapper(monkeypatch, stdin):
     wrapped_conn = aws_module.client(sentinel.PARAM_SERVICE, sentinel.PARAM_WRAPPER)
     assert wrapped_conn.client is sentinel.BOTO3_CONN
     assert wrapped_conn.retry is sentinel.PARAM_WRAPPER
-    assert get_aws_connection_info.call_args == call(aws_module, boto3=True)
+    assert get_aws_connection_info.call_args == call(aws_module)
     assert boto3_conn.call_args == call(
         aws_module,
         conn_type="client",
@@ -166,7 +166,7 @@ def test_client_wrapper(monkeypatch, stdin):
     wrapped_conn = aws_module.client(sentinel.PARAM_SERVICE, sentinel.PARAM_WRAPPER, region=sentinel.PARAM_REGION)
     assert wrapped_conn.client is sentinel.BOTO3_CONN
     assert wrapped_conn.retry is sentinel.PARAM_WRAPPER
-    assert get_aws_connection_info.call_args == call(aws_module, boto3=True)
+    assert get_aws_connection_info.call_args == call(aws_module)
     assert boto3_conn.call_args == call(
         aws_module,
         conn_type="client",
@@ -188,7 +188,7 @@ def test_resource(monkeypatch, stdin):
 
     aws_module = utils_module.AnsibleAWSModule(argument_spec=dict())
     assert aws_module.resource(sentinel.PARAM_SERVICE) is sentinel.BOTO3_CONN
-    assert get_aws_connection_info.call_args == call(aws_module, boto3=True)
+    assert get_aws_connection_info.call_args == call(aws_module)
     assert boto3_conn.call_args == call(
         aws_module,
         conn_type="resource",
@@ -199,7 +199,7 @@ def test_resource(monkeypatch, stdin):
 
     # Check that we can override parameters
     assert aws_module.resource(sentinel.PARAM_SERVICE, region=sentinel.PARAM_REGION) is sentinel.BOTO3_CONN
-    assert get_aws_connection_info.call_args == call(aws_module, boto3=True)
+    assert get_aws_connection_info.call_args == call(aws_module)
     assert boto3_conn.call_args == call(
         aws_module,
         conn_type="resource",


### PR DESCRIPTION
##### SUMMARY

``module_utils.botocore.get_aws_region()``, ``module_utils.botocore.get_aws_connection_info()`` and ``module_utils.ec2.get_ec2_security_group_ids_from_names()`` currently have ``boto3`` parameters which default to None, and do nothing.  This is a leftover from dropping support for the old boto SDK back in release 4.0.0.

Start the cleanup process and deprecate the parameter.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/botocore.py
plugins/module_utils/ec2.py
plugins/module_utils/elbv2.py
plugins/module_utils/modules.py
plugins/modules/ec2_eni.py

##### ADDITIONAL INFORMATION

(see also https://github.com/ansible-collections/community.aws/pull/2075)