### PR TITLE
Minor typing fixups

### DIFF
--- a/changelogs/fragments/20250202-typealias.yml
+++ b/changelogs/fragments/20250202-typealias.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - module_utils.botocore - fixed type aliasing().
+  - plugin_utils.botocore - fixed type aliasing().
+minor_changes:
+  - module_utils._s3 - explicitly cast super to the parent type().
+  - module_utils.botocore - avoid assigning unused parts of exc_info return().
+  - module_utils.exceptions - avoid assigning unused parts of exc_info return().

--- a/changelogs/fragments/20250202-typealias.yml
+++ b/changelogs/fragments/20250202-typealias.yml
@@ -1,7 +1,7 @@
 bugfixes:
-  - module_utils.botocore - fixed type aliasing().
-  - plugin_utils.botocore - fixed type aliasing().
+  - module_utils.botocore - fixed type aliasing (https://github.com/ansible-collections/amazon.aws/pull/2497).
+  - plugin_utils.botocore - fixed type aliasing (https://github.com/ansible-collections/amazon.aws/pull/2497).
 minor_changes:
-  - module_utils._s3 - explicitly cast super to the parent type().
-  - module_utils.botocore - avoid assigning unused parts of exc_info return().
-  - module_utils.exceptions - avoid assigning unused parts of exc_info return().
+  - module_utils._s3 - explicitly cast super to the parent type (https://github.com/ansible-collections/amazon.aws/pull/2497).
+  - module_utils.botocore - avoid assigning unused parts of exc_info return (https://github.com/ansible-collections/amazon.aws/pull/2497).
+  - module_utils.exceptions - avoid assigning unused parts of exc_info return (https://github.com/ansible-collections/amazon.aws/pull/2497).

--- a/plugins/module_utils/_s3/common.py
+++ b/plugins/module_utils/_s3/common.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import functools
+from typing import cast
 
 try:
     # Beware, S3 is a "special" case, it sometimes catches botocore exceptions and
@@ -67,7 +68,7 @@ class S3ErrorHandler(AWSErrorHandler):
     @classmethod
     def common_error_handler(cls, description):
         def wrapper(func):
-            parent_class = super(S3ErrorHandler, cls)
+            parent_class = cast(AWSErrorHandler, super(S3ErrorHandler, cls))
 
             @parent_class.common_error_handler(description)
             @functools.wraps(func)

--- a/plugins/module_utils/botocore.py
+++ b/plugins/module_utils/botocore.py
@@ -463,7 +463,7 @@ def enable_placebo(session: boto3.session.Session) -> None:
         import placebo
 
         replay_entries = sorted([int(i) for i in os.listdir(os.environ["_ANSIBLE_PLACEBO_REPLAY"])])
-        data_path = f"{os.environ['_ANSIBLE_PLACEBO_REPLAY']}/{int(replay_entries[0])}"
+        data_path = f"{os.environ['_ANSIBLE_PLACEBO_REPLAY']}/{replay_entries[0]}"
         try:
             shutil.rmtree("_tmp")
         except FileNotFoundError:

--- a/plugins/module_utils/botocore.py
+++ b/plugins/module_utils/botocore.py
@@ -54,7 +54,7 @@ BOTO3_IMP_ERR = None
 try:
     import boto3
     import botocore
-    from botocore import ClientError
+    from botocore.exceptions import ClientError
 
     HAS_BOTO3 = True
 except ImportError:

--- a/plugins/module_utils/botocore.py
+++ b/plugins/module_utils/botocore.py
@@ -49,7 +49,6 @@ from typing import Set
 from typing import Tuple
 from typing import Type
 from typing import Union
-from typing_extensions import TypeAlias
 
 BOTO3_IMP_ERR = None
 try:
@@ -63,6 +62,8 @@ except ImportError:
     HAS_BOTO3 = False
 
 if typing.TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
     ClientType: TypeAlias = botocore.client.BaseClient
     ResourceType: TypeAlias = boto3.resources.base.ServiceResource
     BotoConn = Union[ClientType, ResourceType, Tuple[ClientType, ResourceType]]
@@ -458,6 +459,7 @@ def enable_placebo(session: boto3.session.Session) -> None:
         pill.record()
     if "_ANSIBLE_PLACEBO_REPLAY" in os.environ:
         import shutil
+
         import placebo
 
         replay_entries = sorted([int(i) for i in os.listdir(os.environ["_ANSIBLE_PLACEBO_REPLAY"])])

--- a/plugins/module_utils/exceptions.py
+++ b/plugins/module_utils/exceptions.py
@@ -48,7 +48,7 @@ def is_ansible_aws_error_code(code, e=None):
     if e is None:
         import sys
 
-        dummy, e, dummy = sys.exc_info()
+        e = sys.exc_info()[1]
     if not isinstance(code, (list, tuple, set)):
         code = [code]
     if (
@@ -79,7 +79,7 @@ def is_ansible_aws_error_message(msg, e=None):
     if e is None:
         import sys
 
-        dummy, e, dummy = sys.exc_info()
+        e = sys.exc_info()[1]
     if (
         isinstance(e, AnsibleAWSError)
         and e.exception

--- a/plugins/plugin_utils/botocore.py
+++ b/plugins/plugin_utils/botocore.py
@@ -18,12 +18,13 @@ from typing import Dict
 from typing import Optional
 from typing import Tuple
 from typing import Union
+from typing_extensions import TypeAlias
 
 if typing.TYPE_CHECKING:
     from .base import AWSPluginBase
 
-    ClientType = botocore.client.BaseClient
-    ResourceType = boto3.resources.base.ServiceResource
+    ClientType: TypeAlias = botocore.client.BaseClient
+    ResourceType: TypeAlias = boto3.resources.base.ServiceResource
     BotoConn = Union[ClientType, ResourceType, Tuple[ClientType, ResourceType]]
 
 from ansible.module_utils.basic import to_native

--- a/plugins/plugin_utils/botocore.py
+++ b/plugins/plugin_utils/botocore.py
@@ -18,9 +18,10 @@ from typing import Dict
 from typing import Optional
 from typing import Tuple
 from typing import Union
-from typing_extensions import TypeAlias
 
 if typing.TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
     from .base import AWSPluginBase
 
     ClientType: TypeAlias = botocore.client.BaseClient


### PR DESCRIPTION
##### SUMMARY

- module_utils.botocore - fixed type aliasing.
- module_utils.botocore - avoid assigning unused parts of exc_info return.
- plugin_utils.botocore - fixed type aliasing.
- module_utils._s3 - explicitly cast super to the parent type.
- module_utils.exceptions - avoid assigning unused parts of exc_info return.


##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

plugins/module_utils/_s3/common.py
plugins/module_utils/botocore.py
plugins/module_utils/exceptions.py
plugins/plugin_utils/botocore.py

##### ADDITIONAL INFORMATION
