### PR TITLE
ec2_vpc_nat_gateway - catch extra error code for invalid elastic IP Id

### DIFF
--- a/changelogs/fragments/20241206-ec2_nat_gateway-retry-on-invalid-elastic-ip-id.yaml
+++ b/changelogs/fragments/20241206-ec2_nat_gateway-retry-on-invalid-elastic-ip-id.yaml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - module_utils/ec2 - catch error code ``InvalidElasticIpID.NotFound`` on function ``create_nat_gateway()``, sometimes the ``allocate_address`` API calls will return the ID for a new elastic IP resource before it can be consistently referenced (https://github.com/ansible-collections/amazon.aws/issues/1872).

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -482,7 +482,7 @@ def delete_nat_gateway(client, nat_gateway_id: str) -> bool:
 
 
 @EC2NatGatewayErrorHandler.common_error_handler("create nat gateway")
-@AWSRetry.jittered_backoff()
+@AWSRetry.jittered_backoff(catch_extra_error_codes=["InvalidElasticIpID.NotFound"])
 def create_nat_gateway(
     client, **params: Dict[str, Union[str, bool, int, EC2TagSpecifications, List[str]]]
 ) -> Dict[str, Any]:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes #1872 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
``ec2_vpc_nat_gateway``