### PR TITLE
ec2_instance add the possibility to upgrade/downgrade instance type on the fly

### DIFF
--- a/changelogs/fragments/20240917-ec2_instance-upgrade-downgrade-instance-type.yml
+++ b/changelogs/fragments/20240917-ec2_instance-upgrade-downgrade-instance-type.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - ec2_instance - add the possibility to upgrade / downgrade existing ec2 instance type (https://github.com/ansible-collections/amazon.aws/issues/469).

--- a/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
@@ -42,7 +42,7 @@
         purge_tags: false
         filters:
           tag:TestId: "{{ ec2_instance_tag_TestId }}"
-        wait: false
+        wait: true
       register: create_multiple_instances
 
     - ansible.builtin.assert:
@@ -146,7 +146,7 @@
         purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
-        wait: false
+        wait: true
       register: create_multiple_instances
 
     - ansible.builtin.assert:
@@ -324,7 +324,7 @@
         purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
-        wait: false
+        wait: true
       register: restart_multiple_instances
 
     - ansible.builtin.assert:
@@ -374,7 +374,7 @@
         purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
-        wait: false
+        wait: true
       register: create_multiple_instances
 
     - name: debug is here

--- a/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
@@ -232,7 +232,7 @@
         purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
-        wait: false
+        wait: true
       register: terminate_multiple_instances
 
     - ansible.builtin.assert:

--- a/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_instance_multiple/tasks/main.yml
@@ -15,6 +15,7 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         state: present
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
         filters:
@@ -38,9 +39,10 @@
         state: present
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
+        purge_tags: false
         filters:
           tag:TestId: "{{ ec2_instance_tag_TestId }}"
-        wait: true
+        wait: false
       register: create_multiple_instances
 
     - ansible.builtin.assert:
@@ -121,6 +123,7 @@
         region: "{{ aws_region }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
         image_id: "{{ ec2_ami_id }}"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
       register: create_multiple_instances
@@ -140,9 +143,10 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
-        wait: true
+        wait: false
       register: create_multiple_instances
 
     - ansible.builtin.assert:
@@ -160,6 +164,7 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
       register: create_multiple_instances
@@ -180,6 +185,7 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
         wait: true
@@ -200,6 +206,7 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
       register: terminate_multiple_instances
@@ -222,9 +229,10 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
-        wait: true
+        wait: false
       register: terminate_multiple_instances
 
     - ansible.builtin.assert:
@@ -243,6 +251,7 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
       register: terminate_multiple_instances
@@ -264,6 +273,7 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
       register: terminate_multiple_instances
@@ -285,6 +295,7 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
       register: restart_multiple_instances
@@ -310,9 +321,10 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
-        wait: true
+        wait: false
       register: restart_multiple_instances
 
     - ansible.builtin.assert:
@@ -335,6 +347,7 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
         wait: true
@@ -358,9 +371,10 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
-        wait: true
+        wait: false
       register: create_multiple_instances
 
     - name: debug is here
@@ -381,6 +395,7 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
         wait: true
@@ -403,6 +418,7 @@
         region: "{{ aws_region }}"
         image_id: "{{ ec2_ami_id }}"
         name: "{{ resource_prefix }}-test-enf_cnt"
+        purge_tags: false
         tags:
           TestId: "{{ ec2_instance_tag_TestId }}"
         wait: true

--- a/tests/integration/targets/ec2_instance_type/aliases
+++ b/tests/integration/targets/ec2_instance_type/aliases
@@ -1,0 +1,4 @@
+time=7m
+cloud/aws
+ec2_instance_info
+ec2_instance

--- a/tests/integration/targets/ec2_instance_type/aliases
+++ b/tests/integration/targets/ec2_instance_type/aliases
@@ -1,4 +1,4 @@
-time=7m
+time=15m
 cloud/aws
 ec2_instance_info
 ec2_instance

--- a/tests/integration/targets/ec2_instance_type/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_type/defaults/main.yml
@@ -1,4 +1,3 @@
 ---
 ec2_instance_type_initial: t2.micro
 ec2_instance_type_updated: t3.nano
-ec2_instance_name: "{{ resource_prefix }}-test-instance-type"

--- a/tests/integration/targets/ec2_instance_type/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance_type/defaults/main.yml
@@ -1,0 +1,4 @@
+---
+ec2_instance_type_initial: t2.micro
+ec2_instance_type_updated: t3.nano
+ec2_instance_name: "{{ resource_prefix }}-test-instance-type"

--- a/tests/integration/targets/ec2_instance_type/meta/main.yml
+++ b/tests/integration/targets/ec2_instance_type/meta/main.yml
@@ -1,0 +1,4 @@
+---
+dependencies:
+  - role: setup_ec2_facts
+  - role: setup_ec2_instance_env

--- a/tests/integration/targets/ec2_instance_type/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_type/tasks/main.yml
@@ -6,77 +6,38 @@
       session_token: "{{ security_token | default(omit) }}"
       region: "{{ aws_region }}"
   block:
-    - name: Make instance in the testing subnet created in the test VPC
-      amazon.aws.ec2_instance:
-        state: present
-        name: "{{ ec2_instance_name }}"
-        image_id: "{{ ec2_ami_id }}"
-        availability_zone: "{{ subnet_b_az }}"
-        instance_type: "{{ ec2_instance_type_initial }}"
-        wait: false
-      register: _instances
+    - include_tasks: single_instance.yml
+      vars:
+        ec2_instance_name: "{{ resource_prefix }}-test-instance-type-single"
 
-    - name: Define instance ids
-      ansible.builtin.set_fact:
-        ec2_instance_ids: "{{ _instances.instance_ids }}"
+    - name: "Test update instance type using exact_count"
+      vars:
+        ec2_instance_name: "{{ resource_prefix }}-test-instance-type-multiple"
+      block:
+        - name: Create multiple ec2 instances
+          amazon.aws.ec2_instance:
+            state: present
+            name: "{{ ec2_instance_name }}"
+            image_id: "{{ ec2_ami_id }}"
+            subnet_id: "{{ testing_subnet_a.subnet.id }}"
+            instance_type: "{{ ec2_instance_type_initial }}"
+            wait: false
+            exact_count: 2
 
-    - name: Update instance type (check mode)
-      amazon.aws.ec2_instance:
-        state: present
-        instance_ids: "{{ ec2_instance_ids }}"
-        instance_type: "{{ ec2_instance_type_updated }}"
-        wait: false
-      register: update_check_mode
-      check_mode: true
+        - name: Test upgrade instance type with various number of instances
+          include_tasks: update_instance_type.yml
+          with_items:
+            - new_instance_type: "{{ ec2_instance_type_updated }}"
+              new_instance_count: 2
+            - new_instance_type: "{{ ec2_instance_type_initial }}"
+              new_instance_count: 3
+            - new_instance_type: "{{ ec2_instance_type_updated }}"
+              new_instance_count: 2
 
-    - name: Gather ec2 instances info
-      amazon.aws.ec2_instance_info:
-        instance_ids: "{{ ec2_instance_ids }}"
-      register: _instances_info
-
-    - name: Ensure module reported change while the instance type was not changed (check_mode)
-      ansible.builtin.assert:
-        that:
-          - update_check_mode is changed
-          - _instances_info.instances | map(attribute='instance_type') | unique | list == [ec2_instance_type_initial]
-
-    - name: Update instance type
-      amazon.aws.ec2_instance:
-        state: present
-        instance_ids: "{{ ec2_instance_ids }}"
-        instance_type: "{{ ec2_instance_type_updated }}"
-        wait: false
-      register: _update_instance_type
-
-    - name: Gather ec2 instances info
-      amazon.aws.ec2_instance_info:
-        instance_ids: "{{ ec2_instance_ids }}"
-      register: _instances_info
-
-    - name: Ensure module reported change while the instance type was not changed (check_mode)
-      ansible.builtin.assert:
-        that:
-          - _update_instance_type is changed
-          - _instances_info.instances | map(attribute='instance_type') | unique | list == [ec2_instance_type_updated]
-
-    - name: Update instance type (idempotency)
-      amazon.aws.ec2_instance:
-        state: present
-        instance_ids: "{{ ec2_instance_ids }}"
-        instance_type: "{{ ec2_instance_type_updated }}"
-        wait: false
-      register: _update_idempotency
-
-    - name: Validate idempotency did not reported change
-      ansible.builtin.assert:
-        that:
-          - _update_idempotency is not changed
-
-  always:
-    - name: Delete instance created for tests
-      amazon.aws.ec2_instance:
-        state: absent
-        instance_ids: "{{ ec2_instance_ids }}"
-        wait: false
-      ignore_errors: true
-      when: ec2_instance_ids is defined
+      always:
+        - name: Delete ec2 instances
+          amazon.aws.ec2_instance:
+            state: absent
+            instance_ids: "{{ _instances_info.instances | map(attribute='instance_id') | list }}"
+            wait: false
+          when: _instances_info is defined

--- a/tests/integration/targets/ec2_instance_type/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance_type/tasks/main.yml
@@ -1,0 +1,82 @@
+---
+- module_defaults:
+    group/aws:
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+    - name: Make instance in the testing subnet created in the test VPC
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ ec2_instance_name }}"
+        image_id: "{{ ec2_ami_id }}"
+        availability_zone: "{{ subnet_b_az }}"
+        instance_type: "{{ ec2_instance_type_initial }}"
+        wait: false
+      register: _instances
+
+    - name: Define instance ids
+      ansible.builtin.set_fact:
+        ec2_instance_ids: "{{ _instances.instance_ids }}"
+
+    - name: Update instance type (check mode)
+      amazon.aws.ec2_instance:
+        state: present
+        instance_ids: "{{ ec2_instance_ids }}"
+        instance_type: "{{ ec2_instance_type_updated }}"
+        wait: false
+      register: update_check_mode
+      check_mode: true
+
+    - name: Gather ec2 instances info
+      amazon.aws.ec2_instance_info:
+        instance_ids: "{{ ec2_instance_ids }}"
+      register: _instances_info
+
+    - name: Ensure module reported change while the instance type was not changed (check_mode)
+      ansible.builtin.assert:
+        that:
+          - update_check_mode is changed
+          - _instances_info.instances | map(attribute='instance_type') | unique | list == [ec2_instance_type_initial]
+
+    - name: Update instance type
+      amazon.aws.ec2_instance:
+        state: present
+        instance_ids: "{{ ec2_instance_ids }}"
+        instance_type: "{{ ec2_instance_type_updated }}"
+        wait: false
+      register: _update_instance_type
+
+    - name: Gather ec2 instances info
+      amazon.aws.ec2_instance_info:
+        instance_ids: "{{ ec2_instance_ids }}"
+      register: _instances_info
+
+    - name: Ensure module reported change while the instance type was not changed (check_mode)
+      ansible.builtin.assert:
+        that:
+          - _update_instance_type is changed
+          - _instances_info.instances | map(attribute='instance_type') | unique | list == [ec2_instance_type_updated]
+
+    - name: Update instance type (idempotency)
+      amazon.aws.ec2_instance:
+        state: present
+        instance_ids: "{{ ec2_instance_ids }}"
+        instance_type: "{{ ec2_instance_type_updated }}"
+        wait: false
+      register: _update_idempotency
+
+    - name: Validate idempotency did not reported change
+      ansible.builtin.assert:
+        that:
+          - _update_idempotency is not changed
+
+  always:
+    - name: Delete instance created for tests
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids: "{{ ec2_instance_ids }}"
+        wait: false
+      ignore_errors: true
+      when: ec2_instance_ids is defined

--- a/tests/integration/targets/ec2_instance_type/tasks/single_instance.yml
+++ b/tests/integration/targets/ec2_instance_type/tasks/single_instance.yml
@@ -1,0 +1,77 @@
+---
+- name: Test upgrade instance type from a single created instance
+  block:
+    - name: Create ec2 instance
+      amazon.aws.ec2_instance:
+        state: present
+        name: "{{ ec2_instance_name }}"
+        image_id: "{{ ec2_ami_id }}"
+        subnet_id: "{{ testing_subnet_a.subnet.id }}"
+        instance_type: "{{ ec2_instance_type_initial }}"
+        wait: false
+      register: _instances
+
+    - name: Define instance ids
+      ansible.builtin.set_fact:
+        ec2_instance_ids: "{{ _instances.instance_ids }}"
+
+    - name: Update instance type (check mode)
+      amazon.aws.ec2_instance:
+        state: present
+        instance_ids: "{{ ec2_instance_ids }}"
+        instance_type: "{{ ec2_instance_type_updated }}"
+        wait: false
+      register: update_check_mode
+      check_mode: true
+
+    - name: Gather ec2 instances info
+      amazon.aws.ec2_instance_info:
+        instance_ids: "{{ ec2_instance_ids }}"
+      register: _instances_info
+
+    - name: Ensure module reported change while the instance type was not changed (check_mode)
+      ansible.builtin.assert:
+        that:
+          - update_check_mode is changed
+          - _instances_info.instances | map(attribute='instance_type') | unique | list == [ec2_instance_type_initial]
+
+    - name: Update instance type
+      amazon.aws.ec2_instance:
+        state: present
+        instance_ids: "{{ ec2_instance_ids }}"
+        instance_type: "{{ ec2_instance_type_updated }}"
+        wait: false
+      register: _update_instance_type
+
+    - name: Gather ec2 instances info
+      amazon.aws.ec2_instance_info:
+        instance_ids: "{{ ec2_instance_ids }}"
+      register: _instances_info
+
+    - name: Ensure module reported change while the instance type was not changed (check_mode)
+      ansible.builtin.assert:
+        that:
+          - _update_instance_type is changed
+          - _instances_info.instances | map(attribute='instance_type') | unique | list == [ec2_instance_type_updated]
+
+    - name: Update instance type (idempotency)
+      amazon.aws.ec2_instance:
+        state: present
+        instance_ids: "{{ ec2_instance_ids }}"
+        instance_type: "{{ ec2_instance_type_updated }}"
+        wait: false
+      register: _update_idempotency
+
+    - name: Validate idempotency did not reported change
+      ansible.builtin.assert:
+        that:
+          - _update_idempotency is not changed
+
+  always:
+    - name: Delete instance created for tests
+      amazon.aws.ec2_instance:
+        state: absent
+        instance_ids: "{{ ec2_instance_ids }}"
+        wait: false
+      ignore_errors: true
+      when: ec2_instance_ids is defined

--- a/tests/integration/targets/ec2_instance_type/tasks/single_instance.yml
+++ b/tests/integration/targets/ec2_instance_type/tasks/single_instance.yml
@@ -48,7 +48,7 @@
         instance_ids: "{{ ec2_instance_ids }}"
       register: _instances_info
 
-    - name: Ensure module reported change while the instance type was not changed (check_mode)
+    - name: Ensure module reported change and the instance type was updated
       ansible.builtin.assert:
         that:
           - _update_instance_type is changed
@@ -62,7 +62,7 @@
         wait: false
       register: _update_idempotency
 
-    - name: Validate idempotency did not reported change
+    - name: Validate idempotency did not report change
       ansible.builtin.assert:
         that:
           - _update_idempotency is not changed

--- a/tests/integration/targets/ec2_instance_type/tasks/update_instance_type.yml
+++ b/tests/integration/targets/ec2_instance_type/tasks/update_instance_type.yml
@@ -1,0 +1,77 @@
+---
+- name: Gather current ec2 instances info
+  amazon.aws.ec2_instance_info:
+    filters:
+      "tag:Name": "{{ ec2_instance_name }}"
+      instance-state-name: [pending, running]
+  register: _current_instances_info
+
+# Test update using check_mode
+- name: Update instance type using check mode
+  amazon.aws.ec2_instance:
+    state: present
+    name: "{{ ec2_instance_name }}"
+    image_id: "{{ ec2_ami_id }}"
+    subnet_id: "{{ testing_subnet_a.subnet.id }}"
+    instance_type: "{{ item.new_instance_type }}"
+    wait: false
+    exact_count: "{{ item.new_instance_count }}"
+  register: run_check_mode
+  check_mode: true
+
+- name: Gather ec2 instances info
+  amazon.aws.ec2_instance_info:
+    filters:
+      "tag:Name": "{{ ec2_instance_name }}"
+      instance-state-name: [pending, running]
+  register: _instances_info
+
+- name: Ensure module reported change while the instance type was not updated (check_mode=true)
+  ansible.builtin.assert:
+    that:
+      - run_check_mode is changed
+      - _instances_info.instances | length == _current_instances_info.instances | length
+      - _instances_info.instances | map(attribute='instance_type') | list == _current_instances_info.instances | map(attribute='instance_type') | list
+
+# Run update
+- name: Update instance type
+  amazon.aws.ec2_instance:
+    state: present
+    name: "{{ ec2_instance_name }}"
+    image_id: "{{ ec2_ami_id }}"
+    subnet_id: "{{ testing_subnet_a.subnet.id }}"
+    instance_type: "{{ item.new_instance_type }}"
+    wait: false
+    exact_count: "{{ item.new_instance_count }}"
+  register: _run_update
+
+- name: Gather ec2 instances info
+  amazon.aws.ec2_instance_info:
+    filters:
+      "tag:Name": "{{ ec2_instance_name }}"
+      instance-state-name: [pending, running]
+  register: _instances_info
+
+- name: Ensure module reported change and the instance type changed
+  ansible.builtin.assert:
+    that:
+      - _run_update is changed
+      - _instances_info.instances | length == item.new_instance_count
+      - _instances_info.instances | map(attribute='instance_type') | unique | list == [item.new_instance_type]
+
+# Test idempotency
+- name: Update instance type once again (idempotency)
+  amazon.aws.ec2_instance:
+    state: present
+    name: "{{ ec2_instance_name }}"
+    image_id: "{{ ec2_ami_id }}"
+    subnet_id: "{{ testing_subnet_a.subnet.id }}"
+    instance_type: "{{ item.new_instance_type }}"
+    wait: false
+    exact_count: "{{ item.new_instance_count }}"
+  register: _run_idempotency
+
+- name: Validate idempotency
+  ansible.builtin.assert:
+    that:
+      - _run_idempotency is not changed

--- a/tests/unit/plugins/modules/ec2_instance/test_modify_instance_type.py
+++ b/tests/unit/plugins/modules/ec2_instance/test_modify_instance_type.py
@@ -3,7 +3,6 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from unittest.mock import ANY
 from unittest.mock import MagicMock
 from unittest.mock import call
 from unittest.mock import patch

--- a/tests/unit/plugins/modules/ec2_instance/test_modify_instance_type.py
+++ b/tests/unit/plugins/modules/ec2_instance/test_modify_instance_type.py
@@ -1,0 +1,84 @@
+# (c) 2024 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import ANY
+from unittest.mock import MagicMock
+from unittest.mock import call
+from unittest.mock import patch
+
+import pytest
+
+from ansible_collections.amazon.aws.plugins.modules import ec2_instance
+
+module_path = "ansible_collections.amazon.aws.plugins.modules.ec2_instance"
+
+
+@pytest.fixture
+def ansible_aws_module():
+    module = MagicMock()
+    module.params = {}
+    module.check_mode = False
+    module.fail_json.side_effect = SystemExit(1)
+    module.fail_json_aws.side_effect = SystemExit(1)
+    return module
+
+
+@pytest.mark.parametrize("state", ["present", "started", "running", "stopped", "restarted", "rebooted"])
+@patch(module_path + ".modify_instance_attribute")
+@patch(module_path + ".await_instances")
+@patch(module_path + ".ensure_instance_state")
+def test_modify_instance_type(
+    m_ensure_instance_state, m_await_instances, m_modify_instance_attribute, ansible_aws_module, state
+):
+    instance_id = MagicMock()
+    client = MagicMock()
+    state = "present"
+    changes = MagicMock()
+    desired_module_state = "running" if state == "present" else state
+
+    ec2_instance.modify_instance_type(client, ansible_aws_module, state, instance_id, changes)
+    m_await_instances.assert_called_once_with(
+        client, ansible_aws_module, ids=[instance_id], desired_module_state="stopped", force_wait=True
+    )
+    m_modify_instance_attribute.assert_called_once_with(client, instance_id=instance_id, **changes)
+    filters = {"instance-id": [instance_id]}
+    m_ensure_instance_state.assert_has_calls(
+        [
+            call(client, ansible_aws_module, "stopped", filters),
+            call(client, ansible_aws_module, desired_module_state, filters),
+        ]
+    )
+
+
+@pytest.mark.parametrize("check_mode", [True, False])
+@pytest.mark.parametrize("attribute", ["InstanceType", "Ramdisk", "DisableApiTermination"])
+@patch(module_path + ".modify_instance_attribute")
+@patch(module_path + ".modify_instance_type")
+def test_modify_ec2_instance_attribute(
+    m_modify_instance_type, m_modify_instance_attribute, ansible_aws_module, check_mode, attribute
+):
+    client = MagicMock()
+    state = MagicMock()
+    instance_id = MagicMock()
+    attribute_value = MagicMock()
+
+    ansible_aws_module.check_mode = check_mode
+
+    ec2_instance.modify_ec2_instance_attribute(
+        client, ansible_aws_module, state, [{"InstanceId": instance_id, attribute: attribute_value}]
+    )
+    if check_mode:
+        m_modify_instance_type.assert_not_called()
+        m_modify_instance_attribute.assert_not_called()
+    elif "InstanceType" == attribute:
+        m_modify_instance_type.assert_called_once_with(
+            client, ansible_aws_module, state, instance_id, {attribute: attribute_value}
+        )
+        m_modify_instance_attribute.assert_not_called()
+    else:
+        m_modify_instance_type.assert_not_called()
+        m_modify_instance_attribute.assert_called_once_with(
+            client, instance_id=instance_id, **{attribute: attribute_value}
+        )


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes #469 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Add the possibiliy to upgrade/downgrade instance type on existing ec2 instances.
The module will stop the instance, modify the instance and then ensure the instance is in the expected state set in `state` argument.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`ec2_instance`
