### PR TITLE
Update return blocks of cloud* modules

### DIFF
--- a/changelogs/fragments/update_return_block_cloud_modules.yml
+++ b/changelogs/fragments/update_return_block_cloud_modules.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Update return block in the module documentation for cloudtrail, cloudtrail_info, cloudwatchevent_rule, cloudwatchlogs_log_group modules.

--- a/plugins/modules/cloudtrail.py
+++ b/plugins/modules/cloudtrail.py
@@ -201,8 +201,19 @@ trail:
             returned: success
             type: bool
             sample: true
+        is_organization_trail:
+            description:
+            - Specifies whether the trail is created for all accounts in an organization in Organizations, or only for the current Amazon Web Services account.
+            returned: success
+            type: bool
+            sample: true
         has_custom_event_selectors:
             description: Whether any custom event selectors are used for this trail.
+            returned: success
+            type: bool
+            sample: False
+        has_insight_selectors:
+            description: Whether any insight selectors are used for this trail.
             returned: success
             type: bool
             sample: False

--- a/plugins/modules/cloudtrail_info.py
+++ b/plugins/modules/cloudtrail_info.py
@@ -116,9 +116,6 @@ trail_list:
         latest_delivery_error:
             description: Displays any Amazon S3 error that CloudTrail encountered when attempting to deliver log files to the designated bucket.
             type: str
-        latest_delivery_error:
-            description: Displays any Amazon S3 error that CloudTrail encountered when attempting to deliver log files to the designated bucket.
-            type: str
         latest_notification_attempt_time:
             description: Specifies the date and time that CloudTrail last attempt to deliver a notification.
             type: str
@@ -130,6 +127,7 @@ trail_list:
             type: str
         latest_delivery_attempt_succeeded:
             description: Specifies the date and time that CloudTrail last successful attempt to deliver log files to an account's Amazon S3 bucket.
+            type: str
         latest_delivery_attempt_time:
             description: Specifies the date and time that CloudTrail last attempt to deliver log files to an account's Amazon S3 bucket.
             type: str

--- a/plugins/modules/cloudtrail_info.py
+++ b/plugins/modules/cloudtrail_info.py
@@ -116,8 +116,22 @@ trail_list:
         latest_delivery_error:
             description: Displays any Amazon S3 error that CloudTrail encountered when attempting to deliver log files to the designated bucket.
             type: str
+        latest_delivery_error:
+            description: Displays any Amazon S3 error that CloudTrail encountered when attempting to deliver log files to the designated bucket.
+            type: str
+        latest_notification_attempt_time:
+            description: Specifies the date and time that CloudTrail last attempt to deliver a notification.
+            type: str
+        latest_notification_attempt_succeeded:
+            description: Specifies the date and time that CloudTrail last successful attempt to deliver a notification.
+            type: str
         latest_notification_error:
             description: Displays any Amazon SNS error that CloudTrail encountered when attempting to send a notification.
+            type: str
+        latest_delivery_attempt_succeeded:
+            description: Specifies the date and time that CloudTrail last successful attempt to deliver log files to an account's Amazon S3 bucket.
+        latest_delivery_attempt_time:
+            description: Specifies the date and time that CloudTrail last attempt to deliver log files to an account's Amazon S3 bucket.
             type: str
         latest_delivery_time:
             description: Specifies the date and time that CloudTrail last delivered log files to an account's Amazon S3 bucket.

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -166,6 +166,7 @@ EXAMPLES = r"""
 RETURN = r"""
 rule:
     description: CloudWatch Event rule data.
+    returned: success
     type: dict
     contains:
       name:
@@ -199,6 +200,7 @@ rule:
         sample: 'arn:aws:events:us-east-1:123456789012:rule/MyCronTask'
 targets:
     description: CloudWatch Event target(s) assigned to the rule.
+    returned: success
     type: list
     elements: dict
     contains:

--- a/plugins/modules/cloudwatchevent_rule.py
+++ b/plugins/modules/cloudwatchevent_rule.py
@@ -166,19 +166,52 @@ EXAMPLES = r"""
 RETURN = r"""
 rule:
     description: CloudWatch Event rule data.
-    returned: success
     type: dict
-    sample:
-      arn: 'arn:aws:events:us-east-1:123456789012:rule/MyCronTask'
-      description: 'Run my scheduled task'
-      name: 'MyCronTask'
-      schedule_expression: 'cron(0 20 * * ? *)'
-      state: 'ENABLED'
+    contains:
+      name:
+        description:
+          - The name of the rule you are creating, updating or deleting.
+        returned: success
+        type: str
+        sample: "MyCronTask"
+      schedule_expression:
+        description:
+          - A cron or rate expression that defines the schedule the rule will trigger on.
+        returned: success
+        type: str
+        sample: 'cron(0 20 * * ? *)'
+      state:
+        description:
+          - Whether the rule is present (and enabled), disabled, or absent.
+        returned: success
+        type: str
+        sample: "enabled"
+      description:
+        description:
+          - A description of the rule.
+        returned: success
+        type: str
+        sample: "Run my scheduled task"
+      arn:
+        description: The ARN associated with the rule.
+        type: str
+        returned: success
+        sample: 'arn:aws:events:us-east-1:123456789012:rule/MyCronTask'
 targets:
     description: CloudWatch Event target(s) assigned to the rule.
-    returned: success
     type: list
-    sample: "[{ 'arn': 'arn:aws:lambda:us-east-1:123456789012:function:MyFunction', 'id': 'MyTargetId' }]"
+    elements: dict
+    contains:
+      id:
+        description: The unique target assignment ID.
+        type: str
+        returned: success
+        sample: 'MyTargetId'
+      arn:
+        description: The ARN associated with the target.
+        type: str
+        returned: success
+        sample: 'arn:aws:lambda:us-east-1:123456789012:function:MyFunction'
 """
 
 import json

--- a/plugins/modules/cloudwatchlogs_log_group.py
+++ b/plugins/modules/cloudwatchlogs_log_group.py
@@ -90,6 +90,38 @@ EXAMPLES = r"""
 """
 
 RETURN = r"""
+log_group_name:
+    description: The name of the log group.
+    returned: always
+    type: str
+creation_time:
+    description: The creation time of the log group.
+    returned: always
+    type: int
+retention_in_days:
+    description: The number of days to retain the log events in the specified log group.
+    returned: always
+    type: int
+metric_filter_count:
+    description: The number of metric filters.
+    returned: always
+    type: int
+arn:
+    description: The Amazon Resource Name (ARN) of the log group.
+    returned: always
+    type: str
+stored_bytes:
+    description: The number of bytes stored.
+    returned: always
+    type: str
+kms_key_id:
+    description: The Amazon Resource Name (ARN) of the CMK to use when encrypting log data.
+    returned: always
+    type: str
+tags:
+    description: A dictionary representing the tags on the log group.
+    returned: always
+    type: dict
 log_groups:
     description: Return the list of complex objects representing log groups.
     returned: success


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Refer : https://issues.redhat.com/browse/ACA-1476

This PR updates the module documentation with the correct return values for the following modules

cloudtrail, cloudtrail_info, cloudwatchevent_rule, cloudwatchlogs_log_group

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
