### PR TITLE
Fix performance_insights_kms_key_id snake case variation

### DIFF
--- a/changelogs/fragments/20240810-rds_instance-performance_insights_kms_key_id.yml
+++ b/changelogs/fragments/20240810-rds_instance-performance_insights_kms_key_id.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - rds_instance - snake case for parameter ``performance_insights_kms_key_id`` was incorrect according to boto documentation (https://github.com/ansible-collections/amazon.aws/pull/2163).

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -531,7 +531,7 @@ def get_snapshot(client, snapshot_identifier: str, snapshot_type: str, convert_t
         snapshot = snapshots[0]
 
     if snapshot and convert_tags:
-        snapshot["Tags"] = boto3_tag_list_to_ansible_dict(snapshot.pop("TagList"))
+        snapshot["Tags"] = boto3_tag_list_to_ansible_dict(snapshot.pop("TagList", None))
 
     return snapshot
 

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -581,7 +581,7 @@ def arg_spec_to_rds_params(options_dict: Dict[str, Any]) -> Dict[str, Any]:
         ("Iam", "IAM"),
         ("Az", "AZ"),
         ("Ca", "CA"),
-        ("PerformanceInsightsKmsKeyId", "PerformanceInsightsKMSKeyId")
+        ("PerformanceInsightsKmsKeyId", "PerformanceInsightsKMSKeyId"),
     )
     for key in list(camel_options.keys()):
         for old, new in aws_replace_keys:

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -571,18 +571,32 @@ def arg_spec_to_rds_params(options_dict: Dict[str, Any]) -> Dict[str, Any]:
             camel_options (dct): Options formatted for boto3 rds client
     """
     tags = options_dict.pop("tags")
+
     has_processor_features = False
+    has_performance_insights_kms_key = False
+
     if "processor_features" in options_dict:
         has_processor_features = True
         processor_features = options_dict.pop("processor_features")
+
+    if "performance_insights_kms_key_id" in options_dict:
+        has_performance_insights_kms_key = True
+        performance_insights_kms_key_id = options_dict.pop("performance_insights_kms_key_id")
+
     camel_options = snake_dict_to_camel_dict(options_dict, capitalize_first=True)
     for key in list(camel_options.keys()):
         for old, new in (("Db", "DB"), ("Iam", "IAM"), ("Az", "AZ"), ("Ca", "CA")):
             if old in key:
                 camel_options[key.replace(old, new)] = camel_options.pop(key)
+
     camel_options["Tags"] = tags
+
     if has_processor_features:
         camel_options["ProcessorFeatures"] = processor_features
+
+    if has_performance_insights_kms_key:
+        camel_options["PerformanceInsightsKMSKeyId"] = performance_insights_kms_key_id
+
     return camel_options
 
 

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -571,32 +571,25 @@ def arg_spec_to_rds_params(options_dict: Dict[str, Any]) -> Dict[str, Any]:
             camel_options (dct): Options formatted for boto3 rds client
     """
     tags = options_dict.pop("tags")
-
     has_processor_features = False
-    has_performance_insights_kms_key = False
-
     if "processor_features" in options_dict:
         has_processor_features = True
         processor_features = options_dict.pop("processor_features")
-
-    if "performance_insights_kms_key_id" in options_dict:
-        has_performance_insights_kms_key = True
-        performance_insights_kms_key_id = options_dict.pop("performance_insights_kms_key_id")
-
     camel_options = snake_dict_to_camel_dict(options_dict, capitalize_first=True)
+    aws_replace_keys = (
+        ("Db", "DB"),
+        ("Iam", "IAM"),
+        ("Az", "AZ"),
+        ("Ca", "CA"),
+        ("PerformanceInsightsKmsKeyId", "PerformanceInsightsKMSKeyId")
+    )
     for key in list(camel_options.keys()):
-        for old, new in (("Db", "DB"), ("Iam", "IAM"), ("Az", "AZ"), ("Ca", "CA")):
+        for old, new in aws_replace_keys:
             if old in key:
                 camel_options[key.replace(old, new)] = camel_options.pop(key)
-
     camel_options["Tags"] = tags
-
     if has_processor_features:
         camel_options["ProcessorFeatures"] = processor_features
-
-    if has_performance_insights_kms_key:
-        camel_options["PerformanceInsightsKMSKeyId"] = performance_insights_kms_key_id
-
     return camel_options
 
 

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1144,9 +1144,8 @@ def get_options_with_changing_values(client, module: AnsibleAWSModule, parameter
 
     instance_performance_insights_kms_key_id = instance.get("PerformanceInsightsKMSKeyId")
     if (
-            instance_performance_insights_kms_key_id == module.params.get("performance_insights_kms_key_id")
-            or
-            instance_performance_insights_kms_key_id[-1] == module.params.get("performance_insights_kms_key_id")
+        instance_performance_insights_kms_key_id == module.params.get("performance_insights_kms_key_id")
+        or instance_performance_insights_kms_key_id.split('/')[-1] == module.params.get("performance_insights_kms_key_id")
     ):
         parameters.pop("PerformanceInsightsKMSKeyId")
 

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1142,6 +1142,14 @@ def get_options_with_changing_values(client, module: AnsibleAWSModule, parameter
                     # must be always specified when changing iops
                     parameters["AllocatedStorage"] = new_allocated_storage
 
+    instance_performance_insights_kms_key_id = instance.get("PerformanceInsightsKMSKeyId")
+    if (
+            instance_performance_insights_kms_key_id == module.params.get("performance_insights_kms_key_id")
+            or
+            instance_performance_insights_kms_key_id[-1] == module.params.get("performance_insights_kms_key_id")
+    ):
+        parameters.pop("PerformanceInsightsKMSKeyId")
+
     if parameters.get("NewDBInstanceIdentifier") and instance.get("PendingModifiedValues", {}).get(
         "DBInstanceIdentifier"
     ):

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1143,9 +1143,10 @@ def get_options_with_changing_values(client, module: AnsibleAWSModule, parameter
                     parameters["AllocatedStorage"] = new_allocated_storage
 
     instance_performance_insights_kms_key_id = instance.get("PerformanceInsightsKMSKeyId")
-    if (
-        instance_performance_insights_kms_key_id == module.params.get("performance_insights_kms_key_id")
-        or instance_performance_insights_kms_key_id.split('/')[-1] == module.params.get("performance_insights_kms_key_id")
+    if instance_performance_insights_kms_key_id == module.params.get(
+        "performance_insights_kms_key_id"
+    ) or instance_performance_insights_kms_key_id.split("/")[-1] == module.params.get(
+        "performance_insights_kms_key_id"
     ):
         parameters.pop("PerformanceInsightsKMSKeyId", None)
 

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1147,7 +1147,7 @@ def get_options_with_changing_values(client, module: AnsibleAWSModule, parameter
         instance_performance_insights_kms_key_id == module.params.get("performance_insights_kms_key_id")
         or instance_performance_insights_kms_key_id.split('/')[-1] == module.params.get("performance_insights_kms_key_id")
     ):
-        parameters.pop("PerformanceInsightsKMSKeyId")
+        parameters.pop("PerformanceInsightsKMSKeyId", None)
 
     if parameters.get("NewDBInstanceIdentifier") and instance.get("PendingModifiedValues", {}).get(
         "DBInstanceIdentifier"


### PR DESCRIPTION
##### SUMMARY
performance_insights_kms_key_id parameter has a variation in AWS snake case

Fixes #2217 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
rds_instance - parameter: performance_insights_kms_key_id

##### ADDITIONAL INFORMATION
I have successfully created an rds_instance instance w/ correct custom performance_insights_kms_key_id (not the default: "aws/rds")
