### PR TITLE
iam_role - Deprecate creating/deleting instance profiles through iam_role

### DIFF
--- a/changelogs/fragments/20240820-iam_role-profiles.yml
+++ b/changelogs/fragments/20240820-iam_role-profiles.yml
@@ -1,0 +1,3 @@
+---
+deprecated_features:
+- iam_role - support for creating and deleting IAM instance profiles using the ``create_instance_profile`` and ``delete_instance_profile`` options has been deprecated and will be removed in a release after 2026-05-01.  To manage IAM instance profiles the ``amazon.aws.iam_instance_profile`` module can be used instead (https://github.com/ansible-collections/amazon.aws/pull/2221).


### PR DESCRIPTION
##### SUMMARY

Before the addition of iam_instance_profile the only way to create instance profiles was through iam_role.  We now have a dedicated module.  With the principle of "do one thing and do it well", let's formally deprecate support for creating/deleting instance profiles from the iam_role module.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

iam_role

##### ADDITIONAL INFORMATION

There's also some kind of issue around profiles already existing (see #2102 )