### PR TITLE
Update return block of ec2 modules (part 2)

### DIFF
--- a/changelogs/fragments/update_return_block_ec2_2.yml
+++ b/changelogs/fragments/update_return_block_ec2_2.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Update return block in the module documentation for ec2_snapshot ec2_snapshot_info ec2_spot_instance  ec2_vol ec2_vpc_endpoint ec2_vpc_endpoint_info ec2_vpc_endpoint_service_info ec2_vpc_nat_gateway ec2_vpc_nat_gateway_info ec2_vpc_route_table ec2_vpc_subnet ec2_vpc_subnet_info

--- a/plugins/modules/ec2_snapshot.py
+++ b/plugins/modules/ec2_snapshot.py
@@ -187,6 +187,7 @@ snapshot_id:
     sample: snap-01234567
 snapshots:
     description: List of snapshots.
+    returned: always
     type: list
     elements: dict
     contains:
@@ -217,13 +218,13 @@ snapshots:
             sample: snap-1234
         start_time:
             description: Time this snapshot was started. This is the same for all snapshots initiated by the same request.
-            type: datetime
+            type: str
             returned: always
-            sample: 2024-05-07T14:29:24.523000+00:00
+            sample: "2024-05-07T14:29:24.523000+00:00"
         state:
             description: Current state of the snapshot.
             type: str
-            return: always
+            returned: always
             sample: pending
         tags:
             description: Tags associated with this snapshot.

--- a/plugins/modules/ec2_snapshot.py
+++ b/plugins/modules/ec2_snapshot.py
@@ -185,6 +185,61 @@ snapshot_id:
     type: str
     returned: always
     sample: snap-01234567
+snapshots:
+    description: List of snapshots.
+    type: list
+    elements: dict
+    contains:
+        description:
+            description: Description specified by the CreateSnapshotRequest that has been applied to all snapshots.
+            type: str
+            returned: always
+            sample: ""
+        encrypted:
+            description: Indicates whether the snapshot is encrypted.
+            type: bool
+            returned: always
+            sample: false
+        owner_id:
+            description: Account id used when creating this snapshot.
+            type: str
+            returned: always
+            sample: 123456
+        progress:
+            description: Progress this snapshot has made towards completing.
+            type: str
+            returned: always
+            sample: ""
+        snapshot_id:
+            description: Snapshot id that can be used to describe this snapshot.
+            type: str
+            returned: always
+            sample: snap-1234
+        start_time:
+            description: Time this snapshot was started. This is the same for all snapshots initiated by the same request.
+            type: datetime
+            returned: always
+            sample: 2024-05-07T14:29:24.523000+00:00
+        state:
+            description: Current state of the snapshot.
+            type: str
+            return: always
+            sample: pending
+        tags:
+            description: Tags associated with this snapshot.
+            type: dict
+            returned: always
+            sample: "{ 'Name': 'instance-name' }"
+        volume_id:
+            description: The ID of the volume that was used to create the snapshot.
+            type: str
+            returned: always
+            sample: vol-01234567
+        volume_size:
+            description: The size of the volume, in GiB.
+            type: int
+            returned: always
+            sample: 8
 tags:
     description: Any tags assigned to the snapshot.
     type: dict

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -117,16 +117,56 @@ snapshots:
     returned: success
     elements: dict
     contains:
+        create_volume_permissions:
+            description:
+              - The users and groups that have the permissions for creating volumes from the snapshot.
+              - The module will return empty list if the create volume permissions on snapshot are 'private'.
+            type: list
+            elements: dict
+            sample: [{"group": "all"}]
+        data_encryption_key_id:
+            description:
+              - The data encryption key identifier for the snapshot. This value is a unique identifier that
+                corresponds to the data encryption key that was used to encrypt the original volume or snapshot copy.
+            type: str
+            returned: always
+            sample: "arn:aws:kms:ap-southeast-2:123456789012:key/74c9742a-a1b2-45cb-b3fe-abcdef123456"
+        description:
+            description: The description for the snapshot.
+            type: str
+            returned: always
+            sample: "My important backup"
+        encrypted:
+            description: Indicates whether the snapshot is encrypted.
+            type: bool
+            returned: always
+            sample: "True"
+        kms_key_id:
+            description:
+              - The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) that was used to
+                protect the volume encryption key for the parent volume.
+            type: str
+            sample: "74c9742a-a1b2-45cb-b3fe-abcdef123456"
+        owner_id:
+            description: The AWS account ID of the EBS snapshot owner.
+            type: str
+            returned: always
+            sample: "123456789012"
+        progress:
+            description: The progress of the snapshot, as a percentage.
+            type: str
+            returned: always
+            sample: "100%"
         snapshot_id:
             description: The ID of the snapshot. Each snapshot receives a unique identifier when it is created.
             type: str
             returned: always
             sample: snap-01234567
-        volume_id:
-            description: The ID of the volume that was used to create the snapshot.
+        start_time:
+            description: The time stamp when the snapshot was initiated.
             type: str
             returned: always
-            sample: vol-01234567
+            sample: "2015-02-12T02:14:02+00:00"
         state:
             description: The snapshot state (completed, pending or error).
             type: str
@@ -138,69 +178,27 @@ snapshots:
                 AWS Key Management Service (AWS KMS) permissions are not obtained) this field displays error state details to help you diagnose why the
                 error occurred.
             type: str
-            returned: always
             sample:
-        start_time:
-            description: The time stamp when the snapshot was initiated.
-            type: str
+        storage_tier:
+            description: The storage tier in which the snapshot is stored.
+            type: string
             returned: always
-            sample: "2015-02-12T02:14:02+00:00"
-        progress:
-            description: The progress of the snapshot, as a percentage.
-            type: str
-            returned: always
-            sample: "100%"
-        owner_id:
-            description: The AWS account ID of the EBS snapshot owner.
-            type: str
-            returned: always
-            sample: "123456789012"
-        description:
-            description: The description for the snapshot.
-            type: str
-            returned: always
-            sample: "My important backup"
-        volume_size:
-            description: The size of the volume, in GiB.
-            type: int
-            returned: always
-            sample: 8
-        owner_alias:
-            description: The AWS account alias (for example, amazon, self) or AWS account ID that owns the snapshot.
-            type: str
-            returned: always
-            sample: "123456789012"
+            sample: standard
         tags:
             description: Any tags assigned to the snapshot.
             type: dict
             returned: always
             sample: "{ 'my_tag_key': 'my_tag_value' }"
-        encrypted:
-            description: Indicates whether the snapshot is encrypted.
-            type: bool
-            returned: always
-            sample: "True"
-        kms_key_id:
-            description:
-              - The full ARN of the AWS Key Management Service (AWS KMS) customer master key (CMK) that was used to
-                protect the volume encryption key for the parent volume.
+        volume_id:
+            description: The ID of the volume that was used to create the snapshot.
             type: str
             returned: always
-            sample: "74c9742a-a1b2-45cb-b3fe-abcdef123456"
-        data_encryption_key_id:
-            description:
-              - The data encryption key identifier for the snapshot. This value is a unique identifier that
-                corresponds to the data encryption key that was used to encrypt the original volume or snapshot copy.
-            type: str
+            sample: vol-01234567
+        volume_size:
+            description: The size of the volume, in GiB.
+            type: int
             returned: always
-            sample: "arn:aws:kms:ap-southeast-2:123456789012:key/74c9742a-a1b2-45cb-b3fe-abcdef123456"
-        create_volume_permissions:
-            description:
-              - The users and groups that have the permissions for creating volumes from the snapshot.
-              - The module will return empty list if the create volume permissions on snapshot are 'private'.
-            type: list
-            elements: dict
-            sample: [{"group": "all"}]
+            sample: 8
 next_token_id:
     description:
     - Contains the value returned from a previous paginated request where C(max_results) was used and the results exceeded the value of that parameter.

--- a/plugins/modules/ec2_snapshot_info.py
+++ b/plugins/modules/ec2_snapshot_info.py
@@ -181,7 +181,7 @@ snapshots:
             sample:
         storage_tier:
             description: The storage tier in which the snapshot is stored.
-            type: string
+            type: str
             returned: always
             sample: standard
         tags:

--- a/plugins/modules/ec2_spot_instance.py
+++ b/plugins/modules/ec2_spot_instance.py
@@ -394,13 +394,12 @@ spot_request:
             "message": "Your Spot request has been submitted for review, and is pending evaluation.",
             "update_time": "2021-08-23T22:59:12+00:00"
         },
+        "tags": {},
         "type": "one-time"
-
         }
 
 cancelled_spot_request:
     description: The spot instance request details that has been cancelled
-    returned: always
     type: str
     sample: 'Spot requests with IDs: sir-1234abcd have been cancelled'
 """

--- a/plugins/modules/ec2_spot_instance.py
+++ b/plugins/modules/ec2_spot_instance.py
@@ -401,6 +401,7 @@ spot_request:
 cancelled_spot_request:
     description: The spot instance request details that has been cancelled
     type: str
+    returned: when cancellation is successful
     sample: 'Spot requests with IDs: sir-1234abcd have been cancelled'
 """
 

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -222,28 +222,67 @@ volume_type:
 volume:
     description: a dictionary containing detailed attributes of the volume
     returned: when success
-    type: str
-    sample: {
-        "attachment_set": [{
-            "attach_time": "2015-10-23T00:22:29.000Z",
-            "deleteOnTermination": "false",
-            "device": "/dev/sdf",
-            "instance_id": "i-8356263c",
-            "status": "attached"
-        }],
-        "create_time": "2015-10-21T14:36:08.870Z",
-        "encrypted": false,
-        "id": "vol-35b333d9",
-        "iops": null,
-        "size": 1,
-        "snapshot_id": "",
-        "status": "in-use",
-        "tags": {
-            "env": "dev"
-        },
-        "type": "standard",
-        "zone": "us-east-1b"
-    }
+    type: dict
+    contains:
+        attachment_set:
+                description:
+                    - Information about the volume attachments.
+                    - This was changed in version 2.0.0 from a dictionary to a list of dictionaries.
+                type: list
+                elements: dict
+                sample: [{
+                    "attach_time": "2015-10-23T00:22:29.000Z",
+                    "deleteOnTermination": "false",
+                    "device": "/dev/sdf",
+                    "instance_id": "i-8356263c",
+                    "status": "attached"
+                }]
+            create_time:
+                description: The time stamp when volume creation was initiated.
+                type: str
+                sample: "2015-10-21T14:36:08.870Z"
+            encrypted:
+                description: Indicates whether the volume is encrypted.
+                type: bool
+                sample: False
+            id:
+                description: The ID of the volume.
+                type: str
+                sample: "vol-35b333d9"
+            iops:
+                description: The number of I/O operations per second (IOPS) that the volume supports.
+                type: int
+                sample: null
+            size:
+                description: The size of the volume, in GiBs.
+                type: int
+                sample: 1
+            snapshot_id:
+                description: The snapshot from which the volume was created, if applicable.
+                type: str
+                sample: ""
+            status:
+                description: The volume state.
+                type: str
+                sample: "in-use"
+            tags:
+                description: Any tags assigned to the volume.
+                type: dict
+                sample: {
+                    env: "dev"
+                    }
+            type:
+                description: The volume type. This can be gp2, io1, st1, sc1, or standard.
+                type: str
+                sample: "standard"
+            zone:
+                description: The Availability Zone of the volume.
+                type: str
+                sample: "us-east-1b"
+            throughput:
+                description: The throughput that the volume supports, in MiB/s.
+                type: int
+                sample: 131
 """
 
 import time

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -225,64 +225,64 @@ volume:
     type: dict
     contains:
         attachment_set:
-                description:
-                    - Information about the volume attachments.
-                    - This was changed in version 2.0.0 from a dictionary to a list of dictionaries.
-                type: list
-                elements: dict
-                sample: [{
-                    "attach_time": "2015-10-23T00:22:29.000Z",
-                    "deleteOnTermination": "false",
-                    "device": "/dev/sdf",
-                    "instance_id": "i-8356263c",
-                    "status": "attached"
-                }]
-            create_time:
-                description: The time stamp when volume creation was initiated.
-                type: str
-                sample: "2015-10-21T14:36:08.870Z"
-            encrypted:
-                description: Indicates whether the volume is encrypted.
-                type: bool
-                sample: False
-            id:
-                description: The ID of the volume.
-                type: str
-                sample: "vol-35b333d9"
-            iops:
-                description: The number of I/O operations per second (IOPS) that the volume supports.
-                type: int
-                sample: null
-            size:
-                description: The size of the volume, in GiBs.
-                type: int
-                sample: 1
-            snapshot_id:
-                description: The snapshot from which the volume was created, if applicable.
-                type: str
-                sample: ""
-            status:
-                description: The volume state.
-                type: str
-                sample: "in-use"
-            tags:
-                description: Any tags assigned to the volume.
-                type: dict
-                sample: {
-                    env: "dev"
-                    }
-            type:
-                description: The volume type. This can be gp2, io1, st1, sc1, or standard.
-                type: str
-                sample: "standard"
-            zone:
-                description: The Availability Zone of the volume.
-                type: str
-                sample: "us-east-1b"
-            throughput:
-                description: The throughput that the volume supports, in MiB/s.
-                type: int
-                sample: 131
+            description:
+                - Information about the volume attachments.
+                - This was changed in version 2.0.0 from a dictionary to a list of dictionaries.
+            type: list
+            elements: dict
+            sample: [{
+                "attach_time": "2015-10-23T00:22:29.000Z",
+                "deleteOnTermination": "false",
+                "device": "/dev/sdf",
+                "instance_id": "i-8356263c",
+                "status": "attached"
+            }]
+        create_time:
+            description: The time stamp when volume creation was initiated.
+            type: str
+            sample: "2015-10-21T14:36:08.870Z"
+        encrypted:
+            description: Indicates whether the volume is encrypted.
+            type: bool
+            sample: False
+        id:
+            description: The ID of the volume.
+            type: str
+            sample: "vol-35b333d9"
+        iops:
+            description: The number of I/O operations per second (IOPS) that the volume supports.
+            type: int
+            sample: null
+        size:
+            description: The size of the volume, in GiBs.
+            type: int
+            sample: 1
+        snapshot_id:
+            description: The snapshot from which the volume was created, if applicable.
+            type: str
+            sample: ""
+        status:
+            description: The volume state.
+            type: str
+            sample: "in-use"
+        tags:
+            description: Any tags assigned to the volume.
+            type: dict
+            sample: {
+                env: "dev"
+                }
+        type:
+            description: The volume type. This can be gp2, io1, st1, sc1, or standard.
+            type: str
+            sample: "standard"
+        zone:
+            description: The Availability Zone of the volume.
+            type: str
+            sample: "us-east-1b"
+        throughput:
+            description: The throughput that the volume supports, in MiB/s.
+            type: int
+            sample: 131
 """
 
 import time

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -230,6 +230,7 @@ volume:
                 - This was changed in version 2.0.0 from a dictionary to a list of dictionaries.
             type: list
             elements: dict
+            returned: when success
             sample: [{
                 "attach_time": "2015-10-23T00:22:29.000Z",
                 "deleteOnTermination": "false",
@@ -240,48 +241,59 @@ volume:
         create_time:
             description: The time stamp when volume creation was initiated.
             type: str
+            returned: when success
             sample: "2015-10-21T14:36:08.870Z"
         encrypted:
             description: Indicates whether the volume is encrypted.
             type: bool
+            returned: when success
             sample: False
         id:
             description: The ID of the volume.
             type: str
+            returned: when success
             sample: "vol-35b333d9"
         iops:
             description: The number of I/O operations per second (IOPS) that the volume supports.
             type: int
+            returned: when success
             sample: null
         size:
             description: The size of the volume, in GiBs.
             type: int
+            returned: when success
             sample: 1
         snapshot_id:
             description: The snapshot from which the volume was created, if applicable.
             type: str
+            returned: when success
             sample: ""
         status:
             description: The volume state.
             type: str
+            returned: when success
             sample: "in-use"
         tags:
             description: Any tags assigned to the volume.
             type: dict
+            returned: when success
             sample: {
                 env: "dev"
                 }
         type:
             description: The volume type. This can be gp2, io1, st1, sc1, or standard.
             type: str
+            returned: when success
             sample: "standard"
         zone:
             description: The Availability Zone of the volume.
             type: str
+            returned: when success
             sample: "us-east-1b"
         throughput:
             description: The throughput that the volume supports, in MiB/s.
             type: int
+            returned: when success
             sample: 131
 """
 

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -244,51 +244,6 @@ endpoints:
       description: The ID of the VPC.
       returned: always
       type: str
-  sample: [
-      {
-        "creation_timestamp": "2017-02-20T05:04:15+00:00",
-        "dns_entries": [],
-        "dns_options": {
-            "dns_record_ip_type": "ipv4"
-        },
-        "groups": [
-            {
-                "group_id": "sg-03196a047b95d36ad",
-                "group_name": "default"
-            }
-        ],
-        "ip_address_type": "ipv4",
-        "network_interface_ids": [],
-        "owner_id": "721066863947",
-        "policy_document": {
-          "Id": "Policy1450910922815",
-          "Statement": [
-            {
-              "Action": "s3:*",
-              "Effect": "Allow",
-              "Principal": "*",
-              "Resource": [
-                "arn:aws:s3:::*/*",
-                "arn:aws:s3:::*"
-              ],
-              "Sid": "Stmt1450910920641"
-            }
-          ],
-          "Version": "2012-10-17"
-        },
-        "private_dns_enabled": false,
-        "requester_managed"s: false,
-        "route_table_ids": [],
-        "service_name": "io.spotinst.vpce.us-east-1.linkapi",
-        "state": "pendingAcceptance",
-        "subnet_ids": [],
-        "tags": [],
-        "vpc_endpoint_id": "vpce-1234",
-        "vpc_endpoint_type": "Interface",
-        "vpc_id": "vpc-0ee1a4b203c587ffa"
-        "route_table_ids": [],
-      }
-    ]
 """
 
 import datetime

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -153,9 +153,113 @@ endpoints:
   description: The resulting endpoints from the module call
   returned: success
   type: list
+  elements: dict
+  contains:
+    creation_timestamp:
+      description: The date and time that the endpoint was created.
+      returned: always
+      type: str
+    dns_entries:
+      description: List of DNS entires for the endpoint.
+      returned: always
+      type: list
+      elements: dict
+      contains:
+        dns_name:
+          description: The DNS name.
+          returned: always
+          type: str
+        hosted_zone_id:
+          description: The ID of the private hosted zone.
+          type: str
+    groups:
+      description: List of security groups associated with the network interface.
+      returned: always
+      type: list
+      elements: dict
+      contains:
+        group_id:
+          description: The ID of the security group.
+          returned: always
+          type: str
+        group_name:
+          description: The name of the security group.
+          returned: always
+          type: str
+    ip_address_type:
+      description: The IP address type for the endpoint.
+      type: str
+    network_interface_ids:
+      description: List of network interfaces for the endpoint.
+      returned: always
+      type: list
+      elements: str
+    owner_id:
+      description: The ID of the AWS account that owns the endpoint.
+      returned: always
+      type: str
+    policy_document:
+      description: The policy document associated with the endpoint.
+      returned: always
+      type: str
+    private_dns_enabled:
+      description: Indicates whether the VPC is associated with a private hosted zone.
+      returned: always
+      type: bool
+    requester_managed:
+      description: Indicated whether the endpoint is being managed by its service.
+      returned: always
+      type: bool
+    route_table_ids:
+      description: List of route table IDs associated with the endpoint.
+      returned: always
+      type: list
+      elements: str
+    service_name:
+      description: The name of the service to which the endpoint is associated.
+      returned: always
+      type: str
+    state:
+      description: The state of the endpoint.
+      returned: always
+      type: str
+    subnet_ids:
+      description: List of subnets associated with the endpoint.
+      returned: always
+      type: list
+    tags:
+      description: List of tags associated with the endpoint.
+      returned: always
+      type: list
+      elements: dict
+    vpc_endpoint_id:
+      description: The ID of the endpoint.
+      returned: always
+      type: str
+    vpc_endpoint_type:
+      description: The type of endpoint.
+      returned: always
+      type: str
+    vpc_id:
+      description: The ID of the VPC.
+      returned: always
+      type: str
   sample: [
       {
         "creation_timestamp": "2017-02-20T05:04:15+00:00",
+        "dns_entries": [],
+        "dns_options": {
+            "dns_record_ip_type": "ipv4"
+        },
+        "groups": [
+            {
+                "group_id": "sg-03196a047b95d36ad",
+                "group_name": "default"
+            }
+        ],
+        "ip_address_type": "ipv4",
+        "network_interface_ids": [],
+        "owner_id": "721066863947",
         "policy_document": {
           "Id": "Policy1450910922815",
           "Statement": [
@@ -172,12 +276,17 @@ endpoints:
           ],
           "Version": "2012-10-17"
         },
-        "route_table_ids": [
-          "rtb-abcd1234"
-        ],
-        "service_name": "com.amazonaws.ap-southeast-2.s3",
-        "vpc_endpoint_id": "vpce-a1b2c3d4",
-        "vpc_id": "vpc-abbad0d0"
+        "private_dns_enabled": false,
+        "requester_managed"s: false,
+        "route_table_ids": [],
+        "service_name": "io.spotinst.vpce.us-east-1.linkapi",
+        "state": "pendingAcceptance",
+        "subnet_ids": [],
+        "tags": [],
+        "vpc_endpoint_id": "vpce-1234",
+        "vpc_endpoint_type": "Interface",
+        "vpc_id": "vpc-0ee1a4b203c587ffa"
+        "route_table_ids": [],
       }
     ]
 """

--- a/plugins/modules/ec2_vpc_endpoint_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_info.py
@@ -86,7 +86,6 @@ vpc_endpoints:
           type: str
         hosted_zone_id:
           description: The ID of the private hosted zone.
-          returned: always
           type: str
     groups:
       description: List of security groups associated with the network interface.
@@ -102,6 +101,9 @@ vpc_endpoints:
           description: The name of the security group.
           returned: always
           type: str
+    ip_address_type:
+      description: The IP address type for the endpoint.
+      type: str
     network_interface_ids:
       description: List of network interfaces for the endpoint.
       returned: always
@@ -139,7 +141,7 @@ vpc_endpoints:
     subnet_ids:
       description: List of subnets associated with the endpoint.
       returned: always
-      type: str
+      type: list
     tags:
       description: List of tags associated with the endpoint.
       returned: always

--- a/plugins/modules/ec2_vpc_endpoint_service_info.py
+++ b/plugins/modules/ec2_vpc_endpoint_service_info.py
@@ -109,6 +109,10 @@ service_details:
       - The verification state of the VPC endpoint service.
       - Consumers of an endpoint service cannot use the private name when the state is not C(verified).
       type: str
+    supported_ip_address_types:
+      returned: success
+      description: The supported IP address types.
+      type: str
 """
 
 try:

--- a/plugins/modules/ec2_vpc_igw_info.py
+++ b/plugins/modules/ec2_vpc_igw_info.py
@@ -75,27 +75,27 @@ internet_gateways:
     contains:
         attachments:
             description: Any VPCs attached to the internet gateway.
-            returned: I(state=present)
+            returned: always
             type: complex
             contains:
                 state:
                     description: The current state of the attachment.
-                    returned: I(state=present)
+                    returned: always
                     type: str
                     sample: available
                 vpc_id:
                     description: The ID of the VPC.
-                    returned: I(state=present)
+                    returned: always
                     type: str
                     sample: vpc-02123b67
         internet_gateway_id:
             description: The ID of the internet gateway.
-            returned: I(state=present)
+            returned: always
             type: str
             sample: igw-2123634d
         tags:
             description: Any tags assigned to the internet gateway.
-            returned: I(state=present)
+            returned: always
             type: dict
             sample:
                 tags:

--- a/plugins/modules/ec2_vpc_nat_gateway.py
+++ b/plugins/modules/ec2_vpc_nat_gateway.py
@@ -197,6 +197,12 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+connectivity_type:
+    description:
+      - Indicates whether the NAT gateway supports public or private connectivity.
+    returned: always
+    type: str
+    sample: public
 create_time:
   description: The ISO 8601 date time format in UTC.
   returned: In all cases.
@@ -232,14 +238,53 @@ vpc_id:
 nat_gateway_addresses:
   description: List of dictionaries containing the public_ip, network_interface_id, private_ip, and allocation_id.
   returned: In all cases.
-  type: str
+  type: complex
+  contains:
+    allocation_id:
+        description: The allocation ID of the Elastic IP address that's associated with the NAT gateway.
+        returned: always
+        type: str
+        sample: eipalloc-0853e66a40803da76
+    association_id:
+        description: The association ID of the Elastic IP address that is associated with the NAT gateway.
+        returned: always
+        type: str
+        sample: eipassoc-0d6365c7eeb7d4932
+    is_primary:
+        description: Defines if the IP address is the primary address.
+        returned: always
+        type: bool
+        sample: true
+    network_interface_id:
+        description: The ID of the network interface associated with the NAT gateway.
+        returned: always
+        type: str
+        sample: eni-0a37acdbe306c661c
+    private_ip:
+        description: The private IP address associated with the Elastic IP address.
+        returned: always
+        type: str
+        sample: 10.0.238.227
+    public_ip:
+        description: The Elastic IP address associated with the NAT gateway.
+        returned: always
+        type: str
+        sample: 34.204.123.52
+    status:
+        description: The address status.
+        returned: always
+        type: str
+        sample: succeeded
   sample: [
-      {
-        'public_ip': '52.52.52.52',
-        'network_interface_id': 'eni-12345',
-        'private_ip': '10.0.0.100',
-        'allocation_id': 'eipalloc-12345'
-      }
+       {
+            "allocation_id": "eipalloc-08ec128d03629671d",
+            "association_id": "eipassoc-0d6365c7eeb7d4932",
+            "is_primary": true,
+            "network_interface_id": "eni-095104e630881bad6",
+            "private_ip": "10.1.0.250",
+            "public_ip": "34.202.90.172",
+            "status": "succeeded"
+        }
   ]
 """
 

--- a/plugins/modules/ec2_vpc_nat_gateway_info.py
+++ b/plugins/modules/ec2_vpc_nat_gateway_info.py
@@ -79,6 +79,12 @@ result:
   returned: suceess
   type: list
   contains:
+    connectivity_type:
+        description:
+          - Indicates whether the NAT gateway supports public or private connectivity.
+        returned: always
+        type: str
+        sample: public
     create_time:
         description: The date and time the NAT gateway was created.
         returned: always
@@ -99,6 +105,16 @@ result:
                 returned: always
                 type: str
                 sample: eipalloc-0853e66a40803da76
+            association_id:
+                description: The association ID of the Elastic IP address that is associated with the NAT gateway.
+                returned: always
+                type: str
+                sample: eipassoc-0d6365c7eeb7d4932
+            is_primary:
+                description: Defines if the IP address is the primary address.
+                returned: always
+                type: bool
+                sample: true
             network_interface_id:
                 description: The ID of the network interface associated with the NAT gateway.
                 returned: always
@@ -114,6 +130,11 @@ result:
                 returned: always
                 type: str
                 sample: 34.204.123.52
+            status:
+                description: The address status.
+                returned: always
+                type: str
+                sample: succeeded
     nat_gateway_id:
         description: The ID of the NAT gateway.
         returned: always

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -211,6 +211,10 @@ route_table:
       returned: always
       type: str
       sample: rtb-bf779ed7
+    owner_id:
+        description: AWS account owning resource.
+        type: str
+        sample: 123456789012
     propagating_vgws:
       description: List of Virtual Private Gateways propagating routes.
       returned: always

--- a/plugins/modules/ec2_vpc_subnet.py
+++ b/plugins/modules/ec2_vpc_subnet.py
@@ -138,6 +138,11 @@ subnet:
             returned: I(state=present)
             type: str
             sample: us-east-1a
+        availability_zone_id:
+            description: The AZ ID of the subnet.
+            returned: I(state=present)
+            type: str
+            sample: use1-az6
         state:
             description: state of the Subnet
             returned: I(state=present)
@@ -173,11 +178,20 @@ subnet:
             returned: I(state=present)
             type: bool
             sample: false
+        enable_dns64:
+            description:
+            - Indicates whether DNS queries made to the Amazon-provided DNS Resolver in this subnet should return synthetic IPv6 addresses for IPv4-only destinations.
+            type: bool
+            sample: false
         ipv6_association_id:
             description: The IPv6 association ID for the currently associated CIDR
             returned: I(state=present)
             type: str
             sample: subnet-cidr-assoc-b85c74d2
+        ipv6_native:
+            description: Indicates whether this is an IPv6 only subnet.
+            type: bool
+            sample: false
         ipv6_cidr_block_association_set:
             description: An array of IPv6 cidr block association set information.
             returned: I(state=present)
@@ -200,6 +214,27 @@ subnet:
                             description: The CIDR block association state.
                             returned: always
                             type: str
+        map_customer_owned_ip_on_launch:
+            description: Indicates whether a network interface created in this subnet (including a network interface created by RunInstances) receives a customer-owned IPv4 address.
+            type: bool
+            sample: flase
+        owner_id:
+            description: The ID of the Amazon Web Services account that owns the subnet.
+            type: str
+            sample: 12344567
+        private_dns_name_options_on_launch:
+            description: The type of hostnames to assign to instances in the subnet at launch. An instance hostname is based on the IPv4 address or ID of the instance.
+            type: dict
+            sample: "{
+                "enable_resource_name_dns_a_record": false,
+                "enable_resource_name_dns_aaaa_record": false,
+                "hostname_type": "ip-name"
+            }"
+        subnet_arn:
+            description: The Amazon Resource Name (ARN) of the subnet.
+            type: str
+            sample: arn:aws:ec2:us-east-1:xxx:subnet/subnet-xxx
+
 """
 
 

--- a/plugins/modules/ec2_vpc_subnet.py
+++ b/plugins/modules/ec2_vpc_subnet.py
@@ -115,67 +115,67 @@ EXAMPLES = r"""
 RETURN = r"""
 subnet:
     description: Dictionary of subnet values
-    returned: I(state=present)
+    returned: O(state=present)
     type: complex
     contains:
         id:
             description: Subnet resource id
-            returned: I(state=present)
+            returned: O(state=present)
             type: str
             sample: subnet-b883b2c4
         cidr_block:
             description: The IPv4 CIDR of the Subnet
-            returned: I(state=present)
+            returned: O(state=present)
             type: str
             sample: "10.0.0.0/16"
         ipv6_cidr_block:
             description: The IPv6 CIDR block actively associated with the Subnet
-            returned: I(state=present)
+            returned: O(state=present)
             type: str
             sample: "2001:db8:0:102::/64"
         availability_zone:
             description: Availability zone of the Subnet
-            returned: I(state=present)
+            returned: O(state=present)
             type: str
             sample: us-east-1a
         availability_zone_id:
             description: The AZ ID of the subnet.
-            returned: I(state=present)
+            returned: O(state=present)
             type: str
             sample: use1-az6
         state:
             description: state of the Subnet
-            returned: I(state=present)
+            returned: O(state=present)
             type: str
             sample: available
         tags:
             description: tags attached to the Subnet, includes name
-            returned: I(state=present)
+            returned: O(state=present)
             type: dict
             sample: {"Name": "My Subnet", "env": "staging"}
         map_public_ip_on_launch:
             description: whether public IP is auto-assigned to new instances
-            returned: I(state=present)
+            returned: O(state=present)
             type: bool
             sample: false
         assign_ipv6_address_on_creation:
             description: whether IPv6 address is auto-assigned to new instances
-            returned: I(state=present)
+            returned: O(state=present)
             type: bool
             sample: false
         vpc_id:
             description: the id of the VPC where this Subnet exists
-            returned: I(state=present)
+            returned: O(state=present)
             type: str
             sample: vpc-67236184
         available_ip_address_count:
             description: number of available IPv4 addresses
-            returned: I(state=present)
+            returned: O(state=present)
             type: str
             sample: 251
         default_for_az:
             description: indicates whether this is the default Subnet for this Availability Zone
-            returned: I(state=present)
+            returned: O(state=present)
             type: bool
             sample: false
         enable_dns64:
@@ -185,7 +185,7 @@ subnet:
             sample: false
         ipv6_association_id:
             description: The IPv6 association ID for the currently associated CIDR
-            returned: I(state=present)
+            returned: O(state=present)
             type: str
             sample: subnet-cidr-assoc-b85c74d2
         ipv6_native:
@@ -194,7 +194,7 @@ subnet:
             sample: false
         ipv6_cidr_block_association_set:
             description: An array of IPv6 cidr block association set information.
-            returned: I(state=present)
+            returned: O(state=present)
             type: complex
             contains:
                 association_id:

--- a/plugins/modules/ec2_vpc_subnet.py
+++ b/plugins/modules/ec2_vpc_subnet.py
@@ -180,7 +180,7 @@ subnet:
             sample: false
         enable_dns64:
             description:
-            - Indicates whether DNS queries made to the Amazon-provided DNS Resolver in this subnet should return synthetic IPv6 addresses for IPv4-only destinations.
+            - Indicates whether DNS queries made should return synthetic IPv6 addresses for IPv4-only destinations.
             type: bool
             sample: false
         ipv6_association_id:
@@ -215,7 +215,8 @@ subnet:
                             returned: always
                             type: str
         map_customer_owned_ip_on_launch:
-            description: Indicates whether a network interface created in this subnet (including a network interface created by RunInstances) receives a customer-owned IPv4 address.
+            description:
+            - Indicates whether a network interface receives a customer-owned IPv4 address.
             type: bool
             sample: flase
         owner_id:
@@ -223,13 +224,15 @@ subnet:
             type: str
             sample: 12344567
         private_dns_name_options_on_launch:
-            description: The type of hostnames to assign to instances in the subnet at launch. An instance hostname is based on the IPv4 address or ID of the instance.
+            description:
+            - The type of hostnames to assign to instances in the subnet at launch.
+            - An instance hostname is based on the IPv4 address or ID of the instance.
             type: dict
-            sample: "{
+            sample: {
                 "enable_resource_name_dns_a_record": false,
                 "enable_resource_name_dns_aaaa_record": false,
                 "hostname_type": "ip-name"
-            }"
+            }
         subnet_arn:
             description: The Amazon Resource Name (ARN) of the subnet.
             type: str

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -138,7 +138,7 @@ subnets:
             sample: false
         enable_dns64:
             description:
-            - Indicates whether DNS queries made to the Amazon-provided DNS Resolver in this subnet should return synthetic IPv6 addresses for IPv4-only destinations.
+            - Indicates whether DNS queries made should return synthetic IPv6 addresses for IPv4-only destinations.
             type: bool
             sample: false
         ipv6_association_id:
@@ -173,7 +173,8 @@ subnets:
                             returned: always
                             type: str
         map_customer_owned_ip_on_launch:
-            description: Indicates whether a network interface created in this subnet (including a network interface created by RunInstances) receives a customer-owned IPv4 address.
+            description:
+            - Indicates whether a network interface receives a customer-owned IPv4 address.
             type: bool
             sample: flase
         owner_id:
@@ -181,13 +182,15 @@ subnets:
             type: str
             sample: 12344567
         private_dns_name_options_on_launch:
-            description: The type of hostnames to assign to instances in the subnet at launch. An instance hostname is based on the IPv4 address or ID of the instance.
+            description:
+            - The type of hostnames to assign to instances in the subnet at launch.
+            - An instance hostname is based on the IPv4 address or ID of the instance.
             type: dict
-            sample: "{
+            sample: {
                 "enable_resource_name_dns_a_record": false,
                 "enable_resource_name_dns_aaaa_record": false,
                 "hostname_type": "ip-name"
-            }"
+            }
         subnet_arn:
             description: The Amazon Resource Name (ARN) of the subnet.
             type: str

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -78,62 +78,62 @@ subnets:
     contains:
         id:
             description: Subnet resource id
-            returned: I(state=present)
+            returned: always
             type: str
             sample: subnet-b883b2c4
         cidr_block:
             description: The IPv4 CIDR of the Subnet
-            returned: I(state=present)
+            returned: always
             type: str
             sample: "10.0.0.0/16"
         ipv6_cidr_block:
             description: The IPv6 CIDR block actively associated with the Subnet
-            returned: I(state=present)
+            returned: always
             type: str
             sample: "2001:db8:0:102::/64"
         availability_zone:
             description: Availability zone of the Subnet
-            returned: I(state=present)
+            returned: always
             type: str
             sample: us-east-1a
         availability_zone_id:
             description: The AZ ID of the subnet.
-            returned: I(state=present)
+            returned: always
             type: str
             sample: use1-az6
         state:
             description: state of the Subnet
-            returned: I(state=present)
+            returned: always
             type: str
             sample: available
         tags:
             description: tags attached to the Subnet, includes name
-            returned: I(state=present)
+            returned: always
             type: dict
             sample: {"Name": "My Subnet", "env": "staging"}
         map_public_ip_on_launch:
             description: whether public IP is auto-assigned to new instances
-            returned: I(state=present)
+            returned: always
             type: bool
             sample: false
         assign_ipv6_address_on_creation:
             description: whether IPv6 address is auto-assigned to new instances
-            returned: I(state=present)
+            returned: always
             type: bool
             sample: false
         vpc_id:
             description: the id of the VPC where this Subnet exists
-            returned: I(state=present)
+            returned: always
             type: str
             sample: vpc-67236184
         available_ip_address_count:
             description: number of available IPv4 addresses
-            returned: I(state=present)
+            returned: always
             type: str
             sample: 251
         default_for_az:
             description: indicates whether this is the default Subnet for this Availability Zone
-            returned: I(state=present)
+            returned: always
             type: bool
             sample: false
         enable_dns64:
@@ -143,7 +143,7 @@ subnets:
             sample: false
         ipv6_association_id:
             description: The IPv6 association ID for the currently associated CIDR
-            returned: I(state=present)
+            returned: always
             type: str
             sample: subnet-cidr-assoc-b85c74d2
         ipv6_native:
@@ -152,7 +152,7 @@ subnets:
             sample: false
         ipv6_cidr_block_association_set:
             description: An array of IPv6 cidr block association set information.
-            returned: I(state=present)
+            returned: always
             type: complex
             contains:
                 association_id:

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -112,7 +112,7 @@ subnets:
             type: dict
             sample: {"Name": "My Subnet", "env": "staging"}
         map_public_ip_on_launch:
-            description: whether public IP is auto-assigned to new instances
+            description: whether public IP is auto-assigned to new instances.
             returned: always
             type: bool
             sample: false

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -76,53 +76,83 @@ subnets:
     returned: success
     type: complex
     contains:
-        subnet_id:
-            description: The ID of the Subnet.
-            returned: always
-            type: str
         id:
-            description: The ID of the Subnet (for backwards compatibility).
-            returned: always
+            description: Subnet resource id
+            returned: I(state=present)
             type: str
-        vpc_id:
-            description: The ID of the VPC .
-            returned: always
-            type: str
-        state:
-            description: The state of the subnet.
-            returned: always
-            type: str
-        tags:
-            description: A dict of tags associated with the Subnet.
-            returned: always
-            type: dict
-        map_public_ip_on_launch:
-            description: True/False depending on attribute setting for public IP mapping.
-            returned: always
-            type: bool
-        default_for_az:
-            description: True if this is the default subnet for AZ.
-            returned: always
-            type: bool
+            sample: subnet-b883b2c4
         cidr_block:
-            description: The IPv4 CIDR block assigned to the subnet.
-            returned: always
+            description: The IPv4 CIDR of the Subnet
+            returned: I(state=present)
             type: str
-        available_ip_address_count:
-            description: Count of available IPs in subnet.
-            returned: always
+            sample: "10.0.0.0/16"
+        ipv6_cidr_block:
+            description: The IPv6 CIDR block actively associated with the Subnet
+            returned: I(state=present)
             type: str
+            sample: "2001:db8:0:102::/64"
         availability_zone:
-            description: The availability zone where the subnet exists.
-            returned: always
+            description: Availability zone of the Subnet
+            returned: I(state=present)
             type: str
-        assign_ipv6_address_on_creation:
-            description: True/False depending on attribute setting for IPv6 address assignment.
-            returned: always
+            sample: us-east-1a
+        availability_zone_id:
+            description: The AZ ID of the subnet.
+            returned: I(state=present)
+            type: str
+            sample: use1-az6
+        state:
+            description: state of the Subnet
+            returned: I(state=present)
+            type: str
+            sample: available
+        tags:
+            description: tags attached to the Subnet, includes name
+            returned: I(state=present)
+            type: dict
+            sample: {"Name": "My Subnet", "env": "staging"}
+        map_public_ip_on_launch:
+            description: whether public IP is auto-assigned to new instances
+            returned: I(state=present)
             type: bool
+            sample: false
+        assign_ipv6_address_on_creation:
+            description: whether IPv6 address is auto-assigned to new instances
+            returned: I(state=present)
+            type: bool
+            sample: false
+        vpc_id:
+            description: the id of the VPC where this Subnet exists
+            returned: I(state=present)
+            type: str
+            sample: vpc-67236184
+        available_ip_address_count:
+            description: number of available IPv4 addresses
+            returned: I(state=present)
+            type: str
+            sample: 251
+        default_for_az:
+            description: indicates whether this is the default Subnet for this Availability Zone
+            returned: I(state=present)
+            type: bool
+            sample: false
+        enable_dns64:
+            description:
+            - Indicates whether DNS queries made to the Amazon-provided DNS Resolver in this subnet should return synthetic IPv6 addresses for IPv4-only destinations.
+            type: bool
+            sample: false
+        ipv6_association_id:
+            description: The IPv6 association ID for the currently associated CIDR
+            returned: I(state=present)
+            type: str
+            sample: subnet-cidr-assoc-b85c74d2
+        ipv6_native:
+            description: Indicates whether this is an IPv6 only subnet.
+            type: bool
+            sample: false
         ipv6_cidr_block_association_set:
             description: An array of IPv6 cidr block association set information.
-            returned: always
+            returned: I(state=present)
             type: complex
             contains:
                 association_id:
@@ -142,6 +172,30 @@ subnets:
                             description: The CIDR block association state.
                             returned: always
                             type: str
+        map_customer_owned_ip_on_launch:
+            description: Indicates whether a network interface created in this subnet (including a network interface created by RunInstances) receives a customer-owned IPv4 address.
+            type: bool
+            sample: flase
+        owner_id:
+            description: The ID of the Amazon Web Services account that owns the subnet.
+            type: str
+            sample: 12344567
+        private_dns_name_options_on_launch:
+            description: The type of hostnames to assign to instances in the subnet at launch. An instance hostname is based on the IPv4 address or ID of the instance.
+            type: dict
+            sample: "{
+                "enable_resource_name_dns_a_record": false,
+                "enable_resource_name_dns_aaaa_record": false,
+                "hostname_type": "ip-name"
+            }"
+        subnet_arn:
+            description: The Amazon Resource Name (ARN) of the subnet.
+            type: str
+            sample: arn:aws:ec2:us-east-1:xxx:subnet/subnet-xxx
+        subnet_id:
+            description: The ID of the Subnet.
+            returned: always
+            type: str
 """
 
 try:

--- a/plugins/modules/ec2_vpc_subnet_info.py
+++ b/plugins/modules/ec2_vpc_subnet_info.py
@@ -77,22 +77,22 @@ subnets:
     type: complex
     contains:
         id:
-            description: Subnet resource id
+            description: Subnet resource id.
             returned: always
             type: str
             sample: subnet-b883b2c4
         cidr_block:
-            description: The IPv4 CIDR of the Subnet
+            description: The IPv4 CIDR of the Subnet.
             returned: always
             type: str
             sample: "10.0.0.0/16"
         ipv6_cidr_block:
-            description: The IPv6 CIDR block actively associated with the Subnet
+            description: The IPv6 CIDR block actively associated with the Subnet.
             returned: always
             type: str
             sample: "2001:db8:0:102::/64"
         availability_zone:
-            description: Availability zone of the Subnet
+            description: Availability zone of the Subnet.
             returned: always
             type: str
             sample: us-east-1a
@@ -102,12 +102,12 @@ subnets:
             type: str
             sample: use1-az6
         state:
-            description: state of the Subnet
+            description: state of the Subnet.
             returned: always
             type: str
             sample: available
         tags:
-            description: tags attached to the Subnet, includes name
+            description: tags attached to the Subnet, includes name.
             returned: always
             type: dict
             sample: {"Name": "My Subnet", "env": "staging"}
@@ -117,22 +117,22 @@ subnets:
             type: bool
             sample: false
         assign_ipv6_address_on_creation:
-            description: whether IPv6 address is auto-assigned to new instances
+            description: whether IPv6 address is auto-assigned to new instances.
             returned: always
             type: bool
             sample: false
         vpc_id:
-            description: the id of the VPC where this Subnet exists
+            description: the id of the VPC where this Subnet exists.
             returned: always
             type: str
             sample: vpc-67236184
         available_ip_address_count:
-            description: number of available IPv4 addresses
+            description: number of available IPv4 addresses.
             returned: always
             type: str
             sample: 251
         default_for_az:
-            description: indicates whether this is the default Subnet for this Availability Zone
+            description: indicates whether this is the default Subnet for this Availability Zone.
             returned: always
             type: bool
             sample: false
@@ -142,7 +142,7 @@ subnets:
             type: bool
             sample: false
         ipv6_association_id:
-            description: The IPv6 association ID for the currently associated CIDR
+            description: The IPv6 association ID for the currently associated CIDR.
             returned: always
             type: str
             sample: subnet-cidr-assoc-b85c74d2
@@ -156,7 +156,7 @@ subnets:
             type: complex
             contains:
                 association_id:
-                    description: The association ID
+                    description: The association ID.
                     returned: always
                     type: str
                 ipv6_cidr_block:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Refer #1983 

This PR aligns the RETURN blocks in the module documentation to accurately reflect what the module returns, ensuring consistency.

Modules updated:

ec2_snapshot ec2_snapshot_info ec2_spot_instance ec2_vol ec2_vpc_endpoint ec2_vpc_endpoint_info ec2_vpc_endpoint_service_info ec2_vpc_nat_gateway ec2_vpc_nat_gateway_info ec2_vpc_route_table ec2_vpc_subnet ec2_vpc_subnet_info

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
