### PR TITLE
Make the ami pattern generic to avoid searching for deprecated amis

### DIFF
--- a/changelogs/fragments/fix_deperecated_ami.yml
+++ b/changelogs/fragments/fix_deperecated_ami.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Make the ami pattern generic to avoid searching for deprecated amis.

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -670,17 +670,17 @@ class InventoryModule(AWSInventoryBase):
                     break
 
     def _get_multiple_ssm_inventories(self, connection, instance_ids):
-        result = {}
+        result = []
         # SSM inventory filters Values list can contain a maximum of 40 items so we need to retrieve 40 at a time
         # https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_InventoryFilter.html
         while len(instance_ids) > 40:
             filters = [{"Key": "AWS:InstanceInformation.InstanceId", "Values": instance_ids[:40]}]
-            result.update(_get_ssm_information(connection, filters))
+            result.extend(_get_ssm_information(connection, filters).get("Entities", []))
             instance_ids = instance_ids[40:]
         if instance_ids:
             filters = [{"Key": "AWS:InstanceInformation.InstanceId", "Values": instance_ids}]
-            result.update(_get_ssm_information(connection, filters))
-        return result
+            result.extend(_get_ssm_information(connection, filters).get("Entities", []))
+        return {"Entities": result}
 
     def _populate(
         self,

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -670,17 +670,17 @@ class InventoryModule(AWSInventoryBase):
                     break
 
     def _get_multiple_ssm_inventories(self, connection, instance_ids):
-        result = []
+        result = {}
         # SSM inventory filters Values list can contain a maximum of 40 items so we need to retrieve 40 at a time
         # https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_InventoryFilter.html
         while len(instance_ids) > 40:
             filters = [{"Key": "AWS:InstanceInformation.InstanceId", "Values": instance_ids[:40]}]
-            result.extend(_get_ssm_information(connection, filters).get("Entities", []))
+            result.update(_get_ssm_information(connection, filters).get("Entities", []))
             instance_ids = instance_ids[40:]
         if instance_ids:
             filters = [{"Key": "AWS:InstanceInformation.InstanceId", "Values": instance_ids}]
-            result.extend(_get_ssm_information(connection, filters).get("Entities", []))
-        return {"Entities": result}
+            result.update(_get_ssm_information(connection, filters).get("Entities", []))
+        return result
 
     def _populate(
         self,

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -675,11 +675,11 @@ class InventoryModule(AWSInventoryBase):
         # https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_InventoryFilter.html
         while len(instance_ids) > 40:
             filters = [{"Key": "AWS:InstanceInformation.InstanceId", "Values": instance_ids[:40]}]
-            result.update(_get_ssm_information(connection, filters).get("Entities", []))
+            result.update(_get_ssm_information(connection, filters))
             instance_ids = instance_ids[40:]
         if instance_ids:
             filters = [{"Key": "AWS:InstanceInformation.InstanceId", "Values": instance_ids}]
-            result.update(_get_ssm_information(connection, filters).get("Entities", []))
+            result.update(_get_ssm_information(connection, filters))
         return result
 
     def _populate(

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_inventory_ssm.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_inventory_ssm.yml
@@ -18,7 +18,7 @@
   vars:
     ami_details:
       owner: 125523088429
-      name: Fedora-Cloud-Base-37-1.2.x86_64*
+      name: Fedora-Cloud-Base-37*
       user_data: |
         #!/bin/sh
         sudo dnf install -y https://s3.amazonaws.com/ec2-downloads-windows/SSMAgent/latest/linux_amd64/amazon-ssm-agent.rpm
@@ -45,6 +45,7 @@
           amazon.aws.ec2_ami_info:
             owners: '{{ ami_details.owner | default("amazon") }}'
             filters:
+              architecture: x86_64
               name: "{{ ami_details.name }}"
           register: ec2_amis
           no_log: true

--- a/tests/integration/targets/inventory_aws_ec2/tasks/setup.yml
+++ b/tests/integration/targets/inventory_aws_ec2/tasks/setup.yml
@@ -7,7 +7,7 @@
       owner-id: "125523088429"
       virtualization-type: hvm
       root-device-type: ebs
-      name: Fedora-Cloud-Base-37-1.2.x86_64*
+      name: Fedora-Cloud-Base-37*
   register: fedora_images
 
 - name: Set image id, vpc cidr and subnet cidr


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This fixes the failure seen in https://d04ed4904ec3d4928496-5828abdaefb23a8975ffbcdc8ff7f222.ssl.cf1.rackcdn.com/2227/82e7cd3fcc15efebea7c6fbbcb447e99449af9d3/check/integration-amazon.aws-1/baa1dcd/job-output.txt

```
TASK [Set image id, vpc cidr and subnet cidr] **********************************
2024-08-23 20:07:43.220507 | controller | task path: /home/zuul-worker/.ansible/collections/ansible_collections/amazon/aws/tests/integration/targets/inventory_aws_ec2/playbooks/tasks/setup.yml:13
2024-08-23 20:07:43.220523 | controller | fatal: [127.0.0.1]: FAILED! => {
2024-08-23 20:07:43.222302 | controller |     "msg": "The task includes an option with an undefined variable. The error was: list object has no element 0\n\nThe error appears to be in '/home/zuul-worker/.ansible/collections/ansible_collections/amazon/aws/tests/integration/targets/inventory_aws_ec2/playbooks/tasks/setup.yml': line 13, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Set image id, vpc cidr and subnet cidr\n  ^ here\n"
2024-08-23 20:07:43.222349 | controller | }
```

AMIs can be deprecated to indicate they are outdated or no longer actively maintained. Fedora-Cloud-Base-37-1.2.x86_64*  ami is not available.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
