### PR TITLE
[PR #2219 backport][stable-8] Fix performance_insights_kms_key_id snake case variation

### DIFF
--- a/changelogs/fragments/20240810-rds_instance-performance_insights_kms_key_id.yml
+++ b/changelogs/fragments/20240810-rds_instance-performance_insights_kms_key_id.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - rds_instance - snake case for parameter ``performance_insights_kms_key_id`` was incorrect according to boto documentation (https://github.com/ansible-collections/amazon.aws/pull/2163).

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -373,8 +373,15 @@ def arg_spec_to_rds_params(options_dict):
         has_processor_features = True
         processor_features = options_dict.pop("processor_features")
     camel_options = snake_dict_to_camel_dict(options_dict, capitalize_first=True)
+    aws_replace_keys = (
+        ("Db", "DB"),
+        ("Iam", "IAM"),
+        ("Az", "AZ"),
+        ("Ca", "CA"),
+        ("PerformanceInsightsKmsKeyId", "PerformanceInsightsKMSKeyId"),
+    )
     for key in list(camel_options.keys()):
-        for old, new in (("Db", "DB"), ("Iam", "IAM"), ("Az", "AZ"), ("Ca", "CA")):
+        for old, new in aws_replace_keys:
             if old in key:
                 camel_options[key.replace(old, new)] = camel_options.pop(key)
     camel_options["Tags"] = tags

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -1096,6 +1096,14 @@ def get_options_with_changing_values(client, module, parameters):
                     # must be always specified when changing iops
                     parameters["AllocatedStorage"] = new_allocated_storage
 
+    instance_performance_insights_kms_key_id = instance.get("PerformanceInsightsKMSKeyId")
+    if instance_performance_insights_kms_key_id == module.params.get(
+        "performance_insights_kms_key_id"
+    ) or instance_performance_insights_kms_key_id.split("/")[-1] == module.params.get(
+        "performance_insights_kms_key_id"
+    ):
+        parameters.pop("PerformanceInsightsKMSKeyId", None)
+
     if parameters.get("NewDBInstanceIdentifier") and instance.get("PendingModifiedValues", {}).get(
         "DBInstanceIdentifier"
     ):


### PR DESCRIPTION
This is a manual backport of PR https://github.com/ansible-collections/amazon.aws/pull/2219 as merged into main (https://github.com/ansible-collections/amazon.aws/commit/1f65ad9baa1dac8504a530202c6f454710bb74c4).

##### SUMMARY

performance_insights_kms_key_id parameter has a variation in AWS snake case 

Fixes #2217

##### ISSUE TYPE

Bugfix Pull Request

##### COMPONENT NAME

rds_instance - parameter: performance_insights_kms_key_id 

##### ADDITIONAL INFORMATION

I have successfully created an rds_instance instance w/ correct custom performance_insights_kms_key_id (not the default: "aws/rds")

Reviewed-by: Mark Chappell
Reviewed-by: Gabriel PREDA
Reviewed-by: Alina Buzachis
