### PR TITLE
s3_object - use copy rather than copy_object

### DIFF
--- a/changelogs/fragments/2117-s3_object-copy.yml
+++ b/changelogs/fragments/2117-s3_object-copy.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+ - s3_object - use the ``copy`` rather than ``copy_object`` method when performing an S3 to S3 copy (https://github.com/ansible-collections/amazon.aws/issues/2117).


### PR DESCRIPTION
##### SUMMARY

fixes: #2117 

The `copy_object` API call has a built-in limit of 5G when copying objects.  The `copy` method is aware of this limit and performs a multipart download/upload instead when the 5G limit has been exceeded.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

s3_object

##### ADDITIONAL INFORMATION

See also: https://github.com/boto/boto3/issues/1715