### PR TITLE
[DNM] s3_object: fix removal of max_keys=0 from params for list_keys operation

### DIFF
--- a/changelogs/fragments/2293-s3_object-keep-max_keys-0-in-pagination_params.yml
+++ b/changelogs/fragments/2293-s3_object-keep-max_keys-0-in-pagination_params.yml
@@ -1,3 +1,0 @@
----
-bugfixes:
-- s3_object - fix removal of max_keys=0 from params for list_keys operation (https://github.com/ansible-collections/amazon.aws/pull/2293).

--- a/changelogs/fragments/2293-s3_object-keep-max_keys-0-in-pagination_params.yml
+++ b/changelogs/fragments/2293-s3_object-keep-max_keys-0-in-pagination_params.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- s3_object - fix removal of max_keys=0 from params for list_keys operation (https://github.com/ansible-collections/amazon.aws/pull/2293).

--- a/changelogs/fragments/2294-s3_object-keep-max_keys-0-in-pagination_params.yml
+++ b/changelogs/fragments/2294-s3_object-keep-max_keys-0-in-pagination_params.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- s3_object - fix removal of max_keys=0 from params for list_keys operation (https://github.com/ansible-collections/amazon.aws/pull/2294).

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -594,7 +594,7 @@ def list_keys(s3, bucket, prefix=None, marker=None, max_keys=None):
         "StartAfter": marker,
         "MaxKeys": max_keys,
     }
-    pagination_params = {k: v for k, v in pagination_params.items() if v}
+    pagination_params = {k: v for k, v in pagination_params.items() if v is not None}
 
     try:
         return list(paginated_list(s3, **pagination_params))

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -448,6 +448,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_extra_para
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import validate_bucket_name
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+from ansible_collections.amazon.aws.plugins.module_utils.transformation import scrub_none_parameters
 
 IGNORE_S3_DROP_IN_EXCEPTIONS = ["XNotImplemented", "NotImplemented"]
 
@@ -594,7 +595,7 @@ def list_keys(s3, bucket, prefix=None, marker=None, max_keys=None):
         "StartAfter": marker,
         "MaxKeys": max_keys,
     }
-    pagination_params = {k: v for k, v in pagination_params.items() if v is not None}
+    pagination_params = {k: v for k, v in pagination_params.items() if v not in ('', None)}
 
     try:
         return list(paginated_list(s3, **pagination_params))

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -448,7 +448,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_extra_para
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import validate_bucket_name
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
-from ansible_collections.amazon.aws.plugins.module_utils.transformation import scrub_none_parameters
 
 IGNORE_S3_DROP_IN_EXCEPTIONS = ["XNotImplemented", "NotImplemented"]
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
fix accidental removal of max_keys: 0 from params
The current code removes all falsy values including 0, causing 'max_keys: 0' being removed from pagination_params

builds up on work from #1954 
Fixes #1953 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request


##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
s3_object
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
    - name: List keys all options
      amazon.aws.s3_object:
        bucket: my-test-bucket
        mode: list
        max_keys: 0
```
current code
```
list_keys: 'before param cleanup ', {'Bucket': 'mandkulk-test-bucket', 'MaxKeys': 0, 'Prefix': '', 'StartAfter': ''}
list_keys: 'after param cleanup ', {'Bucket': 'mandkulk-test-bucket'}
```
PR code
```
list_keys: 'before param cleanup ', {'Bucket': 'mandkulk-test-bucket', 'MaxKeys': 0, 'Prefix': '', 'StartAfter': ''}
list_keys: 'after param cleanup ', {'Bucket': 'mandkulk-test-bucket', 'MaxKeys': 0}
```
