### PR TITLE
[PR #1659/26d7243 backport][stable-8] Fix ec2_instance 'state' processing when exact_count is used

### DIFF
--- a/changelogs/fragments/1659-ec2_instance-ensure-state-exact_count.yml
+++ b/changelogs/fragments/1659-ec2_instance-ensure-state-exact_count.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- ec2_instance - fix state processing when exact_count is used (https://github.com/ansible-collections/amazon.aws/pull/1659).

--- a/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
@@ -277,6 +277,57 @@
           - '"terminated_ids" not in terminate_multiple_instances'
           - '"ec2:TerminateInstances" not in terminate_multiple_instances.resource_actions'
 
+    - name: Trigger restart of instances with exact_count (check_mode)
+      amazon.aws.ec2_instance:
+        state: restarted
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 3
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+      register: restart_multiple_instances
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - restart_multiple_instances is not failed
+          - restart_multiple_instances.changed
+          - '"instances" in restart_multiple_instances'
+          - restart_multiple_instances.instances | length == 3
+          - '"reboot_success" in restart_multiple_instances'
+          - '"reboot_failed" in restart_multiple_instances'
+          - '"ec2:StopInstances" not in restart_multiple_instances.resource_actions'
+          - '"ec2:StartInstances" not in restart_multiple_instances.resource_actions'
+
+
+    - name: Trigger restart of instances with exact_count
+      amazon.aws.ec2_instance:
+        state: restarted
+        instance_type: "{{ ec2_instance_type }}"
+        exact_count: 3
+        region: "{{ aws_region }}"
+        image_id: "{{ ec2_ami_id }}"
+        name: "{{ resource_prefix }}-test-enf_cnt"
+        tags:
+          TestId: "{{ ec2_instance_tag_TestId }}"
+        wait: true
+      register: restart_multiple_instances
+
+    - ansible.builtin.assert:
+        that:
+          - restart_multiple_instances is not failed
+          - restart_multiple_instances.changed
+          - '"instances" in restart_multiple_instances'
+          - restart_multiple_instances.instances | length == 3
+          - '"reboot_success" in restart_multiple_instances'
+          - restart_multiple_instances.reboot_success | length == 3
+          - '"reboot_failed" in restart_multiple_instances'
+          - restart_multiple_instances.reboot_failed | length == 0
+          - '"ec2:StopInstances" in restart_multiple_instances.resource_actions'
+          - '"ec2:StartInstances" in restart_multiple_instances.resource_actions'
+
     - name: Enforce instance count to 6 - Launch 3 more instances (check_mode)
       amazon.aws.ec2_instance:
         instance_type: "{{ ec2_instance_type }}"


### PR DESCRIPTION
**This is a MANUAL backport of PR https://github.com/ansible-collections/amazon.aws/pull/1659 as merged into main (https://github.com/ansible-collections/amazon.aws/commit/26d72438e29bf2fff8216da4a6f20974be008f64).**

##### SUMMARY
Fixes (ie adds) 'state' processing for ec2_instance when 'exact_count' is used rather than 'instance_ids'

Note this only has effect when the exact_count is the same as the number of already existing, matching instances.
In other words, it (still) has no effect when instances are either added or terminated as a result of exact_count. This is probably OK, as those other cases already have set target states (ie running or terminated respectively).
But for the cases of managing the state of an existing group of instances, this adds that ability.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_instance

##### ADDITIONAL INFORMATION
Currently, given an ec2_instance call where exact_count == existing instance count, any specification of 'state' has no effect.