### PR TITLE
rds_cluster: state change fix

### DIFF
--- a/changelogs/fragments/2214-rds_cluster-limit-params-sent-to-api-for-states.yml
+++ b/changelogs/fragments/2214-rds_cluster-limit-params-sent-to-api-for-states.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - rds_cluster - Limit params sent to api call to DBClusterIdentifier when using state started or stopped (https://github.com/ansible-collections/amazon.aws/pull/2214).

--- a/changelogs/fragments/2214-rds_cluster-limit-params-sent-to-api-for-states.yml
+++ b/changelogs/fragments/2214-rds_cluster-limit-params-sent-to-api-for-states.yml
@@ -1,3 +1,3 @@
 ---
-bugfix:
+bugfixes:
   - rds_cluster - Limit params sent to api call to DBClusterIdentifier when using state started or stopped (https://github.com/ansible-collections/amazon.aws/issues/2197).

--- a/changelogs/fragments/2214-rds_cluster-limit-params-sent-to-api-for-states.yml
+++ b/changelogs/fragments/2214-rds_cluster-limit-params-sent-to-api-for-states.yml
@@ -1,3 +1,3 @@
 ---
-minor_changes:
-  - rds_cluster - Limit params sent to api call to DBClusterIdentifier when using state started or stopped (https://github.com/ansible-collections/amazon.aws/pull/2214).
+bugfix:
+  - rds_cluster - Limit params sent to api call to DBClusterIdentifier when using state started or stopped (https://github.com/ansible-collections/amazon.aws/issues/2197).

--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -1124,11 +1124,15 @@ def changing_cluster_options(modify_params, current_cluster):
     if module.params["state"] == "started":
         if current_cluster["Engine"] in ["mysql", "postgres"]:
             module.fail_json("Only aurora clusters can use the state started")
+        # start_db_cluster supports only DBClusterIdentifier
+        changing_params = {}
         changing_params["DBClusterIdentifier"] = db_cluster_id
 
     if module.params["state"] == "stopped":
         if current_cluster["Engine"] in ["mysql", "postgres"]:
             module.fail_json("Only aurora clusters can use the state stopped")
+        # stop_db_cluster supports only DBClusterIdentifier
+        changing_params = {}
         changing_params["DBClusterIdentifier"] = db_cluster_id
 
     return changing_params

--- a/tests/integration/targets/rds_cluster_states/tasks/main.yml
+++ b/tests/integration/targets/rds_cluster_states/tasks/main.yml
@@ -16,6 +16,7 @@
         username: "{{ username }}"
         password: "{{ password }}"
         skip_final_snapshot: true
+        backup_retention_period: 3
       register: _result_delete_db_cluster
 
     - ansible.builtin.assert:
@@ -31,6 +32,7 @@
         engine_mode: provisioned
         username: "{{ username }}"
         password: "{{ password }}"
+        backup_retention_period: 3
       register: _result_create_source_db_cluster
 
     - ansible.builtin.assert:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #2197

Limit params sent to api call to DBClusterIdentifier when using state started or stopped as 
start_db_cluster and start_db_cluster supports only DBClusterIdentifier

https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/rds/client/start_db_cluster.html

https://boto3.amazonaws.com/v1/documentation/api/1.26.120/reference/services/rds/client/stop_db_cluster.html

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
rds_cluster
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
