### PR TITLE
[WIP] Rework s3_object to use ErrorHandler model

### DIFF
--- a/plugins/module_utils/s3.py
+++ b/plugins/module_utils/s3.py
@@ -603,6 +603,38 @@ def ensure_s3_object_tags(
     return current_tags_dict, True
 
 
+@S3ErrorHandler.common_error_handler("generate presigned URL", "")
+def generate_s3_presigned_url(
+    client,
+    bucket_name: str,
+    object_key: str,
+    client_method: str = "get_object",
+    expiry: int = 600,
+    **params
+) -> str:
+    """
+    Generate a presigned URL for S3 object operations.
+
+    Parameters:
+        client (boto3.client): The Boto3 S3 client object.
+        bucket_name (str): The name of the S3 bucket.
+        object_key (str): The key of the S3 object.
+        client_method (str): The boto3 client method name ('get_object', 'put_object', etc.).
+        expiry (int): URL expiration time in seconds (default: 600).
+        **params: Additional parameters for the presigned URL.
+
+    Returns:
+        str: The presigned URL, or empty string on error.
+
+    Raises:
+        AnsibleS3Error: If URL generation fails.
+    """
+    url_params = {"Bucket": bucket_name, "Key": object_key}
+    url_params.update(params)
+
+    return client.generate_presigned_url(ClientMethod=client_method, Params=url_params, ExpiresIn=expiry)
+
+
 def s3_head_objects(client, parts, bucket, obj, versionId):
     args = {"Bucket": bucket, "Key": obj}
     if versionId:

--- a/plugins/module_utils/s3.py
+++ b/plugins/module_utils/s3.py
@@ -639,7 +639,7 @@ def ensure_s3_object_tags(
     return current_tags_dict, True
 
 
-@S3ErrorHandler.common_error_handler("generate presigned URL", "")
+@S3ErrorHandler.common_error_handler("generate presigned URL")
 def generate_s3_presigned_url(
     client: ClientType,
     bucket_name: str,

--- a/plugins/module_utils/s3.py
+++ b/plugins/module_utils/s3.py
@@ -229,6 +229,28 @@ def head_s3_bucket(client, bucket_name: str) -> Dict:
     return client.head_bucket(Bucket=bucket_name)
 
 
+@S3ErrorHandler.list_error_handler("get bucket location", {})
+@AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
+def get_bucket_location(client, bucket_name: str) -> Dict:
+    """
+    Retrieve the AWS region where an S3 bucket is located.
+
+    Parameters:
+        client (boto3.client): The Boto3 S3 client object.
+        bucket_name (str): The name of the S3 bucket.
+
+    Returns:
+        Dict: Bucket location information containing 'LocationConstraint'.
+              Returns {} if bucket doesn't exist (404).
+              Note: LocationConstraint is None for us-east-1 buckets.
+
+    Raises:
+        AnsibleS3PermissionsError: If access is denied (403).
+        AnsibleS3Error: For other S3 errors.
+    """
+    return client.get_bucket_location(Bucket=bucket_name)
+
+
 @S3ErrorHandler.list_error_handler("get object metadata", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
 def head_s3_object(client, bucket_name: str, object_key: str, version_id: Optional[str] = None, **kwargs) -> Dict:

--- a/plugins/module_utils/s3.py
+++ b/plugins/module_utils/s3.py
@@ -15,7 +15,8 @@ if typing.TYPE_CHECKING:
     from typing import List
     from typing import Optional
     from typing import Tuple
-    from .retries import RetryingBotoClientWrapper
+
+    from .botocore import ClientType
 
 from urllib.parse import urlparse
 
@@ -59,13 +60,13 @@ s3_acl_to_name = _transformations.s3_acl_to_name
 merge_tags = _transformations.merge_tags
 
 
-def get_s3_waiter(client: RetryingBotoClientWrapper, waiter_name: str) -> Any:
+def get_s3_waiter(client: ClientType, waiter_name: str) -> Any:
     return _waiters.waiter_factory.get_waiter(client, waiter_name)
 
 
 @S3ErrorHandler.list_error_handler("get bucket encryption settings", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def get_s3_bucket_accelerate_configuration(s3_client, bucket_name: str) -> Dict:
+def get_s3_bucket_accelerate_configuration(s3_client: ClientType, bucket_name: str) -> Dict:
     """
     Get transfer accelerate configuration of the S3 bucket.
     Parameters:
@@ -86,7 +87,7 @@ def get_s3_bucket_accelerate_configuration(s3_client, bucket_name: str) -> Dict:
 
 @S3ErrorHandler.list_error_handler("get bucket ACLs", [])
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def get_s3_bucket_acl(s3_client, bucket_name: str) -> List:
+def get_s3_bucket_acl(s3_client: ClientType, bucket_name: str) -> List:
     """
     Get ACLs of the S3 bucket.
     Parameters:
@@ -100,7 +101,7 @@ def get_s3_bucket_acl(s3_client, bucket_name: str) -> List:
 
 @S3ErrorHandler.list_error_handler("get bucket encryption settings", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def get_s3_bucket_encryption(client, bucket_name: str) -> Dict:
+def get_s3_bucket_encryption(client: ClientType, bucket_name: str) -> Dict:
     """
     Retrieve the encryption configuration for an S3 bucket.
     Parameters:
@@ -114,7 +115,7 @@ def get_s3_bucket_encryption(client, bucket_name: str) -> Dict:
 
 @S3ErrorHandler.list_error_handler("get bucket ownership settings", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def get_s3_bucket_ownership_controls(client, bucket_name: str) -> Dict:
+def get_s3_bucket_ownership_controls(client: ClientType, bucket_name: str) -> Dict:
     """
     Retrieve bucket ownership controls for S3 bucket
     Parameters:
@@ -128,7 +129,7 @@ def get_s3_bucket_ownership_controls(client, bucket_name: str) -> Dict:
 
 @S3ErrorHandler.list_error_handler("get bucket policy", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def get_s3_bucket_policy(client, bucket_name: str) -> Dict:
+def get_s3_bucket_policy(client: ClientType, bucket_name: str) -> Dict:
     """
     Retrieve bucket policy for an S3 bucket
     Parameters:
@@ -146,7 +147,7 @@ def get_s3_bucket_policy(client, bucket_name: str) -> Dict:
 
 @S3ErrorHandler.list_error_handler("get bucket request payment settings", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def get_s3_bucket_request_payment(client, bucket_name: str) -> Dict:
+def get_s3_bucket_request_payment(client: ClientType, bucket_name: str) -> Dict:
     """
     Retrieve bucket request payment settings for an S3 bucket
     Parameters:
@@ -160,7 +161,7 @@ def get_s3_bucket_request_payment(client, bucket_name: str) -> Dict:
 
 @S3ErrorHandler.list_error_handler("get bucket tags", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def get_s3_bucket_tagging(client, bucket_name: str) -> Dict:
+def get_s3_bucket_tagging(client: ClientType, bucket_name: str) -> Dict:
     """
     Retrieve tagging for an S3 bucket
     Parameters:
@@ -175,7 +176,7 @@ def get_s3_bucket_tagging(client, bucket_name: str) -> Dict:
 
 @S3ErrorHandler.list_error_handler("get bucket versioning settings", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def get_s3_bucket_versioning(client, bucket_name: str) -> Dict:
+def get_s3_bucket_versioning(client: ClientType, bucket_name: str) -> Dict:
     """
     Retrieve bucket versioning settings for an S3 bucket
     Parameters:
@@ -189,7 +190,7 @@ def get_s3_bucket_versioning(client, bucket_name: str) -> Dict:
 
 @S3ErrorHandler.list_error_handler("get bucket object lock settings", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def get_s3_object_lock_configuration(client, bucket_name: str) -> Dict:
+def get_s3_object_lock_configuration(client: ClientType, bucket_name: str) -> Dict:
     """
     Retrieve object lock configuration for an S3 bucket.
     Parameters:
@@ -203,7 +204,7 @@ def get_s3_object_lock_configuration(client, bucket_name: str) -> Dict:
 
 @S3ErrorHandler.list_error_handler("get bucket public access block settings", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def get_s3_bucket_public_access_block(client, bucket_name: str) -> Dict:
+def get_s3_bucket_public_access_block(client: ClientType, bucket_name: str) -> Dict:
     """
     Get current public access block configuration for a bucket.
     Parameters:
@@ -217,7 +218,7 @@ def get_s3_bucket_public_access_block(client, bucket_name: str) -> Dict:
 
 @S3ErrorHandler.list_error_handler("determine if bucket exisits", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["OperationAborted"])
-def head_s3_bucket(client, bucket_name: str) -> Dict:
+def head_s3_bucket(client: ClientType, bucket_name: str) -> Dict:
     """
     Retrieve basic information about an S3 bucket
     Parameters:
@@ -231,7 +232,7 @@ def head_s3_bucket(client, bucket_name: str) -> Dict:
 
 @S3ErrorHandler.list_error_handler("get bucket location", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def get_bucket_location(client, bucket_name: str) -> Dict:
+def get_bucket_location(client: ClientType, bucket_name: str) -> Dict:
     """
     Retrieve the AWS region where an S3 bucket is located.
 
@@ -253,7 +254,9 @@ def get_bucket_location(client, bucket_name: str) -> Dict:
 
 @S3ErrorHandler.list_error_handler("get object metadata", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def head_s3_object(client, bucket_name: str, object_key: str, version_id: Optional[str] = None, **kwargs) -> Dict:
+def head_s3_object(
+    client: ClientType, bucket_name: str, object_key: str, version_id: Optional[str] = None, **kwargs
+) -> Dict:
     """
     Retrieve metadata about an S3 object without downloading the object itself.
 
@@ -278,7 +281,7 @@ def head_s3_object(client, bucket_name: str, object_key: str, version_id: Option
 @S3ErrorHandler.list_error_handler("get object content", None)
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
 def get_s3_object_content(
-    client, bucket_name: str, object_key: str, version_id: Optional[str] = None, **kwargs
+    client: ClientType, bucket_name: str, object_key: str, version_id: Optional[str] = None, **kwargs
 ) -> Optional[bytes]:
     """
     Download the content of an S3 object.
@@ -304,7 +307,7 @@ def get_s3_object_content(
 @S3ErrorHandler.list_error_handler("get object tags", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
 def get_s3_object_tagging(
-    client, bucket_name: str, object_key: str, version_id: Optional[str] = None, **kwargs
+    client: ClientType, bucket_name: str, object_key: str, version_id: Optional[str] = None, **kwargs
 ) -> Dict:
     """
     Retrieve tags for an S3 object.
@@ -330,7 +333,9 @@ def get_s3_object_tagging(
 
 @S3ErrorHandler.list_error_handler("get object ACL", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def get_s3_object_acl(client, bucket_name: str, object_key: str, version_id: Optional[str] = None, **kwargs) -> Dict:
+def get_s3_object_acl(
+    client: ClientType, bucket_name: str, object_key: str, version_id: Optional[str] = None, **kwargs
+) -> Dict:
     """
     Retrieve ACL for an S3 object.
 
@@ -355,7 +360,7 @@ def get_s3_object_acl(client, bucket_name: str, object_key: str, version_id: Opt
 @S3ErrorHandler.list_error_handler("get object legal hold status", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
 def get_s3_object_legal_hold(
-    client, bucket_name: str, object_key: str, version_id: Optional[str] = None, **kwargs
+    client: ClientType, bucket_name: str, object_key: str, version_id: Optional[str] = None, **kwargs
 ) -> Dict:
     """
     Retrieve legal hold status for an S3 object.
@@ -382,7 +387,7 @@ def get_s3_object_legal_hold(
 @S3ErrorHandler.list_error_handler("get object retention settings", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
 def get_s3_object_retention(
-    client, bucket_name: str, object_key: str, version_id: Optional[str] = None, **kwargs
+    client: ClientType, bucket_name: str, object_key: str, version_id: Optional[str] = None, **kwargs
 ) -> Dict:
     """
     Retrieve retention settings for an S3 object.
@@ -409,7 +414,12 @@ def get_s3_object_retention(
 @S3ErrorHandler.list_error_handler("get object attributes", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
 def get_s3_object_attributes(
-    client, bucket_name: str, object_key: str, object_attributes: List[str], version_id: Optional[str] = None, **kwargs
+    client: ClientType,
+    bucket_name: str,
+    object_key: str,
+    object_attributes: List[str],
+    version_id: Optional[str] = None,
+    **kwargs,
 ) -> Dict:
     """
     Retrieve specific attributes for an S3 object.
@@ -438,7 +448,9 @@ def get_s3_object_attributes(
     return client.get_object_attributes(**params)
 
 
-def s3_object_exists(client, bucket_name: str, object_key: str, version_id: Optional[str] = None) -> bool:
+def s3_object_exists(
+    client: ClientType, bucket_name: str, object_key: str, version_id: Optional[str] = None
+) -> bool:
     """
     Check if an S3 object exists.
 
@@ -459,7 +471,7 @@ def s3_object_exists(client, bucket_name: str, object_key: str, version_id: Opti
     return bool(result)
 
 
-def s3_bucket_exists(client, bucket_name: str) -> bool:
+def s3_bucket_exists(client: ClientType, bucket_name: str) -> bool:
     """
     Check if an S3 bucket exists.
 
@@ -480,7 +492,7 @@ def s3_bucket_exists(client, bucket_name: str) -> bool:
 
 @S3ErrorHandler.deletion_error_handler("delete object")
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def delete_s3_object(client, bucket_name: str, object_key: str, **kwargs) -> Dict:
+def delete_s3_object(client: ClientType, bucket_name: str, object_key: str, **kwargs) -> Dict:
     """
     Delete an S3 object.
 
@@ -500,7 +512,9 @@ def delete_s3_object(client, bucket_name: str, object_key: str, **kwargs) -> Dic
 
 @S3ErrorHandler.common_error_handler("update object tags")
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def put_s3_object_tagging(client, bucket_name: str, object_key: str, tags: Dict, **kwargs) -> Dict:
+def put_s3_object_tagging(
+    client: ClientType, bucket_name: str, object_key: str, tags: Dict, **kwargs
+) -> Dict:
     """
     Set tags on an S3 object.
 
@@ -525,7 +539,7 @@ def put_s3_object_tagging(client, bucket_name: str, object_key: str, tags: Dict,
 
 @S3ErrorHandler.deletion_error_handler("delete object tags")
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def delete_s3_object_tagging(client, bucket_name: str, object_key: str, **kwargs) -> Dict:
+def delete_s3_object_tagging(client: ClientType, bucket_name: str, object_key: str, **kwargs) -> Dict:
     """
     Remove all tags from an S3 object.
 
@@ -545,7 +559,7 @@ def delete_s3_object_tagging(client, bucket_name: str, object_key: str, **kwargs
 
 @S3ErrorHandler.common_error_handler("update object ACL")
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def put_s3_object_acl(client, bucket_name: str, object_key: str, acl: str, **kwargs) -> Dict:
+def put_s3_object_acl(client: ClientType, bucket_name: str, object_key: str, acl: str, **kwargs) -> Dict:
     """
     Set ACL on an S3 object.
 
@@ -565,7 +579,7 @@ def put_s3_object_acl(client, bucket_name: str, object_key: str, acl: str, **kwa
 
 
 def ensure_s3_object_tags(
-    client, bucket_name: str, object_key: str, desired_tags: Optional[Dict], purge_tags: bool = True
+    client: ClientType, bucket_name: str, object_key: str, desired_tags: Optional[Dict], purge_tags: bool = True
 ) -> Tuple[Dict, bool]:
     """
     Ensure S3 object has desired tags, optionally purging unspecified tags.
@@ -627,7 +641,7 @@ def ensure_s3_object_tags(
 
 @S3ErrorHandler.common_error_handler("generate presigned URL", "")
 def generate_s3_presigned_url(
-    client,
+    client: ClientType,
     bucket_name: str,
     object_key: str,
     client_method: str = "get_object",
@@ -789,14 +803,14 @@ def s3_extra_params(options, sigv4=False):
 
 @S3ErrorHandler.list_error_handler("get bucket inventory settings", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def _list_bucket_inventory_configurations(client, **params):
+def _list_bucket_inventory_configurations(client: ClientType, **params) -> Dict:
     return client.list_bucket_inventory_configurations(**params)
 
 
 # _list_backup_inventory_configurations is a workaround for a missing paginator for listing
 # bucket inventory configuration in boto3:
 # https://github.com/boto/botocore/blob/1.34.141/botocore/data/s3/2006-03-01/paginators-1.json
-def list_bucket_inventory_configurations(client, bucket_name: str) -> list:
+def list_bucket_inventory_configurations(client: ClientType, bucket_name: str) -> list:
     first_iteration = False
     next_token = None
 
@@ -817,7 +831,7 @@ def list_bucket_inventory_configurations(client, bucket_name: str) -> list:
 
 
 @AWSRetry.jittered_backoff()
-def _list_objects_v2(client, **params):
+def _list_objects_v2(client: ClientType, **params) -> Dict:
     params = {k: v for k, v in params.items() if v is not None}
     # For practical purposes, the paginator ignores MaxKeys, if we've been passed MaxKeys we need to
     # explicitly call list_objects_v3 rather than re-use the paginator
@@ -829,7 +843,9 @@ def _list_objects_v2(client, **params):
 
 
 @S3ErrorHandler.list_error_handler("list bucket objects", [])
-def list_bucket_object_keys(client, bucket, prefix=None, max_keys=None, start_after=None):
+def list_bucket_object_keys(
+    client: ClientType, bucket: str, prefix: Optional[str] = None, max_keys: Optional[int] = None, start_after: Optional[str] = None
+) -> List[str]:
     """
     List object keys in an S3 bucket with optional filtering.
 

--- a/plugins/module_utils/s3.py
+++ b/plugins/module_utils/s3.py
@@ -450,7 +450,10 @@ def get_s3_object_attributes(
 
 
 def s3_object_exists(
-    client: ClientType, bucket_name: str, object_key: str, version_id: Optional[str] = None
+    client: ClientType,
+    bucket_name: str,
+    object_key: str,
+    version_id: Optional[str] = None,
 ) -> bool:
     """
     Check if an S3 object exists.
@@ -514,7 +517,11 @@ def delete_s3_object(client: ClientType, bucket_name: str, object_key: str, **kw
 @S3ErrorHandler.common_error_handler("update object tags")
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
 def put_s3_object_tagging(
-    client: ClientType, bucket_name: str, object_key: str, tags: Dict, **kwargs
+    client: ClientType,
+    bucket_name: str,
+    object_key: str,
+    tags: Dict,
+    **kwargs,
 ) -> Dict:
     """
     Set tags on an S3 object.
@@ -845,7 +852,11 @@ def _list_objects_v2(client: ClientType, **params) -> Dict:
 
 @S3ErrorHandler.list_error_handler("list bucket objects", [])
 def list_bucket_object_keys(
-    client: ClientType, bucket: str, prefix: Optional[str] = None, max_keys: Optional[int] = None, start_after: Optional[str] = None
+    client: ClientType,
+    bucket: str,
+    prefix: Optional[str] = None,
+    max_keys: Optional[int] = None,
+    start_after: Optional[str] = None,
 ) -> List[str]:
     """
     List object keys in an S3 bucket with optional filtering.

--- a/plugins/module_utils/s3.py
+++ b/plugins/module_utils/s3.py
@@ -632,7 +632,7 @@ def generate_s3_presigned_url(
     object_key: str,
     client_method: str = "get_object",
     expiry: int = 600,
-    **params
+    **params,
 ) -> str:
     """
     Generate a presigned URL for S3 object operations.

--- a/plugins/module_utils/s3.py
+++ b/plugins/module_utils/s3.py
@@ -37,6 +37,7 @@ from ansible.module_utils.basic import to_text
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 IGNORE_S3_DROP_IN_EXCEPTIONS = ["XNotImplemented", "NotImplemented", "AccessControlListNotSupported"]

--- a/plugins/module_utils/s3.py
+++ b/plugins/module_utils/s3.py
@@ -806,7 +806,25 @@ def _list_objects_v2(client, **params):
     return paginator.paginate(**params).build_full_result()
 
 
+@S3ErrorHandler.list_error_handler("list bucket objects", [])
 def list_bucket_object_keys(client, bucket, prefix=None, max_keys=None, start_after=None):
+    """
+    List object keys in an S3 bucket with optional filtering.
+
+    Parameters:
+        client (boto3.client): The Boto3 S3 client object.
+        bucket (str): The name of the S3 bucket.
+        prefix (str, optional): Limits the response to keys that begin with the specified prefix.
+        max_keys (int, optional): Maximum number of keys to return.
+        start_after (str, optional): StartAfter key for pagination.
+
+    Returns:
+        List[str]: List of object keys. Returns [] if bucket has no objects or on 404.
+
+    Raises:
+        AnsibleS3PermissionsError: If access is denied (403).
+        AnsibleS3Error: For other S3 errors.
+    """
     response = _list_objects_v2(client, Bucket=bucket, Prefix=prefix, StartAfter=start_after, MaxKeys=max_keys)
     return [c["Key"] for c in response.get("Contents", [])]
 

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -576,7 +576,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket_versioning
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object_lock_configuration
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_waiter
-from ansible_collections.amazon.aws.plugins.module_utils.s3 import head_s3_bucket
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import list_bucket_inventory_configurations
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import merge_tags
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import normalize_s3_bucket_acls

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -583,6 +583,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import normalize_s3_
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import normalize_s3_bucket_public_access
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import normalize_s3_bucket_versioning
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_acl_to_name
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_bucket_exists
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_extra_params
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import validate_bucket_name
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
@@ -1170,7 +1171,7 @@ def create_or_update_bucket(s3_client: ClientType, module: AnsibleAWSModule) -> 
     changed = False
     result: dict = {}
 
-    bucket_is_present = bucket_exists(s3_client, name)
+    bucket_is_present = s3_bucket_exists(s3_client, name)
 
     if not bucket_is_present:
         changed = create_bucket(s3_client, name, location, object_lock_enabled)
@@ -1246,18 +1247,6 @@ def create_or_update_bucket(s3_client: ClientType, module: AnsibleAWSModule) -> 
         or bucket_inventory_changed
     )
     module.exit_json(changed=changed, name=name, **result)
-
-
-def bucket_exists(s3_client: ClientType, bucket_name: str) -> bool:
-    """
-    Checks if a given bucket exists in an AWS S3 account.
-    Parameters:
-        s3_client (boto3.client): The Boto3 S3 client object.
-        bucket_name (str): The name of the bucket to check for existence.
-    Returns:
-        True if the bucket exists, False otherwise.
-    """
-    return bool(head_s3_bucket(s3_client, bucket_name))
 
 
 @S3ErrorHandler.common_error_handler("create S3 bucket")
@@ -1962,7 +1951,7 @@ def destroy_bucket(s3_client: ClientType, module: AnsibleAWSModule) -> None:
     """
     force = module.params.get("force")
     name = cast(str, module.params.get("name"))
-    bucket_is_present = bucket_exists(s3_client, name)
+    bucket_is_present = s3_bucket_exists(s3_client, name)
 
     if not bucket_is_present:
         module.exit_json(changed=False)

--- a/plugins/modules/s3_bucket_info.py
+++ b/plugins/modules/s3_bucket_info.py
@@ -516,6 +516,14 @@ buckets:
       version_added: 7.2.0
 """
 
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import Dict
+    from typing import List
+
+    from ansible_collections.amazon.aws.plugins.module_utils.botocore import ClientType
+
 try:
     import botocore
 except ImportError:
@@ -540,7 +548,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 
-def get_bucket_list(module, connection, name="", name_filter=""):
+def get_bucket_list(module: AnsibleAWSModule, connection: ClientType, name: str = "", name_filter: str = "") -> List[Dict]:
     """
     Return result of list_buckets json encoded
     Filter only buckets matching 'name' or name_filter if defined
@@ -576,7 +584,9 @@ def get_bucket_list(module, connection, name="", name_filter=""):
     return final_buckets
 
 
-def get_buckets_facts(connection, buckets, requested_facts, transform_location):
+def get_buckets_facts(
+    connection: ClientType, buckets: List[Dict], requested_facts: Dict, transform_location: bool
+) -> List[Dict]:
     """
     Retrieve additional information about S3 buckets
     """
@@ -589,7 +599,7 @@ def get_buckets_facts(connection, buckets, requested_facts, transform_location):
     return full_bucket_list
 
 
-def get_bucket_details(connection, name, requested_facts, transform_location):
+def get_bucket_details(connection: ClientType, name: str, requested_facts: Dict, transform_location: bool) -> Dict:
     """
     Execute all enabled S3API get calls for selected bucket using module_utils functions.
     """
@@ -636,7 +646,7 @@ def get_bucket_details(connection, name, requested_facts, transform_location):
 
 @S3ErrorHandler.list_error_handler("get bucket property", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def get_bucket_property(name, connection, get_api_name):
+def get_bucket_property(name: str, connection: ClientType, get_api_name: str) -> Dict:
     """
     Get bucket property
     """
@@ -649,7 +659,7 @@ def get_bucket_property(name, connection, get_api_name):
     return data
 
 
-def main():
+def main() -> None:
     """
     Get list of S3 buckets
     :return:

--- a/plugins/modules/s3_bucket_info.py
+++ b/plugins/modules/s3_bucket_info.py
@@ -526,6 +526,7 @@ from ansible.module_utils.common.dict_transformations import camel_dict_to_snake
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import AnsibleS3Error
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import S3ErrorHandler
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_bucket_location
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket_accelerate_configuration
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket_acl
@@ -629,13 +630,11 @@ def get_bucket_details(connection, name, requested_facts, transform_location):
         except AnsibleS3Error:
             # Silent failure for missing/inaccessible bucket properties (backward compatibility)
             pass
-        except botocore.exceptions.ClientError:
-            # Catch remaining ClientErrors for properties using get_bucket_property
-            pass
 
     return all_facts
 
 
+@S3ErrorHandler.list_error_handler("get bucket property", {})
 @AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
 def get_bucket_property(name, connection, get_api_name):
     """

--- a/plugins/modules/s3_bucket_info.py
+++ b/plugins/modules/s3_bucket_info.py
@@ -545,7 +545,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket_request_payment
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket_tagging
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket_versioning
-from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 
 def get_bucket_list(module: AnsibleAWSModule, connection: ClientType, name: str = "", name_filter: str = "") -> List[Dict]:

--- a/plugins/modules/s3_bucket_info.py
+++ b/plugins/modules/s3_bucket_info.py
@@ -547,7 +547,12 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket_versioning
 
 
-def get_bucket_list(module: AnsibleAWSModule, connection: ClientType, name: str = "", name_filter: str = "") -> List[Dict]:
+def get_bucket_list(
+    module: AnsibleAWSModule,
+    connection: ClientType,
+    name: str = "",
+    name_filter: str = "",
+) -> List[Dict]:
     """
     Return result of list_buckets json encoded
     Filter only buckets matching 'name' or name_filter if defined

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -465,6 +465,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import HAS_MD5
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import IGNORE_S3_DROP_IN_EXCEPTIONS
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import calculate_etag
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import calculate_etag_content
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import delete_s3_object
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import delete_s3_object_tagging
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import ensure_s3_object_tags
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import generate_s3_presigned_url
@@ -566,14 +567,10 @@ def delete_key(module, s3, bucket, obj):
             changed=True,
         )
     try:
-        s3.delete_object(aws_retry=True, Bucket=bucket, Key=obj)
+        delete_s3_object(s3, bucket, obj)
         module.exit_json(msg=f"Object deleted from bucket {bucket}.", changed=True)
-    except (
-        botocore.exceptions.ClientError,
-        botocore.exceptions.BotoCoreError,
-        boto3.exceptions.Boto3Error,
-    ) as e:
-        raise AnsibleS3Error(message=f"Failed while trying to delete {obj}.", exception=e)
+    except AnsibleS3Error as e:
+        module.fail_json_aws(e, msg=f"Failed to delete object {obj}.")
 
 
 def put_object_acl(module, s3, bucket, obj, params=None):

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -440,7 +440,6 @@ import base64
 import copy
 import mimetypes
 import os
-import time
 import typing
 from ssl import SSLError
 
@@ -463,12 +462,9 @@ except ImportError:
 
 from ansible.module_utils.basic import to_native
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import HAS_MD5
-from ansible_collections.amazon.aws.plugins.module_utils.s3 import IGNORE_S3_DROP_IN_EXCEPTIONS
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import AnsibleS3Error
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import AnsibleS3PermissionsError
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import AnsibleS3Sigv4RequiredError
@@ -476,7 +472,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import AnsibleS3Supp
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import calculate_etag
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import calculate_etag_content
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import delete_s3_object
-from ansible_collections.amazon.aws.plugins.module_utils.s3 import delete_s3_object_tagging
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import ensure_s3_object_tags
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import generate_s3_presigned_url
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket_ownership_controls
@@ -485,13 +480,10 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import head_s3_object
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import list_bucket_object_keys
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import put_s3_object_acl
-from ansible_collections.amazon.aws.plugins.module_utils.s3 import put_s3_object_tagging
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_bucket_exists
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_extra_params
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_object_exists
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import validate_bucket_name
-from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
-from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 
 class Sigv4Required(Exception):

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -457,12 +457,12 @@ from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import HAS_MD5
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import IGNORE_S3_DROP_IN_EXCEPTIONS
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import AnsibleS3Error
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import AnsibleS3PermissionsError
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import AnsibleS3Sigv4RequiredError
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import AnsibleS3SupportError
-from ansible_collections.amazon.aws.plugins.module_utils.s3 import HAS_MD5
-from ansible_collections.amazon.aws.plugins.module_utils.s3 import IGNORE_S3_DROP_IN_EXCEPTIONS
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import calculate_etag
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import calculate_etag_content
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import delete_s3_object

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -594,18 +594,17 @@ def put_object_acl(module, s3, bucket, obj, params=None):
         for acl in module.params.get("permission"):
             s3.put_object_acl(aws_retry=True, ACL=acl, Bucket=bucket, Key=obj)
     except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
+        # S3 drop-ins (MinIO, Ceph, etc.) may not support ACL operations
         module.warn(
-            "PutObjectAcl is not implemented by your storage provider. Set the permissions parameters to the empty list"
-            " to avoid this warning"
+            "Setting object ACLs is not supported by your storage provider. "
+            "Set the 'permission' parameter to an empty list to avoid this warning."
         )
-    except is_boto3_error_code("AccessControlListNotSupported"):  # pylint: disable=duplicate-except
-        module.warn("PutObjectAcl operation : The bucket does not allow ACLs.")
     except (
         botocore.exceptions.BotoCoreError,
         botocore.exceptions.ClientError,
         boto3.exceptions.Boto3Error,
-    ) as e:  # pylint: disable=duplicate-except
-        raise AnsibleS3Error(message=f"Failed while creating object {obj}.", exception=e)
+    ) as e:
+        raise AnsibleS3Error(message=f"Failed to set ACL on object {obj}.", exception=e)
 
 
 def create_dirkey(module, s3, bucket, obj, encrypt, expiry, metadata):

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -559,17 +559,6 @@ def bucket_check(module, s3, bucket, validate=True):
         raise AnsibleS3Error(message=f"Failed while looking up bucket '{bucket}'.", exception=e)
 
 
-def list_keys(s3, bucket, prefix=None, marker=None, max_keys=None):
-    try:
-        return list_bucket_object_keys(s3, bucket, prefix=prefix, start_after=marker, max_keys=max_keys)
-    except (
-        botocore.exceptions.ClientError,
-        botocore.exceptions.BotoCoreError,
-        boto3.exceptions.Boto3Error,
-    ) as e:
-        raise AnsibleS3Error(message=f"Failed while listing the keys in the bucket {bucket}", exception=e)
-
-
 def delete_key(module, s3, bucket, obj):
     if module.check_mode:
         module.exit_json(
@@ -1002,13 +991,16 @@ def s3_object_do_delobj(module, connection, connection_v4, s3_vars):
 
 def s3_object_do_list(module, connection, connection_v4, s3_vars):
     # If the bucket does not exist then bail out
-    keys = list_keys(
-        connection,
-        s3_vars["bucket"],
-        s3_vars["prefix"],
-        s3_vars["marker"],
-        s3_vars["max_keys"],
-    )
+    try:
+        keys = list_bucket_object_keys(
+            connection,
+            s3_vars["bucket"],
+            prefix=s3_vars["prefix"],
+            start_after=s3_vars["marker"],
+            max_keys=s3_vars["max_keys"],
+        )
+    except AnsibleS3Error as e:
+        module.fail_json_aws(e, msg=f"Failed to list objects in bucket {s3_vars['bucket']}.")
 
     module.exit_json(msg="LIST operation complete", s3_keys=keys)
 
@@ -1228,7 +1220,10 @@ def s3_object_do_copy(module, connection, connection_v4, s3_vars):
     if not copy_src.get("object"):
         # copy recursively object(s) from source bucket to destination bucket
         # list all the objects from the source bucket
-        keys = list_keys(connection, src_bucket, copy_src.get("prefix"))
+        try:
+            keys = list_bucket_object_keys(connection, src_bucket, prefix=copy_src.get("prefix"))
+        except AnsibleS3Error as e:
+            module.fail_json_aws(e, msg=f"Failed to list objects in source bucket {src_bucket}.")
         if len(keys) == 0:
             module.exit_json(msg=f"No object found to be copied from source bucket {src_bucket}.")
 

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -492,9 +492,9 @@ def key_check(module, s3, bucket, obj, version=None, validate=True):
     try:
         exists = s3_object_exists(s3, bucket, obj, version_id=version)
         return exists
-    except AnsibleS3PermissionsError as e:
+    except AnsibleS3PermissionsError:
         if validate:
-            module.fail_json_aws(e, msg=f"Failed while looking up object {obj} (permission denied).")
+            raise  # Let the original AnsibleS3PermissionsError propagate
         return False  # If not validating, treat permission errors as "doesn't exist"
     # Let other AnsibleS3Error exceptions propagate naturally
 

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -496,8 +496,7 @@ def key_check(module, s3, bucket, obj, version=None, validate=True):
         if validate:
             module.fail_json_aws(e, msg=f"Failed while looking up object {obj} (permission denied).")
         return False  # If not validating, treat permission errors as "doesn't exist"
-    except AnsibleS3Error as e:
-        raise AnsibleS3Error(message=f"Failed while looking up object {obj}.", exception=e)
+    # Let other AnsibleS3Error exceptions propagate naturally
 
 
 def etag_compare(module, s3, bucket, obj, version=None, local_file=None, content=None):
@@ -554,11 +553,11 @@ def bucket_check(module, s3, bucket, validate=True):
                 "Support for automatically creating buckets was removed in release 6.0.0. "
                 "The amazon.aws.s3_bucket module can be used to create buckets."
             )
-    except AnsibleS3PermissionsError as e:
+    except AnsibleS3PermissionsError:
         if validate:
-            raise AnsibleS3Error(message=f"Permission denied accessing bucket '{bucket}'.", exception=e)
-    except AnsibleS3Error as e:
-        raise AnsibleS3Error(message=f"Failed while looking up bucket '{bucket}'.", exception=e)
+            raise  # Let the original AnsibleS3PermissionsError propagate
+        # If not validating, silently ignore permission errors
+    # Let other AnsibleS3Error exceptions propagate naturally
 
 
 def delete_key(module, s3, bucket, obj):
@@ -820,8 +819,7 @@ def get_current_object_tags_dict(module, s3, bucket, obj, version=None):
     except AnsibleS3SupportError:
         module.warn("GetObjectTagging is not implemented by your storage provider.")
         return {}
-    except AnsibleS3Error as e:
-        raise AnsibleS3Error(message="Failed to get object tags.", exception=e)
+    # Let other AnsibleS3Error exceptions propagate naturally
 
 
 def ensure_tags(client, module, bucket, obj):

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -465,10 +465,13 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import HAS_MD5
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import IGNORE_S3_DROP_IN_EXCEPTIONS
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import calculate_etag
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import calculate_etag_content
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import delete_s3_object_tagging
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import ensure_s3_object_tags
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object_content
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object_tagging
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import head_s3_object
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import list_bucket_object_keys
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import put_s3_object_tagging
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_bucket_exists
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_extra_params
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_object_exists
@@ -857,94 +860,12 @@ def get_current_object_tags_dict(module, s3, bucket, obj, version=None):
         raise AnsibleS3Error(message="Failed to get object tags.", exception=e)
 
 
-@AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def put_object_tagging(s3, bucket, obj, tags):
-    s3.put_object_tagging(
-        Bucket=bucket,
-        Key=obj,
-        Tagging={"TagSet": ansible_dict_to_boto3_tag_list(tags)},
-    )
-
-
-@AWSRetry.jittered_backoff(max_delay=120, catch_extra_error_codes=["NoSuchBucket", "OperationAborted"])
-def delete_object_tagging(s3, bucket, obj):
-    s3.delete_object_tagging(Bucket=bucket, Key=obj)
-
-
-def wait_tags_are_applied(module, s3, bucket, obj, expected_tags_dict, version=None):
-    for _dummy in range(0, 12):
-        try:
-            current_tags_dict = get_current_object_tags_dict(module, s3, bucket, obj, version)
-        except (
-            botocore.exceptions.ClientError,
-            botocore.exceptions.BotoCoreError,
-            boto3.exceptions.Boto3Error,
-        ) as e:
-            raise AnsibleS3Error(message="Failed to get object tags.", exception=e)
-
-        if current_tags_dict != expected_tags_dict:
-            time.sleep(5)
-        else:
-            return current_tags_dict
-
-    module.fail_json(
-        msg="Object tags failed to apply in the expected time.",
-        requested_tags=expected_tags_dict,
-        live_tags=current_tags_dict,
-    )
-
-
 def ensure_tags(client, module, bucket, obj):
+    """Wrapper for ensure_s3_object_tags to maintain backward compatibility."""
     tags = module.params.get("tags")
     purge_tags = module.params.get("purge_tags")
-    changed = False
 
-    try:
-        current_tags_dict = get_current_object_tags_dict(module, client, bucket, obj)
-    except (
-        botocore.exceptions.BotoCoreError,
-        botocore.exceptions.ClientError,
-        boto3.exceptions.Boto3Error,
-    ) as e:  # pylint: disable=duplicate-except
-        raise AnsibleS3Error(message="Failed to get object tags.", exception=e)
-
-    # Tags is None, we shouldn't touch anything
-    if tags is None:
-        return current_tags_dict, changed
-
-    if not purge_tags:
-        # Ensure existing tags that aren't updated by desired tags remain
-        current_copy = current_tags_dict.copy()
-        current_copy.update(tags)
-        tags = current_copy
-
-    # Nothing to change, we shouldn't touch anything
-    if current_tags_dict == tags:
-        return current_tags_dict, changed
-
-    if tags:
-        try:
-            put_object_tagging(client, bucket, obj, tags)
-        except (
-            botocore.exceptions.BotoCoreError,
-            botocore.exceptions.ClientError,
-            boto3.exceptions.Boto3Error,
-        ) as e:
-            raise AnsibleS3Error(message="Failed to update object tags.", exception=e)
-    else:
-        try:
-            delete_object_tagging(client, bucket, obj)
-        except (
-            botocore.exceptions.BotoCoreError,
-            botocore.exceptions.ClientError,
-            boto3.exceptions.Boto3Error,
-        ) as e:
-            raise AnsibleS3Error(message="Failed to delete object tags.", exception=e)
-
-    current_tags_dict = wait_tags_are_applied(module, client, bucket, obj, tags)
-    changed = True
-
-    return current_tags_dict, changed
+    return ensure_s3_object_tags(client, bucket, obj, tags, purge_tags)
 
 
 def get_binary_content(s3_vars):

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -469,6 +469,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import delete_s3_obj
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import delete_s3_object_tagging
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import ensure_s3_object_tags
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import generate_s3_presigned_url
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_bucket_ownership_controls
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object_content
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object_tagging
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import head_s3_object
@@ -1311,15 +1312,13 @@ def validate_bucket(module, s3, var_dict):
     bucket_check(module, s3, var_dict["bucket"], validate=var_dict["validate"])
 
     try:
-        ownership_controls = s3.get_bucket_ownership_controls(aws_retry=True, Bucket=var_dict["bucket"])[
-            "OwnershipControls"
-        ]
-        if ownership_controls.get("Rules"):
+        ownership_controls = get_s3_bucket_ownership_controls(s3, var_dict["bucket"])
+        if ownership_controls and ownership_controls.get("Rules"):
             object_ownership = ownership_controls["Rules"][0]["ObjectOwnership"]
             if object_ownership == "BucketOwnerEnforced":
                 var_dict["acl_disabled"] = True
-    # if bucket ownership controls are not found
-    except botocore.exceptions.ClientError:
+    except AnsibleS3Error:
+        # Bucket ownership controls not found or not accessible
         pass
 
     if not var_dict["acl_disabled"]:

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -473,6 +473,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object_tagging
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import head_s3_object
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import list_bucket_object_keys
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import put_s3_object_acl
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import put_s3_object_tagging
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_bucket_exists
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_extra_params
@@ -574,23 +575,26 @@ def delete_key(module, s3, bucket, obj):
 
 
 def put_object_acl(module, s3, bucket, obj, params=None):
-    try:
-        if params:
+    if params:
+        try:
             s3.put_object(aws_retry=True, **params)
-        for acl in module.params.get("permission"):
-            s3.put_object_acl(aws_retry=True, ACL=acl, Bucket=bucket, Key=obj)
-    except is_boto3_error_code(IGNORE_S3_DROP_IN_EXCEPTIONS):
-        # S3 drop-ins (MinIO, Ceph, etc.) may not support ACL operations
-        module.warn(
-            "Setting object ACLs is not supported by your storage provider. "
-            "Set the 'permission' parameter to an empty list to avoid this warning."
-        )
-    except (
-        botocore.exceptions.BotoCoreError,
-        botocore.exceptions.ClientError,
-        boto3.exceptions.Boto3Error,
-    ) as e:
-        raise AnsibleS3Error(message=f"Failed to set ACL on object {obj}.", exception=e)
+        except (
+            botocore.exceptions.BotoCoreError,
+            botocore.exceptions.ClientError,
+            boto3.exceptions.Boto3Error,
+        ) as e:
+            raise AnsibleS3Error(message=f"Failed to create object {obj}.", exception=e)
+
+    for acl in module.params.get("permission"):
+        try:
+            put_s3_object_acl(s3, bucket, obj, acl)
+        except AnsibleS3SupportError:
+            # S3 drop-ins (MinIO, Ceph, etc.) may not support ACL operations
+            module.warn(
+                "Setting object ACLs is not supported by your storage provider. "
+                "Set the 'permission' parameter to an empty list to avoid this warning."
+            )
+            return  # Don't try other ACLs if this one failed
 
 
 def create_dirkey(module, s3, bucket, obj, encrypt, expiry, metadata):

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -441,7 +441,17 @@ import copy
 import mimetypes
 import os
 import time
+import typing
 from ssl import SSLError
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+    from typing import Dict
+    from typing import List
+    from typing import Optional
+    from typing import Tuple
+
+    from ansible_collections.amazon.aws.plugins.module_utils.botocore import ClientType
 
 try:
     # Beware, S3 is a "special" case, it sometimes catches botocore exceptions and
@@ -488,7 +498,14 @@ class Sigv4Required(Exception):
     pass
 
 
-def key_check(module, s3, bucket, obj, version=None, validate=True):
+def key_check(
+    module: AnsibleAWSModule,
+    s3: ClientType,
+    bucket: str,
+    obj: str,
+    version: Optional[str] = None,
+    validate: bool = True,
+) -> bool:
     """Check if object exists with optional validation."""
     try:
         exists = s3_object_exists(s3, bucket, obj, version_id=version)
@@ -500,7 +517,15 @@ def key_check(module, s3, bucket, obj, version=None, validate=True):
     # Let other AnsibleS3Error exceptions propagate naturally
 
 
-def etag_compare(module, s3, bucket, obj, version=None, local_file=None, content=None):
+def etag_compare(
+    module: AnsibleAWSModule,
+    s3: ClientType,
+    bucket: str,
+    obj: str,
+    version: Optional[str] = None,
+    local_file: Optional[str] = None,
+    content: Optional[bytes] = None,
+) -> bool:
     s3_etag = _head_object(s3, bucket, obj, version=version).get("ETag")
     if local_file is not None:
         local_etag = calculate_etag(module, local_file, s3_etag, s3, bucket, obj, version)
@@ -509,12 +534,18 @@ def etag_compare(module, s3, bucket, obj, version=None, local_file=None, content
     return s3_etag == local_etag
 
 
-def _head_object(s3, bucket, obj, version=None):
+def _head_object(s3: ClientType, bucket: str, obj: str, version: Optional[str] = None) -> Dict:
     """Wrapper for head_s3_object with backward-compatible interface."""
     return head_s3_object(s3, bucket, obj, version_id=version)
 
 
-def _get_object_content(module, s3, bucket, obj, version=None):
+def _get_object_content(
+    module: AnsibleAWSModule,
+    s3: ClientType,
+    bucket: str,
+    obj: str,
+    version: Optional[str] = None,
+) -> bytes:
     """Wrapper for get_s3_object_content with module-specific error handling."""
     try:
         return get_s3_object_content(s3, bucket, obj, version_id=version)
@@ -528,7 +559,12 @@ def _get_object_content(module, s3, bucket, obj, version=None):
         module.fail_json_aws(e, msg=f"Could not find the key {obj}.")
 
 
-def get_s3_last_modified_timestamp(s3, bucket, obj, version=None):
+def get_s3_last_modified_timestamp(
+    s3: ClientType,
+    bucket: str,
+    obj: str,
+    version: Optional[str] = None,
+) -> Optional[float]:
     last_modified = None
     obj_info = _head_object(s3, bucket, obj, version)
     if obj_info:
@@ -536,7 +572,13 @@ def get_s3_last_modified_timestamp(s3, bucket, obj, version=None):
     return last_modified
 
 
-def is_local_object_latest(s3, bucket, obj, version=None, local_file=None):
+def is_local_object_latest(
+    s3: ClientType,
+    bucket: str,
+    obj: str,
+    version: Optional[str] = None,
+    local_file: Optional[str] = None,
+) -> bool:
     s3_last_modified = get_s3_last_modified_timestamp(s3, bucket, obj, version)
     if not os.path.exists(local_file):
         return False
@@ -544,7 +586,7 @@ def is_local_object_latest(s3, bucket, obj, version=None, local_file=None):
     return s3_last_modified <= local_last_modified
 
 
-def bucket_check(module, s3, bucket, validate=True):
+def bucket_check(module: AnsibleAWSModule, s3: ClientType, bucket: str, validate: bool = True) -> None:
     """Check if bucket exists and is accessible."""
     try:
         exists = s3_bucket_exists(s3, bucket)
@@ -561,7 +603,7 @@ def bucket_check(module, s3, bucket, validate=True):
     # Let other AnsibleS3Error exceptions propagate naturally
 
 
-def delete_key(module, s3, bucket, obj):
+def delete_key(module: AnsibleAWSModule, s3: ClientType, bucket: str, obj: str) -> None:
     if module.check_mode:
         module.exit_json(
             msg="DELETE operation skipped - running in check mode",
@@ -574,7 +616,13 @@ def delete_key(module, s3, bucket, obj):
         module.fail_json_aws(e, msg=f"Failed to delete object {obj}.")
 
 
-def put_object_acl(module, s3, bucket, obj, params=None):
+def put_object_acl(
+    module: AnsibleAWSModule,
+    s3: ClientType,
+    bucket: str,
+    obj: str,
+    params: Optional[Dict] = None,
+) -> None:
     if params:
         try:
             s3.put_object(aws_retry=True, **params)
@@ -597,7 +645,15 @@ def put_object_acl(module, s3, bucket, obj, params=None):
             return  # Don't try other ACLs if this one failed
 
 
-def create_dirkey(module, s3, bucket, obj, encrypt, expiry, metadata):
+def create_dirkey(
+    module: AnsibleAWSModule,
+    s3: ClientType,
+    bucket: str,
+    obj: str,
+    encrypt: bool,
+    expiry: int,
+    metadata: Optional[Dict],
+) -> None:
     if module.check_mode:
         module.exit_json(msg="PUT operation skipped - running in check mode", changed=True)
     params = {"Bucket": bucket, "Key": obj, "Body": b""}
@@ -624,11 +680,11 @@ def create_dirkey(module, s3, bucket, obj, encrypt, expiry, metadata):
     )
 
 
-def path_check(path):
+def path_check(path: str) -> bool:
     return bool(os.path.exists(path))
 
 
-def guess_content_type(src):
+def guess_content_type(src: Optional[str]) -> str:
     if src:
         content_type = mimetypes.guess_type(src)[0]
         if content_type:
@@ -639,11 +695,11 @@ def guess_content_type(src):
 
 
 def get_extra_params(
-    encrypt=None,
-    encryption_mode=None,
-    encryption_kms_key_id=None,
-    metadata=None,
-):
+    encrypt: Optional[bool] = None,
+    encryption_mode: Optional[str] = None,
+    encryption_kms_key_id: Optional[str] = None,
+    metadata: Optional[Dict] = None,
+) -> Dict:
     extra = {}
     if encrypt:
         extra["ServerSideEncryption"] = encryption_mode
@@ -661,7 +717,7 @@ def get_extra_params(
     return extra
 
 
-def option_in_extra_args(option):
+def option_in_extra_args(option: str) -> Optional[str]:
     temp_option = option.replace("-", "").lower()
 
     allowed_extra_args = {
@@ -689,21 +745,22 @@ def option_in_extra_args(option):
 
     if temp_option in allowed_extra_args:
         return allowed_extra_args[temp_option]
+    return None
 
 
 def upload_s3file(
-    module,
-    s3,
-    bucket,
-    obj,
-    expiry,
-    metadata,
-    encrypt,
-    headers,
-    src=None,
-    content=None,
-    acl_disabled=False,
-):
+    module: AnsibleAWSModule,
+    s3: ClientType,
+    bucket: str,
+    obj: str,
+    expiry: int,
+    metadata: Optional[Dict],
+    encrypt: bool,
+    headers: Optional[Dict],
+    src: Optional[str] = None,
+    content: Optional[bytes] = None,
+    acl_disabled: bool = False,
+) -> None:
     if module.check_mode:
         module.exit_json(msg="PUT operation skipped - running in check mode", changed=True)
     try:
@@ -762,7 +819,15 @@ def upload_s3file(
     module.exit_json(msg="PUT operation complete", url=url, tags=tags, changed=True)
 
 
-def download_s3file(module, s3, bucket, obj, dest, retries, version=None):
+def download_s3file(
+    module: AnsibleAWSModule,
+    s3: ClientType,
+    bucket: str,
+    obj: str,
+    dest: str,
+    retries: int,
+    version: Optional[str] = None,
+) -> None:
     if module.check_mode:
         module.exit_json(msg="GET operation skipped - running in check mode", changed=True)
 
@@ -787,14 +852,28 @@ def download_s3file(module, s3, bucket, obj, dest, retries, version=None):
             # otherwise, try again, this may be a transient timeout.
 
 
-def download_s3str(module, s3, bucket, obj, version=None):
+def download_s3str(
+    module: AnsibleAWSModule,
+    s3: ClientType,
+    bucket: str,
+    obj: str,
+    version: Optional[str] = None,
+) -> None:
     if module.check_mode:
         module.exit_json(msg="GET operation skipped - running in check mode", changed=True)
     contents = to_native(_get_object_content(module, s3, bucket, obj, version))
     module.exit_json(msg="GET operation complete", contents=contents, changed=True)
 
 
-def get_download_url(module, s3, bucket, obj, expiry, tags=None, changed=True):
+def get_download_url(
+    module: AnsibleAWSModule,
+    s3: ClientType,
+    bucket: str,
+    obj: str,
+    expiry: int,
+    tags: Optional[Dict] = None,
+    changed: bool = True,
+) -> None:
     url = generate_s3_presigned_url(s3, bucket, obj, client_method="get_object", expiry=expiry)
     module.exit_json(
         msg="Download url:",
@@ -805,11 +884,17 @@ def get_download_url(module, s3, bucket, obj, expiry, tags=None, changed=True):
     )
 
 
-def put_download_url(s3, bucket, obj, expiry):
+def put_download_url(s3: ClientType, bucket: str, obj: str, expiry: int) -> str:
     return generate_s3_presigned_url(s3, bucket, obj, client_method="put_object", expiry=expiry)
 
 
-def get_current_object_tags_dict(module, s3, bucket, obj, version=None):
+def get_current_object_tags_dict(
+    module: AnsibleAWSModule,
+    s3: ClientType,
+    bucket: str,
+    obj: str,
+    version: Optional[str] = None,
+) -> Dict:
     """Get object tags with module-specific parameter handling."""
     kwargs = {}
     if module.params.get("expected_bucket_owner"):
@@ -823,7 +908,7 @@ def get_current_object_tags_dict(module, s3, bucket, obj, version=None):
     # Let other AnsibleS3Error exceptions propagate naturally
 
 
-def ensure_tags(client, module, bucket, obj):
+def ensure_tags(client: ClientType, module: AnsibleAWSModule, bucket: str, obj: str) -> Tuple[Dict, bool]:
     """Wrapper for ensure_s3_object_tags to maintain backward compatibility."""
     tags = module.params.get("tags")
     purge_tags = module.params.get("purge_tags")
@@ -831,7 +916,7 @@ def ensure_tags(client, module, bucket, obj):
     return ensure_s3_object_tags(client, bucket, obj, tags, purge_tags)
 
 
-def get_binary_content(s3_vars):
+def get_binary_content(s3_vars: Dict) -> Optional[bytes]:
     # the content will be uploaded as a byte string, so we must encode it first
     bincontent = None
     if s3_vars.get("content"):
@@ -1266,7 +1351,7 @@ def s3_object_do_copy(module, connection, connection_v4, s3_vars):
         module.exit_json(changed=changed, **result)
 
 
-def populate_params(module):
+def populate_params(module: AnsibleAWSModule) -> Dict:
     # Copy the parameters dict, we shouldn't be directly modifying it.
     variable_dict = copy.deepcopy(module.params)
 
@@ -1308,7 +1393,7 @@ def populate_params(module):
     return variable_dict
 
 
-def validate_bucket(module, s3, var_dict):
+def validate_bucket(module: AnsibleAWSModule, s3: ClientType, var_dict: Dict) -> Dict:
     bucket_check(module, s3, var_dict["bucket"], validate=var_dict["validate"])
 
     try:

--- a/plugins/modules/s3_object_info.py
+++ b/plugins/modules/s3_object_info.py
@@ -450,6 +450,14 @@ object_info:
                             sample: "xxxxxxxxxxxx"
 """
 
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import Dict
+    from typing import List
+
+    from ansible_collections.amazon.aws.plugins.module_utils.botocore import ClientType
+
 try:
     import botocore
 except ImportError:
@@ -477,7 +485,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_object_exi
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 
-def describe_s3_object_acl(connection, bucket_name, object_name):
+def describe_s3_object_acl(connection: ClientType, bucket_name: str, object_name: str) -> Dict:
     """Get object ACL."""
     try:
         acl_info = get_s3_object_acl(connection, bucket_name, object_name)
@@ -492,7 +500,9 @@ def describe_s3_object_acl(connection, bucket_name, object_name):
         return {}
 
 
-def describe_s3_object_attributes(connection, module, bucket_name, object_name):
+def describe_s3_object_attributes(
+    connection: ClientType, module: AnsibleAWSModule, bucket_name: str, object_name: str
+) -> Dict:
     """Get object attributes."""
     try:
         attributes_list = module.params.get("object_details", {}).get("attributes_list", [])
@@ -510,7 +520,7 @@ def describe_s3_object_attributes(connection, module, bucket_name, object_name):
         return {"msg": "Object attributes not found"}
 
 
-def describe_s3_object_legal_hold(connection, bucket_name, object_name):
+def describe_s3_object_legal_hold(connection: ClientType, bucket_name: str, object_name: str) -> Dict:
     """Get object legal hold status."""
     try:
         legal_hold = get_s3_object_legal_hold(connection, bucket_name, object_name)
@@ -525,7 +535,7 @@ def describe_s3_object_legal_hold(connection, bucket_name, object_name):
         return {}
 
 
-def describe_s3_object_lock_configuration(connection, bucket_name):
+def describe_s3_object_lock_configuration(connection: ClientType, bucket_name: str) -> Dict:
     """Get bucket-level object lock configuration."""
     try:
         lock_config = get_s3_object_lock_configuration(connection, bucket_name)
@@ -540,7 +550,7 @@ def describe_s3_object_lock_configuration(connection, bucket_name):
         return {}
 
 
-def describe_s3_object_retention(connection, bucket_name, object_name):
+def describe_s3_object_retention(connection: ClientType, bucket_name: str, object_name: str) -> Dict:
     """Get object retention settings."""
     try:
         retention = get_s3_object_retention(connection, bucket_name, object_name)
@@ -555,7 +565,7 @@ def describe_s3_object_retention(connection, bucket_name, object_name):
         return {}
 
 
-def describe_s3_object_tagging(connection, bucket_name, object_name):
+def describe_s3_object_tagging(connection: ClientType, bucket_name: str, object_name: str) -> Dict:
     """Get object tags."""
     try:
         return get_s3_object_tagging(connection, bucket_name, object_name)
@@ -567,7 +577,9 @@ def describe_s3_object_tagging(connection, bucket_name, object_name):
         return {}
 
 
-def get_object_details(connection, module, bucket_name, object_name, requested_facts):
+def get_object_details(
+    connection: ClientType, module: AnsibleAWSModule, bucket_name: str, object_name: str, requested_facts: Dict
+) -> Dict:
     all_facts = {}
 
     # Remove non-requested facts
@@ -601,7 +613,7 @@ def get_object_details(connection, module, bucket_name, object_name, requested_f
     return all_facts
 
 
-def get_object(connection, bucket_name, object_name):
+def get_object(connection: ClientType, bucket_name: str, object_name: str) -> Dict:
     """Get basic object metadata."""
     try:
         object_info = head_s3_object(connection, bucket_name, object_name)
@@ -616,7 +628,7 @@ def get_object(connection, bucket_name, object_name):
         return {"object_data": {}}
 
 
-def list_bucket_objects(connection, module, bucket_name):
+def list_bucket_objects(connection: ClientType, module: AnsibleAWSModule, bucket_name: str) -> List[str]:
     try:
         keys = list_bucket_object_keys(
             connection,
@@ -630,7 +642,7 @@ def list_bucket_objects(connection, module, bucket_name):
     return keys
 
 
-def bucket_check(connection, module, bucket_name):
+def bucket_check(connection: ClientType, module: AnsibleAWSModule, bucket_name: str) -> None:
     """Check if bucket exists and is accessible."""
     try:
         if not s3_bucket_exists(connection, bucket_name):
@@ -641,7 +653,7 @@ def bucket_check(connection, module, bucket_name):
         module.fail_json_aws(e, msg=f"Failed to check if bucket {bucket_name} exists.")
 
 
-def object_check(connection, module, bucket_name, object_name):
+def object_check(connection: ClientType, module: AnsibleAWSModule, bucket_name: str, object_name: str) -> None:
     """Check if object exists and is accessible."""
     try:
         if not s3_object_exists(connection, bucket_name, object_name):
@@ -652,7 +664,7 @@ def object_check(connection, module, bucket_name, object_name):
         module.fail_json_aws(e, msg=f"Failed to check if object {object_name} exists.")
 
 
-def main():
+def main() -> None:
     argument_spec = dict(
         object_details=dict(
             type="dict",

--- a/plugins/modules/s3_object_info.py
+++ b/plugins/modules/s3_object_info.py
@@ -465,7 +465,6 @@ except ImportError:
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import AnsibleS3Error
@@ -482,7 +481,6 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import list_bucket_o
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_bucket_exists
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_extra_params
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_object_exists
-from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 
 def describe_s3_object_acl(connection: ClientType, bucket_name: str, object_name: str) -> Dict:

--- a/plugins/modules/s3_object_info.py
+++ b/plugins/modules/s3_object_info.py
@@ -460,129 +460,111 @@ from ansible.module_utils.common.dict_transformations import camel_dict_to_snake
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import AnsibleS3Error
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import AnsibleS3PermissionsError
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import AnsibleS3SupportError
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object_acl
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object_attributes
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object_legal_hold
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object_lock_configuration
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object_retention
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import get_s3_object_tagging
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import head_s3_object
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import list_bucket_object_keys
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_bucket_exists
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_extra_params
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_object_exists
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 
 def describe_s3_object_acl(connection, bucket_name, object_name):
-    params = {}
-    params["Bucket"] = bucket_name
-    params["Key"] = object_name
-
-    object_acl_info = {}
-
+    """Get object ACL."""
     try:
-        object_acl_info = connection.get_object_acl(**params)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
-        pass
-
-    if len(object_acl_info) != 0:
-        # Remove ResponseMetadata from object_acl_info, convert to snake_case
-        del object_acl_info["ResponseMetadata"]
-        object_acl_info = camel_dict_to_snake_dict(object_acl_info)
-
-    return object_acl_info
+        acl_info = get_s3_object_acl(connection, bucket_name, object_name)
+        if acl_info:
+            return camel_dict_to_snake_dict(acl_info)
+        return {}
+    except AnsibleS3SupportError:
+        # Silent failure for unsupported operations on S3 drop-ins
+        return {}
+    except AnsibleS3Error:
+        # Silent failure to maintain backward compatibility
+        return {}
 
 
 def describe_s3_object_attributes(connection, module, bucket_name, object_name):
-    params = {}
-    params["Bucket"] = bucket_name
-    params["Key"] = object_name
-    params["ObjectAttributes"] = module.params.get("object_details")["attributes_list"]
-
-    object_attributes_info = {}
-
+    """Get object attributes."""
     try:
-        object_attributes_info = connection.get_object_attributes(**params)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
-        object_attributes_info["msg"] = "Object attributes not found"
+        attributes_list = module.params.get("object_details", {}).get("attributes_list", [])
+        if not attributes_list:
+            return {}
 
-    if len(object_attributes_info) != 0 and "msg" not in object_attributes_info.keys():
-        # Remove ResponseMetadata from object_attributes_info, convert to snake_case
-        del object_attributes_info["ResponseMetadata"]
-        object_attributes_info = camel_dict_to_snake_dict(object_attributes_info)
-
-    return object_attributes_info
+        attrs = get_s3_object_attributes(connection, bucket_name, object_name, object_attributes=attributes_list)
+        if attrs:
+            return camel_dict_to_snake_dict(attrs)
+        return {}
+    except AnsibleS3SupportError:
+        # Silent failure for unsupported operations on S3 drop-ins
+        return {"msg": "Object attributes not found"}
+    except AnsibleS3Error:
+        return {"msg": "Object attributes not found"}
 
 
 def describe_s3_object_legal_hold(connection, bucket_name, object_name):
-    params = {}
-    params["Bucket"] = bucket_name
-    params["Key"] = object_name
-
-    object_legal_hold_info = {}
-
+    """Get object legal hold status."""
     try:
-        object_legal_hold_info = connection.get_object_legal_hold(**params)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
-        pass
-
-    if len(object_legal_hold_info) != 0:
-        # Remove ResponseMetadata from object_legal_hold_info, convert to snake_case
-        del object_legal_hold_info["ResponseMetadata"]
-        object_legal_hold_info = camel_dict_to_snake_dict(object_legal_hold_info)
-
-    return object_legal_hold_info
+        legal_hold = get_s3_object_legal_hold(connection, bucket_name, object_name)
+        if legal_hold:
+            return {"legal_hold": camel_dict_to_snake_dict(legal_hold)}
+        return {}
+    except AnsibleS3SupportError:
+        # Silent failure for unsupported operations on S3 drop-ins
+        return {}
+    except AnsibleS3Error:
+        # Silent failure to maintain backward compatibility
+        return {}
 
 
 def describe_s3_object_lock_configuration(connection, bucket_name):
-    params = {}
-    params["Bucket"] = bucket_name
-
-    object_legal_lock_configuration_info = {}
-
+    """Get bucket-level object lock configuration."""
     try:
-        object_legal_lock_configuration_info = connection.get_object_lock_configuration(**params)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
-        pass
-
-    if len(object_legal_lock_configuration_info) != 0:
-        # Remove ResponseMetadata from object_legal_lock_configuration_info, convert to snake_case
-        del object_legal_lock_configuration_info["ResponseMetadata"]
-        object_legal_lock_configuration_info = camel_dict_to_snake_dict(object_legal_lock_configuration_info)
-
-    return object_legal_lock_configuration_info
+        lock_config = get_s3_object_lock_configuration(connection, bucket_name)
+        if lock_config:
+            return camel_dict_to_snake_dict(lock_config)
+        return {}
+    except AnsibleS3SupportError:
+        # Silent failure for unsupported operations on S3 drop-ins
+        return {}
+    except AnsibleS3Error:
+        # Silent failure to maintain backward compatibility
+        return {}
 
 
 def describe_s3_object_retention(connection, bucket_name, object_name):
-    params = {}
-    params["Bucket"] = bucket_name
-    params["Key"] = object_name
-
-    object_retention_info = {}
-
+    """Get object retention settings."""
     try:
-        object_retention_info = connection.get_object_retention(**params)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
-        pass
-
-    if len(object_retention_info) != 0:
-        # Remove ResponseMetadata from object_retention_info, convert to snake_case
-        del object_retention_info["ResponseMetadata"]
-        object_retention_info = camel_dict_to_snake_dict(object_retention_info)
-
-    return object_retention_info
+        retention = get_s3_object_retention(connection, bucket_name, object_name)
+        if retention:
+            return {"retention": camel_dict_to_snake_dict(retention)}
+        return {}
+    except AnsibleS3SupportError:
+        # Silent failure for unsupported operations on S3 drop-ins
+        return {}
+    except AnsibleS3Error:
+        # Silent failure to maintain backward compatibility
+        return {}
 
 
 def describe_s3_object_tagging(connection, bucket_name, object_name):
-    params = {}
-    params["Bucket"] = bucket_name
-    params["Key"] = object_name
-
-    object_tagging_info = {}
-
+    """Get object tags."""
     try:
-        object_tagging_info = connection.get_object_tagging(**params)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
-        pass
-
-    if len(object_tagging_info) != 0:
-        # Remove ResponseMetadata from object_tagging_info, convert to snake_case
-        del object_tagging_info["ResponseMetadata"]
-        object_tagging_info = boto3_tag_list_to_ansible_dict(object_tagging_info["TagSet"])
-
-    return object_tagging_info
+        return get_s3_object_tagging(connection, bucket_name, object_name)
+    except AnsibleS3SupportError:
+        # Silent failure for unsupported operations on S3 drop-ins
+        return {}
+    except AnsibleS3Error:
+        # Silent failure to maintain backward compatibility
+        return {}
 
 
 def get_object_details(connection, module, bucket_name, object_name, requested_facts):
@@ -620,26 +602,18 @@ def get_object_details(connection, module, bucket_name, object_name, requested_f
 
 
 def get_object(connection, bucket_name, object_name):
-    params = {}
-    params["Bucket"] = bucket_name
-    params["Key"] = object_name
-
-    result = {}
-    object_info = {}
-
+    """Get basic object metadata."""
     try:
-        object_info = connection.head_object(**params)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
-        pass
-
-    if len(object_info) != 0:
-        # Remove ResponseMetadata from object_info, convert to snake_case
-        del object_info["ResponseMetadata"]
-        object_info = camel_dict_to_snake_dict(object_info)
-
-    result["object_data"] = object_info
-
-    return result
+        object_info = head_s3_object(connection, bucket_name, object_name)
+        if object_info:
+            object_info = camel_dict_to_snake_dict(object_info)
+        return {"object_data": object_info}
+    except AnsibleS3SupportError:
+        # Silent failure for unsupported operations on S3 drop-ins
+        return {"object_data": {}}
+    except AnsibleS3Error:
+        # Silent failure to maintain backward compatibility
+        return {"object_data": {}}
 
 
 def list_bucket_objects(connection, module, bucket_name):
@@ -656,22 +630,26 @@ def list_bucket_objects(connection, module, bucket_name):
     return keys
 
 
-def bucket_check(
-    connection,
-    module,
-    bucket_name,
-):
+def bucket_check(connection, module, bucket_name):
+    """Check if bucket exists and is accessible."""
     try:
-        connection.head_bucket(Bucket=bucket_name)
-    except is_boto3_error_code(["404", "403"]) as e:
-        module.fail_json_aws(e, msg=f"The bucket {bucket_name} does not exist or is missing access permissions.")
+        if not s3_bucket_exists(connection, bucket_name):
+            module.fail_json(msg=f"The bucket {bucket_name} does not exist.")
+    except AnsibleS3PermissionsError as e:
+        module.fail_json_aws(e, msg=f"Permission denied accessing bucket {bucket_name}.")
+    except AnsibleS3Error as e:
+        module.fail_json_aws(e, msg=f"Failed to check if bucket {bucket_name} exists.")
 
 
 def object_check(connection, module, bucket_name, object_name):
+    """Check if object exists and is accessible."""
     try:
-        connection.head_object(Bucket=bucket_name, Key=object_name)
-    except is_boto3_error_code(["404", "403"]) as e:
-        module.fail_json_aws(e, msg=f"The object {object_name} does not exist or is missing access permissions.")
+        if not s3_object_exists(connection, bucket_name, object_name):
+            module.fail_json(msg=f"The object {object_name} does not exist.")
+    except AnsibleS3PermissionsError as e:
+        module.fail_json_aws(e, msg=f"Permission denied accessing object {object_name}.")
+    except AnsibleS3Error as e:
+        module.fail_json_aws(e, msg=f"Failed to check if object {object_name} exists.")
 
 
 def main():


### PR DESCRIPTION
Depends-On: https://github.com/ansible-collections/amazon.aws/pull/2776

##### SUMMARY

- Refactor S3 modules to use centralized module_utils functions
- Consolidate duplicated S3 object-level operations from s3_object.py and s3_object_info.py into module_utils/s3.py following the established S3ErrorHandler pattern.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

s3_object
s3_object_info
s3_bucket
s3_bucket_info
plugins/module_utils/s3.py

##### ADDITIONAL INFORMATION

See also: #2478
Assisted-by: Claude Sonnet 4.5