### PR TITLE
Refactor rds instance

### DIFF
--- a/changelogs/fragments/refactor_rds_instance.yml
+++ b/changelogs/fragments/refactor_rds_instance.yml
@@ -1,0 +1,5 @@
+---
+minor_changes:
+  - module_utils/rds.py - Refactor shared boto3 client functionality, add type hinting and function docstrings (https://github.com/ansible-collections/amazon.aws/pull/2119).
+  - rds_instance - Refactor shared boto3 client functionality, add type hinting and function docstrings (https://github.com/ansible-collections/amazon.aws/pull/2119).
+  - rds_instance_info - Refactor shared boto3 client functionality, add type hinting and function docstrings (https://github.com/ansible-collections/amazon.aws/pull/2119).

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -104,6 +104,13 @@ def describe_db_instances(client, **params: Dict) -> List[Dict[str, Any]]:
     return paginator.paginate(**params).build_full_result()["DBInstances"]
 
 
+@RDSErrorHandler.list_error_handler("describe db snapshots", [])
+@AWSRetry.jittered_backoff()
+def describe_db_snapshots(client, **params: Dict) -> List[Dict]:
+    paginator = client.get_paginator("describe_db_snapshots")
+    return paginator.paginate(**params).build_full_result()["DBSnapshots"]
+
+
 @RDSErrorHandler.list_error_handler("list tags for resource", [])
 @AWSRetry.jittered_backoff()
 def list_tags_for_resource(client, resource_arn: str) -> List[Dict[str, str]]:

--- a/tests/unit/plugins/modules/test_rds_instance.py
+++ b/tests/unit/plugins/modules/test_rds_instance.py
@@ -1,0 +1,104 @@
+# (c) 2024 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
+from ansible_collections.amazon.aws.plugins.modules.rds_instance import get_final_snapshot
+from ansible_collections.amazon.aws.plugins.modules.rds_instance import get_instance
+
+mod_name = "ansible_collections.amazon.aws.plugins.modules.rds_instance"
+
+
+@pytest.mark.parametrize(
+    "instances, expected",
+    [
+        ([], {}),
+        (
+            [
+                {
+                    "DBInstanceIdentifier": "my-instance",
+                    "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:og:my-instance",
+                    "TagList": [],
+                }
+            ],
+            {
+                "DBInstanceIdentifier": "my-instance",
+                "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:og:my-instance",
+                "Tags": {},
+            },
+        ),
+        (
+            [
+                {
+                    "DBInstanceIdentifier": "my-instance",
+                    "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:og:my-instance",
+                    "TagList": [{"Key": "My Tag", "Value": "My Value"}],
+                    "ProcessorFeatures": [{"Name": "coreCount", "Value": "1"}],
+                    "PendingModifiedValues": {
+                        "ProcessorFeatures": [{"Name": "coreCount", "Value": "2"}],
+                    },
+                }
+            ],
+            {
+                "DBInstanceIdentifier": "my-instance",
+                "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:og:my-instance",
+                "Tags": {"My Tag": "My Value"},
+                "ProcessorFeatures": {"coreCount": "1"},
+                "PendingModifiedValues": {"ProcessorFeatures": {"coreCount": "2"}},
+            },
+        ),
+    ],
+)
+@patch(mod_name + ".describe_db_instances")
+def test_get_instance_success(m_describe_db_instances, instances, expected):
+    client = MagicMock()
+    module = MagicMock()
+    m_describe_db_instances.return_value = instances
+    assert get_instance(client, module, "my-instance") == expected
+
+
+@patch(mod_name + ".describe_db_instances")
+def test_get_instance_failure(m_describe_db_instances):
+    client = MagicMock()
+    module = MagicMock()
+    e = AnsibleRDSError()
+    m_describe_db_instances.side_effect = e
+    get_instance(client, module, "my-instance")
+    module.fail_json_aws.assert_called_once_with(e, msg="Failed to get DB instance my-instance")
+
+
+@pytest.mark.parametrize(
+    "snapshots, expected",
+    [
+        ([], {}),
+        (
+            [{"DBSnapshotIdentifier": "my-snapshot", "DBInstanceIdentifier": "my-instance"}],
+            {"DBSnapshotIdentifier": "my-snapshot", "DBInstanceIdentifier": "my-instance"},
+        ),
+        ([{"DBSnapshotIdentifier": "snapshot-1"}, {"DBSnapshotIdentifier": "snapshot-2"}], {}),
+    ],
+)
+@patch(mod_name + ".describe_db_snapshots")
+def test_get_final_snapshot_success(m_describe_db_snapshots, snapshots, expected):
+    client = MagicMock()
+    module = MagicMock()
+    m_describe_db_snapshots.return_value = snapshots
+    assert get_final_snapshot(client, module, "my-snapshot") == expected
+
+
+@patch(mod_name + ".describe_db_snapshots")
+def test_get_final_snapshot_failure(m_describe_db_snapshots):
+    client = MagicMock()
+    module = MagicMock()
+    e = AnsibleRDSError()
+    m_describe_db_snapshots.side_effect = e
+    get_final_snapshot(client, module, "my-snapshot")
+    module.fail_json_aws.assert_called_once_with(
+        e, msg="Failed to retrieve information about the final snapshot: my-snapshot"
+    )

--- a/tests/unit/plugins/modules/test_rds_instance_info.py
+++ b/tests/unit/plugins/modules/test_rds_instance_info.py
@@ -2,99 +2,70 @@
 #
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
-from unittest.mock import ANY
+
 from unittest.mock import MagicMock
-from unittest.mock import call
 from unittest.mock import patch
 
-import botocore.exceptions
-import pytest
-
+from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
 from ansible_collections.amazon.aws.plugins.modules import rds_instance_info
+from ansible_collections.amazon.aws.plugins.modules.rds_instance_info import instance_info
 
 mod_name = "ansible_collections.amazon.aws.plugins.modules.rds_instance_info"
 
 
-def a_boto_exception():
-    return botocore.exceptions.UnknownServiceError(service_name="Whoops", known_service_names="Oula")
-
-
-@patch(mod_name + "._describe_db_instances")
-@patch(mod_name + ".get_instance_tags")
-def test_instance_info_one_instance(m_get_instance_tags, m_describe_db_instances):
+@patch(mod_name + ".describe_db_instances")
+def test_instance_info_one_instance(m_describe_db_instances):
     conn = MagicMock()
+    module = MagicMock()
     instance_name = "my-instance"
-    m_get_instance_tags.return_value = []
     m_describe_db_instances.return_value = [
         {
             "DBInstanceIdentifier": instance_name,
             "DBInstanceArn": "arn:aws:rds:us-east-2:123456789012:og:" + instance_name,
+            "TagList": [],
         }
     ]
-    rds_instance_info.instance_info(conn, instance_name, filters={})
 
+    assert instance_info(conn, module, instance_name, filters={}) == [
+        {
+            "db_instance_identifier": instance_name,
+            "db_instance_arn": "arn:aws:rds:us-east-2:123456789012:og:" + instance_name,
+            "tags": {},
+        }
+    ]
     m_describe_db_instances.assert_called_with(conn, DBInstanceIdentifier=instance_name)
-    m_get_instance_tags.assert_called_with(conn, arn="arn:aws:rds:us-east-2:123456789012:og:" + instance_name)
 
 
-@patch(mod_name + "._describe_db_instances")
-@patch(mod_name + ".get_instance_tags")
-def test_instance_info_all_instances(m_get_instance_tags, m_describe_db_instances):
+@patch(mod_name + ".describe_db_instances")
+def test_instance_info_all_instances(m_describe_db_instances):
     conn = MagicMock()
-    m_get_instance_tags.return_value = []
+    module = MagicMock()
     m_describe_db_instances.return_value = [
         {
             "DBInstanceIdentifier": "first-instance",
             "DBInstanceArn": "arn:aws:rds:us-east-2:123456789012:og:first-instance",
+            "TagList": [],
         },
         {
             "DBInstanceIdentifier": "second-instance",
             "DBInstanceArn": "arn:aws:rds:us-east-2:123456789012:og:second-instance",
+            "TagList": [{"Key": "MyTag", "Value": "My tag value"}],
         },
     ]
-    rds_instance_info.instance_info(conn, instance_name=None, filters={"engine": "postgres"})
 
+    assert instance_info(conn, module, instance_name=None, filters={"engine": "postgres"}) == [
+        {
+            "db_instance_identifier": "first-instance",
+            "db_instance_arn": "arn:aws:rds:us-east-2:123456789012:og:first-instance",
+            "tags": {},
+        },
+        {
+            "db_instance_identifier": "second-instance",
+            "db_instance_arn": "arn:aws:rds:us-east-2:123456789012:og:second-instance",
+            "tags": {"MyTag": "My tag value"},
+        },
+    ]
     m_describe_db_instances.assert_called_with(conn, Filters=[{"Name": "engine", "Values": ["postgres"]}])
-    assert m_get_instance_tags.call_count == 2
-    m_get_instance_tags.assert_has_calls(
-        [
-            call(conn, arn="arn:aws:rds:us-east-2:123456789012:og:first-instance"),
-            call(conn, arn="arn:aws:rds:us-east-2:123456789012:og:second-instance"),
-        ]
-    )
-
-
-def test_get_instance_tags():
-    conn = MagicMock()
-    conn.list_tags_for_resource.return_value = {
-        "TagList": [
-            {"Key": "My-tag", "Value": "the-value$"},
-        ],
-        "NextToken": "some-token",
-    }
-
-    tags = rds_instance_info.get_instance_tags(conn, "arn:aws:rds:us-east-2:123456789012:og:second-instance")
-    conn.list_tags_for_resource.assert_called_with(
-        ResourceName="arn:aws:rds:us-east-2:123456789012:og:second-instance",
-        aws_retry=True,
-    )
-    assert tags == {"My-tag": "the-value$"}
-
-
-def test_api_failure_get_tag():
-    conn = MagicMock()
-    conn.list_tags_for_resource.side_effect = a_boto_exception()
-
-    with pytest.raises(rds_instance_info.RdsInstanceInfoFailure):
-        rds_instance_info.get_instance_tags(conn, "arn:blabla")
-
-
-def test_api_failure_describe():
-    conn = MagicMock()
-    conn.get_paginator.side_effect = a_boto_exception()
-
-    with pytest.raises(rds_instance_info.RdsInstanceInfoFailure):
-        rds_instance_info.instance_info(conn, None, {})
 
 
 @patch(mod_name + ".AnsibleAWSModule")
@@ -104,18 +75,19 @@ def test_main_success(m_AnsibleAWSModule):
 
     rds_instance_info.main()
 
-    m_module.client.assert_called_with("rds", retry_decorator=ANY)
+    m_module.client.assert_called_with("rds")
     m_module.exit_json.assert_called_with(changed=False, instances=[])
 
 
-@patch(mod_name + "._describe_db_instances")
+@patch(mod_name + ".describe_db_instances")
 @patch(mod_name + ".AnsibleAWSModule")
 def test_main_failure(m_AnsibleAWSModule, m_describe_db_instances):
     m_module = MagicMock()
     m_AnsibleAWSModule.return_value = m_module
-    m_describe_db_instances.side_effect = a_boto_exception()
+    e = AnsibleRDSError()
+    m_describe_db_instances.side_effect = e
 
     rds_instance_info.main()
 
-    m_module.client.assert_called_with("rds", retry_decorator=ANY)
-    m_module.fail_json_aws.assert_called_with(ANY, "Couldn't get instance information")
+    m_module.client.assert_called_with("rds")
+    m_module.fail_json_aws.assert_called_with(e)


### PR DESCRIPTION
##### SUMMARY
This is an initial refactor PR for rds modules, focusing on documentation and shared boto3 client functionality in rds `module_utils`, `rds_instance_info`, and `rds_instance`. First PR for https://github.com/ansible-collections/amazon.aws/issues/2003 / https://issues.redhat.com/browse/ACA-1343.

##### COMPONENT NAME
rds_instance_info
rds_instance
module_utils/rds.py

##### ADDITIONAL INFORMATION
Detailed summary of all the changes:

module_utils/rds.py:
- Add RDS error class and handler
- Add describe_db_instances(), describe_db_snapshots(), and list_tags_for_resource() functions to handle boto3 client call
- Refactor get_tags() to use new list_tags_for_resource() function 
- Add type hinting and function docstrings

rds_instance_info module:
- Replace internal error handler and `_describe_db_instances()` functions with calls to new functions from module_utils/rds.py
- Remove extra boto3 call to retrieve tags for resource and just reformat instance `TagList` attribute since it is always returned by `describe_db_instances`
- Update `instance_info()` function return value for clarity
- Add type hinting and function docstrings
- Remove unit tests for functions no longer in module
- Refactor remaining unit tests to match updated `instance_info()` function

rds_instance module:
- Refactor internal `get_instance()` function to use `describe_db_instances()` from module_utils/rds.py, remove extra boto3 call to get resource tags, and remove manual retry logic
- Refactor internal `get_final_snapshot()` function to use `describe_db_snapshots()` from module_utils/rds.py
- Add type hinting and function docstrings, and in some cases inline comments to explain complex logic
- Add unit tests for refactored functions