### PR TITLE
Rework of client creation error handling.

### DIFF
--- a/changelogs/fragments/20240628-boto3_conn.yml
+++ b/changelogs/fragments/20240628-boto3_conn.yml
@@ -1,0 +1,9 @@
+breaking_changes:
+- module_utils.botocore - ``boto3_conn``'s  ``conn_type`` parameter is now mandatory ().
+minor_changes:
+- module_utils.botocore - the ``boto3_conn`` method now catches ``BotoCoreError`` rather than an incomplete list of subclasses ().
+- plugin_utils.botocore - the ``boto3_conn`` method now catches ``BotoCoreError`` rather than an incomplete list of subclasses ().
+trivial_changes:
+- module_utils.botocore - added Type hints ().
+- plugin_utils.botocore - added Type hints ().
+- plugin_utils.base - added Type hints ().

--- a/changelogs/fragments/20240628-boto3_conn.yml
+++ b/changelogs/fragments/20240628-boto3_conn.yml
@@ -3,6 +3,7 @@ breaking_changes:
 minor_changes:
 - module_utils.botocore - the ``boto3_conn`` method now catches ``BotoCoreError`` rather than an incomplete list of subclasses ().
 - plugin_utils.botocore - the ``boto3_conn`` method now catches ``BotoCoreError`` rather than an incomplete list of subclasses ().
+- module_utils.botocore - replace use of ``botocore.Session`` with ``boto3.Session`` for consistency ().
 trivial_changes:
 - module_utils.botocore - added Type hints ().
 - plugin_utils.botocore - added Type hints ().

--- a/changelogs/fragments/20240628-boto3_conn.yml
+++ b/changelogs/fragments/20240628-boto3_conn.yml
@@ -1,10 +1,10 @@
 breaking_changes:
-- module_utils.botocore - ``boto3_conn``'s  ``conn_type`` parameter is now mandatory ().
+- module_utils.botocore - ``boto3_conn``'s  ``conn_type`` parameter is now mandatory (https://github.com/ansible-collections/amazon.aws/pull/2157).
 minor_changes:
-- module_utils.botocore - the ``boto3_conn`` method now catches ``BotoCoreError`` rather than an incomplete list of subclasses ().
-- plugin_utils.botocore - the ``boto3_conn`` method now catches ``BotoCoreError`` rather than an incomplete list of subclasses ().
-- module_utils.botocore - replace use of ``botocore.Session`` with ``boto3.Session`` for consistency ().
-trivial_changes:
-- module_utils.botocore - added Type hints ().
-- plugin_utils.botocore - added Type hints ().
-- plugin_utils.base - added Type hints ().
+- module_utils.botocore - the ``boto3_conn`` method now catches ``BotoCoreError`` rather than an incomplete list of subclasses (https://github.com/ansible-collections/amazon.aws/pull/2157).
+- plugin_utils.botocore - the ``boto3_conn`` method now catches ``BotoCoreError`` rather than an incomplete list of subclasses (https://github.com/ansible-collections/amazon.aws/pull/2157).
+- module_utils.botocore - replace use of ``botocore.Session`` with ``boto3.Session`` for consistency (https://github.com/ansible-collections/amazon.aws/pull/2157).
+trivial:
+- module_utils.botocore - added Type hints (https://github.com/ansible-collections/amazon.aws/pull/2157).
+- plugin_utils.botocore - added Type hints (https://github.com/ansible-collections/amazon.aws/pull/2157).
+- plugin_utils.base - added Type hints (https://github.com/ansible-collections/amazon.aws/pull/2157).

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -41,7 +41,6 @@ import logging
 import os
 import re
 import traceback
-import typing
 from io import StringIO
 from typing import Any
 from typing import Dict

--- a/plugins/plugin_utils/base.py
+++ b/plugins/plugin_utils/base.py
@@ -3,8 +3,12 @@
 # (c) 2022 Red Hat Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from typing import NoReturn
+from typing import Optional
+
 from ansible.errors import AnsibleError
 from ansible.module_utils.basic import to_native
+from ansible.plugins import AnsiblePlugin
 from ansible.utils.display import Display
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import check_sdk_version_supported
@@ -17,24 +21,24 @@ display = Display()
 
 
 class AWSPluginBase:
-    def warn(self, message):
+    def warn(self, message: str):
         display.warning(message)
 
-    def debug(self, message):
+    def debug(self, message: str):
         display.debug(message)
 
     # Should be overridden with the plugin-type specific exception
-    def _do_fail(self, message):
+    def _do_fail(self, message: str) -> NoReturn:
         raise AnsibleError(message)
 
     # We don't know what the correct exception is to raise, so the actual "raise" is handled by
     # _do_fail()
-    def fail_aws(self, message, exception=None):
+    def fail_aws(self, message: str, exception: Optional[Exception] = None) -> NoReturn:
         if not exception:
             self._do_fail(to_native(message))
         self._do_fail(f"{message}: {to_native(exception)}")
 
-    def client(self, service, retry_decorator=None, **extra_params):
+    def client(self, service: str, retry_decorator=None, **extra_params):
         region, endpoint_url, aws_connect_kwargs = get_aws_connection_info(self)
         kw_args = dict(region=region, endpoint=endpoint_url, **aws_connect_kwargs)
         kw_args.update(extra_params)
@@ -48,10 +52,10 @@ class AWSPluginBase:
         return boto3_conn(self, conn_type="resource", resource=service, **kw_args)
 
     @property
-    def region(self):
+    def region(self) -> Optional[str]:
         return get_aws_region(self)
 
-    def require_aws_sdk(self, botocore_version=None, boto3_version=None):
+    def require_aws_sdk(self, botocore_version: Optional[str] = None, boto3_version: Optional[str] = None) -> bool:
         return check_sdk_version_supported(
             botocore_version=botocore_version, boto3_version=boto3_version, warn=self.warn
         )

--- a/plugins/plugin_utils/base.py
+++ b/plugins/plugin_utils/base.py
@@ -8,7 +8,6 @@ from typing import Optional
 
 from ansible.errors import AnsibleError
 from ansible.module_utils.basic import to_native
-from ansible.plugins import AnsiblePlugin
 from ansible.utils.display import Display
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import check_sdk_version_supported

--- a/plugins/plugin_utils/botocore.py
+++ b/plugins/plugin_utils/botocore.py
@@ -20,7 +20,7 @@ from typing import Tuple
 from typing import Union
 
 if typing.TYPE_CHECKING:
-    from ansible_collections.amazon.aws.plugins.plugin_utils.base import AWSPluginBase
+    from .base import AWSPluginBase
 
     ClientType = botocore.client.BaseClient
     ResourceType = boto3.resources.base.ServiceResource
@@ -54,7 +54,7 @@ def boto3_conn(
         plugin.fail_aws("Couldn't connect to AWS", exception=e)
     except botocore.exceptions.NoRegionError:
         plugin.fail_aws(
-            f"The {plugin.ansible_name} plugin requires a region and none was found in configuration, "
+            f"The {plugin.ansible_name} plugin requires a region and none was found in configuration, "  # pyright: ignore[reportAttributeAccessIssue]
             "environment variables or module parameters"
         )
     except botocore.exceptions.BotoCoreError as e:
@@ -63,13 +63,13 @@ def boto3_conn(
 
 def get_aws_connection_info(plugin: AWSPluginBase) -> Tuple[Optional[str], Optional[str], Dict[str, Any]]:
     try:
-        return _aws_connection_info(plugin.get_options())
+        return _aws_connection_info(plugin.get_options())  # pyright: ignore[reportAttributeAccessIssue]
     except AnsibleBotocoreError as e:
         plugin.fail_aws(to_native(e))
 
 
 def get_aws_region(plugin: AWSPluginBase) -> Optional[str]:
     try:
-        return _aws_region(plugin.get_options())
+        return _aws_region(plugin.get_options())  # pyright: ignore[reportAttributeAccessIssue]
     except AnsibleBotocoreError as e:
         plugin.fail_aws(to_native(e))

--- a/plugins/plugin_utils/botocore.py
+++ b/plugins/plugin_utils/botocore.py
@@ -3,10 +3,28 @@
 # (c) 2022 Red Hat Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 try:
+    import boto3
     import botocore
 except ImportError:
     pass  # will be captured by imported HAS_BOTO3
+
+
+import typing
+from typing import Any
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
+if typing.TYPE_CHECKING:
+    from ansible_collections.amazon.aws.plugins.plugin_utils.base import AWSPluginBase
+
+    ClientType = botocore.client.BaseClient
+    ResourceType = boto3.resources.base.ServiceResource
+    BotoConn = Union[ClientType, ResourceType, Tuple[ClientType, ResourceType]]
 
 from ansible.module_utils.basic import to_native
 
@@ -16,7 +34,14 @@ from ansible_collections.amazon.aws.plugins.module_utils.botocore import _boto3_
 from ansible_collections.amazon.aws.plugins.module_utils.exceptions import AnsibleBotocoreError
 
 
-def boto3_conn(plugin, conn_type=None, resource=None, region=None, endpoint=None, **params):
+def boto3_conn(
+    plugin: AWSPluginBase,
+    conn_type: str,
+    resource: Optional[str] = None,
+    region: Optional[str] = None,
+    endpoint: Optional[str] = None,
+    **params,
+) -> BotoConn:
     """
     Builds a boto3 resource/client connection cleanly wrapping the most common failures.
     Handles:
@@ -36,14 +61,14 @@ def boto3_conn(plugin, conn_type=None, resource=None, region=None, endpoint=None
         plugin.fail_aws("Couldn't connect to AWS", exception=e)
 
 
-def get_aws_connection_info(plugin):
+def get_aws_connection_info(plugin: AWSPluginBase) -> Tuple[Optional[str], Optional[str], Dict[str, Any]]:
     try:
         return _aws_connection_info(plugin.get_options())
     except AnsibleBotocoreError as e:
         plugin.fail_aws(to_native(e))
 
 
-def get_aws_region(plugin):
+def get_aws_region(plugin: AWSPluginBase) -> Optional[str]:
     try:
         return _aws_region(plugin.get_options())
     except AnsibleBotocoreError as e:

--- a/plugins/plugin_utils/botocore.py
+++ b/plugins/plugin_utils/botocore.py
@@ -20,33 +20,20 @@ def boto3_conn(plugin, conn_type=None, resource=None, region=None, endpoint=None
     """
     Builds a boto3 resource/client connection cleanly wrapping the most common failures.
     Handles:
-        ValueError,
-        botocore.exceptions.ProfileNotFound, botocore.exceptions.PartialCredentialsError,
-        botocore.exceptions.NoCredentialsError, botocore.exceptions.ConfigParseError,
-        botocore.exceptions.NoRegionError
+        ValueError, botocore.exceptions.BotoCoreError
     """
 
     try:
         return _boto3_conn(conn_type=conn_type, resource=resource, region=region, endpoint=endpoint, **params)
     except ValueError as e:
-        plugin.fail_aws(f"Couldn't connect to AWS: {to_native(e)}")
-    except (
-        botocore.exceptions.ProfileNotFound,
-        botocore.exceptions.PartialCredentialsError,
-        botocore.exceptions.NoCredentialsError,
-        botocore.exceptions.ConfigParseError,
-    ) as e:
-        plugin.fail_aws(to_native(e))
+        plugin.fail_aws("Couldn't connect to AWS", exception=e)
     except botocore.exceptions.NoRegionError:
-        # ansible_name is added in 2.14
-        if hasattr(plugin, "ansible_name"):
-            plugin.fail_aws(
-                f"The {plugin.ansible_name} plugin requires a region and none was found in configuration, "
-                "environment variables or module parameters"
-            )
         plugin.fail_aws(
-            "A region is required and none was found in configuration, environment variables or module parameters"
+            f"The {plugin.ansible_name} plugin requires a region and none was found in configuration, "
+            "environment variables or module parameters"
         )
+    except botocore.exceptions.BotoCoreError as e:
+        plugin.fail_aws("Couldn't connect to AWS", exception=e)
 
 
 def get_aws_connection_info(plugin):

--- a/tests/unit/module_utils/botocore/test_aws_region.py
+++ b/tests/unit/module_utils/botocore/test_aws_region.py
@@ -4,7 +4,6 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from unittest.mock import MagicMock
-from unittest.mock import PropertyMock
 from unittest.mock import call
 from unittest.mock import sentinel
 

--- a/tests/unit/module_utils/botocore/test_aws_region.py
+++ b/tests/unit/module_utils/botocore/test_aws_region.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from unittest.mock import MagicMock
+from unittest.mock import PropertyMock
 from unittest.mock import call
 from unittest.mock import sentinel
 
@@ -33,18 +34,18 @@ def aws_module(monkeypatch):
 
 
 @pytest.fixture
-def fake_botocore(monkeypatch):
+def fake_boto3(monkeypatch):
     # Note: this isn't a monkey-patched real-botocore, this is a complete fake.
     fake_session = MagicMock()
-    fake_session.get_config_variable.return_value = sentinel.BOTO3_REGION
+    fake_session.region_name = sentinel.BOTO3_REGION
     fake_session_module = MagicMock()
     fake_session_module.Session.return_value = fake_session
-    fake_botocore = MagicMock()
-    monkeypatch.setattr(fake_botocore, "session", fake_session_module)
+    fake_boto3 = MagicMock()
+    monkeypatch.setattr(fake_boto3, "session", fake_session_module)
     # Patch exceptions back in
-    monkeypatch.setattr(fake_botocore, "exceptions", botocore.exceptions)
+    monkeypatch.setattr(fake_boto3, "exceptions", botocore.exceptions)
 
-    return fake_botocore
+    return fake_boto3
 
 
 @pytest.fixture
@@ -126,48 +127,45 @@ def test_aws_region_no_boto(monkeypatch, botocore_utils):
     assert e.value.exception is sentinel.BOTO3_IMPORT_EXCEPTION
 
 
-def test_aws_region_no_profile(monkeypatch, botocore_utils, fake_botocore):
-    monkeypatch.setattr(botocore_utils, "botocore", fake_botocore)
-    fake_session_module = fake_botocore.session
+def test_aws_region_no_profile(monkeypatch, botocore_utils, fake_boto3):
+    monkeypatch.setattr(botocore_utils, "boto3", fake_boto3)
+    fake_session_module = fake_boto3.session
     fake_session = fake_session_module.Session(sentinel.RETRIEVAL)
 
     assert botocore_utils._aws_region(dict(region=sentinel.PARAM_REGION)) is sentinel.PARAM_REGION
     assert fake_session_module.Session.call_args == call(sentinel.RETRIEVAL)
 
     assert botocore_utils._aws_region(dict()) is sentinel.BOTO3_REGION
-    assert fake_session_module.Session.call_args == call(profile=None)
-    assert fake_session.get_config_variable.call_args == call("region")
+    assert fake_session_module.Session.call_args == call(profile_name=None)
 
 
-def test_aws_region_none_profile(monkeypatch, botocore_utils, fake_botocore):
-    monkeypatch.setattr(botocore_utils, "botocore", fake_botocore)
-    fake_session_module = fake_botocore.session
+def test_aws_region_none_profile(monkeypatch, botocore_utils, fake_boto3):
+    monkeypatch.setattr(botocore_utils, "boto3", fake_boto3)
+    fake_session_module = fake_boto3.session
     fake_session = fake_session_module.Session(sentinel.RETRIEVAL)
 
     assert botocore_utils._aws_region(dict(region=sentinel.PARAM_REGION, profile=None)) is sentinel.PARAM_REGION
     assert fake_session_module.Session.call_args == call(sentinel.RETRIEVAL)
 
     assert utils_botocore._aws_region(dict(profile=None)) is sentinel.BOTO3_REGION
-    assert fake_session_module.Session.call_args == call(profile=None)
-    assert fake_session.get_config_variable.call_args == call("region")
+    assert fake_session_module.Session.call_args == call(profile_name=None)
 
 
-def test_aws_region_empty_profile(monkeypatch, botocore_utils, fake_botocore):
-    monkeypatch.setattr(botocore_utils, "botocore", fake_botocore)
-    fake_session_module = fake_botocore.session
+def test_aws_region_empty_profile(monkeypatch, botocore_utils, fake_boto3):
+    monkeypatch.setattr(botocore_utils, "boto3", fake_boto3)
+    fake_session_module = fake_boto3.session
     fake_session = fake_session_module.Session(sentinel.RETRIEVAL)
 
     assert botocore_utils._aws_region(dict(region=sentinel.PARAM_REGION, profile="")) is sentinel.PARAM_REGION
     assert fake_session_module.Session.call_args == call(sentinel.RETRIEVAL)
 
     assert utils_botocore._aws_region(dict(profile="")) is sentinel.BOTO3_REGION
-    assert fake_session_module.Session.call_args == call(profile=None)
-    assert fake_session.get_config_variable.call_args == call("region")
+    assert fake_session_module.Session.call_args == call(profile_name=None)
 
 
-def test_aws_region_with_profile(monkeypatch, botocore_utils, fake_botocore):
-    monkeypatch.setattr(botocore_utils, "botocore", fake_botocore)
-    fake_session_module = fake_botocore.session
+def test_aws_region_with_profile(monkeypatch, botocore_utils, fake_boto3):
+    monkeypatch.setattr(botocore_utils, "boto3", fake_boto3)
+    fake_session_module = fake_boto3.session
     fake_session = fake_session_module.Session(sentinel.RETRIEVAL)
 
     assert (
@@ -177,15 +175,14 @@ def test_aws_region_with_profile(monkeypatch, botocore_utils, fake_botocore):
     assert fake_session_module.Session.call_args == call(sentinel.RETRIEVAL)
 
     assert utils_botocore._aws_region(dict(profile=sentinel.PARAM_PROFILE)) is sentinel.BOTO3_REGION
-    assert fake_session_module.Session.call_args == call(profile=sentinel.PARAM_PROFILE)
-    assert fake_session.get_config_variable.call_args == call("region")
+    assert fake_session_module.Session.call_args == call(profile_name=sentinel.PARAM_PROFILE)
 
 
-def test_aws_region_bad_profile(monkeypatch, botocore_utils, fake_botocore):
+def test_aws_region_bad_profile(monkeypatch, botocore_utils, fake_boto3):
     not_found_exception = botocore.exceptions.ProfileNotFound(profile=sentinel.ERROR_PROFILE)
 
-    monkeypatch.setattr(botocore_utils, "botocore", fake_botocore)
-    fake_session_module = fake_botocore.session
+    monkeypatch.setattr(botocore_utils, "boto3", fake_boto3)
+    fake_session_module = fake_boto3.session
 
     assert (
         botocore_utils._aws_region(dict(region=sentinel.PARAM_REGION, profile=sentinel.PARAM_PROFILE))
@@ -196,4 +193,4 @@ def test_aws_region_bad_profile(monkeypatch, botocore_utils, fake_botocore):
     # bad profile name they'll see the ProfileNotFound exception
     fake_session_module.Session.side_effect = not_found_exception
     assert utils_botocore._aws_region(dict(profile=sentinel.PARAM_PROFILE)) is None
-    assert fake_session_module.Session.call_args == call(profile=sentinel.PARAM_PROFILE)
+    assert fake_session_module.Session.call_args == call(profile_name=sentinel.PARAM_PROFILE)

--- a/tests/unit/module_utils/botocore/test_boto3_conn.py
+++ b/tests/unit/module_utils/botocore/test_boto3_conn.py
@@ -42,9 +42,9 @@ def test_boto3_conn_success(monkeypatch, aws_module, botocore_utils):
     monkeypatch.setattr(botocore_utils, "_boto3_conn", connection_method)
     connection_method.return_value = sentinel.RETURNED_CONNECTION
 
-    assert botocore_utils.boto3_conn(aws_module) is sentinel.RETURNED_CONNECTION
+    assert botocore_utils.boto3_conn(aws_module, sentinel.PARAM_CONNTYPE) is sentinel.RETURNED_CONNECTION
     passed_args = connection_method.call_args
-    assert passed_args == call(conn_type=None, resource=None, region=None, endpoint=None)
+    assert passed_args == call(conn_type=sentinel.PARAM_CONNTYPE, resource=None, region=None, endpoint=None)
 
     result = botocore_utils.boto3_conn(
         aws_module,
@@ -108,7 +108,7 @@ def test_boto3_conn_exception(monkeypatch, aws_module, botocore_utils, failure, 
         custom_error = str(failure)
 
     with pytest.raises(FailException):
-        botocore_utils.boto3_conn(aws_module)
+        botocore_utils.boto3_conn(aws_module, sentinel.PARAM_CONNTYPE)
 
     fail_args = aws_module.fail_json.call_args
     assert custom_error in fail_args[1]["msg"]


### PR DESCRIPTION
##### SUMMARY

breaking_changes:
- module_utils.botocore - ``boto3_conn``'s  ``conn_type`` parameter is now mandatory.

minor_changes:
- module_utils.botocore - the ``boto3_conn`` method now catches ``BotoCoreError`` rather than an incomplete list of subclasses.
- plugin_utils.botocore - the ``boto3_conn`` method now catches ``BotoCoreError`` rather than an incomplete list of subclasses.
- module_utils.modules - replace use of ``botocore.Session`` with ``boto3.Session`` for consistency.

trivial_changes:
- module_utils.botocore - added Type hints.
- plugin_utils.botocore - added Type hints.
- plugin_utils.base - added Type hints.
- module_utils.modules - added Type hints.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/botocore.py
plugins/module_utils/modules.py
plugins/plugin_utils/base.py
plugins/plugin_utils/botocore.py

##### ADDITIONAL INFORMATION
