### PR TITLE
iam_role - makes EntityAlreadyExists error a warning and fixes bug when not creating a profile

### DIFF
--- a/changelogs/fragments/2281-iam_role-support-not-creating.yml
+++ b/changelogs/fragments/2281-iam_role-support-not-creating.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+- iam_role - fixes issue where IAM instance profiles were created when ``create_instance_profile`` was set to ``false`` (https://github.com/ansible-collections/amazon.aws/issues/2281).
+- iam_role - fixes ``EntityAlreadyExists`` exception when ``create_instance_profile`` was set to ``false`` and the instance profile already existed (https://github.com/ansible-collections/amazon.aws/issues/2102).

--- a/tests/integration/targets/iam_role/tasks/instance_profile.yml
+++ b/tests/integration/targets/iam_role/tasks/instance_profile.yml
@@ -1,0 +1,292 @@
+---
+
+- block:
+    # Ensure profile doesn't already exist (from an old test)
+    - name: Delete Instance Profile
+      amazon.aws.iam_instance_profile:
+        state: absent
+        name: "{{ test_role }}"
+
+    ##################################################################
+
+    # Profile doesn't exist, don't create
+    - name: Minimal IAM Role without instance profile (without existing profile)
+      amazon.aws.iam_role:
+        name: "{{ test_role }}"
+        create_instance_profile: false
+      register: iam_role
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - '"iam:CreateInstanceProfile" not in iam_role.resource_actions'
+
+    - name: Verify instance profile doesn't exist
+      amazon.aws.iam_instance_profile_info:
+        name: "{{ test_role }}"
+      register: iam_instance_profile
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile.iam_instance_profiles | length == 0
+
+    # Profile doesn't exist, do delete
+    - name: Remove IAM Role and profile (with non-existent profile)
+      amazon.aws.iam_role:
+        state: absent
+        name: "{{ test_role }}"
+        delete_instance_profile: true
+      register: iam_role
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - '"iam:DeleteInstanceProfile" not in iam_role.resource_actions'
+
+    - name: Verify instance profile doesn't exist
+      amazon.aws.iam_instance_profile_info:
+        name: "{{ test_role }}"
+      register: iam_instance_profile
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile.iam_instance_profiles | length == 0
+
+    ##################################################################
+
+    # Profile doesn't exist, do create
+    - name: Minimal IAM Role with instance profile (without existing profile)
+      amazon.aws.iam_role:
+        name: "{{ test_role }}"
+        create_instance_profile: true
+      register: iam_role
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - '"iam:CreateInstanceProfile" in iam_role.resource_actions'
+
+    - name: Verify instance profile exists
+      amazon.aws.iam_instance_profile_info:
+        name: "{{ test_role }}"
+      register: iam_instance_profile
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile.iam_instance_profiles | length == 1
+
+    # Profile does exist, don't delete
+    - name: Remove IAM Role and not profile (with existent profile)
+      amazon.aws.iam_role:
+        state: absent
+        name: "{{ test_role }}"
+        delete_instance_profile: false
+      register: iam_role
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - '"iam:DeleteInstanceProfile" not in iam_role.resource_actions'
+
+    - name: Verify instance profile exists
+      amazon.aws.iam_instance_profile_info:
+        name: "{{ test_role }}"
+      register: iam_instance_profile
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile.iam_instance_profiles | length == 1
+
+    ##################################################################
+
+    # Profile does exist, do create
+    - name: Minimal IAM Role with instance profile (profile exists)
+      amazon.aws.iam_role:
+        name: "{{ test_role }}"
+        create_instance_profile: true
+      register: iam_role
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - '"iam:CreateInstanceProfile" not in iam_role.resource_actions'
+
+    - name: Verify instance profile exists
+      amazon.aws.iam_instance_profile_info:
+        name: "{{ test_role }}"
+      register: iam_instance_profile
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile.iam_instance_profiles | length == 1
+
+
+    # Profile does exist, don't delete
+    - name: Remove IAM Role and don't delete profile (with existent profile)
+      amazon.aws.iam_role:
+        state: absent
+        name: "{{ test_role }}"
+        delete_instance_profile: false
+      register: iam_role
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - '"iam:DeleteInstanceProfile" not in iam_role.resource_actions'
+
+    - name: Verify instance profile exists
+      amazon.aws.iam_instance_profile_info:
+        name: "{{ test_role }}"
+      register: iam_instance_profile
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile.iam_instance_profiles | length == 1
+
+    ##################################################################
+    #  No create profile - profile already exists
+
+    # Profile does exist, don't create
+    - name: Minimal IAM Role without instance profile (profile exists)
+      amazon.aws.iam_role:
+        name: "{{ test_role }}"
+        create_instance_profile: false
+      register: iam_role
+
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - '"iam:CreateInstanceProfile" not in iam_role.resource_actions'
+
+    - name: Verify instance profile exists
+      amazon.aws.iam_instance_profile_info:
+        name: "{{ test_role }}"
+      register: iam_instance_profile
+
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile.iam_instance_profiles | length == 1
+
+    - name: Attach Role to profile
+      amazon.aws.iam_instance_profile:
+        name: "{{ test_role }}"
+        role: "{{ test_role }}"
+      register: iam_instance_profile
+
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile is changed
+
+    # Profile does exist, do delete
+    - name: Remove IAM Role and delete profile (with existent profile)
+      amazon.aws.iam_role:
+        state: absent
+        name: "{{ test_role }}"
+        delete_instance_profile: true
+      register: iam_role
+
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - '"iam:DeleteInstanceProfile" in iam_role.resource_actions'
+
+    - name: Verify instance profile exists
+      amazon.aws.iam_instance_profile_info:
+        name: "{{ test_role }}"
+      register: iam_instance_profile
+
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile.iam_instance_profiles | length == 0
+
+    ##################################################################
+
+    # Profile doesn't exist, don't create
+    - name: Minimal IAM Role without instance profile (without existing profile)
+      amazon.aws.iam_role:
+        name: "{{ test_role }}"
+        create_instance_profile: false
+      register: iam_role
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - '"iam:CreateInstanceProfile" not in iam_role.resource_actions'
+
+    - name: Verify instance profile doesn't exist
+      amazon.aws.iam_instance_profile_info:
+        name: "{{ test_role }}"
+      register: iam_instance_profile
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile.iam_instance_profiles | length == 0
+
+    # Profile doesn't exist, don't delete
+    - name: Remove IAM Role and profile (with non-existent profile)
+      amazon.aws.iam_role:
+        state: absent
+        name: "{{ test_role }}"
+        delete_instance_profile: false
+      register: iam_role
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - '"iam:DeleteInstanceProfile" not in iam_role.resource_actions'
+
+    - name: Verify instance profile doesn't exist
+      amazon.aws.iam_instance_profile_info:
+        name: "{{ test_role }}"
+      register: iam_instance_profile
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile.iam_instance_profiles | length == 0
+
+    ##################################################################
+
+    # Profile doesn't exist, do create
+    - name: Minimal IAM Role with instance profile (profile does not exist)
+      amazon.aws.iam_role:
+        name: "{{ test_role }}"
+        create_instance_profile: true
+      register: iam_role
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - '"iam:CreateInstanceProfile" in iam_role.resource_actions'
+
+    - name: Decouple Instance Profile from role
+      amazon.aws.iam_instance_profile:
+        name: "{{ test_role }}"
+        role: ""
+      register: iam_instance_profile
+
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile is changed
+
+    # Detached profile exists, we shouldn't delete it.
+    - name: Remove IAM Role and "delete" profile (with detached profile)
+      amazon.aws.iam_role:
+        state: absent
+        name: "{{ test_role }}"
+        delete_instance_profile: true
+      register: iam_role
+    - ansible.builtin.assert:
+        that:
+          - iam_role is changed
+          - '"iam:DeleteInstanceProfile" not in iam_role.resource_actions'
+
+    - name: Verify instance profile exists
+      amazon.aws.iam_instance_profile_info:
+        name: "{{ test_role }}"
+      register: iam_instance_profile
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile.iam_instance_profiles | length == 1
+
+    ##################################################################
+    #  Delete profile
+
+    - name: Delete Instance Profile
+      amazon.aws.iam_instance_profile:
+        state: absent
+        name: "{{ test_role }}"
+      register: iam_instance_profile
+
+    - ansible.builtin.assert:
+        that:
+          - iam_instance_profile is changed
+
+  always:
+    - name: Delete Instance Profiles
+      amazon.aws.iam_instance_profile:
+        state: absent
+        name: "{{ test_role }}"
+      ignore_errors: true

--- a/tests/integration/targets/iam_role/tasks/main.yml
+++ b/tests/integration/targets/iam_role/tasks/main.yml
@@ -45,7 +45,7 @@
           - create_managed_policy is succeeded
 
     # ===================================================================
-    # Rapid Role Creation and deletion
+    - ansible.builtin.include_tasks: instance_profile.yml
     - ansible.builtin.include_tasks: creation_deletion.yml
     - ansible.builtin.include_tasks: max_session_update.yml
     - ansible.builtin.include_tasks: description_update.yml


### PR DESCRIPTION
fixes: #2102
fixes: #2281

##### SUMMARY

- #2221 deprecation logic accidentally forced create_instance_profile to True
- The IAM refactor made iam_role sensitive to pre-existing instance profiles with the same name.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

iam_role

##### ADDITIONAL INFORMATION
