### PR TITLE
iam_role_info - fix bug in prefix_path handling of missing /s

### DIFF
--- a/changelogs/fragments/2065-iam_role_info.yml
+++ b/changelogs/fragments/2065-iam_role_info.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - iam_role_info - fixes bug in handling paths missing the ``/`` prefix and/or suffix (https://github.com/ansible-collections/amazon.aws/issues/2065).

--- a/plugins/modules/iam_role_info.py
+++ b/plugins/modules/iam_role_info.py
@@ -229,10 +229,10 @@ def main():
         if validation_error:
             _prefix = "/" if not path_prefix.startswith("/") else ""
             _suffix = "/" if not path_prefix.endswith("/") else ""
-            path_prefix = "{_prefix}{path_prefix}{_suffix}"
+            path_prefix = f"{_prefix}{path_prefix}{_suffix}"
             module.deprecate(
                 "In a release after 2026-05-01 paths must begin and end with /.  "
-                "path_prefix has been modified to '{path_prefix}'",
+                f"path_prefix has been modified to '{path_prefix}'",
                 date="2026-05-01",
                 collection_name="amazon.aws",
             )

--- a/tests/integration/targets/iam_role/defaults/main.yml
+++ b/tests/integration/targets/iam_role/defaults/main.yml
@@ -1,6 +1,7 @@
 ---
 test_role: "{{ resource_prefix }}-role"
-test_path: /{{ resource_prefix }}/
+test_path: "/{{ resource_prefix }}/"
+bad_test_path: "{{ resource_prefix }}"
 safe_managed_policy: AWSDenyAll
 custom_policy_name: "{{ resource_prefix }}-denyall"
-boundary_policy: arn:aws:iam::aws:policy/AWSDenyAll
+boundary_policy: "arn:aws:iam::aws:policy/AWSDenyAll"

--- a/tests/integration/targets/iam_role/tasks/creation_deletion.yml
+++ b/tests/integration/targets/iam_role/tasks/creation_deletion.yml
@@ -285,6 +285,32 @@
       - role_info.iam_roles[0].role_name == test_role
       - role_info.iam_roles[0].tags | length == 0
 
+- name: iam_role_info after Role creation (searching a path without / prefix and suffix)
+  amazon.aws.iam_role_info:
+    path_prefix: "{{ bad_test_path }}"
+  register: role_info
+- ansible.builtin.assert:
+    that:
+      - role_info is succeeded
+      - role_info.iam_roles | length == 1
+      - role_info.iam_roles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].arn.endswith("role" + test_path + test_role )
+      - '"assume_role_policy_document" in role_info.iam_roles[0]'
+      - '"create_date" in role_info.iam_roles[0]'
+      - '"description" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].inline_policies | length == 0
+      - role_info.iam_roles[0].instance_profiles | length == 1
+      - role_info.iam_roles[0].instance_profiles[0].instance_profile_name == test_role
+      - role_info.iam_roles[0].instance_profiles[0].arn.startswith("arn")
+      - role_info.iam_roles[0].instance_profiles[0].arn.endswith("instance-profile" + test_path + test_role)
+      - role_info.iam_roles[0].managed_policies | length == 0
+      - role_info.iam_roles[0].max_session_duration == 3600
+      - '"permissions_boundary" not in role_info.iam_roles[0]'
+      - role_info.iam_roles[0].path == test_path
+      - role_info.iam_roles[0].role_id == iam_role.iam_role.role_id
+      - role_info.iam_roles[0].role_name == test_role
+      - role_info.iam_roles[0].tags | length == 0
+
 - name: Remove IAM Role
   amazon.aws.iam_role:
     state: absent


### PR DESCRIPTION
##### SUMMARY

fixes: #2065

When updating the code in iam_role_info to handle missing `/` at the start/end of prefix_path, the string as finally built should be an f-string not a simple string/

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

iam_role_info

##### ADDITIONAL INFORMATION

Thanks to vonschultz  for catching this one.