### PR TITLE
Add Github worflow that adds backport_failed label when automatic backports fail

### DIFF
--- a/.github/workflows/check_backports.yml
+++ b/.github/workflows/check_backports.yml
@@ -1,0 +1,31 @@
+name: Detect Patchback Bot Backport Failures
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+jobs:
+  detect_backport_failure:
+    if: github.event.pull_request.merged == true  # Only run for merged PRs
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for Patchback Bot Comments
+        id: check_comments
+        shell: bash
+        run: |
+          # Check if the comment exists from patchback with the specific failure text
+          comment_exists=$(gh pr view ${{ github.event.pull_request.number }} -R ${{ github.repository }} --json comments --jq '[.comments[] | select(.body and (.body | capture("💔 cherry-picking failed"))) ] | length > 0')
+
+          # Output the result directly
+          echo "::set-output name=comment_exists::$comment_exists"
+
+      - name: Add Backport Failed Label
+        if: steps.check_comment.outputs.comment_exists == 'true'  # Run only if failure was detected
+        shell: bash
+        run: |
+          # Add the backport_failed label
+          gh pr edit ${{ github.event.pull_request.number }} --add-label "backport_failed"

--- a/.github/workflows/check_backports.yml
+++ b/.github/workflows/check_backports.yml
@@ -1,31 +1,19 @@
-name: Detect Patchback Bot Backport Failures
+name: Check Patchback Comment on Edit
 
 on:
-  pull_request:
-    branches:
-      - main
+  issue_comment:
     types:
-      - closed
+      - edited
 
 jobs:
-  detect_backport_failure:
-    if: github.event.pull_request.merged == true  # Only run for merged PRs
+  check_patchback_comment:
+    if: >
+      github.event.issue.pull_request.merged == true &&
+      github.event.comment.user.login == 'patchback' &&
+      contains(github.event.comment.body, '💔 cherry-picking failed')
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check for Patchback Bot Comments
-        id: check_comments
-        shell: bash
+      - name: Add Label for Backport Failure
         run: |
-          # Check if the comment exists from patchback with the specific failure text
-          comment_exists=$(gh pr view ${{ github.event.pull_request.number }} -R ${{ github.repository }} --json comments --jq '[.comments[] | select(.body and (.body | capture("💔 cherry-picking failed"))) ] | length > 0')
-
-          # Output the result directly
-          echo "::set-output name=comment_exists::$comment_exists"
-
-      - name: Add Backport Failed Label
-        if: steps.check_comment.outputs.comment_exists == 'true'  # Run only if failure was detected
-        shell: bash
-        run: |
-          # Add the backport_failed label
-          gh pr edit ${{ github.event.pull_request.number }} --add-label "backport_failed"
+          gh pr edit ${{ github.event.issue.number }} -R ${{ github.repository }} --add-label 'backport-failed'


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Add Github worflow that adds backport_failed label when automatic backports fail.
This will help keep track of any failed back doors that require manual actions to be taken.
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
