### PR TITLE
[Backport][Stable-9]Minor typing fixups (#2497)

### DIFF
--- a/changelogs/fragments/20250202-typealias.yml
+++ b/changelogs/fragments/20250202-typealias.yml
@@ -1,0 +1,7 @@
+bugfixes:
+  - module_utils.botocore - fixed type aliasing (https://github.com/ansible-collections/amazon.aws/pull/2497).
+  - plugin_utils.botocore - fixed type aliasing (https://github.com/ansible-collections/amazon.aws/pull/2497).
+minor_changes:
+  - module_utils._s3 - explicitly cast super to the parent type (https://github.com/ansible-collections/amazon.aws/pull/2497).
+  - module_utils.botocore - avoid assigning unused parts of exc_info return (https://github.com/ansible-collections/amazon.aws/pull/2497).
+  - module_utils.exceptions - avoid assigning unused parts of exc_info return (https://github.com/ansible-collections/amazon.aws/pull/2497).

--- a/plugins/module_utils/_s3/common.py
+++ b/plugins/module_utils/_s3/common.py
@@ -1,0 +1,106 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import functools
+from typing import cast
+
+try:
+    # Beware, S3 is a "special" case, it sometimes catches botocore exceptions and
+    # re-raises them as boto3 exceptions.
+    import boto3
+    import botocore
+except ImportError:
+    pass  # Handled by the calling module
+
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message
+from ansible_collections.amazon.aws.plugins.module_utils.errors import AWSErrorHandler
+from ansible_collections.amazon.aws.plugins.module_utils.exceptions import AnsibleAWSError
+
+IGNORE_S3_DROP_IN_EXCEPTIONS = ["XNotImplemented", "NotImplemented", "AccessControlListNotSupported"]
+
+
+class AnsibleS3Error(AnsibleAWSError):
+    pass
+
+
+class AnsibleS3Sigv4RequiredError(AnsibleS3Error):
+    pass
+
+
+class AnsibleS3PermissionsError(AnsibleS3Error):
+    pass
+
+
+class AnsibleS3SupportError(AnsibleS3Error):
+    pass
+
+
+class AnsibleS3RegionSupportError(AnsibleS3SupportError):
+    pass
+
+
+class S3ErrorHandler(AWSErrorHandler):
+    _CUSTOM_EXCEPTION = AnsibleS3Error
+
+    @classmethod
+    def _is_missing(cls):
+        return is_boto3_error_code(
+            [
+                "404",
+                "NoSuchTagSet",
+                "NoSuchTagSetError",
+                "ObjectLockConfigurationNotFoundError",
+                "NoSuchBucketPolicy",
+                "ServerSideEncryptionConfigurationNotFoundError",
+                "NoSuchBucket",
+                "NoSuchPublicAccessBlockConfiguration",
+                "OwnershipControlsNotFoundError",
+                "NoSuchOwnershipControls",
+            ]
+        )
+
+    @classmethod
+    def common_error_handler(cls, description):
+        def wrapper(func):
+            parent_class = cast(AWSErrorHandler, super(S3ErrorHandler, cls))
+
+            @parent_class.common_error_handler(description)
+            @functools.wraps(func)
+            def handler(*args, **kwargs):
+                try:
+                    return func(*args, **kwargs)
+                except is_boto3_error_code(["403", "AccessDenied"]) as e:
+                    # FUTURE: there's a case to be made that this moves up into AWSErrorHandler
+                    # for now, we'll handle this just for S3, but wait and see if it pops up in too
+                    # many other places
+                    raise AnsibleS3PermissionsError(
+                        message=f"Failed to {description} (permission denied)", exception=e
+                    ) from e
+                except is_boto3_error_message(  # pylint: disable=duplicate-except
+                    "require AWS Signature Version 4"
+                ) as e:
+                    raise AnsibleS3Sigv4RequiredError(
+                        message=f"Failed to {description} (not supported by cloud)", exception=e
+                    ) from e
+                except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS) as e:  # pylint: disable=duplicate-except
+                    # Unlike most of our modules, we attempt to handle non-AWS clouds.  For read-only
+                    # actions we sometimes need the ability to ignore unsupported features.
+                    raise AnsibleS3SupportError(
+                        message=f"Failed to {description} (not supported by cloud)", exception=e
+                    ) from e
+                except botocore.exceptions.EndpointConnectionError as e:
+                    raise cls._CUSTOM_EXCEPTION(
+                        message=f"Failed to {description} - Invalid endpoint provided", exception=e
+                    ) from e
+                except boto3.exceptions.Boto3Error as e:
+                    raise cls._CUSTOM_EXCEPTION(message=f"Failed to {description}", exception=e) from e
+
+            return handler
+
+        return wrapper

--- a/plugins/module_utils/botocore.py
+++ b/plugins/module_utils/botocore.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 import traceback
 import typing
 from typing import Any
@@ -53,6 +54,7 @@ BOTO3_IMP_ERR = None
 try:
     import boto3
     import botocore
+    from botocore.exceptions import ClientError
 
     HAS_BOTO3 = True
 except ImportError:
@@ -60,8 +62,10 @@ except ImportError:
     HAS_BOTO3 = False
 
 if typing.TYPE_CHECKING:
-    ClientType = botocore.client.BaseClient
-    ResourceType = boto3.resources.base.ServiceResource
+    from typing_extensions import TypeAlias
+
+    ClientType: TypeAlias = botocore.client.BaseClient
+    ResourceType: TypeAlias = boto3.resources.base.ServiceResource
     BotoConn = Union[ClientType, ResourceType, Tuple[ClientType, ResourceType]]
     from .modules import AnsibleAWSModule
 
@@ -114,6 +118,7 @@ def boto3_conn(
         return _boto3_conn(conn_type=conn_type, resource=resource, region=region, endpoint=endpoint, **params)
     except botocore.exceptions.NoRegionError:
         module.fail_json(
+            # pylint: disable-next=protected-access
             msg=f"The {module._name} module requires a region and none was found in configuration, "
             "environment variables or module parameters",
         )
@@ -228,15 +233,7 @@ def _aws_region(params: Dict) -> Optional[str]:
 
 def get_aws_region(
     module: AnsibleAWSModule,
-    boto3: Optional[bool] = None,
-) -> Optional[str]:  # pylint: disable=redefined-outer-name
-    if boto3 is not None:
-        module.deprecate(
-            "get_aws_region(): the boto3 parameter will be removed in a release after 2025-05-01. "
-            "The parameter has been ignored since release 4.0.0.",
-            date="2025-05-01",
-            collection_name="amazon.aws",
-        )
+) -> Optional[str]:
     try:
         return _aws_region(module.params)
     except AnsibleBotocoreError as e:
@@ -302,15 +299,7 @@ def _aws_connection_info(params: Dict) -> Tuple[Optional[str], Optional[str], Di
 
 def get_aws_connection_info(
     module: AnsibleAWSModule,
-    boto3: Optional[bool] = None,
-) -> Tuple[Optional[str], Optional[str], Dict]:  # pylint: disable=redefined-outer-name
-    if boto3 is not None:
-        module.deprecate(
-            "get_aws_connection_info(): the boto3 parameter will be removed in a release after 2025-05-01. "
-            "The parameter has been ignored since release 4.0.0.",
-            date="2025-05-01",
-            collection_name="amazon.aws",
-        )
+) -> Tuple[Optional[str], Optional[str], Dict]:
     try:
         return _aws_connection_info(module.params)
     except AnsibleBotocoreError as e:
@@ -385,12 +374,8 @@ def is_boto3_error_code(
     except botocore.exceptions.ClientError as e:
         # handle the generic error case for all other codes
     """
-    from botocore.exceptions import ClientError
-
     if e is None:
-        import sys
-
-        dummy, e, dummy = sys.exc_info()
+        e = sys.exc_info()[1]
     if not isinstance(code, (list, tuple, set)):
         code = [code]
     if isinstance(e, ClientError) and e.response["Error"]["Code"] in code:
@@ -414,12 +399,9 @@ def is_boto3_error_message(
     except botocore.exceptions.ClientError as e:
         # handle the generic error case for all other codes
     """
-    from botocore.exceptions import ClientError
 
     if e is None:
-        import sys
-
-        dummy, e, dummy = sys.exc_info()
+        e = sys.exc_info()[1]
     if isinstance(e, ClientError) and msg in e.response["Error"]["Message"]:
         return ClientError
     return type("NeverEverRaisedException", (Exception,), {})
@@ -431,7 +413,7 @@ def get_boto3_client_method_parameters(
     required=False,
 ) -> List:
     op = client.meta.method_to_api_mapping.get(method_name)
-    input_shape = client._service_model.operation_model(op).input_shape
+    input_shape = client._service_model.operation_model(op).input_shape  # pylint: disable=protected-access
     if not input_shape:
         parameters = []
     elif required:
@@ -466,12 +448,12 @@ def enable_placebo(session: boto3.session.Session) -> None:
     """
     Helper to record or replay offline modules for testing purpose.
     """
+    # pylint: disable=import-outside-toplevel
     if "_ANSIBLE_PLACEBO_RECORD" in os.environ:
         import placebo
 
-        existing_entries = os.listdir(os.environ["_ANSIBLE_PLACEBO_RECORD"])
-        idx = len(existing_entries)
-        data_path = f"{os.environ['_ANSIBLE_PLACEBO_RECORD']}/{idx}"
+        recorded_entries = os.listdir(os.environ["_ANSIBLE_PLACEBO_RECORD"])
+        data_path = f"{os.environ['_ANSIBLE_PLACEBO_RECORD']}/{len(recorded_entries)}"
         os.mkdir(data_path)
         pill = placebo.attach(session, data_path=data_path)
         pill.record()
@@ -480,18 +462,18 @@ def enable_placebo(session: boto3.session.Session) -> None:
 
         import placebo
 
-        existing_entries = sorted([int(i) for i in os.listdir(os.environ["_ANSIBLE_PLACEBO_REPLAY"])])
-        idx = str(existing_entries[0])
-        data_path = os.environ["_ANSIBLE_PLACEBO_REPLAY"] + "/" + idx
+        replay_entries = sorted([int(i) for i in os.listdir(os.environ["_ANSIBLE_PLACEBO_REPLAY"])])
+        data_path = f"{os.environ['_ANSIBLE_PLACEBO_REPLAY']}/{replay_entries[0]}"
         try:
             shutil.rmtree("_tmp")
         except FileNotFoundError:
             pass
         shutil.move(data_path, "_tmp")
-        if len(existing_entries) == 1:
+        if len(replay_entries) == 1:
             os.rmdir(os.environ["_ANSIBLE_PLACEBO_REPLAY"])
         pill = placebo.attach(session, data_path="_tmp")
         pill.playback()
+    # pylint: enable=import-outside-toplevel
 
 
 def check_sdk_version_supported(

--- a/plugins/module_utils/exceptions.py
+++ b/plugins/module_utils/exceptions.py
@@ -48,7 +48,7 @@ def is_ansible_aws_error_code(code, e=None):
     if e is None:
         import sys
 
-        dummy, e, dummy = sys.exc_info()
+        e = sys.exc_info()[1]
     if not isinstance(code, (list, tuple, set)):
         code = [code]
     if (
@@ -79,7 +79,7 @@ def is_ansible_aws_error_message(msg, e=None):
     if e is None:
         import sys
 
-        dummy, e, dummy = sys.exc_info()
+        e = sys.exc_info()[1]
     if (
         isinstance(e, AnsibleAWSError)
         and e.exception

--- a/plugins/plugin_utils/botocore.py
+++ b/plugins/plugin_utils/botocore.py
@@ -20,10 +20,12 @@ from typing import Tuple
 from typing import Union
 
 if typing.TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
     from .base import AWSPluginBase
 
-    ClientType = botocore.client.BaseClient
-    ResourceType = boto3.resources.base.ServiceResource
+    ClientType: TypeAlias = botocore.client.BaseClient
+    ResourceType: TypeAlias = boto3.resources.base.ServiceResource
     BotoConn = Union[ClientType, ResourceType, Tuple[ClientType, ResourceType]]
 
 from ansible.module_utils.basic import to_native


### PR DESCRIPTION
SUMMARY

module_utils.botocore - fixed type aliasing.
module_utils.botocore - avoid assigning unused parts of exc_info return. plugin_utils.botocore - fixed type aliasing.
module_utils._s3 - explicitly cast super to the parent type. module_utils.exceptions - avoid assigning unused parts of exc_info return.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME
plugins/module_utils/_s3/common.py
plugins/module_utils/botocore.py
plugins/module_utils/exceptions.py
plugins/plugin_utils/botocore.py
ADDITIONAL INFORMATION

Reviewed-by: Bikouo Aubin
(cherry picked from commit 2564b0d90eb6abec6c8313a047210c5abfcbb561)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
