### PR TITLE
amazon.aws.ec2_placement_group : Add EC2 placement group with NLB endpoint

### DIFF
--- a/plugins/modules/ec2_placement_group.py
+++ b/plugins/modules/ec2_placement_group.py
@@ -81,6 +81,14 @@ EXAMPLES = r"""
   amazon.aws.ec2_placement_group:
     name: my-cluster
     state: absent
+
+- name: Create placement group through NLB
+  amazon.aws.ec2_placement_group:
+    name: my-cluster
+    state: present
+    endpoint_url: "https://internal-nlb-12345.us-east-1.elb.amazonaws.com"
+    region: us-east-1
+    
 """
 
 RETURN = r"""


### PR DESCRIPTION


##### SUMMARY
Add EC2 placement group with NLB endpoint
- Created 'my-cluster' placement group
- Access through internal NLB endpoint
- Default cluster strategy enabled
- Region: us-east-1



##### ISSUE TYPE
- Docs Pull Request


##### COMPONENT NAME

amazon.aws.ec2_placement_group:
    endpoint_url: 
