### PR TITLE
Corrected spelling of word

### DIFF
--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -82,7 +82,7 @@ options:
         callback (Linux only).
       - For Windows instances, to enable remote access via Ansible set O(aap_callback.windows) to V(true), and
         optionally set an admin password.
-      - If using O(aap_callback.windows) and O(aap_callback.set_password), callback ton Ansible Automation Platform will not
+      - If using O(aap_callback.windows) and O(aap_callback.set_password), callback to Ansible Automation Platform will not
         be performed but the instance will be ready to receive winrm connections from Ansible.
       - Mutually exclusive with O(user_data).
     type: dict


### PR DESCRIPTION
Corrected spelling of the word to

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Small spelling mistake the current word of "ton" does not make sense and assume it should be "to".
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
Doc spelling correction

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
