### PR TITLE
fix: remove default value for accelerate_enabled variable

### DIFF
--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -2016,7 +2016,7 @@ def main():
         acl=dict(type="str", choices=["private", "public-read", "public-read-write", "authenticated-read"]),
         validate_bucket_name=dict(type="bool", default=True),
         dualstack=dict(default=False, type="bool"),
-        accelerate_enabled=dict(default=False, type="bool"),
+        accelerate_enabled=dict(type="bool"),
         object_lock_enabled=dict(type="bool"),
         object_lock_default_retention=dict(
             type="dict",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Remove default value for `accelerate_enabled` variable.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
amazon.aws.s3_bucket

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Starting version 8.1.0, module execution failed on NetApp StorageGRID systems.

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
...
TASK [Create Bucket and Apply Bucket Policy] ************************************************************************************************************************************************************************************************
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: botocore.exceptions.ClientError: An error occurred (XNotImplemented) when calling the GetBucketAccelerateConfiguration operation: The request you provided implies functionality that is not implemented.
fatal: [localhost]: FAILED! => {"boto3_version": "1.34.154", "botocore_version": "1.34.154", "changed": false, "error": {"code": "XNotImplemented", "message": "The request you provided implies functionality that is not implemented.", "resource": "/my-bucket?accelerate"}, "msg": "Fetching bucket transfer acceleration state is not supported: An error occurred (XNotImplemented) when calling the GetBucketAccelerateConfiguration operation: The request you provided implies functionality that is not implemented.", "response_metadata": {"host_id": "12329880", "http_headers": {"connection": "CLOSE", "content-length": "253", "content-type": "application/xml", "date": "Tue, 06 Aug 2024 11:51:52 GMT", "server": "StorageGRID/11.8.0.5", "x-amz-id-2": "12329880", "x-amz-request-id": "1722945112091352", "x-ntap-sg-trace-id": "53350fe8388e570f"}, "http_status_code": 501, "request_id": "1722945112091352", "retry_attempts": 0}}
...
```

This is because there is a default value set to `accelerate_enabled` variable.
With this default value, condition in line [956](https://github.com/ansible-collections/amazon.aws/blob/5756ac437c79393c009d99df71d9ded95dd6be84/plugins/modules/s3_bucket.py#L956) (`if accelerate_enabled is not None:`) is always true and the module failed even if the functionality is not implemented in StorageGRID systems.