### PR TITLE
Add filters to list of templatable inventory options.

### DIFF
--- a/changelogs/fragments/20241129-fix_filter.yml
+++ b/changelogs/fragments/20241129-fix_filter.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - fix filter attribute in the inventory too allow env vars

--- a/changelogs/fragments/20241129-fix_filter.yml
+++ b/changelogs/fragments/20241129-fix_filter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - fix filter attribute in the inventory too allow env vars
+  - plugin_utils/inventory - Fix filter attribute in the inventory too allow env vars (https://github.com/ansible-collections/amazon.aws/pull/2379)

--- a/changelogs/fragments/20241129-fix_filter.yml
+++ b/changelogs/fragments/20241129-fix_filter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - plugin_utils/inventory - Fix filter attribute in the inventory too allow env vars (https://github.com/ansible-collections/amazon.aws/pull/2379)
+  - plugin_utils/inventory - Add ``filters`` to list of templatable inventory parameters (https://github.com/ansible-collections/amazon.aws/pull/2379)

--- a/changelogs/fragments/20241129-fix_filter.yml
+++ b/changelogs/fragments/20241129-fix_filter.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - plugin_utils/inventory - Add ``filters`` to list of templatable inventory parameters (https://github.com/ansible-collections/amazon.aws/pull/2379)
+  - plugin_utils/inventory - Add ``filters`` to list of templatable inventory options (https://github.com/ansible-collections/amazon.aws/pull/2379)

--- a/plugins/plugin_utils/inventory.py
+++ b/plugins/plugin_utils/inventory.py
@@ -52,7 +52,7 @@ class AWSInventoryBase(BaseInventoryPlugin, Constructable, Cacheable, AWSPluginB
 
         def get(self, *args):
             value = self.original_options.get(*args)
-             if (
+            if (
                 not value
                 or not self.templar
                 or args[0] not in self.TEMPLATABLE_OPTIONS

--- a/plugins/plugin_utils/inventory.py
+++ b/plugins/plugin_utils/inventory.py
@@ -65,6 +65,9 @@ class AWSInventoryBase(BaseInventoryPlugin, Constructable, Cacheable, AWSPluginB
                     new[i] = self.templar.template(variable=value[i], disable_lookups=False)
                 return new
 
+            elif not self.templar.is_template(value):
+                return value
+                
             return self.templar.template(variable=value, disable_lookups=False)
 
     def get_options(self, *args):

--- a/plugins/plugin_utils/inventory.py
+++ b/plugins/plugin_utils/inventory.py
@@ -63,7 +63,7 @@ class AWSInventoryBase(BaseInventoryPlugin, Constructable, Cacheable, AWSPluginB
 
             elif not self.templar.is_template(value):
                 return value
-                
+
             return self.templar.template(variable=value, disable_lookups=False)
 
     def get_options(self, *args):

--- a/plugins/plugin_utils/inventory.py
+++ b/plugins/plugin_utils/inventory.py
@@ -52,11 +52,7 @@ class AWSInventoryBase(BaseInventoryPlugin, Constructable, Cacheable, AWSPluginB
 
         def get(self, *args):
             value = self.original_options.get(*args)
-            if (
-                not value
-                or not self.templar
-                or args[0] not in self.TEMPLATABLE_OPTIONS
-            ):
+            if not value or not self.templar or args[0] not in self.TEMPLATABLE_OPTIONS:
                 return value
 
             if isinstance(value, dict):

--- a/plugins/plugin_utils/inventory.py
+++ b/plugins/plugin_utils/inventory.py
@@ -37,6 +37,7 @@ class AWSInventoryBase(BaseInventoryPlugin, Constructable, Cacheable, AWSPluginB
             "assume_role_arn",
             "region",
             "regions",
+            "filters",
         )
 
         def __init__(self, templar, options):
@@ -51,13 +52,18 @@ class AWSInventoryBase(BaseInventoryPlugin, Constructable, Cacheable, AWSPluginB
 
         def get(self, *args):
             value = self.original_options.get(*args)
-            if (
+             if (
                 not value
                 or not self.templar
                 or args[0] not in self.TEMPLATABLE_OPTIONS
-                or not self.templar.is_template(value)
             ):
                 return value
+
+            if isinstance(value, dict):
+                new = {}
+                for i in value:
+                    new[i] = self.templar.template(variable=value[i], disable_lookups=False)
+                return new
 
             return self.templar.template(variable=value, disable_lookups=False)
 

--- a/plugins/plugin_utils/inventory.py
+++ b/plugins/plugin_utils/inventory.py
@@ -56,12 +56,11 @@ class AWSInventoryBase(BaseInventoryPlugin, Constructable, Cacheable, AWSPluginB
                 return value
 
             if isinstance(value, dict):
-                new = {}
-                for i in value:
-                    new[i] = self.templar.template(variable=value[i], disable_lookups=False)
-                return new
+                return {k: self.templar.template(variable=v, disable_lookups=False) for k, v in value.items()}
+            if isinstance(value, list):
+                return [self.templar.template(variable=v, disable_lookups=False) for v in value]
 
-            elif not self.templar.is_template(value):
+            if not self.templar.is_template(value):
                 return value
 
             return self.templar.template(variable=value, disable_lookups=False)


### PR DESCRIPTION

##### SUMMARY
Add 'filters' too the list of vars in the aws_ec2.yml inventory file that support lookups.

Fixed #2378

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
plugins/plugin_utils/inventory.py

##### ADDITIONAL INFORMATION
Added filters too the list of vars that re supported and fixed the get function too be able too parse dicts

