### PR TITLE
aws_ec2: fix populating SSM inventory for multiple hosts

### DIFF
--- a/changelogs/fragments/2227-fix-ssm-inventory.yml
+++ b/changelogs/fragments/2227-fix-ssm-inventory.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- aws_ec2 - fix SSM inventory collection for multiple (>40) hosts  (https://github.com/ansible-collections/amazon.aws/pull/2227).

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -670,17 +670,17 @@ class InventoryModule(AWSInventoryBase):
                     break
 
     def _get_multiple_ssm_inventories(self, connection, instance_ids):
-        result = {}
+        result = []
         # SSM inventory filters Values list can contain a maximum of 40 items so we need to retrieve 40 at a time
         # https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_InventoryFilter.html
         while len(instance_ids) > 40:
             filters = [{"Key": "AWS:InstanceInformation.InstanceId", "Values": instance_ids[:40]}]
-            result.update(_get_ssm_information(connection, filters))
+            result.extend(_get_ssm_information(connection, filters).get("Entities", []))
             instance_ids = instance_ids[40:]
         if instance_ids:
             filters = [{"Key": "AWS:InstanceInformation.InstanceId", "Values": instance_ids}]
-            result.update(_get_ssm_information(connection, filters))
-        return result
+            result.extend(_get_ssm_information(connection, filters).get("Entities", []))
+        return {"Entities": result}
 
     def _populate(
         self,


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The function `_get_ssm_information()` returns dicts with one object. Multiple results cannot be concatenated/merged using `d.update()` since it will keep overwriting one object.
Concatenate the nested lists instead.

Fixes #2226 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_ec2
