### PR TITLE
Remove deprecated boto3 parameter

### DIFF
--- a/changelogs/fragments/2443-boto-final-clean.yml
+++ b/changelogs/fragments/2443-boto-final-clean.yml
@@ -1,0 +1,3 @@
+---
+breaking_changes:
+  - module_utils.botocore - drop deprecated ``boto3`` parameter for ``get_aws_region()`` and ``get_aws_connection_info()``, this parameter has had no effect since release 4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/2443).

--- a/plugins/module_utils/botocore.py
+++ b/plugins/module_utils/botocore.py
@@ -228,15 +228,7 @@ def _aws_region(params: Dict) -> Optional[str]:
 
 def get_aws_region(
     module: AnsibleAWSModule,
-    boto3: Optional[bool] = None,
 ) -> Optional[str]:  # pylint: disable=redefined-outer-name
-    if boto3 is not None:
-        module.deprecate(
-            "get_aws_region(): the boto3 parameter will be removed in a release after 2025-05-01. "
-            "The parameter has been ignored since release 4.0.0.",
-            date="2025-05-01",
-            collection_name="amazon.aws",
-        )
     try:
         return _aws_region(module.params)
     except AnsibleBotocoreError as e:
@@ -302,15 +294,7 @@ def _aws_connection_info(params: Dict) -> Tuple[Optional[str], Optional[str], Di
 
 def get_aws_connection_info(
     module: AnsibleAWSModule,
-    boto3: Optional[bool] = None,
 ) -> Tuple[Optional[str], Optional[str], Dict]:  # pylint: disable=redefined-outer-name
-    if boto3 is not None:
-        module.deprecate(
-            "get_aws_connection_info(): the boto3 parameter will be removed in a release after 2025-05-01. "
-            "The parameter has been ignored since release 4.0.0.",
-            date="2025-05-01",
-            collection_name="amazon.aws",
-        )
     try:
         return _aws_connection_info(module.params)
     except AnsibleBotocoreError as e:


### PR DESCRIPTION
##### SUMMARY

Since we dropped support for the old boto SDK (#630) the `boto3` parameter for `get_aws_region()` and `get_aws_connection_info()` has done nothing.  This finally removes the parameter (deprecated #2047)

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

plugins/module_utils/botocore.py

##### ADDITIONAL INFORMATION