### PR TITLE
Use pull_request_target for backport workflow

### DIFF
--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -6,7 +6,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - labeled
       - opened


### PR DESCRIPTION
##### SUMMARY

By default workflows are run using the latest workflows in the PR itself, this results in dropping all write permissions.

So that we can label the PR we need to use `pull_request_target` rather than `pull_request` to ensure the workflow runs using the latest 'target' workflows rather than the latest workflows in the PR (which would be a security risk).

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

.github

##### ADDITIONAL INFORMATION

See also https://github.com/actions/labeler?tab=readme-ov-file#permissions  (Thanks @alinabuzachis for catching this - my testing was all done within the same fork)
