### PR TITLE
Add pi rds cluster

### DIFF
--- a/plugins/modules/rds_cluster.py
+++ b/plugins/modules/rds_cluster.py
@@ -97,6 +97,10 @@ options:
         description:
           - The character set to associate with the DB cluster.
         type: str
+    database_insights_mode
+        description:
+          - Indicates which mode of Database Insights to enable for the target DB cluster. Options are 'advanced' or 'standard'
+        type: str
     database_name:
         description:
           - The name for your database. If a name is not provided Amazon RDS will not create a database.
@@ -176,6 +180,10 @@ options:
         description:
           - Enable mapping of AWS Identity and Access Management (IAM) accounts to database accounts.
             If this option is omitted when creating the cluster, Amazon RDS sets this to C(false).
+        type: bool
+    enable_performance_insights:
+        description:
+          - Whether to enable Performance Insights for the DB instance.
         type: bool
     allocated_storage:
         description:
@@ -285,6 +293,14 @@ options:
         description:
           - The option group to associate with the DB cluster.
         type: str
+    performance_insights_kms_key_id:
+        description:
+          - The AWS KMS key identifier (ARN, name, or alias) for encryption of Performance Insights data.
+        type: str
+    performance_insights_retention_period:
+        description:
+          - The amount of time, in days, to retain Performance Insights data. Valid values are 7 or 731.
+        type: int
     port:
         description:
           - The port number on which the instances in the DB cluster accept connections. If not specified, Amazon RDS
@@ -586,10 +602,6 @@ cross_account_clone:
   returned: always
   type: bool
   sample: false
-database_insights_mode
-    description:
-      - Indicates which mode of Database Insights to enable for the target DB cluster. Options are 'advanced' or 'standard'
-    type: str
 db_cluster_arn:
   description: The Amazon Resource Name (ARN) for the DB cluster.
   returned: always
@@ -641,10 +653,6 @@ earliest_restorable_time:
   returned: always
   type: str
   sample: "2018-06-29T14:09:34.797000+00:00"
-enable_performance_insights:
-    description:
-      - Whether to enable Performance Insights for the DB instance.
-    type: bool
 endpoint:
   description: The connection endpoint for the primary instance of the DB cluster.
   returned: always
@@ -696,14 +704,6 @@ multi_az:
   returned: always
   type: bool
   sample: false
-performance_insights_kms_key_id:
-    description:
-      - The AWS KMS key identifier (ARN, name, or alias) for encryption of Performance Insights data.
-    type: str
-performance_insights_retention_period:
-    description:
-      - The amount of time, in days, to retain Performance Insights data. Valid values are 7 or 731.
-    type: int
 port:
   description: The port that the database engine is listening on.
   returned: always


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The following change stems from #2531 and adds the ability to enable Performance Insights (at the cluster level), the related parameters associated with it, and adds the Database Insights Mode functionality as well. 
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
performance_insights_cluster
database_insights_cluster
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
The following parameters were added:

enable_performance_insights (EnablePerformanceInsights)
performance_insights_kms_key_id (PerformanceInsightsKMSKeyId)
performance_insights_retention_period (PerformanceInsightsRetentionPeriod)
database_insights_mode (DatabaseInsightsMode)


As of right now, I am hitting an error with the implementation. I have mirrored, to my best ability, what other contributors have done with other parameters. I verified that, indeed, boto3 does have the functionality present for these features for rds clusters. However, when I run a test playbook against my contribution, I receive the following error:
```text
  File "/var/folders/xf/9g1j8gwx46g13dyjw6_fnj8c0000gp/T/ansible_amazon.aws.rds_cluster_payload_v_sx5ebx/ansible_amazon.aws.rds_cluster_payload.zip/ansible_collections/amazon/aws/plugins/modules/rds_cluster.py", line 1136, in changing_cluster_options
KeyError: 'EnablePerformanceInsights'
fatal: [localhost]: FAILED! => {
    "changed": false,
    "module_stderr": "Traceback (most recent call last):\n  File \"/Users/jfrye/.ansible/tmp/ansible-tmp-1741219030.4587781-50196-31706941389543/AnsiballZ_rds_cluster.py\", line 107, in <module>\n    _ansiballz_main()\n    ~~~~~~~~~~~~~~~^^\n  File \"/Users/jfrye/.ansible/tmp/ansible-tmp-1741219030.4587781-50196-31706941389543/AnsiballZ_rds_cluster.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/jfrye/.ansible/tmp/ansible-tmp-1741219030.4587781-50196-31706941389543/AnsiballZ_rds_cluster.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.amazon.aws.plugins.modules.rds_cluster', init_globals=dict(_module_fqn='ansible_collections.amazon.aws.plugins.modules.rds_cluster', _modlib_path=modlib_path),\n    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n                     run_name='__main__', alter_sys=True)\n                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"<frozen runpy>\", line 226, in run_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/var/folders/xf/9g1j8gwx46g13dyjw6_fnj8c0000gp/T/ansible_amazon.aws.rds_cluster_payload_v_sx5ebx/ansible_amazon.aws.rds_cluster_payload.zip/ansible_collections/amazon/aws/plugins/modules/rds_cluster.py\", line 1495, in <module>\n  File \"/var/folders/xf/9g1j8gwx46g13dyjw6_fnj8c0000gp/T/ansible_amazon.aws.rds_cluster_payload_v_sx5ebx/ansible_amazon.aws.rds_cluster_payload.zip/ansible_collections/amazon/aws/plugins/modules/rds_cluster.py\", line 1473, in main\n  File \"/var/folders/xf/9g1j8gwx46g13dyjw6_fnj8c0000gp/T/ansible_amazon.aws.rds_cluster_payload_v_sx5ebx/ansible_amazon.aws.rds_cluster_payload.zip/ansible_collections/amazon/aws/plugins/modules/rds_cluster.py\", line 1235, in ensure_present\n  File \"/var/folders/xf/9g1j8gwx46g13dyjw6_fnj8c0000gp/T/ansible_amazon.aws.rds_cluster_payload_v_sx5ebx/ansible_amazon.aws.rds_cluster_payload.zip/ansible_collections/amazon/aws/plugins/modules/rds_cluster.py\", line 1136, in changing_cluster_options\nKeyError: 'EnablePerformanceInsights'\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE: No start of json char found\nSee stdout/stderr for the exact error",
    "rc": 1
}
```
This is what versions of ansible and boto3 I have on my local machine:

```text
ansible [core 2.18.1]                                                                                                                                     

  config file = None                                                                                                                                       

  configured module search path = ['/Users/jfrye/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']                                         

  ansible python module location = /opt/homebrew/Cellar/ansible/11.1.0_1/libexec/lib/python3.13/site-packages/ansible                                     

  ansible collection location = /Users/jfrye/.ansible/collections:/usr/share/ansible/collections                                                          

  executable location = /opt/homebrew/bin/ansible                                                                                                         

  python version = 3.13.1 (main, Dec  3 2024, 17:59:52) [Clang 16.0.0 (clang-1600.0.26.4)] (/opt/homebrew/Cellar/ansible/11.1.0_1/libexec/bin/python)     

  jinja version = 3.1.5                                                                                                                                   

  libyaml = True      

boto3 version ( 1.37.6)                                                
```

And here is the sample playbook I am using
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
---
- name: Enforce DBA Settings
  hosts: localhost
  tasks:
    - name: enforce DBA setting for clusters
      amazon.aws.rds_cluster:
        region: us-east-1
        access_key: "{{ access_key }}"
        secret_key: "{{ secret_key }}"
        session_token: "{{ session_token }}"
        id: target_cluster  
        state: present
        copy_tags_to_snapshot: true
        deletion_protection: true
        enable_performance_insights: True
        performance_insights_retention_period: 7
        storage_encrypted: true
        preferred_maintenance_window: "Sun:05:00-Sun:06:00"
        purge_tags: false
        apply_immediately: true
        backup_retention_period: 14
```
I have that the collection is installed on my local machine and that there isn't another amazon.aws module that is conflicting with this. Additionally, I went to the `~/.ansible` directory on my device and was able to look at the `rds_cluster.py` module to verify it had my changes in it. This is my first contribution, so if I missed an obvious step, please let me know as I plan to do more. Thank you! 