### PR TITLE
s3_bucket - Fix cannot unpack non-iterable NoneType object while handling errors 

### DIFF
--- a/changelogs/fragments/20240824-s3_bucket-unpack.yml
+++ b/changelogs/fragments/20240824-s3_bucket-unpack.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - "s3_bucket - fixes ``TypeError: cannot unpack non-iterable NoneType object`` errors related to bucket versioning, policies, tags or encryption (https://github.com/ansible-collections/amazon.aws/pull/2228)."


### PR DESCRIPTION
fixes: #2229 

##### SUMMARY

Due to an indentation issue, when cleanly catching permissions/support exceptions for features that aren't being actively used the functions would sometimes (implicitly) return a None, which can't be unpacked with `changed, current_state = some_funtion()` , resulting in strange errors

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

s3_bucket

##### ADDITIONAL INFORMATION
