### PR TITLE
[Manual Backport][Stable-8] s3_bucket - do not use default region as location constraint when creating bucket on ceph cluster

### DIFF
--- a/changelogs/fragments/20250113-s3_bucket-location-constraints-for-ceph-cluster.yml
+++ b/changelogs/fragments/20250113-s3_bucket-location-constraints-for-ceph-cluster.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - s3_bucket - Do not use default region as location constraint when creating bucket on ceph cluster (https://github.com/ansible-collections/amazon.aws/issues/2420).

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -561,6 +561,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.policy import compare_policies
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket_location
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import list_bucket_inventory_configurations
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_extra_params
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import validate_bucket_name
@@ -1232,9 +1233,7 @@ def create_or_update_bucket(s3_client, module: AnsibleAWSModule):
     """
     name = module.params.get("name")
     object_lock_enabled = module.params.get("object_lock_enabled")
-    # default to US Standard region,
-    # note: module.region will also try to pull a default out of the boto3 configs.
-    location = module.region or "us-east-1"
+    location = get_s3_bucket_location(module)
 
     changed = False
     result = {}


### PR DESCRIPTION

Manual Backport to stable-8 for #2457 


SUMMARY

Closes #2420
Do not use the default region as a location constraint when creating a bucket.

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

s3_bucket

Reviewed-by: Mark Chappell
Reviewed-by: Alina Buzachis
(cherry picked from commit 6bbf22f440b3fac0e7ba42d37d00fe40ef186813)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
