### PR TITLE
Part 6 - 2.19 data tagging

### DIFF
--- a/plugins/modules/elb_classic_lb.py
+++ b/plugins/modules/elb_classic_lb.py
@@ -1804,7 +1804,7 @@ class ElbManager:
                 aws_retry=True, LoadBalancerName=self.name, LoadBalancerAttributes=attributes
             )
         except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
-            self.module.fail_json_aws(e, msg="Failed to apply load balancer attrbutes")
+            self.module.fail_json_aws(e, msg="Failed to apply load balancer attributes")
 
     def _proxy_policy_name(self):
         return "ProxyProtocol-policy"

--- a/tests/integration/targets/cloudwatchevent_rule/tasks/test_json_input_template.yml
+++ b/tests/integration/targets/cloudwatchevent_rule/tasks/test_json_input_template.yml
@@ -40,7 +40,7 @@
     - name: Assert that event rule is created with a valid json value for input_template
       ansible.builtin.assert:
         that:
-          - event_rule_input_transformer_output.targets[0].input_transformer.input_template | from_json
+          - event_rule_input_transformer_output.targets[0].input_transformer.input_template | from_json != {}
 
     - name: Create cloudwatch event rule with input transformer (idempotent)
       amazon.aws.cloudwatchevent_rule:

--- a/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
+++ b/tests/integration/targets/rds_cluster_param_group/tasks/main.yaml
@@ -54,7 +54,7 @@
       ansible.builtin.assert:
         that:
           - create_group is changed
-          - create_group.db_cluster_parameter_group.db_cluster_parameter_group_arn
+          - create_group.db_cluster_parameter_group.db_cluster_parameter_group_arn != ""
           - create_group.db_cluster_parameter_group.db_cluster_parameter_group_name == rds_cluster_param_group_name
           - create_group.db_cluster_parameter_group.db_parameter_group_family == dbparam_group_family
           - cluster_params.db_cluster_parameter_groups | length == 1


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This updates tests to work for changes coming in ansible 2.19.

TestedTargets=rds_subnet_group, lambda_policy, rds_cluster_*, cloudwatchevent_rule, rds_instance_snapshot, ec2_transit_gateway, elb_classic_lb.

Targets not tested:
- iam_group - reason: unsupported
- rds_global_cluster_create - reason: disabled
- rds_cluster_multi_az - reason: disabled
- rds_cluster_promote- reason: disabled
- iam_password_policy - reason: unsupported

https://issues.redhat.com/browse/ACA-2259

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
several 
