### PR TITLE
cloudformation: Fix bug when updating stack's termination_protection with create_changeset set

### DIFF
--- a/changelogs/fragments/2391-cloudformation-update-stack-termination_protection.yml
+++ b/changelogs/fragments/2391-cloudformation-update-stack-termination_protection.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - cloudformation - Fix bug where termination protection is not updated when create_changeset=true is used for stack updates (https://github.com/ansible-collections/amazon.aws/pull/2391).

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -529,6 +529,7 @@ def update_termination_protection(module, cfn, stack_name, desired_termination_p
                 module.fail_json_aws(e)
     return changed
 
+
 def stack_operation(module, cfn, stack_name, operation, events_limit, op_token=None):
     """gets the status of a stack while it is created/updated/deleted"""
     existed = []
@@ -787,7 +788,7 @@ def main():
                 result = create_changeset(module, stack_params, cfn, module.params.get("events_limit"))
                 changeset_updated = True
             if module.params.get("termination_protection") is not None:
-                result['changed'] = update_termination_protection(
+                result["changed"] = update_termination_protection(
                     module, cfn, stack_params["StackName"], bool(module.params.get("termination_protection"))
                 )
             if not changeset_updated:

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -779,14 +779,17 @@ def main():
     if state == "present":
         if not stack_info:
             result = create_stack(module, stack_params, cfn, module.params.get("events_limit"))
-        elif module.params.get("create_changeset"):
-            result = create_changeset(module, stack_params, cfn, module.params.get("events_limit"))
         else:
+            changeset_updated = False
+            if module.params.get("create_changeset"):
+                result = create_changeset(module, stack_params, cfn, module.params.get("events_limit"))
+                changeset_updated = True
             if module.params.get("termination_protection") is not None:
                 update_termination_protection(
                     module, cfn, stack_params["StackName"], bool(module.params.get("termination_protection"))
                 )
-            result = update_stack(module, stack_params, cfn, module.params.get("events_limit"))
+            if not changeset_updated:
+                result = update_stack(module, stack_params, cfn, module.params.get("events_limit"))
 
         # format the stack output
 

--- a/tests/integration/targets/cloudformation/defaults/main.yml
+++ b/tests/integration/targets/cloudformation/defaults/main.yml
@@ -2,6 +2,7 @@
 stack_name: "{{ resource_prefix }}"
 stack_name_disable_rollback_true: "{{ resource_prefix }}-drb-true"
 stack_name_disable_rollback_false: "{{ resource_prefix }}-drb-false"
+stack_name_update_termination_protection: "{{ resource_prefix }}-update-tp"
 
 availability_zone: "{{ ec2_availability_zone_names[0] }}"
 

--- a/tests/integration/targets/cloudformation/tasks/main.yml
+++ b/tests/integration/targets/cloudformation/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 - name: Wrap up all tests and setup AWS credentials
   module_defaults:
-  group/aws:
-    access_key: "{{ aws_access_key }}"
-    secret_key: "{{ aws_secret_key }}"
-    session_token: "{{ security_token | default(omit) }}"
-    region: "{{ aws_region }}"
+    group/aws:
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ security_token | default(omit) }}"
+      region: "{{ aws_region }}"
 
   block:
     # ==== Env setup ==========================================================

--- a/tests/integration/targets/cloudformation/tasks/main.yml
+++ b/tests/integration/targets/cloudformation/tasks/main.yml
@@ -26,8 +26,13 @@
 
     # ==== Cloudformation tests with disable_rollback ====================
 
-    - ansible.builtin.import_tasks: test_disable_rollback.yml
-    - name: create a cloudformation stack (check mode)
+    - name: Run tests for testing update stack termination protection
+      ansible.builtin.import_tasks: test_update_termination_protection.yml
+
+    - name: Run tests for testing stack disable rollback
+      ansible.builtin.import_tasks: test_disable_rollback.yml
+
+    - name: Create a cloudformation stack (Check mode)
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         template_body: "{{ lookup('file','cf_template.json') }}"
@@ -41,13 +46,13 @@
       register: cf_stack
       check_mode: true
 
-    - name: check task return attributes
+    - name: Check task return attributes
       ansible.builtin.assert:
         that:
           - cf_stack.changed
           - "'msg' in cf_stack and 'New stack would be created' in cf_stack.msg"
 
-    - name: create a cloudformation stack
+    - name: Create a cloudformation stack
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         template_body: "{{ lookup('file','cf_template.json') }}"
@@ -60,7 +65,7 @@
           test: "{{ resource_prefix }}"
       register: cf_stack
 
-    - name: check task return attributes
+    - name: Check task return attributes
       ansible.builtin.assert:
         that:
           - cf_stack.changed
@@ -69,7 +74,7 @@
           - "'stack_outputs' in cf_stack and 'InstanceId' in cf_stack.stack_outputs"
           - "'stack_resources' in cf_stack"
 
-    - name: create a cloudformation stack (check mode) (idempotent)
+    - name: Create a cloudformation stack (Check mode) (idempotent)
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         template_body: "{{ lookup('file','cf_template.json') }}"
@@ -83,12 +88,12 @@
       register: cf_stack
       check_mode: true
 
-    - name: check task return attributes
+    - name: Check task return attributes
       ansible.builtin.assert:
         that:
           - not cf_stack.changed
 
-    - name: create a cloudformation stack (idempotent)
+    - name: Create a cloudformation stack (idempotent)
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         template_body: "{{ lookup('file','cf_template.json') }}"
@@ -101,7 +106,7 @@
           test: "{{ resource_prefix }}"
       register: cf_stack
 
-    - name: check task return attributes
+    - name: Check task return attributes
       ansible.builtin.assert:
         that:
           - not cf_stack.changed
@@ -109,21 +114,21 @@
           - "'stack_outputs' in cf_stack and 'InstanceId' in cf_stack.stack_outputs"
           - "'stack_resources' in cf_stack"
 
-    - name: get all stacks details
+    - name: Get all stacks details
       amazon.aws.cloudformation_info:
       register: all_stacks_info
 
-    - name: assert all stacks info
+    - name: Assert all stacks info
       ansible.builtin.assert:
         that:
           - all_stacks_info | length > 0
 
-    - name: get stack details
+    - name: Get stack details
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
-    - name: assert stack info
+    - name: Assert stack info
       ansible.builtin.assert:
         that:
           - "'cloudformation' in stack_info"
@@ -135,13 +140,13 @@
           - "'stack_tags' in stack_info.cloudformation[stack_name]"
           - stack_info.cloudformation[stack_name].stack_tags.Stack == stack_name
 
-    - name: get stack details (checkmode)
+    - name: Get stack details (checkmode)
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
       check_mode: true
 
-    - name: assert stack info
+    - name: Assert stack info
       ansible.builtin.assert:
         that:
           - "'cloudformation' in stack_info"
@@ -153,13 +158,13 @@
           - "'stack_tags' in stack_info.cloudformation[stack_name]"
           - stack_info.cloudformation[stack_name].stack_tags.Stack == stack_name
 
-    - name: get stack details (all_facts)
+    - name: Get stack details (all_facts)
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
         all_facts: true
       register: stack_info
 
-    - name: assert stack info
+    - name: Assert stack info
       ansible.builtin.assert:
         that:
           - "'stack_events' in stack_info.cloudformation[stack_name]"
@@ -168,14 +173,14 @@
           - "'stack_resources' in stack_info.cloudformation[stack_name]"
           - "'stack_template' in stack_info.cloudformation[stack_name]"
 
-    - name: get stack details (all_facts) (checkmode)
+    - name: Get stack details (all_facts) (checkmode)
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
         all_facts: true
       register: stack_info
       check_mode: true
 
-    - name: assert stack info
+    - name: Assert stack info
       ansible.builtin.assert:
         that:
           - "'stack_events' in stack_info.cloudformation[stack_name]"
@@ -184,10 +189,10 @@
           - "'stack_resources' in stack_info.cloudformation[stack_name]"
           - "'stack_template' in stack_info.cloudformation[stack_name]"
 
-    # ==== Cloudformation tests (create changeset) ============================
+    # ==== Cloudformation tests (Create changeset) ============================
 
-    # try to create a changeset by changing instance type
-    - name: create a changeset
+    # try to Create a changeset by changing instance type
+    - name: Create a changeset
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         create_changeset: true
@@ -202,38 +207,38 @@
           test: "{{ resource_prefix }}"
       register: create_changeset_result
 
-    - name: assert changeset created
+    - name: Assert changeset created
       ansible.builtin.assert:
         that:
           - create_changeset_result.changed
           - "'change_set_id' in create_changeset_result"
           - "'Stack CREATE_CHANGESET complete' in create_changeset_result.output"
 
-    - name: get stack details with changesets
+    - name: Get stack details with changesets
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
         stack_change_sets: true
       register: stack_info
 
-    - name: assert changesets in info
+    - name: Assert changesets in info
       ansible.builtin.assert:
         that:
           - "'stack_change_sets' in stack_info.cloudformation[stack_name]"
 
-    - name: get stack details with changesets (checkmode)
+    - name: Get stack details with changesets (checkmode)
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
         stack_change_sets: true
       register: stack_info
       check_mode: true
 
-    - name: assert changesets in info
+    - name: Assert changesets in info
       ansible.builtin.assert:
         that:
           - "'stack_change_sets' in stack_info.cloudformation[stack_name]"
 
-    # try to create an empty changeset by passing in unchanged template
-    - name: create a changeset
+    # try to Create an empty changeset by passing in unchanged template
+    - name: Create a changeset
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         create_changeset: true
@@ -247,7 +252,7 @@
           test: "{{ resource_prefix }}"
       register: create_changeset_result
 
-    - name: assert changeset created
+    - name: Assert changeset created
       ansible.builtin.assert:
         that:
           - not create_changeset_result.changed
@@ -255,7 +260,7 @@
 
     # ==== Cloudformation tests (termination_protection) ======================
 
-    - name: set termination protection to true
+    - name: Set termination protection to true
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         termination_protection: true
@@ -275,28 +280,28 @@
     #        that:
     #          - cf_stack.changed
 
-    - name: get stack details
+    - name: Get stack details
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
-    - name: assert stack info
+    - name: Assert stack info
       ansible.builtin.assert:
         that:
           - stack_info.cloudformation[stack_name].stack_description.enable_termination_protection
 
-    - name: get stack details (checkmode)
+    - name: Get stack details (checkmode)
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
       check_mode: true
 
-    - name: assert stack info
+    - name: Assert stack info
       ansible.builtin.assert:
         that:
           - stack_info.cloudformation[stack_name].stack_description.enable_termination_protection
 
-    - name: set termination protection to false
+    - name: Set termination protection to false
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         termination_protection: false
@@ -316,30 +321,30 @@
     #        that:
     #          - cf_stack.changed
 
-    - name: get stack details
+    - name: Get stack details
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
-    - name: assert stack info
+    - name: Assert stack info
       ansible.builtin.assert:
         that:
           - not stack_info.cloudformation[stack_name].stack_description.enable_termination_protection
 
-    - name: get stack details (checkmode)
+    - name: Get stack details (checkmode)
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
       check_mode: true
 
-    - name: assert stack info
+    - name: Assert stack info
       ansible.builtin.assert:
         that:
           - not stack_info.cloudformation[stack_name].stack_description.enable_termination_protection
 
     # ==== Cloudformation tests (update_policy) ======================
 
-    - name: setting an stack policy with json body
+    - name: Setting an stack policy with json body
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         stack_policy_body: "{{ lookup('file','update_policy.json') }}"
@@ -353,12 +358,12 @@
           test: "{{ resource_prefix }}"
       register: cf_stack
 
-    - name: get stack details
+    - name: Get stack details
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
-    - name: setting an stack policy on update
+    - name: Setting an stack policy on update
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         stack_policy_on_update_body: "{{ lookup('file','update_policy.json') }}"
@@ -372,46 +377,46 @@
           test: "{{ resource_prefix }}"
       register: cf_stack
 
-    - name: get stack details
+    - name: Get stack details
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
     # ==== Cloudformation tests (delete stack tests) ==========================
 
-    - name: delete cloudformation stack (check mode)
+    - name: Delete cloudformation stack (Check mode)
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         state: absent
       check_mode: true
       register: cf_stack
 
-    - name: check task return attributes
+    - name: Check task return attributes
       ansible.builtin.assert:
         that:
           - cf_stack.changed
           - "'msg' in cf_stack and 'Stack would be deleted' in cf_stack.msg"
 
-    - name: delete cloudformation stack
+    - name: Delete cloudformation stack
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         state: absent
       register: cf_stack
 
-    - name: check task return attributes
+    - name: Check task return attributes
       ansible.builtin.assert:
         that:
           - cf_stack.changed
           - "'output' in cf_stack and 'Stack Deleted' in cf_stack.output"
 
-    - name: delete cloudformation stack (check mode) (idempotent)
+    - name: Delete cloudformation stack (Check mode) (idempotent)
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         state: absent
       check_mode: true
       register: cf_stack
 
-    - name: check task return attributes
+    - name: Check task return attributes
       ansible.builtin.assert:
         that:
           - not cf_stack.changed
@@ -419,35 +424,35 @@
           - >-
             "Stack doesn't exist" in cf_stack.msg
 
-    - name: delete cloudformation stack (idempotent)
+    - name: Delete cloudformation stack (idempotent)
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         state: absent
       register: cf_stack
 
-    - name: check task return attributes
+    - name: Check task return attributes
       ansible.builtin.assert:
         that:
           - not cf_stack.changed
           - "'output' in cf_stack and 'Stack not found.' in cf_stack.output"
 
-    - name: get stack details
+    - name: Get stack details
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
-    - name: assert stack info
+    - name: Assert stack info
       ansible.builtin.assert:
         that:
           - not stack_info.cloudformation
 
-    - name: get stack details (checkmode)
+    - name: Get stack details (checkmode)
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
       check_mode: true
 
-    - name: assert stack info
+    - name: Assert stack info
       ansible.builtin.assert:
         that:
           - not stack_info.cloudformation
@@ -455,7 +460,7 @@
   # ==== Cleanup ============================================================
 
   always:
-    - name: delete stack
+    - name: Delete stack
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         state: absent

--- a/tests/integration/targets/cloudformation/tasks/main.yml
+++ b/tests/integration/targets/cloudformation/tasks/main.yml
@@ -1,10 +1,11 @@
 ---
-- module_defaults:
-    group/aws:
-      access_key: "{{ aws_access_key }}"
-      secret_key: "{{ aws_secret_key }}"
-      session_token: "{{ security_token | default(omit) }}"
-      region: "{{ aws_region }}"
+- name: Wrap up all tests and setup AWS credentials
+  module_defaults:
+  group/aws:
+    access_key: "{{ aws_access_key }}"
+    secret_key: "{{ aws_secret_key }}"
+    session_token: "{{ security_token | default(omit) }}"
+    region: "{{ aws_region }}"
 
   block:
     # ==== Env setup ==========================================================

--- a/tests/integration/targets/cloudformation/tasks/test_disable_rollback.yml
+++ b/tests/integration/targets/cloudformation/tasks/test_disable_rollback.yml
@@ -2,7 +2,7 @@
 - name: Run cloudformation tests for `disable_rollback` parameter
   block:
     # disable rollback to true
-    - name: create a cloudformation stack (disable_rollback=true) (check mode)
+    - name: Create a cloudformation stack (disable_rollback=true) (check mode)
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name_disable_rollback_true }}"
         state: present
@@ -15,13 +15,13 @@
       register: cf_stack
       check_mode: true
 
-    - name: check task return attributes
+    - name: Check task return attributes
       ansible.builtin.assert:
         that:
           - cf_stack.changed
           - "'msg' in cf_stack and 'New stack would be created' in cf_stack.msg"
 
-    - name: create a cloudformation stack (disable_rollback=true)
+    - name: Create a cloudformation stack (disable_rollback=true)
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name_disable_rollback_true }}"
         state: present
@@ -33,12 +33,12 @@
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
 
-    - name: get stack details
+    - name: Get stack details
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name_disable_rollback_true }}"
       register: stack_info
 
-    - name: assert stack info
+    - name: Assert stack info
       ansible.builtin.assert:
         that:
           - "'cloudformation' in stack_info"
@@ -46,7 +46,7 @@
           - stack_info.cloudformation[stack_name_disable_rollback_true].stack_description.disable_rollback == true
 
     # disable rollback to false
-    - name: create a cloudformation stack (disable_rollback=false) (check mode)
+    - name: Create a cloudformation stack (disable_rollback=false) (check mode)
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name_disable_rollback_false }}"
         state: present
@@ -59,13 +59,13 @@
       register: cf_stack
       check_mode: true
 
-    - name: check task return attributes
+    - name: Check task return attributes
       ansible.builtin.assert:
         that:
           - cf_stack.changed
           - "'msg' in cf_stack and 'New stack would be created' in cf_stack.msg"
 
-    - name: create a cloudformation stack (disable_rollback=false)
+    - name: Create a cloudformation stack (disable_rollback=false)
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name_disable_rollback_false }}"
         state: present
@@ -77,12 +77,12 @@
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
 
-    - name: get stack details
+    - name: Get stack details
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name_disable_rollback_false }}"
       register: stack_info
 
-    - name: assert stack info
+    - name: Assert stack info
       ansible.builtin.assert:
         that:
           - "'cloudformation' in stack_info"
@@ -90,7 +90,7 @@
           - stack_info.cloudformation[stack_name_disable_rollback_false].stack_description.disable_rollback == false
 
     # disable rollback not set
-    - name: create a cloudformation stack (disable_rollback not set) (check mode)
+    - name: Create a cloudformation stack (disable_rollback not set) (check mode)
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         state: present
@@ -102,13 +102,13 @@
       register: cf_stack
       check_mode: true
 
-    - name: check task return attributes
+    - name: Check task return attributes
       ansible.builtin.assert:
         that:
           - cf_stack.changed
           - "'msg' in cf_stack and 'New stack would be created' in cf_stack.msg"
 
-    - name: create a cloudformation stack (disable_rollback not set)
+    - name: Create a cloudformation stack (disable_rollback not set)
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name }}"
         state: present
@@ -119,12 +119,12 @@
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
 
-    - name: get stack details
+    - name: Get stack details
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}"
       register: stack_info
 
-    - name: assert stack info
+    - name: Assert stack info
       ansible.builtin.assert:
         that:
           - "'cloudformation' in stack_info"
@@ -191,7 +191,7 @@
           SubnetId: "{{ testing_subnet.subnet.id }}"
       register: cf_stack
 
-    - name: get stack details
+    - name: Get stack details
       amazon.aws.cloudformation_info:
         stack_name: "{{ stack_name }}-failtest"
       register: stack_info

--- a/tests/integration/targets/cloudformation/tasks/test_disable_rollback.yml
+++ b/tests/integration/targets/cloudformation/tasks/test_disable_rollback.yml
@@ -204,7 +204,7 @@
           - stack_info.cloudformation[stack_name+"-failtest"].stack_description.stack_status == "UPDATE_COMPLETE"
 
   always:
-    - name: delete stack
+    - name: Delete stack
       amazon.aws.cloudformation:
         stack_name: "{{ item }}"
         state: absent

--- a/tests/integration/targets/cloudformation/tasks/test_update_termination_protection.yml
+++ b/tests/integration/targets/cloudformation/tasks/test_update_termination_protection.yml
@@ -1,0 +1,130 @@
+---
+- name: Run cloudformation tests for upating `termination_protection` parameter when `create_changeset=true`
+  block:
+    - name: Create a cloudformation stack (termination_protection=true and create_changeset=true)
+      amazon.aws.cloudformation:
+        stack_name: "{{ stack_name_update_termination_protection }}"
+        state: present
+        disable_rollback: true
+        template_body: "{{ lookup('file','cf_template.json') }}"
+        create_changeset: true
+        termination_protection: true
+        template_parameters:
+          InstanceType: t3.nano
+          ImageId: "{{ ec2_ami_id }}"
+          SubnetId: "{{ testing_subnet.subnet.id }}"
+      register: cf_stack
+
+    - name: Get stack details
+      amazon.aws.cloudformation_info:
+        stack_name: "{{ stack_name_update_termination_protection }}"
+        all_facts: true
+      register: stack_info
+
+    - name: Assert stack info
+      ansible.builtin.assert:
+        that:
+          - cf_stack is changed
+          - cf_stack is not failed
+          - "'cloudformation' in stack_info"
+          - stack_info.cloudformation | length == 1
+          - stack_info.cloudformation[stack_name_update_termination_protection].stack_description.enable_termination_protection == true
+          - stack_info.cloudformation[stack_name_update_termination_protection].stack_change_sets is defined
+
+    - name: Update cloudformation stack `termination_protection=false` (create_changeset=true)
+      amazon.aws.cloudformation:
+        stack_name: "{{ stack_name_update_termination_protection }}"
+        state: present
+        disable_rollback: true
+        template_body: "{{ lookup('file','cf_template.json') }}"
+        create_changeset: true
+        termination_protection: false
+        template_parameters:
+          InstanceType: t3.nano
+          ImageId: "{{ ec2_ami_id }}"
+          SubnetId: "{{ testing_subnet.subnet.id }}"
+      register: cf_stack
+
+    - name: Get stack details
+      amazon.aws.cloudformation_info:
+        stack_name: "{{ stack_name_update_termination_protection }}"
+        all_facts: true
+      register: stack_info
+
+    - name: Assert stack info
+      ansible.builtin.assert:
+        that:
+          - cf_stack is changed
+          - cf_stack is not failed
+          - "'cloudformation' in stack_info"
+          - stack_info.cloudformation | length == 1
+          - stack_info.cloudformation[stack_name_update_termination_protection].stack_description.enable_termination_protection == false
+          - stack_info.cloudformation[stack_name_update_termination_protection].stack_change_sets is defined
+
+    - name: Update cloudformation stack `termination_protection=true` (create_changeset=true)
+      amazon.aws.cloudformation:
+        stack_name: "{{ stack_name_update_termination_protection }}"
+        state: present
+        disable_rollback: true
+        template_body: "{{ lookup('file','cf_template.json') }}"
+        create_changeset: true
+        termination_protection: true
+        template_parameters:
+          InstanceType: t3.nano
+          ImageId: "{{ ec2_ami_id }}"
+          SubnetId: "{{ testing_subnet.subnet.id }}"
+      register: cf_stack
+
+    - name: Get stack details
+      amazon.aws.cloudformation_info:
+        stack_name: "{{ stack_name_update_termination_protection }}"
+        all_facts: true
+      register: stack_info
+
+    - name: Assert stack info
+      ansible.builtin.assert:
+        that:
+          - cf_stack is changed
+          - cf_stack is not failed
+          - "'cloudformation' in stack_info"
+          - stack_info.cloudformation | length == 1
+          - stack_info.cloudformation[stack_name_update_termination_protection].stack_description.enable_termination_protection == true
+          - stack_info.cloudformation[stack_name_update_termination_protection].stack_change_sets is defined
+
+    - name: Update cloudformation stack `termination_protection=fale` (create_changeset=true) #required to delete stack
+      amazon.aws.cloudformation:
+        stack_name: "{{ stack_name_update_termination_protection }}"
+        state: present
+        disable_rollback: true
+        template_body: "{{ lookup('file','cf_template.json') }}"
+        create_changeset: true
+        termination_protection: false
+        template_parameters:
+          InstanceType: t3.nano
+          ImageId: "{{ ec2_ami_id }}"
+          SubnetId: "{{ testing_subnet.subnet.id }}"
+      register: cf_stack
+
+    - name: Get stack details
+      amazon.aws.cloudformation_info:
+        stack_name: "{{ stack_name_update_termination_protection }}"
+        all_facts: true
+      register: stack_info
+
+    - name: Assert stack info
+      ansible.builtin.assert:
+        that:
+          - cf_stack is changed
+          - cf_stack is not failed
+          - "'cloudformation' in stack_info"
+          - stack_info.cloudformation | length == 1
+          - stack_info.cloudformation[stack_name_update_termination_protection].stack_description.enable_termination_protection == false
+          - stack_info.cloudformation[stack_name_update_termination_protection].stack_change_sets is defined
+  always:
+    - name: Delete stack
+      amazon.aws.cloudformation:
+        stack_name: "{{ item }}"
+        state: absent
+      ignore_errors: true
+      with_items:
+        - "{{ stack_name_update_termination_protection }}"

--- a/tests/integration/targets/cloudformation/tasks/test_update_termination_protection.yml
+++ b/tests/integration/targets/cloudformation/tasks/test_update_termination_protection.yml
@@ -91,7 +91,7 @@
           - stack_info.cloudformation[stack_name_update_termination_protection].stack_description.enable_termination_protection == true
           - stack_info.cloudformation[stack_name_update_termination_protection].stack_change_sets is defined
 
-    - name: Update cloudformation stack `termination_protection=fale` (create_changeset=true) #required to delete stack
+    - name: Update cloudformation stack `termination_protection=fale` (create_changeset=true) # required to delete stack
       amazon.aws.cloudformation:
         stack_name: "{{ stack_name_update_termination_protection }}"
         state: present


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes #2149 
Fix bug where termination protection is not updated when create_changeset=true is used for stack updates
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
cloudformation
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
