### PR TITLE
Fix missing FQCN cloudwatch_metric_alarm

### DIFF
--- a/changelogs/fragments/20241106-fqcn-cloudwatch-metric-alarm.yml
+++ b/changelogs/fragments/20241106-fqcn-cloudwatch-metric-alarm.yml
@@ -1,0 +1,2 @@
+trivial:
+  - cloudwatch_metric_alarm - Fix missing FQCN for integration tests cloudwatch_metric_alarm.

--- a/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
+++ b/tests/integration/targets/cloudwatch_metric_alarm/tasks/main.yml
@@ -510,7 +510,7 @@
           - '"parameters are mutually exclusive" in ec2_instance_metric_mutually_exclusive.msg'
 
     - name: create alarm without dimensions
-      cloudwatch_metric_alarm:
+      amazon.aws.cloudwatch_metric_alarm:
         state: present
         name: '{{ alarm_full_name }}'
         metric: CPUUtilization
@@ -539,7 +539,7 @@
           - alarm_info_metrics_alarm_no_dimensions.metric_alarms[0].dimensions | length == 0
 
     - name: create alarm without dimensions (idempotent)
-      cloudwatch_metric_alarm:
+      amazon.aws.cloudwatch_metric_alarm:
         state: present
         name: '{{ alarm_full_name }}'
         metric: CPUUtilization


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add some missing FQCN on cloudwatch_metric_alarm integration tests,
and fix failure on downstream integration test run.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Refer: https://issues.redhat.com/browse/ACA-1961

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
