### PR TITLE
Update tests for ansible 2.19

### DIFF
--- a/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/main.yml
+++ b/tests/integration/targets/autoscaling_group/roles/ec2_asg/tasks/main.yml
@@ -20,7 +20,7 @@
     - name: Set async_dir for HOME env
       ansible.builtin.set_fact:
         ansible_async_dir: "{{ lookup('env', 'HOME') }}/.ansible_async_{{ tiny_prefix }}/"
-      when: (lookup('env', 'HOME'))
+      when: lookup('env', 'HOME') is defined and lookup('env', 'HOME') | length > 0
 
     - ansible.builtin.debug:
         msg: "{{ inventory_hostname }} start: {{ lookup('pipe', 'date') }}"
@@ -31,13 +31,13 @@
     - ansible.builtin.set_fact:
         _role_complete: true
     - vars:
-        completed_hosts: '{{ ansible_play_hosts_all | map("extract", hostvars, "_role_complete") | list | select("defined") | list | length }}'
+        completed_hosts: "{{ ansible_play_hosts_all | map('extract', hostvars, '_role_complete') | select('defined') | list | length }}"
         hosts_in_play: "{{ ansible_play_hosts_all | length }}"
       ansible.builtin.debug:
         msg: "{{ completed_hosts }} of {{ hosts_in_play }} complete"
     - ansible.builtin.include_tasks: env_cleanup.yml
       vars:
-        completed_hosts: '{{ ansible_play_hosts_all | map("extract", hostvars, "_role_complete") | list | select("defined") | list | length }}'
+        completed_hosts: "{{ ansible_play_hosts_all | map('extract', hostvars, '_role_complete') | select('defined') | list | length }}"
         hosts_in_play: "{{ ansible_play_hosts_all | length }}"
       when:
         - completed_hosts == hosts_in_play

--- a/tests/integration/targets/ec2_launch_template/tasks/deletion.yml
+++ b/tests/integration/targets/ec2_launch_template/tasks/deletion.yml
@@ -49,7 +49,7 @@
       amazon.aws.ec2_launch_template:
         name: "{{ deletion_launch_template_name }}"
         state: absent
-        versions_to_delete: "{{ range(1, 6) }}"
+        versions_to_delete: "{{ range(1, 6) | list }}"
       ignore_errors: true
       register: delete_default_v
 
@@ -63,7 +63,7 @@
       amazon.aws.ec2_launch_template:
         name: "{{ deletion_launch_template_name }}"
         state: absent
-        versions_to_delete: "{{ range(3, 6) }}"
+        versions_to_delete: "{{ range(3, 6) | list }}"
         default_version: 6
       ignore_errors: true
       register: delete_set_non_existing_v

--- a/tests/integration/targets/ec2_vpc_vpn/tasks/main.yml
+++ b/tests/integration/targets/ec2_vpc_vpn/tasks/main.yml
@@ -51,7 +51,7 @@
       ansible.builtin.assert:
         that:
           - result is failed
-          - result.msg == "parameters are mutually exclusive: vpn_gateway_id|transit_gateway_id"
+          - "'parameters are mutually exclusive: vpn_gateway_id|transit_gateway_id' in result.msg"
 
     - name: Create EC2 VPN Connection, with customer gateway and transit_gateway
       amazon.aws.ec2_vpc_vpn:


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

This updates tests to work for changes coming in ansible 2.19.


TestedTargets=rds_option_group, lambda_layer, ec2_launch_template, ec2_vpc_vpn, cloudtrail, autoscaling_group, backup_vault, iam_instance_profile, ec2_import_image

https://issues.redhat.com/browse/ACA-2260
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
