### PR TITLE
Deprecate managing instances through autoscaling_group

### DIFF
--- a/changelogs/fragments/2396-autoscaling_groups-deprecations.yml
+++ b/changelogs/fragments/2396-autoscaling_groups-deprecations.yml
@@ -23,6 +23,6 @@ deprecated_features:
 - autoscaling_group - the ``decrement_desired_capacity`` parameter has been deprecated and will be removed in release 14.0.0 of this collection.
   Management of instances attached an autoscaling group can be performed using the  ``amazon.aws.autoscaling_instance`` module
   (https://github.com/ansible-collections/amazon.aws/pull/2396).
-trivial_changes:
+trivial:
 - autoscaling_instance - tweak the state description to better explain replacing individual instances
   (https://github.com/ansible-collections/amazon.aws/pull/2396).

--- a/changelogs/fragments/2396-autoscaling_groups-deprecations.yml
+++ b/changelogs/fragments/2396-autoscaling_groups-deprecations.yml
@@ -1,0 +1,28 @@
+minor_changes:
+- autoscaling_group - adds ``group_name`` as an alias for the ``name`` parameter
+  (https://github.com/ansible-collections/amazon.aws/pull/2396).
+- autoscaling_group_info - adds ``group_name`` as an alias for the ``name`` parameter
+  (https://github.com/ansible-collections/amazon.aws/pull/2396).
+- autoscaling_instance_refresh - adds ``group_name`` as an alias for the ``name`` parameter
+  (https://github.com/ansible-collections/amazon.aws/pull/2396).
+- autoscaling_instance_refresh_info - adds ``group_name`` as an alias for the ``name`` parameter
+  (https://github.com/ansible-collections/amazon.aws/pull/2396).
+deprecated_features:
+- autoscaling_group - the functionality provided through the ``replace_all_instances`` parameter has been deprecated and will be removed in release 14.0.0 of this collection.
+  Rolling replacement of instances in an autoscaling group can be performed using the  ``amazon.aws.autoscaling_instance_refresh`` module
+  (https://github.com/ansible-collections/amazon.aws/pull/2396).
+- autoscaling_group - the ``replace_batch_size``, ``lc_check`` and ``lt_check`` parameters have been deprecated and will be removed in release 14.0.0 of this collection.
+  Rolling replacement of instances in an autoscaling group can be performed using the  ``amazon.aws.autoscaling_instance_refresh`` module
+  (https://github.com/ansible-collections/amazon.aws/pull/2396).
+- autoscaling_group - the functionality provided through the ``detach_instances`` parameter has been deprecated and will be removed in release 14.0.0 of this collection.
+  Management of instances attached an autoscaling group can be performed using the  ``amazon.aws.autoscaling_instance`` module
+  (https://github.com/ansible-collections/amazon.aws/pull/2396).
+- autoscaling_group - the functionality provided through the ``replace_instances`` parameter has been deprecated and will be removed in release 14.0.0 of this collection.
+  Management of instances attached an autoscaling group can be performed using the  ``amazon.aws.autoscaling_instance`` module
+  (https://github.com/ansible-collections/amazon.aws/pull/2396).
+- autoscaling_group - the ``decrement_desired_capacity`` parameter has been deprecated and will be removed in release 14.0.0 of this collection.
+  Management of instances attached an autoscaling group can be performed using the  ``amazon.aws.autoscaling_instance`` module
+  (https://github.com/ansible-collections/amazon.aws/pull/2396).
+trivial_changes:
+- autoscaling_instance - tweak the state description to better explain replacing individual instances
+  (https://github.com/ansible-collections/amazon.aws/pull/2396).

--- a/plugins/modules/autoscaling_group.py
+++ b/plugins/modules/autoscaling_group.py
@@ -27,6 +27,7 @@ options:
   name:
     description:
       - Unique name for group to be created or deleted.
+    aliases: ['group_name']
     required: true
     type: str
   load_balancers:
@@ -1852,7 +1853,7 @@ def asg_exists(connection):
 
 def main():
     argument_spec = dict(
-        name=dict(required=True, type="str"),
+        name=dict(required=True, type="str", aliases=["group_name"]),
         load_balancers=dict(type="list", elements="str"),
         target_group_arns=dict(type="list", elements="str"),
         availability_zones=dict(type="list", elements="str"),

--- a/plugins/modules/autoscaling_group.py
+++ b/plugins/modules/autoscaling_group.py
@@ -176,6 +176,10 @@ options:
     type: int
   replace_all_instances:
     description:
+      - Support for the O(replace_all_instances) parameter has been deprecated and will be removed
+        in release 14.0.0.
+        The M(amazon.aws.autoscaling_instance_refresh) module can be used to perform an automated
+        replacement of instances.
       - In a rolling fashion, replace all instances that used the old launch configuration with one from the new launch configuration.
         It increases the ASG size by O(replace_batch_size), waits for the new instances to be up and running.
         After that, it terminates a batch of old instances, waits for the replacements, and repeats, until all old instances are replaced.
@@ -184,12 +188,20 @@ options:
     type: bool
   replace_batch_size:
     description:
+      - Support for the O(replace_all_instances) and O(replace_batch_size) parameters has been
+        deprecated and will be removed in release 14.0.0.
+        The M(amazon.aws.autoscaling_instance_refresh) module can be used to perform an automated
+        replacement of instances.
       - Number of instances you'd like to replace at a time.  Used with O(replace_all_instances).
     required: false
     default: 1
     type: int
   replace_instances:
     description:
+      - Support for the O(replace_instances) parameter has been deprecated and will be removed in
+        release 14.0.0.
+        The M(amazon.aws.autoscaling_instance) module can be used to terminate instances attached
+        to an AutoScaling Group.
       - List of instance ids belonging to the named AutoScalingGroup that you would like to terminate and be replaced with instances
         matching the current launch configuration.
     type: list
@@ -197,6 +209,10 @@ options:
     default: []
   detach_instances:
     description:
+      - Support for the O(detach_instances) parameter has been deprecated and will be removed in
+        release 14.0.0.
+        The M(amazon.aws.autoscaling_instance) module can be used to attach instances to and detach
+        and detach instances from an AutoScaling Group.
       - Removes one or more instances from the specified AutoScalingGroup.
       - If O(decrement_desired_capacity) flag is not set, new instance(s) are launched to replace the detached instance(s).
       - If a Classic Load Balancer is attached to the AutoScalingGroup, the instances are also deregistered from the load balancer.
@@ -208,6 +224,10 @@ options:
     version_added_collection: community.aws
   decrement_desired_capacity:
     description:
+      - Support for the O(detach_instances) and O(decrement_desired_capacity) parameters has been
+        deprecated and will be removed in release 14.0.0.
+        The M(amazon.aws.autoscaling_instance) module can be used to attach instances to and detach
+        and detach instances from an AutoScaling Group.
       - Indicates whether the AutoScalingGroup decrements the desired capacity value by the number of instances detached.
     default: false
     type: bool
@@ -215,11 +235,19 @@ options:
     version_added_collection: community.aws
   lc_check:
     description:
+      - Support for the O(detach_instances) and O(lc_check) parameters has been deprecated and will
+        be removed in release 14.0.0.
+        The M(amazon.aws.autoscaling_instance) module can be used to attach instances to and detach
+        and detach instances from an AutoScaling Group.
       - Check to make sure instances that are being replaced with O(replace_instances) do not already have the current launch config.
     default: true
     type: bool
   lt_check:
     description:
+      - Support for the O(detach_instances) and O(lt_check) parameters has been deprecated and will
+        be removed in release 14.0.0.
+        The M(amazon.aws.autoscaling_instance) module can be used to attach instances to and detach
+        and detach instances from an AutoScaling Group.
       - Check to make sure instances that are being replaced with O(replace_instances) do not already have the current
         O(launch_template) or O(launch_template) O(launch_template.version).
     default: true
@@ -1892,13 +1920,50 @@ def main():
         placement_group=dict(type="str"),
         desired_capacity=dict(type="int"),
         vpc_zone_identifier=dict(type="list", elements="str"),
-        replace_batch_size=dict(type="int", default=1),
-        replace_all_instances=dict(type="bool", default=False),
-        replace_instances=dict(type="list", default=[], elements="str"),
-        detach_instances=dict(type="list", default=[], elements="str"),
-        decrement_desired_capacity=dict(type="bool", default=False),
-        lc_check=dict(type="bool", default=True),
-        lt_check=dict(type="bool", default=True),
+        replace_batch_size=dict(
+            removed_in_version="14.0.0",
+            removed_from_collection="amazon.aws",
+            type="int",
+            default=1,
+        ),
+        replace_all_instances=dict(
+            removed_in_version="14.0.0",
+            removed_from_collection="amazon.aws",
+            type="bool",
+            default=False,
+        ),
+        replace_instances=dict(
+            removed_in_version="14.0.0",
+            removed_from_collection="amazon.aws",
+            type="list",
+            default=[],
+            elements="str",
+        ),
+        detach_instances=dict(
+            removed_in_version="14.0.0",
+            removed_from_collection="amazon.aws",
+            type="list",
+            default=[],
+            elements="str",
+        ),
+        decrement_desired_capacity=dict(
+            removed_in_version="14.0.0",
+            removed_from_collection="amazon.aws",
+            type="bool",
+            default=False,
+        ),
+        lc_check=dict(
+            removed_in_version="14.0.0",
+            removed_from_collection="amazon.aws",
+            type="bool",
+            default=True,
+        ),
+        lt_check=dict(
+            removed_in_version="14.0.0",
+            removed_from_collection="amazon.aws",
+            type="bool",
+            default=True,
+        ),
         wait_timeout=dict(type="int", default=300),
         state=dict(default="present", choices=["present", "absent"]),
         tags=dict(type="list", default=[], elements="dict"),

--- a/plugins/modules/autoscaling_group_info.py
+++ b/plugins/modules/autoscaling_group_info.py
@@ -23,6 +23,7 @@ options:
       - "Note: This is a regular expression match with implicit '^' (beginning of string). Append '$' for a complete name match."
     type: str
     required: false
+    aliases: ["group_name"]
   tags:
     description:
       - >
@@ -549,7 +550,7 @@ def find_asgs(conn, module, name=None, tags=None):
 
 def main():
     argument_spec = dict(
-        name=dict(type="str"),
+        name=dict(type="str", aliases=["group_name"]),
         tags=dict(type="dict"),
     )
 

--- a/plugins/modules/autoscaling_instance.py
+++ b/plugins/modules/autoscaling_instance.py
@@ -31,6 +31,8 @@ options:
         Instances must already be part of the AutoScaling Group.
       - V(detached) - The instance(s) will be detached from the AutoScaling Group.
       - V(terminated) - The instance(s) will be terminated.
+        By default terminated instances will be replaced with new instances, to reduce the desired
+        capacity at the same time as terminating instances set O(decrement_desired_capacity=True).
       - B(Note:) When adding instances to an AutoScaling Group or returning instances to service
         from standby, the desired capacity is B(always) incremented.  If the total number of
         instances would exceed the maximum size of the group then the operation will fail.

--- a/plugins/modules/autoscaling_instance_refresh.py
+++ b/plugins/modules/autoscaling_instance_refresh.py
@@ -27,6 +27,7 @@ options:
   name:
     description:
       - The name of the auto scaling group you are searching for.
+    aliases: ['group_name']
     type: str
     required: true
   strategy:
@@ -271,7 +272,7 @@ def main():
             required=True,
             choices=["started", "cancelled"],
         ),
-        name=dict(required=True),
+        name=dict(required=True, aliases=["group_name"]),
         strategy=dict(type="str", default="Rolling", required=False),
         preferences=dict(
             type="dict",

--- a/plugins/modules/autoscaling_instance_refresh_info.py
+++ b/plugins/modules/autoscaling_instance_refresh_info.py
@@ -23,6 +23,7 @@ options:
       - The name of the Auto Scaling group.
     type: str
     required: true
+    aliases: ["group_name"]
   ids:
     description:
       - One or more instance refresh IDs.
@@ -205,7 +206,7 @@ def find_asg_instance_refreshes(client, module: AnsibleAWSModule) -> None:
 
 def main():
     argument_spec = dict(
-        name=dict(required=True, type="str"),
+        name=dict(required=True, type="str", aliases=["group_name"]),
         ids=dict(required=False, default=[], elements="str", type="list"),
         next_token=dict(required=False, default=None, type="str", no_log=True),
         max_records=dict(required=False, type="int"),


### PR DESCRIPTION
##### SUMMARY

Managing instances directly through autoscaling_group has lead to a significant sprawl in the code which is difficult to test.  With Amazon now also supporting "Instance Refresh" through its own API we can handle rolling replacements using less home-brew code (available through autoscaling_instance_refresh).  The autoscaling_instance also has support for a more complete set of attach/detach/standby/terminate functionality (including instance protection management).

Deprecates the following parameters:

- replace_all_instances -> amazon.aws.autoscaling_instance_refresh
- replace_batch_size (tied to replace_all_instances)
- lc_check (tied to replace_all_instances)
- lt_check (tied to replace_all_instances)
- detach_instances -> amazon.aws.autoscaling_instance
- replace_instances -> amazon.aws.autoscaling_instance
- decrement_desired_capacity (tied to detach_instances and replace_instances)

This functionality provided through these parameters is now available through autoscaling_instance and autoscaling_instance_refresh

Also adds `group_name` as an alias for `name` on both autoscaling_instance_refresh and autoscaling_group for consistency with autoscaling_instance where `name` would be ambiguous.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

- autoscaling_group
- autoscaling_instance
- autoscaling_instance_refresh

##### ADDITIONAL INFORMATION
