### PR TITLE
Enable metadata folder settings in create mode

### DIFF
--- a/changelogs/fragments/2529-s3_object-create-metadata.yml
+++ b/changelogs/fragments/2529-s3_object-create-metadata.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - s3_object - support passing metadata in ``create`` mode (https://github.com/ansible-collections/amazon.aws/pull/2529).

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -67,7 +67,7 @@ options:
     type: int
   metadata:
     description:
-      - Metadata to use when O(mode=put) or O(mode=copy) as a dictionary of key value pairs.
+      - Metadata to use when O(mode=copy), O(mode=create) or O(mode=put) as a dictionary of key value pairs.
     type: dict
   mode:
     description:

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -629,7 +629,7 @@ def put_object_acl(module, s3, bucket, obj, params=None):
         raise S3ObjectFailure(f"Failed while creating object {obj}.", e)
 
 
-def create_dirkey(module, s3, bucket, obj, encrypt, expiry):
+def create_dirkey(module, s3, bucket, obj, encrypt, expiry, metadata):
     if module.check_mode:
         module.exit_json(msg="PUT operation skipped - running in check mode", changed=True)
     params = {"Bucket": bucket, "Key": obj, "Body": b""}
@@ -638,6 +638,7 @@ def create_dirkey(module, s3, bucket, obj, encrypt, expiry):
             encrypt,
             module.params.get("encryption_mode"),
             module.params.get("encryption_kms_key_id"),
+            metadata,
         )
     )
     put_object_acl(module, s3, bucket, obj, params)
@@ -1151,6 +1152,7 @@ def s3_object_do_create(module, connection, connection_v4, s3_vars):
         s3_vars["object"],
         s3_vars["encrypt"],
         s3_vars["expiry"],
+        s3_vars["metadata"],
     )
 
 


### PR DESCRIPTION
##### SUMMARY
Enable metadata folder settings in create mode

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
amazon.aws.s3_object

##### ADDITIONAL INFORMATION
Default action in "create" mode, doesn't allow set owner and permissions over extra aws metadata.
Patch fix this issue.

Create a list of folders with owner "2:2"(ex: daemon:daemon or bin:bin) and permissions "40755"
```
  - name: Create folders
    aws_s3:
      endpoint_url: "{{ S3FS_URL }}"
      bucket: "{{ S3FS_BUCKET }}"
      object: "{{ item }}"
      mode: create
      encrypt: false
      validate_certs: false
      metadata:
        mode: "16877"
        gid: "2"
        uid: "2"
    with_items:
      - "{{ S3FS_FOLDER }}"
      - "{{ S3FS_FOLDER }}/public"
      - "{{ S3FS_FOLDER }}/preview"
      - "{{ S3FS_FOLDER }}/private"
```
