### PR TITLE
Add Object Lock default retention configuration for S3 buckets

### DIFF
--- a/changelogs/fragments/s3_bucket-object-retention.yml
+++ b/changelogs/fragments/s3_bucket-object-retention.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - s3_bucket - Add ``object_lock_default_retention`` to set Object Lock default retention configuration for S3 buckets (https://github.com/ansible-collections/amazon.aws/pull/2062).

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -322,6 +322,7 @@ EXAMPLES = r"""
     name: mys3bucket
     state: present
     accelerate_enabled: true
+
 # Default Object Lock retention
 - amazon.aws.s3_bucket:
     name: mys3bucket
@@ -974,6 +975,7 @@ def handle_bucket_accelerate(s3_client, module: AnsibleAWSModule, name: str) -> 
             module.fail_json_aws(e, msg="Failed to update bucket transfer acceleration")
     return accelerate_enabled_changed, accelerate_enabled_result
 
+
 def handle_bucket_object_lock_retention(s3_client, module: AnsibleAWSModule, name: str) -> tuple[bool, dict]:
     """
     Manage object lock retention configuration for an S3 bucket.
@@ -1103,6 +1105,7 @@ def create_or_update_bucket(s3_client, module: AnsibleAWSModule):
     # -- Transfer Acceleration
     bucket_accelerate_changed, bucket_accelerate_result = handle_bucket_accelerate(s3_client, module, name)
     result["accelerate_enabled"] = bucket_accelerate_result
+
     # -- Object Lock Default Retention
     bucket_object_lock_retention_changed, bucket_object_lock_retention_result = handle_bucket_object_lock_retention(
         s3_client, module, name

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -174,16 +174,22 @@ options:
     version_added: 8.1.0
   object_lock_default_retention:
     description:
-      - Default Object Lock configuration that will be applied by default to every new object placed in the specified bucket.
+      - Default Object Lock configuration that will be applied by default to
+        every new object placed in the specified bucket.
     suboptions:
       mode:
-        description: 'GOVERNANCE' or 'COMPLIANCE
+        description: Type of retention modes
+        choices: [ 'GOVERNANCE', 'COMPLIANCE']
         type: str
       days:
-        description: The number of days that you want to specify for the default retention period. 
+        description:
+            - The number of days that you want to specify for the default retention period.
+            - Mutually exclusive with I(years).
         type: int
       years:
-        description: The number of years that you want to specify for the default retention period.
+        description:
+            - The number of years that you want to specify for the default retention period.
+            - Mutually exclusive with I(days).
         type: int
     type: dict
     version_added: 7.6.0
@@ -308,13 +314,11 @@ EXAMPLES = r"""
     state: present
     acl: public-read
 
-<<<<<<< HEAD
 # Enable transfer acceleration
 - amazon.aws.s3_bucket:
     name: mys3bucket
     state: present
     accelerate_enabled: true
-=======
 # Default Object Lock retention
 - amazon.aws.s3_bucket:
     name: mys3bucket
@@ -322,7 +326,6 @@ EXAMPLES = r"""
     object_lock_default_retention:
       mode: governance
       days: 1
->>>>>>> 523553f39 (Object Lock default retention)
 """
 
 RETURN = r"""

--- a/tests/integration/targets/s3_bucket/inventory
+++ b/tests/integration/targets/s3_bucket/inventory
@@ -1,5 +1,4 @@
 [tests]
-default_retention
 ownership_controls
 missing
 simple
@@ -13,6 +12,7 @@ public_access
 acl
 object_lock
 accelerate
+default_retention
 
 [all:vars]
 ansible_connection=local

--- a/tests/integration/targets/s3_bucket/inventory
+++ b/tests/integration/targets/s3_bucket/inventory
@@ -1,4 +1,5 @@
 [tests]
+default_retention
 ownership_controls
 missing
 simple

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/default_retention.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/default_retention.yml
@@ -1,0 +1,136 @@
+---
+- module_defaults:
+    group/aws:
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+    - ansible.builtin.set_fact:
+        local_bucket_name: "{{ bucket_name | hash('md5')}}-default-retention"
+
+    # ============================================================
+
+    - name: Create a simple bucket with object lock
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        state: present
+        object_lock_enabled: true
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output.changed
+          - output.object_lock_enabled
+
+    - name: Add object lock default retention
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        state: present
+        object_lock_enabled: true
+        object_lock_default_retention:
+          mode: GOVERNANCE
+          days: 1
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output.changed
+          - output.object_lock_enabled
+          - output.object_lock_default_retention
+
+    - name: Delete test s3 bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        state: absent
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output.changed
+
+    # ============================================================
+
+    - name: Create a bucket with object lock and default retention enabled
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
+        state: present
+        object_lock_enabled: true
+        object_lock_default_retention:
+          mode: GOVERNANCE
+          days: 1
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output.changed
+          - output.object_lock_enabled
+          - output.object_lock_default_retention
+    
+    - name: Touch bucket with object lock enabled (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
+        state: present
+        object_lock_enabled: true
+        object_lock_default_retention:
+          mode: GOVERNANCE
+          days: 1
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - not output.changed
+          - output.object_lock_enabled
+          - output.object_lock_default_retention
+
+    - name: Change bucket with object lock default retention enabled
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
+        state: present
+        object_lock_enabled: true
+        object_lock_default_retention:
+          mode: GOVERNANCE
+          days: 2
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output.changed
+          - output.object_lock_enabled
+          - output.object_lock_default_retention
+
+    - name: Disable object lock default retention
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
+        state: present
+        object_lock_enabled: true
+      register: output
+      ignore_errors: true
+
+    - ansible.builtin.assert:
+        that:
+          - not output.changed
+
+    - name: Delete test s3 bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
+        state: absent
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output.changed
+
+  # ============================================================
+  always:
+    - name: Ensure all buckets are deleted
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        state: absent
+      ignore_errors: true
+
+    - name: Ensure all buckets are deleted
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
+        state: absent
+      ignore_errors: true

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/default_retention.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/default_retention.yml
@@ -66,7 +66,7 @@
           - output.changed
           - output.object_lock_enabled
           - output.object_lock_default_retention
-    
+
     - name: Touch bucket with object lock enabled (idempotency)
       amazon.aws.s3_bucket:
         name: "{{ local_bucket_name }}-2"


### PR DESCRIPTION
##### SUMMARY
https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-configure.html#object-lock-configure-set-retention-period-object

Design detail:
AWS API doesn't support unsetting the default retention, though it is possible in the Web console.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
s3_bucket
