### PR TITLE
backup_vault: remove unnecessary return values from code block

### DIFF
--- a/changelogs/fragments/2105-backup_vault-remove-unnecessary-return-values.yml
+++ b/changelogs/fragments/2105-backup_vault-remove-unnecessary-return-values.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - Update code to remove unnecessary return values returned as None (https://github.com/ansible-collections/amazon.aws/pull/2105).
+  - backup_vault - Update code to remove unnecessary return values returned as None (https://github.com/ansible-collections/amazon.aws/pull/2105).

--- a/changelogs/fragments/2105-backup_vault-remove-unnecessary-return-values.yml
+++ b/changelogs/fragments/2105-backup_vault-remove-unnecessary-return-values.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - Update code to remove unnecessary return values returned as None (https://github.com/ansible-collections/amazon.aws/pull/2105).

--- a/plugins/modules/backup_vault.py
+++ b/plugins/modules/backup_vault.py
@@ -187,19 +187,6 @@ def get_vault_facts(module, client, vault_name):
             resource = resp.get("BackupVaultArn")
             resp["tags"] = get_backup_resource_tags(module, client, resource)
 
-        # Check for non-existent values and populate with None
-        optional_vals = set(
-            [
-                "S3KeyPrefix",
-                "SnsTopicName",
-                "SnsTopicARN",
-                "CloudWatchLogsLogGroupArn",
-                "CloudWatchLogsRoleArn",
-                "KmsKeyId",
-            ]
-        )
-        for v in optional_vals - set(resp.keys()):
-            resp[v] = None
         return resp
 
     else:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Removed unnecessary return values from code block
These parameters are not present in response syntax of [create_backup_vault](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/backup/client/create_backup_vault.html) and [describe_backup_vault](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/backup/client/describe_backup_vault.html)
and are never returned by API.
```
optional_vals = set(
            [
                "S3KeyPrefix",
                "SnsTopicName",
                "SnsTopicARN",
                "CloudWatchLogsLogGroupArn",
                "CloudWatchLogsRoleArn",
                "KmsKeyId",
            ]
        )
```
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
backup_vault
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
