### PR TITLE
ec2_vpc_peering_info - Deprecate result returned key

### DIFF
--- a/changelogs/fragments/20241024-ec2_vpc_peering_info.yml
+++ b/changelogs/fragments/20241024-ec2_vpc_peering_info.yml
@@ -1,0 +1,2 @@
+deprecated_features:
+  - ec2_vpc_peering_info - ``result`` return key has been deprecated and will be removed in release 11.0.0.  Use the ``vpc_peering_connections`` return key instead (https://github.com/ansible-collections/amazon.aws/pull/2359).

--- a/plugins/modules/ec2_vpc_peering_info.py
+++ b/plugins/modules/ec2_vpc_peering_info.py
@@ -381,6 +381,15 @@ def main():
     for peer in results:
         peer["tags"] = boto3_tag_list_to_ansible_dict(peer.get("tags", []))
 
+    module.deprecate(
+            (
+                "The 'result' return key is deprecated and will be replaced by 'vpc_peering_connections'. Both values are"
+                " returned for now."
+            ),
+            version="11.0.0",
+            collection_name="amazon.aws",
+        )
+
     module.exit_json(result=results, vpc_peering_connections=results)
 
 

--- a/plugins/modules/ec2_vpc_peering_info.py
+++ b/plugins/modules/ec2_vpc_peering_info.py
@@ -382,13 +382,13 @@ def main():
         peer["tags"] = boto3_tag_list_to_ansible_dict(peer.get("tags", []))
 
     module.deprecate(
-            (
-                "The 'result' return key is deprecated and will be replaced by 'vpc_peering_connections'. Both values are"
-                " returned for now."
-            ),
-            version="11.0.0",
-            collection_name="amazon.aws",
-        )
+        (
+            "The 'result' return key is deprecated and will be replaced by 'vpc_peering_connections'. Both values are"
+            " returned for now."
+        ),
+        version="11.0.0",
+        collection_name="amazon.aws",
+    )
 
     module.exit_json(result=results, vpc_peering_connections=results)
 


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
ec2_vpc_peering_info - Deprecate result returned key
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
