### PR TITLE
[9.0.0] Bump botocore/boto3 requirements (add deprecation reminder about Python 3.8 support)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ As such support for Python less than 3.8 will be removed in a release after 2024
 
 Starting with the 2.0.0 releases of amazon.aws and community.aws, it is generally the collection's policy to support the versions of `botocore` and `boto3` that were released 12 months prior to the most recent major collection release, following semantic versioning (for example, 2.0.0, 3.0.0).
 
-Version 7.0.0 of this collection supports `boto3 >= 1.26.0` and `botocore >= 1.29.0`
+Version 9.0.0 of this collection supports `boto3 >= 1.28.0` and `botocore >= 1.31.0`
 
 All support for the original AWS SDK `boto` was removed in release 4.0.0.
 

--- a/changelogs/fragments/botocore-python.yaml
+++ b/changelogs/fragments/botocore-python.yaml
@@ -1,0 +1,14 @@
+---
+breaking_changes:
+  - The amazon.aws collection has dropped support for ``botocore<1.31.0`` and
+    ``boto3<1.28.0``. Most modules will continue to work with older versions of
+    the AWS SDK.  However, compatability with older versions of the SDK is not guaranteed
+    and will not be tested. When using older versions of the SDK a warning will
+    be emitted by Ansible
+    (https://github.com/ansible-collections/amazon.aws/pull/2161).
+deprecated_features:
+  - amazon.aws collection - due to the AWS SDKs announcing the end of support
+    for Python less than 3.8 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/)
+    support for Python less than 3.8 by this collection has been deprecated
+    and will removed in release 10.0.0
+    (https://github.com/ansible-collections/amazon.aws/pull/2161).

--- a/plugins/module_utils/botocore.py
+++ b/plugins/module_utils/botocore.py
@@ -82,8 +82,8 @@ from .common import get_collection_info
 from .exceptions import AnsibleBotocoreError
 from .retries import AWSRetry
 
-MINIMUM_BOTOCORE_VERSION = "1.29.0"
-MINIMUM_BOTO3_VERSION = "1.26.0"
+MINIMUM_BOTOCORE_VERSION = "1.31.0"
+MINIMUM_BOTO3_VERSION = "1.28.0"
 
 
 def _get_user_agent_string():

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -422,7 +422,6 @@ options:
         - The storage throughput when the O(storage_type) is V(gp3).
         - When the allocated storage is below 400 GB, the storage throughput will always be 125 mb/s.
         - When the allocated storage is large than or equal 400 GB, the througput starts at 500 mb/s.
-        - Requires botocore >= 1.29.0.
       type: int
       version_added: 5.2.0
     tde_credential_arn:
@@ -600,7 +599,6 @@ backup_retention_period:
 ca_certificate_identifier:
   description:
     - The identifier of the CA certificate for the DB instance.
-    - Requires minimum botocore version 1.29.44.
   returned: always
   type: str
   sample: rds-ca-2015
@@ -1720,13 +1718,6 @@ def main():
         mutually_exclusive=mutually_exclusive,
         supports_check_mode=True,
     )
-
-    if module.params["ca_certificate_identifier"]:
-        module.require_botocore_at_least(
-            "1.29.44", reason="to use 'ca_certificate_identifier' while creating/updating rds instance"
-        )
-    if module.params["multi_tenant"]:
-        module.require_botocore_at_least("1.28.80", reason="to use 'multi_tenant' while creating rds instance")
 
     # Sanitize instance identifiers
     module.params["db_instance_identifier"] = module.params["db_instance_identifier"].lower()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 # - tests/unit/constraints.txt
 # - tests/integration/constraints.txt
 # - tests/integration/targets/setup_botocore_pip
-botocore>=1.29.0
-boto3>=1.26.0
+botocore>=1.31.0
+boto3>=1.28.0

--- a/tests/integration/constraints.txt
+++ b/tests/integration/constraints.txt
@@ -1,10 +1,10 @@
 # Specifically run tests against the oldest versions that we support
-botocore==1.29.0
-boto3==1.26.0
+botocore==1.31.0
+boto3==1.28.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.27.0
+awscli==1.29.0
 
 # AWS CLI depends on PyYAML <5.5,>=3.10; the latest PyYAML release in that range, 5.4.1, fails to install.
 # Use a version in that range that is known to work (https://github.com/yaml/pyyaml/issues/736)

--- a/tests/integration/targets/ec2_eni/tasks/test_modifying_delete_on_termination.yaml
+++ b/tests/integration/targets/ec2_eni/tasks/test_modifying_delete_on_termination.yaml
@@ -57,7 +57,9 @@
 - ansible.builtin.assert:
     that:
       - result.changed
-      - result.interface.attachment.delete_on_termination == true
+      # Although we wait for the changethe API sometimes returns the old state *after* having
+      # returned the new state.
+      # - result.interface.attachment.delete_on_termination == true
       - _interface_0.attachment.delete_on_termination == True
   vars:
     _interface_0: "{{ eni_info.network_interfaces[0] }}"
@@ -129,7 +131,9 @@
 - ansible.builtin.assert:
     that:
       - result.changed
-      - result.interface.attachment.delete_on_termination == false
+      # Although we wait for the changethe API sometimes returns the old state *after* having
+      # returned the new state.
+      # - result.interface.attachment.delete_on_termination == false
       - _interface_0.attachment.delete_on_termination == False
   vars:
     _interface_0: "{{ eni_info.network_interfaces[0] }}"

--- a/tests/integration/targets/rds_instance_modify/meta/main.yml
+++ b/tests/integration/targets/rds_instance_modify/meta/main.yml
@@ -1,5 +1,2 @@
 ---
-dependencies:
-  - role: setup_botocore_pip
-    vars:
-      botocore_version: 1.29.44
+dependencies: []

--- a/tests/integration/targets/rds_instance_modify/tasks/main.yml
+++ b/tests/integration/targets/rds_instance_modify/tasks/main.yml
@@ -208,8 +208,6 @@
           Created_by: Ansible rds_instance tests
       register: result
       check_mode: true
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Get curent CA certificate identifier
       amazon.aws.rds_instance_info:
@@ -233,8 +231,6 @@
           Name: "{{ modified_instance_id }}"
           Created_by: Ansible rds_instance tests
       register: result
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Get curent CA certificate identifier
       amazon.aws.rds_instance_info:
@@ -260,8 +256,6 @@
           Name: "{{ modified_instance_id }}"
           Created_by: Ansible rds_instance tests
       register: result
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Get curent CA certificate identifier
       amazon.aws.rds_instance_info:
@@ -288,8 +282,6 @@
           Created_by: Ansible rds_instance tests
       register: result
       check_mode: true
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Get curent CA certificate identifier
       amazon.aws.rds_instance_info:
@@ -314,8 +306,6 @@
         enable_cloudwatch_logs_exports: ["audit", "error", "general", "slowquery"]
       register: result
       check_mode: true
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Get current cloudwatch log exports
       amazon.aws.rds_instance_info:
@@ -334,8 +324,6 @@
         db_instance_identifier: "{{ modified_instance_id }}"
         enable_cloudwatch_logs_exports: ["audit", "error", "general", "slowquery"]
       register: result
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Get current cloudwatch log exports
       amazon.aws.rds_instance_info:
@@ -361,8 +349,6 @@
         db_instance_identifier: "{{ modified_instance_id }}"
         enable_cloudwatch_logs_exports: ["audit", "error", "general", "slowquery"]
       register: result
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Get current cloudwatch log exports
       amazon.aws.rds_instance_info:
@@ -383,8 +369,6 @@
         enable_cloudwatch_logs_exports: ["audit", "error"]
       register: result
       check_mode: true
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Get current cloudwatch log exports
       amazon.aws.rds_instance_info:
@@ -403,8 +387,6 @@
         db_instance_identifier: "{{ modified_instance_id }}"
         enable_cloudwatch_logs_exports: ["audit", "error"]
       register: result
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Get current cloudwatch log exports
       amazon.aws.rds_instance_info:
@@ -430,8 +412,6 @@
         enable_cloudwatch_logs_exports: []
         purge_cloudwatch_logs_exports: false
       register: result
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Get current cloudwatch log exports
       amazon.aws.rds_instance_info:
@@ -452,8 +432,6 @@
         enable_cloudwatch_logs_exports: []
       register: result
       check_mode: true
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Get current cloudwatch log exports
       amazon.aws.rds_instance_info:
@@ -472,8 +450,6 @@
         db_instance_identifier: "{{ modified_instance_id }}"
         enable_cloudwatch_logs_exports: []
       register: result
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Get current cloudwatch log exports
       amazon.aws.rds_instance_info:

--- a/tests/unit/constraints.txt
+++ b/tests/unit/constraints.txt
@@ -1,8 +1,7 @@
 # Specifically run tests against the oldest versions that we support
-botocore==1.29.0; python_version < '3.13'
-botocore==1.29.0; python_version >= '3.13'
-boto3==1.26.0
+botocore==1.31.0
+boto3==1.28.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.27.0
+awscli==1.29.0

--- a/tests/unit/module_utils/modules/ansible_aws_module/test_minimal_versions.py
+++ b/tests/unit/module_utils/modules/ansible_aws_module/test_minimal_versions.py
@@ -26,10 +26,10 @@ class TestMinimalVersionTestSuite:
     # Prepare some data for use in our testing
     # ========================================================
     def setup_method(self):
-        self.MINIMAL_BOTO3 = "1.26.0"
-        self.MINIMAL_BOTOCORE = "1.29.0"
-        self.OLD_BOTO3 = "1.25.999"
-        self.OLD_BOTOCORE = "1.28.999"
+        self.MINIMAL_BOTO3 = "1.28.0"
+        self.MINIMAL_BOTOCORE = "1.31.0"
+        self.OLD_BOTO3 = "1.27.999"
+        self.OLD_BOTOCORE = "1.30.999"
 
     # ========================================================
     #   Test we don't warn when using valid versions


### PR DESCRIPTION
##### SUMMARY

Bump botocore/boto3 requirements inline with general policy.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

README.md
changelogs/fragments/botocore-python.yaml
plugins/module_utils/botocore.py
plugins/modules/rds_instance.py
requirements.txt
tests/integration/constraints.txt
tests/unit/constraints.txt

##### ADDITIONAL INFORMATION

Note: For Python 3.13 users botocore >= 1.29.13 or later is a hard requirement (import errors due to cgi being removed)