### PR TITLE
ec2_vpc_nacl_info - Fix failure when listing NetworkACLs (#2425)

### DIFF
--- a/changelogs/fragments/20241219-ec2_vpc_nacl_info-fix-issue-returning-results.yml
+++ b/changelogs/fragments/20241219-ec2_vpc_nacl_info-fix-issue-returning-results.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ec2_vpc_nacl_info - Fix failure when listing NetworkACLs and no ACLs are found (https://github.com/ansible-collections/amazon.aws/issues/2425).

--- a/plugins/modules/ec2_vpc_nacl_info.py
+++ b/plugins/modules/ec2_vpc_nacl_info.py
@@ -166,8 +166,11 @@ def list_ec2_vpc_nacls(connection, module: AnsibleAWSModule) -> None:
 
     try:
         network_acls = describe_network_acls(connection, **params)
-        if not network_acls:
-            module.fail_json(msg="Unable to describe ACL. NetworkAcl does not exist")
+        if nacl_ids and not len(nacl_ids) == len(network_acls):
+            if len(nacl_ids) == 1:
+                module.fail_json(msg="Unable to describe ACL. NetworkAcl does not exist.")
+            else:
+                module.fail_json(msg="Unable to describe all ACLs. One or more NetworkAcls does not exist.")
     except AnsibleEC2Error as e:
         module.fail_json_aws_error(e)
 

--- a/tests/integration/targets/ec2_vpc_nacl/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_nacl/tasks/main.yml
@@ -42,7 +42,33 @@
         that:
           - nacl_facts is failed
           - '"does not exist" in nacl_facts.msg'
+          - '"One or more" not in nacl_facts.msg'
 
+    - name: Get network multiple ACLs info with invalid ID
+      amazon.aws.ec2_vpc_nacl_info:
+        nacl_ids:
+        - 'acl-000000000000'
+        - 'acl-000000000001'
+      register: nacl_facts
+      ignore_errors: true
+
+    - name: Assert message mentions missing ACLs
+      assert:
+        that:
+          - nacl_facts is failed
+          - '"does not exist" in nacl_facts.msg'
+          - '"One or more" in nacl_facts.msg'
+
+    - name: Get network ACL info with filters
+      amazon.aws.ec2_vpc_nacl_info:
+        filters:
+          default: false
+      register: nacl_facts
+
+    - name: Assert error is not returned
+      ansible.builtin.assert:
+        that:
+          - nacl_facts is succeeded
     # ============================================================
 
     - name: Fetch AZ availability


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Only fail listing NetworkACLs if specific ACLs were requested and not found.

Fixes: #2425 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vpc_nacl_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
