### PR TITLE
use correct names arguments for get_origin_access_identity

### DIFF
--- a/changelogs/fragments/1915-cloudfront_distribution_info-TypeError.yml
+++ b/changelogs/fragments/1915-cloudfront_distribution_info-TypeError.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - module_utils/cloudfront_facts - fix TypeError in CloudFrontFactsServiceManager.describe_cloudfront_property (https://github.com/ansible-collections/community.aws/issues/1915).

--- a/plugins/module_utils/cloudfront_facts.py
+++ b/plugins/module_utils/cloudfront_facts.py
@@ -164,7 +164,7 @@ class CloudFrontFactsServiceManager:
             origin_access_identities = []
             for origin_access_identity in self.list_origin_access_identities():
                 oai_id = origin_access_identity["Id"]
-                oai_full_response = self.get_origin_access_identity(oai_id)
+                oai_full_response = self.get_origin_access_identity(id=oai_id)
                 oai_summary = {"Id": oai_id, "ETag": oai_full_response["ETag"]}
                 origin_access_identities.append(oai_summary)
             return {"origin_access_identities": origin_access_identities}

--- a/tests/unit/plugins/module_utils/test_cloudfront_facts.py
+++ b/tests/unit/plugins/module_utils/test_cloudfront_facts.py
@@ -472,8 +472,8 @@ def test_summary_get_origin_access_identity_list(cloudfront_facts_service, origi
     cloudfront_facts_service.list_origin_access_identities = MagicMock()
     cloudfront_facts_service.list_origin_access_identities.return_value = origin_access_identities
     cloudfront_facts_service.get_origin_access_identity = MagicMock()
-    cloudfront_facts_service.get_origin_access_identity.side_effect = lambda x: [
-        o["response"] for o in origin_access_identities if o["Id"] == x
+    cloudfront_facts_service.get_origin_access_identity.side_effect = lambda id: [
+        o["response"] for o in origin_access_identities if o["Id"] == id
     ][0]
 
     assert {"origin_access_identities": expected} == cloudfront_facts_service.summary_get_origin_access_identity_list()


### PR DESCRIPTION
##### SUMMARY
Without this any call will fail with 
  describe_cloudfront_property() takes 4 positional arguments but 5 were given
This affects `community.aws` collections `community.aws.cloudfront_distribution_info` module

Fixes: https://github.com/ansible-collections/community.aws/issues/1915

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
`plugins/module_utils/cloudfront_facts.py`
