### PR TITLE
backup_plan: modify args spec and add examples for advanced_backup_settings parameter

### DIFF
--- a/changelogs/fragments/fix_args_spec_supoptions.yml
+++ b/changelogs/fragments/fix_args_spec_supoptions.yml
@@ -1,4 +1,4 @@
 ---
 trivial:
-  - backup_plan: Modify the argspec to use options for a dict parameter.
-  - backup_plan: add example for advanced_backup_settings usage.
+  - backup_plan - Modify the argspec to use options for a dict parameter.
+  - backup_plan - add example for advanced_backup_settings usage.

--- a/changelogs/fragments/fix_args_spec_supoptions.yml
+++ b/changelogs/fragments/fix_args_spec_supoptions.yml
@@ -1,0 +1,4 @@
+---
+trivial:
+  - backup_plan: Modify the argspec to use options for a dict parameter.
+  - backup_plan: add example for advanced_backup_settings usage.

--- a/plugins/modules/backup_plan.py
+++ b/plugins/modules/backup_plan.py
@@ -186,7 +186,8 @@ EXAMPLES = r"""
       - rule_name: daily
         advanced_backup_settings:
           - resource_type: "EC2"
-            backup_options: {"WindowsVSS": "enabled"}
+            backup_options:
+              WindowsVSS: enabled
         target_backup_vault_name: "{{ backup_vault_name }}"
         schedule_expression: 'cron(0 5 ? * * *)'
         start_window_minutes: 60

--- a/plugins/modules/backup_plan.py
+++ b/plugins/modules/backup_plan.py
@@ -153,7 +153,11 @@ options:
           - Specifies the backup option for a selected resource.
           - This option is only available for Windows VSS backup jobs.
         type: dict
-        choices: [{'WindowsVSS': 'enabled'}, {'WindowsVSS': 'disabled'}]
+        suboptions:
+          WindowsVSS:
+            description: Enable or disable WindowsVSS backup option.
+            type: str
+            choices: ['enabled', 'disabled']
   creator_request_id:
     description: Identifies the request and allows failed requests to be retried
       without the risk of running the operation twice. If the request includes a
@@ -180,6 +184,9 @@ EXAMPLES = r"""
     backup_plan_name: elastic
     rules:
       - rule_name: daily
+        advanced_backup_settings:
+          - resource_type: "EC2"
+            backup_options: {"WindowsVSS": "enabled"}
         target_backup_vault_name: "{{ backup_vault_name }}"
         schedule_expression: 'cron(0 5 ? * * *)'
         start_window_minutes: 60
@@ -387,7 +394,9 @@ ARGUMENT_SPEC = dict(
             resource_type=dict(type="str", choices=["EC2"]),
             backup_options=dict(
                 type="dict",
-                choices=[{"WindowsVSS": "enabled"}, {"WindowsVSS": "disabled"}],
+                options=dict(
+                    WindowsVSS=dict(type="str", choices=["enabled", "disabed"])
+                ),
             ),
         ),
     ),

--- a/plugins/modules/backup_plan.py
+++ b/plugins/modules/backup_plan.py
@@ -395,9 +395,7 @@ ARGUMENT_SPEC = dict(
             resource_type=dict(type="str", choices=["EC2"]),
             backup_options=dict(
                 type="dict",
-                options=dict(
-                    WindowsVSS=dict(type="str", choices=["enabled", "disabled"])
-                ),
+                options=dict(WindowsVSS=dict(type="str", choices=["enabled", "disabled"])),
             ),
         ),
     ),

--- a/plugins/modules/backup_plan.py
+++ b/plugins/modules/backup_plan.py
@@ -395,7 +395,7 @@ ARGUMENT_SPEC = dict(
             backup_options=dict(
                 type="dict",
                 options=dict(
-                    WindowsVSS=dict(type="str", choices=["enabled", "disabed"])
+                    WindowsVSS=dict(type="str", choices=["enabled", "disabled"])
                 ),
             ),
         ),


### PR DESCRIPTION
Fixes #2110 

This PR
- adds an example to showcase the usage of advanced_backup_settings parameter
- adds option in args spec and suboption in module doc
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
