### PR TITLE
s3_bucket - fix MethodNotAllowed in regions that don't support transfer acceleration

### DIFF
--- a/changelogs/fragments/2266-acceleration-eu_north_1.yml
+++ b/changelogs/fragments/2266-acceleration-eu_north_1.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+ - s3_bucket - fixes ``MethodNotAllowed`` exceptions caused by fetching transfer acceleration state in regions that don't support it (https://github.com/ansible-collections/amazon.aws/issues/2266).

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -972,9 +972,11 @@ def handle_bucket_accelerate(s3_client, module: AnsibleAWSModule, name: str) -> 
     except is_boto3_error_code(["NotImplemented", "XNotImplemented"]) as e:
         if accelerate_enabled is not None:
             module.fail_json_aws(e, msg="Fetching bucket transfer acceleration state is not supported")
-    except is_boto3_error_code("UnsupportedArgument") as e:  # pylint: disable=duplicate-except
-        # -- Transfer Acceleration is not available in AWS GovCloud (US).
-        # -- https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html#govcloud-S3-diffs
+    except is_boto3_error_code(["UnsupportedArgument", "MethodNotAllowed"]) as e:  # pylint: disable=duplicate-except
+        # - Transfer Acceleration is not available in AWS GovCloud (US) and throws UnsupportedArgument.
+        # https://docs.aws.amazon.com/govcloud-us/latest/UserGuide/govcloud-s3.html#govcloud-S3-diffs
+        # - Transfer Acceleration is not available in some AWS regions and throws MethodNotAllowed
+        # https://docs.aws.amazon.com/AmazonS3/latest/userguide/transfer-acceleration.html
         module.warn("Tranfer acceleration is not available in S3 bucket region.")
         accelerate_enabled_result = False
     except is_boto3_error_code("AccessDenied") as e:  # pylint: disable=duplicate-except


### PR DESCRIPTION
fixes: https://github.com/ansible-collections/amazon.aws/issues/2266

##### SUMMARY

While #2202 (combined with #2222) fixes the issue for the `aws-gov` partition, the `aws` partition throws a different Error (`MethodNotAllowed`).

I suspect the two different exceptions are a side effect of how AWS implement the Gov-Cloud partition vs the normal partition.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

s3_bucket

##### ADDITIONAL INFORMATION

See also: #2266