### PR TITLE
Tests - Replace use of db.t2 instance class

### DIFF
--- a/changelogs/fragments/2141-rds-t3-m4.yml
+++ b/changelogs/fragments/2141-rds-t3-m4.yml
@@ -1,0 +1,2 @@
+trivial:
+- rds_instance - remove references to deprecated ``m4`` and ``t2`` RDS instance types (https://github.com/ansible-collections/amazon.aws/pull/2141).

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -120,7 +120,7 @@ options:
         type: str
     db_instance_class:
         description:
-          - The compute and memory capacity of the DB instance, for example db.t2.micro.
+          - The compute and memory capacity of the DB instance, for example V(db.t3.micro).
         aliases:
           - class
           - instance_type
@@ -463,7 +463,7 @@ EXAMPLES = r"""
   amazon.aws.rds_instance:
     engine: aurora
     db_instance_identifier: ansible-test-aurora-db-instance
-    instance_type: db.t2.small
+    instance_type: db.t3.small
     password: "{{ password }}"
     username: "{{ username }}"
     cluster_id: ansible-test-cluster  # This cluster must exist - see rds_cluster to manage it
@@ -474,7 +474,7 @@ EXAMPLES = r"""
     state: present
     engine: mariadb
     storage_encrypted: true
-    db_instance_class: db.t2.medium
+    db_instance_class: db.t3.medium
     username: "{{ username }}"
     password: "{{ password }}"
     allocated_storage: "{{ allocated_storage }}"
@@ -602,7 +602,7 @@ db_instance_class:
   description: The name of the compute and memory capacity class of the DB instance.
   returned: always
   type: str
-  sample: db.m4.large
+  sample: db.m5.large
 db_instance_identifier:
   description: The identifier of the DB instance
   returned: always

--- a/plugins/modules/rds_instance_info.py
+++ b/plugins/modules/rds_instance_info.py
@@ -91,7 +91,7 @@ instances:
       description: Instance class of the database instance
       returned: always
       type: str
-      sample: db.t2.small
+      sample: db.t3.small
     db_instance_identifier:
       description: Database instance identifier
       returned: always

--- a/tests/integration/targets/inventory_aws_rds/playbooks/tasks/rds_instance_create.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/tasks/rds_instance_create.yml
@@ -3,7 +3,7 @@
   amazon.aws.rds_instance:
     state: present
     engine: "{{ instance_engine }}"
-    db_instance_class: db.t2.micro
+    db_instance_class: db.t3.micro
     allocated_storage: 20
     instance_id: "{{ instance_id }}"
     master_username: ansibletestuser

--- a/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_with_hostvars_prefix_suffix.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_with_hostvars_prefix_suffix.yml
@@ -23,7 +23,7 @@
     - name: assert the hostvars are defined with prefix and/or suffix
       ansible.builtin.assert:
         that:
-          - hostvars[instance_id][vars_prefix+"db_instance_class"+vars_suffix] == 'db.t2.micro'
+          - hostvars[instance_id][vars_prefix+"db_instance_class"+vars_suffix] == 'db.t3.micro'
           - hostvars[instance_id][vars_prefix+"engine"+vars_suffix] == instance_engine
           - hostvars[instance_id][vars_prefix+"db_instance_status"+vars_suffix] in ('available', 'creating')
           - "'db_instance_class' not in hostvars[instance_id]"

--- a/tests/integration/targets/rds_option_group/defaults/main.yml
+++ b/tests/integration/targets/rds_option_group/defaults/main.yml
@@ -6,8 +6,8 @@ option_group_description: "{{ resource_prefix }}rds-option-group test"
 instance_id: "{{ resource_prefix }}"
 username: test
 password: test12345678
-db_instance_class: db.t2.small
-storage_encrypted_db_instance_class: db.t2.small
+db_instance_class: db.t3.small
+storage_encrypted_db_instance_class: db.t3.small
 allocated_storage: 20
 vpc_name: "{{ resource_prefix }}-vpc"
 vpc_seed: "{{ resource_prefix }}"


### PR DESCRIPTION
##### SUMMARY

Amazon's dropping support for M4/R4/T2 RDS DB instances, replace their use in tests before something suddenly fails.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

rds

##### ADDITIONAL INFORMATION