### PR TITLE
ansible-core 2.19 data tagging testing with amazon.aws modules - part 4

### DIFF
--- a/plugins/modules/aws_az_info.py
+++ b/plugins/modules/aws_az_info.py
@@ -31,6 +31,7 @@ extends_documentation_fragment:
 
 EXAMPLES = r"""
 # Note: These examples do not set authentication details, see the AWS Guide for details.
+# testing
 
 - name: Gather information about all availability zones
   amazon.aws.aws_az_info:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Depends-On: https://github.com/ansible/ansible-zuul-jobs/pull/1897

TestedTargets=aws_az_info,cloudwatch_metric_alarm,iam_access_key,iam_user,rds_instance_aurora,rds_instance_complex,rds_instance_modify,rds_instance_processor,rds_instance_replica,rds_instance_restore,rds_instance_sgroups,rds_instance_snapshot,rds_instance_snapshot_mgmt,rds_instance_states,rds_instance_tagging,rds_instance_upgrade,rds_option_group,rds_param_group,rds_subnet_group,iam_policy,iam_managed_policy,lambda_alias,lambda_event,lambda_layer,lambda_policy

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Feature Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
