### PR TITLE
Use ansible-ref: devel for docs build workflows

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -20,7 +20,7 @@ jobs:
       init-fail-on-error: true
       intersphinx-links: |
         community_aws:https://ansible-collections.github.io/community.aws/branch/main/
-        ansible_devel:https://docs.ansible.com/ansible-core/devel/
+        ansible_stable:https://docs.ansible.com/ansible-core/2.17/
       artifact-name: ${{ github.event.repository.name }}_validate_docs_${{ github.event.pull_request.head.sha }}
 
 
@@ -34,7 +34,7 @@ jobs:
       init-fail-on-error: false
       intersphinx-links: |
         community_aws:https://ansible-collections.github.io/community.aws/branch/main/
-        ansible_devel:https://docs.ansible.com/ansible-core/devel/
+        ansible_stable:https://docs.ansible.com/ansible-core/2.17/
 
   comment:
     permissions:

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -18,9 +18,10 @@ jobs:
     with:
       init-lenient: false
       init-fail-on-error: true
+      ansible-ref: devel
       intersphinx-links: |
         community_aws:https://ansible-collections.github.io/community.aws/branch/main/
-        ansible_stable:https://docs.ansible.com/ansible-core/2.17/
+        ansible_devel:https://docs.ansible.com/ansible-core/devel/
       artifact-name: ${{ github.event.repository.name }}_validate_docs_${{ github.event.pull_request.head.sha }}
 
 
@@ -32,9 +33,10 @@ jobs:
     with:
       init-lenient: true
       init-fail-on-error: false
+      ansible-ref: devel
       intersphinx-links: |
         community_aws:https://ansible-collections.github.io/community.aws/branch/main/
-        ansible_stable:https://docs.ansible.com/ansible-core/2.17/
+        ansible_devel:https://docs.ansible.com/ansible-core/devel/
 
   comment:
     permissions:

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -22,9 +22,10 @@ jobs:
     with:
       init-lenient: false
       init-fail-on-error: true
+      ansible-ref: devel
       intersphinx-links: |
         community_aws:https://ansible-collections.github.io/community.aws/branch/main/
-        ansible_stable:https://docs.ansible.com/ansible-core/2.17/
+        ansible_devel:https://docs.ansible.com/ansible-core/devel/
 
   publish-docs-gh-pages:
     # use to prevent running on forks

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -24,7 +24,7 @@ jobs:
       init-fail-on-error: true
       intersphinx-links: |
         community_aws:https://ansible-collections.github.io/community.aws/branch/main/
-        ansible_devel:https://docs.ansible.com/ansible-core/devel/
+        ansible_stable:https://docs.ansible.com/ansible-core/2.17/
 
   publish-docs-gh-pages:
     # use to prevent running on forks


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Use `ansible-ref: devel` for docs build workflows.

This needs to be merged in order to reflect the change.

Because of this change https://github.com/ansible/ansible/commit/4f6276d72db8ca5d2e42e52b9cf87455ec3ec46e documentation build process was failing with:

```
  /home/runner/work/_temp/docsbuild/head/rst/collections/amazon/aws/aws_ec2_inventory.rst:309: WARNING: 'envvar' reference target not found: ANSIBLE_INVENTORY_CACHE [ref.envvar]
  /home/runner/work/_temp/docsbuild/head/rst/collections/amazon/aws/aws_ec2_inventory.rst:370: WARNING: 'envvar' reference target not found: ANSIBLE_INVENTORY_CACHE_CONNECTION [ref.envvar]
  /home/runner/work/_temp/docsbuild/head/rst/collections/amazon/aws/aws_ec2_inventory.rst:435: WARNING: 'envvar' reference target not found: ANSIBLE_INVENTORY_CACHE_PLUGIN [ref.envvar]
  /home/runner/work/_temp/docsbuild/head/rst/collections/amazon/aws/aws_ec2_inventory.rst:500: WARNING: 'envvar' reference target not found: ANSIBLE_INVENTORY_CACHE_PLUGIN_PREFIX [ref.envvar]
  /home/runner/work/_temp/docsbuild/head/rst/collections/amazon/aws/aws_ec2_inventory.rst:565: WARNING: 'envvar' reference target not found: ANSIBLE_INVENTORY_CACHE_TIMEOUT [ref.envvar]
  /home/runner/work/_temp/docsbuild/head/rst/collections/amazon/aws/aws_rds_inventory.rst:259: WARNING: 'envvar' reference target not found: ANSIBLE_INVENTORY_CACHE [ref.envvar]
  /home/runner/work/_temp/docsbuild/head/rst/collections/amazon/aws/aws_rds_inventory.rst:320: WARNING: 'envvar' reference target not found: ANSIBLE_INVENTORY_CACHE_CONNECTION [ref.envvar]
  /home/runner/work/_temp/docsbuild/head/rst/collections/amazon/aws/aws_rds_inventory.rst:385: WARNING: 'envvar' reference target not found: ANSIBLE_INVENTORY_CACHE_PLUGIN [ref.envvar]
  /home/runner/work/_temp/docsbuild/head/rst/collections/amazon/aws/aws_rds_inventory.rst:450: WARNING: 'envvar' reference target not found: ANSIBLE_INVENTORY_CACHE_PLUGIN_PREFIX [ref.envvar]
  /home/runner/work/_temp/docsbuild/head/rst/collections/amazon/aws/aws_rds_inventory.rst:515: WARNING: 'envvar' reference target not found: ANSIBLE_INVENTORY_CACHE_TIMEOUT [ref.envvar]
```

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
