### PR TITLE
ansible 2.19 data tagging testing

### DIFF
--- a/changelogs/fragments/20250319-ansible-core-2-19-testing.yaml
+++ b/changelogs/fragments/20250319-ansible-core-2-19-testing.yaml
@@ -1,0 +1,5 @@
+---
+bugfixes:
+  - lookup/aws_account_attribute - plugin should return a list when ``wantlist=True`` (https://github.com/ansible-collections/amazon.aws/pull/2552).
+minor_changes:
+  - inventory/aws_ec2 - Update templating mechanism to support ansible-core 2.19 changes (https://github.com/ansible-collections/amazon.aws/pull/2552).

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -86,7 +86,7 @@ class LookupModule(AWSLookupBase):
 
         if check_ec2_classic:
             attr = response[0]
-            return any(value["AttributeValue"] == "EC2" for value in attr["AttributeValues"])
+            return [any(value["AttributeValue"] == "EC2" for value in attr["AttributeValues"])]
 
         if attribute:
             attr = response[0]
@@ -95,4 +95,4 @@ class LookupModule(AWSLookupBase):
         flattened = {}
         for k_v_dict in response:
             flattened[k_v_dict["AttributeName"]] = [value["AttributeValue"] for value in k_v_dict["AttributeValues"]]
-        return flattened
+        return [flattened]

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_with_jinja2_filters.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostnames_with_jinja2_filters.yml
@@ -33,34 +33,30 @@
         # refresh inventory
         - ansible.builtin.meta: refresh_inventory
 
-        - name: Display ansible hostvars variable
+        - name: Display ansible groups variable
           ansible.builtin.debug:
-            var: hostvars
+            var: groups
 
-        - name: Assert that hostvars contain multiple hostnames (hostnames with multiple tags and allow_duplicated_hosts=true)
+        - name: Assert that aws_ec2 group contain multiple hostnames (hostnames with multiple tags and allow_duplicated_hosts=true)
           ansible.builtin.assert:
             that:
-              - hostvars.keys() | length == 2
-              - '"tag1.prod-Ansible" in hostvars'
-              - '"tag2.prod-Ansible" in hostvars'
+              - groups["aws_ec2"] | list | sort == ["Tag1.prod-Ansible", "Tag2.prod-Ansible"]
           when:
             - search_multiple_tags | default(false) | bool
             - (allow_duplicated_hosts | default(false) | bool)
 
-        - name: Assert that hostvars contain only 1 hostname (hostnames with multiple tags and allow_duplicated_hosts=false)
+        - name: Assert that aws_ec2 group contain only 1 hostname (hostnames with multiple tags and allow_duplicated_hosts=false)
           ansible.builtin.assert:
             that:
-              - hostvars.keys() | length == 1
-              - '"tag1.prod-Ansible" in hostvars'
+              - groups["aws_ec2"] | list == ["Tag1.prod-Ansible"]
           when:
             - search_multiple_tags | default(false) | bool
             - not (allow_duplicated_hosts | default(false) | bool)
 
-        - name: Assert that hostvars contain only 1 hostname (hostnames with single tag)
+        - name: Assert that aws_ec2 group contain only 1 hostname (hostnames with single tag)
           ansible.builtin.assert:
             that:
-              - hostvars.keys() | length == 1
-              - '"TAG1.PROD-ANSIBLE" in hostvars'
+              - groups["aws_ec2"] | list == ["TAG1.PROD-ANSIBLE"]
           when:
             - not (search_multiple_tags | default(false) | bool)
             - not (allow_duplicated_hosts | default(false) | bool)

--- a/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_hostnames_with_jinja2_filters.yml.j2
+++ b/tests/integration/targets/inventory_aws_ec2/templates/inventory_with_hostnames_with_jinja2_filters.yml.j2
@@ -11,7 +11,7 @@ regions:
 - '{{ aws_region }}'
 hostnames:
 {% if search_multiple_tags | default(false) %}
-- "tag:Tag1,Tag2 | replace('test', 'prod') | title()"
+- "tag:Tag1,Tag2 | map('replace', 'test', 'prod') | map('title')"
 {% else %}
 - "tag:Tag1 | replace('test', 'prod') | upper()"
 {% endif %}

--- a/tests/integration/targets/lookup_aws_account_attribute/tasks/main.yaml
+++ b/tests/integration/targets/lookup_aws_account_attribute/tasks/main.yaml
@@ -15,12 +15,19 @@
       secret_key: "{{ aws_secret_key }}"
       session_token: "{{ security_token | default(omit) }}"
   block:
-    - name: Check for EC2 Classic support (has-ec2-classic)
+    - name: Check for EC2 Classic support (has-ec2-classic) (wantlist=False)
+      ansible.builtin.set_fact:
+        has_ec2_classic: "{{ lookup('amazon.aws.aws_account_attribute', attribute='has-ec2-classic', wantlist=False, **connection_args) }}"
+    - ansible.builtin.assert:
+        that:
+          - ( has_ec2_classic is sameas true ) or ( has_ec2_classic is sameas false )
+
+    - name: Check for EC2 Classic support (has-ec2-classic) (wantlist=True)
       ansible.builtin.set_fact:
         has_ec2_classic: "{{ lookup('amazon.aws.aws_account_attribute', attribute='has-ec2-classic', wantlist=True, **connection_args) }}"
     - ansible.builtin.assert:
         that:
-          - ( has_ec2_classic is sameas true ) or ( has_ec2_classic is sameas false )
+          - ( has_ec2_classic == [true] ) or ( has_ec2_classic == [false] )
 
     - name: Fetch all account attributes (wantlist=True)
       ansible.builtin.set_fact:
@@ -28,18 +35,19 @@
     - ansible.builtin.assert:
         that:
           # Not guaranteed that there will be a default-vpc
-          - '"default-vpc" in account_attrs'
-          - '"max-elastic-ips" in account_attrs'
-          - account_attrs['max-elastic-ips'][0] | int
-          - '"max-instances" in account_attrs'
-          - account_attrs['max-instances'][0] | int
+          - (account_attrs is not string) and (account_attrs is not mapping) and (account_attrs is iterable)
+          - '"default-vpc" in account_attrs[0]'
+          - '"max-elastic-ips" in account_attrs[0]'
+          - account_attrs[0]['max-elastic-ips'][0] | int | string == account_attrs[0]['max-elastic-ips'][0]
+          - '"max-instances" in account_attrs[0]'
+          - account_attrs[0]['max-instances'][0] | int | string == account_attrs[0]['max-instances'][0]
           # EC2 and VPC are both valid values, but we can't guarantee which are available
-          - '"supported-platforms" in account_attrs'
-          - account_attrs['supported-platforms'] | difference(['VPC', 'EC2']) | length == 0
-          - '"vpc-max-elastic-ips" in account_attrs'
-          - account_attrs['vpc-max-elastic-ips'][0] | int
-          - '"vpc-max-security-groups-per-interface" in account_attrs'
-          - account_attrs['vpc-max-security-groups-per-interface'][0] | int
+          - '"supported-platforms" in account_attrs[0]'
+          - account_attrs[0]['supported-platforms'] | difference(['VPC', 'EC2']) | length == 0
+          - '"vpc-max-elastic-ips" in account_attrs[0]'
+          - account_attrs[0]['vpc-max-elastic-ips'][0] | int | string == account_attrs[0]['vpc-max-elastic-ips'][0]
+          - '"vpc-max-security-groups-per-interface" in account_attrs[0]'
+          - account_attrs[0]['vpc-max-security-groups-per-interface'][0] | int | string == account_attrs[0]['vpc-max-security-groups-per-interface'][0]
 
     # Not espcially useful, but let's be thorough and leave hints what folks could
     # expect
@@ -48,14 +56,12 @@
         account_attrs: "{{ lookup('amazon.aws.aws_account_attribute', wantlist=False, **connection_args) }}"
     - ansible.builtin.assert:
         that:
-          - '"default-vpc" in split_attrs'
-          - '"max-elastic-ips" in split_attrs'
-          - '"max-instances" in split_attrs'
-          - '"supported-platforms" in split_attrs'
-          - '"vpc-max-elastic-ips" in split_attrs'
-          - '"vpc-max-security-groups-per-interface" in split_attrs'
-      vars:
-        split_attrs: '{{ account_attrs.split(",") }}'
+          - '"default-vpc" in account_attrs'
+          - '"max-elastic-ips" in account_attrs'
+          - '"max-instances" in account_attrs'
+          - '"supported-platforms" in account_attrs'
+          - '"vpc-max-elastic-ips" in account_attrs'
+          - '"vpc-max-security-groups-per-interface" in account_attrs'
 
     - name: Check for Default VPC (default-vpc)
       ansible.builtin.set_fact:
@@ -69,28 +75,28 @@
         max_eips: "{{ lookup('amazon.aws.aws_account_attribute', attribute='max-elastic-ips', **connection_args) }}"
     - ansible.builtin.assert:
         that:
-          - max_eips | int
+          - max_eips | int | string == max_eips
 
     - name: Check for maximum number of Instances (max-instances)
       ansible.builtin.set_fact:
         max_instances: "{{ lookup('amazon.aws.aws_account_attribute', attribute='max-instances', **connection_args) }}"
     - ansible.builtin.assert:
         that:
-          - max_instances | int
+          - max_instances | int | string == max_instances
 
     - name: Check for maximum number of EIPs in a VPC (vpc-max-elastic-ips)
       ansible.builtin.set_fact:
         vpc_max_eips: "{{ lookup('amazon.aws.aws_account_attribute', attribute='vpc-max-elastic-ips', **connection_args) }}"
     - ansible.builtin.assert:
         that:
-          - vpc_max_eips | int
+          - vpc_max_eips | int |  string == vpc_max_eips
 
     - name: Check for maximum number of Security Groups per Interface (vpc-max-security-groups-per-interface)
       ansible.builtin.set_fact:
         max_sg_per_int: "{{ lookup('amazon.aws.aws_account_attribute', attribute='vpc-max-security-groups-per-interface', **connection_args) }}"
     - ansible.builtin.assert:
         that:
-          - max_sg_per_int | int
+          - max_sg_per_int | int | string == max_sg_per_int
 
     - name: Check for support of Classic EC2 vs VPC (supported-platforms)
       ansible.builtin.set_fact:

--- a/tests/integration/targets/route53_health_check/aliases
+++ b/tests/integration/targets/route53_health_check/aliases
@@ -1,1 +1,2 @@
+time=4m
 cloud/aws

--- a/tests/unit/plugins/inventory/test_aws_ec2.py
+++ b/tests/unit/plugins/inventory/test_aws_ec2.py
@@ -192,10 +192,10 @@ def test_inventory_verify_file(m_base_verify_file, inventory, base_verify_file_r
     [
         ("tag:os_provider", {"Tags": []}, []),
         ("tag:os_provider", {}, []),
-        ("tag:os_provider", {"Tags": [{"Key": "os_provider", "Value": "RedHat"}]}, ["RedHat"]),
+        ("tag:os_provider", {"Tags": [{"Key": "os_provider", "Value": "RedHat"}]}, "RedHat"),
         ("tag:OS_Provider", {"Tags": [{"Key": "os_provider", "Value": "RedHat"}]}, []),
         ("tag:tag:os_provider", {"Tags": [{"Key": "os_provider", "Value": "RedHat"}]}, []),
-        ("tag:os_provider=RedHat", {"Tags": [{"Key": "os_provider", "Value": "RedHat"}]}, ["os_provider_RedHat"]),
+        ("tag:os_provider=RedHat", {"Tags": [{"Key": "os_provider", "Value": "RedHat"}]}, "os_provider_RedHat"),
         ("tag:os_provider=CoreOS", {"Tags": [{"Key": "os_provider", "Value": "RedHat"}]}, []),
         (
             "tag:os_provider=RedHat,os_release=7",


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

TestedTargets=route53_health_check,elb_application_lb,iam_access_key,lookup_aws_collection_constants,iam_instance_profile,backup_tag,ec2_vpc_vpn,backup_selection,lookup_aws_service_ip_ranges,ec2_vpc_endpoint_service_info,rds_cluster_tag,elb_classic_lb,elb_classic_lb_info,iam_password_policy,ec2_launch_template,ec2_placement_group,rds_cluster_param_group,ec2_vpc_vgw,ec2_transit_gateway_vpc_attachment,ec2_vpc_dhcp_option,ec2_vpc_egress_igw,aws_region_info,inventory_aws_ec2,rds_cluster_modify,lookup_ssm_parameter,iam_group,ec2_vpc_nat_gateway,cloudwatchlogs,inventory_aws_rds,cloudtrail,ec2_vpc_nacl,rds_cluster_create_sgs,lookup_secretsmanager_secret,iam_user,route53_zone,backup_plan,rds_cluster_states,ec2_ami_instance,callback_aws_resource_actions,module_utils_core,autoscaling_instance,lambda,ec2_spot_instance,ec2_vpc_peering,ec2_transit_gateway,cloudwatchevent_rule,backup_vault,ec2_vpc_endpoint,rds_cluster_snapshot,rds_cluster_create,rds_cluster_restore,lookup_aws_account_attribute,autoscaling_instance_refresh,route53_key_signing_key,module_utils_botocore_recorder,module_utils_waiter,aws_caller_info
