### PR TITLE
Refactor ec2_instance and ec2_instance_info modules

### DIFF
--- a/changelogs/fragments/20240712-refactor-ec2_instance-modules.yaml
+++ b/changelogs/fragments/20240712-refactor-ec2_instance-modules.yaml
@@ -1,0 +1,6 @@
+---
+minor_changes:
+  - ec2_instance_info - refactored code to use ``AnsibleEC2Error`` and shared code from module_utils.ec2 (https://github.com/ansible-collections/amazon.aws/pull/2192).
+  - ec2_instance_info - Replaced call to deprecated function `datetime.utcnow()` by `datetime.now(timezone.utc)` (https://github.com/ansible-collections/amazon.aws/pull/2192).
+  - ec2_instance - Pass variables `client` and `module` as function arguments instead of global variables (https://github.com/ansible-collections/amazon.aws/pull/2192).
+  - ec2_instance - refactored code to use ``AnsibleEC2Error`` and shared code from module_utils.ec2 (https://github.com/ansible-collections/amazon.aws/pull/2192).

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -653,22 +653,22 @@ def modify_instance_attribute(
     return True
 
 
-@EC2InstanceErrorHandler.common_error_handler("terminate instances")
-@AWSRetry.jittered_backoff(catch_extra_error_codes=EC2_INSTANCE_CATCH_EXTRA_CODES)
+@EC2InstanceErrorHandler.list_error_handler("terminate instances", [])
+@AWSRetry.jittered_backoff()
 def terminate_instances(client, instance_ids: List[str]) -> List[Dict[str, Any]]:
     return client.terminate_instances(InstanceIds=instance_ids)["TerminatingInstances"]
 
 
-@EC2InstanceErrorHandler.common_error_handler("stop instances")
-@AWSRetry.jittered_backoff(catch_extra_error_codes=EC2_INSTANCE_CATCH_EXTRA_CODES)
+@EC2InstanceErrorHandler.list_error_handler("stop instances", [])
+@AWSRetry.jittered_backoff()
 def stop_instances(
     client, instance_ids: List[str], **params: Dict[str, Union[bool, List[str]]]
 ) -> List[Dict[str, Any]]:
     return client.stop_instances(InstanceIds=instance_ids, **params)["StoppingInstances"]
 
 
-@EC2InstanceErrorHandler.common_error_handler("start instances")
-@AWSRetry.jittered_backoff(catch_extra_error_codes=EC2_INSTANCE_CATCH_EXTRA_CODES)
+@EC2InstanceErrorHandler.list_error_handler("start instances", [])
+@AWSRetry.jittered_backoff()
 def start_instances(
     client, instance_ids: List[str], **params: Dict[str, Union[str, List[str]]]
 ) -> List[Dict[str, Any]]:

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1853,7 +1853,9 @@ def await_instances(
         module.warn(f"Instances {instance_ids} took too long to reach state {boto3_waiter_type}. {to_native(e)}")
 
 
-def diff_instance_and_params(client, module: AnsibleAWSModule, instance: Dict[str, Any], skip: Optional[List[str]] = None) -> List[Dict[str, Any]]:
+def diff_instance_and_params(
+    client, module: AnsibleAWSModule, instance: Dict[str, Any], skip: Optional[List[str]] = None
+) -> List[Dict[str, Any]]:
     """boto3 instance obj, module params"""
 
     if skip is None:

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1762,7 +1762,7 @@ def build_top_level_options(module: AnsibleAWSModule) -> Dict[str, Any]:
     return spec
 
 
-def build_instance_tags(params: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+def build_instance_tags(params: Dict[str, Any]) -> List[Dict[str, Any]]:
     tags = params.get("tags") or {}
     if params.get("name") is not None:
         tags["Name"] = params.get("name")
@@ -1853,7 +1853,7 @@ def await_instances(
         module.warn(f"Instances {instance_ids} took too long to reach state {boto3_waiter_type}. {to_native(e)}")
 
 
-def diff_instance_and_params(client, module: AnsibleAWSModule, instance: Dict[str, Any], skip=None):
+def diff_instance_and_params(client, module: AnsibleAWSModule, instance: Dict[str, Any], skip: Optional[List[str]] = None) -> List[Dict[str, Any]]:
     """boto3 instance obj, module params"""
 
     if skip is None:

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1770,15 +1770,12 @@ def build_instance_tags(params: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     return specs
 
 
-def build_run_instance_spec(client, module: AnsibleAWSModule, current_count: Optional[int] = None) -> Dict[str, Any]:
+def build_run_instance_spec(client, module: AnsibleAWSModule, current_count: int = 0) -> Dict[str, Any]:
     spec = dict(
         ClientToken=uuid.uuid4().hex,
     )
     params = module.params
     spec.update(**build_top_level_options(module))
-
-    if current_count is None:
-        current_count = 0
 
     nb_instances = params.get("count") or 1
     if params.get("exact_count"):

--- a/tests/integration/targets/ec2_instance_network/tasks/enis.yml
+++ b/tests/integration/targets/ec2_instance_network/tasks/enis.yml
@@ -19,14 +19,14 @@
 
 - name: Make instance with 1 existing ENI
   amazon.aws.ec2_instance:
-    state: present
+    state: started
     name: "{{ ec2_instance_name }}-a"
     image_id: "{{ ec2_ami_id }}"
     network_interfaces_ids:
       - id: "{{ eni_a.interface.id }}"
         device_index: 0
     instance_type: "t2.micro"
-    wait: false
+    wait: true
   register: create_instance
 
 - name: Set instance Id

--- a/tests/unit/plugins/modules/ec2_instance/test_build_run_instance_spec.py
+++ b/tests/unit/plugins/modules/ec2_instance/test_build_run_instance_spec.py
@@ -3,6 +3,7 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from unittest.mock import MagicMock
 from unittest.mock import sentinel
 
 import pytest
@@ -11,15 +12,16 @@ import ansible_collections.amazon.aws.plugins.modules.ec2_instance as ec2_instan
 
 
 @pytest.fixture
-def params_object():
-    params = {
+def ansible_aws_module():
+    module = MagicMock()
+    module.params = {
         "iam_instance_profile": None,
         "exact_count": None,
         "count": None,
         "launch_template": None,
         "instance_type": sentinel.INSTANCE_TYPE,
     }
-    return params
+    return module
 
 
 @pytest.fixture
@@ -30,10 +32,10 @@ def ec2_instance(monkeypatch):
     monkeypatch.setattr(
         ec2_instance_module, "build_top_level_options", lambda params: {"TOP_LEVEL_OPTIONS": sentinel.TOP_LEVEL}
     )
-    monkeypatch.setattr(ec2_instance_module, "build_network_spec", lambda params: sentinel.NETWORK_SPEC)
+    monkeypatch.setattr(ec2_instance_module, "build_network_spec", lambda client, params: sentinel.NETWORK_SPEC)
     monkeypatch.setattr(ec2_instance_module, "build_volume_spec", lambda params: sentinel.VOlUME_SPEC)
     monkeypatch.setattr(ec2_instance_module, "build_instance_tags", lambda params: sentinel.TAG_SPEC)
-    monkeypatch.setattr(ec2_instance_module, "determine_iam_role", lambda params: sentinel.IAM_PROFILE_ARN)
+    monkeypatch.setattr(ec2_instance_module, "determine_iam_role", lambda module, name_or_arn: sentinel.IAM_PROFILE_ARN)
     return ec2_instance_module
 
 
@@ -76,52 +78,57 @@ def _assert_defaults(instance_spec, to_skip=None):
         instance_spec["InstanceType"] == sentinel.INSTANCE_TYPE
 
 
-def test_build_run_instance_spec_defaults(params_object, ec2_instance):
-    instance_spec = ec2_instance.build_run_instance_spec(params_object)
+def test_build_run_instance_spec_defaults(ansible_aws_module, ec2_instance):
+    client = MagicMock()
+    instance_spec = ec2_instance.build_run_instance_spec(client, ansible_aws_module)
     _assert_defaults(instance_spec)
 
 
-def test_build_run_instance_spec_type_required(params_object, ec2_instance):
-    params_object["instance_type"] = None
-    params_object["launch_template"] = None
-    # Test that we throw an Ec2InstanceAWSError if passed neither
-    with pytest.raises(ec2_instance.Ec2InstanceAWSError):
-        instance_spec = ec2_instance.build_run_instance_spec(params_object)
+def test_build_run_instance_spec_type_required(ansible_aws_module, ec2_instance):
+    client = MagicMock()
+    ansible_aws_module.params["instance_type"] = None
+    ansible_aws_module.params["launch_template"] = None
+    # Test that we throw an AnsibleEC2Error if passed neither
+    with pytest.raises(ec2_instance.AnsibleEC2Error):
+        instance_spec = ec2_instance.build_run_instance_spec(client, ansible_aws_module)
 
     # Test that instance_type can be None if launch_template is set
-    params_object["launch_template"] = sentinel.LAUNCH_TEMPLATE
-    instance_spec = ec2_instance.build_run_instance_spec(params_object)
+    ansible_aws_module.params["launch_template"] = sentinel.LAUNCH_TEMPLATE
+    instance_spec = ec2_instance.build_run_instance_spec(client, ansible_aws_module)
     _assert_defaults(instance_spec, ["InstanceType"])
     assert "InstanceType" not in instance_spec
 
 
-def test_build_run_instance_spec_tagging(params_object, ec2_instance, monkeypatch):
+def test_build_run_instance_spec_tagging(ansible_aws_module, ec2_instance, monkeypatch):
+    client = MagicMock()
     # build_instance_tags can return None, RunInstance doesn't like this
     monkeypatch.setattr(ec2_instance_module, "build_instance_tags", lambda params: None)
-    instance_spec = ec2_instance.build_run_instance_spec(params_object)
+    instance_spec = ec2_instance.build_run_instance_spec(client, ansible_aws_module)
     _assert_defaults(instance_spec, ["TagSpecifications"])
     assert "TagSpecifications" not in instance_spec
 
     # if someone *explicitly* passes {} (rather than not setting it), then [] can be returned
     monkeypatch.setattr(ec2_instance_module, "build_instance_tags", lambda params: [])
-    instance_spec = ec2_instance.build_run_instance_spec(params_object)
+    instance_spec = ec2_instance.build_run_instance_spec(client, ansible_aws_module)
     _assert_defaults(instance_spec, ["TagSpecifications"])
     assert "TagSpecifications" in instance_spec
     assert instance_spec["TagSpecifications"] == []
 
 
-def test_build_run_instance_spec_instance_profile(params_object, ec2_instance):
-    params_object["iam_instance_profile"] = sentinel.INSTANCE_PROFILE_NAME
-    instance_spec = ec2_instance.build_run_instance_spec(params_object)
+def test_build_run_instance_spec_instance_profile(ansible_aws_module, ec2_instance):
+    client = MagicMock()
+    ansible_aws_module.params["iam_instance_profile"] = sentinel.INSTANCE_PROFILE_NAME
+    instance_spec = ec2_instance.build_run_instance_spec(client, ansible_aws_module)
     _assert_defaults(instance_spec, ["IamInstanceProfile"])
     assert "IamInstanceProfile" in instance_spec
     assert instance_spec["IamInstanceProfile"] == {"Arn": sentinel.IAM_PROFILE_ARN}
 
 
-def test_build_run_instance_spec_count(params_object, ec2_instance):
+def test_build_run_instance_spec_count(ansible_aws_module, ec2_instance):
+    client = MagicMock()
     # When someone passes 'count', that number of instances will be *launched*
-    params_object["count"] = sentinel.COUNT
-    instance_spec = ec2_instance.build_run_instance_spec(params_object)
+    ansible_aws_module.params["count"] = sentinel.COUNT
+    instance_spec = ec2_instance.build_run_instance_spec(client, ansible_aws_module)
     _assert_defaults(instance_spec, ["MaxCount", "MinCount"])
     assert "MaxCount" in instance_spec
     assert "MinCount" in instance_spec
@@ -129,13 +136,14 @@ def test_build_run_instance_spec_count(params_object, ec2_instance):
     assert instance_spec["MinCount"] == sentinel.COUNT
 
 
-def test_build_run_instance_spec_exact_count(params_object, ec2_instance):
+def test_build_run_instance_spec_exact_count(ansible_aws_module, ec2_instance):
+    client = MagicMock()
     # The "exact_count" logic relies on enforce_count doing the math to figure out how many
     # instances to start/stop.  The enforce_count call is responsible for ensuring that 'to_launch'
     # is set and is a positive integer.
-    params_object["exact_count"] = 42
-    params_object["to_launch"] = sentinel.TO_LAUNCH
-    instance_spec = ec2_instance.build_run_instance_spec(params_object)
+    ansible_aws_module.params["exact_count"] = 42
+    ansible_aws_module.params["to_launch"] = sentinel.TO_LAUNCH
+    instance_spec = ec2_instance.build_run_instance_spec(client, ansible_aws_module)
 
     _assert_defaults(instance_spec, ["MaxCount", "MinCount"])
     assert "MaxCount" in instance_spec
@@ -143,7 +151,7 @@ def test_build_run_instance_spec_exact_count(params_object, ec2_instance):
     assert instance_spec["MaxCount"] == 42
     assert instance_spec["MinCount"] == 42
 
-    instance_spec = ec2_instance.build_run_instance_spec(params_object, 7)
+    instance_spec = ec2_instance.build_run_instance_spec(client, ansible_aws_module, 7)
 
     _assert_defaults(instance_spec, ["MaxCount", "MinCount"])
     assert "MaxCount" in instance_spec

--- a/tests/unit/plugins/modules/ec2_instance/test_determine_iam_role.py
+++ b/tests/unit/plugins/modules/ec2_instance/test_determine_iam_role.py
@@ -33,18 +33,6 @@ def _client_error(code="GenericError"):
     )
 
 
-@pytest.fixture
-def params_object():
-    params = {
-        "instance_role": None,
-        "exact_count": None,
-        "count": None,
-        "launch_template": None,
-        "instance_type": None,
-    }
-    return params
-
-
 class FailJsonException(Exception):
     def __init__(self):
         pass
@@ -53,53 +41,58 @@ class FailJsonException(Exception):
 @pytest.fixture
 def ec2_instance(monkeypatch):
     monkeypatch.setattr(ec2_instance_module, "validate_aws_arn", lambda arn, service, resource_type: None)
-    monkeypatch.setattr(ec2_instance_module, "module", MagicMock())
-    ec2_instance_module.module.fail_json.side_effect = FailJsonException()
-    ec2_instance_module.module.fail_json_aws.side_effect = FailJsonException()
     return ec2_instance_module
 
 
-def test_determine_iam_role_arn(params_object, ec2_instance, monkeypatch):
+@pytest.fixture
+def ansible_module():
+    module = MagicMock()
+    module.fail_json.side_effect = FailJsonException()
+    module.fail_json_aws.side_effect = FailJsonException()
+    return module
+
+
+def test_determine_iam_role_arn(ec2_instance, ansible_module, monkeypatch):
     # Revert the default monkey patch to make it simple to try passing a valid ARNs
     monkeypatch.setattr(ec2_instance, "validate_aws_arn", utils_arn.validate_aws_arn)
 
     # Simplest example, someone passes a valid instance profile ARN
-    arn = ec2_instance.determine_iam_role("arn:aws:iam::123456789012:instance-profile/myprofile")
+    arn = ec2_instance.determine_iam_role(ansible_module, "arn:aws:iam::123456789012:instance-profile/myprofile")
     assert arn == "arn:aws:iam::123456789012:instance-profile/myprofile"
 
 
-def test_determine_iam_role_name(params_object, ec2_instance):
+def test_determine_iam_role_name(ec2_instance, ansible_module):
     profile_description = {"InstanceProfile": {"Arn": sentinel.IAM_PROFILE_ARN}}
     iam_client = MagicMock(**{"get_instance_profile.return_value": profile_description})
-    ec2_instance_module.module.client.return_value = iam_client
+    ansible_module.client.return_value = iam_client
 
-    arn = ec2_instance.determine_iam_role(sentinel.IAM_PROFILE_NAME)
+    arn = ec2_instance.determine_iam_role(ansible_module, sentinel.IAM_PROFILE_NAME)
     assert arn == sentinel.IAM_PROFILE_ARN
 
 
-def test_determine_iam_role_missing(params_object, ec2_instance):
+def test_determine_iam_role_missing(ec2_instance, ansible_module):
     missing_exception = _client_error("NoSuchEntity")
     iam_client = MagicMock(**{"get_instance_profile.side_effect": missing_exception})
-    ec2_instance_module.module.client.return_value = iam_client
+    ansible_module.client.return_value = iam_client
 
     with pytest.raises(FailJsonException):
-        ec2_instance.determine_iam_role(sentinel.IAM_PROFILE_NAME)
+        ec2_instance.determine_iam_role(ansible_module, sentinel.IAM_PROFILE_NAME)
 
-    assert ec2_instance_module.module.fail_json_aws.call_count == 1
-    assert ec2_instance_module.module.fail_json_aws.call_args.args[0] is missing_exception
-    assert "Could not find" in ec2_instance_module.module.fail_json_aws.call_args.kwargs["msg"]
+    assert ansible_module.fail_json_aws.call_count == 1
+    assert ansible_module.fail_json_aws.call_args.args[0] is missing_exception
+    assert "Could not find" in ansible_module.fail_json_aws.call_args.kwargs["msg"]
 
 
 @pytest.mark.skipif(sys.version_info < (3, 8), reason="call_args behaviour changed in Python 3.8")
-def test_determine_iam_role_missing(params_object, ec2_instance):
+def test_determine_iam_role_missing(ec2_instance, ansible_module):
     missing_exception = _client_error()
     iam_client = MagicMock(**{"get_instance_profile.side_effect": missing_exception})
-    ec2_instance_module.module.client.return_value = iam_client
+    ansible_module.client.return_value = iam_client
 
     with pytest.raises(FailJsonException):
-        ec2_instance.determine_iam_role(sentinel.IAM_PROFILE_NAME)
+        ec2_instance.determine_iam_role(ansible_module, sentinel.IAM_PROFILE_NAME)
 
-    assert ec2_instance_module.module.fail_json_aws.call_count == 1
-    assert ec2_instance_module.module.fail_json_aws.call_args.args[0] is missing_exception
-    assert "An error occurred while searching" in ec2_instance_module.module.fail_json_aws.call_args.kwargs["msg"]
-    assert "Please try supplying the full ARN" in ec2_instance_module.module.fail_json_aws.call_args.kwargs["msg"]
+    assert ansible_module.fail_json_aws.call_count == 1
+    assert ansible_module.fail_json_aws.call_args.args[0] is missing_exception
+    assert "An error occurred while searching" in ansible_module.fail_json_aws.call_args.kwargs["msg"]
+    assert "Please try supplying the full ARN" in ansible_module.fail_json_aws.call_args.kwargs["msg"]


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Refactor `ec2_instance` and `ec2_instance_info` modules
- Call to AWS was moved to `module_utils/ec2`, update module to use this shared code.
- `ec2_instance_info`: replace python deprecated function `datetime.utcnow()` with `datetime.now(timezone.utc)`.
- `ec2_instance`: Pass variable `client` and `module` as function arguments instead of using global variables.
- Add type hinting

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
- `ec2_instance`
- `ec2_instance_info`
