### PR TITLE
backup_plan_info: bugfix to enable getting info of all backup plans

### DIFF
--- a/changelogs/fragments/2083-backup_plan_info-bugfix-get-info-for-all-plans.yml
+++ b/changelogs/fragments/2083-backup_plan_info-bugfix-get-info-for-all-plans.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - backup_plan_info - Bugfix to enable getting info of all backup plans (https://github.com/ansible-collections/amazon.aws/pull/2083).

--- a/plugins/modules/backup_plan_info.py
+++ b/plugins/modules/backup_plan_info.py
@@ -20,7 +20,6 @@ options:
   backup_plan_names:
     type: list
     elements: str
-    required: false
     description:
       - Specifies a list of plan names.
 extends_documentation_fragment:
@@ -122,8 +121,8 @@ def get_backup_plan_detail(client, module):
     if backup_plan_names is None:
         backup_plan_names = []
         backup_plan_list_info = get_all_backup_plans_info(client)["BackupPlansList"]
-        for mylist in backup_plan_list_info:
-            backup_plan_names.append(mylist["BackupPlanName"])
+        for backup_plan in backup_plan_list_info:
+            backup_plan_names.append(backup_plan["BackupPlanName"])
 
     for name in backup_plan_names:
         backup_plan_list.extend(get_plan_details(module, client, name))

--- a/plugins/modules/backup_plan_info.py
+++ b/plugins/modules/backup_plan_info.py
@@ -30,10 +30,11 @@ extends_documentation_fragment:
 
 EXAMPLES = r"""
 # Note: These examples do not set authentication details, see the AWS Guide for details.
-# Gather information about all backup plans
-- amazon.aws.backup_plan_info
-# Gather information about a particular backup plan
-- amazon.aws.backup_plan_info:
+- name: Gather information about all backup plans
+  amazon.aws.backup_plan_info
+
+- name: Gather information about a particular backup plan
+  amazon.aws.backup_plan_info:
     backup plan_names:
       - elastic
 """

--- a/plugins/modules/backup_plan_info.py
+++ b/plugins/modules/backup_plan_info.py
@@ -20,7 +20,7 @@ options:
   backup_plan_names:
     type: list
     elements: str
-    required: true
+    required: false
     description:
       - Specifies a list of plan names.
 extends_documentation_fragment:
@@ -110,9 +110,20 @@ from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleA
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 
 
+def get_all_backup_plans_info(client):
+    paginator = client.get_paginator('list_backup_plans')
+    return paginator.paginate().build_full_result()
+
+
 def get_backup_plan_detail(client, module):
     backup_plan_list = []
     backup_plan_names = module.params.get("backup_plan_names")
+
+    if backup_plan_names is None:
+        backup_plan_names = []
+        backup_plan_list_info = get_all_backup_plans_info(client)["BackupPlansList"]
+        for mylist in backup_plan_list_info:
+            backup_plan_names.append(mylist["BackupPlanName"])
 
     for name in backup_plan_names:
         backup_plan_list.extend(get_plan_details(module, client, name))
@@ -122,7 +133,7 @@ def get_backup_plan_detail(client, module):
 
 def main():
     argument_spec = dict(
-        backup_plan_names=dict(type="list", elements="str", required=True),
+        backup_plan_names=dict(type="list", elements="str", required=False),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)

--- a/plugins/modules/backup_plan_info.py
+++ b/plugins/modules/backup_plan_info.py
@@ -111,7 +111,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 
 
 def get_all_backup_plans_info(client):
-    paginator = client.get_paginator('list_backup_plans')
+    paginator = client.get_paginator("list_backup_plans")
     return paginator.paginate().build_full_result()
 
 

--- a/plugins/modules/backup_plan_info.py
+++ b/plugins/modules/backup_plan_info.py
@@ -133,7 +133,7 @@ def get_backup_plan_detail(client, module):
 
 def main():
     argument_spec = dict(
-        backup_plan_names=dict(type="list", elements="str", required=False),
+        backup_plan_names=dict(type="list", elements="str"),
     )
 
     module = AnsibleAWSModule(argument_spec=argument_spec, supports_check_mode=True)

--- a/plugins/modules/backup_plan_info.py
+++ b/plugins/modules/backup_plan_info.py
@@ -31,7 +31,7 @@ extends_documentation_fragment:
 EXAMPLES = r"""
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 - name: Gather information about all backup plans
-  amazon.aws.backup_plan_info
+  amazon.aws.backup_plan_info:
 
 - name: Gather information about a particular backup plan
   amazon.aws.backup_plan_info:

--- a/tests/integration/targets/backup_plan/tasks/main.yml
+++ b/tests/integration/targets/backup_plan/tasks/main.yml
@@ -344,12 +344,41 @@
           - backup_plan_create_result.exists is true
           - backup_plan_create_result.changed is false
 
+    - name: Create another backup plan
+      amazon.aws.backup_plan:
+        backup_plan_name: "{{ backup_plan_name }}-1"
+        rules:
+          - rule_name: daily
+            target_backup_vault_name: "{{ backup_vault_name }}"
+        tags:
+          Environment: Test
+      register: backup_plan_create_result_1
+
+    - name: Verify backup plan create result
+      ansible.builtin.assert:
+        that:
+          - backup_plan_create_result_1.exists is true
+          - backup_plan_create_result_1.changed is true
+
+    - name: Get info of all install plans
+      amazon.aws.backup_plan_info:
+      register: backup_plan_info_result
+
+    - name: Assert that info of all backup plans is fetched
+      ansible.builtin.assert:
+        that:
+          - backup_plan_info_result is not failed
+          - backup_plan_info_result.backup_plans | length > 1
+
   always:
     - name: Delete AWS Backup plan created during this test
       amazon.aws.backup_plan:
-        backup_plan_name: "{{ backup_plan_name }}"
+        backup_plan_name: "{{ item }}"
         state: absent
       ignore_errors: true
+      with_items:
+        - "{{ backup_plan_name }}"
+        - "{{ backup_plan_name }}-1"
 
     - name: Delete AWS Backup vault created during this test
       amazon.aws.backup_vault:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix being unable to fetch info of all backup plans.
With `backup_plan_names` being a required parameter, the functionality to get all plans info was not working
```
# Gather information about all backup plans
- name: Get info of all backup plans 
  amazon.aws.backup_plan_info:
  register: plan_info_result

gave
**********
fatal: [localhost]: FAILED! => {"changed": false, "msg": "missing required arguments: backup_plan_names"}

```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
backup_plan_info
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
