### PR TITLE
Add 'alternative' for EC2_REGION deprecation for non-module plugins

### DIFF
--- a/plugins/doc_fragments/region.py
+++ b/plugins/doc_fragments/region.py
@@ -47,4 +47,5 @@ options:
           removed_at_date: '2024-12-01'
           collection_name: amazon.aws
           why: 'EC2 in the name implied it was limited to EC2 resources, when it is used for all connections'
+          alternatives: AWS_REGION
 """


### PR DESCRIPTION
##### SUMMARY

Adds "alternative" key to documentation for deprecated `EC2_REGION` env variable.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/doc_fragments/region.py

##### ADDITIONAL INFORMATION

Fixes sanity issue:
```
 ERROR: Found 5 validate-modules issue(s) which need to be resolved:
ERROR: plugins/inventory/aws_ec2.py:0:0: invalid-documentation: DOCUMENTATION.options.region.env.1.deprecated.Any('alternatives', 'alternative', msg=None): required key not provided @ data['options']['region']['env'][1]['deprecated'][Any('alternatives', 'alternative', msg=None)]. Got None
ERROR: plugins/inventory/aws_rds.py:0:0: invalid-documentation: DOCUMENTATION.options.region.env.1.deprecated.Any('alternatives', 'alternative', msg=None): required key not provided @ data['options']['region']['env'][1]['deprecated'][Any('alternatives', 'alternative', msg=None)]. Got None
ERROR: plugins/lookup/aws_account_attribute.py:0:0: invalid-documentation: DOCUMENTATION.options.region.env.1.deprecated.Any('alternatives', 'alternative', msg=None): required key not provided @ data['options']['region']['env'][1]['deprecated'][Any('alternatives', 'alternative', msg=None)]. Got None
ERROR: plugins/lookup/secretsmanager_secret.py:0:0: invalid-documentation: DOCUMENTATION.options.region.env.1.deprecated.Any('alternatives', 'alternative', msg=None): required key not provided @ data['options']['region']['env'][1]['deprecated'][Any('alternatives', 'alternative', msg=None)]. Got None
ERROR: plugins/lookup/ssm_parameter.py:0:0: invalid-documentation: DOCUMENTATION.options.region.env.1.deprecated.Any('alternatives', 'alternative', msg=None): required key not provided @ data['options']['region']['env'][1]['deprecated'][Any('alternatives', 'alternative', msg=None)]. Got None
```