### PR TITLE
ec2_key / setup_sshkey - fix integration tests (OpenSSH 9.5)

### DIFF
--- a/changelogs/fragments/setup_sshkey.yml
+++ b/changelogs/fragments/setup_sshkey.yml
@@ -1,0 +1,2 @@
+trivial:
+  - setup_sshkey - fix SSH key generation post OpenSSH 9.5 changed default key type to ed25519

--- a/tests/integration/targets/ec2_key/tasks/main.yml
+++ b/tests/integration/targets/ec2_key/tasks/main.yml
@@ -605,6 +605,7 @@
         that:
           - result.changed
           - result.key.fingerprint != fingerprint
+          - result.key.fingerprint == another_fingerprint
 
     # ============================================================
     - name: test state=absent (expect changed=true)

--- a/tests/integration/targets/setup_sshkey/tasks/main.yml
+++ b/tests/integration/targets/setup_sshkey/tasks/main.yml
@@ -38,24 +38,30 @@
     sshkey_pub: "{{ sshkey_dir.path }}/key_one.pub"
     another_sshkey_pub: "{{ sshkey_dir.path }}/key_two.pub"
 
-- name: generate sshkey
-  ansible.builtin.shell: echo 'y' | ssh-keygen -P '' -f '{{ sshkey }}'
+# Because some older OSes don't like the Elliptic Curve keys we'll stick to 4096 bit RSA for now
+- name: generate sshkey (4096 bit RSA)
+  ansible.builtin.shell: echo 'y' | ssh-keygen -t rsa -b 4096 -P '' -f '{{ sshkey }}'
   tags:
     - prepare
 
+# AWS uses a custom MD5 checksum for its RSA keys (rather than the modern default of a base64 encoded sha256 hash)
 - name: record fingerprint
   ansible.builtin.shell: "{{ sshkey_dir.path }}/ec2-fingerprint.py {{ sshkey_pub }}"
   register: fingerprint
   tags:
     - prepare
 
-- name: generate another_sshkey
-  ansible.builtin.shell: echo 'y' | ssh-keygen -P '' -f {{ another_sshkey }}
+# With OpenSSH 9.5 the default changed to ED25519, to avoid confusing issues when running locally vs
+# in CI, we set the default
+- name: generate another_sshkey (ED25519)
+  ansible.builtin.shell: echo 'y' | ssh-keygen -t ed25519 -P '' -f {{ another_sshkey }}
   tags:
     - prepare
 
+# When adding support for ED25519 Amazon stuck to the newer default of base64 encoded sha256 hashes, this means we can
+# ask ssh-keygen for the fingerprint, but we'll explicitly ask for the sha256 version just in case the default changes
 - name: record another fingerprint
-  ansible.builtin.shell: "{{ sshkey_dir.path }}/ec2-fingerprint.py {{ another_sshkey_pub }}"
+  ansible.builtin.shell: "ssh-keygen -l -E sha256 -f {{ another_sshkey_pub }} | cut -c 12-54"
   register: another_fingerprint
   tags:
     - prepare
@@ -63,10 +69,14 @@
 - name: set facts for future roles
   ansible.builtin.set_fact:
     # Public SSH keys (OpenSSH format)
+    # - 4096 bit RSA (broad support)
     key_material: "{{ lookup('file', sshkey_pub) }}"
+    # - ED25519 (modern, not supported by some older services/OSes)
     another_key_material: "{{ lookup('file', another_sshkey_pub) }}"
-    # AWS 'fingerprint' (md5digest)
+    # AWS Format fingerprints
+    # - RSA: MD5sum based
     fingerprint: "{{ fingerprint.stdout }}"
-    another_fingerprint: "{{ another_fingerprint.stdout }}"
+    # - ED25519: AWS pad the base64 output (technically correct), ssh-keygen truncates the output
+    another_fingerprint: "{{ another_fingerprint.stdout }}="
   tags:
     - prepare


### PR DESCRIPTION
##### SUMMARY

With OpenSSH 9.5 the default format for SSH key generation was switched over to ed25519 (a good thing).  However, some older OSes don't support ed25519 (eg the older image we use for testing ec2_metadata_facts python 2 compatibility).

setup_sshkey now:
- Explicitly generates an 4096 bit RSA key (`key_material`)
- Generates the somewhat quirky md5sum based fingerprint AWS uses for RSA keys (`fingerprint`)
- Explicitly generates an ed25519 key (`another_key_material`)
- Pads the standard sha256 fingerprint to match the, technically correct, AWS format (`another_fingerprint`)

ec2_key test now also checks the fingerprint of the second imported key.

(Also fixes the issue seen in #2398 by switching ssh key generation back to the old 4096 bit RSA for `key_material`)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tests/integration/targets/setup_sshkey
tests/integration/targets/ec2_key

##### ADDITIONAL INFORMATION