### PR TITLE
Ensure placement group is deleted

### DIFF
--- a/tests/integration/targets/ec2_instance_placement_options/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_placement_options/tasks/main.yml
@@ -97,3 +97,9 @@
         wait: false
       ignore_errors: true
       when: instance_creation_tenancy is defined
+
+    - name: Delete placement group.
+      community.aws.ec2_placement_group:
+        name: "{{ ec2_placement_group_name }}"
+        state: absent
+      ignore_errors: true


### PR DESCRIPTION
##### SUMMARY

ec2_instance tests aren't deleting the placement groups they created (and the cleanup lambda isn't deleting them either)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tests/integration/targets/ec2_instance_placement_options/tasks/main.yml

##### ADDITIONAL INFORMATION
