### PR TITLE
Tweak 'version_added' information for PRs based on actual backport dates

### DIFF
--- a/plugins/modules/cloudwatch_metric_alarm.py
+++ b/plugins/modules/cloudwatch_metric_alarm.py
@@ -160,7 +160,7 @@ options:
           - If you specify V(evaluate) or omit this parameter, alarm is evaluated and possibly changes state no matter how many data points are available.
         type: str
         choices: ['ignore', 'evaluate']
-        version_added: 9.0.0
+        version_added: 8.2.0
     datapoints_to_alarm:
         description:
           - The number of data points that must be breaching to trigger the alarm.

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -225,7 +225,7 @@ options:
     description:
       - Controls whether source/destination checking is enabled on the interface.
     type: bool
-    version_added: 8.1.0
+    version_added: 8.2.0
   network_interfaces:
     description:
       - A list of dictionaries containing specifications for network interfaces.
@@ -233,7 +233,7 @@ options:
       - Mutually exclusive with O(network).
     type: list
     elements: dict
-    version_added: 8.1.0
+    version_added: 8.2.0
     suboptions:
       assign_public_ip:
         description:
@@ -298,7 +298,7 @@ options:
       - Mutually exclusive with O(security_groups).
     type: list
     elements: dict
-    version_added: 8.1.0
+    version_added: 8.2.0
     suboptions:
       id:
         description:

--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -190,7 +190,7 @@ options:
           - For multi-AZ DB clusters, O(storage_type) defaults to V(io1) and a value for the O(iops) parameter is required.
           - For Aurora DB clusters, O(storage_type) defaults to V(aurora) standard.
           - For mysql and postgres DB clusters, O(storage_type) defaults to V(io1).
-          - Support for V(aurora) and V(aurora-iopt1) was added in release 8.1.0.
+          - Support for V(aurora) and V(aurora-iopt1) was added in release 8.2.0.
         type: str
         choices:
           - io1


### PR DESCRIPTION
##### SUMMARY

A number of PRs got backported late/early and as such don't match up with their "version_added" information in the docs.

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME

plugins/modules/cloudwatch_metric_alarm.py
plugins/modules/ec2_instance.py
plugins/modules/rds_cluster.py

##### ADDITIONAL INFORMATION
