### PR TITLE
[Manual Backport][Stable-8] Add support for AWS RDS Multi-Tenant CDB Databases (#2275)

### DIFF
--- a/changelogs/fragments/rds_instance_multitenant.yml
+++ b/changelogs/fragments/rds_instance_multitenant.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - rds_instance - Add support for  Multi-Tenant CDB Databases(https://github.com/ansible-collections/amazon.aws/pull/2275).

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -280,6 +280,14 @@ options:
         description:
           - Specifies if the DB instance is a Multi-AZ deployment. Mutually exclusive with O(availability_zone).
         type: bool
+    multi_tenant:
+        description:
+          - Specifies whether to use the multi-tenant configuration or the single-tenant configuration (default).
+          - This parameter only applies to RDS for Oracle container database (CDB) engines.
+          - The DB engine that you specify in the request must support the multi-tenant configuration.
+          - If the multi-tenant configuration is enabled during creation of the DB instance, it cannot be modified later.
+        type: bool
+        version_added: 9.0.0
     new_db_instance_identifier:
         description:
           - The new DB instance (lowercase) identifier for the DB instance when renaming a DB instance. The identifier must contain
@@ -782,6 +790,12 @@ multi_az:
   returned: always
   type: bool
   sample: false
+multi_tenant:
+  description: Specifies whether to use the multi-tenant configuration or the single-tenant configuration (default).
+  returned: for Oracle container database (CDB) engines and boto3_version == "1.28.80"
+  type: bool
+  version_added: 9.0.0
+  sample: false
 option_group_memberships:
   description: The list of option group memberships for this DB instance.
   returned: always
@@ -862,6 +876,10 @@ vpc_security_groups:
 """
 
 from time import sleep
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
 
 try:
     import botocore
@@ -1023,6 +1041,7 @@ def get_options_with_changing_values(client, module, parameters):
     cloudwatch_logs_enabled = module.params["enable_cloudwatch_logs_exports"]
     purge_security_groups = module.params["purge_security_groups"]
     ca_certificate_identifier = module.params["ca_certificate_identifier"]
+    multi_tenant = module.params.get("multi_tenant")
 
     if ca_certificate_identifier:
         parameters["CACertificateIdentifier"] = ca_certificate_identifier
@@ -1036,12 +1055,22 @@ def get_options_with_changing_values(client, module, parameters):
         parameters.pop("Iops", None)
 
     instance = get_instance(client, module, instance_id)
+    # Determine which parameters need to be modified
     updated_parameters = get_changing_options_with_inconsistent_keys(
         parameters, instance, purge_cloudwatch_logs, purge_security_groups
     )
     updated_parameters.update(get_changing_options_with_consistent_keys(parameters, instance))
     parameters = updated_parameters
 
+    # Validate multi_tenant option
+    # Once set to True, it cannot be modified to False
+    if multi_tenant is False:  # noqa: E712
+        if instance.get("MultiTenant"):
+            module.fail_json(
+                msg="A DB which is configured to be a multi tenant cannot be modified to use single tenant configuration."
+            )
+
+    # Validate changes to storage type options
     if instance.get("StorageType") == "io1":
         # Bundle Iops and AllocatedStorage while updating io1 RDS Instance
         current_iops = instance.get("PendingModifiedValues", {}).get("Iops", instance["Iops"])
@@ -1220,13 +1249,23 @@ def get_changing_options_with_inconsistent_keys(modify_params, instance, purge_c
                 changing_params[option] = list(set(current_option) | set(desired_option))
         else:
             changing_params[option] = desired_option
-
     return changing_params
 
 
-def get_changing_options_with_consistent_keys(modify_params, instance):
-    changing_params = {}
+def get_changing_options_with_consistent_keys(
+    modify_params: Dict[str, Any], instance: Dict[str, Any]
+) -> Dict[str, Any]:
+    """
+    Compares current instance attributes with provided parameters whose attribute and parameter formats match.
 
+        Parameters:
+            modify_params (dict): Parameters to be supplied to boto3 client modify_db_instance method; should already be validated and formatted
+            instance (dict): Current instance attributes as returned by get_instance()
+
+        Returns:
+            changing_params (dict): Parameters to be modified
+    """
+    changing_params: Dict[str, Any] = {}
     for param in modify_params:
         current_option = instance.get("PendingModifiedValues", {}).get(param, None)
         if current_option is None:
@@ -1247,6 +1286,7 @@ def validate_options(client, module, instance):
     read_replica = module.params["read_replica"]
     creation_source = module.params["creation_source"]
     source_instance = module.params["source_db_instance_identifier"]
+    multi_tenant = module.params["multi_tenant"]
 
     if modified_id:
         modified_instance = get_instance(client, module, modified_id)
@@ -1272,6 +1312,12 @@ def validate_options(client, module, instance):
             msg=(
                 "read_replica is true and the instance does not exist yet but all of the following are missing:"
                 " source_db_instance_identifier"
+            )
+        )
+    if multi_tenant is not None and engine not in ["oracle-se2-cdb", "oracle-ee-cdb"]:
+        module.fail_json(
+            msg=(
+                f"Multi Tenant parameter only applies to RDS for Oracle container database (CDB) engines and not to {engine}."
             )
         )
 
@@ -1434,6 +1480,7 @@ def main():
         monitoring_interval=dict(type="int"),
         monitoring_role_arn=dict(),
         multi_az=dict(type="bool"),
+        multi_tenant=dict(type="bool"),
         new_db_instance_identifier=dict(aliases=["new_instance_id", "new_id"]),
         option_group_name=dict(),
         performance_insights_kms_key_id=dict(),
@@ -1500,6 +1547,8 @@ def main():
         module.require_botocore_at_least(
             "1.29.44", reason="to use 'ca_certificate_identifier' while creating/updating rds instance"
         )
+    if module.params["multi_tenant"]:
+        module.require_botocore_at_least("1.28.80", reason="to use 'multi_tenant' while creating rds instance")
 
     # Sanitize instance identifiers
     module.params["db_instance_identifier"] = module.params["db_instance_identifier"].lower()

--- a/tests/unit/plugins/modules/test_rds_instance.py
+++ b/tests/unit/plugins/modules/test_rds_instance.py
@@ -1,0 +1,164 @@
+# (c) 2024 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
+from ansible_collections.amazon.aws.plugins.modules import rds_instance
+from ansible_collections.amazon.aws.plugins.modules.rds_instance import get_instance
+
+mod_name = "ansible_collections.amazon.aws.plugins.modules.rds_instance"
+
+
+@pytest.mark.parametrize(
+    "instances, expected",
+    [
+        ([], {}),
+        (
+            [
+                {
+                    "DBInstanceIdentifier": "my-instance",
+                    "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:og:my-instance",
+                    "TagList": [],
+                }
+            ],
+            {
+                "DBInstanceIdentifier": "my-instance",
+                "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:og:my-instance",
+                "Tags": {},
+            },
+        ),
+        (
+            [
+                {
+                    "DBInstanceIdentifier": "my-instance",
+                    "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:og:my-instance",
+                    "TagList": [{"Key": "My Tag", "Value": "My Value"}],
+                    "ProcessorFeatures": [{"Name": "coreCount", "Value": "1"}],
+                    "PendingModifiedValues": {
+                        "ProcessorFeatures": [{"Name": "coreCount", "Value": "2"}],
+                    },
+                }
+            ],
+            {
+                "DBInstanceIdentifier": "my-instance",
+                "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:og:my-instance",
+                "Tags": {"My Tag": "My Value"},
+                "ProcessorFeatures": {"coreCount": "1"},
+                "PendingModifiedValues": {"ProcessorFeatures": {"coreCount": "2"}},
+            },
+        ),
+        (
+            [
+                {
+                    "DBInstanceIdentifier": "my-instance",
+                    "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:og:my-instance",
+                    "TagList": [{"Key": "My Tag", "Value": "My Value"}],
+                    "Engine": "oracle-ee-cdb",
+                    "MultiTenant": "True",
+                }
+            ],
+            {
+                "DBInstanceIdentifier": "my-instance",
+                "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:og:my-instance",
+                "Tags": {"My Tag": "My Value"},
+                "Engine": "oracle-ee-cdb",
+                "MultiTenant": "True",
+            },
+        ),
+    ],
+)
+@patch(mod_name + ".describe_db_instances")
+def test_get_instance_success(m_describe_db_instances, instances, expected):
+    client = MagicMock()
+    module = MagicMock()
+    m_describe_db_instances.return_value = instances
+    assert get_instance(client, module, "my-instance") == expected
+
+
+@patch(mod_name + ".describe_db_instances")
+def test_get_instance_failure(m_describe_db_instances):
+    client = MagicMock()
+    module = MagicMock()
+    e = AnsibleRDSError()
+    m_describe_db_instances.side_effect = e
+    get_instance(client, module, "my-instance")
+    module.fail_json_aws.assert_called_once_with(e, msg="Failed to get DB instance my-instance")
+
+
+@patch(mod_name + ".describe_db_instances")
+@patch(mod_name + ".get_changing_options_with_inconsistent_keys")
+def test_get_options_with_changing_values(m_get_changing_options_with_inconsistent_keys, m_describe_db_instances):
+    module = MagicMock()
+    client = MagicMock()
+    instance = {}
+
+    m_describe_db_instances.return_value = [
+        {
+            "DBInstanceIdentifier": "my-instance",
+            "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:og:my-instance",
+            "TagList": [{"Key": "My Tag", "Value": "My Value"}],
+            "Engine": "oracle-ee-cdb",
+            "MultiTenant": True,
+            "Endpoint": {"Port": "3000"},
+            "DBSubnetGroup": {
+                "DBSubnetGroupDescription": "default",
+                "DBSubnetGroupName": "default",
+            },
+        }
+    ]
+
+    module.params = {
+        "db_instance_identifier": "my-instance",
+        "purge_cloudwatch_logs_exports": None,
+        "force_update_password": None,
+        "port": None,
+        "enable_cloudwatch_logs_exports": None,
+        "storage_type": None,
+        "purge_security_groups": None,
+        "ca_certificate_identifier": None,
+        "db_instance_arn": "arn:aws:rds:us-east-1:123456789012:og:my-instance",
+        "engine": "oracle-ee-cdb",
+        "multi_tenant": False,
+        "db_subnet_group": {
+            "db_subnet_group_description": "default",
+            "db_subnet_group_name": "default",
+            "subnet_group_status": "Complete",
+        },
+    }
+    m_get_changing_options_with_inconsistent_keys.return_value = {}
+    rds_instance.get_options_with_changing_values(client, module, instance)
+    assert module.require_botocore_at_least.call_count == 0
+    module.fail_json.assert_called_with(
+        msg="A DB which is configured to be a multi tenant cannot be modified to use single tenant configuration."
+    )
+
+
+def test_validate_options():
+    module = MagicMock()
+    client = MagicMock()
+    instance = ""
+
+    module.params = {
+        "skip_final_snapshot": None,
+        "final_db_snapshot_identifier": None,
+        "new_db_instance_identifier": None,
+        "tde_credential_password": False,
+        "tde_credential_arn": False,
+        "read_replica": None,
+        "creation_source": None,
+        "source_db_instance_identifier": None,
+        "engine": "Aurora",
+        "multi_tenant": True,
+        "state": "present",
+    }
+    rds_instance.validate_options(client, module, instance)
+    assert module.require_botocore_at_least.call_count == 0
+    module.fail_json.assert_called_with(
+        msg="Multi Tenant parameter only applies to RDS for Oracle container database (CDB) engines and not to Aurora."
+    )


### PR DESCRIPTION
Manual backport to stable-8 for #2275 
SUMMARY

Fixes #1931
This PR adds multi_tenant arg to rds_instance module. ISSUE TYPE

Feature Pull Request

COMPONENT NAME

ADDITIONAL INFORMATION

Reviewed-by: Mark Chappell
Reviewed-by: Bikouo Aubin
Reviewed-by: GomathiselviS
Reviewed-by: Alina Buzachis
(cherry picked from commit 00e0e61d07d13154d1fb82a69824a21d1fdff64d)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
