### PR TITLE
Ec2 transit gateway empty description

### DIFF
--- a/changelogs/fragments/fix_tgw_description.yml
+++ b/changelogs/fragments/fix_tgw_description.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ec2_transit_gateway - handle empty description while deleting transit gateway (https://github.com/ansible-collections/community.aws/pull/2086).

--- a/plugins/modules/ec2_transit_gateway.py
+++ b/plugins/modules/ec2_transit_gateway.py
@@ -306,7 +306,7 @@ class AnsibleEc2Tgw:
                 tgws.extend(response)
 
         for gateway in response:
-            if description == gateway["Description"] and gateway["State"] != "deleted":
+            if description == gateway.get("Description", "") and gateway["State"] != "deleted":
                 tgws.append(gateway)
 
         if len(tgws) > 1:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
When one or more TGWs exist with an empty description, the module will fail.

Fixes #2368 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_transit_gateway

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
Apparently, https://github.com/ansible-collections/community.aws/pull/2086 failed to merge, and the `ec2_transit_gateway` module has now been migrated to amazon.aws. This PR just cherry-picks the commits on top of this repo.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
