### PR TITLE
route53_zone - Remove default value of `false` for `dnssec` parameter

### DIFF
--- a/changelogs/fragments/2553-route53_zone-remove-dnssec-default.yml
+++ b/changelogs/fragments/2553-route53_zone-remove-dnssec-default.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - route53_zone - Remove the default value for ``dnssec`` parameter to avoid idempotency issues (https://github.com/ansible-collections/amazon.aws/pull/2553).

--- a/plugins/modules/route53_zone.py
+++ b/plugins/modules/route53_zone.py
@@ -67,7 +67,6 @@ options:
         description:
             - Enables DNSSEC signing in a specific hosted zone.
         type: bool
-        default: false
         version_added: 9.2.0
 extends_documentation_fragment:
     - amazon.aws.common.modules
@@ -351,6 +350,9 @@ def get_hosted_zone(hosted_zone_id: str) -> Dict[str, Any]:
 def ensure_dnssec(zone_id: str) -> bool:
     changed = False
     dnssec = module.params.get("dnssec")
+
+    if dnssec is None:
+        return changed
 
     response = get_dnssec(zone_id)
     dnssec_status = response["Status"]["ServeSignature"]
@@ -661,7 +663,7 @@ def main():
         delegation_set_id=dict(),
         tags=dict(type="dict", aliases=["resource_tags"]),
         purge_tags=dict(type="bool", default=True),
-        dnssec=dict(type="bool", default=False),
+        dnssec=dict(type="bool"),
     )
 
     mutually_exclusive = [


### PR DESCRIPTION
##### SUMMARY

I suggest removing the default value for `dnssec` parameter in `route53_zone` module.

The current implementation results in a "catch-22": enabling DNSSEC for Route53 zone requires a key-signing key to be created (e.g., via `route53_key_signing_key` module), while creating a key-signing key requires a zone to exist.

Consider the following tasks:

```
- name: Create zone
  amazon.aws.route53_zone:
    zone: example.com
  register: __zone

- name: Create KSK
  amazon.aws.route53_key_signing_key:
    name: ksk1
    hosted_zone_id: "{{ __zone.id }}"
    key_management_service_arn: "{{ kms_arn }}"

- name: Enable DNSSEC
  amazon.aws.route53_zone:
    zone: example.com
    dnssec: true
```

On the first execution, these three tasks produce the expected result: create a zone, create a KSK, and then enable DNSSEC for that zone.

However, the subsequent executions of the same tasks will first disable DNSSEC (task 1) and then re-enable it (task 3), which is not idempotent and, more importantly, will likely result in DNS resolution disruption.

Removing the default value addresses this behavior.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
route53_zone