### PR TITLE
[Manual Backport] Various pylint fixups (#2444)

### DIFF
--- a/changelogs/fragments/2444-pylint.yml
+++ b/changelogs/fragments/2444-pylint.yml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - ec2_ami - avoid redefining ``delete_snapshot`` inside ``DeregisterImage.do`` (https://github.com/ansible-collections/amazon.aws/pull/2444).
+  - s3_bucket - avoid redefining ``id`` inside ``handle_bucket_inventory`` and ``delete_bucket_inventory`` (https://github.com/ansible-collections/amazon.aws/pull/2444).
+  - s3_object - avoid redefining ``key_check`` inside ``_head_object`` (https://github.com/ansible-collections/amazon.aws/pull/2444).
+  - s3_object - simplify ``path_check`` logic (https://github.com/ansible-collections/amazon.aws/pull/2444).
+  - ec2_vpc_vpn - minor linting fixups (https://github.com/ansible-collections/amazon.aws/pull/2444).

--- a/plugins/modules/ec2_ami.py
+++ b/plugins/modules/ec2_ami.py
@@ -646,7 +646,6 @@ class DeregisterImage:
     @classmethod
     def do(cls, module, connection, image_id):
         """Entry point to deregister an image"""
-        delete_snapshot = module.params.get("delete_snapshot")
         wait = module.params.get("wait")
         wait_timeout = module.params.get("wait_timeout")
         image = get_image_by_id(connection, image_id)
@@ -671,7 +670,7 @@ class DeregisterImage:
 
         exit_params = {"msg": "AMI deregister operation complete.", "changed": True}
 
-        if delete_snapshot:
+        if module.params.get("delete_snapshot"):
             exit_params["snapshots_deleted"] = list(purge_snapshots(connection))
 
         module.exit_json(**exit_params)

--- a/plugins/modules/ec2_vpc_vpn.py
+++ b/plugins/modules/ec2_vpc_vpn.py
@@ -565,9 +565,9 @@ def create_filter(module, provided_filters: Dict[str, Any]) -> List[Dict[str, An
                 flat_filter_dict[param] = [str(provided_filters[param])]
 
     # if customer_gateway, vpn_gateway, or vpn_connection was specified in the task but not the filter, add it
-    for param in param_to_filter:
-        if param_to_filter[param] not in flat_filter_dict and module.params.get(param):
-            flat_filter_dict[param_to_filter[param]] = [module.params.get(param)]
+    for param, param_value in param_to_filter.items():
+        if param_value not in flat_filter_dict and module.params.get(param):
+            flat_filter_dict[param_value] = [module.params.get(param)]
 
     # change the flat dict into something boto3 will understand
     formatted_filter = [{"Name": key, "Values": value} for key, value in flat_filter_dict.items()]
@@ -710,7 +710,7 @@ def check_for_routes_update(client, module: AnsibleAWSModule, vpn_connection_id:
     for attribute in current_attrs:
         if attribute in ("tags", "routes", "state"):
             continue
-        elif attribute == "options":
+        if attribute == "options":
             will_be = module.params.get("static_only")
             is_now = bool(current_attrs[attribute]["static_routes_only"])
             attribute = "static_only"

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -1209,9 +1209,9 @@ def handle_bucket_inventory(s3_client, module: AnsibleAWSModule, name: str) -> T
 
         results.append(declared_inventory_api)
 
-    for id in present_inventories.keys():
+    for inventory_id in present_inventories.keys():
         try:
-            delete_bucket_inventory(s3_client, name, id)
+            delete_bucket_inventory(s3_client, name, inventory_id)
         except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
             module.fail_json_aws(e, msg="Failed to delete bucket inventory")
         bucket_changed = True
@@ -1476,7 +1476,7 @@ def put_bucket_tagging(s3_client, bucket_name: str, tags: dict):
 
 
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def delete_bucket_inventory(s3_client, bucket_name: str, id: str) -> None:
+def delete_bucket_inventory(s3_client, bucket_name: str, inventory_id: str) -> None:
     """
     Delete the inventory settings for an S3 bucket.
     Parameters:
@@ -1486,7 +1486,7 @@ def delete_bucket_inventory(s3_client, bucket_name: str, id: str) -> None:
     Returns:
         None
     """
-    s3_client.delete_bucket_inventory_configuration(Bucket=bucket_name, Id=id)
+    s3_client.delete_bucket_inventory_configuration(Bucket=bucket_name, Id=inventory_id)
 
 
 @AWSRetry.exponential_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -500,13 +500,13 @@ def etag_compare(module, s3, bucket, obj, version=None, local_file=None, content
 def _head_object(s3, bucket, obj, version=None):
     try:
         if version:
-            key_check = s3.head_object(aws_retry=True, Bucket=bucket, Key=obj, VersionId=version)
+            obj_head = s3.head_object(aws_retry=True, Bucket=bucket, Key=obj, VersionId=version)
         else:
-            key_check = s3.head_object(aws_retry=True, Bucket=bucket, Key=obj)
-        if not key_check:
+            obj_head = s3.head_object(aws_retry=True, Bucket=bucket, Key=obj)
+        if not obj_head:
             return {}
-        key_check.pop("ResponseMetadata")
-        return key_check
+        obj_head.pop("ResponseMetadata")
+        return obj_head
     except is_boto3_error_code("404"):
         return {}
 
@@ -656,10 +656,7 @@ def create_dirkey(module, s3, bucket, obj, encrypt, expiry):
 
 
 def path_check(path):
-    if os.path.exists(path):
-        return True
-    else:
-        return False
+    return bool(os.path.exists(path))
 
 
 def guess_content_type(src):

--- a/tests/integration/targets/s3_object/library/test_s3_upload_multipart.py
+++ b/tests/integration/targets/s3_object/library/test_s3_upload_multipart.py
@@ -93,7 +93,7 @@ def main():
     )
 
     bucket = module.params.get("bucket")
-    object = module.params.get("object")
+    object_key = module.params.get("object")
     part_size = module.params.get("part_size")
     parts = module.params.get("parts")
 
@@ -109,13 +109,13 @@ def main():
         module.fail_json_aws(e, msg="Failed to connect to AWS")
 
     # create multipart upload
-    response = s3.create_multipart_upload(Bucket=bucket, Key=object)
+    response = s3.create_multipart_upload(Bucket=bucket, Key=object_key)
     upload_id = response.get("UploadId")
 
     # upload parts
     upload_params = {
         "Bucket": bucket,
-        "Key": object,
+        "Key": object_key,
         "UploadId": upload_id,
     }
 
@@ -124,7 +124,7 @@ def main():
     # complete the upload
     response = s3.complete_multipart_upload(
         Bucket=bucket,
-        Key=object,
+        Key=object_key,
         MultipartUpload={"Parts": multiparts},
         UploadId=upload_id,
     )

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -1,0 +1,9 @@
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+# pylint: disable=unused-import
+
+import pytest
+
+from .utils.amazon_placebo_fixtures import fixture_maybe_sleep
+from .utils.amazon_placebo_fixtures import fixture_placeboify

--- a/tests/unit/module_utils/botocore/test_aws_region.py
+++ b/tests/unit/module_utils/botocore/test_aws_region.py
@@ -23,8 +23,8 @@ class FailException(Exception):
     pass
 
 
-@pytest.fixture
-def aws_module(monkeypatch):
+@pytest.fixture(name="aws_module")
+def fixture_aws_module(monkeypatch):
     aws_module = MagicMock()
     aws_module.fail_json.side_effect = FailException()
     aws_module.fail_json_aws.side_effect = FailException()
@@ -32,8 +32,8 @@ def aws_module(monkeypatch):
     return aws_module
 
 
-@pytest.fixture
-def fake_boto3(monkeypatch):
+@pytest.fixture(name="fake_boto3")
+def fixture_fake_boto3(monkeypatch):
     # Note: this isn't a monkey-patched real-botocore, this is a complete fake.
     fake_session = MagicMock()
     fake_session.region_name = sentinel.BOTO3_REGION
@@ -47,8 +47,8 @@ def fake_boto3(monkeypatch):
     return fake_boto3
 
 
-@pytest.fixture
-def botocore_utils(monkeypatch):
+@pytest.fixture(name="botocore_utils")
+def fixture_botocore_utils(monkeypatch):
     return utils_botocore
 
 

--- a/tests/unit/module_utils/botocore/test_boto3_conn.py
+++ b/tests/unit/module_utils/botocore/test_boto3_conn.py
@@ -21,16 +21,16 @@ class FailException(Exception):
     pass
 
 
-@pytest.fixture
-def aws_module(monkeypatch):
+@pytest.fixture(name="aws_module")
+def fixture_aws_module(monkeypatch):
     aws_module = MagicMock()
     aws_module.fail_json.side_effect = FailException()
     monkeypatch.setattr(aws_module, "_name", sentinel.MODULE_NAME)
     return aws_module
 
 
-@pytest.fixture
-def botocore_utils(monkeypatch):
+@pytest.fixture(name="botocore_utils")
+def fixture_botocore_utils(monkeypatch):
     return utils_botocore
 
 

--- a/tests/unit/module_utils/botocore/test_connection_info.py
+++ b/tests/unit/module_utils/botocore/test_connection_info.py
@@ -31,8 +31,8 @@ class FailException(Exception):
     pass
 
 
-@pytest.fixture
-def aws_module(monkeypatch):
+@pytest.fixture(name="aws_module")
+def fixture_aws_module(monkeypatch):
     aws_module = MagicMock()
     aws_module.fail_json.side_effect = FailException()
     aws_module.fail_json_aws.side_effect = FailException()
@@ -40,8 +40,8 @@ def aws_module(monkeypatch):
     return aws_module
 
 
-@pytest.fixture
-def fake_botocore(monkeypatch):
+@pytest.fixture(name="fake_botocore")
+def fixture_fake_botocore(monkeypatch):
     # Note: this isn't a monkey-patched real-botocore, this is a complete fake.
     fake_session = MagicMock()
     fake_session.get_config_variable.return_value = sentinel.BOTO3_REGION
@@ -58,8 +58,8 @@ def fake_botocore(monkeypatch):
     return fake_botocore
 
 
-@pytest.fixture
-def botocore_utils(monkeypatch):
+@pytest.fixture(name="botocore_utils")
+def fixture_botocore_utils(monkeypatch):
     region_method = MagicMock(name="_aws_region")
     monkeypatch.setattr(utils_botocore, "_aws_region", region_method)
     region_method.return_value = sentinel.RETURNED_REGION
@@ -204,7 +204,7 @@ def test_aws_connection_info_validation(monkeypatch, botocore_utils, options, ex
     assert region is sentinel.RETURNED_REGION
     assert endpoint_url is None
     assert boto_params == expected_params
-    boto_params["verify"] is expected_validate
+    assert boto_params["verify"] == expected_validate
 
 
 def test_aws_connection_info_profile(monkeypatch, botocore_utils):

--- a/tests/unit/module_utils/botocore/test_merge_botocore_config.py
+++ b/tests/unit/module_utils/botocore/test_merge_botocore_config.py
@@ -20,8 +20,8 @@ MINIMAL_CONFIG = {
 }
 
 
-@pytest.fixture
-def basic_config():
+@pytest.fixture(name="basic_config")
+def fixture_basic_config():
     config = botocore.config.Config(**MINIMAL_CONFIG)
     return config
 

--- a/tests/unit/module_utils/cloud/test_decorator_generation.py
+++ b/tests/unit/module_utils/cloud/test_decorator_generation.py
@@ -18,8 +18,8 @@ if sys.version_info < (3, 8):
     )
 
 
-@pytest.fixture
-def patch_cloud_retry(monkeypatch):
+@pytest.fixture(name="patch_cloud_retry")
+def fixture_patch_cloud_retry(monkeypatch):
     """
     replaces CloudRetry.base_decorator with a MagicMock so that we can exercise the generation of
     the various "public" decorators.  We can then check that base_decorator was called as expected.

--- a/tests/unit/module_utils/cloud/test_retry_func.py
+++ b/tests/unit/module_utils/cloud/test_retry_func.py
@@ -27,8 +27,8 @@ class ExceptionB(Exception):
         pass
 
 
-@pytest.fixture
-def retrier():
+@pytest.fixture(name="retrier")
+def fixture_retrier():
     def do_retry(
         func=None,
         sleep_generator=None,

--- a/tests/unit/module_utils/conftest.py
+++ b/tests/unit/module_utils/conftest.py
@@ -16,8 +16,8 @@ from ansible.module_utils.six import PY3
 from ansible.module_utils.six import string_types
 
 
-@pytest.fixture
-def stdin(mocker, request):
+@pytest.fixture(name="stdin")
+def fixture_stdin(mocker, request):
     old_args = ansible.module_utils.basic._ANSIBLE_ARGS
     ansible.module_utils.basic._ANSIBLE_ARGS = None
     old_argv = sys.argv
@@ -56,8 +56,8 @@ def stdin(mocker, request):
     sys.argv = old_argv
 
 
-@pytest.fixture
-def am(stdin, request):
+@pytest.fixture(name="am")
+def fixture_am(stdin, request):
     old_args = ansible.module_utils.basic._ANSIBLE_ARGS
     ansible.module_utils.basic._ANSIBLE_ARGS = None
     old_argv = sys.argv

--- a/tests/unit/module_utils/ec2/test_determine_iam_role.py
+++ b/tests/unit/module_utils/ec2/test_determine_iam_role.py
@@ -37,14 +37,14 @@ class FailJsonException(Exception):
         pass
 
 
-@pytest.fixture
-def ec2_utils_fixture(monkeypatch):
+@pytest.fixture(name="ec2_utils_fixture")
+def fixture_ec2_utils_fixture(monkeypatch):
     monkeypatch.setattr(ec2_utils, "validate_aws_arn", lambda arn, service, resource_type: None)
     return ec2_utils
 
 
-@pytest.fixture
-def iam_client():
+@pytest.fixture(name="iam_client")
+def fixture_iam_client():
     client = MagicMock()
     return client
 

--- a/tests/unit/module_utils/elbv2/test_listener_rules.py
+++ b/tests/unit/module_utils/elbv2/test_listener_rules.py
@@ -11,8 +11,8 @@ import pytest
 from ansible_collections.amazon.aws.plugins.module_utils import elbv2
 
 
-@pytest.fixture
-def elb_listener_rules(mocker):
+@pytest.fixture(name="elb_listener_rules")
+def fixture_elb_listener_rules(mocker):
     module = MagicMock()
     connection = MagicMock()
     rules = MagicMock()

--- a/tests/unit/module_utils/exceptions/test_exceptions.py
+++ b/tests/unit/module_utils/exceptions/test_exceptions.py
@@ -10,8 +10,8 @@ import pytest
 import ansible_collections.amazon.aws.plugins.module_utils.exceptions as aws_exceptions
 
 
-@pytest.fixture
-def utils_exceptions():
+@pytest.fixture(name="utils_exceptions")
+def fixture_utils_exceptions():
     return aws_exceptions
 
 

--- a/tests/unit/module_utils/retries/test_retry_wrapper.py
+++ b/tests/unit/module_utils/retries/test_retry_wrapper.py
@@ -18,8 +18,8 @@ import ansible_collections.amazon.aws.plugins.module_utils.botocore as util_boto
 import ansible_collections.amazon.aws.plugins.module_utils.retries as util_retries
 
 
-@pytest.fixture
-def fake_client():
+@pytest.fixture(name="fake_client")
+def fixture_fake_client():
     retryable_response = {"Error": {"Code": "RequestLimitExceeded", "Message": "Something went wrong"}}
     retryable_exception = botocore.exceptions.ClientError(retryable_response, "fail_retryable")
     not_retryable_response = {"Error": {"Code": "AnotherProblem", "Message": "Something went wrong"}}
@@ -35,8 +35,8 @@ def fake_client():
     return client
 
 
-@pytest.fixture
-def quick_backoff():
+@pytest.fixture(name="quick_backoff")
+def fixture_quick_backoff():
     # Because RetryingBotoClientWrapper will wrap resources using the this decorator,
     # we're going to rely on AWSRetry.jittered_backoff rather than trying to mock out
     # a decorator use a really short delay to keep the tests quick, and we only need

--- a/tests/unit/module_utils/test_acm.py
+++ b/tests/unit/module_utils/test_acm.py
@@ -17,15 +17,14 @@ except ImportError:
     # Handled by HAS_BOTO3
     pass
 
-
 from ansible_collections.amazon.aws.plugins.module_utils.acm import ACMServiceManager
 from ansible_collections.amazon.aws.plugins.module_utils.acm import acm_catch_boto_exception
 
 MODULE_NAME = "ansible_collections.amazon.aws.plugins.module_utils.acm"
 
 
-@pytest.fixture()
-def acm_service_mgr():
+@pytest.fixture(name="acm_service_mgr")
+def fixture_acm_service_mgr():
     module = MagicMock()
     module.fail_json_aws.side_effect = SystemExit(2)
     module.fail_json.side_effect = SystemExit(1)
@@ -122,7 +121,7 @@ def test_acm_service_manager_get_domain_of_cert_failure(acm_service_mgr):
     acm_service_mgr.module.fail.assert_not_called()
 
 
-def test_acm_service_manager_get_domain_of_cert_with_retry_and_success(acm_service_mgr):
+def test_acm_service_manager_get_domain_of_cert_with_retry_and_success(maybe_sleep, acm_service_mgr):
     arn = "arn:aws:acm:us-west-01:123456789012:certificate/12345678-1234-1234-1234-123456789012"
     boto_err = raise_botocore_error(code="ResourceNotFoundException")
     certificate = {"Certificate": {"DomainName": MagicMock()}, "ResponseMetaData": {"code": 200}}
@@ -130,7 +129,7 @@ def test_acm_service_manager_get_domain_of_cert_with_retry_and_success(acm_servi
     assert acm_service_mgr.get_domain_of_cert(arn=arn) == certificate["Certificate"]["DomainName"]
 
 
-def test_acm_service_manager_get_domain_of_cert_with_retry_and_failure(acm_service_mgr):
+def test_acm_service_manager_get_domain_of_cert_with_retry_and_failure(maybe_sleep, acm_service_mgr):
     arn = "arn:aws:acm:us-west-01:123456789012:certificate/12345678-1234-1234-1234-123456789012"
     boto_err = raise_botocore_error(code="ResourceNotFoundException")
 

--- a/tests/unit/module_utils/test_cloudfront_facts.py
+++ b/tests/unit/module_utils/test_cloudfront_facts.py
@@ -25,8 +25,8 @@ MODULE_NAME = "ansible_collections.amazon.aws.plugins.module_utils.cloudfront_fa
 MOCK_CLOUDFRONT_FACTS_KEYED_LIST_HELPER = MODULE_NAME + ".cloudfront_facts_keyed_list_helper"
 
 
-@pytest.fixture()
-def cloudfront_facts_service():
+@pytest.fixture(name="cloudfront_facts_service")
+def fixture_cloudfront_facts_service():
     module = MagicMock()
     cloudfront_facts = CloudFrontFactsServiceManager(module)
 

--- a/tests/unit/module_utils/test_rds.py
+++ b/tests/unit/module_utils/test_rds.py
@@ -29,11 +29,11 @@ if not HAS_BOTO3:
 mod_name = "ansible_collections.amazon.aws.plugins.module_utils.rds"
 
 
-def expected(x):
+def helper_expected(x):
     return x, nullcontext()
 
 
-def error(*args, **kwargs):
+def helper_error(*args, **kwargs):
     return MagicMock(), pytest.raises(*args, **kwargs)
 
 
@@ -66,7 +66,7 @@ def test__wait_for_cluster_snapshot_status(waiter_name):
 
 
 @pytest.mark.parametrize(
-    "input, expected",
+    "waiter_name, expected",
     [
         (
             "db_snapshot_available",
@@ -75,18 +75,18 @@ def test__wait_for_cluster_snapshot_status(waiter_name):
         ("db_snapshot_deleted", "Failed to wait for DB snapshot test to be deleted"),
     ],
 )
-def test__wait_for_instance_snapshot_status_failed(input, expected):
+def test__wait_for_instance_snapshot_status_failed(waiter_name, expected):
     spec = {"get_waiter.side_effect": [botocore.exceptions.WaiterError(None, None, None)]}
     client = MagicMock(**spec)
     module = MagicMock()
 
-    rds.wait_for_instance_snapshot_status(client, module, "test", input)
-    module.fail_json_aws.assert_called_once
-    module.fail_json_aws.call_args[1]["msg"] == expected
+    rds.wait_for_instance_snapshot_status(client, module, "test", waiter_name)
+    module.fail_json_aws.assert_called_once()
+    assert module.fail_json_aws.call_args[1]["msg"] == expected
 
 
 @pytest.mark.parametrize(
-    "input, expected",
+    "waiter_name, expected",
     [
         (
             "db_cluster_snapshot_available",
@@ -98,14 +98,14 @@ def test__wait_for_instance_snapshot_status_failed(input, expected):
         ),
     ],
 )
-def test__wait_for_cluster_snapshot_status_failed(input, expected):
+def test__wait_for_cluster_snapshot_status_failed(waiter_name, expected):
     spec = {"get_waiter.side_effect": [botocore.exceptions.WaiterError(None, None, None)]}
     client = MagicMock(**spec)
     module = MagicMock()
 
-    rds.wait_for_cluster_snapshot_status(client, module, "test", input)
-    module.fail_json_aws.assert_called_once
-    module.fail_json_aws.call_args[1]["msg"] == expected
+    rds.wait_for_cluster_snapshot_status(client, module, "test", waiter_name)
+    module.fail_json_aws.assert_called_once()
+    assert module.fail_json_aws.call_args[1]["msg"] == expected
 
 
 @pytest.mark.parametrize(
@@ -116,7 +116,7 @@ def test__wait_for_cluster_snapshot_status_failed(input, expected):
             {
                 "new_db_cluster_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="delete_db_cluster",
                     waiter="cluster_deleted",
@@ -131,7 +131,7 @@ def test__wait_for_cluster_snapshot_status_failed(input, expected):
             {
                 "new_db_cluster_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="create_db_cluster",
                     waiter="cluster_available",
@@ -146,7 +146,7 @@ def test__wait_for_cluster_snapshot_status_failed(input, expected):
             {
                 "new_db_cluster_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="start_db_cluster",
                     waiter="cluster_available",
@@ -161,7 +161,7 @@ def test__wait_for_cluster_snapshot_status_failed(input, expected):
             {
                 "new_db_cluster_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="stop_db_cluster",
                     waiter="cluster_available",
@@ -176,7 +176,7 @@ def test__wait_for_cluster_snapshot_status_failed(input, expected):
             {
                 "new_db_cluster_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="restore_db_cluster_from_snapshot",
                     waiter="cluster_available",
@@ -191,7 +191,7 @@ def test__wait_for_cluster_snapshot_status_failed(input, expected):
             {
                 "new_db_cluster_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="modify_db_cluster",
                     waiter="cluster_available",
@@ -206,7 +206,7 @@ def test__wait_for_cluster_snapshot_status_failed(input, expected):
             {
                 "new_db_cluster_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="list_tags_for_resource",
                     waiter="cluster_available",
@@ -219,7 +219,7 @@ def test__wait_for_cluster_snapshot_status_failed(input, expected):
         (
             "fake_method",
             {"wait": False},
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="fake_method", waiter="", operation_description="fake method", resource="", retry_codes=[]
                 )
@@ -228,7 +228,7 @@ def test__wait_for_cluster_snapshot_status_failed(input, expected):
         (
             "fake_method",
             {"wait": True},
-            *error(
+            *helper_error(
                 NotImplementedError,
                 match=(
                     "method fake_method hasn't been added to the list of accepted methods to use a waiter in"
@@ -253,7 +253,7 @@ def test__get_rds_method_attribute_cluster(method_name, params, expected, error)
             {
                 "new_db_instance_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="delete_db_instance",
                     waiter="db_instance_deleted",
@@ -268,7 +268,7 @@ def test__get_rds_method_attribute_cluster(method_name, params, expected, error)
             {
                 "new_db_instance_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="create_db_instance",
                     waiter="db_instance_available",
@@ -283,7 +283,7 @@ def test__get_rds_method_attribute_cluster(method_name, params, expected, error)
             {
                 "new_db_instance_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="stop_db_instance",
                     waiter="db_instance_stopped",
@@ -298,7 +298,7 @@ def test__get_rds_method_attribute_cluster(method_name, params, expected, error)
             {
                 "new_db_instance_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="promote_read_replica",
                     waiter="read_replica_promoted",
@@ -313,7 +313,7 @@ def test__get_rds_method_attribute_cluster(method_name, params, expected, error)
             {
                 "new_db_instance_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="restore_db_instance_from_db_snapshot",
                     waiter="db_instance_available",
@@ -328,7 +328,7 @@ def test__get_rds_method_attribute_cluster(method_name, params, expected, error)
             {
                 "new_db_instance_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="modify_db_instance",
                     waiter="db_instance_available",
@@ -343,7 +343,7 @@ def test__get_rds_method_attribute_cluster(method_name, params, expected, error)
             {
                 "new_db_instance_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="add_role_to_db_instance",
                     waiter="role_associated",
@@ -358,7 +358,7 @@ def test__get_rds_method_attribute_cluster(method_name, params, expected, error)
             {
                 "new_db_instance_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="remove_role_from_db_instance",
                     waiter="role_disassociated",
@@ -373,7 +373,7 @@ def test__get_rds_method_attribute_cluster(method_name, params, expected, error)
             {
                 "new_db_instance_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="list_tags_for_resource",
                     waiter="db_instance_available",
@@ -386,7 +386,7 @@ def test__get_rds_method_attribute_cluster(method_name, params, expected, error)
         (
             "fake_method",
             {"wait": False},
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="fake_method", waiter="", operation_description="fake method", resource="", retry_codes=[]
                 )
@@ -395,7 +395,7 @@ def test__get_rds_method_attribute_cluster(method_name, params, expected, error)
         (
             "fake_method",
             {"wait": True},
-            *error(
+            *helper_error(
                 NotImplementedError,
                 match=(
                     "method fake_method hasn't been added to the list of accepted methods to use a waiter in"
@@ -420,7 +420,7 @@ def test__get_rds_method_attribute_instance(method_name, params, expected, error
             {
                 "db_snapshot_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="delete_db_snapshot",
                     waiter="db_snapshot_deleted",
@@ -435,7 +435,7 @@ def test__get_rds_method_attribute_instance(method_name, params, expected, error
             {
                 "db_snapshot_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="create_db_snapshot",
                     waiter="db_snapshot_available",
@@ -448,7 +448,7 @@ def test__get_rds_method_attribute_instance(method_name, params, expected, error
         (
             "copy_db_snapshot",
             {"source_db_snapshot_identifier": "test", "db_snapshot_identifier": "test-copy"},
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="copy_db_snapshot",
                     waiter="db_snapshot_available",
@@ -463,7 +463,7 @@ def test__get_rds_method_attribute_instance(method_name, params, expected, error
             {
                 "db_snapshot_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="list_tags_for_resource",
                     waiter="db_snapshot_available",
@@ -478,7 +478,7 @@ def test__get_rds_method_attribute_instance(method_name, params, expected, error
             {
                 "db_cluster_snapshot_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="delete_db_cluster_snapshot",
                     waiter="db_cluster_snapshot_deleted",
@@ -493,7 +493,7 @@ def test__get_rds_method_attribute_instance(method_name, params, expected, error
             {
                 "db_cluster_snapshot_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="create_db_cluster_snapshot",
                     waiter="db_cluster_snapshot_available",
@@ -506,7 +506,7 @@ def test__get_rds_method_attribute_instance(method_name, params, expected, error
         (
             "copy_db_cluster_snapshot",
             {"source_db_cluster_snapshot_identifier": "test", "db_cluster_snapshot_identifier": "test-copy"},
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="copy_db_cluster_snapshot",
                     waiter="db_cluster_snapshot_available",
@@ -521,7 +521,7 @@ def test__get_rds_method_attribute_instance(method_name, params, expected, error
             {
                 "db_cluster_snapshot_identifier": "test",
             },
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="list_tags_for_resource",
                     waiter="db_cluster_snapshot_available",
@@ -534,7 +534,7 @@ def test__get_rds_method_attribute_instance(method_name, params, expected, error
         (
             "fake_method",
             {"wait": False},
-            *expected(
+            *helper_expected(
                 rds.Boto3ClientMethod(
                     name="fake_method", waiter="", operation_description="fake method", resource="", retry_codes=[]
                 )
@@ -543,7 +543,7 @@ def test__get_rds_method_attribute_instance(method_name, params, expected, error
         (
             "fake_method",
             {"wait": True},
-            *error(
+            *helper_error(
                 NotImplementedError,
                 match=(
                     "method fake_method hasn't been added to the list of accepted methods to use a waiter in"
@@ -669,7 +669,7 @@ def test__handle_errors(method_name, exception, expected):
                 code="InvalidParameterCombination",
                 message="ModifyDbCluster API",
             ),
-            *expected(
+            *helper_expected(
                 "It appears you are trying to modify attributes that are managed at the cluster level. Please see"
                 " rds_cluster"
             ),
@@ -677,7 +677,7 @@ def test__handle_errors(method_name, exception, expected):
         (
             "modify_db_instance",
             build_exception("modify_db_instance", code="InvalidParameterCombination"),
-            *error(
+            *helper_error(
                 NotImplementedError,
                 match=(
                     "method modify_db_instance hasn't been added to the list of accepted methods to use a waiter in"
@@ -688,7 +688,7 @@ def test__handle_errors(method_name, exception, expected):
         (
             "promote_read_replica",
             build_exception("promote_read_replica", code="InvalidDBInstanceState"),
-            *error(
+            *helper_error(
                 NotImplementedError,
                 match=(
                     "method promote_read_replica hasn't been added to the list of accepted methods to use a waiter in"
@@ -699,7 +699,7 @@ def test__handle_errors(method_name, exception, expected):
         (
             "promote_read_replica_db_cluster",
             build_exception("promote_read_replica_db_cluster", code="InvalidDBClusterStateFault"),
-            *error(
+            *helper_error(
                 NotImplementedError,
                 match=(
                     "method promote_read_replica_db_cluster hasn't been added to the list of accepted methods to use a"
@@ -710,7 +710,9 @@ def test__handle_errors(method_name, exception, expected):
         (
             "create_db_cluster",
             build_exception("create_db_cluster", code="InvalidParameterValue"),
-            *expected("DB engine fake_engine should be one of aurora, aurora-mysql, aurora-postgresql"),
+            *helper_expected(
+                "DB engine fake_engine should be one of ['aurora', 'aurora-mysql', 'aurora-postgresql', 'mysql', 'postgres']"
+            ),
         ),
     ],
 )
@@ -719,8 +721,8 @@ def test__handle_errors_failed(method_name, exception, expected, error):
 
     with error:
         rds.handle_errors(module, exception, method_name, {"Engine": "fake_engine"})
-        module.fail_json_aws.assert_called_once
-        module.fail_json_aws.call_args[1]["msg"] == expected
+        module.fail_json_aws.assert_called_once()
+        assert module.fail_json_aws.call_args[1]["msg"] == expected
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/plugin_utils/botocore/test_boto3_conn_plugin.py
+++ b/tests/unit/plugin_utils/botocore/test_boto3_conn_plugin.py
@@ -21,16 +21,16 @@ class FailException(Exception):
     pass
 
 
-@pytest.fixture
-def aws_plugin(monkeypatch):
+@pytest.fixture(name="aws_plugin")
+def fixture_aws_plugin(monkeypatch):
     aws_plugin = MagicMock()
     aws_plugin.fail_aws.side_effect = FailException()
     monkeypatch.setattr(aws_plugin, "ansible_name", sentinel.PLUGIN_NAME)
     return aws_plugin
 
 
-@pytest.fixture
-def botocore_utils(monkeypatch):
+@pytest.fixture(name="botocore_utils")
+def fixture_botocore_utils(monkeypatch):
     return utils_botocore
 
 

--- a/tests/unit/plugin_utils/botocore/test_get_aws_region.py
+++ b/tests/unit/plugin_utils/botocore/test_get_aws_region.py
@@ -17,8 +17,8 @@ class FailException(Exception):
     pass
 
 
-@pytest.fixture
-def aws_plugin(monkeypatch):
+@pytest.fixture(name="aws_plugin")
+def fixture_aws_plugin(monkeypatch):
     aws_plugin = MagicMock()
     aws_plugin.fail_aws.side_effect = FailException()
     aws_plugin.get_options.return_value = sentinel.PLUGIN_OPTIONS
@@ -26,8 +26,8 @@ def aws_plugin(monkeypatch):
     return aws_plugin
 
 
-@pytest.fixture
-def botocore_utils(monkeypatch):
+@pytest.fixture(name="botocore_utils")
+def fixture_botocore_utils(monkeypatch):
     return utils_botocore
 
 

--- a/tests/unit/plugin_utils/botocore/test_get_connection_info.py
+++ b/tests/unit/plugin_utils/botocore/test_get_connection_info.py
@@ -17,16 +17,16 @@ class FailException(Exception):
     pass
 
 
-@pytest.fixture
-def aws_plugin(monkeypatch):
+@pytest.fixture(name="aws_plugin")
+def fixture_aws_plugin(monkeypatch):
     aws_plugin = MagicMock()
     aws_plugin.fail_aws.side_effect = FailException()
     aws_plugin.get_options.return_value = sentinel.PLUGIN_OPTIONS
     return aws_plugin
 
 
-@pytest.fixture
-def botocore_utils(monkeypatch):
+@pytest.fixture(name="botocore_utils")
+def fixture_botocore_utils(monkeypatch):
     return utils_botocore
 
 

--- a/tests/unit/plugin_utils/inventory/test_inventory_base.py
+++ b/tests/unit/plugin_utils/inventory/test_inventory_base.py
@@ -100,8 +100,8 @@ class AwsUnitTestTemplar:
         return variable
 
 
-@pytest.fixture
-def aws_inventory_base():
+@pytest.fixture(name="aws_inventory_base")
+def fixture_aws_inventory_base():
     inventory = utils_inventory.AWSInventoryBase()
     inventory._options = {}
     inventory.templar = None

--- a/tests/unit/plugins/inventory/test_aws_ec2.py
+++ b/tests/unit/plugins/inventory/test_aws_ec2.py
@@ -38,8 +38,8 @@ from ansible_collections.amazon.aws.plugins.inventory.aws_ec2 import _get_tag_ho
 from ansible_collections.amazon.aws.plugins.inventory.aws_ec2 import _prepare_host_vars
 
 
-@pytest.fixture()
-def inventory():
+@pytest.fixture(name="inventory")
+def fixture_inventory():
     inventory = InventoryModule()
     inventory._options = {
         "aws_profile": "first_precedence",

--- a/tests/unit/plugins/inventory/test_aws_rds.py
+++ b/tests/unit/plugins/inventory/test_aws_rds.py
@@ -57,8 +57,8 @@ def make_clienterror_exception(code="AccessDenied"):
     )
 
 
-@pytest.fixture()
-def inventory():
+@pytest.fixture(name="inventory")
+def fixture_inventory():
     inventory = InventoryModule()
     inventory.inventory = MagicMock()
     inventory._populate_host_vars = MagicMock()
@@ -78,8 +78,8 @@ def inventory():
     return inventory
 
 
-@pytest.fixture()
-def connection():
+@pytest.fixture(name="connection")
+def fixture_connection():
     conn = MagicMock()
     return conn
 
@@ -543,13 +543,13 @@ def test_inventory_add_hosts(m_get_rds_hostname, inventory, hostvars_prefix, hos
         tmp = []
         for host in camel_hosts:
             new_host = copy.deepcopy(host)
-            for key in host:
+            for key, value in host.items():
                 new_key = key
                 if hostvars_prefix:
                     new_key = _options["hostvars_prefix"] + new_key
                 if hostvars_suffix:
                     new_key += _options["hostvars_suffix"]
-                new_host[new_key] = host[key]
+                new_host[new_key] = value
             tmp.append(new_host)
         camel_hosts = tmp
 

--- a/tests/unit/plugins/lookup/test_secretsmanager_secret.py
+++ b/tests/unit/plugins/lookup/test_secretsmanager_secret.py
@@ -18,8 +18,8 @@ from ansible.errors import AnsibleLookupError
 from ansible_collections.amazon.aws.plugins.lookup.secretsmanager_secret import LookupModule
 
 
-@pytest.fixture
-def lookup_plugin():
+@pytest.fixture(name="lookup_plugin")
+def fixture_lookup_plugin():
     lookup = LookupModule()
     lookup.params = {}
 

--- a/tests/unit/plugins/modules/ec2_eip/test_check_is_instance.py
+++ b/tests/unit/plugins/modules/ec2_eip/test_check_is_instance.py
@@ -56,8 +56,8 @@ EXAMPLE_DATA = [
 ]
 
 
-@pytest.fixture
-def ansible_module():
+@pytest.fixture(name="ansible_module")
+def fixture_ansible_module():
     module = MagicMock()
     module.params = {}
     module.fail_json.side_effect = SystemExit(1)

--- a/tests/unit/plugins/modules/ec2_eip/test_generate_tag_dict.py
+++ b/tests/unit/plugins/modules/ec2_eip/test_generate_tag_dict.py
@@ -9,8 +9,8 @@ import pytest
 from ansible_collections.amazon.aws.plugins.modules import ec2_eip
 
 
-@pytest.fixture
-def ansible_module():
+@pytest.fixture(name="ansible_module")
+def fixture_ansible_module():
     module = MagicMock()
     module.params = {}
     module.fail_json.side_effect = SystemExit(1)

--- a/tests/unit/plugins/modules/ec2_eip/test_reverse_dns_record_updates.py
+++ b/tests/unit/plugins/modules/ec2_eip/test_reverse_dns_record_updates.py
@@ -15,8 +15,8 @@ class FailJsonException(Exception):
         pass
 
 
-@pytest.fixture
-def ansible_module():
+@pytest.fixture(name="ansible_module")
+def fixture_ansible_module():
     module = MagicMock()
     module.fail_json.side_effect = FailJsonException()
     module.fail_json_aws.side_effect = FailJsonException()

--- a/tests/unit/plugins/modules/ec2_instance/test_build_run_instance_spec.py
+++ b/tests/unit/plugins/modules/ec2_instance/test_build_run_instance_spec.py
@@ -11,8 +11,8 @@ import pytest
 import ansible_collections.amazon.aws.plugins.modules.ec2_instance as ec2_instance_module
 
 
-@pytest.fixture
-def ansible_aws_module():
+@pytest.fixture(name="ansible_aws_module")
+def fixture_ansible_aws_module():
     module = MagicMock()
     module.params = {
         "iam_instance_profile": None,
@@ -24,8 +24,8 @@ def ansible_aws_module():
     return module
 
 
-@pytest.fixture
-def ec2_instance(monkeypatch):
+@pytest.fixture(name="ec2_instance")
+def fixture_ec2_instance(monkeypatch):
     # monkey patches various ec2_instance module functions, we'll separately test the operation of
     # these functions, we just care that it's passing the results into the right place in the
     # instance spec.
@@ -65,11 +65,11 @@ def _assert_defaults(instance_spec, to_skip=None):
 
     if "MinCount" not in to_skip:
         assert "MinCount" in instance_spec
-        instance_spec["MinCount"] == 1
+        assert instance_spec["MinCount"] == 1
 
     if "MaxCount" not in to_skip:
         assert "MaxCount" in instance_spec
-        instance_spec["MaxCount"] == 1
+        assert instance_spec["MaxCount"] == 1
 
     if "TOP_LEVEL_OPTIONS" not in to_skip:
         assert "TOP_LEVEL_OPTIONS" in instance_spec
@@ -77,7 +77,7 @@ def _assert_defaults(instance_spec, to_skip=None):
 
     if "InstanceType" not in to_skip:
         assert "InstanceType" in instance_spec
-        instance_spec["InstanceType"] == sentinel.INSTANCE_TYPE
+        assert instance_spec["InstanceType"] == sentinel.INSTANCE_TYPE
 
 
 def test_build_run_instance_spec_defaults(ansible_aws_module, ec2_instance):

--- a/tests/unit/plugins/modules/ec2_instance/test_modify_instance_type.py
+++ b/tests/unit/plugins/modules/ec2_instance/test_modify_instance_type.py
@@ -14,8 +14,8 @@ from ansible_collections.amazon.aws.plugins.modules import ec2_instance
 module_path = "ansible_collections.amazon.aws.plugins.modules.ec2_instance"
 
 
-@pytest.fixture
-def ansible_aws_module():
+@pytest.fixture(name="ansible_aws_module")
+def fixture_ansible_aws_module():
     module = MagicMock()
     module.params = {}
     module.check_mode = False

--- a/tests/unit/plugins/modules/ec2_security_group/test_get_target_from_rule.py
+++ b/tests/unit/plugins/modules/ec2_security_group/test_get_target_from_rule.py
@@ -11,8 +11,8 @@ import pytest
 import ansible_collections.amazon.aws.plugins.modules.ec2_security_group as ec2_security_group_module
 
 
-@pytest.fixture
-def ec2_security_group(monkeypatch):
+@pytest.fixture(name="ec2_security_group")
+def fixture_ec2_security_group(monkeypatch):
     # monkey patches various ec2_security_group module functions, we'll separately test the operation of
     # these functions, we just care that it's passing the results into the right place in the
     # instance spec.

--- a/tests/unit/plugins/modules/ec2_security_group/test_validate_ip.py
+++ b/tests/unit/plugins/modules/ec2_security_group/test_validate_ip.py
@@ -12,15 +12,15 @@ import pytest
 import ansible_collections.amazon.aws.plugins.modules.ec2_security_group as ec2_security_group_module
 
 
-@pytest.fixture
-def aws_module():
+@pytest.fixture(name="aws_module")
+def fixture_aws_module():
     aws_module = MagicMock()
     aws_module.warn = warnings.warn
     return aws_module
 
 
-@pytest.fixture
-def ec2_security_group(monkeypatch):
+@pytest.fixture(name="ec2_security_group")
+def fixture_ec2_security_group(monkeypatch):
     # monkey patches various ec2_security_group module functions, we'll separately test the operation of
     # these functions, we just care that it's passing the results into the right place in the
     # instance spec.

--- a/tests/unit/plugins/modules/s3_bucket/test_handle_bucket_accelerate.py
+++ b/tests/unit/plugins/modules/s3_bucket/test_handle_bucket_accelerate.py
@@ -17,8 +17,8 @@ def a_botocore_exception(message):
     return botocore.exceptions.ClientError({"Error": {"Code": message}}, sentinel.BOTOCORE_ACTION)
 
 
-@pytest.fixture
-def ansible_module():
+@pytest.fixture(name="ansible_module")
+def fixure_ansible_module():
     mock = MagicMock()
     mock.params = {"accelerate_enabled": sentinel.ACCELERATE_ENABLED}
     mock.fail_json_aws.side_effect = SystemExit(1)

--- a/tests/unit/plugins/modules/test_backup_restore_job_info.py
+++ b/tests/unit/plugins/modules/test_backup_restore_job_info.py
@@ -67,7 +67,7 @@ def test__describe_restore_job():
 
     assert result == [camel_dict_to_snake_dict(restore_job_info)]
     connection.describe_restore_job.assert_called_with(RestoreJobId=restore_job_id)
-    connection.describe_restore_job.call_count == 1
+    assert connection.describe_restore_job.call_count == 1
 
 
 def test__list_restore_jobs():

--- a/tests/unit/plugins/modules/test_cloudformation.py
+++ b/tests/unit/plugins/modules/test_cloudformation.py
@@ -10,16 +10,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.retries import RetryingBotoClientWrapper
 from ansible_collections.amazon.aws.plugins.modules import cloudformation as cfn_module
 
-# isort: off
-# Magic...
-# pylint: disable-next=unused-import
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import maybe_sleep
-
-# pylint: disable-next=unused-import
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify
-
-# isort: on
-
 basic_yaml_tpl = """
 ---
 AWSTemplateFormatVersion: '2010-09-09'

--- a/tests/unit/plugins/modules/test_ec2_ami_info.py
+++ b/tests/unit/plugins/modules/test_ec2_ami_info.py
@@ -16,8 +16,8 @@ from ansible_collections.amazon.aws.plugins.modules import ec2_ami_info
 module_name = "ansible_collections.amazon.aws.plugins.modules.ec2_ami_info"
 
 
-@pytest.fixture
-def ec2_client():
+@pytest.fixture(name="ec2_client")
+def fixture_ec2_client():
     return MagicMock()
 
 
@@ -80,14 +80,14 @@ def test_get_images(m_describe_images):
     ec2_client = MagicMock()
     get_images_result = ec2_ami_info.get_images(ec2_client, request_args)
 
-    m_describe_images.call_count == 2
+    assert m_describe_images.call_count >= 1
     m_describe_images.assert_called_with(ec2_client, **request_args)
     assert get_images_result == m_describe_images.return_value
 
 
 @patch(module_name + ".describe_image_attribute")
 @patch(module_name + ".get_images")
-def test_list_ec2_images(m_get_images, m_describe_image_attribute):
+def test_list_ec2_images(m_get_images, m_describe_image_attribute, ec2_client):
     module = MagicMock()
 
     m_get_images.return_value = [
@@ -187,7 +187,7 @@ def a_ami_info_exception():
 
 
 @patch(module_name + ".describe_images")
-def test_api_failure_get_images(m_describe_images):
+def test_api_failure_get_images(m_describe_images, ec2_client):
     request_args = {}
     m_describe_images.side_effect = a_ami_info_exception()
 

--- a/tests/unit/plugins/modules/test_ec2_eni_info.py
+++ b/tests/unit/plugins/modules/test_ec2_eni_info.py
@@ -47,7 +47,7 @@ def test_get_network_interfaces(m_describe_network_interfaces):
 
     network_interfaces_result = ec2_eni_info.get_network_interfaces(connection, module, request_args)
 
-    m_describe_network_interfaces.call_count == 1
+    assert m_describe_network_interfaces.call_count == 1
     m_describe_network_interfaces.assert_called_with(connection, **request_args)
     assert len(network_interfaces_result["NetworkInterfaces"]) == 1
 
@@ -90,7 +90,7 @@ def test_list_eni(m_get_network_interfaces):
 
     camel_network_interfaces = ec2_eni_info.list_eni(connection, module, request_args)
 
-    m_get_network_interfaces.call_count == 1
+    assert m_get_network_interfaces.call_count == 1
     m_get_network_interfaces.assert_has_calls(
         [
             call(connection, module, request_args),

--- a/tests/unit/plugins/modules/test_ec2_import_image.py
+++ b/tests/unit/plugins/modules/test_ec2_import_image.py
@@ -13,7 +13,7 @@ module_name = "ansible_collections.amazon.aws.plugins.modules.ec2_import_image"
 module_name_info = "ansible_collections.amazon.aws.plugins.modules.ec2_import_image_info"
 utils = "ansible_collections.amazon.aws.plugins.module_utils.ec2"
 
-expected_result = {
+p_expected_result = {
     "import_task_id": "import-ami-0c207d759080a3dff",
     "progress": "19",
     "snapshot_details": [
@@ -30,7 +30,7 @@ expected_result = {
     "task_name": "clone-vm-import-image",
 }
 
-describe_import_image_tasks = [
+p_describe_import_image_tasks = [
     {
         "import_task_id": "import-ami-0c207d759080a3dff",
         "progress": "19",
@@ -49,8 +49,8 @@ describe_import_image_tasks = [
 ]
 
 
-@pytest.fixture
-def module():
+@pytest.fixture(name="module")
+def fixture_module():
     # Create a MagicMock for the module object
     module_mock = MagicMock()
     module_mock.params = {
@@ -71,15 +71,15 @@ def module():
     "import_image_info, expected_result",
     [
         (
-            [[], describe_import_image_tasks],
-            {"changed": True, "import_image": expected_result},
+            [[], p_describe_import_image_tasks],
+            {"changed": True, "import_image": p_expected_result},
         ),
         (
-            [describe_import_image_tasks, describe_import_image_tasks],
+            [p_describe_import_image_tasks, p_describe_import_image_tasks],
             {
                 "changed": False,
                 "msg": "An import task with the specified name already exists",
-                "import_image": expected_result,
+                "import_image": p_expected_result,
             },
         ),
     ],
@@ -113,11 +113,11 @@ def test_present_no_check_mode(
             {"changed": True, "msg": "Would have created the import task if not in check mode"},
         ),
         (
-            describe_import_image_tasks,
+            p_describe_import_image_tasks,
             {
                 "changed": False,
                 "msg": "An import task with the specified name already exists",
-                "import_image": expected_result,
+                "import_image": p_expected_result,
             },
         ),
     ],
@@ -151,8 +151,8 @@ def test_present_check_mode(
             },
         ),
         (
-            describe_import_image_tasks,
-            {"changed": True, "import_image": expected_result},
+            p_describe_import_image_tasks,
+            {"changed": True, "import_image": p_expected_result},
         ),
     ],
 )
@@ -190,7 +190,7 @@ def test_absent_no_check_mode(
             },
         ),
         (
-            describe_import_image_tasks,
+            p_describe_import_image_tasks,
             {"changed": True, "msg": "Would have cancelled the import task if not in check mode"},
         ),
     ],

--- a/tests/unit/plugins/modules/test_ec2_metadata_facts.py
+++ b/tests/unit/plugins/modules/test_ec2_metadata_facts.py
@@ -17,8 +17,8 @@ class FailJson(Exception):
     pass
 
 
-@pytest.fixture()
-def ec2_instance():
+@pytest.fixture(name="ec2_instance")
+def fixture_ec2_instance():
     module = MagicMock()
     return ec2_metadata_facts.Ec2Metadata(module)
 

--- a/tests/unit/plugins/modules/test_ec2_vpc_dhcp_option.py
+++ b/tests/unit/plugins/modules/test_ec2_vpc_dhcp_option.py
@@ -8,33 +8,12 @@ from unittest.mock import patch
 from ansible_collections.amazon.aws.plugins.modules import ec2_vpc_dhcp_option as dhcp_module
 from ansible_collections.amazon.aws.tests.unit.plugins.modules.utils import ModuleTestCase
 
-# Magic...  Incorrectly identified by pylint as unused
-# pylint: disable-next=unused-import
-from ansible_collections.amazon.aws.tests.unit.utils.amazon_placebo_fixtures import placeboify
-
-test_module_params = {
-    "domain_name": "us-west-2.compute.internal",
-    "dns_servers": ["AmazonProvidedDNS"],
-    "ntp_servers": ["10.10.2.3", "10.10.4.5"],
-    "netbios_name_servers": ["10.20.2.3", "10.20.4.5"],
-    "netbios_node_type": 2,
-}
-
 test_create_config = [
     {"Key": "domain-name", "Values": [{"Value": "us-west-2.compute.internal"}]},
     {"Key": "domain-name-servers", "Values": [{"Value": "AmazonProvidedDNS"}]},
     {"Key": "ntp-servers", "Values": [{"Value": "10.10.2.3"}, {"Value": "10.10.4.5"}]},
     {"Key": "netbios-name-servers", "Values": [{"Value": "10.20.2.3"}, {"Value": "10.20.4.5"}]},
     {"Key": "netbios-node-type", "Values": 2},
-]
-
-
-test_create_option_set = [
-    {"Key": "domain-name", "Values": ["us-west-2.compute.internal"]},
-    {"Key": "domain-name-servers", "Values": ["AmazonProvidedDNS"]},
-    {"Key": "ntp-servers", "Values": ["10.10.2.3", "10.10.4.5"]},
-    {"Key": "netbios-name-servers", "Values": ["10.20.2.3", "10.20.4.5"]},
-    {"Key": "netbios-node-type", "Values": ["2"]},
 ]
 
 test_normalize_config = {
@@ -44,26 +23,6 @@ test_normalize_config = {
     "netbios-name-servers": ["10.20.2.3", "10.20.4.5"],
     "netbios-node-type": "2",
 }
-
-
-class FakeModule:
-    def __init__(self, **kwargs):
-        self.params = kwargs
-
-    def fail_json(self, *args, **kwargs):
-        self.exit_args = args
-        self.exit_kwargs = kwargs
-        raise Exception("FAIL")
-
-    def fail_json_aws(self, *args, **kwargs):
-        self.exit_args = args
-        self.exit_kwargs = kwargs
-        raise Exception("FAIL")
-
-    def exit_json(self, *args, **kwargs):
-        self.exit_args = args
-        self.exit_kwargs = kwargs
-        raise Exception("EXIT")
 
 
 @patch.object(dhcp_module.AnsibleAWSModule, "client")

--- a/tests/unit/plugins/modules/test_ec2_vpc_net.py
+++ b/tests/unit/plugins/modules/test_ec2_vpc_net.py
@@ -15,8 +15,8 @@ from ansible_collections.amazon.aws.plugins.modules import ec2_vpc_net
 module_name = "ansible_collections.amazon.aws.plugins.modules.ec2_vpc_net"
 
 
-@pytest.fixture
-def ansible_module():
+@pytest.fixture(name="ansible_module")
+def fixture_ansible_module():
     module = MagicMock()
     module.check_mode = False
     module.params = {}

--- a/tests/unit/plugins/modules/test_lambda_event.py
+++ b/tests/unit/plugins/modules/test_lambda_event.py
@@ -20,8 +20,8 @@ mock_get_qualifier = "ansible_collections.amazon.aws.plugins.modules.lambda_even
 mock_camel_dict_to_snake_dict = "ansible_collections.amazon.aws.plugins.modules.lambda_event.camel_dict_to_snake_dict"
 
 
-@pytest.fixture
-def ansible_aws_module():
+@pytest.fixture(name="ansible_aws_module")
+def fixture_ansible_aws_module():
     module = MagicMock()
     module.check_mode = False
     module.params = {
@@ -169,7 +169,7 @@ EventSourceMappings = [
 )
 @patch(mock_camel_dict_to_snake_dict)
 def test_lambda_event_stream_with_state_absent(
-    mock_camel_dict_to_snake_dict, ansible_aws_module, check_mode, existing_event_source
+    m_camel_dict_to_snake_dict, ansible_aws_module, check_mode, existing_event_source
 ):
     function_name = "sqs_consumer"
     ansible_aws_module.params.update({"lambda_function_arn": function_name, "state": "absent"})
@@ -184,7 +184,7 @@ def test_lambda_event_stream_with_state_absent(
     client.delete_event_source_mapping = MagicMock()
     event_source_deleted = {"msg": "event source successfully deleted."}
     client.delete_event_source_mapping.return_value = event_source_deleted
-    mock_camel_dict_to_snake_dict.side_effect = lambda x: x
+    m_camel_dict_to_snake_dict.side_effect = lambda x: x
 
     events = []
     changed = False
@@ -307,7 +307,7 @@ def test_lambda_event_stream_create_event_missing_starting_position(ansible_aws_
 )
 @patch(mock_camel_dict_to_snake_dict)
 def test_lambda_event_stream_create_event(
-    mock_camel_dict_to_snake_dict, ansible_aws_module, check_mode, module_params, api_params
+    m_camel_dict_to_snake_dict, ansible_aws_module, check_mode, module_params, api_params
 ):
     ansible_aws_module.params = module_params
     ansible_aws_module.check_mode = check_mode
@@ -319,7 +319,7 @@ def test_lambda_event_stream_create_event(
     client.create_event_source_mapping = MagicMock()
     event_source_created = {"msg": "event source successfully created."}
     client.create_event_source_mapping.return_value = event_source_created
-    mock_camel_dict_to_snake_dict.side_effect = lambda x: x
+    m_camel_dict_to_snake_dict.side_effect = lambda x: x
 
     result = lambda_event_stream(ansible_aws_module, client)
 
@@ -355,7 +355,7 @@ def test_lambda_event_stream_create_event(
 )
 @patch(mock_camel_dict_to_snake_dict)
 def test_lambda_event_stream_update_event(
-    mock_camel_dict_to_snake_dict, ansible_aws_module, check_mode, module_source_params, current_mapping, api_params
+    m_camel_dict_to_snake_dict, ansible_aws_module, check_mode, module_source_params, current_mapping, api_params
 ):
     function_name = "ansible-test-update-event-function"
     ansible_aws_module.params.update({"lambda_function_arn": function_name})
@@ -371,7 +371,7 @@ def test_lambda_event_stream_update_event(
     client.update_event_source_mapping = MagicMock()
     event_source_updated = {"msg": "event source successfully updated."}
     client.update_event_source_mapping.return_value = event_source_updated
-    mock_camel_dict_to_snake_dict.side_effect = lambda x: x
+    m_camel_dict_to_snake_dict.side_effect = lambda x: x
 
     result = lambda_event_stream(ansible_aws_module, client)
     if not api_params:

--- a/tests/unit/plugins/modules/test_rds_cluster.py
+++ b/tests/unit/plugins/modules/test_rds_cluster.py
@@ -11,8 +11,8 @@ import pytest
 from ansible_collections.amazon.aws.plugins.modules import rds_cluster
 
 
-@pytest.fixture
-def ansible_module():
+@pytest.fixture(name="ansible_module")
+def fixture_ansible_module():
     module = MagicMock()
     module.check_mode = False
     module.params = {}


### PR DESCRIPTION
SUMMARY
fixes various linting warnings:

redefined-builtin
redefined-outer-name
no-else-continue
simplifiable-if-statement
unused-import

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
plugins/modules/ec2_ami.py
plugins/modules/ec2_vpc_vpn.py
plugins/modules/s3_bucket.py
plugins/modules/s3_object.py
tests/unit/
ADDITIONAL INFORMATION
Also applies the "maybe_sleep" fixture to the ACM tests which have retries attached to them.

Reviewed-by: Alina Buzachis

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
