### PR TITLE
Rework s3_bucket to use ErrorHandler model

### DIFF
--- a/changelogs/fragments/20250117-s3_bucket-error_handler.yml
+++ b/changelogs/fragments/20250117-s3_bucket-error_handler.yml
@@ -1,0 +1,5 @@
+minor_changes:
+- s3_bucket - migrated to use updated error handlers for better handling of non-AWS errors (https://github.com/ansible-collections/amazon.aws/pull/2478).
+bugfixes:
+- s3_bucket - fixed idempotency when setting bucket ACLs (https://github.com/ansible-collections/amazon.aws/pull/2478).
+- s3_bucket - bucket ACLs now consistently returned (https://github.com/ansible-collections/amazon.aws/pull/2478).

--- a/plugins/module_utils/_s3/common.py
+++ b/plugins/module_utils/_s3/common.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import functools
+
+try:
+    # Beware, S3 is a "special" case, it sometimes catches botocore exceptions and
+    # re-raises them as boto3 exceptions.
+    import boto3
+    import botocore
+except ImportError:
+    pass  # Handled by the calling module
+
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message
+from ansible_collections.amazon.aws.plugins.module_utils.errors import AWSErrorHandler
+from ansible_collections.amazon.aws.plugins.module_utils.exceptions import AnsibleAWSError
+
+IGNORE_S3_DROP_IN_EXCEPTIONS = ["XNotImplemented", "NotImplemented", "AccessControlListNotSupported"]
+
+
+class AnsibleS3Error(AnsibleAWSError):
+    pass
+
+
+class AnsibleS3Sigv4RequiredError(AnsibleS3Error):
+    pass
+
+
+class AnsibleS3PermissionsError(AnsibleS3Error):
+    pass
+
+
+class AnsibleS3SupportError(AnsibleS3Error):
+    pass
+
+
+class AnsibleS3RegionSupportError(AnsibleS3SupportError):
+    pass
+
+
+class S3ErrorHandler(AWSErrorHandler):
+    _CUSTOM_EXCEPTION = AnsibleS3Error
+
+    @classmethod
+    def _is_missing(cls):
+        return is_boto3_error_code(
+            [
+                "404",
+                "NoSuchTagSet",
+                "NoSuchTagSetError",
+                "ObjectLockConfigurationNotFoundError",
+                "NoSuchBucketPolicy",
+                "ServerSideEncryptionConfigurationNotFoundError",
+                "NoSuchBucket",
+                "NoSuchPublicAccessBlockConfiguration",
+                "OwnershipControlsNotFoundError",
+                "NoSuchOwnershipControls",
+            ]
+        )
+
+    @classmethod
+    def common_error_handler(cls, description):
+        def wrapper(func):
+            @super(S3ErrorHandler, cls).common_error_handler(description)
+            @functools.wraps(func)
+            def handler(*args, **kwargs):
+                try:
+                    return func(*args, **kwargs)
+                except is_boto3_error_code(["403", "AccessDenied"]) as e:
+                    # FUTURE: there's a case to be made that this moves up into AWSErrorHandler
+                    # for now, we'll handle this just for S3, but wait and see if it pops up in too
+                    # many other places
+                    raise AnsibleS3PermissionsError(
+                        message=f"Failed to {description} (permission denied)", exception=e
+                    ) from e
+                except is_boto3_error_message(  # pylint: disable=duplicate-except
+                    "require AWS Signature Version 4"
+                ) as e:
+                    raise AnsibleS3Sigv4RequiredError(
+                        message=f"Failed to {description} (not supported by cloud)", exception=e
+                    ) from e
+                except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS) as e:  # pylint: disable=duplicate-except
+                    # Unlike most of our modules, we attempt to handle non-AWS clouds.  For read-only
+                    # actions we sometimes need the ability to ignore unsupported features.
+                    raise AnsibleS3SupportError(
+                        message=f"Failed to {description} (not supported by cloud)", exception=e
+                    ) from e
+                except botocore.exceptions.EndpointConnectionError as e:
+                    raise cls._CUSTOM_EXCEPTION(
+                        message=f"Failed to {description} - Invalid endpoint provided", exception=e
+                    ) from e
+                except boto3.exceptions.Boto3Error as e:
+                    raise cls._CUSTOM_EXCEPTION(message=f"Failed to {description}", exception=e) from e
+
+            return handler
+
+        return wrapper

--- a/plugins/module_utils/_s3/common.py
+++ b/plugins/module_utils/_s3/common.py
@@ -67,7 +67,9 @@ class S3ErrorHandler(AWSErrorHandler):
     @classmethod
     def common_error_handler(cls, description):
         def wrapper(func):
-            @super(S3ErrorHandler, cls).common_error_handler(description)
+            parent_class = super(S3ErrorHandler, cls)
+
+            @parent_class.common_error_handler(description)
             @functools.wraps(func)
             def handler(*args, **kwargs):
                 try:

--- a/plugins/module_utils/_s3/transformations.py
+++ b/plugins/module_utils/_s3/transformations.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+
+# Copyright (c) 2018 Red Hat, Inc.
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import copy
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import Optional
+
+from ansible.module_utils.basic import to_text
+
+from ansible_collections.amazon.aws.plugins.module_utils.transformation import boto3_resource_to_ansible_dict
+
+
+def normalize_s3_bucket_versioning(versioning_status: Optional[dict]) -> Optional[dict]:
+    if not versioning_status:
+        return versioning_status
+    versioning_result = typing.cast(dict, boto3_resource_to_ansible_dict(versioning_status))
+    # Original s3_bucket format, no longer advertised but not officially deprecated
+    versioning_result["Versioning"] = versioning_status.get("Status", "Disabled")
+    versioning_result["MfaDelete"] = versioning_status.get("MFADelete", "Disabled")
+    # Original s3_bucket_info format, no longer advertised but not officially deprecated
+    versioning_result["Status"] = versioning_status.get("Status", "Disabled")
+    versioning_result["MFADelete"] = versioning_status.get("MFADelete", "Disabled")
+    return versioning_result
+
+
+def normalize_s3_bucket_public_access(public_access_status: Optional[dict]) -> Optional[dict]:
+    if not public_access_status:
+        return public_access_status
+    public_access_result = typing.cast(dict, boto3_resource_to_ansible_dict(public_access_status))
+    public_access_result["PublicAccessBlockConfiguration"] = copy.deepcopy(public_access_status)
+    public_access_result.update(public_access_status)
+    return public_access_result
+
+
+def normalize_s3_bucket_acls(acls: Optional[dict]) -> Optional[dict]:
+    if not acls:
+        return acls
+    acls_result = typing.cast(dict, boto3_resource_to_ansible_dict(acls))
+    return typing.cast(dict, acls_result["grants"])
+
+
+def _grantee_is_owner(grant, owner_id):
+    return grant.get("Grantee", {}).get("ID") == owner_id
+
+
+def _grantee_is_public(grant):
+    return grant.get("Grantee", {}).get("URI") == "http://acs.amazonaws.com/groups/global/AllUsers"
+
+
+def _grantee_is_authenticated(grant):
+    return grant.get("Grantee", {}).get("URI") == "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"
+
+
+def _acl_permissions(grants):
+    if not grants:
+        return []
+    return [grant.get("Permission") for grant in grants if grant]
+
+
+def s3_acl_to_name(acl):
+    if not acl:
+        return None
+
+    try:
+        grants = acl["Grants"]
+        owner_id = acl["Owner"]["ID"]
+        owner_acl = [grant for grant in grants if _grantee_is_owner(grant, owner_id)]
+        auth_acl = [grant for grant in grants if _grantee_is_authenticated(grant)]
+        public_acl = [grant for grant in grants if _grantee_is_public(grant)]
+
+        if len(grants) > (len(owner_acl) + len(auth_acl) + len(public_acl)):
+            raise ValueError("Unrecognised Grantee")
+        if public_acl and auth_acl:
+            raise ValueError("Public ACLs and Authenticated User ACLs are only used alone in templated ACL")
+
+        if ["FULL_CONTROL"] != _acl_permissions(owner_acl):
+            raise ValueError("Owner doesn't have full control")
+        if len(grants) == 1:
+            return "private"
+
+        if auth_acl:
+            if ["READ"] == _acl_permissions(auth_acl):
+                return "authenticated-read"
+            raise ValueError("Authenticated User ACLs don't match templated ACL")
+
+        permissions = sorted(_acl_permissions(public_acl))
+        if permissions == ["READ"]:
+            return "public-read"
+        if permissions == ["READ", "WRITE"]:
+            return "public-read-write"
+
+        raise ValueError("Public ACLs don't match templated ACL")
+
+    except (KeyError, IndexError, ValueError):
+        return None
+
+
+def merge_tags(current_tags: dict, new_tags: dict, purge_tags: bool = True) -> dict:
+    """
+    Compare and merge two dicts of tags.
+
+    :param current_tags: The current tags
+    :param new_tags: The tags passed as a parameter
+    :param purge_tags: Whether to remove current tags that aren't in new_tags
+    :return: updated_tags: The updated dictionary of tags
+    """
+
+    if new_tags is None:
+        return current_tags
+
+    updated_tags = copy.deepcopy(current_tags) if not purge_tags else {}
+    # Tags are always returned as text
+    new_tags = dict((to_text(k), to_text(v)) for k, v in new_tags.items())
+    updated_tags.update(new_tags)
+
+    return updated_tags

--- a/plugins/module_utils/_s3/waiters.py
+++ b/plugins/module_utils/_s3/waiters.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ..waiter import BaseWaiterFactory
+
+
+class S3WaiterFactory(BaseWaiterFactory):
+    @property
+    def _waiter_model_data(self):
+        PATH_BUCKET_KEY_ENABLED = "ServerSideEncryptionConfiguration.Rules[].BucketKeyEnabled"
+        data = dict(
+            bucket_exists=dict(
+                operation="HeadBucket",
+                delay=5,
+                maxAttempts=20,
+                acceptors=[
+                    dict(state="success", matcher="status", expected=200),
+                    dict(state="success", matcher="status", expected=301),
+                    dict(state="success", matcher="status", expected=403),
+                ],
+            ),
+            bucket_not_exists=dict(
+                operation="HeadBucket",
+                delay=5,
+                maxAttempts=60,
+                acceptors=[
+                    dict(state="success", matcher="status", expected=404),
+                ],
+            ),
+            bucket_versioning_enabled=dict(
+                operation="GetBucketVersioning",
+                delay=8,
+                maxAttempts=25,
+                acceptors=[
+                    dict(state="success", matcher="path", argument="Status", expected="Enabled"),
+                ],
+            ),
+            bucket_versioning_suspended=dict(
+                operation="GetBucketVersioning",
+                delay=8,
+                maxAttempts=25,
+                acceptors=[
+                    dict(state="success", matcher="path", argument="Status", expected="Suspended"),
+                ],
+            ),
+            bucket_key_encryption_enabled=dict(
+                operation="GetBucketEncryption",
+                delay=5,
+                maxAttempts=12,
+                acceptors=[
+                    dict(state="success", matcher="pathAll", argument=PATH_BUCKET_KEY_ENABLED, expected=True),
+                ],
+            ),
+            bucket_key_encryption_disabled=dict(
+                operation="GetBucketEncryption",
+                delay=5,
+                maxAttempts=12,
+                acceptors=[
+                    dict(state="success", matcher="pathAll", argument=PATH_BUCKET_KEY_ENABLED, expected=False),
+                ],
+            ),
+        )
+
+        return data
+
+
+waiter_factory = S3WaiterFactory()

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/acl.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/acl.yml
@@ -28,36 +28,136 @@
 
     - ansible.builtin.assert:
         that:
-          - private_acl.changed
+          - private_acl.acl == "private"
+          - private_acl is not changed
 
+    # failure expected - public ACLs prohibited by "block_public_acls"
     - name: Update bucket ACL, new value = public-read
       amazon.aws.s3_bucket:
         name: "{{ local_bucket_name }}"
         acl: public-read
         state: present
-      ignore_errors: true
+      ignore_errors: true  # noqa: ignore-errors
       register: public_read_acl
 
     - ansible.builtin.assert:
         that:
           - public_read_acl is failed
 
+    - name: Update bucket public access configuration (allow public access so we can test ACLs)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        state: present
+        public_access:
+          block_public_acls: false
+          block_public_policy: true
+          ignore_public_acls: false
+          restrict_public_buckets: true
+      register: public_access
+
+    - ansible.builtin.assert:
+        that:
+          - public_access.changed
+
     - name: Update bucket ACL, new value = public-read
       amazon.aws.s3_bucket:
         name: "{{ local_bucket_name }}"
         acl: public-read
         state: present
-        public_access:
-          block_public_acls: false
-          block_public_policy: true
-          ignore_public_acls: true
-          restrict_public_buckets: true
       ignore_errors: true
       register: public_read_acl
 
     - ansible.builtin.assert:
         that:
           - public_read_acl.changed
+          - public_read_acl.acl == "public-read"
+
+    - name: Update bucket ACL, new value = public-read (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        acl: public-read
+        state: present
+      ignore_errors: true
+      register: public_read_acl
+
+    - ansible.builtin.assert:
+        that:
+          - public_read_acl is not changed
+          - public_read_acl.acl == "public-read"
+
+    - name: Update bucket ACL, new value = public-write
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        acl: public-read-write
+        state: present
+      ignore_errors: true
+      register: public_write_acl
+
+    - ansible.builtin.assert:
+        that:
+          - public_write_acl.changed
+          - public_write_acl.acl == "public-read-write"
+
+    - name: Update bucket ACL, new value = public-write (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        acl: public-read-write
+        state: present
+      ignore_errors: true
+      register: public_write_acl
+
+    - ansible.builtin.assert:
+        that:
+          - public_write_acl is not changed
+          - public_write_acl.acl == "public-read-write"
+
+    - name: Update bucket ACL, new value = authenticated-read
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        acl: authenticated-read
+        state: present
+      register: auth_acl
+
+    - ansible.builtin.assert:
+        that:
+          - auth_acl.changed
+          - auth_acl.acl == "authenticated-read"
+
+    - name: Update bucket ACL, new value = authenticated-read (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        acl: authenticated-read
+        state: present
+      register: auth_acl
+
+    - ansible.builtin.assert:
+        that:
+          - auth_acl is not changed
+          - auth_acl.acl == "authenticated-read"
+
+    - name: Update bucket ACL, new value = private
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        acl: private
+        state: present
+      register: private_acl
+
+    - ansible.builtin.assert:
+        that:
+          - private_acl.changed
+          - private_acl.acl == "private"
+
+    - name: Update bucket ACL, new value = private (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        acl: private
+        state: present
+      register: private_acl
+
+    - ansible.builtin.assert:
+        that:
+          - private_acl is not changed
+          - private_acl.acl == "private"
 
   # ============================================================
   always:
@@ -65,4 +165,4 @@
       amazon.aws.s3_bucket:
         name: "{{ local_bucket_name }}"
         state: absent
-      ignore_errors: true
+      ignore_errors: true  # noqa: ignore-errors

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_bucket_key.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_bucket_key.yml
@@ -97,6 +97,13 @@
   # ============================================================
   always:
     - name: Ensure all buckets are deleted
+      amazon.aws.s3_bucket_info:
+        name: "{{ local_bucket_name }}"
+        bucket_facts:
+          bucket_encryption: true
+      failed_when: false
+
+    - name: Ensure all buckets are deleted
       amazon.aws.s3_bucket:
         name: "{{ local_bucket_name }}"
         state: absent

--- a/tests/unit/plugins/module_utils/s3/test_s3_acl_to_name.py
+++ b/tests/unit/plugins/module_utils/s3/test_s3_acl_to_name.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+#
+# (c) 2021 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+
+from ansible_collections.amazon.aws.plugins.module_utils import s3
+
+SAMPLE_OWNER = {
+    "DisplayName": "example-root+123456789012",
+    "ID": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+}
+
+SAMPLE_GRANT_FULL = {
+    "Grantee": {
+        "DisplayName": "example-root+123456789012",
+        "ID": "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef",
+        "Type": "CanonicalUser",
+    },
+    "Permission": "FULL_CONTROL",
+}
+
+SAMPLE_GRANT_PUBLIC_READ = {
+    "Grantee": {"Type": "Group", "URI": "http://acs.amazonaws.com/groups/global/AllUsers"},
+    "Permission": "READ",
+}
+
+SAMPLE_GRANT_PUBLIC_WRITE = {
+    "Grantee": {"Type": "Group", "URI": "http://acs.amazonaws.com/groups/global/AllUsers"},
+    "Permission": "WRITE",
+}
+
+SAMPLE_GRANT_AUTH_READ = {
+    "Grantee": {"Type": "Group", "URI": "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"},
+    "Permission": "READ",
+}
+
+SAMPLE_GRANT_OTHER = {
+    "Grantee": {
+        "DisplayName": "example-root+001122334455",
+        "ID": "123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef0",
+        "Type": "CanonicalUser",
+    },
+    "Permission": "FULL_CONTROL",
+}
+
+
+@pytest.mark.parametrize(
+    "acl,result",
+    [
+        ({"Grants": [SAMPLE_GRANT_FULL]}, None),
+        ({"Owner": SAMPLE_OWNER}, None),
+        ({"Owner": SAMPLE_OWNER, "Grants": [SAMPLE_GRANT_FULL]}, "private"),
+        ({"Owner": SAMPLE_OWNER, "Grants": [SAMPLE_GRANT_FULL, SAMPLE_GRANT_AUTH_READ]}, "authenticated-read"),
+        ({"Owner": SAMPLE_OWNER, "Grants": [SAMPLE_GRANT_AUTH_READ, SAMPLE_GRANT_FULL]}, "authenticated-read"),
+        ({"Owner": SAMPLE_OWNER, "Grants": [SAMPLE_GRANT_FULL, SAMPLE_GRANT_PUBLIC_READ]}, "public-read"),
+        ({"Owner": SAMPLE_OWNER, "Grants": [SAMPLE_GRANT_PUBLIC_READ, SAMPLE_GRANT_FULL]}, "public-read"),
+        (
+            {"Owner": SAMPLE_OWNER, "Grants": [SAMPLE_GRANT_FULL, SAMPLE_GRANT_PUBLIC_READ, SAMPLE_GRANT_PUBLIC_WRITE]},
+            "public-read-write",
+        ),
+        (
+            {"Owner": SAMPLE_OWNER, "Grants": [SAMPLE_GRANT_FULL, SAMPLE_GRANT_PUBLIC_WRITE, SAMPLE_GRANT_PUBLIC_READ]},
+            "public-read-write",
+        ),
+        (
+            {"Owner": SAMPLE_OWNER, "Grants": [SAMPLE_GRANT_PUBLIC_READ, SAMPLE_GRANT_FULL, SAMPLE_GRANT_PUBLIC_WRITE]},
+            "public-read-write",
+        ),
+        (
+            {"Owner": SAMPLE_OWNER, "Grants": [SAMPLE_GRANT_PUBLIC_WRITE, SAMPLE_GRANT_FULL, SAMPLE_GRANT_PUBLIC_READ]},
+            "public-read-write",
+        ),
+    ],
+)
+def test_s3_acl_to_name(acl, result):
+    assert result == s3.s3_acl_to_name(acl)

--- a/tests/unit/plugins/modules/s3_bucket/test_handle_bucket_accelerate.py
+++ b/tests/unit/plugins/modules/s3_bucket/test_handle_bucket_accelerate.py
@@ -2,19 +2,28 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from unittest.mock import MagicMock
-from unittest.mock import patch
 from unittest.mock import sentinel
 
 import botocore
 import pytest
 
+import ansible_collections.amazon.aws.plugins.module_utils.s3 as s3_utils
 from ansible_collections.amazon.aws.plugins.modules.s3_bucket import handle_bucket_accelerate
 
-module_name = "ansible_collections.amazon.aws.plugins.modules.s3_bucket"
+SKIPABLE_ERRORS = [
+    ("NotImplemented", "Fetching bucket transfer acceleration state is not supported", s3_utils.AnsibleS3SupportError),
+    ("XNotImplemented", "Fetching bucket transfer acceleration state is not supported", s3_utils.AnsibleS3SupportError),
+    ("UnsupportedArgument", "Argument not supported in the current Region", s3_utils.AnsibleS3RegionSupportError),
+    ("AccessDenied", "Permission denied fetching transfer acceleration for bucket", s3_utils.AnsibleS3PermissionsError),
+]
+
+BAD_ERRORS = [
+    ("GenericBadClientError", "Failed to fetch bucket transfer acceleration state", s3_utils.AnsibleS3Error),
+]
 
 
-def a_botocore_exception(message):
-    return botocore.exceptions.ClientError({"Error": {"Code": message}}, sentinel.BOTOCORE_ACTION)
+def a_botocore_exception(code, message):
+    return botocore.exceptions.ClientError({"Error": {"Code": code, "Message": message}}, sentinel.BOTOCORE_ACTION)
 
 
 @pytest.fixture(name="ansible_module")
@@ -22,69 +31,46 @@ def fixure_ansible_module():
     mock = MagicMock()
     mock.params = {"accelerate_enabled": sentinel.ACCELERATE_ENABLED}
     mock.fail_json_aws.side_effect = SystemExit(1)
+    mock.fail_json.side_effect = SystemExit(1)
     return mock
 
 
-@pytest.mark.parametrize(
-    "code,message",
-    [
-        ("NotImplemented", "Fetching bucket transfer acceleration state is not supported"),
-        ("XNotImplemented", "Fetching bucket transfer acceleration state is not supported"),
-        ("AccessDenied", "Permission denied fetching transfer acceleration for bucket"),
-        (sentinel.BOTO_CLIENT_ERROR, "Failed to fetch bucket transfer acceleration state"),
-    ],
-)
-@patch(module_name + ".get_bucket_accelerate_status")
-def test_failure(m_get_bucket_accelerate_status, ansible_module, code, message):
+# Test that we fail "gracefully" if we don't support bucket acceleration
+@pytest.mark.parametrize("code,message,exception", [*BAD_ERRORS, *SKIPABLE_ERRORS])
+def test_failure(ansible_module, code, message, exception):
     bucket_name = sentinel.BUCKET_NAME
+    exc = a_botocore_exception(code, message)
     client = MagicMock()
-    exc = a_botocore_exception(code)
-    m_get_bucket_accelerate_status.side_effect = exc
-    with pytest.raises(SystemExit):
+    client.get_bucket_accelerate_configuration.side_effect = exc
+    with pytest.raises(exception):
         handle_bucket_accelerate(client, ansible_module, bucket_name)
-    ansible_module.fail_json_aws.assert_called_once_with(exc, msg=message)
 
 
-@patch(module_name + ".get_bucket_accelerate_status")
-def test_unsupported(m_get_bucket_accelerate_status, ansible_module):
+# Test that we only emit a warning if we don't support bucket acceleration but aren't trying to
+# manage the acceleration configuration
+@pytest.mark.parametrize("code,message,exception", SKIPABLE_ERRORS)
+def test_no_argument(ansible_module, code, message, exception):
     bucket_name = sentinel.BUCKET_NAME
+    exc = a_botocore_exception(code, message)
     client = MagicMock()
-    m_get_bucket_accelerate_status.side_effect = a_botocore_exception("UnsupportedArgument")
+    client.get_bucket_accelerate_configuration.side_effect = exc
+
+    ansible_module.params["accelerate_enabled"] = None
     changed, result = handle_bucket_accelerate(client, ansible_module, bucket_name)
     assert changed is False
-    assert result is False
+    assert result is None
     ansible_module.warn.assert_called_once()
 
 
-@pytest.mark.parametrize("accelerate_enabled", [True, False])
-@patch(module_name + ".delete_bucket_accelerate_configuration")
-@patch(module_name + ".get_bucket_accelerate_status")
-def test_delete(
-    m_get_bucket_accelerate_status, m_delete_bucket_accelerate_configuration, ansible_module, accelerate_enabled
-):
+# Test that we're not being "too" relaxed with our handling, we should only be ignoring errors
+# caused by a total lack of support from the platform
+@pytest.mark.parametrize("code,message,exception", BAD_ERRORS)
+def test_no_argument_fatal(ansible_module, code, message, exception):
     bucket_name = sentinel.BUCKET_NAME
+    exc = a_botocore_exception(code, message)
     client = MagicMock()
-    ansible_module.params.update({"accelerate_enabled": accelerate_enabled})
-    m_get_bucket_accelerate_status.return_value = True
-    if not accelerate_enabled:
-        assert (True, False) == handle_bucket_accelerate(client, ansible_module, bucket_name)
-        m_delete_bucket_accelerate_configuration.assert_called_once_with(client, bucket_name)
-    else:
-        assert (False, True) == handle_bucket_accelerate(client, ansible_module, bucket_name)
-        m_delete_bucket_accelerate_configuration.assert_not_called()
+    client.get_bucket_accelerate_configuration.side_effect = exc
 
-
-@pytest.mark.parametrize("accelerate_enabled", [True, False])
-@patch(module_name + ".put_bucket_accelerate_configuration")
-@patch(module_name + ".get_bucket_accelerate_status")
-def test_put(m_get_bucket_accelerate_status, m_put_bucket_accelerate_configuration, ansible_module, accelerate_enabled):
-    bucket_name = sentinel.BUCKET_NAME
-    client = MagicMock()
-    ansible_module.params.update({"accelerate_enabled": accelerate_enabled})
-    m_get_bucket_accelerate_status.return_value = False
-    if accelerate_enabled:
-        assert (True, True) == handle_bucket_accelerate(client, ansible_module, bucket_name)
-        m_put_bucket_accelerate_configuration.assert_called_once_with(client, bucket_name)
-    else:
-        assert (False, False) == handle_bucket_accelerate(client, ansible_module, bucket_name)
-        m_put_bucket_accelerate_configuration.assert_not_called()
+    ansible_module.params["accelerate_enabled"] = None
+    with pytest.raises(exception):
+        handle_bucket_accelerate(client, ansible_module, bucket_name)


### PR DESCRIPTION
##### SUMMARY

s3_bucket has some support for non-AWS "S3" APIs, this PR reworks s3_bucket module to more consistently handle the various Errors that get thrown when the non-AWS-S3 API doesn't cleanly support some of the more advanced S3 features.

Our testing for non-AWS APIs is near non-existent, so it's important that the patterns displayed in the module are easy to follow and cleanly handle things a feature not being supported if someone doesn't try to use it.

Also fixes idempotency when setting the simplistic "templated" ACLs.

##### ISSUE TYPE

- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME

s3_bucket

##### ADDITIONAL INFORMATION

I plan on migrating the remaining S3 modules in amazon.aws but this is just the first one.