### PR TITLE
Add option "metadata_token_ttl_seconds" to ec2_metadata_facts module.

### DIFF
--- a/changelogs/fragments/2209-ec2_metadata_facts-add-configurable-ttl-parameter.yml
+++ b/changelogs/fragments/2209-ec2_metadata_facts-add-configurable-ttl-parameter.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ec2_metadata_facts - Add parameter `metadata_token_ttl_seconds` (https://github.com/ansible-collections/amazon.aws/pull/2209).

--- a/changelogs/fragments/2209-ec2_metadata_facts-add-configurable-ttl-parameter.yml
+++ b/changelogs/fragments/2209-ec2_metadata_facts-add-configurable-ttl-parameter.yml
@@ -1,3 +1,3 @@
 ---
 minor_changes:
-  - ec2_metadata_facts - Add parameter `metadata_token_ttl_seconds` (https://github.com/ansible-collections/amazon.aws/pull/2209).
+  - ec2_metadata_facts - Add parameter ``metadata_token_ttl_seconds`` (https://github.com/ansible-collections/amazon.aws/pull/2209).

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -23,11 +23,22 @@ description:
       is set to disabled for the EC2 instance, the module will return an error while retrieving a session token.
 notes:
     - Parameters to filter on ec2_metadata_facts may be added later.
+options:
+    metadata_token_ttl_seconds:
+        description:
+            - Specify a value for the V(X-aws-ec2-metadata-token-ttl-seconds) header.
+            - Value must be between V(1) and V(21600).
+        type: int
+        default: V(60)
 """
 
 EXAMPLES = r"""
 # Gather EC2 metadata facts
 - amazon.aws.ec2_metadata_facts:
+
+# Set a bigger value for X-aws-ec2-metadata-token-ttl-seconds header
+- amazon.aws.ec2_metadata_facts:
+    metadata_token_ttl_seconds: 240
 
 - debug:
     msg: "This instance is a t1.micro"
@@ -610,7 +621,8 @@ class Ec2Metadata:
 
     def fetch_session_token(self, uri_token):
         """Used to get a session token for IMDSv2"""
-        headers = {"X-aws-ec2-metadata-token-ttl-seconds": "60"}
+        metadata_token_ttl_seconds = module.params.get("metadata_token_ttl_seconds")
+        headers = {"X-aws-ec2-metadata-token-ttl-seconds": metadata_token_ttl_seconds}
         response, info = fetch_url(self.module, uri_token, method="PUT", headers=headers, force=True)
 
         if info.get("status") == 403:
@@ -657,10 +669,19 @@ class Ec2Metadata:
 
 
 def main():
+    argument_spec = dict(
+        metadata_token_ttl_seconds=dict(required=False, default=60, type="int"),
+    )
+
     module = AnsibleModule(
-        argument_spec={},
+        argument_spec=argument_spec,
         supports_check_mode=True,
     )
+
+    metadata_token_ttl_seconds = module.params.get("metadata_token_ttl_seconds")
+
+    if metadata_token_ttl_seconds <= 0 or metadata_token_ttl_seconds > 21600:
+        module.fail_json(msg="The option 'metadata_token_ttl_seconds' must be set to a value between 1 and 21600.")
 
     ec2_metadata_facts = Ec2Metadata(module).run()
     ec2_metadata_facts_result = dict(changed=False, ansible_facts=ec2_metadata_facts)

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -26,7 +26,7 @@ notes:
 options:
     metadata_token_ttl_seconds:
         description:
-            - Specify a value for the V(X-aws-ec2-metadata-token-ttl-seconds) header.
+            - Specify a value for the C(X-aws-ec2-metadata-token-ttl-seconds) header.
             - Value must be between V(1) and V(21600).
         type: int
         default: 60

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -30,6 +30,7 @@ options:
             - Value must be between V(1) and V(21600).
         type: int
         default: 60
+        version_added: 8.2.0
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -671,7 +671,7 @@ class Ec2Metadata:
 
 def main():
     argument_spec = dict(
-        metadata_token_ttl_seconds=dict(required=False, default=60, type="int"),
+        metadata_token_ttl_seconds=dict(required=False, default=60, type="int", no_log=False),
     )
 
     module = AnsibleModule(

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -29,7 +29,7 @@ options:
             - Specify a value for the V(X-aws-ec2-metadata-token-ttl-seconds) header.
             - Value must be between V(1) and V(21600).
         type: int
-        default: V(60)
+        default: 60
 """
 
 EXAMPLES = r"""

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -621,7 +621,7 @@ class Ec2Metadata:
 
     def fetch_session_token(self, uri_token):
         """Used to get a session token for IMDSv2"""
-        metadata_token_ttl_seconds = module.params.get("metadata_token_ttl_seconds")
+        metadata_token_ttl_seconds = self.module.params.get("metadata_token_ttl_seconds")
         headers = {"X-aws-ec2-metadata-token-ttl-seconds": metadata_token_ttl_seconds}
         response, info = fetch_url(self.module, uri_token, method="PUT", headers=headers, force=True)
 

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
@@ -15,3 +15,19 @@
           - ansible_ec2_user_data == "None"
           - ansible_ec2_instance_tags_keys is defined
           - ansible_ec2_instance_tags_keys | length == 3
+
+    - name: Clear facts for another test
+      ansible.builtin.meta: clear_facts
+
+    - amazon.aws.ec2_metadata_facts:
+        metadata_token_ttl_seconds: 240
+
+    - name: Assert initial metadata for the instance
+      ansible.builtin.assert:
+        that:
+          - ansible_ec2_ami_id == image_id
+          - ansible_ec2_placement_availability_zone == availability_zone
+          - ansible_ec2_security_groups == resource_prefix+"-sg"
+          - ansible_ec2_user_data == "None"
+          - ansible_ec2_instance_tags_keys is defined
+          - ansible_ec2_instance_tags_keys | length == 3


### PR DESCRIPTION
Fixes: https://github.com/ansible-collections/amazon.aws/issues/2205

##### SUMMARY
`ec2_metadata_facts` sometimes returns `401 unauthorized` if the IMDSv2 token times out. The token TTL is currently hardcoded to `60`, this pull request aims to make it configurable.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_metadata_facts