### PR TITLE
ec2_eip: add support of updating reverse dns record for eip

### DIFF
--- a/changelogs/fragments/2292-ec2_eip-add-support-to-update-reverse-dns-record.yml
+++ b/changelogs/fragments/2292-ec2_eip-add-support-to-update-reverse-dns-record.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ec2_eip - Add support to update reverse DNS record of an EIP (https://github.com/ansible-collections/amazon.aws/pull/2292).

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -77,9 +77,10 @@ options:
         only applies to newly allocated Elastic IPs, isn't validated when O(reuse_existing_ip_allowed=true).
     type: str
   domain_name:
-    description: The domain name to modify for the IP address.
+    description: The domain name to attach to the IP address.
     required: false
     type: str
+    version_added: 9.0.0
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -80,7 +80,7 @@ options:
     description: The domain name to attach to the IP address.
     required: false
     type: str
-    version_added: 9.0.0
+    version_added: 8.3.0
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules
@@ -285,10 +285,11 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleEC2Error
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import allocate_address as allocate_ip_address
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import associate_address
-from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import describe_addresses
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import describe_instances
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import describe_network_interfaces

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -222,7 +222,7 @@ EXAMPLES = r"""
 
 - name: Modify reverse DNS record of EIP
   amazon.aws.ec2_eip:
-    update_reverse_dns: true
+    update_reverse_dns_record: true
     allocation_id: eipalloc-00a61ec1234567890
     domain_name: example.com
 """

--- a/tests/integration/targets/ec2_eip/defaults/main.yml
+++ b/tests/integration/targets/ec2_eip/defaults/main.yml
@@ -9,3 +9,4 @@ eip_test_tags:
 eip_info_filters:
   tag:AnsibleEIPTestPrefix: "{{ resource_prefix }}"
 test_domain: "{{ resource_prefix }}.example.xyz"
+test_hosted_zone: "{{ resource_prefix }}.example.xyz"

--- a/tests/integration/targets/ec2_eip/defaults/main.yml
+++ b/tests/integration/targets/ec2_eip/defaults/main.yml
@@ -8,4 +8,4 @@ eip_test_tags:
   AnsibleEIPTestPrefix: "{{ resource_prefix }}"
 eip_info_filters:
   tag:AnsibleEIPTestPrefix: "{{ resource_prefix }}"
-test_domain: test-xyz.com
+test_domain: "{{ resource_prefix }}.example.xyz"

--- a/tests/integration/targets/ec2_eip/defaults/main.yml
+++ b/tests/integration/targets/ec2_eip/defaults/main.yml
@@ -8,3 +8,4 @@ eip_test_tags:
   AnsibleEIPTestPrefix: "{{ resource_prefix }}"
 eip_info_filters:
   tag:AnsibleEIPTestPrefix: "{{ resource_prefix }}"
+test_domain: test-xyz.com

--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -17,6 +17,7 @@
     - ansible.builtin.include_tasks: tasks/release.yml
     - ansible.builtin.include_tasks: tasks/attach_detach_to_eni.yml
     - ansible.builtin.include_tasks: tasks/attach_detach_to_instance.yml
+    - ansible.builtin.include_tasks: tasks/update_reverse_dns_record.yml
 
   always:
     - ansible.builtin.include_tasks: tasks/teardown.yml

--- a/tests/integration/targets/ec2_eip/tasks/main.yml
+++ b/tests/integration/targets/ec2_eip/tasks/main.yml
@@ -17,7 +17,9 @@
     - ansible.builtin.include_tasks: tasks/release.yml
     - ansible.builtin.include_tasks: tasks/attach_detach_to_eni.yml
     - ansible.builtin.include_tasks: tasks/attach_detach_to_instance.yml
-    - ansible.builtin.include_tasks: tasks/update_reverse_dns_record.yml
+
+    # Disabled as it requires a registered domain, and corresponding hosted zone
+    # - ansible.builtin.include_tasks: tasks/update_reverse_dns_record.yml
 
   always:
     - ansible.builtin.include_tasks: tasks/teardown.yml

--- a/tests/integration/targets/ec2_eip/tasks/update_reverse_dns_record.yml
+++ b/tests/integration/targets/ec2_eip/tasks/update_reverse_dns_record.yml
@@ -1,0 +1,43 @@
+- name: Test EIP allocation
+  block:
+    # ------------------------------------------------------------------------------------------
+    # Allocate EIP with reverse DNS record
+    # ------------------------------------------------------------------------------------------
+    - name: Allocate a new EIP and modify it's reverse DNS record - check_mode
+      amazon.aws.ec2_eip:
+        state: present
+        domain_name: "{{ test_domain }}"
+        tags: "{{ eip_test_tags }}"
+      register: eip
+      check_mode: true
+
+    - ansible.builtin.assert:
+        that:
+          - eip is changed
+
+    - name: Ensure no new EIP was created
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        has_no_new_eip: true
+
+    - name: Allocate a new EIP and modify it's reverse DNS record
+      amazon.aws.ec2_eip:
+        state: present
+        domain_name: "{{ test_domain }}"
+        tags: "{{ eip_test_tags }}"
+      register: eip
+
+    - ansible.builtin.assert:
+        that:
+          - eip is changed
+          - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
+          - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
+          - eip.update_reverse_dns_record_result is defined
+          - eip.update_reverse_dns_record_result.address.ptr_record_update is defined
+          - eip.update_reverse_dns_record_result.address.ptr_record_update.value == "{{ test_domain }}"
+
+  always:
+    - name: Delete EIP
+      ansible.builtin.include_tasks: tasks/common.yml
+      vars:
+        delete_eips: true

--- a/tests/integration/targets/ec2_eip/tasks/update_reverse_dns_record.yml
+++ b/tests/integration/targets/ec2_eip/tasks/update_reverse_dns_record.yml
@@ -1,7 +1,7 @@
-- name: Test EIP allocation
+- name: Test EIP allocation and reverse DNS record operations
   block:
     # ------------------------------------------------------------------------------------------
-    # Allocate EIP with reverse DNS record
+    # Allocate EIP with reverse DNS record - check mode
     # ------------------------------------------------------------------------------------------
     - name: Allocate a new EIP and modify it's reverse DNS record - check_mode
       amazon.aws.ec2_eip:
@@ -11,7 +11,8 @@
       register: eip
       check_mode: true
 
-    - ansible.builtin.assert:
+    - name: Assert that task result was as expected
+      ansible.builtin.assert:
         that:
           - eip is changed
 
@@ -20,6 +21,9 @@
       vars:
         has_no_new_eip: true
 
+    # ------------------------------------------------------------------------------------------
+    # Allocate EIP with reverse DNS record
+    # ------------------------------------------------------------------------------------------
     - name: Allocate a new EIP and modify it's reverse DNS record
       amazon.aws.ec2_eip:
         state: present
@@ -27,16 +31,86 @@
         tags: "{{ eip_test_tags }}"
       register: eip
 
-    - ansible.builtin.assert:
+    - name: Add EIP IP address an A record
+      amazon.aws.route53:
+        state: present
+        zone: "ansiblecloud.xyz"
+        record: "{{ test_domain }}"
+        type: A
+        ttl: 7200
+        value: "{{ eip.public_ip}}"
+        identifier: "{{ resource_prefix }}"
+        wait: true
+
+    - name: Wait for reverse DNS record update to complete
+      pause:
+        minutes: 3
+
+    - name: Assert that task result was as expected
+      ansible.builtin.assert:
         that:
           - eip is changed
           - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
           - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
           - eip.update_reverse_dns_record_result is defined
           - eip.update_reverse_dns_record_result.address.ptr_record_update is defined
-          - eip.update_reverse_dns_record_result.address.ptr_record_update.value == "{{ test_domain }}"
+          - eip.update_reverse_dns_record_result.address.ptr_record_update.value == "{{ test_domain }}."
+
+    # ------------------------------------------------------------------------------------------
+    # Allocate EIP with reverse DNS record - idempotence
+    # ------------------------------------------------------------------------------------------
+    - name: Try modifying reverse DNS record of EIP to same domain as current - Idempotent
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        domain_name: "{{ test_domain }}"
+        tags: "{{ eip_test_tags }}"
+      register: eip
+
+    - name: Assert that task result was as expected
+      ansible.builtin.assert:
+        that:
+          - eip is not changed
+          - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
+          - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
+          - eip.update_reverse_dns_record_result is defined
+          - eip.update_reverse_dns_record_result.ptr_record == "{{ test_domain }}."
+
+    # ------------------------------------------------------------------------------------------
+    # Update reverse DNS record of existing EIP - remove reverse DNS record
+    # ------------------------------------------------------------------------------------------
+    - name: Try modifying reverse DNS record of EIP to different domain than current
+      amazon.aws.ec2_eip:
+        state: present
+        public_ip: "{{ eip.public_ip }}"
+        domain_name: ""
+        tags: "{{ eip_test_tags }}"
+      register: eip
+
+    - name: Assert that changes were applied
+      ansible.builtin.assert:
+        that:
+          - eip is changed
+          - eip.public_ip is defined and ( eip.public_ip | ansible.utils.ipaddr )
+          - eip.allocation_id is defined and eip.allocation_id.startswith("eipalloc-")
+
+    - name: Wait for reverse DNS record update to complete
+      pause:
+        minutes: 3
 
   always:
+
+    - name: Delete EIP IP address an A record
+      amazon.aws.route53:
+        state: present
+        zone: "ansiblecloud.xyz"
+        record: "{{ test_domain }}"
+        type: A
+        ttl: 7200
+        value: "{{ eip.public_ip}}"
+        identifier: "{{ resource_prefix }}"
+        wait: true
+
     - name: Delete EIP
       ansible.builtin.include_tasks: tasks/common.yml
       vars:

--- a/tests/integration/targets/ec2_eip/tasks/update_reverse_dns_record.yml
+++ b/tests/integration/targets/ec2_eip/tasks/update_reverse_dns_record.yml
@@ -34,7 +34,7 @@
     - name: Add EIP IP address an A record
       amazon.aws.route53:
         state: present
-        zone: "ansiblecloud.xyz"
+        zone: "{{ test_hosted_zone }}"
         record: "{{ test_domain }}"
         type: A
         ttl: 7200
@@ -103,7 +103,7 @@
     - name: Delete EIP IP address an A record
       amazon.aws.route53:
         state: present
-        zone: "ansiblecloud.xyz"
+        zone: "{{ test_hosted_zone }}"
         record: "{{ test_domain }}"
         type: A
         ttl: 7200

--- a/tests/unit/plugins/modules/ec2_eip/test_reverse_dns_record_updates.py
+++ b/tests/unit/plugins/modules/ec2_eip/test_reverse_dns_record_updates.py
@@ -2,6 +2,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from unittest.mock import MagicMock
+
 import pytest
 
 from ansible_collections.amazon.aws.plugins.modules import ec2_eip

--- a/tests/unit/plugins/modules/ec2_eip/test_reverse_dns_record_updates.py
+++ b/tests/unit/plugins/modules/ec2_eip/test_reverse_dns_record_updates.py
@@ -1,0 +1,187 @@
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+import pytest
+
+from ansible_collections.amazon.aws.plugins.modules import ec2_eip
+
+module_name = "ansible_collections.amazon.aws.plugins.modules.ec2_eip"
+
+
+class FailJsonException(Exception):
+    def __init__(self):
+        pass
+
+
+@pytest.fixture
+def ansible_module():
+    module = MagicMock()
+    module.fail_json.side_effect = FailJsonException()
+    module.fail_json_aws.side_effect = FailJsonException()
+    module.check_mode = False
+    return module
+
+
+def mock_address():
+    return {
+        "InstanceId": "i-12345678",
+        "PublicIp": "1.2.3.4",
+        "AllocationId": "eipalloc-12345678",
+        "AssociationId": "eipassoc-12345678",
+        "Domain": "vpc",
+        "NetworkInterfaceId": "eni-12345678",
+        "NetworkInterfaceOwnerId": "123456789012",
+        "PrivateIpAddress": "10.0.0.1",
+        "Tags": [{"Key": "Name", "Value": "MyElasticIP"}],
+        "PublicIpv4Pool": "my-ipv4-pool",
+        "NetworkBorderGroup": "my-border-group",
+        "CustomerOwnedIp": "192.0.2.0",
+        "CustomerOwnedIpv4Pool": "my-customer-owned-pool",
+        "CarrierIp": "203.0.113.0",
+    }
+
+
+def mock_return_value_describe_addresses_attribute():
+    return {
+        "Addresses": [
+            {
+                "PublicIp": "1.2.3.4",
+                "AllocationId": "eipalloc-12345678",
+                "PtrRecord": "current.example.com.",
+                "PtrRecordUpdate": {
+                    "Value": "current.example.com.",
+                    "Status": "successful",
+                    "Reason": "updated",
+                },
+            }
+        ]
+    }
+
+
+def test_update_reverse_dns_record_of_eip_no_change_in_dns_record(ansible_module):
+    client = MagicMock()
+
+    address = mock_address()
+    mock_domain_name = "current.example.com"
+
+    client.describe_addresses_attribute.return_value = mock_return_value_describe_addresses_attribute()
+
+    client.modify_address_attribute.return_value = None
+    client.reset_address_attribute.return_value = None
+
+    assert ec2_eip.update_reverse_dns_record_of_eip(client, ansible_module, address, mock_domain_name) == (
+        False,
+        {"ptr_record": mock_domain_name + "."},
+    )
+
+    assert client.describe_addresses_attribute.call_count == 1
+    assert client.modify_address_attribute.call_count == 0
+    assert client.reset_address_attribute.call_count == 0
+
+    client.describe_addresses_attribute.assert_called_once_with(
+        AllocationIds=["eipalloc-12345678"], Attribute="domain-name"
+    )
+
+
+def test_update_reverse_dns_record_of_eip_reset_dns_record(ansible_module):
+    client = MagicMock()
+
+    address = mock_address()
+    mock_domain_name = ""
+
+    client.describe_addresses_attribute.return_value = mock_return_value_describe_addresses_attribute()
+
+    client.modify_address_attribute.return_value = None
+    client.reset_address_attribute.return_value = {
+        "Addresses": [
+            {
+                "PublicIp": "1.2.3.4",
+                "AllocationId": "eipalloc-12345678",
+                "PtrRecord": "current.example.com.",
+                "PtrRecordUpdate": {
+                    "Value": "",
+                    "Status": "PENDING",
+                    "Reason": "update in progress",
+                },
+            }
+        ]
+    }
+
+    assert ec2_eip.update_reverse_dns_record_of_eip(client, ansible_module, address, mock_domain_name) == (
+        True,
+        {
+            "addresses": [
+                {
+                    "public_ip": "1.2.3.4",
+                    "allocation_id": "eipalloc-12345678",
+                    "ptr_record": "current.example.com.",
+                    "ptr_record_update": {"value": "", "status": "PENDING", "reason": "update in progress"},
+                }
+            ]
+        },
+    )
+
+    assert client.describe_addresses_attribute.call_count == 1
+    assert client.modify_address_attribute.call_count == 0
+    assert client.reset_address_attribute.call_count == 1
+
+    client.describe_addresses_attribute.assert_called_once_with(
+        AllocationIds=["eipalloc-12345678"], Attribute="domain-name"
+    )
+    client.reset_address_attribute.assert_called_once_with(AllocationId="eipalloc-12345678", Attribute="domain-name")
+
+
+def test_update_reverse_dns_record_of_eip_modify_dns_record(ansible_module):
+    client = MagicMock()
+
+    address = mock_address()
+
+    mock_domain_name = "new.example.com"
+
+    client.describe_addresses_attribute.return_value = mock_return_value_describe_addresses_attribute()
+
+    client.modify_address_attribute.return_value = {
+        "Addresses": [
+            {
+                "PublicIp": "1.2.3.4",
+                "AllocationId": "eipalloc-12345678",
+                "PtrRecord": "current.example.com.",
+                "PtrRecordUpdate": {
+                    "Value": "new.example.com",
+                    "Status": "PENDING",
+                    "Reason": "update in progress",
+                },
+            }
+        ]
+    }
+    client.reset_address_attribute.return_value = None
+
+    assert ec2_eip.update_reverse_dns_record_of_eip(client, ansible_module, address, mock_domain_name) == (
+        True,
+        {
+            "addresses": [
+                {
+                    "public_ip": "1.2.3.4",
+                    "allocation_id": "eipalloc-12345678",
+                    "ptr_record": "current.example.com.",
+                    "ptr_record_update": {
+                        "value": "new.example.com",
+                        "status": "PENDING",
+                        "reason": "update in progress",
+                    },
+                }
+            ]
+        },
+    )
+
+    assert client.describe_addresses_attribute.call_count == 1
+    assert client.modify_address_attribute.call_count == 1
+    assert client.reset_address_attribute.call_count == 0
+
+    client.describe_addresses_attribute.assert_called_once_with(
+        AllocationIds=["eipalloc-12345678"], Attribute="domain-name"
+    )
+    client.modify_address_attribute.assert_called_once_with(
+        AllocationId="eipalloc-12345678", DomainName=mock_domain_name
+    )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add support of updating reverse dns record for eip
Fixes #1296 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_eip
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/modify_address_attribute.html
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
