### PR TITLE
Update version_added for some module options

### DIFF
--- a/changelogs/fragments/20250110-documentation-block-updates.yml
+++ b/changelogs/fragments/20250110-documentation-block-updates.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+- "Update documentation blocks for modules that had options released in 9.0.0 but marked as version_added: 8.3.0. (https://github.com/ansible-collections/amazon.aws/pull/2453)"

--- a/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
+++ b/plugins/modules/cloudwatchlogs_log_group_metric_filter.py
@@ -63,7 +63,7 @@ options:
             - The unit of the value.
             - The various options are available `here <https://docs.aws.amazon.com/AmazonCloudWatch/latest/APIReference/API_MetricDatum.html>`.
           type: str
-          version_added: 8.3.0
+          version_added: 9.0.0
         dimensions:
           description:
             - A dimension is a name/value pair that is a part of the identity of a metric.
@@ -71,7 +71,7 @@ options:
             - Dimensions are only supported for JSON or space-delimited metric filters.
             - The I(default_value) and I(dimensions) options are mutually exclusive.
           type: dict
-          version_added: 8.3.0
+          version_added: 9.0.0
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules

--- a/plugins/modules/ec2_eip.py
+++ b/plugins/modules/ec2_eip.py
@@ -80,7 +80,7 @@ options:
     description: The domain name to attach to the IP address.
     required: false
     type: str
-    version_added: 8.3.0
+    version_added: 9.0.0
 extends_documentation_fragment:
   - amazon.aws.common.modules
   - amazon.aws.region.modules

--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -273,7 +273,7 @@ route_table:
           returned: when the route is via a Transit gateway
           type: str
           sample: tgw-123456789012
-          version_added: 8.3.0
+          version_added: 9.0.0
         origin:
           description: mechanism through which the route is in the table.
           returned: always

--- a/plugins/modules/ec2_vpc_route_table_info.py
+++ b/plugins/modules/ec2_vpc_route_table_info.py
@@ -168,7 +168,7 @@ route_tables:
           returned: when the route is via a Transit gateway.
           type: str
           sample: tgw-123456789012
-          version_added: 8.3.0
+          version_added: 9.0.0
         origin:
           description: mechanism through which the route is in the table.
           returned: always


### PR DESCRIPTION
##### SUMMARY
A few new features were released in version 9.0.0 but had been noted in the module documentation block with options added in version 8.3.0, which we never released. This just updates those documentation blocks to reflect the actual release version. I double checked and these were all included in the 9.0.0 release notes, so no changelog updates are needed.

##### ISSUE TYPE
- Docs Pull Request