### PR TITLE
Remove plugins/modules/ec2_vpc_peering.py from tests/sanity/ignore-2.18.txt

### DIFF
--- a/tests/sanity/ignore-2.18.txt
+++ b/tests/sanity/ignore-2.18.txt
@@ -1,2 +1,1 @@
 plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
-plugins/modules/ec2_vpc_peering.py pylint:collection-deprecated-version


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
`tests/sanity/ignore-2.18.txt:2:1: ansible-test: Ignoring 'collection-deprecated-version' on 'plugins/modules/ec2_vpc_peering.py' is unnecessary`
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
