### PR TITLE
[manual backport] Add Object Lock default retention configuration for S3 buckets (#2062)

### DIFF
--- a/changelogs/fragments/s3_bucket-object-retention.yml
+++ b/changelogs/fragments/s3_bucket-object-retention.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - s3_bucket - Add ``object_lock_default_retention`` to set Object Lock default retention configuration for S3 buckets (https://github.com/ansible-collections/amazon.aws/pull/2062).

--- a/tests/integration/targets/s3_bucket/inventory
+++ b/tests/integration/targets/s3_bucket/inventory
@@ -12,6 +12,7 @@ public_access
 acl
 object_lock
 accelerate
+default_retention
 
 [all:vars]
 ansible_connection=local

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/default_retention.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/default_retention.yml
@@ -1,0 +1,136 @@
+---
+- module_defaults:
+    group/aws:
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+    - ansible.builtin.set_fact:
+        local_bucket_name: "{{ bucket_name | hash('md5')}}-default-retention"
+
+    # ============================================================
+
+    - name: Create a simple bucket with object lock
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        state: present
+        object_lock_enabled: true
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output.changed
+          - output.object_lock_enabled
+
+    - name: Add object lock default retention
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        state: present
+        object_lock_enabled: true
+        object_lock_default_retention:
+          mode: GOVERNANCE
+          days: 1
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output.changed
+          - output.object_lock_enabled
+          - output.object_lock_default_retention
+
+    - name: Delete test s3 bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        state: absent
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output.changed
+
+    # ============================================================
+
+    - name: Create a bucket with object lock and default retention enabled
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
+        state: present
+        object_lock_enabled: true
+        object_lock_default_retention:
+          mode: GOVERNANCE
+          days: 1
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output.changed
+          - output.object_lock_enabled
+          - output.object_lock_default_retention
+
+    - name: Touch bucket with object lock enabled (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
+        state: present
+        object_lock_enabled: true
+        object_lock_default_retention:
+          mode: GOVERNANCE
+          days: 1
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - not output.changed
+          - output.object_lock_enabled
+          - output.object_lock_default_retention
+
+    - name: Change bucket with object lock default retention enabled
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
+        state: present
+        object_lock_enabled: true
+        object_lock_default_retention:
+          mode: GOVERNANCE
+          days: 2
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output.changed
+          - output.object_lock_enabled
+          - output.object_lock_default_retention
+
+    - name: Disable object lock default retention
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
+        state: present
+        object_lock_enabled: true
+      register: output
+      ignore_errors: true
+
+    - ansible.builtin.assert:
+        that:
+          - not output.changed
+
+    - name: Delete test s3 bucket
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
+        state: absent
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output.changed
+
+  # ============================================================
+  always:
+    - name: Ensure all buckets are deleted
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        state: absent
+      ignore_errors: true
+
+    - name: Ensure all buckets are deleted
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}-2"
+        state: absent
+      ignore_errors: true


### PR DESCRIPTION
SUMMARY
https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-configure.html#object-lock-configure-set-retention-period-object Design detail:
AWS API doesn't support unsetting the default retention, though it is possible in the Web console. ISSUE TYPE

Feature Pull Request

COMPONENT NAME
s3_bucket

Reviewed-by: Helen Bailey <hebailey@redhat.com>
Reviewed-by: Alina Buzachis
Reviewed-by: Mike Graves <mgraves@redhat.com>
(cherry picked from commit c2e7aaf5cadbf7873698edd3dce59ec53583e893)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
