### PR TITLE
fixup patchback username in workflow

### DIFF
--- a/.github/workflows/backports-check.yml
+++ b/.github/workflows/backports-check.yml
@@ -7,18 +7,19 @@ on:
       - edited
 
 jobs:
-  dump_context:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Dump context
-        env:
-          EVENT_CONTEXT: ${{ toJson(github.event) }}
-        run: |
-          echo  "${EVENT_CONTEXT}"
+  # dump_context:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Dump context
+  #       env:
+  #         EVENT_CONTEXT: ${{ toJson(github.event) }}
+  #       run: |
+  #         echo  "${EVENT_CONTEXT}"
   check_patchback_comment:
+    # if patchback[bot] stops working we might want to switch to user.id == 45432694
     if: ${{
       github.event.issue.pull_request.merged_at &&
-      github.event.comment.user.login == 'patchback' &&
+      github.event.comment.user.login == 'patchback[bot]' &&
       contains(github.event.comment.body, '💔 cherry-picking failed')
       }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
##### SUMMARY

Apparently the username for a bot in events is appended with [bot]

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

##### ADDITIONAL INFORMATION

![patchback](https://github.com/user-attachments/assets/00a6f58e-f643-428e-aca4-c2af2f2469f1)
