### PR TITLE
Part 8 - 2.19 data tagging

### DIFF
--- a/tests/integration/targets/ec2_vpc_nacl/tasks/ipv6.yml
+++ b/tests/integration/targets/ec2_vpc_nacl/tasks/ipv6.yml
@@ -23,7 +23,7 @@
     - name: Assert that module returned the Network ACL id
       ansible.builtin.assert:
         that:
-          - nacl.nacl_id
+          - nacl.nacl_id != ""
 
     - name: Set fact for Network ACL ID
       ansible.builtin.set_fact:


### PR DESCRIPTION
##### SUMMARY
This updates tests to work for changes coming in ansible 2.19.

TestedTargets=lambda_alias, route53_health_check, lambda_event, cloudwatchlogs, ec2_vpc_peering, ec2_vpc_nacl, ec2_vpc_vgw, rds_param_group

https://issues.redhat.com/browse/ACA-2261

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
several
