### PR TITLE
lambda - Remove non-UTF-8 data from module output

### DIFF
--- a/changelogs/fragments/2386-lambda-remove-non-utf-8-output.yml
+++ b/changelogs/fragments/2386-lambda-remove-non-utf-8-output.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - lambda - Remove non UTF-8 data (contents of Lambda ZIP file) from the module output to avoid Ansible error (https://github.com/ansible-collections/amazon.aws/issues/2386).

--- a/plugins/modules/lambda.py
+++ b/plugins/modules/lambda.py
@@ -808,6 +808,9 @@ def main():
             module.fail_json(msg="Unable to get function information after updating")
         response = format_response(response)
         # We're done
+        # "ZipFile" attribute contains non UTF-8 data. Ansible considers it an error
+        # starting with version 2.18. Removing it from the output avoids the error.
+        code_kwargs.pop("ZipFile", None)
         module.exit_json(changed=changed, code_kwargs=code_kwargs, func_kwargs=func_kwargs, **response)
 
     # Function doesn't exist, create new Lambda function


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #2307.

Ansible previously generated warning is module output contained non UTF-8 data. Starting with version 2.18, it now throws an error, which prevents successful execution of `lambda` module.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
lambda

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
