### PR TITLE
iam_access_key - add missing requirements

### DIFF
--- a/changelogs/fragments/20250114-iam_access_key.yml
+++ b/changelogs/fragments/20250114-iam_access_key.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - iam_access_key - add missing requirements checks (https://github.com/ansible-collections/amazon.aws/pull/2465).

--- a/plugins/modules/iam_access_key.py
+++ b/plugins/modules/iam_access_key.py
@@ -226,6 +226,8 @@ def main():
     module = AnsibleAWSModule(
         argument_spec=argument_spec,
         supports_check_mode=True,
+        required_if=required_if,
+        mutually_exclusive=mutually_exclusive,
     )
 
     client = module.client("iam", retry_decorator=AWSRetry.jittered_backoff())


### PR DESCRIPTION
##### SUMMARY

Someone (me) forgot to actually add the required_if / mutually_exclusive parameters to the module.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

iam_access_key

##### ADDITIONAL INFORMATION
