### PR TITLE
fix(ec2_vol): output volume informations when volume exists in check mode

### DIFF
--- a/changelogs/fragments/202401025-ec2_vol.yml
+++ b/changelogs/fragments/202401025-ec2_vol.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - ec2_vol - output volume informations when volume exists in check mode (https://github.com/ansible-collections/amazon.aws/pull/2133).

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -568,7 +568,7 @@ def attach_volume(
                 module.exit_json(
                     changed=False,
                     msg=f"IN CHECK MODE - volume already attached to instance: {instance_id}.",
-                    **volume_dict,
+                    volume=volume_dict,
                 )
         if not volume_dict["multi_attach_enabled"]:
             # volumes without MultiAttach Enabled can be attached to 1 instance only

--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -566,7 +566,9 @@ def attach_volume(
             if attachment_data[0].get("status") in ["attached", "attaching"]:
                 instance_id = attachment_data[0].get("instance_id", "None")
                 module.exit_json(
-                    changed=False, msg=f"IN CHECK MODE - volume already attached to instance: {instance_id}."
+                    changed=False,
+                    msg=f"IN CHECK MODE - volume already attached to instance: {instance_id}.",
+                    **volume_dict,
                 )
         if not volume_dict["multi_attach_enabled"]:
             # volumes without MultiAttach Enabled can be attached to 1 instance only


### PR DESCRIPTION
##### SUMMARY
When using ec2_vol in check mode if the volume already exists and is attached, the module don't output the volume informations.

This is problematic when used with a "register" directive when writing idempotent playbooks 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_vol

##### ADDITIONAL INFORMATION
Before :
```
    changed: false
    failed: false
    msg: 'IN CHECK MODE - volume already attached to instance: i-xxxxxxxxxxxxxxxxxxx.'
```

After : 
```
     attachments:
    - attach_time: '2024-05-17T15:14:49+00:00'
      delete_on_termination: false
      device: /dev/sdf
      instance_id: i-xxxxxxxxxxxxxxxxxxx
      state: attached
      volume_id: vol-xxxxxxxxxxxxxx
    availability_zone: eu-west-1a
    changed: false
    create_time: '2024-05-17T15:14:33.776000+00:00'
    encrypted: false
    failed: false
    iops: 3000
    msg: 'IN CHECK MODE - volume already attached to instance: i-xxxxxxxxxxxxxxx.'
    multi_attach_enabled: false
    size: 30
    snapshot_id: ''
    state: in-use
    tags:
    - key: Name
      value: xxxxxxxxxxxxxxxxxxxxxxxxxxxxx
    throughput: 125
    volume_id: vol-xxxxxxxxxxxxxx
    volume_type: gp3
```