### PR TITLE
route53: Return diff only when module._diff is true

### DIFF
--- a/changelogs/fragments/fix_module_diff_route53.yml
+++ b/changelogs/fragments/fix_module_diff_route53.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - modify the return value of the route53 module to return diff only when ``module._diff`` is set to true.

--- a/changelogs/fragments/fix_module_diff_route53.yml
+++ b/changelogs/fragments/fix_module_diff_route53.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - modify the return value of the route53 module to return diff only when ``module._diff`` is set to true.
+  - route53 - modify the return value to return diff only when ``module._diff`` is set to true (https://github.com/ansible-collections/amazon.aws/pull/2136).

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -164,6 +164,15 @@ extends_documentation_fragment:
 """
 
 RETURN = r"""
+nameservers:
+  description: Nameservers associated with the zone.
+  returned: when state is 'get'
+  type: list
+  sample:
+  - ns-1036.awsdns-00.org.
+  - ns-516.awsdns-00.net.
+  - ns-1504.awsdns-00.co.uk.
+  - ns-1.awsdns-00.com.
 resource_record_sets:
   description: Info specific to the resource record.
   returned: when state is 'get'

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -823,9 +823,9 @@ def main():
             diff=dict(
                 before=formatted_aws,
                 after=camel_dict_to_snake_dict(formatted_record) if command_in != "delete" else {},
-                resource_record_sets=rr_sets,
-            ),
-        )
+		),
+        	resource_record_sets=[camel_dict_to_snake_dict(formatted_record)] if command_in != "delete" else {},
+            )
     module.exit_json(
         changed=True,
         wait_id=wait_id,

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -813,24 +813,26 @@ def main():
         except Exception as e:
             module.fail_json(msg=f"Unhandled exception. ({to_native(e)})")
 
-    rr_sets = [camel_dict_to_snake_dict(resource_record_set)]
     formatted_aws = format_record(aws_record, zone_in, zone_id)
     formatted_record = format_record(resource_record_set, zone_in, zone_id)
-    if module._diff:
-        module.exit_json(
-            changed=True,
-            wait_id=wait_id,
-            diff=dict(
-                before=formatted_aws,
-                after=camel_dict_to_snake_dict(formatted_record) if command_in != "delete" else {},
-            ),
-            resource_record_sets=[camel_dict_to_snake_dict(formatted_record)] if command_in != "delete" else {},
-        )
-    module.exit_json(
+
+    return_result = dict(
         changed=True,
         wait_id=wait_id,
         resource_record_sets=[camel_dict_to_snake_dict(formatted_record)] if command_in != "delete" else {},
     )
+
+    if module._diff:
+        return_result.update(
+            {
+                "diff": {
+                    "before": formatted_aws,
+                    "after": camel_dict_to_snake_dict(formatted_record) if command_in != "delete" else {},
+                }
+            }
+        )
+
+    module.exit_json(**return_result)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -823,9 +823,9 @@ def main():
             diff=dict(
                 before=formatted_aws,
                 after=camel_dict_to_snake_dict(formatted_record) if command_in != "delete" else {},
-		),
-        	resource_record_sets=[camel_dict_to_snake_dict(formatted_record)] if command_in != "delete" else {},
-            )
+            ),
+            resource_record_sets=[camel_dict_to_snake_dict(formatted_record)] if command_in != "delete" else {},
+        )
     module.exit_json(
         changed=True,
         wait_id=wait_id,

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -187,7 +187,7 @@ resource_record_sets:
       description: Whether this is the primary or secondary resource record set.
       returned: always
       type: str
-      sample: PRIMARY
+      sample: "PRIMARY"
     geo_location:
       description: geograpic location based on which Route53 resonds to DNS queries.
       returned: when configured
@@ -207,17 +207,17 @@ resource_record_sets:
       description: Domain name for the record set.
       returned: always
       type: str
-      sample: new.foo.com.
+      sample: "new.foo.com"
     record:
       description: Domain name for the record set.
       returned: always
       type: str
-      sample: new.foo.com.
+      sample: "new.foo.com"
     region:
       description: Which region this should be associated with for latency-based routing.
       returned: always
       type: str
-      sample: us-west-2
+      sample: "us-west-2"
     resource_records:
       description: Information about the resource records to act upon.
       type: list
@@ -227,17 +227,17 @@ resource_record_sets:
       description: Resource record cache TTL.
       returned: always
       type: str
-      sample: '3600'
+      sample: "3600"
     type:
       description: Resource record set type.
       returned: always
       type: str
-      sample: A
+      sample: "A"
     value:
       description: Record value.
       returned: always
       type: str
-      sample: 52.43.18.27
+      sample: "52.43.18.27"
     values:
       description: Record Values.
       returned: always
@@ -253,7 +253,7 @@ resource_record_sets:
       description: Zone this record set belongs to.
       returned: always
       type: str
-      sample: foo.bar.com.
+      sample: "foo.bar.com"
 wait_id:
   description:
     - The wait ID for the applied change. Can be used to wait for the change to propagate later on when I(wait=false).

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -435,6 +435,7 @@
         type: A
         value:
           - 192.0.2.2
+      diff: true
       register: wc_a_record
     - ansible.builtin.assert:
         that:
@@ -454,7 +455,7 @@
     - name: check return values
       ansible.builtin.assert:
         that:
-          - ttl30.diff.resource_record_sets[0].ttl == 30
+          - ttl30.resource_record_sets[0].ttl == "30"
           - ttl30 is changed
 
     - name: delete previous record without mention ttl and value


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Refer https://issues.redhat.com/browse/ACA-1477
Route53 module, returns `after` and `before` diff as module output. This PR fixes this bug, by adding a check to return the diff only when module._diff is set to true.


##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
