### PR TITLE
s3_bucket - fix transfer acceleration issue with AWS GovCloud

### DIFF
--- a/changelogs/fragments/20240715-s3_bucket-transfer-accelerate.yaml
+++ b/changelogs/fragments/20240715-s3_bucket-transfer-accelerate.yaml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - s3_bucket - Remove the default value for the ``accelerate_enabled`` option (https://github.com/ansible-collections/amazon.aws/issues/2180).

--- a/changelogs/fragments/20240715-s3_bucket-transfer-accelerate.yaml
+++ b/changelogs/fragments/20240715-s3_bucket-transfer-accelerate.yaml
@@ -1,3 +1,3 @@
 ---
-breaking_changes:
-  - s3_bucket - Remove the default value for the ``accelerate_enabled`` option (https://github.com/ansible-collections/amazon.aws/issues/2180).
+bugfixes:
+  - s3_bucket - catch ``UnsupportedArgument`` when calling API ``GetBucketAccelerationConfig`` on region where it is not supported (https://github.com/ansible-collections/amazon.aws/issues/2180).

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -155,7 +155,7 @@ options:
     description:
       - Whether the bucket name should be validated to conform to AWS S3 naming rules.
       - On by default, this may be disabled for S3 backends that do not enforce these rules.
-      - See https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+      - See U(https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html).
     type: bool
     version_added: 3.1.0
     default: true
@@ -169,8 +169,9 @@ options:
   accelerate_enabled:
     description:
       - Enables Amazon S3 Transfer Acceleration, sent data will be routed to Amazon S3 over an optimized network path.
+      - Transfer Acceleration is not available in AWS GovCloud (US).
+      - See U(https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html#govcloud-S3-diffs).
     type: bool
-    default: false
     version_added: 8.1.0
   object_lock_default_retention:
     description:
@@ -448,7 +449,7 @@ public_access_block:
 accelerate_enabled:
     description: S3 bucket acceleration status.
     type: bool
-    returned: O(state=present)
+    returned: When O(state=present) and tranfer acceleration is available in the AWS region where the bucket is located.
     sample: true
 """
 
@@ -456,6 +457,7 @@ import json
 import time
 from typing import Iterator
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 try:
@@ -933,7 +935,7 @@ def handle_bucket_object_lock(s3_client, module: AnsibleAWSModule, name: str) ->
     return object_lock_result
 
 
-def handle_bucket_accelerate(s3_client, module: AnsibleAWSModule, name: str) -> tuple[bool, bool]:
+def handle_bucket_accelerate(s3_client, module: AnsibleAWSModule, name: str) -> tuple[bool, Optional[bool]]:
     """
     Manage transfer accelerate for an S3 bucket.
     Parameters:
@@ -951,11 +953,14 @@ def handle_bucket_accelerate(s3_client, module: AnsibleAWSModule, name: str) -> 
         accelerate_status = get_bucket_accelerate_status(s3_client, name)
         accelerate_enabled_result = accelerate_status
     except is_boto3_error_code(["NotImplemented", "XNotImplemented"]) as e:
-        if accelerate_enabled is not None:
-            module.fail_json_aws(e, msg="Fetching bucket transfer acceleration state is not supported")
+        module.fail_json_aws(e, msg="Fetching bucket transfer acceleration state is not supported")
+    except is_boto3_error_code("UnsupportedArgument") as e:  # pylint: disable=duplicate-except
+        # -- Transfer Acceleration is not available in AWS GovCloud (US).
+        # -- https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html#govcloud-S3-diffs
+        module.warn("Tranfer acceleration is not available in S3 bucket region.")
+        accelerate_enabled_result = None
     except is_boto3_error_code("AccessDenied") as e:  # pylint: disable=duplicate-except
-        if accelerate_enabled is not None:
-            module.fail_json_aws(e, msg="Permission denied fetching transfer acceleration for bucket")
+        module.fail_json_aws(e, msg="Permission denied fetching transfer acceleration for bucket")
     except (
         botocore.exceptions.BotoCoreError,
         botocore.exceptions.ClientError,
@@ -1103,8 +1108,11 @@ def create_or_update_bucket(s3_client, module: AnsibleAWSModule):
     result["object_lock_enabled"] = bucket_object_lock_result
 
     # -- Transfer Acceleration
-    bucket_accelerate_changed, bucket_accelerate_result = handle_bucket_accelerate(s3_client, module, name)
-    result["accelerate_enabled"] = bucket_accelerate_result
+    bucket_accelerate_changed = False
+    if module.params.get("accelerate_enabled") is not None:
+        bucket_accelerate_changed, bucket_accelerate_result = handle_bucket_accelerate(s3_client, module, name)
+        if bucket_accelerate_result is not None:
+            result["accelerate_enabled"] = bucket_accelerate_result
 
     # -- Object Lock Default Retention
     bucket_object_lock_retention_changed, bucket_object_lock_retention_result = handle_bucket_object_lock_retention(
@@ -2009,7 +2017,7 @@ def main():
         acl=dict(type="str", choices=["private", "public-read", "public-read-write", "authenticated-read"]),
         validate_bucket_name=dict(type="bool", default=True),
         dualstack=dict(default=False, type="bool"),
-        accelerate_enabled=dict(default=False, type="bool"),
+        accelerate_enabled=dict(type="bool"),
         object_lock_enabled=dict(type="bool"),
         object_lock_default_retention=dict(
             type="dict",

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/accelerate.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/accelerate.yml
@@ -20,7 +20,7 @@
     - ansible.builtin.assert:
         that:
           - output.changed
-          - not output.accelerate_enabled
+          - '"accelerate_enabled" not in output'
 
     - name: Re-disable transfer acceleration (idempotency)
       amazon.aws.s3_bucket:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/accelerate.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/accelerate.yml
@@ -20,7 +20,7 @@
     - ansible.builtin.assert:
         that:
           - output.changed
-          - '"accelerate_enabled" not in output'
+          - not output.accelerate_enabled
 
     - name: Re-disable transfer acceleration (idempotency)
       amazon.aws.s3_bucket:

--- a/tests/unit/plugins/modules/s3_bucket/test_handle_bucket_accelerate.py
+++ b/tests/unit/plugins/modules/s3_bucket/test_handle_bucket_accelerate.py
@@ -1,0 +1,90 @@
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+from unittest.mock import sentinel
+
+import botocore
+import pytest
+
+from ansible_collections.amazon.aws.plugins.modules.s3_bucket import handle_bucket_accelerate
+
+module_name = "ansible_collections.amazon.aws.plugins.modules.s3_bucket"
+
+
+def a_botocore_exception(message):
+    return botocore.exceptions.ClientError({"Error": {"Code": message}}, sentinel.BOTOCORE_ACTION)
+
+
+@pytest.fixture
+def ansible_module():
+    mock = MagicMock()
+    mock.params = {"accelerate_enabled": sentinel.ACCELERATE_ENABLED}
+    mock.fail_json_aws.side_effect = SystemExit(1)
+    return mock
+
+
+@pytest.mark.parametrize(
+    "code,message",
+    [
+        ("NotImplemented", "Fetching bucket transfer acceleration state is not supported"),
+        ("XNotImplemented", "Fetching bucket transfer acceleration state is not supported"),
+        ("AccessDenied", "Permission denied fetching transfer acceleration for bucket"),
+        (sentinel.BOTO_CLIENT_ERROR, "Failed to fetch bucket transfer acceleration state"),
+    ],
+)
+@patch(module_name + ".get_bucket_accelerate_status")
+def test_failure(m_get_bucket_accelerate_status, ansible_module, code, message):
+    bucket_name = sentinel.BUCKET_NAME
+    client = MagicMock()
+    exc = a_botocore_exception(code)
+    m_get_bucket_accelerate_status.side_effect = exc
+    with pytest.raises(SystemExit):
+        handle_bucket_accelerate(client, ansible_module, bucket_name)
+    ansible_module.fail_json_aws.assert_called_once_with(exc, msg=message)
+
+
+@patch(module_name + ".get_bucket_accelerate_status")
+def test_unsupported(m_get_bucket_accelerate_status, ansible_module):
+    bucket_name = sentinel.BUCKET_NAME
+    client = MagicMock()
+    m_get_bucket_accelerate_status.side_effect = a_botocore_exception("UnsupportedArgument")
+    changed, result = handle_bucket_accelerate(client, ansible_module, bucket_name)
+    assert changed is False
+    assert result is None
+    ansible_module.warn.assert_called_once()
+
+
+@pytest.mark.parametrize("accelerate_enabled", [True, False])
+@patch(module_name + ".delete_bucket_accelerate_configuration")
+@patch(module_name + ".get_bucket_accelerate_status")
+def test_delete(
+    m_get_bucket_accelerate_status, m_delete_bucket_accelerate_configuration, ansible_module, accelerate_enabled
+):
+    bucket_name = sentinel.BUCKET_NAME
+    client = MagicMock()
+    ansible_module.params.update({"accelerate_enabled": accelerate_enabled})
+    m_get_bucket_accelerate_status.return_value = True
+    if not accelerate_enabled:
+        assert (True, False) == handle_bucket_accelerate(client, ansible_module, bucket_name)
+        m_delete_bucket_accelerate_configuration.assert_called_once_with(client, bucket_name)
+    else:
+        assert (False, True) == handle_bucket_accelerate(client, ansible_module, bucket_name)
+        m_delete_bucket_accelerate_configuration.assert_not_called()
+
+
+@pytest.mark.parametrize("accelerate_enabled", [True, False])
+@patch(module_name + ".put_bucket_accelerate_configuration")
+@patch(module_name + ".get_bucket_accelerate_status")
+def test_put(m_get_bucket_accelerate_status, m_put_bucket_accelerate_configuration, ansible_module, accelerate_enabled):
+    bucket_name = sentinel.BUCKET_NAME
+    client = MagicMock()
+    ansible_module.params.update({"accelerate_enabled": accelerate_enabled})
+    m_get_bucket_accelerate_status.return_value = False
+    if accelerate_enabled:
+        assert (True, True) == handle_bucket_accelerate(client, ansible_module, bucket_name)
+        m_put_bucket_accelerate_configuration.assert_called_once_with(client, bucket_name)
+    else:
+        assert (False, False) == handle_bucket_accelerate(client, ansible_module, bucket_name)
+        m_put_bucket_accelerate_configuration.assert_not_called()

--- a/tests/unit/plugins/modules/s3_bucket/test_handle_bucket_accelerate.py
+++ b/tests/unit/plugins/modules/s3_bucket/test_handle_bucket_accelerate.py
@@ -52,7 +52,7 @@ def test_unsupported(m_get_bucket_accelerate_status, ansible_module):
     m_get_bucket_accelerate_status.side_effect = a_botocore_exception("UnsupportedArgument")
     changed, result = handle_bucket_accelerate(client, ansible_module, bucket_name)
     assert changed is False
-    assert result is None
+    assert result is False
     ansible_module.warn.assert_called_once()
 
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes #2180 
`Transfer acceleration is not available for AWS GovCloud region`, this PR performs the following changes
- `GetBucketAccelerateConfiguration` operation is performed only if the user has provided `accelerate_enabled` option
- When `GetBucketAccelerateConfiguration` raises an `UnsupportedArgument` botocore exception, the module will display a warning message
- `accelerate_enabled` is set in the output only if it was provided as input
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`s3_bucket`
