### PR TITLE
DNM Migrate elb_classic_lb_info* modules and tests

### DIFF
--- a/changelogs/fragments/migrate_elb_classic_lb_info.yml
+++ b/changelogs/fragments/migrate_elb_classic_lb_info.yml
@@ -1,0 +1,5 @@
+---
+major_changes:
+  - elb_classic_lb_info - The module has been migrated from the ``community.aws``
+    collection. Playbooks using the Fully Qualified Collection Name for this module
+    should be updated to use ``amazon.aws.elb_classic_lb_info``.

--- a/meta/runtime.yml
+++ b/meta/runtime.yml
@@ -71,6 +71,7 @@ action_groups:
     - elb_application_lb
     - elb_application_lb_info
     - elb_classic_lb
+    - elb_classic_lb_info
     - execute_lambda
     - iam_access_key
     - iam_access_key_info
@@ -162,10 +163,10 @@ plugin_routing:
     rds_param_group:
       redirect: amazon.aws.rds_instance_param_group
       deprecation:
-         removal_version: 10.0.0
-         warning_text: >-
-           rds_param_group has been renamed to rds_instance_param_group.
-           Please update your tasks.
+        removal_version: 10.0.0
+        warning_text: >-
+          rds_param_group has been renamed to rds_instance_param_group.
+          Please update your tasks.
   lookup:
     aws_ssm:
       # Deprecation for this alias should not *start* prior to 2024-09-01

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -1,0 +1,217 @@
+#!/usr/bin/python
+#
+# This is a free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This Ansible library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+
+from __future__ import (absolute_import, division, print_function)
+__metaclass__ = type
+
+ANSIBLE_METADATA = {'metadata_version': '1.1',
+                    'status': ['preview'],
+                    'supported_by': 'community'}
+
+
+DOCUMENTATION = '''
+---
+module: elb_classic_lb_info
+short_description: Gather information about EC2 Elastic Load Balancers in AWS
+description:
+    - Gather information about EC2 Elastic Load Balancers in AWS
+    - This module was called C(elb_classic_lb_facts) before Ansible 2.9. The usage did not change.
+author:
+  - "Michael Schultz (@mjschultz)"
+  - "Fernando Jose Pando (@nand0p)"
+options:
+  names:
+    description:
+      - List of ELB names to gather information about. Pass this option to gather information about a set of ELBs, otherwise, all ELBs are returned.
+    type: list
+extends_documentation_fragment:
+- ansible.amazon.aws
+- ansible.amazon.ec2
+
+requirements:
+  - botocore
+  - boto3
+'''
+
+EXAMPLES = '''
+# Note: These examples do not set authentication details, see the AWS Guide for details.
+# Output format tries to match ec2_elb_lb module input parameters
+
+# Gather information about all ELBs
+- elb_classic_lb_info:
+  register: elb_info
+
+- debug:
+    msg: "{{ item.dns_name }}"
+  loop: "{{ elb_info.elbs }}"
+
+# Gather information about a particular ELB
+- elb_classic_lb_info:
+    names: frontend-prod-elb
+  register: elb_info
+
+- debug:
+    msg: "{{ elb_info.elbs.0.dns_name }}"
+
+# Gather information about a set of ELBs
+- elb_classic_lb_info:
+    names:
+    - frontend-prod-elb
+    - backend-prod-elb
+  register: elb_info
+
+- debug:
+    msg: "{{ item.dns_name }}"
+  loop: "{{ elb_info.elbs }}"
+
+'''
+
+RETURN = '''
+elbs:
+  description: a list of load balancers
+  returned: always
+  type: list
+  sample:
+    elbs:
+      - attributes:
+          access_log:
+            enabled: false
+          connection_draining:
+            enabled: true
+            timeout: 300
+          connection_settings:
+            idle_timeout: 60
+          cross_zone_load_balancing:
+            enabled: true
+        availability_zones:
+          - "us-east-1a"
+          - "us-east-1b"
+          - "us-east-1c"
+          - "us-east-1d"
+          - "us-east-1e"
+        backend_server_description: []
+        canonical_hosted_zone_name: test-lb-XXXXXXXXXXXX.us-east-1.elb.amazonaws.com
+        canonical_hosted_zone_name_id: XXXXXXXXXXXXXX
+        created_time: 2017-08-23T18:25:03.280000+00:00
+        dns_name: test-lb-XXXXXXXXXXXX.us-east-1.elb.amazonaws.com
+        health_check:
+          healthy_threshold: 10
+          interval: 30
+          target: HTTP:80/index.html
+          timeout: 5
+          unhealthy_threshold: 2
+        instances: []
+        instances_inservice: []
+        instances_inservice_count: 0
+        instances_outofservice: []
+        instances_outofservice_count: 0
+        instances_unknownservice: []
+        instances_unknownservice_count: 0
+        listener_descriptions:
+          - listener:
+              instance_port: 80
+              instance_protocol: HTTP
+              load_balancer_port: 80
+              protocol: HTTP
+            policy_names: []
+        load_balancer_name: test-lb
+        policies:
+          app_cookie_stickiness_policies: []
+          lb_cookie_stickiness_policies: []
+          other_policies: []
+        scheme: internet-facing
+        security_groups:
+          - sg-29d13055
+        source_security_group:
+          group_name: default
+          owner_alias: XXXXXXXXXXXX
+        subnets:
+          - subnet-XXXXXXXX
+          - subnet-XXXXXXXX
+        tags: {}
+        vpc_id: vpc-c248fda4
+'''
+
+from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (
+    AWSRetry,
+    camel_dict_to_snake_dict,
+    boto3_tag_list_to_ansible_dict
+)
+
+try:
+    import botocore
+except ImportError:
+    pass  # caught by AnsibleAWSModule
+
+
+@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
+def list_elbs(connection, names):
+    paginator = connection.get_paginator('describe_load_balancers')
+    load_balancers = paginator.paginate(LoadBalancerNames=names).build_full_result().get('LoadBalancerDescriptions', [])
+    results = []
+
+    for lb in load_balancers:
+        description = camel_dict_to_snake_dict(lb)
+        name = lb['LoadBalancerName']
+        instances = lb.get('Instances', [])
+        description['tags'] = get_tags(connection, name)
+        description['instances_inservice'], description['instances_inservice_count'] = lb_instance_health(connection, name, instances, 'InService')
+        description['instances_outofservice'], description['instances_outofservice_count'] = lb_instance_health(connection, name, instances, 'OutOfService')
+        description['instances_unknownservice'], description['instances_unknownservice_count'] = lb_instance_health(connection, name, instances, 'Unknown')
+        description['attributes'] = get_lb_attributes(connection, name)
+        results.append(description)
+    return results
+
+
+def get_lb_attributes(connection, name):
+    attributes = connection.describe_load_balancer_attributes(LoadBalancerName=name).get('LoadBalancerAttributes', {})
+    return camel_dict_to_snake_dict(attributes)
+
+
+def get_tags(connection, load_balancer_name):
+    tags = connection.describe_tags(LoadBalancerNames=[load_balancer_name])['TagDescriptions']
+    if not tags:
+        return {}
+    return boto3_tag_list_to_ansible_dict(tags[0]['Tags'])
+
+
+def lb_instance_health(connection, load_balancer_name, instances, state):
+    instance_states = connection.describe_instance_health(LoadBalancerName=load_balancer_name, Instances=instances).get('InstanceStates', [])
+    instate = [instance['InstanceId'] for instance in instance_states if instance['State'] == state]
+    return instate, len(instate)
+
+
+def main():
+    argument_spec = dict(
+        names={'default': [], 'type': 'list'}
+    )
+    module = AnsibleAWSModule(argument_spec=argument_spec,
+                              supports_check_mode=True)
+    if module._name == 'elb_classic_lb_facts':
+        module.deprecate("The 'elb_classic_lb_facts' module has been renamed to 'elb_classic_lb_info'", version='2.13')
+
+    connection = module.client('elb')
+
+    try:
+        elbs = list_elbs(connection, module.params.get('names'))
+    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
+        module.fail_json_aws(e, msg="Failed to get load balancer information.")
+
+    module.exit_json(elbs=elbs)
+
+
+if __name__ == '__main__':
+    main()

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -142,7 +142,7 @@ elbs:
         vpc_id: vpc-c248fda4
 '''
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     AWSRetry,
     camel_dict_to_snake_dict,
@@ -154,14 +154,17 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
+MAX_AWS_RETRIES = 5
+MAX_AWS_DELAY = 5
 
-@AWSRetry.backoff(tries=5, delay=5, backoff=2.0)
-def list_elbs(connection, names):
-    paginator = connection.get_paginator('describe_load_balancers')
-    load_balancers = paginator.paginate(LoadBalancerNames=names).build_full_result().get('LoadBalancerDescriptions', [])
+
+def list_elbs(connection, load_balancer_names):
     results = []
 
-    for lb in load_balancers:
+    for load_balancer_name in load_balancer_names:
+        lb = get_lb(connection, load_balancer_name)
+        if not lb:
+            continue
         description = camel_dict_to_snake_dict(lb)
         name = lb['LoadBalancerName']
         instances = lb.get('Instances', [])
@@ -174,13 +177,20 @@ def list_elbs(connection, names):
     return results
 
 
-def get_lb_attributes(connection, name):
-    attributes = connection.describe_load_balancer_attributes(LoadBalancerName=name).get('LoadBalancerAttributes', {})
+def get_lb(connection, load_balancer_name):
+    try:
+        return connection.describe_load_balancers(aws_retry=True, LoadBalancerNames=[load_balancer_name])['LoadBalancerDescriptions'][0]
+    except is_boto3_error_code('LoadBalancerNotFound'):
+        return []
+
+
+def get_lb_attributes(connection, load_balancer_name):
+    attributes = connection.describe_load_balancer_attributes(aws_retry=True, LoadBalancerName=load_balancer_name).get('LoadBalancerAttributes', {})
     return camel_dict_to_snake_dict(attributes)
 
 
 def get_tags(connection, load_balancer_name):
-    tags = connection.describe_tags(LoadBalancerNames=[load_balancer_name])['TagDescriptions']
+    tags = connection.describe_tags(aws_retry=True, LoadBalancerNames=[load_balancer_name])['TagDescriptions']
     if not tags:
         return {}
     return boto3_tag_list_to_ansible_dict(tags[0]['Tags'])
@@ -194,14 +204,14 @@ def lb_instance_health(connection, load_balancer_name, instances, state):
 
 def main():
     argument_spec = dict(
-        names={'default': [], 'type': 'list', 'elements': 'str'}
+        names=dict(default=[], type='list', elements='str')
     )
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               supports_check_mode=True)
     if module._name == 'elb_classic_lb_facts':
         module.deprecate("The 'elb_classic_lb_facts' module has been renamed to 'elb_classic_lb_info'", date='2021-12-01', collection_name='community.aws')
 
-    connection = module.client('elb')
+    connection = module.client('elb', retry_decorator=AWSRetry.jittered_backoff(retries=MAX_AWS_RETRIES, delay=MAX_AWS_DELAY))
 
     try:
         elbs = list_elbs(connection, module.params.get('names'))

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -43,10 +43,10 @@ requirements:
 
 EXAMPLES = '''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
-# Output format tries to match ec2_elb_lb module input parameters
+# Output format tries to match amazon.aws.ec2_elb_lb module input parameters
 
 # Gather information about all ELBs
-- elb_classic_lb_info:
+- community.aws.elb_classic_lb_info:
   register: elb_info
 
 - debug:
@@ -54,7 +54,7 @@ EXAMPLES = '''
   loop: "{{ elb_info.elbs }}"
 
 # Gather information about a particular ELB
-- elb_classic_lb_info:
+- community.aws.elb_classic_lb_info:
     names: frontend-prod-elb
   register: elb_info
 
@@ -62,7 +62,7 @@ EXAMPLES = '''
     msg: "{{ elb_info.elbs.0.dns_name }}"
 
 # Gather information about a set of ELBs
-- elb_classic_lb_info:
+- community.aws.elb_classic_lb_info:
     names:
     - frontend-prod-elb
     - backend-prod-elb

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -140,7 +140,7 @@ elbs:
         vpc_id: vpc-c248fda4
 '''
 
-from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     AWSRetry,
     camel_dict_to_snake_dict,

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -32,7 +32,7 @@ EXAMPLES = r"""
 # Output format tries to match amazon.aws.ec2_elb_lb module input parameters
 
 # Gather information about all ELBs
-- community.aws.elb_classic_lb_info:
+- amazon.aws.elb_classic_lb_info:
   register: elb_info
 
 - ansible.builtin.debug:
@@ -40,7 +40,7 @@ EXAMPLES = r"""
   loop: "{{ elb_info.elbs }}"
 
 # Gather information about a particular ELB
-- community.aws.elb_classic_lb_info:
+- amazon.aws.elb_classic_lb_info:
     names: frontend-prod-elb
   register: elb_info
 
@@ -48,7 +48,7 @@ EXAMPLES = r"""
     msg: "{{ elb_info.elbs.0.dns_name }}"
 
 # Gather information about a set of ELBs
-- community.aws.elb_classic_lb_info:
+- amazon.aws.elb_classic_lb_info:
     names:
       - frontend-prod-elb
       - backend-prod-elb

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -1,29 +1,16 @@
 #!/usr/bin/python
-#
-# This is a free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This Ansible library is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this library.  If not, see <http://www.gnu.org/licenses/>.
+# -*- coding: utf-8 -*-
 
-from __future__ import (absolute_import, division, print_function)
-__metaclass__ = type
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-
-DOCUMENTATION = r'''
+DOCUMENTATION = r"""
 ---
 module: elb_classic_lb_info
 version_added: 1.0.0
 short_description: Gather information about EC2 Elastic Load Balancers in AWS
 description:
-    - Gather information about EC2 Elastic Load Balancers in AWS
+  - Gather information about EC2 Elastic Load Balancers in AWS
 author:
   - "Michael Schultz (@mjschultz)"
   - "Fernando Jose Pando (@nand0p)"
@@ -35,12 +22,12 @@ options:
     elements: str
     default: []
 extends_documentation_fragment:
-- amazon.aws.aws
-- amazon.aws.ec2
-- amazon.aws.boto3
-'''
+  - amazon.aws.common.modules
+  - amazon.aws.region.modules
+  - amazon.aws.boto3
+"""
 
-EXAMPLES = r'''
+EXAMPLES = r"""
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 # Output format tries to match amazon.aws.ec2_elb_lb module input parameters
 
@@ -71,9 +58,9 @@ EXAMPLES = r'''
     msg: "{{ item.dns_name }}"
   loop: "{{ elb_info.elbs }}"
 
-'''
+"""
 
-RETURN = r'''
+RETURN = r"""
 elbs:
   description: a list of load balancers
   returned: always
@@ -137,20 +124,21 @@ elbs:
           - subnet-XXXXXXXX
         tags: {}
         vpc_id: vpc-c248fda4
-'''
-
-from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
-    AWSRetry,
-    camel_dict_to_snake_dict,
-    boto3_tag_list_to_ansible_dict
-)
+"""
 
 try:
     import botocore
 except ImportError:
     pass  # caught by AnsibleAWSModule
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+
+from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
+
 
 MAX_AWS_RETRIES = 5
 MAX_AWS_DELAY = 5

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -136,7 +136,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
-from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 
 MAX_AWS_RETRIES = 5
 MAX_AWS_DELAY = 5

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -33,6 +33,7 @@ options:
       - List of ELB names to gather information about. Pass this option to gather information about a set of ELBs, otherwise, all ELBs are returned.
     type: list
     elements: str
+    default: []
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -197,7 +197,7 @@ def main():
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               supports_check_mode=True)
     if module._name == 'elb_classic_lb_facts':
-        module.deprecate("The 'elb_classic_lb_facts' module has been renamed to 'elb_classic_lb_info'", version='2.13')
+        module.deprecate("The 'elb_classic_lb_facts' module has been renamed to 'elb_classic_lb_info'", date='2021-12-01', collection_name='community.aws')
 
     connection = module.client('elb')
 

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -20,6 +20,7 @@ __metaclass__ = type
 DOCUMENTATION = '''
 ---
 module: elb_classic_lb_info
+version_added: 1.0.0
 short_description: Gather information about EC2 Elastic Load Balancers in AWS
 description:
     - Gather information about EC2 Elastic Load Balancers in AWS

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -139,7 +139,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_ta
 
 from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
 
-
 MAX_AWS_RETRIES = 5
 MAX_AWS_DELAY = 5
 

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -104,7 +104,7 @@ elbs:
         backend_server_description: []
         canonical_hosted_zone_name: test-lb-XXXXXXXXXXXX.us-east-1.elb.amazonaws.com
         canonical_hosted_zone_name_id: XXXXXXXXXXXXXX
-        created_time: 2017-08-23T18:25:03.280000+00:00
+        created_time: '2017-08-23T18:25:03.280000+00:00'
         dns_name: test-lb-XXXXXXXXXXXX.us-east-1.elb.amazonaws.com
         health_check:
           healthy_threshold: 10

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -8,6 +8,7 @@ DOCUMENTATION = r"""
 ---
 module: elb_classic_lb_info
 version_added: 1.0.0
+version_added_collection: community.aws
 short_description: Gather information about EC2 Elastic Load Balancers in AWS
 description:
   - Gather information about EC2 Elastic Load Balancers in AWS

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -16,10 +16,6 @@
 from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
-ANSIBLE_METADATA = {'metadata_version': '1.1',
-                    'status': ['preview'],
-                    'supported_by': 'community'}
-
 
 DOCUMENTATION = '''
 ---

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -24,7 +24,6 @@ version_added: 1.0.0
 short_description: Gather information about EC2 Elastic Load Balancers in AWS
 description:
     - Gather information about EC2 Elastic Load Balancers in AWS
-    - This module was called C(elb_classic_lb_facts) before Ansible 2.9. The usage did not change.
 author:
   - "Michael Schultz (@mjschultz)"
   - "Fernando Jose Pando (@nand0p)"
@@ -218,8 +217,6 @@ def main():
     )
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               supports_check_mode=True)
-    if module._name == 'elb_classic_lb_facts':
-        module.deprecate("The 'elb_classic_lb_facts' module has been renamed to 'elb_classic_lb_info'", date='2021-12-01', collection_name='community.aws')
 
     connection = module.client('elb', retry_decorator=AWSRetry.jittered_backoff(retries=MAX_AWS_RETRIES, delay=MAX_AWS_DELAY))
 

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -17,7 +17,7 @@ from __future__ import (absolute_import, division, print_function)
 __metaclass__ = type
 
 
-DOCUMENTATION = '''
+DOCUMENTATION = r'''
 ---
 module: elb_classic_lb_info
 version_added: 1.0.0
@@ -33,6 +33,7 @@ options:
     description:
       - List of ELB names to gather information about. Pass this option to gather information about a set of ELBs, otherwise, all ELBs are returned.
     type: list
+    elements: str
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
@@ -42,7 +43,7 @@ requirements:
   - boto3
 '''
 
-EXAMPLES = '''
+EXAMPLES = r'''
 # Note: These examples do not set authentication details, see the AWS Guide for details.
 # Output format tries to match amazon.aws.ec2_elb_lb module input parameters
 
@@ -75,7 +76,7 @@ EXAMPLES = '''
 
 '''
 
-RETURN = '''
+RETURN = r'''
 elbs:
   description: a list of load balancers
   returned: always
@@ -193,7 +194,7 @@ def lb_instance_health(connection, load_balancer_name, instances, state):
 
 def main():
     argument_spec = dict(
-        names={'default': [], 'type': 'list'}
+        names={'default': [], 'type': 'list', 'elements': 'str'}
     )
     module = AnsibleAWSModule(argument_spec=argument_spec,
                               supports_check_mode=True)

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -50,14 +50,13 @@ EXAMPLES = r"""
 # Gather information about a set of ELBs
 - community.aws.elb_classic_lb_info:
     names:
-    - frontend-prod-elb
-    - backend-prod-elb
+      - frontend-prod-elb
+      - backend-prod-elb
   register: elb_info
 
 - ansible.builtin.debug:
     msg: "{{ item.dns_name }}"
   loop: "{{ elb_info.elbs }}"
-
 """
 
 RETURN = r"""

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -139,7 +139,8 @@ elbs:
         vpc_id: vpc-c248fda4
 '''
 
-from ansible_collections.amazon.aws.plugins.module_utils.core import AnsibleAWSModule, is_boto3_error_code
+from ansible_collections.community.aws.plugins.module_utils.modules import AnsibleCommunityAWSModule as AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.core import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     AWSRetry,
     camel_dict_to_snake_dict,

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -37,8 +37,8 @@ options:
       - List of ELB names to gather information about. Pass this option to gather information about a set of ELBs, otherwise, all ELBs are returned.
     type: list
 extends_documentation_fragment:
-- ansible.amazon.aws
-- ansible.amazon.ec2
+- amazon.aws.aws
+- amazon.aws.ec2
 
 requirements:
   - botocore
@@ -144,8 +144,8 @@ elbs:
         vpc_id: vpc-c248fda4
 '''
 
-from ansible_collections.ansible.amazon.plugins.module_utils.aws.core import AnsibleAWSModule
-from ansible_collections.ansible.amazon.plugins.module_utils.ec2 import (
+from ansible_collections.amazon.aws.plugins.module_utils.aws.core import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import (
     AWSRetry,
     camel_dict_to_snake_dict,
     boto3_tag_list_to_ansible_dict

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -51,7 +51,7 @@ EXAMPLES = r'''
 - community.aws.elb_classic_lb_info:
   register: elb_info
 
-- debug:
+- ansible.builtin.debug:
     msg: "{{ item.dns_name }}"
   loop: "{{ elb_info.elbs }}"
 
@@ -60,7 +60,7 @@ EXAMPLES = r'''
     names: frontend-prod-elb
   register: elb_info
 
-- debug:
+- ansible.builtin.debug:
     msg: "{{ elb_info.elbs.0.dns_name }}"
 
 # Gather information about a set of ELBs
@@ -70,7 +70,7 @@ EXAMPLES = r'''
     - backend-prod-elb
   register: elb_info
 
-- debug:
+- ansible.builtin.debug:
     msg: "{{ item.dns_name }}"
   loop: "{{ elb_info.elbs }}"
 

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -37,10 +37,6 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
-
-requirements:
-  - botocore
-  - boto3
 '''
 
 EXAMPLES = r'''

--- a/plugins/modules/elb_classic_lb_info.py
+++ b/plugins/modules/elb_classic_lb_info.py
@@ -36,6 +36,7 @@ options:
 extends_documentation_fragment:
 - amazon.aws.aws
 - amazon.aws.ec2
+- amazon.aws.boto3
 '''
 
 EXAMPLES = r'''

--- a/tests/integration/targets/elb_classic_lb/tasks/basic_internal.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/basic_internal.yml
@@ -75,7 +75,7 @@
             that:
               - info.network_interfaces | length > 0
 
-        - community.aws.elb_classic_lb_info:
+        - amazon.aws.elb_classic_lb_info:
             names: ["{{ elb_name }}"]
           register: info
 

--- a/tests/integration/targets/elb_classic_lb/tasks/basic_public.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/basic_public.yml
@@ -71,7 +71,7 @@
             that:
               - info.network_interfaces | length > 0
 
-        - community.aws.elb_classic_lb_info:
+        - amazon.aws.elb_classic_lb_info:
             names: ["{{ elb_name }}"]
           register: info
 

--- a/tests/integration/targets/elb_classic_lb_info/aliases
+++ b/tests/integration/targets/elb_classic_lb_info/aliases
@@ -1,0 +1,1 @@
+cloud/aws

--- a/tests/integration/targets/elb_classic_lb_info/defaults/main.yml
+++ b/tests/integration/targets/elb_classic_lb_info/defaults/main.yml
@@ -1,0 +1,3 @@
+---
+# defaults file for test_ec2_eip
+elb_name: 'ansible-test-{{ tiny_prefix }}-ecli'

--- a/tests/integration/targets/elb_classic_lb_info/defaults/main.yml
+++ b/tests/integration/targets/elb_classic_lb_info/defaults/main.yml
@@ -1,3 +1,2 @@
----
 # defaults file for test_ec2_eip
-elb_name: 'ansible-test-{{ tiny_prefix }}-ecli'
+elb_name: ansible-test-{{ tiny_prefix }}-ecli

--- a/tests/integration/targets/elb_classic_lb_info/meta/main.yml
+++ b/tests/integration/targets/elb_classic_lb_info/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - prepare_tests
+  - setup_ec2

--- a/tests/integration/targets/elb_classic_lb_info/meta/main.yml
+++ b/tests/integration/targets/elb_classic_lb_info/meta/main.yml
@@ -1,3 +1,1 @@
-dependencies:
-  - prepare_tests
-  - setup_ec2
+dependencies: []

--- a/tests/integration/targets/elb_classic_lb_info/tasks/main.yml
+++ b/tests/integration/targets/elb_classic_lb_info/tasks/main.yml
@@ -1,0 +1,311 @@
+---
+# __Test Info__
+# Create a self signed cert and upload it to AWS
+# http://www.akadia.com/services/ssh_test_certificate.html
+# http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/ssl-server-cert.html
+
+# __Test Outline__
+#
+# __elb_classic_lb__
+# create test elb with listeners and certificate
+# change AZ's
+# change listeners
+# remove listeners
+# remove elb
+
+# __elb_classic_lb_info_
+# get nonexistent load balancer
+
+- module_defaults:
+    group/aws:
+      region: "{{ ec2_region }}"
+      ec2_access_key: "{{ ec2_access_key }}"
+      ec2_secret_key: "{{ ec2_secret_key }}"
+      security_token: "{{ security_token | default(omit) }}"
+  block:
+
+    # ============================================================
+    # create test elb with listeners, certificate, and health check
+
+    - name: Create ELB
+      elb_classic_lb:
+        name: "{{ elb_name }}"
+        state: present
+        zones:
+          - "{{ ec2_region }}a"
+          - "{{ ec2_region }}b"
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 80
+          - protocol: http
+            load_balancer_port: 8080
+            instance_port: 8080
+        health_check:
+            ping_protocol: http
+            ping_port: 80
+            ping_path: "/index.html"
+            response_timeout: 5
+            interval: 30
+            unhealthy_threshold: 2
+            healthy_threshold: 10
+      register: create
+
+    - assert:
+        that:
+          - create is changed
+          # We rely on these for the info test, make sure they're what we expect
+          - '"{{ ec2_region }}a" in create.elb.zones'
+          - '"{{ ec2_region }}b" in create.elb.zones'
+          - create.elb.health_check.healthy_threshold == 10
+          - create.elb.health_check.interval == 30
+          - create.elb.health_check.target == "HTTP:80/index.html"
+          - create.elb.health_check.timeout == 5
+          - create.elb.health_check.unhealthy_threshold == 2
+          - '[80, 80, "HTTP", "HTTP"] in create.elb.listeners'
+          - '[8080, 8080, "HTTP", "HTTP"] in create.elb.listeners'
+
+    - name: Get ELB info
+      elb_classic_lb_info:
+        names: "{{ elb_name }}"
+      register: info
+
+    - assert:
+        that:
+          - info.elbs|length == 1
+          - elb.availability_zones|length == 2
+          - '"{{ ec2_region }}a" in elb.availability_zones'
+          - '"{{ ec2_region }}b" in elb.availability_zones'
+          - elb.health_check.healthy_threshold == 10
+          - elb.health_check.interval == 30
+          - elb.health_check.target == "HTTP:80/index.html"
+          - elb.health_check.timeout == 5
+          - elb.health_check.unhealthy_threshold == 2
+          - '{"instance_port": 80, "instance_protocol": "HTTP", "load_balancer_port": 80, "protocol": "HTTP"} == listeners[0]'
+          - '{"instance_port": 8080, "instance_protocol": "HTTP", "load_balancer_port": 8080, "protocol": "HTTP"} == listeners[1]'
+      vars:
+        elb: "{{ info.elbs[0] }}"
+        listeners: "{{ elb.listener_descriptions|map(attribute='listener')|sort(attribute='load_balancer_port') }}"
+
+    # ============================================================
+
+    # check ports, would be cool, but we are at the mercy of AWS
+    # to start things in a timely manner
+
+    #- name: check to make sure 80 is listening
+    #  wait_for: host={{ info.elb.dns_name }} port=80 timeout=600
+    #  register: result
+
+    #- name: assert can connect to port#
+    #  assert: 'result.state == "started"'
+
+    #- name: check to make sure 443 is listening
+    #  wait_for: host={{ info.elb.dns_name }} port=443 timeout=600
+    #  register: result
+
+    #- name: assert can connect to port#
+    #  assert: 'result.state == "started"'
+
+    # ============================================================
+
+    # Change AZ's
+
+    - name: Change AZ's
+      elb_classic_lb:
+        name: "{{ elb_name }}"
+        state: present
+        zones:
+          - "{{ ec2_region }}c"
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 80
+        purge_zones: yes
+        health_check:
+            ping_protocol: http
+            ping_port: 80
+            ping_path: "/index.html"
+            response_timeout: 5
+            interval: 30
+            unhealthy_threshold: 2
+            healthy_threshold: 10
+      register: update_az
+
+    - assert:
+        that:
+          - update_az is changed
+          - update_az.elb.zones[0] == "{{ ec2_region }}c"
+
+    - name: Get ELB info after changing AZ's
+      elb_classic_lb_info:
+        names: "{{ elb_name }}"
+      register: info
+
+    - assert:
+        that:
+          - elb.availability_zones|length == 1
+          - '"{{ ec2_region }}c" in elb.availability_zones[0]'
+      vars:
+        elb: "{{ info.elbs[0] }}"
+
+    # ============================================================
+
+    # Update AZ's
+
+    - name: Update AZ's
+      elb_classic_lb:
+        name: "{{ elb_name }}"
+        state: present
+        zones:
+          - "{{ ec2_region }}a"
+          - "{{ ec2_region }}b"
+          - "{{ ec2_region }}c"
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 80
+        purge_zones: yes
+      register: update_az
+
+    - assert:
+        that:
+          - update_az is changed
+          - '"{{ ec2_region }}a" in update_az.elb.zones'
+          - '"{{ ec2_region }}b" in update_az.elb.zones'
+          - '"{{ ec2_region }}c" in update_az.elb.zones'
+
+    - name: Get ELB info after updating AZ's
+      elb_classic_lb_info:
+        names: "{{ elb_name }}"
+      register: info
+
+    - assert:
+        that:
+          - elb.availability_zones|length == 3
+          - '"{{ ec2_region }}a" in elb.availability_zones'
+          - '"{{ ec2_region }}b" in elb.availability_zones'
+          - '"{{ ec2_region }}c" in elb.availability_zones'
+      vars:
+        elb: "{{ info.elbs[0] }}"
+
+    # ============================================================
+
+    # Purge Listeners
+
+    - name: Purge Listeners
+      elb_classic_lb:
+        name: "{{ elb_name }}"
+        state: present
+        zones:
+          - "{{ ec2_region }}a"
+          - "{{ ec2_region }}b"
+          - "{{ ec2_region }}c"
+        listeners:
+          - protocol: http
+            load_balancer_port: 80
+            instance_port: 81
+        purge_listeners: yes
+      register: purge_listeners
+
+    - assert:
+        that:
+          - purge_listeners is changed
+          - '[80, 81, "HTTP", "HTTP"] in purge_listeners.elb.listeners'
+          - purge_listeners.elb.listeners|length == 1
+
+    - name: Get ELB info after purging listeners
+      elb_classic_lb_info:
+        names: "{{ elb_name }}"
+      register: info
+
+    - assert:
+        that:
+          - elb.listener_descriptions|length == 1
+          - '{"instance_port": 81, "instance_protocol": "HTTP", "load_balancer_port": 80, "protocol": "HTTP"} == elb.listener_descriptions[0].listener'
+      vars:
+        elb: "{{ info.elbs[0] }}"
+
+
+    # ============================================================
+
+    # add Listeners
+
+    - name: Add Listeners
+      elb_classic_lb:
+        name: "{{ elb_name }}"
+        state: present
+        zones:
+          - "{{ ec2_region }}a"
+          - "{{ ec2_region }}b"
+          - "{{ ec2_region }}c"
+        listeners:
+          - protocol: http
+            load_balancer_port: 8081
+            instance_port: 8081
+        purge_listeners: no
+      register: update_listeners
+
+    - assert:
+        that:
+          - update_listeners is changed
+          - '[80, 81, "HTTP", "HTTP"] in update_listeners.elb.listeners'
+          - '[8081, 8081, "HTTP", "HTTP"] in update_listeners.elb.listeners'
+          - update_listeners.elb.listeners|length == 2
+
+    - name: Get ELB info after adding listeners
+      elb_classic_lb_info:
+        names: "{{ elb_name }}"
+      register: info
+
+    - assert:
+        that:
+          - elb.listener_descriptions|length == 2
+          - '{"instance_port": 81, "instance_protocol": "HTTP", "load_balancer_port": 80, "protocol": "HTTP"} == listeners[0]'
+          - '{"instance_port": 8081, "instance_protocol": "HTTP", "load_balancer_port": 8081, "protocol": "HTTP"} == listeners[1]'
+      vars:
+        elb: "{{ info.elbs[0] }}"
+        listeners: "{{ elb.listener_descriptions|map(attribute='listener')|sort(attribute='load_balancer_port') }}"
+
+    # ============================================================
+
+    # Test getting nonexistent load balancer
+    - name: get nonexistent load balancer
+      elb_classic_lb_info:
+        names: "invalid-elb"
+      register: info
+
+    - assert:
+        that:
+          - info.elbs|length==0
+
+    # Test getting a valid and nonexistent load balancer
+    - name: get nonexistent load balancer
+      elb_classic_lb_info:
+        names: ["{{ elb_name }}", "invalid-elb"]
+      register: info
+
+    - assert:
+        that:
+          - info.elbs|length==1
+          - info.elbs[0].load_balancer_name == elb_name
+
+    # ============================================================
+
+    - name: get all load balancers
+      elb_classic_lb_info:
+        names: "{{ omit }}"
+      register: info
+
+    - assert:
+        that:
+          - info.elbs|length>0
+
+  always:
+
+    # ============================================================
+    - name: remove the test load balancer completely
+      elb_classic_lb:
+        name: "{{ elb_name }}"
+        state: absent
+      register: result
+      ignore_errors: true

--- a/tests/integration/targets/elb_classic_lb_info/tasks/main.yml
+++ b/tests/integration/targets/elb_classic_lb_info/tasks/main.yml
@@ -55,8 +55,8 @@
         that:
           - create is changed
           # We rely on these for the info test, make sure they're what we expect
-          - '"{{ aws_region }}a" in create.elb.zones'
-          - '"{{ aws_region }}b" in create.elb.zones'
+          - aws_region ~ 'a' in create.elb.zones
+          - aws_region ~ 'b' in create.elb.zones
           - create.elb.health_check.healthy_threshold == 10
           - create.elb.health_check.interval == 30
           - create.elb.health_check.target == "HTTP:80/index.html"
@@ -74,8 +74,8 @@
         that:
           - info.elbs|length == 1
           - elb.availability_zones|length == 2
-          - '"{{ aws_region }}a" in elb.availability_zones'
-          - '"{{ aws_region }}b" in elb.availability_zones'
+          - aws_region ~ 'a' in elb.availability_zones
+          - aws_region ~ 'b' in elb.availability_zones
           - elb.health_check.healthy_threshold == 10
           - elb.health_check.interval == 30
           - elb.health_check.target == "HTTP:80/index.html"
@@ -134,7 +134,7 @@
     - assert:
         that:
           - update_az is changed
-          - update_az.elb.zones[0] == "{{ aws_region }}c"
+          - update_az.elb.zones[0] == aws_region ~ 'c'
 
     - name: Get ELB info after changing AZ's
       elb_classic_lb_info:
@@ -144,7 +144,7 @@
     - assert:
         that:
           - elb.availability_zones|length == 1
-          - '"{{ aws_region }}c" in elb.availability_zones[0]'
+          - aws_region ~ 'c' in elb.availability_zones[0]
       vars:
         elb: "{{ info.elbs[0] }}"
 
@@ -170,9 +170,9 @@
     - assert:
         that:
           - update_az is changed
-          - '"{{ aws_region }}a" in update_az.elb.zones'
-          - '"{{ aws_region }}b" in update_az.elb.zones'
-          - '"{{ aws_region }}c" in update_az.elb.zones'
+          - aws_region ~ 'a' in update_az.elb.zones
+          - aws_region ~ 'b' in update_az.elb.zones
+          - aws_region ~ 'c' in update_az.elb.zones
 
     - name: Get ELB info after updating AZ's
       elb_classic_lb_info:
@@ -182,9 +182,9 @@
     - assert:
         that:
           - elb.availability_zones|length == 3
-          - '"{{ aws_region }}a" in elb.availability_zones'
-          - '"{{ aws_region }}b" in elb.availability_zones'
-          - '"{{ aws_region }}c" in elb.availability_zones'
+          - aws_region ~ 'a' in elb.availability_zones
+          - aws_region ~ 'b' in elb.availability_zones
+          - aws_region ~ 'c' in elb.availability_zones
       vars:
         elb: "{{ info.elbs[0] }}"
 

--- a/tests/integration/targets/elb_classic_lb_info/tasks/main.yml
+++ b/tests/integration/targets/elb_classic_lb_info/tasks/main.yml
@@ -12,7 +12,7 @@
 # remove listeners
 # remove elb
 
-# __elb_classic_lb_info_
+# __amazon.aws.elb_classic_lb_info_
 # get nonexistent load balancer
 
 - module_defaults:
@@ -64,7 +64,7 @@
       - '[8080, 8080, "HTTP", "HTTP"] in create.elb.listeners'
 
   - name: Get ELB info
-    elb_classic_lb_info:
+    amazon.aws.elb_classic_lb_info:
       names: '{{ elb_name }}'
     register: info
   - assert:
@@ -112,7 +112,7 @@
       - update_az.elb.zones[0] == aws_region ~ 'c'
 
   - name: Get ELB info after changing AZ's
-    elb_classic_lb_info:
+    amazon.aws.elb_classic_lb_info:
       names: '{{ elb_name }}'
     register: info
   - assert:
@@ -143,7 +143,7 @@
       - aws_region ~ 'c' in update_az.elb.zones
 
   - name: Get ELB info after updating AZ's
-    elb_classic_lb_info:
+    amazon.aws.elb_classic_lb_info:
       names: '{{ elb_name }}'
     register: info
   - assert:
@@ -175,7 +175,7 @@
       - purge_listeners.elb.listeners|length == 1
 
   - name: Get ELB info after purging listeners
-    elb_classic_lb_info:
+    amazon.aws.elb_classic_lb_info:
       names: '{{ elb_name }}'
     register: info
   - assert:
@@ -207,7 +207,7 @@
       - update_listeners.elb.listeners|length == 2
 
   - name: Get ELB info after adding listeners
-    elb_classic_lb_info:
+    amazon.aws.elb_classic_lb_info:
       names: '{{ elb_name }}'
     register: info
   - assert:
@@ -222,7 +222,7 @@
       listeners: "{{ elb.listener_descriptions|map(attribute='listener')|sort(attribute='load_balancer_port')
         }}"
   - name: get nonexistent load balancer
-    elb_classic_lb_info:
+    amazon.aws.elb_classic_lb_info:
       names: invalid-elb
     register: info
   - assert:
@@ -231,7 +231,7 @@
 
     # Test getting a valid and nonexistent load balancer
   - name: get nonexistent load balancer
-    elb_classic_lb_info:
+    amazon.aws.elb_classic_lb_info:
       names: ['{{ elb_name }}', invalid-elb]
     register: info
   - assert:
@@ -242,7 +242,7 @@
     # ============================================================
 
   - name: get all load balancers
-    elb_classic_lb_info:
+    amazon.aws.elb_classic_lb_info:
       names: '{{ omit }}'
     register: info
   - assert:

--- a/tests/integration/targets/elb_classic_lb_info/tasks/main.yml
+++ b/tests/integration/targets/elb_classic_lb_info/tasks/main.yml
@@ -1,4 +1,3 @@
----
 # __Test Info__
 # Create a self signed cert and upload it to AWS
 # http://www.akadia.com/services/ssh_test_certificate.html
@@ -18,294 +17,244 @@
 
 - module_defaults:
     group/aws:
-      region: "{{ aws_region }}"
-      access_key: "{{ aws_access_key }}"
-      secret_key: "{{ aws_secret_key }}"
-      session_token: "{{ security_token | default(omit) }}"
+      region: '{{ aws_region }}'
+      access_key: '{{ aws_access_key }}'
+      secret_key: '{{ aws_secret_key }}'
+      session_token: '{{ security_token | default(omit) }}'
   block:
 
     # ============================================================
     # create test elb with listeners, certificate, and health check
 
-    - name: Create ELB
-      elb_classic_lb:
-        name: "{{ elb_name }}"
-        state: present
-        zones:
-          - "{{ aws_region }}a"
-          - "{{ aws_region }}b"
-        listeners:
-          - protocol: http
-            load_balancer_port: 80
-            instance_port: 80
-          - protocol: http
-            load_balancer_port: 8080
-            instance_port: 8080
-        health_check:
-            ping_protocol: http
-            ping_port: 80
-            ping_path: "/index.html"
-            response_timeout: 5
-            interval: 30
-            unhealthy_threshold: 2
-            healthy_threshold: 10
-      register: create
-
-    - assert:
-        that:
-          - create is changed
+  - name: Create ELB
+    elb_classic_lb:
+      name: '{{ elb_name }}'
+      state: present
+      zones:
+      - '{{ aws_region }}a'
+      - '{{ aws_region }}b'
+      listeners:
+      - protocol: http
+        load_balancer_port: 80
+        instance_port: 80
+      - protocol: http
+        load_balancer_port: 8080
+        instance_port: 8080
+      health_check:
+        ping_protocol: http
+        ping_port: 80
+        ping_path: /index.html
+        response_timeout: 5
+        interval: 30
+        unhealthy_threshold: 2
+        healthy_threshold: 10
+    register: create
+  - assert:
+      that:
+      - create is changed
           # We rely on these for the info test, make sure they're what we expect
-          - aws_region ~ 'a' in create.elb.zones
-          - aws_region ~ 'b' in create.elb.zones
-          - create.elb.health_check.healthy_threshold == 10
-          - create.elb.health_check.interval == 30
-          - create.elb.health_check.target == "HTTP:80/index.html"
-          - create.elb.health_check.timeout == 5
-          - create.elb.health_check.unhealthy_threshold == 2
-          - '[80, 80, "HTTP", "HTTP"] in create.elb.listeners'
-          - '[8080, 8080, "HTTP", "HTTP"] in create.elb.listeners'
+      - aws_region ~ 'a' in create.elb.zones
+      - aws_region ~ 'b' in create.elb.zones
+      - create.elb.health_check.healthy_threshold == 10
+      - create.elb.health_check.interval == 30
+      - create.elb.health_check.target == "HTTP:80/index.html"
+      - create.elb.health_check.timeout == 5
+      - create.elb.health_check.unhealthy_threshold == 2
+      - '[80, 80, "HTTP", "HTTP"] in create.elb.listeners'
+      - '[8080, 8080, "HTTP", "HTTP"] in create.elb.listeners'
 
-    - name: Get ELB info
-      elb_classic_lb_info:
-        names: "{{ elb_name }}"
-      register: info
+  - name: Get ELB info
+    elb_classic_lb_info:
+      names: '{{ elb_name }}'
+    register: info
+  - assert:
+      that:
+      - info.elbs|length == 1
+      - elb.availability_zones|length == 2
+      - aws_region ~ 'a' in elb.availability_zones
+      - aws_region ~ 'b' in elb.availability_zones
+      - elb.health_check.healthy_threshold == 10
+      - elb.health_check.interval == 30
+      - elb.health_check.target == "HTTP:80/index.html"
+      - elb.health_check.timeout == 5
+      - elb.health_check.unhealthy_threshold == 2
+      - '{"instance_port": 80, "instance_protocol": "HTTP", "load_balancer_port":
+        80, "protocol": "HTTP"} == listeners[0]'
+      - '{"instance_port": 8080, "instance_protocol": "HTTP", "load_balancer_port":
+        8080, "protocol": "HTTP"} == listeners[1]'
+    vars:
+      elb: '{{ info.elbs[0] }}'
+      listeners: "{{ elb.listener_descriptions|map(attribute='listener')|sort(attribute='load_balancer_port')
+        }}"
+  - name: Change AZ's
+    elb_classic_lb:
+      name: '{{ elb_name }}'
+      state: present
+      zones:
+      - '{{ aws_region }}c'
+      listeners:
+      - protocol: http
+        load_balancer_port: 80
+        instance_port: 80
+      purge_zones: yes
+      health_check:
+        ping_protocol: http
+        ping_port: 80
+        ping_path: /index.html
+        response_timeout: 5
+        interval: 30
+        unhealthy_threshold: 2
+        healthy_threshold: 10
+    register: update_az
+  - assert:
+      that:
+      - update_az is changed
+      - update_az.elb.zones[0] == aws_region ~ 'c'
 
-    - assert:
-        that:
-          - info.elbs|length == 1
-          - elb.availability_zones|length == 2
-          - aws_region ~ 'a' in elb.availability_zones
-          - aws_region ~ 'b' in elb.availability_zones
-          - elb.health_check.healthy_threshold == 10
-          - elb.health_check.interval == 30
-          - elb.health_check.target == "HTTP:80/index.html"
-          - elb.health_check.timeout == 5
-          - elb.health_check.unhealthy_threshold == 2
-          - '{"instance_port": 80, "instance_protocol": "HTTP", "load_balancer_port": 80, "protocol": "HTTP"} == listeners[0]'
-          - '{"instance_port": 8080, "instance_protocol": "HTTP", "load_balancer_port": 8080, "protocol": "HTTP"} == listeners[1]'
-      vars:
-        elb: "{{ info.elbs[0] }}"
-        listeners: "{{ elb.listener_descriptions|map(attribute='listener')|sort(attribute='load_balancer_port') }}"
+  - name: Get ELB info after changing AZ's
+    elb_classic_lb_info:
+      names: '{{ elb_name }}'
+    register: info
+  - assert:
+      that:
+      - elb.availability_zones|length == 1
+      - aws_region ~ 'c' in elb.availability_zones[0]
+    vars:
+      elb: '{{ info.elbs[0] }}'
+  - name: Update AZ's
+    elb_classic_lb:
+      name: '{{ elb_name }}'
+      state: present
+      zones:
+      - '{{ aws_region }}a'
+      - '{{ aws_region }}b'
+      - '{{ aws_region }}c'
+      listeners:
+      - protocol: http
+        load_balancer_port: 80
+        instance_port: 80
+      purge_zones: yes
+    register: update_az
+  - assert:
+      that:
+      - update_az is changed
+      - aws_region ~ 'a' in update_az.elb.zones
+      - aws_region ~ 'b' in update_az.elb.zones
+      - aws_region ~ 'c' in update_az.elb.zones
 
-    # ============================================================
+  - name: Get ELB info after updating AZ's
+    elb_classic_lb_info:
+      names: '{{ elb_name }}'
+    register: info
+  - assert:
+      that:
+      - elb.availability_zones|length == 3
+      - aws_region ~ 'a' in elb.availability_zones
+      - aws_region ~ 'b' in elb.availability_zones
+      - aws_region ~ 'c' in elb.availability_zones
+    vars:
+      elb: '{{ info.elbs[0] }}'
+  - name: Purge Listeners
+    elb_classic_lb:
+      name: '{{ elb_name }}'
+      state: present
+      zones:
+      - '{{ aws_region }}a'
+      - '{{ aws_region }}b'
+      - '{{ aws_region }}c'
+      listeners:
+      - protocol: http
+        load_balancer_port: 80
+        instance_port: 81
+      purge_listeners: yes
+    register: purge_listeners
+  - assert:
+      that:
+      - purge_listeners is changed
+      - '[80, 81, "HTTP", "HTTP"] in purge_listeners.elb.listeners'
+      - purge_listeners.elb.listeners|length == 1
 
-    # check ports, would be cool, but we are at the mercy of AWS
-    # to start things in a timely manner
+  - name: Get ELB info after purging listeners
+    elb_classic_lb_info:
+      names: '{{ elb_name }}'
+    register: info
+  - assert:
+      that:
+      - elb.listener_descriptions|length == 1
+      - '{"instance_port": 81, "instance_protocol": "HTTP", "load_balancer_port":
+        80, "protocol": "HTTP"} == elb.listener_descriptions[0].listener'
+    vars:
+      elb: '{{ info.elbs[0] }}'
+  - name: Add Listeners
+    elb_classic_lb:
+      name: '{{ elb_name }}'
+      state: present
+      zones:
+      - '{{ aws_region }}a'
+      - '{{ aws_region }}b'
+      - '{{ aws_region }}c'
+      listeners:
+      - protocol: http
+        load_balancer_port: 8081
+        instance_port: 8081
+      purge_listeners: no
+    register: update_listeners
+  - assert:
+      that:
+      - update_listeners is changed
+      - '[80, 81, "HTTP", "HTTP"] in update_listeners.elb.listeners'
+      - '[8081, 8081, "HTTP", "HTTP"] in update_listeners.elb.listeners'
+      - update_listeners.elb.listeners|length == 2
 
-    #- name: check to make sure 80 is listening
-    #  wait_for: host={{ info.elb.dns_name }} port=80 timeout=600
-    #  register: result
-
-    #- name: assert can connect to port#
-    #  assert: 'result.state == "started"'
-
-    #- name: check to make sure 443 is listening
-    #  wait_for: host={{ info.elb.dns_name }} port=443 timeout=600
-    #  register: result
-
-    #- name: assert can connect to port#
-    #  assert: 'result.state == "started"'
-
-    # ============================================================
-
-    # Change AZ's
-
-    - name: Change AZ's
-      elb_classic_lb:
-        name: "{{ elb_name }}"
-        state: present
-        zones:
-          - "{{ aws_region }}c"
-        listeners:
-          - protocol: http
-            load_balancer_port: 80
-            instance_port: 80
-        purge_zones: yes
-        health_check:
-            ping_protocol: http
-            ping_port: 80
-            ping_path: "/index.html"
-            response_timeout: 5
-            interval: 30
-            unhealthy_threshold: 2
-            healthy_threshold: 10
-      register: update_az
-
-    - assert:
-        that:
-          - update_az is changed
-          - update_az.elb.zones[0] == aws_region ~ 'c'
-
-    - name: Get ELB info after changing AZ's
-      elb_classic_lb_info:
-        names: "{{ elb_name }}"
-      register: info
-
-    - assert:
-        that:
-          - elb.availability_zones|length == 1
-          - aws_region ~ 'c' in elb.availability_zones[0]
-      vars:
-        elb: "{{ info.elbs[0] }}"
-
-    # ============================================================
-
-    # Update AZ's
-
-    - name: Update AZ's
-      elb_classic_lb:
-        name: "{{ elb_name }}"
-        state: present
-        zones:
-          - "{{ aws_region }}a"
-          - "{{ aws_region }}b"
-          - "{{ aws_region }}c"
-        listeners:
-          - protocol: http
-            load_balancer_port: 80
-            instance_port: 80
-        purge_zones: yes
-      register: update_az
-
-    - assert:
-        that:
-          - update_az is changed
-          - aws_region ~ 'a' in update_az.elb.zones
-          - aws_region ~ 'b' in update_az.elb.zones
-          - aws_region ~ 'c' in update_az.elb.zones
-
-    - name: Get ELB info after updating AZ's
-      elb_classic_lb_info:
-        names: "{{ elb_name }}"
-      register: info
-
-    - assert:
-        that:
-          - elb.availability_zones|length == 3
-          - aws_region ~ 'a' in elb.availability_zones
-          - aws_region ~ 'b' in elb.availability_zones
-          - aws_region ~ 'c' in elb.availability_zones
-      vars:
-        elb: "{{ info.elbs[0] }}"
-
-    # ============================================================
-
-    # Purge Listeners
-
-    - name: Purge Listeners
-      elb_classic_lb:
-        name: "{{ elb_name }}"
-        state: present
-        zones:
-          - "{{ aws_region }}a"
-          - "{{ aws_region }}b"
-          - "{{ aws_region }}c"
-        listeners:
-          - protocol: http
-            load_balancer_port: 80
-            instance_port: 81
-        purge_listeners: yes
-      register: purge_listeners
-
-    - assert:
-        that:
-          - purge_listeners is changed
-          - '[80, 81, "HTTP", "HTTP"] in purge_listeners.elb.listeners'
-          - purge_listeners.elb.listeners|length == 1
-
-    - name: Get ELB info after purging listeners
-      elb_classic_lb_info:
-        names: "{{ elb_name }}"
-      register: info
-
-    - assert:
-        that:
-          - elb.listener_descriptions|length == 1
-          - '{"instance_port": 81, "instance_protocol": "HTTP", "load_balancer_port": 80, "protocol": "HTTP"} == elb.listener_descriptions[0].listener'
-      vars:
-        elb: "{{ info.elbs[0] }}"
-
-
-    # ============================================================
-
-    # add Listeners
-
-    - name: Add Listeners
-      elb_classic_lb:
-        name: "{{ elb_name }}"
-        state: present
-        zones:
-          - "{{ aws_region }}a"
-          - "{{ aws_region }}b"
-          - "{{ aws_region }}c"
-        listeners:
-          - protocol: http
-            load_balancer_port: 8081
-            instance_port: 8081
-        purge_listeners: no
-      register: update_listeners
-
-    - assert:
-        that:
-          - update_listeners is changed
-          - '[80, 81, "HTTP", "HTTP"] in update_listeners.elb.listeners'
-          - '[8081, 8081, "HTTP", "HTTP"] in update_listeners.elb.listeners'
-          - update_listeners.elb.listeners|length == 2
-
-    - name: Get ELB info after adding listeners
-      elb_classic_lb_info:
-        names: "{{ elb_name }}"
-      register: info
-
-    - assert:
-        that:
-          - elb.listener_descriptions|length == 2
-          - '{"instance_port": 81, "instance_protocol": "HTTP", "load_balancer_port": 80, "protocol": "HTTP"} == listeners[0]'
-          - '{"instance_port": 8081, "instance_protocol": "HTTP", "load_balancer_port": 8081, "protocol": "HTTP"} == listeners[1]'
-      vars:
-        elb: "{{ info.elbs[0] }}"
-        listeners: "{{ elb.listener_descriptions|map(attribute='listener')|sort(attribute='load_balancer_port') }}"
-
-    # ============================================================
-
-    # Test getting nonexistent load balancer
-    - name: get nonexistent load balancer
-      elb_classic_lb_info:
-        names: "invalid-elb"
-      register: info
-
-    - assert:
-        that:
-          - info.elbs|length==0
+  - name: Get ELB info after adding listeners
+    elb_classic_lb_info:
+      names: '{{ elb_name }}'
+    register: info
+  - assert:
+      that:
+      - elb.listener_descriptions|length == 2
+      - '{"instance_port": 81, "instance_protocol": "HTTP", "load_balancer_port":
+        80, "protocol": "HTTP"} == listeners[0]'
+      - '{"instance_port": 8081, "instance_protocol": "HTTP", "load_balancer_port":
+        8081, "protocol": "HTTP"} == listeners[1]'
+    vars:
+      elb: '{{ info.elbs[0] }}'
+      listeners: "{{ elb.listener_descriptions|map(attribute='listener')|sort(attribute='load_balancer_port')
+        }}"
+  - name: get nonexistent load balancer
+    elb_classic_lb_info:
+      names: invalid-elb
+    register: info
+  - assert:
+      that:
+      - info.elbs|length==0
 
     # Test getting a valid and nonexistent load balancer
-    - name: get nonexistent load balancer
-      elb_classic_lb_info:
-        names: ["{{ elb_name }}", "invalid-elb"]
-      register: info
-
-    - assert:
-        that:
-          - info.elbs|length==1
-          - info.elbs[0].load_balancer_name == elb_name
+  - name: get nonexistent load balancer
+    elb_classic_lb_info:
+      names: ['{{ elb_name }}', invalid-elb]
+    register: info
+  - assert:
+      that:
+      - info.elbs|length==1
+      - info.elbs[0].load_balancer_name == elb_name
 
     # ============================================================
 
-    - name: get all load balancers
-      elb_classic_lb_info:
-        names: "{{ omit }}"
-      register: info
-
-    - assert:
-        that:
-          - info.elbs|length>0
+  - name: get all load balancers
+    elb_classic_lb_info:
+      names: '{{ omit }}'
+    register: info
+  - assert:
+      that:
+      - info.elbs|length>0
 
   always:
 
     # ============================================================
-    - name: remove the test load balancer completely
-      elb_classic_lb:
-        name: "{{ elb_name }}"
-        state: absent
-      register: result
-      ignore_errors: true
+  - name: remove the test load balancer completely
+    elb_classic_lb:
+      name: '{{ elb_name }}'
+      state: absent
+    register: result
+    ignore_errors: true

--- a/tests/integration/targets/elb_classic_lb_info/tasks/main.yml
+++ b/tests/integration/targets/elb_classic_lb_info/tasks/main.yml
@@ -18,10 +18,10 @@
 
 - module_defaults:
     group/aws:
-      region: "{{ ec2_region }}"
-      ec2_access_key: "{{ ec2_access_key }}"
-      ec2_secret_key: "{{ ec2_secret_key }}"
-      security_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
   block:
 
     # ============================================================
@@ -32,8 +32,8 @@
         name: "{{ elb_name }}"
         state: present
         zones:
-          - "{{ ec2_region }}a"
-          - "{{ ec2_region }}b"
+          - "{{ aws_region }}a"
+          - "{{ aws_region }}b"
         listeners:
           - protocol: http
             load_balancer_port: 80
@@ -55,8 +55,8 @@
         that:
           - create is changed
           # We rely on these for the info test, make sure they're what we expect
-          - '"{{ ec2_region }}a" in create.elb.zones'
-          - '"{{ ec2_region }}b" in create.elb.zones'
+          - '"{{ aws_region }}a" in create.elb.zones'
+          - '"{{ aws_region }}b" in create.elb.zones'
           - create.elb.health_check.healthy_threshold == 10
           - create.elb.health_check.interval == 30
           - create.elb.health_check.target == "HTTP:80/index.html"
@@ -74,8 +74,8 @@
         that:
           - info.elbs|length == 1
           - elb.availability_zones|length == 2
-          - '"{{ ec2_region }}a" in elb.availability_zones'
-          - '"{{ ec2_region }}b" in elb.availability_zones'
+          - '"{{ aws_region }}a" in elb.availability_zones'
+          - '"{{ aws_region }}b" in elb.availability_zones'
           - elb.health_check.healthy_threshold == 10
           - elb.health_check.interval == 30
           - elb.health_check.target == "HTTP:80/index.html"
@@ -115,7 +115,7 @@
         name: "{{ elb_name }}"
         state: present
         zones:
-          - "{{ ec2_region }}c"
+          - "{{ aws_region }}c"
         listeners:
           - protocol: http
             load_balancer_port: 80
@@ -134,7 +134,7 @@
     - assert:
         that:
           - update_az is changed
-          - update_az.elb.zones[0] == "{{ ec2_region }}c"
+          - update_az.elb.zones[0] == "{{ aws_region }}c"
 
     - name: Get ELB info after changing AZ's
       elb_classic_lb_info:
@@ -144,7 +144,7 @@
     - assert:
         that:
           - elb.availability_zones|length == 1
-          - '"{{ ec2_region }}c" in elb.availability_zones[0]'
+          - '"{{ aws_region }}c" in elb.availability_zones[0]'
       vars:
         elb: "{{ info.elbs[0] }}"
 
@@ -157,9 +157,9 @@
         name: "{{ elb_name }}"
         state: present
         zones:
-          - "{{ ec2_region }}a"
-          - "{{ ec2_region }}b"
-          - "{{ ec2_region }}c"
+          - "{{ aws_region }}a"
+          - "{{ aws_region }}b"
+          - "{{ aws_region }}c"
         listeners:
           - protocol: http
             load_balancer_port: 80
@@ -170,9 +170,9 @@
     - assert:
         that:
           - update_az is changed
-          - '"{{ ec2_region }}a" in update_az.elb.zones'
-          - '"{{ ec2_region }}b" in update_az.elb.zones'
-          - '"{{ ec2_region }}c" in update_az.elb.zones'
+          - '"{{ aws_region }}a" in update_az.elb.zones'
+          - '"{{ aws_region }}b" in update_az.elb.zones'
+          - '"{{ aws_region }}c" in update_az.elb.zones'
 
     - name: Get ELB info after updating AZ's
       elb_classic_lb_info:
@@ -182,9 +182,9 @@
     - assert:
         that:
           - elb.availability_zones|length == 3
-          - '"{{ ec2_region }}a" in elb.availability_zones'
-          - '"{{ ec2_region }}b" in elb.availability_zones'
-          - '"{{ ec2_region }}c" in elb.availability_zones'
+          - '"{{ aws_region }}a" in elb.availability_zones'
+          - '"{{ aws_region }}b" in elb.availability_zones'
+          - '"{{ aws_region }}c" in elb.availability_zones'
       vars:
         elb: "{{ info.elbs[0] }}"
 
@@ -197,9 +197,9 @@
         name: "{{ elb_name }}"
         state: present
         zones:
-          - "{{ ec2_region }}a"
-          - "{{ ec2_region }}b"
-          - "{{ ec2_region }}c"
+          - "{{ aws_region }}a"
+          - "{{ aws_region }}b"
+          - "{{ aws_region }}c"
         listeners:
           - protocol: http
             load_balancer_port: 80
@@ -235,9 +235,9 @@
         name: "{{ elb_name }}"
         state: present
         zones:
-          - "{{ ec2_region }}a"
-          - "{{ ec2_region }}b"
-          - "{{ ec2_region }}c"
+          - "{{ aws_region }}a"
+          - "{{ aws_region }}b"
+          - "{{ aws_region }}c"
         listeners:
           - protocol: http
             load_balancer_port: 8081

--- a/tests/integration/targets/elb_classic_lb_info/vars/main.yml
+++ b/tests/integration/targets/elb_classic_lb_info/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for test_ec2_elb_lb


### PR DESCRIPTION
Migrate elb_classic_lb_info* modules and tests

remove from community.aws https://github.com/ansible-collections/community.aws/pull/2135

closes #1863 