### PR TITLE
Switch from t3.micro to t3a.micro in some of the integration tests

### DIFF
--- a/changelogs/fragments/use_t3a_micro_in_tests.yml
+++ b/changelogs/fragments/use_t3a_micro_in_tests.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Switch to using t3a.micro in amazon.aws tests to avoid intermittent failures.

--- a/tests/integration/targets/ec2_instance_instance_minimal/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_minimal/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_minimal
-ec2_instance_type: t3.micro
+ec2_instance_type: t3a.micro
 ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-minimal"

--- a/tests/integration/targets/ec2_instance_instance_multiple/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_multiple/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_multiple
-ec2_instance_type: t3.micro
+ec2_instance_type: t3a.micro
 ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-multiple"

--- a/tests/integration/targets/ec2_instance_instance_no_wait/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_no_wait/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_no_wait
-ec2_instance_type: t3.micro
+ec2_instance_type: t3a.micro
 ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-no-wait"

--- a/tests/integration/targets/ec2_instance_license_specifications/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_license_specifications/defaults/main.yml
@@ -1,6 +1,6 @@
 ---
 # defaults file for ec2_instance_block_devices
-ec2_instance_type: t3.micro
+ec2_instance_type: t3a.micro
 ec2_instance_tag_TestId: "{{ resource_prefix }}-license-specifications"
 ec2_host_resource_group_arn: arn:aws:resource-groups:{{ aws_region }}:123456789012:group/{{ resource_prefix }}-resource-group
 ec2_license_configuration_arn: arn:aws:license-manager:{{ aws_region }}:123456789012:license-configuration:lic-0123456789

--- a/tests/integration/targets/ec2_instance_metadata_options/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_metadata_options/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_metadata_options
-ec2_instance_type: t3.micro
+ec2_instance_type: t3a.micro
 ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-metadata"

--- a/tests/integration/targets/ec2_instance_security_group/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_security_group/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_security_group
-ec2_instance_type: t3.micro
+ec2_instance_type: t3a.micro
 ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-sg"

--- a/tests/integration/targets/ec2_instance_state_config_updates/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_state_config_updates/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_state_config_updates
-ec2_instance_type: t3.micro
+ec2_instance_type: t3a.micro
 ec2_instance_tag_TestId: "{{ resource_prefix }}-state-config-updates"

--- a/tests/integration/targets/ec2_instance_tags_and_vpc_settings/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_tags_and_vpc_settings/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_tags_and_vpc_settings
-ec2_instance_type: t3.micro
+ec2_instance_type: t3a.micro
 ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-tags-vpc"

--- a/tests/integration/targets/ec2_instance_termination_protection/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_termination_protection/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_termination_protection
-ec2_instance_type: t3.micro
+ec2_instance_type: t3a.micro
 ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-temination"

--- a/tests/integration/targets/ec2_instance_uptime/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_uptime/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # defaults file for ec2_instance_uptime
-ec2_instance_type: t3.micro
+ec2_instance_type: t3a.micro
 ec2_instance_tag_TestId: "{{ resource_prefix }}-instance-uptime"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Refer: https://issues.redhat.com/browse/ACA-1691

Requires https://github.com/mattclay/aws-terminator/pull/304 for permissions.

Some of the ec2 instance types used in the integration tests are switched to t3a.micro to avoid intermittent failures in the CI

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
