### PR TITLE
Fix assertion way to check the AZ group_name attribute

### DIFF
--- a/changelogs/fragments/20250202-assertion-group-name-aws-az-info.yml
+++ b/changelogs/fragments/20250202-assertion-group-name-aws-az-info.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+- "Fix assertion way to check the AZ group_name attribute"

--- a/changelogs/fragments/20250202-assertion-group-name-aws-az-info.yml
+++ b/changelogs/fragments/20250202-assertion-group-name-aws-az-info.yml
@@ -1,3 +1,3 @@
 ---
 trivial:
-- "Fix assertion way to check the AZ group_name attribute"
+- "Fix assertion way to check the AZ group_name attribute (https://github.com/ansible-collections/amazon.aws/pull/2496)."

--- a/tests/integration/targets/aws_az_info/tasks/main.yml
+++ b/tests/integration/targets/aws_az_info/tasks/main.yml
@@ -105,7 +105,7 @@
           - '"zone_id" in first_az'
           - '"zone_name" in first_az'
           - '"zone_type" in first_az'
-          - first_az.group_name == 'us-west-2'
+          - first_az.group_name.startswith('us-west-2')
           - first_az.network_border_group == 'us-west-2'
           - first_az.region_name == 'us-west-2'
           # AZs are mapped to the 'real' AZs on a per-account basis
@@ -138,7 +138,7 @@
           - '"zone_id" in first_az'
           - '"zone_name" in first_az'
           - '"zone_type" in first_az'
-          - first_az.group_name == 'eu-central-1'
+          - first_az.group_name.startswith('eu-central-1')
           - first_az.network_border_group == 'eu-central-1'
           - first_az.region_name == 'eu-central-1'
           # AZs are mapped to the 'real' AZs on a per-account basis
@@ -172,7 +172,7 @@
           - '"zone_id" in first_az'
           - '"zone_name" in first_az'
           - '"zone_type" in first_az'
-          - first_az.group_name == 'eu-west-2'
+          - first_az.group_name.startswith('eu-west-2')
           - first_az.network_border_group == 'eu-west-2'
           - first_az.region_name == 'eu-west-2'
           # AZs are mapped to the 'real' AZs on a per-account basis


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix downstream integration test assertion failures when checking the AZ group_name attribute,
update assetion to use `startswith` instead of `equal`.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
aws_az_info integration test target

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
