### PR TITLE
Add instance tags to ec2_metadata_facts return values

### DIFF
--- a/changelogs/fragments/20241120-ec2_metadata_facts-tags.yml
+++ b/changelogs/fragments/20241120-ec2_metadata_facts-tags.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ec2_metadata_facts - add ``ansible_ec2_instance_tags`` to return values (https://github.com/ansible-collections/amazon.aws/pull/2398).

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -653,11 +653,12 @@ class Ec2Metadata:
             token_data = None
         return to_text(token_data)
 
-    def get_instance_tags(self, tag_keys):
+    def get_instance_tags(self, tag_keys, data):
         tags = {}
         for key in tag_keys:
-            value = self._fetch("{}/{}".format(self.uri_instance_tags, key))
-            tags[key] = value
+            value = data.get("ansible_ec2_tags_instance_{}".format(key))
+            if value is not None:
+                tags[key] = value
         return tags
 
     def run(self):
@@ -677,7 +678,7 @@ class Ec2Metadata:
         instance_tags_keys = instance_tags_keys.split("\n") if instance_tags_keys != "None" else []
         data[self._prefix % "instance_tags_keys"] = instance_tags_keys
 
-        instance_tags = self.get_instance_tags(instance_tags_keys)
+        instance_tags = self.get_instance_tags(instance_tags_keys, data)
         data[self._prefix % "instance_tags"] = instance_tags
 
         # Maintain old key for backwards compatibility

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -261,6 +261,13 @@ ansible_facts:
             description: The purchasing option of the instance.
             type: str
             sample: "on-demand"
+        ansible_ec2_instance_tags:
+            description:
+                - The dict of tags for the instance.
+                - Returns empty dict if access to tags (InstanceMetadataTags) in instance metadata is not enabled.
+            type: dict
+            sample: {"tagKey1": "tag value 1", "tag_key2": "tag value 2"}
+            version_added: 9.1.0
         ansible_ec2_instance_tags_keys:
             description:
                 - The list of tags keys of the instance.
@@ -646,6 +653,13 @@ class Ec2Metadata:
             token_data = None
         return to_text(token_data)
 
+    def get_instance_tags(self, tag_keys):
+        tags = {}
+        for key in tag_keys:
+            value = self._fetch("{}/{}".format(self.uri_instance_tags, key))
+            tags[key] = value
+        return tags
+
     def run(self):
         self._token = self.fetch_session_token(self.uri_token)  # create session token for IMDS
         self.fetch(self.uri_meta)  # populate _data with metadata
@@ -662,6 +676,9 @@ class Ec2Metadata:
         instance_tags_keys = self._fetch(self.uri_instance_tags)
         instance_tags_keys = instance_tags_keys.split("\n") if instance_tags_keys != "None" else []
         data[self._prefix % "instance_tags_keys"] = instance_tags_keys
+
+        instance_tags = self.get_instance_tags(instance_tags_keys)
+        data[self._prefix % "instance_tags"] = instance_tags
 
         # Maintain old key for backwards compatibility
         if "ansible_ec2_instance_identity_document_region" in data:

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -9,7 +9,7 @@
   hosts: localhost
 
   collections:
-    - amzon.aws
+    - amazon.aws
     - community.aws
 
   vars:

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/setup.yml
@@ -29,6 +29,7 @@
 
     - ansible.builtin.include_role:
         name: ../setup_sshkey
+
     - ansible.builtin.include_role:
         name: ../setup_ec2_facts
 
@@ -102,6 +103,14 @@
         key_material: "{{ key_material }}"
         state: present
       register: ec2_key_result
+
+    - amazon.aws.ec2_key_info:
+        filters:
+          fingerprint: "{{ fingerprint }}"
+      register: key_info
+      until: key_info.keypairs | length == 1
+      retries: 5
+      delay: 10
 
     - name: Set facts to simplify use of extra resources
       ansible.builtin.set_fact:

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
@@ -15,6 +15,7 @@
           - ansible_ec2_user_data == "None"
           - ansible_ec2_instance_tags is defined
           - ansible_ec2_instance_tags | length == 3
+          - ansible_ec2_instance_tags.snake_case_key == "a_snake_case_value"
           - ansible_ec2_instance_tags_keys is defined
           - ansible_ec2_instance_tags_keys | length == 3
 

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
@@ -13,6 +13,8 @@
           - ansible_ec2_placement_availability_zone == availability_zone
           - ansible_ec2_security_groups == resource_prefix+"-sg"
           - ansible_ec2_user_data == "None"
+          - ansible_ec2_instance_tags is defined
+          - ansible_ec2_instance_tags | length == 3
           - ansible_ec2_instance_tags_keys is defined
           - ansible_ec2_instance_tags_keys | length == 3
 
@@ -29,5 +31,7 @@
           - ansible_ec2_placement_availability_zone == availability_zone
           - ansible_ec2_security_groups == resource_prefix+"-sg"
           - ansible_ec2_user_data == "None"
+          - ansible_ec2_instance_tags is defined
+          - ansible_ec2_instance_tags | length == 3
           - ansible_ec2_instance_tags_keys is defined
           - ansible_ec2_instance_tags_keys | length == 3

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
@@ -14,12 +14,11 @@
           - ansible_ec2_security_groups == resource_prefix+"-sg"
           - ansible_ec2_user_data == "None"
           - ansible_ec2_instance_tags is defined
-          - ansible_ec2_instance_tags | length == 3
           - ansible_ec2_instance_tags.snake_case_key == "a_snake_case_value"
           - ansible_ec2_instance_tags.camelCaseKey == "aCamelCaseValue"
-          - ansible_ec2_instance_tags.Name == resource_prefix+"-ec2-metadata-facts"
           - ansible_ec2_instance_tags_keys is defined
-          - ansible_ec2_instance_tags_keys | length == 3
+          - '"snake_case_key" in ansible_ec2_instance_tags_keys'
+          - '"camelCaseKey" in ansible_ec2_instance_tags_keys'
 
     - name: Clear facts for another test
       ansible.builtin.meta: clear_facts
@@ -35,6 +34,8 @@
           - ansible_ec2_security_groups == resource_prefix+"-sg"
           - ansible_ec2_user_data == "None"
           - ansible_ec2_instance_tags is defined
-          - ansible_ec2_instance_tags | length == 3
+          - ansible_ec2_instance_tags.snake_case_key == "a_snake_case_value"
+          - ansible_ec2_instance_tags.camelCaseKey == "aCamelCaseValue"
           - ansible_ec2_instance_tags_keys is defined
-          - ansible_ec2_instance_tags_keys | length == 3
+          - '"snake_case_key" in ansible_ec2_instance_tags_keys'
+          - '"camelCaseKey" in ansible_ec2_instance_tags_keys'

--- a/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
+++ b/tests/integration/targets/ec2_metadata_facts/playbooks/test_metadata.yml
@@ -16,6 +16,8 @@
           - ansible_ec2_instance_tags is defined
           - ansible_ec2_instance_tags | length == 3
           - ansible_ec2_instance_tags.snake_case_key == "a_snake_case_value"
+          - ansible_ec2_instance_tags.camelCaseKey == "aCamelCaseValue"
+          - ansible_ec2_instance_tags.Name == resource_prefix+"-ec2-metadata-facts"
           - ansible_ec2_instance_tags_keys is defined
           - ansible_ec2_instance_tags_keys | length == 3
 


### PR DESCRIPTION
##### SUMMARY
Fixes #2293

A list of instance tag keys was added to the return values in version 5.5.0. This adds a new return value that includes the full key:value pairs for the instance tags.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
ec2_metadata_facts
