### PR TITLE
Updating Outdated Documentation Link

### DIFF
--- a/docs/docsite/rst/guide_aws.rst
+++ b/docs/docsite/rst/guide_aws.rst
@@ -66,7 +66,7 @@ Or they can be specified using "module_defaults" at the top of a playbook.::
             key_name: "example-ssh-key"
             image_id: "..."
 
-Credentials can also be accessed from a `Credentials Profile <https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_profiles.html>`_.::
+Credentials can also be accessed from a `Credentials Profile <https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html>`_.::
 
     - amazon.aws.ec2_instance:
         aws_profile: default


### PR DESCRIPTION

##### SUMMARY

Fixed the link for Credentials Profile authentication documentation to point to the AWS CLI credential file settings article, rather than the PHP SDK article



##### ISSUE TYPE
- Docs Pull Request

##### ADDITIONAL INFORMATION

It looks like maybe Amazon updated their documentation, as the old URL (https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/guide_credentials_profiles.html) now automatically redirects to https://docs.aws.amazon.com/sdk-for-php/v3/developer-guide/welcome.html, which is their PHP SDK documentation. I updated the URL to a more accurate set of documentation for CLI configuration/Credentials Profiles. https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-files.html

```
