### PR TITLE
Integration tests - Delete instances created into default VPC

### DIFF
--- a/changelogs/fragments/20240703-integration-tests-delete-instances.yml
+++ b/changelogs/fragments/20240703-integration-tests-delete-instances.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Delete EC2 instances created in default VPC for integration tests targets ec2_instance_info and ec2_instance_metadata_options. 

--- a/tests/integration/targets/ec2_instance_info/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_info/tasks/main.yml
@@ -17,6 +17,7 @@
         user_data: "{{ ec2_instance_user_data }}"
         instance_type: "{{ ec2_instance_type }}"
         wait: false
+      register: _instances
 
     - name: Gather {{ ec2_instance_name }} info
       amazon.aws.ec2_instance_info:
@@ -74,3 +75,11 @@
           - '"sriov_net_support" in _instance_info.instances[0].attributes'
           # Enclave Options
           - not (_instance_info.instances[0].attributes.enclave_options.enabled | bool)
+
+  always:
+    - name: Delete instance created for tests
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids: "{{ _instances.instance_ids }}"
+        wait: false
+      ignore_errors: true

--- a/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/tasks/main.yml
@@ -66,3 +66,10 @@
           - presented_instance_fact.instances.0.metadata_options.http_endpoint == 'enabled'
           - presented_instance_fact.instances.0.metadata_options.http_tokens == 'optional'
           - presented_instance_fact.instances.0.metadata_options.http_put_response_hop_limit == 4
+  always:
+    - name: Delete instance from default VPC
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids: "{{ instance_creation.instance_ids }}"
+        wait: false
+      ignore_errors: true


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Because the instances created in the default VPC are not directly deleted we may faced some capacity issue while running some CI validation.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`CI`