### PR TITLE
Fix unit tests under Python 3.13

### DIFF
--- a/tests/unit/constraints.txt
+++ b/tests/unit/constraints.txt
@@ -1,5 +1,6 @@
 # Specifically run tests against the oldest versions that we support
-botocore==1.29.0
+botocore==1.29.0; python_version < '3.13'
+botocore==1.29.13; python_version >= '3.13'
 boto3==1.26.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore

--- a/tests/unit/constraints.txt
+++ b/tests/unit/constraints.txt
@@ -1,6 +1,6 @@
 # Specifically run tests against the oldest versions that we support
 botocore==1.29.0; python_version < '3.13'
-botocore==1.29.13; python_version >= '3.13'
+botocore==1.29.0; python_version >= '3.13'
 boto3==1.26.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore


### PR DESCRIPTION
##### SUMMARY

If running Python 3.13 you need at least botocore 1.29.13.  While this isn't really something we generally want to track and display as a "requirement" for the collection, the unit tests break under Python 3.13 unless we're have 1.29.13

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tests/unit

##### ADDITIONAL INFORMATION
