### PR TITLE
Refactor rds snapshot modules

### DIFF
--- a/changelogs/fragments/refactor_rds_snapshot_modules.yml
+++ b/changelogs/fragments/refactor_rds_snapshot_modules.yml
@@ -1,0 +1,8 @@
+---
+minor_changes:
+  - module_utils/rds.py - Add shared functionality from rds snapshot modules (https://github.com/ansible-collections/amazon.aws/pull/2138).
+  - rds_cluster_snapshot - Refactor shared boto3 client functionality, add type hinting and function docstrings (https://github.com/ansible-collections/amazon.aws/pull/2138).
+  - rds_instance - Remove shared functioanlity added to module_utils/rds.py (https://github.com/ansible-collections/amazon.aws/pull/2138).
+  - rds_instance_info - Refactor shared boto3 client functionality, add type hinting and function docstrings (https://github.com/ansible-collections/amazon.aws/pull/2138).
+  - rds_instance_snapshot - Refactor shared boto3 client functionality, add type hinting and function docstrings (https://github.com/ansible-collections/amazon.aws/pull/2138).
+  - rds_snapshot_info - Refactor shared boto3 client functionality, add type hinting and function docstrings (https://github.com/ansible-collections/amazon.aws/pull/2138).

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -521,6 +521,10 @@ def get_snapshot(
         Raises:
             Failes the module if an exception is raised while retrieving the snapshot attributes.
     """
+    valid_types = ("cluster", "instance")
+    if snapshot_type not in valid_types:
+        raise ValueError(f"Invalid snapshot_type. Expected one of: {valid_types}")
+
     snapshot = {}
 
     try:

--- a/plugins/modules/rds_cluster_snapshot.py
+++ b/plugins/modules/rds_cluster_snapshot.py
@@ -334,7 +334,7 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
-    client = module.client("rds", retry_decorator=AWSRetry.jittered_backoff())
+    client = module.client("rds")
     state = module.params.get("state")
 
     if state == "absent":

--- a/plugins/modules/rds_cluster_snapshot.py
+++ b/plugins/modules/rds_cluster_snapshot.py
@@ -231,7 +231,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.rds import call_method
 from ansible_collections.amazon.aws.plugins.module_utils.rds import ensure_tags
 from ansible_collections.amazon.aws.plugins.module_utils.rds import format_rds_client_method_parameters
 from ansible_collections.amazon.aws.plugins.module_utils.rds import get_snapshot
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 
 
 def ensure_snapshot_absent(client, module: AnsibleAWSModule) -> None:

--- a/plugins/modules/rds_cluster_snapshot.py
+++ b/plugins/modules/rds_cluster_snapshot.py
@@ -220,122 +220,88 @@ tags:
         }
 """
 
-try:
-    import botocore
-except ImportError:
-    pass  # caught by AnsibleAWSModule
+from typing import Any
+from typing import Dict
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import get_boto3_client_method_parameters
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.rds import arg_spec_to_rds_params
 from ansible_collections.amazon.aws.plugins.module_utils.rds import call_method
 from ansible_collections.amazon.aws.plugins.module_utils.rds import ensure_tags
-from ansible_collections.amazon.aws.plugins.module_utils.rds import get_rds_method_attribute
-from ansible_collections.amazon.aws.plugins.module_utils.rds import get_tags
+from ansible_collections.amazon.aws.plugins.module_utils.rds import format_rds_client_method_parameters
+from ansible_collections.amazon.aws.plugins.module_utils.rds import get_snapshot
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
 
 
-def get_snapshot(snapshot_id):
-    try:
-        snapshot = client.describe_db_cluster_snapshots(DBClusterSnapshotIdentifier=snapshot_id, aws_retry=True)[
-            "DBClusterSnapshots"
-        ][0]
-        snapshot["Tags"] = get_tags(client, module, snapshot["DBClusterSnapshotArn"])
-    except is_boto3_error_code("DBClusterSnapshotNotFound"):
-        return {}
-    except is_boto3_error_code("DBClusterSnapshotNotFoundFault"):  # pylint: disable=duplicate-except
-        return {}
-    except (
-        botocore.exceptions.BotoCoreError,
-        botocore.exceptions.ClientError,
-    ) as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg=f"Couldn't get snapshot {snapshot_id}")
-    return snapshot
-
-
-def get_parameters(parameters, method_name):
-    if method_name == "copy_db_cluster_snapshot":
-        parameters["TargetDBClusterSnapshotIdentifier"] = module.params["db_cluster_snapshot_identifier"]
-
-    required_options = get_boto3_client_method_parameters(client, method_name, required=True)
-    if any(parameters.get(k) is None for k in required_options):
-        attribute_description = get_rds_method_attribute(method_name, module).operation_description
-        module.fail_json(msg=f"To {attribute_description} requires the parameters: {required_options}")
-    options = get_boto3_client_method_parameters(client, method_name)
-    parameters = dict((k, v) for k, v in parameters.items() if k in options and v is not None)
-
-    return parameters
-
-
-def ensure_snapshot_absent():
-    snapshot_name = module.params.get("db_cluster_snapshot_identifier")
-    params = {"DBClusterSnapshotIdentifier": snapshot_name}
+def ensure_snapshot_absent(client, module: AnsibleAWSModule) -> None:
+    snapshot_id = module.params.get("db_cluster_snapshot_identifier")
     changed = False
 
-    snapshot = get_snapshot(snapshot_name)
+    snapshot = get_snapshot(client, module, snapshot_id, "cluster")
     if not snapshot:
         module.exit_json(changed=changed)
     elif snapshot and snapshot["Status"] != "deleting":
-        snapshot, changed = call_method(client, module, "delete_db_cluster_snapshot", params)
+        snapshot, changed = call_method(
+            client, module, "delete_db_cluster_snapshot", {"DBClusterSnapshotIdentifier": snapshot_id}
+        )
 
     module.exit_json(changed=changed)
 
 
-def copy_snapshot(params):
+def copy_snapshot(client, module: AnsibleAWSModule, params: Dict[str, Any]) -> bool:
     changed = False
     snapshot_id = module.params.get("db_cluster_snapshot_identifier")
-    snapshot = get_snapshot(snapshot_id)
 
+    snapshot = get_snapshot(client, module, snapshot_id, "cluster")
     if not snapshot:
-        method_params = get_parameters(params, "copy_db_cluster_snapshot")
-        if method_params.get("Tags"):
-            method_params["Tags"] = ansible_dict_to_boto3_tag_list(method_params["Tags"])
+        params["TargetDBClusterSnapshotIdentifier"] = snapshot_id
+        method_params = format_rds_client_method_parameters(
+            client, module, params, "copy_db_cluster_snapshot", format_tags=True
+        )
         _result, changed = call_method(client, module, "copy_db_cluster_snapshot", method_params)
 
     return changed
 
 
-def ensure_snapshot_present(params):
+def ensure_snapshot_present(client, module: AnsibleAWSModule, params: Dict[str, Any]) -> None:
     source_id = module.params.get("source_db_cluster_snapshot_identifier")
-    snapshot_name = module.params.get("db_cluster_snapshot_identifier")
+    snapshot_id = module.params.get("db_cluster_snapshot_identifier")
     changed = False
 
-    snapshot = get_snapshot(snapshot_name)
+    snapshot = get_snapshot(client, module, snapshot_id, "cluster")
 
     # Copy snapshot
     if source_id:
-        changed |= copy_snapshot(params)
+        changed |= copy_snapshot(client, module, params)
 
     # Create snapshot
     elif not snapshot:
-        changed |= create_snapshot(params)
+        changed |= create_snapshot(client, module, params)
 
     # Snapshot exists and we're not creating a copy - modify exising snapshot
     else:
-        changed |= modify_snapshot()
+        changed |= modify_snapshot(client, module)
 
-    snapshot = get_snapshot(snapshot_name)
+    snapshot = get_snapshot(client, module, snapshot_id, "cluster")
     module.exit_json(changed=changed, **camel_dict_to_snake_dict(snapshot, ignore_list=["Tags"]))
 
 
-def create_snapshot(params):
-    method_params = get_parameters(params, "create_db_cluster_snapshot")
-    if method_params.get("Tags"):
-        method_params["Tags"] = ansible_dict_to_boto3_tag_list(method_params["Tags"])
+def create_snapshot(client, module: AnsibleAWSModule, params: Dict[str, Any]) -> bool:
+    method_params = format_rds_client_method_parameters(
+        client, module, params, "create_db_cluster_snapshot", format_tags=True
+    )
     _snapshot, changed = call_method(client, module, "create_db_cluster_snapshot", method_params)
 
     return changed
 
 
-def modify_snapshot():
+def modify_snapshot(client, module: AnsibleAWSModule) -> bool:
     # TODO - add other modifications aside from purely tags
     changed = False
     snapshot_id = module.params.get("db_cluster_snapshot_identifier")
-    snapshot = get_snapshot(snapshot_id)
+
+    snapshot = get_snapshot(client, module, snapshot_id, "cluster")
 
     if module.params.get("tags"):
         changed |= ensure_tags(
@@ -351,9 +317,6 @@ def modify_snapshot():
 
 
 def main():
-    global client
-    global module
-
     argument_spec = dict(
         state=dict(type="str", choices=["present", "absent"], default="present"),
         db_cluster_snapshot_identifier=dict(type="str", aliases=["id", "snapshot_id", "snapshot_name"], required=True),
@@ -371,20 +334,14 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
-
-    retry_decorator = AWSRetry.jittered_backoff(retries=10)
-    try:
-        client = module.client("rds", retry_decorator=retry_decorator)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to connect to AWS.")
-
+    client = module.client("rds", retry_decorator=AWSRetry.jittered_backoff())
     state = module.params.get("state")
 
     if state == "absent":
-        ensure_snapshot_absent()
+        ensure_snapshot_absent(client, module)
     elif state == "present":
         params = arg_spec_to_rds_params(dict((k, module.params[k]) for k in module.params if k in argument_spec))
-        ensure_snapshot_present(params)
+        ensure_snapshot_present(client, module, params)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1758,11 +1758,11 @@ def main():
                     sleep(5)
 
         if state == "absent" and changed and not module.params["skip_final_snapshot"]:
-            instance.update(
-                FinalSnapshot=get_snapshot(
-                    client, module, module.params["final_db_snapshot_identifier"], "instance", False
-                )
-            )
+            snapshot_id = module.params["final_db_snapshot_identifier"]
+            try:
+                instance.update(FinalSnapshot=get_snapshot(client, module, snapshot_id, "instance", False))
+            except AnsibleRDSError as e:
+                module.fail_json_aws(e, msg=f"Failed to get snapshot: {snapshot_id}")
 
     pending_processor_features = None
     if instance.get("PendingModifiedValues", {}).get("ProcessorFeatures"):

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1760,7 +1760,7 @@ def main():
         if state == "absent" and changed and not module.params["skip_final_snapshot"]:
             snapshot_id = module.params["final_db_snapshot_identifier"]
             try:
-                instance.update(FinalSnapshot=get_snapshot(client, module, snapshot_id, "instance", False))
+                instance.update(FinalSnapshot=get_snapshot(client, snapshot_id, "instance", False))
             except AnsibleRDSError as e:
                 module.fail_json_aws(e, msg=f"Failed to get snapshot: {snapshot_id}")
 

--- a/plugins/modules/rds_instance_snapshot.py
+++ b/plugins/modules/rds_instance_snapshot.py
@@ -228,61 +228,26 @@ vpc_id:
   sample: vpc-09ff232e222710ae0
 """
 
-try:
-    import botocore
-except ImportError:
-    pass  # protected by AnsibleAWSModule
+from typing import Any
+from typing import Dict
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import get_boto3_client_method_parameters
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
-
-# import module snippets
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.rds import arg_spec_to_rds_params
 from ansible_collections.amazon.aws.plugins.module_utils.rds import call_method
 from ansible_collections.amazon.aws.plugins.module_utils.rds import ensure_tags
-from ansible_collections.amazon.aws.plugins.module_utils.rds import get_rds_method_attribute
-from ansible_collections.amazon.aws.plugins.module_utils.rds import get_tags
+from ansible_collections.amazon.aws.plugins.module_utils.rds import format_rds_client_method_parameters
+from ansible_collections.amazon.aws.plugins.module_utils.rds import get_snapshot
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
 
 
-def get_snapshot(snapshot_id):
-    try:
-        snapshot = client.describe_db_snapshots(DBSnapshotIdentifier=snapshot_id)["DBSnapshots"][0]
-        snapshot["Tags"] = get_tags(client, module, snapshot["DBSnapshotArn"])
-    except is_boto3_error_code("DBSnapshotNotFound"):
-        return {}
-    except (
-        botocore.exceptions.BotoCoreError,
-        botocore.exceptions.ClientError,
-    ) as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg=f"Couldn't get snapshot {snapshot_id}")
-    return snapshot
-
-
-def get_parameters(parameters, method_name):
-    if method_name == "copy_db_snapshot":
-        parameters["TargetDBSnapshotIdentifier"] = module.params["db_snapshot_identifier"]
-
-    required_options = get_boto3_client_method_parameters(client, method_name, required=True)
-    if any(parameters.get(k) is None for k in required_options):
-        method_description = get_rds_method_attribute(method_name, module).operation_description
-        module.fail_json(msg=f"To {method_description} requires the parameters: {*required_options, }")
-    options = get_boto3_client_method_parameters(client, method_name)
-    parameters = dict((k, v) for k, v in parameters.items() if k in options and v is not None)
-
-    return parameters
-
-
-def ensure_snapshot_absent():
-    snapshot_name = module.params.get("db_snapshot_identifier")
-    params = {"DBSnapshotIdentifier": snapshot_name}
+def ensure_snapshot_absent(client, module: AnsibleAWSModule) -> None:
+    snapshot_id = module.params.get("db_snapshot_identifier")
+    params = {"DBSnapshotIdentifier": snapshot_id}
     changed = False
 
-    snapshot = get_snapshot(snapshot_name)
+    snapshot = get_snapshot(client, module, snapshot_id, "instance")
     if not snapshot:
         module.exit_json(changed=changed)
     elif snapshot and snapshot["Status"] != "deleting":
@@ -291,56 +256,56 @@ def ensure_snapshot_absent():
     module.exit_json(changed=changed)
 
 
-def ensure_snapshot_present(params):
+def ensure_snapshot_present(client, module: AnsibleAWSModule, params: Dict[str, Any]) -> None:
     source_id = module.params.get("source_db_snapshot_identifier")
-    snapshot_name = module.params.get("db_snapshot_identifier")
+    snapshot_id = module.params.get("db_snapshot_identifier")
     changed = False
-    snapshot = get_snapshot(snapshot_name)
+
+    snapshot = get_snapshot(client, module, snapshot_id, "instance")
 
     # Copy snapshot
     if source_id:
-        changed |= copy_snapshot(params)
+        changed |= copy_snapshot(client, module, params)
 
     # Create snapshot
     elif not snapshot:
-        changed |= create_snapshot(params)
+        changed |= create_snapshot(client, module, params)
 
     # Snapshot exists and we're not creating a copy - modify exising snapshot
     else:
-        changed |= modify_snapshot()
+        changed |= modify_snapshot(client, module)
 
-    snapshot = get_snapshot(snapshot_name)
+    snapshot = get_snapshot(client, module, snapshot_id, "instance")
     module.exit_json(changed=changed, **camel_dict_to_snake_dict(snapshot, ignore_list=["Tags"]))
 
 
-def create_snapshot(params):
-    method_params = get_parameters(params, "create_db_snapshot")
-    if method_params.get("Tags"):
-        method_params["Tags"] = ansible_dict_to_boto3_tag_list(method_params["Tags"])
+def create_snapshot(client, module: AnsibleAWSModule, params: Dict[str, Any]) -> bool:
+    method_params = format_rds_client_method_parameters(client, module, params, "create_db_snapshot", format_tags=True)
     _snapshot, changed = call_method(client, module, "create_db_snapshot", method_params)
 
     return changed
 
 
-def copy_snapshot(params):
+def copy_snapshot(client, module: AnsibleAWSModule, params: Dict[str, Any]) -> bool:
     changed = False
     snapshot_id = module.params.get("db_snapshot_identifier")
-    snapshot = get_snapshot(snapshot_id)
+    snapshot = get_snapshot(client, module, snapshot_id, "instance")
 
     if not snapshot:
-        method_params = get_parameters(params, "copy_db_snapshot")
-        if method_params.get("Tags"):
-            method_params["Tags"] = ansible_dict_to_boto3_tag_list(method_params["Tags"])
+        params["TargetDBSnapshotIdentifier"] = module.params["db_snapshot_identifier"]
+        method_params = format_rds_client_method_parameters(
+            client, module, params, "copy_db_snapshot", format_tags=True
+        )
         _result, changed = call_method(client, module, "copy_db_snapshot", method_params)
 
     return changed
 
 
-def modify_snapshot():
+def modify_snapshot(client, module: AnsibleAWSModule) -> bool:
     # TODO - add other modifications aside from purely tags
     changed = False
     snapshot_id = module.params.get("db_snapshot_identifier")
-    snapshot = get_snapshot(snapshot_id)
+    snapshot = get_snapshot(client, module, snapshot_id, "instance")
 
     if module.params.get("tags"):
         changed |= ensure_tags(
@@ -356,9 +321,6 @@ def modify_snapshot():
 
 
 def main():
-    global client
-    global module
-
     argument_spec = dict(
         state=dict(choices=["present", "absent"], default="present"),
         db_snapshot_identifier=dict(aliases=["id", "snapshot_id"], required=True),
@@ -376,20 +338,15 @@ def main():
         argument_spec=argument_spec,
         supports_check_mode=True,
     )
-
-    retry_decorator = AWSRetry.jittered_backoff(retries=10)
-    try:
-        client = module.client("rds", retry_decorator=retry_decorator)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to connect to AWS.")
+    client = module.client("rds", retry_decorator=AWSRetry.jittered_backoff())
 
     state = module.params.get("state")
     if state == "absent":
-        ensure_snapshot_absent()
+        ensure_snapshot_absent(client, module)
 
     elif state == "present":
         params = arg_spec_to_rds_params(dict((k, module.params[k]) for k in module.params if k in argument_spec))
-        ensure_snapshot_present(params)
+        ensure_snapshot_present(client, module, params)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/rds_snapshot_info.py
+++ b/plugins/modules/rds_snapshot_info.py
@@ -193,7 +193,9 @@ from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 
-def common_snapshot_info(client, module: AnsibleAWSModule, describe_snapshots_method: Callable, params: Dict[str, Any]) -> List[Dict[str, Any]]:
+def common_snapshot_info(
+    client, module: AnsibleAWSModule, describe_snapshots_method: Callable, params: Dict[str, Any]
+) -> List[Dict[str, Any]]:
     try:
         results = describe_snapshots_method(client, **params)
     except AnsibleRDSError as e:

--- a/plugins/modules/rds_snapshot_info.py
+++ b/plugins/modules/rds_snapshot_info.py
@@ -193,7 +193,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 
-def common_snapshot_info(client, module: AnsibleAWSModule, describe_snapshots_method: Callable, params: Dict[str, Any]):
+def common_snapshot_info(client, module: AnsibleAWSModule, describe_snapshots_method: Callable, params: Dict[str, Any]) -> List[Dict[str, Any]]:
     try:
         results = describe_snapshots_method(client, **params)
     except AnsibleRDSError as e:
@@ -268,7 +268,7 @@ def main():
         ],
     )
 
-    client = module.client("rds", retry_decorator=AWSRetry.jittered_backoff())
+    client = module.client("rds")
     results = dict()
     if not module.params["db_cluster_identifier"] and not module.params["db_cluster_snapshot_identifier"]:
         results["snapshots"] = instance_snapshot_info(client, module)

--- a/plugins/modules/rds_snapshot_info.py
+++ b/plugins/modules/rds_snapshot_info.py
@@ -189,7 +189,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleA
 from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
 from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_cluster_snapshots
 from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_snapshots
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 

--- a/plugins/modules/rds_snapshot_info.py
+++ b/plugins/modules/rds_snapshot_info.py
@@ -178,52 +178,42 @@ cluster_snapshots:
       sample: "vpc-abcd1234"
 """
 
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
+from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_cluster_snapshots
+from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_snapshots
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
-try:
-    import botocore
-except ImportError:
-    pass  # caught by AnsibleAWSModule
 
-
-def common_snapshot_info(module, conn, method, prefix, params):
-    paginator = conn.get_paginator(method)
+def common_snapshot_info(client, module: AnsibleAWSModule, describe_snapshots_method: Callable, params: Dict[str, Any]):
     try:
-        results = paginator.paginate(**params).build_full_result()[f"{prefix}s"]
-    except is_boto3_error_code(f"{prefix}NotFound"):
-        results = []
-    except (
-        botocore.exceptions.ClientError,
-        botocore.exceptions.BotoCoreError,
-    ) as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, "trying to get snapshot information")
+        results = describe_snapshots_method(client, **params)
+    except AnsibleRDSError as e:
+        module.fail_json_aws(e, "Failed to get snapshot information")
 
     for snapshot in results:
-        try:
-            if snapshot["SnapshotType"] != "shared":
-                snapshot["Tags"] = boto3_tag_list_to_ansible_dict(
-                    conn.list_tags_for_resource(ResourceName=snapshot[f"{prefix}Arn"], aws_retry=True)["TagList"]
-                )
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            snapshot_name = snapshot[f"{prefix}Identifier"]
-            module.fail_json_aws(e, f"Couldn't get tags for snapshot {snapshot_name}")
+        if snapshot["SnapshotType"] != "shared":
+            snapshot["Tags"] = boto3_tag_list_to_ansible_dict(snapshot.pop("Tags", []))
 
     return [camel_dict_to_snake_dict(snapshot, ignore_list=["Tags"]) for snapshot in results]
 
 
-def cluster_snapshot_info(module, conn):
-    snapshot_name = module.params.get("db_cluster_snapshot_identifier")
+def cluster_snapshot_info(client, module: AnsibleAWSModule) -> List[Dict[str, Any]]:
+    snapshot_id = module.params.get("db_cluster_snapshot_identifier")
     snapshot_type = module.params.get("snapshot_type")
     instance_name = module.params.get("db_cluster_identifier")
 
     params = dict()
-    if snapshot_name:
-        params["DBClusterSnapshotIdentifier"] = snapshot_name
+    if snapshot_id:
+        params["DBClusterSnapshotIdentifier"] = snapshot_id
     if instance_name:
         params["DBClusterIdentifier"] = instance_name
     if snapshot_type:
@@ -233,17 +223,17 @@ def cluster_snapshot_info(module, conn):
         elif snapshot_type == "shared":
             params["IncludeShared"] = True
 
-    return common_snapshot_info(module, conn, "describe_db_cluster_snapshots", "DBClusterSnapshot", params)
+    return common_snapshot_info(client, module, describe_db_cluster_snapshots, params)
 
 
-def standalone_snapshot_info(module, conn):
-    snapshot_name = module.params.get("db_snapshot_identifier")
+def instance_snapshot_info(client, module: AnsibleAWSModule) -> List[Dict[str, Any]]:
+    snapshot_id = module.params.get("db_snapshot_identifier")
     snapshot_type = module.params.get("snapshot_type")
     instance_name = module.params.get("db_instance_identifier")
 
     params = dict()
-    if snapshot_name:
-        params["DBSnapshotIdentifier"] = snapshot_name
+    if snapshot_id:
+        params["DBSnapshotIdentifier"] = snapshot_id
     if instance_name:
         params["DBInstanceIdentifier"] = instance_name
     if snapshot_type:
@@ -253,7 +243,7 @@ def standalone_snapshot_info(module, conn):
         elif snapshot_type == "shared":
             params["IncludeShared"] = True
 
-    return common_snapshot_info(module, conn, "describe_db_snapshots", "DBSnapshot", params)
+    return common_snapshot_info(client, module, describe_db_snapshots, params)
 
 
 def main():
@@ -278,12 +268,12 @@ def main():
         ],
     )
 
-    conn = module.client("rds", retry_decorator=AWSRetry.jittered_backoff(retries=10))
+    client = module.client("rds", retry_decorator=AWSRetry.jittered_backoff())
     results = dict()
     if not module.params["db_cluster_identifier"] and not module.params["db_cluster_snapshot_identifier"]:
-        results["snapshots"] = standalone_snapshot_info(module, conn)
+        results["snapshots"] = instance_snapshot_info(client, module)
     if not module.params["db_snapshot_identifier"] and not module.params["db_instance_identifier"]:
-        results["cluster_snapshots"] = cluster_snapshot_info(module, conn)
+        results["cluster_snapshots"] = cluster_snapshot_info(client, module)
 
     module.exit_json(changed=False, **results)
 

--- a/tests/unit/module_utils/test_rds.py
+++ b/tests/unit/module_utils/test_rds.py
@@ -792,6 +792,14 @@ def test_get_snapshot_success(
     assert rds.get_snapshot(client, module, "my-snapshot", snapshot_type, convert_tags) == expected
 
 
+def test_get_snapshot_error():
+    client = MagicMock()
+    module = MagicMock()
+    with pytest.raises(ValueError) as e:
+        rds.get_snapshot(client, module, "my-snapshot", "bad parameter")
+    assert "Invalid snapshot_type. Expected one of: ('cluster', 'instance')" in str(e)
+
+
 @patch(mod_name + ".describe_db_snapshots")
 @patch(mod_name + ".describe_db_cluster_snapshots")
 def test_get_snapshot_failure(m_describe_db_cluster_snapshots, m_describe_db_snapshots):

--- a/tests/unit/module_utils/test_rds.py
+++ b/tests/unit/module_utils/test_rds.py
@@ -786,30 +786,16 @@ def test_get_snapshot_success(
     m_describe_db_cluster_snapshots, m_describe_db_snapshots, snapshots, snapshot_type, convert_tags, expected
 ):
     client = MagicMock()
-    module = MagicMock()
     m_describe_db_cluster_snapshots.return_value = snapshots
     m_describe_db_snapshots.return_value = snapshots
-    assert rds.get_snapshot(client, module, "my-snapshot", snapshot_type, convert_tags) == expected
+    assert rds.get_snapshot(client, "my-snapshot", snapshot_type, convert_tags) == expected
 
 
 def test_get_snapshot_error():
     client = MagicMock()
-    module = MagicMock()
     with pytest.raises(ValueError) as e:
-        rds.get_snapshot(client, module, "my-snapshot", "bad parameter")
+        rds.get_snapshot(client, "my-snapshot", "bad parameter")
     assert "Invalid snapshot_type. Expected one of: ('cluster', 'instance')" in str(e)
-
-
-@patch(mod_name + ".describe_db_snapshots")
-@patch(mod_name + ".describe_db_cluster_snapshots")
-def test_get_snapshot_failure(m_describe_db_cluster_snapshots, m_describe_db_snapshots):
-    client = MagicMock()
-    module = MagicMock()
-    e = rds.AnsibleRDSError()
-    m_describe_db_cluster_snapshots.side_effect = e
-    m_describe_db_snapshots.side_effect = e
-    rds.get_snapshot(client, module, "my-snapshot", "instance")
-    module.fail_json_aws.assert_called_once_with(e, msg="Failed to get snapshot: my-snapshot")
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/plugins/modules/test_rds_instance.py
+++ b/tests/unit/plugins/modules/test_rds_instance.py
@@ -9,7 +9,6 @@ from unittest.mock import patch
 import pytest
 
 from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
-from ansible_collections.amazon.aws.plugins.modules.rds_instance import get_final_snapshot
 from ansible_collections.amazon.aws.plugins.modules.rds_instance import get_instance
 
 mod_name = "ansible_collections.amazon.aws.plugins.modules.rds_instance"
@@ -71,34 +70,3 @@ def test_get_instance_failure(m_describe_db_instances):
     m_describe_db_instances.side_effect = e
     get_instance(client, module, "my-instance")
     module.fail_json_aws.assert_called_once_with(e, msg="Failed to get DB instance my-instance")
-
-
-@pytest.mark.parametrize(
-    "snapshots, expected",
-    [
-        ([], {}),
-        (
-            [{"DBSnapshotIdentifier": "my-snapshot", "DBInstanceIdentifier": "my-instance"}],
-            {"DBSnapshotIdentifier": "my-snapshot", "DBInstanceIdentifier": "my-instance"},
-        ),
-        ([{"DBSnapshotIdentifier": "snapshot-1"}, {"DBSnapshotIdentifier": "snapshot-2"}], {}),
-    ],
-)
-@patch(mod_name + ".describe_db_snapshots")
-def test_get_final_snapshot_success(m_describe_db_snapshots, snapshots, expected):
-    client = MagicMock()
-    module = MagicMock()
-    m_describe_db_snapshots.return_value = snapshots
-    assert get_final_snapshot(client, module, "my-snapshot") == expected
-
-
-@patch(mod_name + ".describe_db_snapshots")
-def test_get_final_snapshot_failure(m_describe_db_snapshots):
-    client = MagicMock()
-    module = MagicMock()
-    e = AnsibleRDSError()
-    m_describe_db_snapshots.side_effect = e
-    get_final_snapshot(client, module, "my-snapshot")
-    module.fail_json_aws.assert_called_once_with(
-        e, msg="Failed to retrieve information about the final snapshot: my-snapshot"
-    )


### PR DESCRIPTION
##### SUMMARY
Move shared functionality from rds snapshot modules into rds module_utils. Second PR for https://github.com/ansible-collections/amazon.aws/issues/2003 / https://issues.redhat.com/browse/ACA-1343.

##### COMPONENT NAME
rds_cluster_snapshot
rds_instance_snapshot
rds_instance
rds_snapshot_info
module_utils/rds.py

##### ADDITIONAL INFORMATION

Detailed summary of all the changes:

module_utils/rds.py:

- Add describe_db_cluster_snapshots() function
- Add get_snapshot() function to retrieve a single db instance or cluster snapshot using internal describe_db_snapshots() and describe_db_cluster_snapshots()
- Add format_rds_client_method_parameters() to validate and format parameters for boto3 rds client methods
- Update internal collection imports to use full collection path
- Add unit tests for new functions

rds_instance module:

- Replace get_final_snapshot() function with calls to get_snapshot() from module_utils/rds.py
- Replace parameter formatting logic in get_parameters() with call to format_rds_client_method_parameters() from module_utils/rds.py
- Remove unit tests for deleted get_final_snapshot() function
    
rds_instance_snapshot module:

- Replace get_snapshot() function with calls to get_snapshot() from module_utils/rds.py
- Replace get_parameters() function with call to format_rds_client_method_parameters() from module_utils/rds.py
- Remove global variables
- Add type hinting to all functions
    
rds_cluster_snapshot module:

- Replace get_parameters() function with call to format_rds_client_method_parameters() from module_utils/rds.py
- Remove global variables
- Add type hinting to all functions
    
rds_snapshot_info module:

- Refactor internal common_snapshot_info() function to use describe_db_snapshots() and describe_db_cluster_snapshots() functions from module_utils/rds.py
- Rename some variables to ensure consistent variable naming
- Add type hinting to all functions