### PR TITLE
s3_bucket - do not use the default region as location constraint (ceph)

### DIFF
--- a/changelogs/fragments/20250113-s3_bucket-location-constraints-for-ceph-cluster.yml
+++ b/changelogs/fragments/20250113-s3_bucket-location-constraints-for-ceph-cluster.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - s3_bucket - Do not use default region as location constraint when creating bucket on ceph cluster (https://github.com/ansible-collections/amazon.aws/issues/2420).

--- a/plugins/module_utils/s3.py
+++ b/plugins/module_utils/s3.py
@@ -198,3 +198,9 @@ def _list_objects_v2(client, **params):
 def list_bucket_object_keys(client, bucket, prefix=None, max_keys=None, start_after=None):
     response = _list_objects_v2(client, Bucket=bucket, Prefix=prefix, StartAfter=start_after, MaxKeys=max_keys)
     return [c["Key"] for c in response.get("Contents", [])]
+
+
+def get_s3_bucket_location(module):
+    if module.params.get("ceph") is True:
+        return module.params.get("region")
+    return module.region or "us-east-1"

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -561,6 +561,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.policy import compare_policies
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket_location
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import list_bucket_inventory_configurations
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_extra_params
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import validate_bucket_name
@@ -1232,9 +1233,7 @@ def create_or_update_bucket(s3_client, module: AnsibleAWSModule):
     """
     name = module.params.get("name")
     object_lock_enabled = module.params.get("object_lock_enabled")
-    # default to US Standard region,
-    # note: module.region will also try to pull a default out of the boto3 configs.
-    location = module.region or "us-east-1"
+    location = get_s3_bucket_location(module)
 
     changed = False
     result = {}


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes #2420 
Do not use the default region as a location constraint when creating a bucket.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`s3_bucket`
