### PR TITLE
Integration/ec2_eip - add tags to EIP

### DIFF
--- a/changelogs/fragments/20240718-integration-ec2_eip.yaml
+++ b/changelogs/fragments/20240718-integration-ec2_eip.yaml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - integration/ec2_eip - tags all created Elastic IP to ensure isolation of the tests.

--- a/tests/integration/targets/ec2_eip/defaults/main.yml
+++ b/tests/integration/targets/ec2_eip/defaults/main.yml
@@ -4,3 +4,7 @@
 vpc_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.0.0/16
 subnet_cidr: 10.{{ 256 | random(seed=resource_prefix) }}.42.0/24
 subnet_az: "{{ ec2_availability_zone_names[0] }}"
+eip_test_tags:
+  AnsibleEIPTestPrefix: "{{ resource_prefix }}"
+eip_info_filters:
+  tag:AnsibleEIPTestPrefix: "{{ resource_prefix }}"

--- a/tests/integration/targets/ec2_eip/tasks/allocate.yml
+++ b/tests/integration/targets/ec2_eip/tasks/allocate.yml
@@ -3,15 +3,10 @@
     # ------------------------------------------------------------------------------------------
     # Allocate EIP with no condition
     # ------------------------------------------------------------------------------------------
-    - name: Get current state of EIPs
-      amazon.aws.ec2_eip_info:
-      register: eip_info_start
-
     - name: Allocate a new EIP with no conditions - check_mode
       amazon.aws.ec2_eip:
         state: present
-        tags:
-          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
+        tags: "{{ eip_test_tags }}"
       register: eip
       check_mode: true
 
@@ -19,16 +14,16 @@
         that:
           - eip is changed
 
+    - name: Ensure no new EIP was created
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
     - name: Allocate a new EIP with no conditions
       amazon.aws.ec2_eip:
         state: present
-        tags:
-          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
+        tags: "{{ eip_test_tags }}"
       register: eip
-
-    - amazon.aws.ec2_eip_info:
-      register: eip_info
-      check_mode: true
 
     - ansible.builtin.assert:
         that:
@@ -37,7 +32,11 @@
           - "'ec2:DeleteTags' not in eip.resource_actions"
           - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
           - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
-          - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length )
+
+    - name: Ensure New EIP was created
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_new_eip: true
 
     - name: Get EIP info via public ip
       amazon.aws.ec2_eip_info:
@@ -82,33 +81,36 @@
         that:
           - eip is not changed
 
+    - name: Ensure EIP was not created
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
     - name: Allocate a new ip (idempotence)
       amazon.aws.ec2_eip:
         state: present
         public_ip: "{{ eip.public_ip }}"
       register: eip
 
-    - amazon.aws.ec2_eip_info:
-      register: eip_info
-
     - ansible.builtin.assert:
         that:
           - eip is not changed
           - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
           - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
-          - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length )
+
+    - name: Ensure EIP was not created
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     # ------------------------------------------------------------------------------------------
     # Allocate EIP from a pool
     # ------------------------------------------------------------------------------------------
-    - name: Get current state of EIPs
-      amazon.aws.ec2_eip_info:
-      register: eip_info_start
-
     - name: Allocate a new EIP from a pool - check_mode
       amazon.aws.ec2_eip:
         state: present
         public_ipv4_pool: amazon
+        tags: "{{ eip_test_tags }}"
       register: eip_pool
       check_mode: true
 
@@ -116,31 +118,31 @@
         that:
           - eip_pool is changed
 
+    - name: Ensure EIP was not created
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
     - name: Allocate a new EIP from a pool
       amazon.aws.ec2_eip:
         state: present
         public_ipv4_pool: amazon
+        tags: "{{ eip_test_tags }}"
       register: eip_pool
-
-    - amazon.aws.ec2_eip_info:
-      register: eip_info
 
     - ansible.builtin.assert:
         that:
           - eip_pool is changed
           - eip_pool.public_ip is defined and ( eip_pool.public_ip | ansible.utils.ipaddr )
           - eip_pool.allocation_id is defined and eip_pool.allocation_id.startswith("eipalloc-")
-          - ( eip_info_start.addresses | length ) + 1  == ( eip_info.addresses | length )
+
+    - name: Ensure new EIP was created
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_new_eip: true
 
   always:
-    - name: Release EIP
-      amazon.aws.ec2_eip:
-        state: absent
-        public_ip: "{{ eip.public_ip }}"
-      when: eip is defined
-
-    - name: Release EIP created from pool
-      amazon.aws.ec2_eip:
-        state: absent
-        public_ip: "{{ eip_pool.public_ip }}"
-      when: eip_pool is defined
+    - name: Delete EIP
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        delete_eips: true

--- a/tests/integration/targets/ec2_eip/tasks/attach_detach_to_eni.yml
+++ b/tests/integration/targets/ec2_eip/tasks/attach_detach_to_eni.yml
@@ -4,9 +4,13 @@
     - name: Allocate a new EIP with no conditions
       amazon.aws.ec2_eip:
         state: present
-        tags:
-          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
+        tags: "{{ eip_test_tags }}"
       register: eip
+
+    - name: Ensure EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_new_eip: true
 
     # ------------------------------------------------------------------------------------------
     # Test attach EIP to ENI
@@ -21,6 +25,11 @@
     - ansible.builtin.assert:
         that:
           - associate_eip is changed
+
+    - name: Ensure no new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Attach EIP to ENI A
       amazon.aws.ec2_eip:
@@ -47,6 +56,11 @@
           - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
           - eip_info.addresses[0].network_interface_owner_id == caller_info.account
 
+    - name: Ensure no new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
     - name: Attach EIP to ENI A (idempotence) - check_mode
       amazon.aws.ec2_eip:
         public_ip: "{{ eip.public_ip }}"
@@ -57,6 +71,11 @@
     - ansible.builtin.assert:
         that:
           - associate_eip is not changed
+
+    - name: Ensure no new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Attach EIP to ENI A (idempotence)
       amazon.aws.ec2_eip:
@@ -81,6 +100,11 @@
           - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
           - eip_info.addresses[0].network_interface_id == eni_create_a.interface.id
           - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
+
+    - name: Ensure no new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     # ------------------------------------------------------------------------------------------
     # Test attach EIP already attached
@@ -108,6 +132,11 @@
           - eip_info.addresses[0].network_interface_id == eni_create_a.interface.id
           - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
 
+    - name: Ensure no new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
     - name: Attach EIP to ENI B - check_mode
       amazon.aws.ec2_eip:
         public_ip: "{{ eip.public_ip }}"
@@ -119,6 +148,11 @@
     - ansible.builtin.assert:
         that:
           - associate_eip is changed
+
+    - name: Ensure no new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Attach EIP to ENI B
       amazon.aws.ec2_eip:
@@ -144,6 +178,11 @@
           - eip_info.addresses[0].association_id is defined and eip_info.addresses[0].association_id.startswith("eipassoc-")
           - eip_info.addresses[0].network_interface_id == eni_create_b.interface.id
           - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
+
+    - name: Ensure no new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Attach EIP to ENI B (idempotence) - check_mode
       amazon.aws.ec2_eip:
@@ -182,6 +221,10 @@
           - eip_info.addresses[0].network_interface_id == eni_create_b.interface.id
           - eip_info.addresses[0].private_ip_address is defined and ( eip_info.addresses[0].private_ip_address | ansible.utils.ipaddr )
 
+    - name: Ensure no new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
     # ------------------------------------------------------------------------------------------
     # Detach EIP from ENI B without enabling release on disassociation
     # ------------------------------------------------------------------------------------------
@@ -196,6 +239,11 @@
     - ansible.builtin.assert:
         that:
           - disassociate_eip is changed
+
+    - name: Ensure EIP was not released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Detach EIP from ENI B, without enabling release on disassociation
       amazon.aws.ec2_eip:
@@ -215,6 +263,11 @@
           - disassociate_eip.disassociated
           - not disassociate_eip.released
           - eip_info.addresses | length == 1
+
+    - name: Ensure EIP was not released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Detach EIP from ENI B, without enabling release on disassociation (idempotence) - check_mode
       amazon.aws.ec2_eip:
@@ -247,6 +300,11 @@
           - not disassociate_eip.released
           - eip_info.addresses | length == 1
 
+    - name: Ensure EIP was not released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
     # ------------------------------------------------------------------------------------------
     # Detach EIP from ENI A enabling release on disassociation
     # ------------------------------------------------------------------------------------------
@@ -256,6 +314,11 @@
         public_ip: "{{ eip.public_ip }}"
         device_id: "{{ eni_create_a.interface.id }}"
       register: associate_eip
+
+    - name: Ensure no new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Detach EIP from ENI A, enabling release on disassociation - check_mode
       amazon.aws.ec2_eip:
@@ -269,6 +332,11 @@
     - ansible.builtin.assert:
         that:
           - disassociate_eip is changed
+
+    - name: Ensure EIP was not released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Detach EIP from ENI A, enabling release on disassociation
       amazon.aws.ec2_eip:
@@ -289,6 +357,11 @@
           - disassociate_eip.disassociated
           - disassociate_eip.released
           - eip_info.addresses | length == 0
+
+    - name: Ensure EIP was released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_released_eip: true
 
     - name: Detach EIP from ENI A, enabling release on disassociation (idempotence) - check_mode
       amazon.aws.ec2_eip:
@@ -323,9 +396,13 @@
           - not disassociate_eip.released
           - eip_info.addresses | length == 0
 
+    - name: Ensure no EIP was released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
   always:
-    - name: Release EIP
-      amazon.aws.ec2_eip:
-        state: absent
-        public_ip: "{{ eip.public_ip }}"
-      when: eip is defined
+    - name: Release all allocated EIP
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        delete_eips: true

--- a/tests/integration/targets/ec2_eip/tasks/attach_detach_to_instance.yml
+++ b/tests/integration/targets/ec2_eip/tasks/attach_detach_to_instance.yml
@@ -20,18 +20,25 @@
         device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
         state: present
         release_on_disassociation: true
+        tags: "{{ eip_test_tags }}"
       register: instance_eip
       check_mode: true
 
     - ansible.builtin.assert:
         that:
           - instance_eip is changed
+
+    - name: Ensure no EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Attach EIP to an EC2 instance
       amazon.aws.ec2_eip:
         device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
         state: present
         release_on_disassociation: true
+        tags: "{{ eip_test_tags }}"
       register: instance_eip
 
     - amazon.aws.ec2_eip_info:
@@ -43,13 +50,19 @@
         that:
           - instance_eip is changed
           - eip_info.addresses[0].allocation_id is defined
-          - eip_info.addresses[0].instance_id == create_ec2_instance_result.instance_ids[0] 
+          - eip_info.addresses[0].instance_id == create_ec2_instance_result.instance_ids[0]
+
+    - name: Ensure new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_new_eip: true
 
     - name: Attach EIP to an EC2 instance (idempotence) - check_mode
       amazon.aws.ec2_eip:
         device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
         state: present
         release_on_disassociation: true
+        tags: "{{ eip_test_tags }}"
       register: instance_eip
       check_mode: true
 
@@ -57,11 +70,17 @@
         that:
           - instance_eip is not changed
 
+    - name: Ensure no EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
     - name: Attach EIP to an EC2 instance (idempotence)
       amazon.aws.ec2_eip:
         device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
         state: present
         release_on_disassociation: true
+        tags: "{{ eip_test_tags }}"
       register: instance_eip
 
     - amazon.aws.ec2_eip_info:
@@ -73,7 +92,12 @@
         that:
           - instance_eip is not changed
           - eip_info.addresses[0].allocation_id is defined
-          - eip_info.addresses[0].instance_id == create_ec2_instance_result.instance_ids[0] 
+          - eip_info.addresses[0].instance_id == create_ec2_instance_result.instance_ids[0]
+
+    - name: Ensure no EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     # ------------------------------------------------------------------------------------------
     # Detach EIP to EC2 instance
@@ -88,6 +112,11 @@
     - ansible.builtin.assert:
         that:
           - detach_eip is changed
+
+    - name: Ensure EIP was not released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Detach EIP from EC2 instance, without enabling release on disassociation
       amazon.aws.ec2_eip:
@@ -107,6 +136,11 @@
           - not detach_eip.released
           - eip_info.addresses | length == 1
 
+    - name: Ensure EIP was not released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
     - name: Detach EIP from EC2 instance, without enabling release on disassociation (idempotence) - check_mode
       amazon.aws.ec2_eip:
         state: absent
@@ -117,6 +151,11 @@
     - ansible.builtin.assert:
         that:
           - detach_eip is not changed
+
+    - name: Ensure EIP was not released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Detach EIP from EC2 instance, without enabling release on disassociation (idempotence)
       amazon.aws.ec2_eip:
@@ -136,10 +175,15 @@
           - not detach_eip.released
           - eip_info.addresses | length == 1
 
-    - name: Release EIP
-      amazon.aws.ec2_eip:
-        state: absent
-        public_ip: "{{ instance_eip.public_ip }}"
+    - name: Ensure EIP was not released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
+    - name: Release EIPs
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        delete_eips: true
 
     # ------------------------------------------------------------------------------------------
     # Attach EIP to EC2 instance with Private IP specified
@@ -150,12 +194,18 @@
         private_ip_address: "{{ create_ec2_instance_result.instances[0].private_ip_address }}"
         state: present
         release_on_disassociation: true
+        tags: "{{ eip_test_tags }}"
       register: instance_eip
       check_mode: true
 
     - ansible.builtin.assert:
         that:
           - instance_eip is changed
+
+    - name: Ensure no EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Attach EIP to an EC2 instance with private Ip specified
       amazon.aws.ec2_eip:
@@ -163,6 +213,7 @@
         private_ip_address: "{{ create_ec2_instance_result.instances[0].private_ip_address }}"
         state: present
         release_on_disassociation: true
+        tags: "{{ eip_test_tags }}"
       register: instance_eip
 
     - amazon.aws.ec2_eip_info:
@@ -174,7 +225,12 @@
         that:
           - instance_eip is changed
           - eip_info.addresses[0].allocation_id is defined
-          - eip_info.addresses[0].instance_id == create_ec2_instance_result.instance_ids[0] 
+          - eip_info.addresses[0].instance_id == create_ec2_instance_result.instance_ids[0]
+
+    - name: Ensure EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_new_eip: true
 
     - name: Attach EIP to an EC2 instance with private Ip specified (idempotence) - check_mode
       amazon.aws.ec2_eip:
@@ -182,6 +238,7 @@
         private_ip_address: "{{ create_ec2_instance_result.instances[0].private_ip_address }}"
         state: present
         release_on_disassociation: true
+        tags: "{{ eip_test_tags }}"
       register: instance_eip
       check_mode: true
 
@@ -189,12 +246,18 @@
         that:
           - instance_eip is not changed
 
+    - name: Ensure no EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
     - name: Attach EIP to an EC2 instance with private Ip specified (idempotence)
       amazon.aws.ec2_eip:
         device_id: "{{ create_ec2_instance_result.instance_ids[0] }}"
         private_ip_address: "{{ create_ec2_instance_result.instances[0].private_ip_address }}"
         state: present
         release_on_disassociation: true
+        tags: "{{ eip_test_tags }}"
       register: instance_eip
 
     - amazon.aws.ec2_eip_info:
@@ -206,7 +269,12 @@
         that:
           - instance_eip is not changed
           - eip_info.addresses[0].allocation_id is defined
-          - eip_info.addresses[0].instance_id == create_ec2_instance_result.instance_ids[0] 
+          - eip_info.addresses[0].instance_id == create_ec2_instance_result.instance_ids[0]
+
+    - name: Ensure no EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     # ------------------------------------------------------------------------------------------
     # Detach EIP from EC2 instance enabling release on disassociation
@@ -222,6 +290,11 @@
     - ansible.builtin.assert:
         that:
           - disassociate_eip is changed
+
+    - name: Ensure no EIP was released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Detach EIP from EC2 instance, enabling release on disassociation
       amazon.aws.ec2_eip:
@@ -241,6 +314,11 @@
           - disassociate_eip.disassociated
           - disassociate_eip.released
           - eip_info.addresses | length == 0
+
+    - name: Ensure EIP was released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_released_eip: true
 
     - name: Detach EIP from EC2 instance, enabling release on disassociation (idempotence) - check_mode
       amazon.aws.ec2_eip:
@@ -282,8 +360,7 @@
       ignore_errors: true
       when: create_ec2_instance_result is defined
 
-    - name: Release EIP
-      amazon.aws.ec2_eip:
-        state: absent
-        public_ip: "{{ instance_eip.public_ip }}"
-      when: instance_eip is defined
+    - name: Release EIPs
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        delete_eips: true

--- a/tests/integration/targets/ec2_eip/tasks/common.yml
+++ b/tests/integration/targets/ec2_eip/tasks/common.yml
@@ -1,0 +1,43 @@
+---
+- name: Validate number of EIPs
+  when: (has_new_eip is defined) or (has_no_new_eip is defined) or (has_released_eip is defined)
+  block:
+    - name: Get current state of EIPs
+      amazon.aws.ec2_eip_info:
+        filters: "{{ eip_info_filters }}"
+      register: eips
+
+    - ansible.builtin.assert:
+        that:
+          - (current_addresses | length + 1) == (eips.addresses | length)
+      when: has_new_eip | default('false') | bool
+
+    - ansible.builtin.assert:
+        that:
+          - current_addresses | length == (eips.addresses | length)
+      when: has_no_new_eip | default('false') | bool
+
+    - ansible.builtin.assert:
+        that:
+          - (current_addresses | length - 1) == (eips.addresses | length)
+      when: has_released_eip | default('false') | bool
+
+    - ansible.builtin.set_fact:
+        current_addresses: "{{ eips.addresses }}"
+
+- name: Delete EIPs
+  when: delete_eips | default('false') | bool
+  block:
+    - name: Get current state of EIPs
+      amazon.aws.ec2_eip_info:
+        filters: "{{ eip_info_filters }}"
+      register: eips
+
+    - name: Delete EIP
+      amazon.aws.ec2_eip:
+        state: absent
+        public_ip: "{{ item.public_ip }}"
+      with_items: "{{ eips.addresses }}"
+
+    - ansible.builtin.set_fact:
+        current_addresses: []

--- a/tests/integration/targets/ec2_eip/tasks/release.yml
+++ b/tests/integration/targets/ec2_eip/tasks/release.yml
@@ -3,16 +3,16 @@
     # ------------------------------------------------------------------------------------------
     # Release EIP
     # ------------------------------------------------------------------------------------------
-    - name: Get current state of EIPs
-      amazon.aws.ec2_eip_info:
-      register: eip_info_start
-
     - name: Allocate a new EIP with no conditions
       amazon.aws.ec2_eip:
         state: present
-        tags:
-          ResourcePrefix: "{{ resource_prefix }}"
+        tags: "{{ eip_test_tags }}"
       register: eip
+
+    - name: Ensure new EIP was created
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_new_eip: true
 
     - name: Release EIP - check_mode
       amazon.aws.ec2_eip:
@@ -25,21 +25,27 @@
         that:
           - eip_release.changed
 
+    - name: Ensure EIP was not released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
     - name: Release eip
       amazon.aws.ec2_eip:
         state: absent
         public_ip: "{{ eip.public_ip }}"
       register: eip_release
 
-    - amazon.aws.ec2_eip_info:
-      register: eip_info
-
     - ansible.builtin.assert:
         that:
           - eip_release.changed
           - not eip_release.disassociated
           - eip_release.released
-          - ( eip_info_start.addresses | length ) == ( eip_info.addresses | length )
+
+    - name: Ensure EIP was released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_released_eip: true
 
     - name: Release EIP (idempotence) - check_mode
       amazon.aws.ec2_eip:
@@ -58,18 +64,18 @@
         public_ip: "{{ eip.public_ip }}"
       register: eip_release
 
-    - amazon.aws.ec2_eip_info:
-      register: eip_info
-
     - ansible.builtin.assert:
         that:
           - not eip_release.changed
           - not eip_release.disassociated
           - not eip_release.released
-          - ( eip_info_start.addresses | length ) == ( eip_info.addresses | length )
+
+    - name: Ensure no EIP was released
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
   always:
-    - name: Release eip
-      amazon.aws.ec2_eip:
-        state: absent
-        public_ip: "{{ eip.public_ip }}"
-      when: eip is defined
+    - name: Delete EIP
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        delete_eips: true

--- a/tests/integration/targets/ec2_eip/tasks/reuse_with_tag.yml
+++ b/tests/integration/targets/ec2_eip/tasks/reuse_with_tag.yml
@@ -4,15 +4,12 @@
     # ------------------------------------------------------------------------------------------
     # Reuse with tag - No match available
     # ------------------------------------------------------------------------------------------
-    - name: Get current state of EIPs
-      amazon.aws.ec2_eip_info:
-      register: eip_current
-
     - name: attempt reusing an existing EIP with a tag (No match available) - check_mode
       amazon.aws.ec2_eip:
         state: present
         reuse_existing_ip_allowed: true
-        tag_name: Team
+        tag_name: "Team-{{ resource_prefix }}"
+        tags: "{{ eip_test_tags }}"
       register: no_tagged_eip
       check_mode: true
 
@@ -24,11 +21,9 @@
       amazon.aws.ec2_eip:
         state: present
         reuse_existing_ip_allowed: true
-        tag_name: Team
+        tag_name: "Team-{{ resource_prefix }}"
+        tags: "{{ eip_test_tags }}"
       register: no_tagged_eip
-
-    - amazon.aws.ec2_eip_info:
-      register: eip_info
 
     - ansible.builtin.assert:
         that:
@@ -36,22 +31,27 @@
           - "'ec2:CreateTags' not in no_tagged_eip.resource_actions"
           - no_tagged_eip.public_ip is defined and ( no_tagged_eip.public_ip | ansible.utils.ipaddr )
           - no_tagged_eip.allocation_id is defined and no_tagged_eip.allocation_id.startswith("eipalloc-")
-          - ( eip_current.addresses | length ) + 1  == ( eip_info.addresses | length )
+
+    - name: Ensure new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_new_eip: true
 
     # ------------------------------------------------------------------------------------------
     # Reuse with tag - Match available
     # ------------------------------------------------------------------------------------------
-    - name: Set latest EIPs list
-      ansible.builtin.set_fact:
-        eip_current: "{{ eip_info }}"
-
     - name: Tag EIP so we can try matching it
       amazon.aws.ec2_eip:
         state: present
         public_ip: "{{ no_tagged_eip.public_ip }}"
-        tags:
-          Team: Frontend
+        tags: "{{ lookup('template', 'tag.yaml.j2') | from_yaml }}"
+        purge_tags: false
       register: tag_eip
+
+    - name: Ensure no EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - ansible.builtin.assert:
         that:
@@ -64,7 +64,7 @@
       amazon.aws.ec2_eip:
         state: present
         reuse_existing_ip_allowed: true
-        tag_name: Team
+        tag_name: "Team-{{ resource_prefix }}"
       register: reallocate_eip
       check_mode: true
 
@@ -72,36 +72,39 @@
         that:
           - reallocate_eip is not changed
 
+    - name: Ensure no EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
     - name: Attempt reusing an existing EIP with a tag (Match available)
       amazon.aws.ec2_eip:
         state: present
         reuse_existing_ip_allowed: true
-        tag_name: Team
+        tag_name: "Team-{{ resource_prefix }}"
       register: reallocate_eip
-
-    - amazon.aws.ec2_eip_info:
-      register: eip_info
 
     - ansible.builtin.assert:
         that:
           - reallocate_eip is not changed
           - reallocate_eip.public_ip is defined and ( reallocate_eip.public_ip | ansible.utils.ipaddr )
           - reallocate_eip.allocation_id is defined and reallocate_eip.allocation_id.startswith("eipalloc-")
-          - ( eip_current.addresses | length )  == ( eip_info.addresses | length )
+
+    - name: Ensure no EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     # ------------------------------------------------------------------------------------------
     # Reuse with tag and value - No match available
     # ------------------------------------------------------------------------------------------
-    - name: Set latest EIPs list
-      ansible.builtin.set_fact:
-        eip_current: "{{ eip_info }}"
-
     - name: Attempt reusing an existing EIP with a tag and it's value (no match available) - check_mode
       amazon.aws.ec2_eip:
         state: present
         reuse_existing_ip_allowed: true
-        tag_name: Team
+        tag_name: "Team-{{ resource_prefix }}"
         tag_value: Backend
+        tags: "{{ eip_test_tags }}"
       register: backend_eip
       check_mode: true
 
@@ -109,44 +112,40 @@
         that:
           - backend_eip is changed
 
+    - name: Ensure no EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
     - name: Attempt reusing an existing EIP with a tag and it's value (no match available)
       amazon.aws.ec2_eip:
         state: present
         reuse_existing_ip_allowed: true
-        tag_name: Team
+        tag_name: "Team-{{ resource_prefix }}"
         tag_value: Backend
+        tags: "{{ eip_test_tags }}"
       register: backend_eip
-
-    - amazon.aws.ec2_eip_info:
-      register: eip_info
 
     - ansible.builtin.assert:
         that:
           - backend_eip is changed
           - backend_eip.public_ip is defined and ( backend_eip.public_ip | ansible.utils.ipaddr )
           - backend_eip.allocation_id is defined and backend_eip.allocation_id.startswith("eipalloc-")
-          - ( eip_current.addresses | length ) + 1  == ( eip_info.addresses | length )
+
+    - name: Ensure new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_new_eip: true
 
     # ------------------------------------------------------------------------------------------
     # Reuse with tag - Match available
     # ------------------------------------------------------------------------------------------
-    - name: Set latest EIPs list
-      ansible.builtin.set_fact:
-        eip_current: "{{ eip_info }}"
-
-    - name: Tag EIP so we can try matching it
-      amazon.aws.ec2_eip:
-        state: present
-        public_ip: "{{ backend_eip.public_ip }}"
-        tags:
-          Team: Backend
-
     - name: Attempt reusing an existing EIP with a tag and it's value (match available) - check_mode
       amazon.aws.ec2_eip:
         state: present
         reuse_existing_ip_allowed: true
-        tag_name: Team
-        tag_value: Backend
+        tag_name: "Team-{{ resource_prefix }}"
+        tag_value: Frontend
       register: reallocate_eip
       check_mode: true
 
@@ -154,33 +153,32 @@
         that:
           - reallocate_eip is not changed
 
+    - name: Ensure no new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
     - name: Attempt reusing an existing EIP with a tag and it's value (match available)
       amazon.aws.ec2_eip:
         state: present
         reuse_existing_ip_allowed: true
-        tag_name: Team
-        tag_value: Backend
+        tag_name: "Team-{{ resource_prefix }}"
+        tag_value: Frontend
       register: reallocate_eip
-
-    - amazon.aws.ec2_eip_info:
-      register: eip_info
 
     - ansible.builtin.assert:
         that:
           - reallocate_eip is not changed
           - reallocate_eip.public_ip is defined and reallocate_eip.public_ip != ""
           - reallocate_eip.allocation_id is defined and reallocate_eip.allocation_id != ""
-          - ( eip_current.addresses | length ) == ( eip_info.addresses | length )
+
+    - name: Ensure no new EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
   always:
-    - name: Release backend_eip
-      amazon.aws.ec2_eip:
-        state: absent
-        public_ip: "{{ backend_eip.public_ip }}"
-      when: backend_eip is defined
-
-    - name: Release no_tagged_eip
-      amazon.aws.ec2_eip:
-        state: absent
-        public_ip: "{{ no_tagged_eip.public_ip }}"
-      when: no_tagged_eip is defined
+    - name: Release EIPs
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        delete_eips: true

--- a/tests/integration/targets/ec2_eip/tasks/setup.yml
+++ b/tests/integration/targets/ec2_eip/tasks/setup.yml
@@ -52,3 +52,8 @@
   amazon.aws.ec2_eni:
     subnet_id: "{{ vpc_subnet_create.subnet.id }}"
   register: eni_create_b
+
+- name: Delete all existing EIP with the same tag
+  ansible.builtin.include_tasks: tasks/common.yml
+  vars:
+    delete_eips: true

--- a/tests/integration/targets/ec2_eip/tasks/tagging.yml
+++ b/tests/integration/targets/ec2_eip/tasks/tagging.yml
@@ -1,13 +1,12 @@
 ---
 - name: Test EIP tagging
+  vars:
+    add_tags:
+      another_tag: another Value {{ resource_prefix }}
   block:
     # ------------------------------------------------------------------------------------------
     # Test tagging
     # ------------------------------------------------------------------------------------------
-    - name: Get current state of EIPs
-      amazon.aws.ec2_eip_info:
-      register: eip_info_start
-
     - name: Allocate a new eip
       amazon.aws.ec2_eip:
         state: present
@@ -17,9 +16,7 @@
       amazon.aws.ec2_eip:
         state: present
         public_ip: "{{ eip.public_ip }}"
-        tags:
-          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
-          another_tag: another Value {{ resource_prefix }}
+        tags: "{{ eip_test_tags | combine(add_tags) }}"
       register: tag_eip
       check_mode: true
 
@@ -31,9 +28,7 @@
       amazon.aws.ec2_eip:
         state: present
         public_ip: "{{ eip.public_ip }}"
-        tags:
-          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
-          another_tag: another Value {{ resource_prefix }}
+        tags: "{{ eip_test_tags | combine(add_tags) }}"
       register: tag_eip
 
     - amazon.aws.ec2_eip_info:
@@ -48,15 +43,12 @@
           - '"another_tag" in eip_info.addresses[0].tags'
           - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
           - eip_info.addresses[0].tags['another_tag'] == 'another Value ' + resource_prefix
-          - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length )
 
     - name: Tag EIP (idempotence) - check_mode
       amazon.aws.ec2_eip:
         state: present
         public_ip: "{{ eip.public_ip }}"
-        tags:
-          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
-          another_tag: another Value {{ resource_prefix }}
+        tags: "{{ eip_test_tags | combine(add_tags) }}"
       register: tag_eip
       check_mode: true
 
@@ -68,9 +60,7 @@
       amazon.aws.ec2_eip:
         state: present
         public_ip: "{{ eip.public_ip }}"
-        tags:
-          AnsibleEIPTestPrefix: "{{ resource_prefix }}"
-          another_tag: another Value {{ resource_prefix }}
+        tags: "{{ eip_test_tags | combine(add_tags) }}"
       register: tag_eip
 
     - amazon.aws.ec2_eip_info:
@@ -85,15 +75,15 @@
           - '"another_tag" in eip_info.addresses[0].tags'
           - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
           - eip_info.addresses[0].tags['another_tag'] == 'another Value ' + resource_prefix
-          - ( eip_info_start.addresses | length ) + 1 == ( eip_info.addresses | length )
+
+    - name: Ensure only 1 EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_new_eip: true
 
     # ------------------------------------------------------------------------------------------
     # Test updating tags
     # ------------------------------------------------------------------------------------------
-    - name: Get current state of EIPs
-      amazon.aws.ec2_eip_info:
-      register: eip_info_start
-
     - name: Add another Tag - check_mode
       amazon.aws.ec2_eip:
         state: present
@@ -131,7 +121,11 @@
           - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
           - eip_info.addresses[0].tags['another_tag'] == 'another Value ' + resource_prefix
           - eip_info.addresses[0].tags['third tag'] == 'Third tag - ' + resource_prefix
-          - ( eip_info_start.addresses | length ) == ( eip_info.addresses | length )
+
+    - name: Ensure no EIP was allocated
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
 
     - name: Add another Tag (idempotence) - check_mode
       amazon.aws.ec2_eip:
@@ -178,8 +172,7 @@
       amazon.aws.ec2_eip:
         state: present
         public_ip: "{{ eip.public_ip }}"
-        tags:
-          third tag: Third tag - {{ resource_prefix }}
+        tags: "{{ eip_test_tags }}"
         purge_tags: true
       register: tag_eip
       check_mode: true
@@ -192,8 +185,7 @@
       amazon.aws.ec2_eip:
         state: present
         public_ip: "{{ eip.public_ip }}"
-        tags:
-          third tag: Third tag - {{ resource_prefix }}
+        tags: "{{ eip_test_tags }}"
         purge_tags: true
       register: tag_eip
 
@@ -205,17 +197,16 @@
     - ansible.builtin.assert:
         that:
           - tag_eip is changed
-          - '"AnsibleEIPTestPrefix" not in eip_info.addresses[0].tags'
+          - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
           - '"another_tag" not in eip_info.addresses[0].tags'
-          - '"third tag" in eip_info.addresses[0].tags'
-          - eip_info.addresses[0].tags['third tag'] == 'Third tag - ' + resource_prefix
+          - '"third tag" not in eip_info.addresses[0].tags'
+          - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
 
     - name: Purge tags (idempotence) - check_mode
       amazon.aws.ec2_eip:
         state: present
         public_ip: "{{ eip.public_ip }}"
-        tags:
-          third tag: Third tag - {{ resource_prefix }}
+        tags: "{{ eip_test_tags }}"
         purge_tags: true
       register: tag_eip
       check_mode: true
@@ -228,8 +219,7 @@
       amazon.aws.ec2_eip:
         state: present
         public_ip: "{{ eip.public_ip }}"
-        tags:
-          third tag: Third tag - {{ resource_prefix }}
+        tags: "{{ eip_test_tags }}"
         purge_tags: true
       register: tag_eip
 
@@ -241,14 +231,13 @@
     - ansible.builtin.assert:
         that:
           - tag_eip is not changed
-          - '"AnsibleEIPTestPrefix" not in eip_info.addresses[0].tags'
+          - '"AnsibleEIPTestPrefix" in eip_info.addresses[0].tags'
           - '"another_tag" not in eip_info.addresses[0].tags'
-          - '"third tag" in eip_info.addresses[0].tags'
-          - eip_info.addresses[0].tags['third tag'] == 'Third tag - ' + resource_prefix
+          - '"third tag" not in eip_info.addresses[0].tags'
+          - eip_info.addresses[0].tags['AnsibleEIPTestPrefix'] == resource_prefix
 
   always:
-    - name: Release EIP
-      amazon.aws.ec2_eip:
-        state: absent
-        public_ip: "{{ eip.public_ip }}"
-      when: eip is defined
+    - name: Release EIPs
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        delete_eips: true

--- a/tests/integration/targets/ec2_eip/templates/tag.yaml.j2
+++ b/tests/integration/targets/ec2_eip/templates/tag.yaml.j2
@@ -1,0 +1,1 @@
+Team-{{ resource_prefix }}: Frontend


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The validation of the tests consists in checking ***all*** the existing EIP from the account, this is unstable as it may generate unexpected if another process is running and create EIP in the same time.
We are fixing by adding tag with the `resource_prefix` to all EIP created and restrict EIP comparison to the ones having this tag.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

