### PR TITLE
module_utils.s3 - added 501 to the list of tolerated 'NotImplemented' error codes

### DIFF
--- a/changelogs/fragments/s3_bucket-501.yml
+++ b/changelogs/fragments/s3_bucket-501.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module_utils.s3 - added "501" to the list of error codes thrown by S3 replacements (https://github.com/ansible-collections/amazon.aws/issues/2447).

--- a/plugins/module_utils/_s3/common.py
+++ b/plugins/module_utils/_s3/common.py
@@ -22,7 +22,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto
 from ansible_collections.amazon.aws.plugins.module_utils.errors import AWSErrorHandler
 from ansible_collections.amazon.aws.plugins.module_utils.exceptions import AnsibleAWSError
 
-IGNORE_S3_DROP_IN_EXCEPTIONS = ["XNotImplemented", "NotImplemented", "AccessControlListNotSupported"]
+IGNORE_S3_DROP_IN_EXCEPTIONS = ["XNotImplemented", "NotImplemented", "AccessControlListNotSupported", "501"]
 
 
 class AnsibleS3Error(AnsibleAWSError):


### PR DESCRIPTION
##### SUMMARY

As per #2447 "Hetzner Object storage" throws a 501 (HTTP Error - Not Implemented) rather than the standard NotImplemented error.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

module_utlis.s3

##### ADDITIONAL INFORMATION
