### PR TITLE
Fix sanity errors occurring with the devel branch of ansible

### DIFF
--- a/changelogs/fragments/20240919-sanity_fixes_devel.yml
+++ b/changelogs/fragments/20240919-sanity_fixes_devel.yml
@@ -1,0 +1,2 @@
+trivial:
+  - "Fix sanity errors occurring with the devel branch of ansible."

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -419,6 +419,7 @@ def create_vpc_endpoint(client, module):
 
 def setup_removal(client, module):
     params = dict()
+    result = {}
     changed = False
 
     if module.check_mode:

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -763,6 +763,7 @@ def ensure_route_table_present(connection, module):
 
     changed = False
     tags_valid = False
+    route_table = None
 
     if lookup == "tag":
         if tags is not None:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fix sanity errors occurring with the devel branch of ansible 

```
ERROR: Found 2 pylint issue(s) which need to be resolved:
ERROR: plugins/modules/ec2_vpc_endpoint.py:441:24: used-before-assignment: Using variable 'result' before assignment
ERROR: plugins/modules/ec2_vpc_route_table.py:792:7: used-before-assignment: Using variable 'route_table' before assignment
```
See https://github.com/ansible-collections/amazon.aws/pull/2295
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
