### PR TITLE
RDS Integration tests - Bump MySQL/MariaDB versions to match AWS support

### DIFF
--- a/tests/integration/targets/rds_instance_complex/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_complex/defaults/main.yml
@@ -14,4 +14,4 @@ storage_type: io1
 iops: 1000
 
 # For mariadb tests
-mariadb_engine_version: 10.6.10
+mariadb_engine_version: 10.11.7

--- a/tests/integration/targets/rds_instance_modify/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_modify/defaults/main.yml
@@ -7,4 +7,4 @@ db_instance_class: db.t3.micro
 allocated_storage: 20
 
 # For mariadb tests
-mariadb_engine_version: 10.6.10
+mariadb_engine_version: 10.11.7

--- a/tests/integration/targets/rds_instance_snapshot/defaults/main.yml
+++ b/tests/integration/targets/rds_instance_snapshot/defaults/main.yml
@@ -8,7 +8,7 @@ password: "{{ lookup('password', '/dev/null') }}"
 db_instance_class: db.t3.micro
 allocated_storage: 10
 engine: mariadb
-mariadb_engine_version: 10.6.10
+mariadb_engine_version: 10.11.7
 
 # Create snapshot
 snapshot_id: "{{ instance_id }}-snapshot"

--- a/tests/integration/targets/rds_option_group/defaults/main.yml
+++ b/tests/integration/targets/rds_option_group/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 option_group_name: "{{ resource_prefix }}rds-option-group"
 engine_name: mysql
-major_engine_version: 5.6
+major_engine_version: 8.0
 option_group_description: "{{ resource_prefix }}rds-option-group test"
 instance_id: "{{ resource_prefix }}"
 username: test


### PR DESCRIPTION
##### SUMMARY

Bump MySQL/MariaDB versions to match AWS support.  AWS dropped the versions we were using in our integration tests, bump them

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

rds_instance
rds_option_group

##### ADDITIONAL INFORMATION