### PR TITLE
Ec2 ami imdsv2 enable

### DIFF
--- a/changelogs/fragments/add_imdsv2.yml
+++ b/changelogs/fragments/add_imdsv2.yml
@@ -1,4 +1,4 @@
 ---
 minor_changes:
-  - ec2_ami - adds ``imdsv2_enable`` parameter to enable IMDSv2 when creating/updating an image.
-  - ec2_ami_info - add ``imdsv2_enable`` return when ``describe_image_attributes`` is set.
+  - ec2_ami - adds ``imdsv2_enable`` parameter to enable IMDSv2 when creating/updating an image (https://github.com/ansible-collections/amazon.aws/pull/2310).
+  - ec2_ami_info - add ``imdsv2_enable`` return when ``describe_image_attributes`` is set (https://github.com/ansible-collections/amazon.aws/pull/2310).

--- a/changelogs/fragments/add_imdsv2.yml
+++ b/changelogs/fragments/add_imdsv2.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - ec2_ami - adds ``imdsv2_enable`` parameter to enable IMDSv2 when creating/updating an image.
+  - ec2_ami_info - add ``imdsv2_enable`` return when ``describe_image_attributes`` is set.

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -967,7 +967,7 @@ def deregister_image(client, image_id: str) -> bool:
 
 
 @EC2ImageErrorHandler.common_error_handler("modify image attribute")
-@AWSRetry.jittered_backoff()
+@AWSRetry.jittered_backoff(catch_extra_error_codes=["InvalidAMIID.Unavailable"])
 def modify_image_attribute(client, image_id: str, **params: Dict[str, Any]) -> bool:
     client.modify_image_attribute(ImageId=image_id, **params)
     return True

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -193,6 +193,7 @@ options:
       - U(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html#configure-IMDS-new-instances-ami-configuration).
     type: bool
     default: false
+    version_added: 9.0.0
 author:
   - "Evan Duffield (@scicoin-project) <eduffield@iacquire.com>"
   - "Constantin Bugneac (@Constantin07) <constantin.bugneac@endava.com>"

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -189,7 +189,8 @@ options:
   imdsv2_enable:
     description:
       - Force IMDS v2 on the AMI
-      - See the AWS documentation for more detail U(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html#configure-IMDS-new-instances-ami-configuration).
+      - See the AWS documentation for more detail
+      - U(https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-IMDS-new-instances.html#configure-IMDS-new-instances-ami-configuration).
     type: bool
     default: false
 author:

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -553,12 +553,15 @@ def get_image_by_id(connection, image_id):
 
     result = images[0]
     try:
-        image_attribue = describe_image_attribute(connection, attribute="launchPermission", image_id=image_id)
-        if image_attribue:
-            result["LaunchPermissions"] = image_attribue["LaunchPermissions"]
-        image_attribue = describe_image_attribute(connection, attribute="productCodes", image_id=image_id)
-        if image_attribue:
-            result["ProductCodes"] = image_attribue["ProductCodes"]
+        image_attribute = describe_image_attribute(connection, attribute="launchPermission", image_id=image_id)
+        if image_attribute:
+            result["LaunchPermissions"] = image_attribute["LaunchPermissions"]
+        image_attribute = describe_image_attribute(connection, attribute="productCodes", image_id=image_id)
+        if image_attribute:
+            result["ProductCodes"] = image_attribute["ProductCodes"]
+        image_attribute = describe_image_attribute(connection, attribute="imdsSupport", image_id=image_id)
+        if image_attribute:
+            result["ImdsSupport"] = image_attribute["Value"]
     except AnsibleEC2Error as e:
         raise Ec2AmiFailure(f"Error retrieving image attributes for image {image_id}", e)
     return result

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -569,7 +569,7 @@ def get_image_by_id(connection, image_id):
             result["ProductCodes"] = image_attribute["ProductCodes"]
         image_attribute = describe_image_attribute(connection, attribute="imdsSupport", image_id=image_id)
         if image_attribute:
-            result["ImdsSupport"] = image_attribute["Value"]
+            result["ImdsSupport"] = image_attribute["ImdsSupport"]["Value"]
     except AnsibleEC2Error as e:
         raise Ec2AmiFailure(f"Error retrieving image attributes for image {image_id}", e)
     return result

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -786,7 +786,7 @@ class UpdateImage:
 
         try:
             modify_image_attribute(
-                connection, image_id=image["imageId"], Attribute="ImdsSupport", ImdsSupport={"Value": "v2.0"}
+                connection, image_id=image["imageId"], Attribute="imdsSupport", ImdsSupport={"Value": "v2.0"}
             )
             return True
         except AnsibleEC2Error as e:
@@ -875,7 +875,7 @@ class CreateImage:
     def set_imdsv2(connection, image_id):
         try:
             modify_image_attribute(
-                connection, image_id=image_id, Attribute="ImdsSupport", ImdsSupport={"Value": "v2.0"}
+                connection, image_id=image_id, Attribute="imdsSupport", ImdsSupport={"Value": "v2.0"}
             )
         except AnsibleEC2Error as e:
             raise Ec2AmiFailure(f"Error setting IMDS Support to v2 for image {image_id}", e)

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -785,9 +785,7 @@ class UpdateImage:
             return False
 
         try:
-            modify_image_attribute(
-                connection, image_id=image["imageId"], Attribute="imdsSupport", ImdsSupport={"Value": "v2.0"}
-            )
+            modify_image_attribute(connection, image_id=image["imageId"], Attribute="imdsSupport", Value="v2.0")
             return True
         except AnsibleEC2Error as e:
             raise Ec2AmiFailure(f"Error setting IMDS Support to v2 for image {image['imageId']}", e)
@@ -874,9 +872,7 @@ class CreateImage:
     @staticmethod
     def set_imdsv2(connection, image_id):
         try:
-            modify_image_attribute(
-                connection, image_id=image_id, Attribute="imdsSupport", ImdsSupport={"Value": "v2.0"}
-            )
+            modify_image_attribute(connection, image_id=image_id, Attribute="imdsSupport", Value="v2.0")
         except AnsibleEC2Error as e:
             raise Ec2AmiFailure(f"Error setting IMDS Support to v2 for image {image_id}", e)
 

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -784,9 +784,10 @@ class UpdateImage:
         if image["ImdsSupport"] == "v2.0":
             return False
 
-        imds_params = {"Attribute": "ImdsSupport", "ImdsSupport": {"Value": "v2.0"}}
         try:
-            modify_image_attribute(connection, image_id=image["imageId"], **imds_params)
+            modify_image_attribute(
+                connection, image_id=image["imageId"], Attribute="ImdsSupport", ImdsSupport={"Value": "v2.0"}
+            )
             return True
         except AnsibleEC2Error as e:
             raise Ec2AmiFailure(f"Error setting IMDS Support to v2 for image {image['imageId']}", e)
@@ -872,9 +873,10 @@ class CreateImage:
 
     @staticmethod
     def set_imdsv2(connection, image_id):
-        imds_params = {"Attribute": "ImdsSupport", "ImdsSupport": {"Value": "v2.0"}}
         try:
-            modify_image_attribute(connection, image_id=image_id, **imds_params)
+            modify_image_attribute(
+                connection, image_id=image_id, Attribute="ImdsSupport", ImdsSupport={"Value": "v2.0"}
+            )
         except AnsibleEC2Error as e:
             raise Ec2AmiFailure(f"Error setting IMDS Support to v2 for image {image_id}", e)
 

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -784,7 +784,7 @@ class UpdateImage:
         if image["ImdsSupport"] == "v2.0":
             return False
 
-        imds_params = {"Attribute": "ImdsSupport", "ImdsSupport": "v2.0"}
+        imds_params = {"Attribute": "ImdsSupport", "ImdsSupport": {"Value": "v2.0"}}
         try:
             modify_image_attribute(connection, image_id=image["imageId"], **imds_params)
             return True
@@ -872,7 +872,7 @@ class CreateImage:
 
     @staticmethod
     def set_imdsv2(connection, image_id):
-        imds_params = {"Attribute": "ImdsSupport", "ImdsSupport": "v2.0"}
+        imds_params = {"Attribute": "ImdsSupport", "ImdsSupport": {"Value": "v2.0"}}
         try:
             modify_image_attribute(connection, image_id=image_id, **imds_params)
         except AnsibleEC2Error as e:

--- a/plugins/modules/ec2_ami_info.py
+++ b/plugins/modules/ec2_ami_info.py
@@ -283,8 +283,10 @@ def list_ec2_images(ec2_client, module, request_args):
                 image["launch_permissions"] = [camel_dict_to_snake_dict(perm) for perm in launch_permissions]
                 imdsv2_enabled = describe_image_attribute(
                     ec2_client, attribute="imdsSupport", image_id=image["image_id"]
-                ).get("ImdsSupport", "")
-                image["imdsv2_enabled"] = True if imdsv2_enabled["Value"] == "v2.0" else False
+                ).get("ImdsSupport", {})
+                image["imdsv2_enabled"] = (
+                    True if "Value" in imdsv2_enabled and imdsv2_enabled["Value"] == "v2.0" else False
+                )
         except is_ansible_aws_error_code("AuthFailure"):
             # describing launch permissions of images owned by others is not permitted, but shouldn't cause failures
             pass

--- a/plugins/modules/ec2_ami_info.py
+++ b/plugins/modules/ec2_ami_info.py
@@ -282,9 +282,9 @@ def list_ec2_images(ec2_client, module, request_args):
                 ).get("LaunchPermissions", [])
                 image["launch_permissions"] = [camel_dict_to_snake_dict(perm) for perm in launch_permissions]
                 imdsv2_enabled = describe_image_attribute(
-                    ec2_client, attribute="ImdsSupport", image_id=image["image_id"]
+                    ec2_client, attribute="imdsSupport", image_id=image["image_id"]
                 ).get("ImdsSupport", "")
-                image["imdsv2_enabled"] = True if imdsv2_enabled == "v2.0" else False
+                image["imdsv2_enabled"] = True if imdsv2_enabled["Value"] == "v2.0" else False
         except is_ansible_aws_error_code("AuthFailure"):
             # describing launch permissions of images owned by others is not permitted, but shouldn't cause failures
             pass

--- a/plugins/modules/ec2_ami_info.py
+++ b/plugins/modules/ec2_ami_info.py
@@ -152,6 +152,10 @@ images:
             description: An AWS account ID with permissions to launch the AMI.
             type: str
       sample: [{"group": "all"}, {"user_id": "123456789012"}]
+    imdsv2_enabled:
+      description: Whether the image has IMDSv2 enabled or not.
+      returned: When O(describe_image_attributes=true).
+      type: bool
     name:
       description: The name of the AMI that was provided during image creation.
       returned: always
@@ -277,6 +281,10 @@ def list_ec2_images(ec2_client, module, request_args):
                     ec2_client, attribute="launchPermission", image_id=image["image_id"]
                 ).get("LaunchPermissions", [])
                 image["launch_permissions"] = [camel_dict_to_snake_dict(perm) for perm in launch_permissions]
+                imdsv2_enabled = describe_image_attribute(
+                    ec2_client, attribute="ImdsSupport", image_id=image["image_id"]
+                ).get("ImdsSupport", "")
+                image["imdsv2_enabled"] = True if imdsv2_enabled == "v2.0" else False
         except is_ansible_aws_error_code("AuthFailure"):
             # describing launch permissions of images owned by others is not permitted, but shouldn't cause failures
             pass

--- a/tests/integration/targets/ec2_ami/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami/tasks/main.yml
@@ -706,8 +706,12 @@
         tags:
           Name: "{{ ec2_ami_name }}_permissions"
         launch_permissions:
-          org_arns: ["arn:aws:organizations::123456789012:organization/o-123ab4cdef"]
-          org_unit_arns: ["arn:aws:organizations::123456789012:ou/o-123example/ou-1234-5exampld"]
+          org_arns:
+            ["arn:aws:organizations::123456789012:organization/o-123ab4cdef"]
+          org_unit_arns:
+            [
+              "arn:aws:organizations::123456789012:ou/o-123example/ou-1234-5exampld",
+            ]
       register: permissions_update_result
 
     - name: Get ami info
@@ -724,6 +728,27 @@
           - permissions_info_result.images[0].launch_permissions[0]['organization_arn'] == 'arn:aws:organizations::123456789012:organization/o-123ab4cdef'
           - "'organizational_unit_arn' in permissions_info_result.images[0].launch_permissions[1]"
           - permissions_info_result.images[0].launch_permissions[1]['organizational_unit_arn'] == 'arn:aws:organizations::123456789012:ou/o-123example/ou-1234-5exampld'
+
+    - name: Create image with imdsv2 enabled
+      amazon.aws.ec2_ami:
+        state: present
+        instance_id: "{{ ec2_instance_id }}"
+        name: "{{ ec2_ami_name }}_imdsv2"
+        tags:
+          Name: "{{ ec2_ami_name }}_imdsv2"
+        imdsv2_enable: true
+      register: imdsv2_image
+
+    - name: Get ami info
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ imdsv2_image.image_id }}"
+        describe_image_attributes: true
+      register: imdsv2_info
+
+    - name: Assert ami IMDSV2 is set
+      ansible.builtin.assert:
+        that:
+          - imdsv2_info.images[0].imdsv2_enabled
 
   # ============================================================
 

--- a/tests/integration/targets/ec2_ami_instance/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami_instance/tasks/main.yml
@@ -90,10 +90,10 @@
       amazon.aws.ec2_ami:
         instance_id: "{{ ec2_instance_id }}"
         state: present
-        name: "{{ ec2_ami_name }}_ami"
+        name: "{{ ec2_ami_name }}_ami_check"
         description: "{{ ec2_ami_description }}"
         tags:
-          Name: "{{ ec2_ami_name }}_ami"
+          Name: "{{ ec2_ami_name }}_ami_check"
         wait: true
         root_device_name: "{{ ec2_ami_root_disk }}"
       check_mode: true
@@ -108,10 +108,10 @@
       amazon.aws.ec2_ami:
         instance_id: "{{ ec2_instance_id }}"
         state: present
-        name: "{{ ec2_ami_name }}_ami"
+        name: "{{ ec2_ami_name }}_ami_instance"
         description: "{{ ec2_ami_description }}"
         tags:
-          Name: "{{ ec2_ami_name }}_ami"
+          Name: "{{ ec2_ami_name }}_ami_instance"
         wait: true
         root_device_name: "{{ ec2_ami_root_disk }}"
       register: result
@@ -125,7 +125,7 @@
         that:
           - result.changed
           - result.image_id.startswith('ami-')
-          - "'Name' in result.tags and result.tags.Name == ec2_ami_name + '_ami'"
+          - "'Name' in result.tags and result.tags.Name == ec2_ami_name + '_ami_instance'"
 
     - name: Get related snapshot info and ensure the tags have been propagated
       amazon.aws.ec2_snapshot_info:
@@ -137,7 +137,7 @@
       ansible.builtin.assert:
         that:
           - "'tags' in snapshot_result.snapshots[0]"
-          - "'Name' in snapshot_result.snapshots[0].tags and snapshot_result.snapshots[0].tags.Name == ec2_ami_name + '_ami'"
+          - "'Name' in snapshot_result.snapshots[0].tags and snapshot_result.snapshots[0].tags.Name == ec2_ami_name + '_ami_instance'"
 
     # ============================================================
 
@@ -344,6 +344,29 @@
         that:
           - result.failed
           - "result.msg == 'state is absent but all of the following are missing: image_id'"
+
+    # ==============================================================
+
+    - name: Create image with imdsv2 enabled
+      amazon.aws.ec2_ami:
+        state: present
+        instance_id: "{{ ec2_instance_id }}"
+        name: "{{ ec2_ami_name }}_imdsv2"
+        imdsv2_enable: true
+        tags:
+          Name: "{{ ec2_ami_name }}_imdsv2"
+      register: imdsv2_image
+
+    - name: Get ami info
+      amazon.aws.ec2_ami_info:
+        image_ids: "{{ imdsv2_image.image_id }}"
+        describe_image_attributes: true
+      register: imdsv2_info
+
+    - name: Assert ami IMDSV2 is set
+      ansible.builtin.assert:
+        that:
+          - imdsv2_info.images[0].imdsv2_enabled
 
   always:
     # ============================================================

--- a/tests/integration/targets/ec2_ami_instance/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami_instance/tasks/main.yml
@@ -353,6 +353,7 @@
         instance_id: "{{ ec2_instance_id }}"
         name: "{{ ec2_ami_name }}_imdsv2"
         imdsv2_enable: true
+        wait: true
         tags:
           Name: "{{ ec2_ami_name }}_imdsv2"
       register: imdsv2_image

--- a/tests/integration/targets/ec2_ami_instance/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami_instance/tasks/main.yml
@@ -369,6 +369,10 @@
         that:
           - imdsv2_info.images[0].imdsv2_enabled
 
+    - name: set image id fact for deletion later
+      ansible.builtin.set_fact:
+        ec2_ami_image_id_imdsv2: "{{ imdsv2_image.image_id }}"
+
   always:
     # ============================================================
 
@@ -398,6 +402,14 @@
         state: absent
         image_id: "{{ ec2_ami_image_id_simple }}"
         name: "{{ ec2_ami_name }}_ami"
+        wait: true
+      ignore_errors: true
+
+    - name: delete imdsv2 ami
+      amazon.aws.ec2_ami:
+        state: absent
+        image_id: "{{ ec2_ami_image_id_imdsv2 }}"
+        name: "{{ ec2_ami_name }}_imdsv2"
         wait: true
       ignore_errors: true
 

--- a/tests/integration/targets/ec2_ami_tpm/tasks/main.yml
+++ b/tests/integration/targets/ec2_ami_tpm/tasks/main.yml
@@ -71,6 +71,14 @@
         state: present
       register: setup_snapshot
 
+    - name: Make sure the snapshot is available
+      amazon.aws.ec2_snapshot_info:
+        snapshot_ids:
+          - "{{ setup_snapshot.snapshot_id }}"
+      register: snapshot_info
+      until: snapshot_info.snapshots[0].state == 'completed'
+      retries: 100
+
     # ============================================================
 
     - name: Create an image from the snapshot with boot_mode and tpm_support

--- a/tests/unit/plugins/modules/test_ec2_ami.py
+++ b/tests/unit/plugins/modules/test_ec2_ami.py
@@ -63,7 +63,7 @@ def test_get_image_by_id_found(m_describe_images, m_describe_image_attribute):
     image = ec2_ami.get_image_by_id(connection, "ami-0c7a795306730b288")
     assert image["ImageId"] == "ami-0c7a795306730b288"
     assert m_describe_images.call_count == 1
-    assert m_describe_image_attribute.call_count == 2
+    assert m_describe_image_attribute.call_count == 3
     m_describe_images.assert_has_calls(
         [
             call(

--- a/tests/unit/plugins/modules/test_ec2_ami_info.py
+++ b/tests/unit/plugins/modules/test_ec2_ami_info.py
@@ -160,10 +160,14 @@ def test_list_ec2_images(m_get_images, m_describe_image_attribute, ec2_client):
     assert m_get_images.call_count == 1
     m_get_images.assert_called_with(ec2_client, request_args)
 
-    assert m_describe_image_attribute.call_count == 2
+    assert m_describe_image_attribute.call_count == 4
     m_describe_image_attribute.assert_has_calls(
         [call(ec2_client, attribute="launchPermission", image_id=images[0]["image_id"])],
         [call(ec2_client, attribute="launchPermission", image_id=images[1]["image_id"])],
+    )
+    m_describe_image_attribute.assert_has_calls(
+        [call(ec2_client, attribute="ImdsSupport", image_id=images[0]["image_id"])],
+        [call(ec2_client, attribute="ImdsSupport", image_id=images[1]["image_id"])],
     )
 
     assert len(list_ec2_images_result) == 2

--- a/tests/unit/plugins/modules/test_ec2_ami_info.py
+++ b/tests/unit/plugins/modules/test_ec2_ami_info.py
@@ -140,6 +140,7 @@ def test_list_ec2_images(m_get_images, m_describe_image_attribute, ec2_client):
     m_describe_image_attribute.return_value = {
         "ImageId": "ami-1234567890",
         "LaunchPermissions": [{"UserId": "1234567890"}, {"UserId": "0987654321"}],
+        "ImdsSupport": {"Value": "v2.0"},
     }
 
     images = m_get_images.return_value
@@ -166,13 +167,14 @@ def test_list_ec2_images(m_get_images, m_describe_image_attribute, ec2_client):
         [call(ec2_client, attribute="launchPermission", image_id=images[1]["image_id"])],
     )
     m_describe_image_attribute.assert_has_calls(
-        [call(ec2_client, attribute="ImdsSupport", image_id=images[0]["image_id"])],
-        [call(ec2_client, attribute="ImdsSupport", image_id=images[1]["image_id"])],
+        [call(ec2_client, attribute="imdsSupport", image_id=images[0]["image_id"])],
+        [call(ec2_client, attribute="imdsSupport", image_id=images[1]["image_id"])],
     )
 
     assert len(list_ec2_images_result) == 2
     assert list_ec2_images_result[0]["image_id"] == "ami-1234567890"
     assert list_ec2_images_result[1]["image_id"] == "ami-1523498760"
+    assert list_ec2_images_result[0]["imdsv2_enabled"]
 
 
 @patch(module_name + ".AnsibleAWSModule")


### PR DESCRIPTION
##### SUMMARY
Add option to set the IMDS support for the AMI to `v2.0` in the `ec2_ami` module when creating or updating the AMI.

The option value is a bool since the only valid attribute values are either `None` or `v2.0`.

The option defaults to `false` to keep backwards compatibility.

Update the `ec2_ami_info` module to return the `imdsv2_enabled` attribute.


##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
`ec2_ami`
`ec2_ami_info`

##### ADDITIONAL INFORMATION
N/A it's a new feature
