### PR TITLE
Clean up a range of small pylint warnings

### DIFF
--- a/changelogs/fragments/sanity-simple.yml
+++ b/changelogs/fragments/sanity-simple.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - elb_classic_lb - fixes bug where ``proxy_protocol`` not being set or being set to ``None`` may result in unexpected behaviour or errors ().

--- a/changelogs/fragments/sanity-simple.yml
+++ b/changelogs/fragments/sanity-simple.yml
@@ -1,2 +1,5 @@
 bugfixes:
   - elb_classic_lb - fixes bug where ``proxy_protocol`` not being set or being set to ``None`` may result in unexpected behaviour or errors ().
+
+minor_changes:
+  - cloudformation - apply automatic retries when paginating through stack events without a filter ().

--- a/changelogs/fragments/sanity-simple.yml
+++ b/changelogs/fragments/sanity-simple.yml
@@ -1,5 +1,5 @@
 bugfixes:
-  - elb_classic_lb - fixes bug where ``proxy_protocol`` not being set or being set to ``None`` may result in unexpected behaviour or errors ().
+  - elb_classic_lb - fixes bug where ``proxy_protocol`` not being set or being set to ``None`` may result in unexpected behaviour or errors (https://github.com/ansible-collections/amazon.aws/pull/2049).
 
 minor_changes:
-  - cloudformation - apply automatic retries when paginating through stack events without a filter ().
+  - cloudformation - apply automatic retries when paginating through stack events without a filter (https://github.com/ansible-collections/amazon.aws/pull/2049).

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -633,17 +633,17 @@ class InventoryModule(AWSInventoryBase):
         """
         instances = []
         ids_to_ignore = []
-        for filter in exclude_filters:
+        for filter_dict in exclude_filters:
             for i in self._get_instances_by_region(
                 regions,
-                ansible_dict_to_boto3_filter_list(filter),
+                ansible_dict_to_boto3_filter_list(filter_dict),
                 strict_permissions,
             ):
                 ids_to_ignore.append(i["InstanceId"])
-        for filter in include_filters:
+        for filter_dict in include_filters:
             for i in self._get_instances_by_region(
                 regions,
-                ansible_dict_to_boto3_filter_list(filter),
+                ansible_dict_to_boto3_filter_list(filter_dict),
                 strict_permissions,
             ):
                 if i["InstanceId"] not in ids_to_ignore:

--- a/plugins/lookup/aws_collection_constants.py
+++ b/plugins/lookup/aws_collection_constants.py
@@ -49,7 +49,7 @@ except ImportError:
 
 
 class LookupModule(LookupBase):
-    def lookup_constant(self, name):
+    def lookup_constant(self, name):  # pylint: disable=too-many-return-statements
         if name == "MINIMUM_BOTOCORE_VERSION":
             return botocore_utils.MINIMUM_BOTOCORE_VERSION
         if name == "MINIMUM_BOTO3_VERSION":

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -44,11 +44,11 @@ _raw:
 
 import json
 
+import ansible.module_utils.six.moves.urllib.error
+import ansible.module_utils.urls
 from ansible.errors import AnsibleLookupError
 from ansible.module_utils._text import to_native
 from ansible.plugins.lookup import LookupBase
-import ansible.module_utils.six.moves.urllib.error
-import ansible.module_utils.urls
 
 
 class LookupModule(LookupBase):

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -46,12 +46,9 @@ import json
 
 from ansible.errors import AnsibleLookupError
 from ansible.module_utils._text import to_native
-from ansible.module_utils.six.moves.urllib.error import HTTPError
-from ansible.module_utils.six.moves.urllib.error import URLError
-from ansible.module_utils.urls import ConnectionError
-from ansible.module_utils.urls import SSLValidationError
-from ansible.module_utils.urls import open_url
 from ansible.plugins.lookup import LookupBase
+import ansible.module_utils.six.moves.urllib.error
+import ansible.module_utils.urls
 
 
 class LookupModule(LookupBase):
@@ -64,19 +61,19 @@ class LookupModule(LookupBase):
             ip_prefix_label = "ip_prefix"
 
         try:
-            resp = open_url("https://ip-ranges.amazonaws.com/ip-ranges.json")
+            resp = ansible.module_utils.urls.open_url("https://ip-ranges.amazonaws.com/ip-ranges.json")
             amazon_response = json.load(resp)[prefixes_label]
         except getattr(json.decoder, "JSONDecodeError", ValueError) as e:
             # on Python 3+, json.decoder.JSONDecodeError is raised for bad
             # JSON. On 2.x it's a ValueError
             raise AnsibleLookupError(f"Could not decode AWS IP ranges: {to_native(e)}")
-        except HTTPError as e:
+        except ansible.module_utils.six.moves.urllib.error.HTTPError as e:
             raise AnsibleLookupError(f"Received HTTP error while pulling IP ranges: {to_native(e)}")
-        except SSLValidationError as e:
+        except ansible.module_utils.urls.SSLValidationError as e:
             raise AnsibleLookupError(f"Error validating the server's certificate for: {to_native(e)}")
-        except URLError as e:
+        except ansible.module_utils.six.moves.urllib.error.URLError as e:
             raise AnsibleLookupError(f"Failed look up IP range service: {to_native(e)}")
-        except ConnectionError as e:
+        except ansible.module_utils.urls.ConnectionError as e:
             raise AnsibleLookupError(f"Error connecting to IP range service: {to_native(e)}")
 
         if "region" in kwargs:

--- a/plugins/lookup/secretsmanager_secret.py
+++ b/plugins/lookup/secretsmanager_secret.py
@@ -182,9 +182,9 @@ class LookupModule(AWSLookupBase):
             secrets = {}
             for term in terms:
                 try:
-                    for object in _list_secrets(client, term):
-                        if "SecretList" in object:
-                            for secret_obj in object["SecretList"]:
+                    for secret_wrapper in _list_secrets(client, term):
+                        if "SecretList" in secret_wrapper:
+                            for secret_obj in secret_wrapper["SecretList"]:
                                 secrets.update(
                                     {
                                         secret_obj["Name"]: self.get_secret_value(

--- a/plugins/module_utils/acm.py
+++ b/plugins/module_utils/acm.py
@@ -40,7 +40,7 @@ def acm_catch_boto_exception(func):
             return func(*args, **kwargs)
         except is_boto3_error_code(ignore_error_codes):
             return None
-        except (BotoCoreError, ClientError) as e:
+        except (BotoCoreError, ClientError) as e:  # pylint: disable=duplicate-except
             if not module:
                 raise
             module.fail_json_aws(e, msg=error)

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -84,11 +84,11 @@ class AnsibleAWSModule:
 
     def __init__(self, **kwargs):
         local_settings = {}
-        for key in AnsibleAWSModule.default_settings:
+        for key, default_value in AnsibleAWSModule.default_settings.items():
             try:
                 local_settings[key] = kwargs.pop(key)
             except KeyError:
-                local_settings[key] = AnsibleAWSModule.default_settings[key]
+                local_settings[key] = default_value
         self.settings = local_settings
 
         if local_settings["default_args"]:

--- a/plugins/modules/autoscaling_group.py
+++ b/plugins/modules/autoscaling_group.py
@@ -1090,7 +1090,7 @@ def wait_for_target_group(asg_connection, group_name):
 
 
 def suspend_processes(ec2_connection, as_group):
-    suspend_processes = set(module.params.get("suspend_processes"))
+    processes_to_suspend = set(module.params.get("suspend_processes"))
 
     try:
         suspended_processes = set([p["ProcessName"] for p in as_group["SuspendedProcesses"]])
@@ -1098,15 +1098,15 @@ def suspend_processes(ec2_connection, as_group):
         # New ASG being created, no suspended_processes defined yet
         suspended_processes = set()
 
-    if suspend_processes == suspended_processes:
+    if processes_to_suspend == suspended_processes:
         return False
 
-    resume_processes = list(suspended_processes - suspend_processes)
+    resume_processes = list(suspended_processes - processes_to_suspend)
     if resume_processes:
         resume_asg_processes(ec2_connection, module.params.get("name"), resume_processes)
 
-    if suspend_processes:
-        suspend_asg_processes(ec2_connection, module.params.get("name"), list(suspend_processes))
+    if processes_to_suspend:
+        suspend_asg_processes(ec2_connection, module.params.get("name"), list(processes_to_suspend))
 
     return True
 

--- a/plugins/modules/ec2_eni.py
+++ b/plugins/modules/ec2_eni.py
@@ -368,10 +368,7 @@ def correct_ip_count(connection, ip_count, module, eni_id):
         for ip in eni["PrivateIpAddresses"]:
             private_addresses.add(ip["PrivateIpAddress"])
 
-    if len(private_addresses) == ip_count:
-        return True
-    else:
-        return False
+    return bool(len(private_addresses) == ip_count)
 
 
 def wait_for(function_pointer, *args):

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -2029,7 +2029,7 @@ def handle_existing(existing_matches, state, filters):
     return result
 
 
-def enforce_count(existing_matches, module, desired_module_state):
+def enforce_count(existing_matches, desired_module_state):
     exact_count = module.params.get("exact_count")
 
     current_count = len(existing_matches)
@@ -2390,7 +2390,7 @@ def main():
                     changed=False,
                 )
         elif module.params.get("exact_count"):
-            result = enforce_count(existing_matches, module, desired_module_state=state)
+            result = enforce_count(existing_matches, desired_module_state=state)
         elif existing_matches and not module.params.get("count"):
             for match in existing_matches:
                 warn_if_public_ip_assignment_changed(match)

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1930,7 +1930,7 @@ def change_instance_state(filters, desired_module_state):
                 if inst["State"]["Name"] in ("pending", "running"):
                     unchanged.add(inst["InstanceId"])
                     continue
-                elif inst["State"]["Name"] == "stopping":
+                if inst["State"]["Name"] == "stopping":
                     await_instances([inst["InstanceId"]], desired_module_state="stopped", force_wait=True)
 
                 if module.check_mode:

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -2068,7 +2068,10 @@ def enforce_count(existing_matches, desired_module_state):
         await_instances(terminate_ids, desired_module_state="terminated", force_wait=True)
     except is_boto3_error_code("InvalidInstanceID.NotFound"):
         pass
-    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
+    except (
+        botocore.exceptions.BotoCoreError,
+        botocore.exceptions.ClientError,
+    ) as e:  # pylint: disable=duplicate-except
         module.fail_json(e, msg="Unable to terminate instances")
 
     # include data for all matched instances in addition to the list of terminations

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -2032,60 +2032,54 @@ def handle_existing(existing_matches, state, filters):
 def enforce_count(existing_matches, module, desired_module_state):
     exact_count = module.params.get("exact_count")
 
+    current_count = len(existing_matches)
+    if current_count == exact_count:
+        return dict(
+            changed=False,
+            instances=[pretty_instance(i) for i in existing_matches],
+            instance_ids=[i["InstanceId"] for i in existing_matches],
+            msg=f"{exact_count} instances already running, nothing to do.",
+        )
+
+    if current_count < exact_count:
+        # launch instances
+        return ensure_present(
+            existing_matches=existing_matches,
+            desired_module_state=desired_module_state,
+            current_count=current_count,
+        )
+
+    to_terminate = current_count - exact_count
+    # sort the instances from least recent to most recent based on launch time
+    existing_matches = sorted(existing_matches, key=lambda inst: inst["LaunchTime"])
+    # get the instance ids of instances with the count tag on them
+    all_instance_ids = [x["InstanceId"] for x in existing_matches]
+    terminate_ids = all_instance_ids[0:to_terminate]
+    if module.check_mode:
+        return dict(
+            changed=True,
+            terminated_ids=terminate_ids,
+            instance_ids=all_instance_ids,
+            msg=f"Would have terminated following instances if not in check mode {terminate_ids}",
+        )
+    # terminate instances
     try:
-        current_count = len(existing_matches)
-        if current_count == exact_count:
-            module.exit_json(
-                changed=False,
-                instances=[pretty_instance(i) for i in existing_matches],
-                instance_ids=[i["InstanceId"] for i in existing_matches],
-                msg=f"{exact_count} instances already running, nothing to do.",
-            )
+        client.terminate_instances(aws_retry=True, InstanceIds=terminate_ids)
+        await_instances(terminate_ids, desired_module_state="terminated", force_wait=True)
+    except is_boto3_error_code("InvalidInstanceID.NotFound"):
+        pass
+    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:  # pylint: disable=duplicate-except
+        module.fail_json(e, msg="Unable to terminate instances")
 
-        elif current_count < exact_count:
-            # launch instances
-            try:
-                ensure_present(
-                    existing_matches=existing_matches,
-                    desired_module_state=desired_module_state,
-                    current_count=current_count,
-                )
-            except botocore.exceptions.ClientError as e:
-                module.fail_json(e, msg="Unable to launch instances")
-        elif current_count > exact_count:
-            to_terminate = current_count - exact_count
-            # sort the instances from least recent to most recent based on launch time
-            existing_matches = sorted(existing_matches, key=lambda inst: inst["LaunchTime"])
-            # get the instance ids of instances with the count tag on them
-            all_instance_ids = [x["InstanceId"] for x in existing_matches]
-            terminate_ids = all_instance_ids[0:to_terminate]
-            if module.check_mode:
-                module.exit_json(
-                    changed=True,
-                    terminated_ids=terminate_ids,
-                    instance_ids=all_instance_ids,
-                    msg=f"Would have terminated following instances if not in check mode {terminate_ids}",
-                )
-            # terminate instances
-            try:
-                client.terminate_instances(aws_retry=True, InstanceIds=terminate_ids)
-                await_instances(terminate_ids, desired_module_state="terminated", force_wait=True)
-            except is_boto3_error_code("InvalidInstanceID.NotFound"):
-                pass
-            except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
-                module.fail_json(e, msg="Unable to terminate instances")
-            # include data for all matched instances in addition to the list of terminations
-            # allowing for recovery of metadata from the destructive operation
-            module.exit_json(
-                changed=True,
-                msg="Successfully terminated instances.",
-                terminated_ids=terminate_ids,
-                instance_ids=all_instance_ids,
-                instances=existing_matches,
-            )
-
-    except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
-        module.fail_json_aws(e, msg="Failed to enforce instance count")
+    # include data for all matched instances in addition to the list of terminations
+    # allowing for recovery of metadata from the destructive operation
+    return dict(
+        changed=True,
+        msg="Successfully terminated instances.",
+        terminated_ids=terminate_ids,
+        instance_ids=all_instance_ids,
+        instances=existing_matches,
+    )
 
 
 def ensure_present(existing_matches, desired_module_state, current_count=None):
@@ -2100,7 +2094,7 @@ def ensure_present(existing_matches, desired_module_state, current_count=None):
         if module.check_mode:
             if existing_matches:
                 instance_ids = [x["InstanceId"] for x in existing_matches]
-                module.exit_json(
+                return dict(
                     changed=True,
                     instance_ids=instance_ids,
                     instances=existing_matches,
@@ -2108,7 +2102,7 @@ def ensure_present(existing_matches, desired_module_state, current_count=None):
                     msg="Would have launched instances if not in check_mode.",
                 )
             else:
-                module.exit_json(
+                return dict(
                     changed=True,
                     spec=instance_spec,
                     msg="Would have launched instances if not in check_mode.",
@@ -2144,14 +2138,14 @@ def ensure_present(existing_matches, desired_module_state, current_count=None):
             all_instance_ids = [x["InstanceId"] for x in existing_matches] + instance_ids
         if not module.params.get("wait"):
             if existing_matches:
-                module.exit_json(
+                return dict(
                     changed=True,
                     changed_ids=instance_ids,
                     instance_ids=all_instance_ids,
                     spec=instance_spec,
                 )
             else:
-                module.exit_json(
+                return dict(
                     changed=True,
                     instance_ids=instance_ids,
                     spec=instance_spec,
@@ -2161,7 +2155,7 @@ def ensure_present(existing_matches, desired_module_state, current_count=None):
 
         if existing_matches:
             all_instances = existing_matches + instances
-            module.exit_json(
+            return dict(
                 changed=True,
                 changed_ids=instance_ids,
                 instance_ids=all_instance_ids,
@@ -2169,7 +2163,7 @@ def ensure_present(existing_matches, desired_module_state, current_count=None):
                 spec=instance_spec,
             )
         else:
-            module.exit_json(
+            return dict(
                 changed=True,
                 instance_ids=instance_ids,
                 instances=[pretty_instance(i) for i in instances],
@@ -2396,7 +2390,7 @@ def main():
                     changed=False,
                 )
         elif module.params.get("exact_count"):
-            enforce_count(existing_matches, module, desired_module_state=state)
+            result = enforce_count(existing_matches, module, desired_module_state=state)
         elif existing_matches and not module.params.get("count"):
             for match in existing_matches:
                 warn_if_public_ip_assignment_changed(match)

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -450,6 +450,8 @@ socket.setdefaulttimeout(5)
 # The ec2_metadata_facts module is a special case, while we generally dropped support for Python < 3.6
 # this module doesn't depend on the SDK and still has valid use cases for folks working with older
 # OSes.
+
+# pylint: disable=consider-using-f-string
 try:
     json_decode_error = json.JSONDecodeError
 except AttributeError:

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -532,7 +532,7 @@ def rule_cmp(a, b):
             # equal protocols can interchange `(-1, -1)` and `(None, None)`
             if a.port_range in ((None, None), (-1, -1)) and b.port_range in ((None, None), (-1, -1)):
                 continue
-            elif getattr(a, prop) != getattr(b, prop):
+            if getattr(a, prop) != getattr(b, prop):
                 return False
         elif getattr(a, prop) != getattr(b, prop):
             return False

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -843,7 +843,8 @@ def ensure_route_table_present(connection, module):
     if changed:
         # pause to allow route table routes/subnets/associations to be updated before exiting with final state
         sleep(5)
-    module.exit_json(changed=changed, route_table=get_route_table_info(connection, module, route_table))
+
+    return dict(changed=changed, route_table=get_route_table_info(connection, module, route_table))
 
 
 def main():

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -1717,10 +1717,10 @@ class ElbManager:
         if any(proxy_ports.values()):
             changed |= self._set_proxy_protocol_policy(proxy_policy_name)
 
-        for port in proxy_ports:
+        for port, port_policy in proxy_ports.items():
             current_policies = set(backend_policies.get(port, []))
             new_policies = list(current_policies - proxy_policies)
-            if proxy_ports[port]:
+            if port_policy:
                 new_policies.append(proxy_policy_name)
 
             changed |= self._set_backend_policy(port, new_policies)

--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -1412,7 +1412,7 @@ class ElbManager:
         if not self.health_check:
             return False
 
-        """Set health check values on ELB as needed"""
+        # Set health check values on ELB as needed
         health_check_config = self._format_healthcheck()
 
         if self.elb and health_check_config == self.elb["HealthCheck"]:
@@ -1697,7 +1697,7 @@ class ElbManager:
             proxy_protocol = listener.get("proxy_protocol", None)
             # Only look at the listeners for which proxy_protocol is defined
             if proxy_protocol is None:
-                next
+                continue
             instance_port = listener.get("instance_port")
             if proxy_ports.get(instance_port, None) is not None:
                 if proxy_ports[instance_port] != proxy_protocol:

--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -1174,7 +1174,7 @@ def ensure_present(cluster, parameters, method_name, method_options_name):
     return changed
 
 
-def handle_remove_from_global_db(module, cluster):
+def handle_remove_from_global_db(cluster):
     global_cluster_id = module.params.get("global_cluster_identifier")
     db_cluster_id = module.params.get("db_cluster_identifier")
     db_cluster_arn = cluster["DBClusterArn"]
@@ -1361,7 +1361,7 @@ def main():
         if method_name == "delete_db_cluster":
             if cluster and module.params.get("remove_from_global_db"):
                 if cluster["Engine"] in ["aurora", "aurora-mysql", "aurora-postgresql"]:
-                    changed = handle_remove_from_global_db(module, cluster)
+                    changed = handle_remove_from_global_db(cluster)
 
             call_method(client, module, method_name, eval(method_options_name)(parameters))
             changed = True
@@ -1377,7 +1377,7 @@ def main():
         if cluster["Engine"] in ["aurora", "aurora-mysql", "aurora-postgresql"]:
             if changed:
                 wait_for_cluster_status(client, module, cluster_id, "cluster_available")
-        changed |= handle_remove_from_global_db(module, cluster)
+        changed |= handle_remove_from_global_db(cluster)
 
     result = camel_dict_to_snake_dict(get_cluster(cluster_id))
 

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1566,8 +1566,7 @@ def main():
                     instance = get_instance(client, module, instance_id)
                     if instance:
                         break
-                    else:
-                        sleep(5)
+                    sleep(5)
 
         if state == "absent" and changed and not module.params["skip_final_snapshot"]:
             instance.update(

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1164,8 +1164,7 @@ def get_current_attributes_with_inconsistent_keys(instance):
 def get_changing_options_with_inconsistent_keys(modify_params, instance, purge_cloudwatch_logs, purge_security_groups):
     changing_params = {}
     current_options = get_current_attributes_with_inconsistent_keys(instance)
-    for option in current_options:
-        current_option = current_options[option]
+    for option, current_option in current_options.items():
         desired_option = modify_params.pop(option, None)
         if desired_option is None:
             continue

--- a/plugins/modules/rds_param_group.py
+++ b/plugins/modules/rds_param_group.py
@@ -149,9 +149,9 @@ def convert_parameter(param, value):
     if param["DataType"] == "integer":
         if isinstance(value, string_types):
             try:
-                for modifier in INT_MODIFIERS.keys():
-                    if value.endswith(modifier):
-                        converted_value = int(value[:-1]) * INT_MODIFIERS[modifier]
+                for name, modifier in INT_MODIFIERS.items():
+                    if value.endswith(name):
+                        converted_value = int(value[:-1]) * modifier
             except ValueError:
                 # may be based on a variable (ie. {foo*3/4}) so
                 # just pass it on through to the AWS SDK

--- a/plugins/modules/route53_health_check.py
+++ b/plugins/modules/route53_health_check.py
@@ -535,21 +535,21 @@ def update_health_check(existing_check):
     return True, "update", check_id
 
 
-def describe_health_check(id):
-    if not id:
+def describe_health_check(check_id):
+    if not check_id:
         return dict()
 
     try:
         result = client.get_health_check(
             aws_retry=True,
-            HealthCheckId=id,
+            HealthCheckId=check_id,
         )
     except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
-        module.fail_json_aws(e, msg="Failed to get health check.", id=id)
+        module.fail_json_aws(e, msg="Failed to get health check.", id=check_id)
 
     health_check = result.get("HealthCheck", {})
     health_check = camel_dict_to_snake_dict(health_check)
-    tags = get_tags(module, client, "healthcheck", id)
+    tags = get_tags(module, client, "healthcheck", check_id)
     health_check["tags"] = tags
     return health_check
 
@@ -705,7 +705,7 @@ def main():
         if check_id:
             changed |= manage_tags(module, client, "healthcheck", check_id, tags, purge_tags)
 
-    health_check = describe_health_check(id=check_id)
+    health_check = describe_health_check(check_id)
     health_check["action"] = action
     module.exit_json(
         changed=changed,

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -641,10 +641,7 @@ def create_or_update_bucket(s3_client, module):
             current_encryption_algorithm = current_encryption.get("SSEAlgorithm") if current_encryption else None
             if current_encryption_algorithm == "aws:kms":
                 if get_bucket_key(s3_client, name) != bucket_key_enabled:
-                    if bucket_key_enabled:
-                        expected_encryption = True
-                    else:
-                        expected_encryption = False
+                    expected_encryption = bool(bucket_key_enabled)
                     current_encryption = put_bucket_key_with_retry(module, s3_client, name, expected_encryption)
                     changed = True
         result["encryption"] = current_encryption

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -736,10 +736,9 @@ def create_or_update_bucket(s3_client, module):
 def bucket_exists(s3_client, bucket_name):
     try:
         s3_client.head_bucket(Bucket=bucket_name)
-        bucket_exists = True
+        return True
     except is_boto3_error_code("404"):
-        bucket_exists = False
-    return bucket_exists
+        return False
 
 
 @AWSRetry.exponential_backoff(max_delay=120)

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -656,10 +656,7 @@ def create_dirkey(module, s3, bucket, obj, encrypt, expiry):
 
 
 def path_check(path):
-    if os.path.exists(path):
-        return True
-    else:
-        return False
+    return bool(os.path.exists(path))
 
 
 def guess_content_type(src):

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -656,7 +656,10 @@ def create_dirkey(module, s3, bucket, obj, encrypt, expiry):
 
 
 def path_check(path):
-    return bool(os.path.exists(path))
+    if os.path.exists(path):
+        return True
+    else:
+        return False
 
 
 def guess_content_type(src):

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -962,13 +962,13 @@ def ensure_tags(client, module, bucket, obj):
     return current_tags_dict, changed
 
 
-def get_binary_content(vars):
+def get_binary_content(s3_vars):
     # the content will be uploaded as a byte string, so we must encode it first
     bincontent = None
-    if vars.get("content"):
-        bincontent = vars["content"].encode("utf-8")
-    if vars.get("content_base64"):
-        bincontent = base64.standard_b64decode(vars["content_base64"])
+    if s3_vars.get("content"):
+        bincontent = s3_vars["content"].encode("utf-8")
+    if s3_vars.get("content_base64"):
+        bincontent = base64.standard_b64decode(s3_vars["content_base64"])
     return bincontent
 
 

--- a/plugins/modules/s3_object_info.py
+++ b/plugins/modules/s3_object_info.py
@@ -741,8 +741,10 @@ def main():
             result.append(object_details)
         elif object_name is None:
             object_list = list_bucket_objects(connection, module, bucket_name)
-            for object in object_list:
-                result.append(get_object_details(connection, module, bucket_name, object, requested_object_details))
+            for bucket_object in object_list:
+                result.append(
+                    get_object_details(connection, module, bucket_name, bucket_object, requested_object_details)
+                )
 
     elif not requested_object_details and object_name:
         # if specific details are not requested, return object metadata

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = clean,ansible{2.12,2.13}-py{38,39,310}-{with_constraints,without_const
 # Tox4 supports labels which allow us to group the environments rather than dumping all commands into a single environment
 labels =
     format = flynt, black, isort
-    lint = complexity-report, ansible-lint, black-lint, isort-lint, flake8-lint, flynt-lint, pylint-lint
+    lint = complexity-report, ansible-lint, black-lint, isort-lint, flake8-lint, flynt-lint
     units = ansible{2.12,2.13}-py{38,39,310}-{with_constraints,without_constraints}
 
 [common]

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = clean,ansible{2.12,2.13}-py{38,39,310}-{with_constraints,without_const
 # Tox4 supports labels which allow us to group the environments rather than dumping all commands into a single environment
 labels =
     format = flynt, black, isort
-    lint = complexity-report, ansible-lint, black-lint, isort-lint, flake8-lint, flynt-lint
+    lint = complexity-report, ansible-lint, black-lint, isort-lint, flake8-lint, flynt-lint, pylint-lint
     units = ansible{2.12,2.13}-py{38,39,310}-{with_constraints,without_constraints}
 
 [common]
@@ -73,6 +73,16 @@ deps =
   flake8
 commands =
   flake8 {posargs} {[common]format_dirs}
+
+[testenv:pylint-lint]
+# Additional pylint tests that ansible-test currently ignores
+deps =
+  pylint
+commands =
+  pylint \
+    --disable R,C,W,E \
+    --enable consider-using-dict-items,assignment-from-no-return,no-else-continue,no-else-break,simplifiable-if-statement,pointless-string-statement,redefined-outer-name,redefined-builtin \
+    {toxinidir}/plugins
 
 [testenv:flynt]
 deps =


### PR DESCRIPTION
##### SUMMARY

Cleans up a range of pylint warnings
- consider-using-dict-items
- assignment-from-no-return
- no-else-continue
- no-else-break
- simplifiable-if-statement
- duplicate-except
- pointless-string-statement
- redefined-outer-name
- redefined-builtin

In the process this also highlighted two bugs which have been fixed
- elb_classic_lb - ``proxy_protocol`` not being set or being set to ``None`` can result in unexpected behaviour or errors ("next" used rather than "continue")
- cloudformation - when fetching stack events automatic retries were only applied when using a filter.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/inventory/aws_ec2.py
plugins/lookup/aws_collection_constants.py
plugins/lookup/aws_service_ip_ranges.py
plugins/lookup/secretsmanager_secret.py
plugins/module_utils/acm.py
plugins/module_utils/modules.py
plugins/modules/autoscaling_group.py
plugins/modules/cloudformation.py
plugins/modules/ec2_eni.py
plugins/modules/ec2_instance.py
plugins/modules/ec2_metadata_facts.py
plugins/modules/ec2_security_group.py
plugins/modules/ec2_vpc_route_table.py
plugins/modules/elb_classic_lb.py
plugins/modules/rds_cluster.py
plugins/modules/rds_instance.py
plugins/modules/rds_param_group.py
plugins/modules/route53_health_check.py
plugins/modules/s3_bucket.py
plugins/modules/s3_object.py
plugins/modules/s3_object_info.py

##### ADDITIONAL INFORMATION
