### PR TITLE
ec2_vpc_vpn - Add additional VPN tunnel options

### DIFF
--- a/plugins/modules/ec2_vpc_vpn.py
+++ b/plugins/modules/ec2_vpc_vpn.py
@@ -71,6 +71,38 @@ options:
     elements: dict
     default: []
     suboptions:
+        LogOptions:
+            type: dict
+            description:
+              - Options for VPN connection logging.
+            version_added: 9.4.0
+            suboptions:
+                CloudWatchLogOptions:
+                    type: dict
+                    description:
+                      - Options for sending VPN connections logs to CloudWatch.
+                    suboptions:
+                        LogEnabled:
+                            type: bool
+                            description:
+                              - Enable or disable VPN tunnel logging feature.
+                        LogGroupArn:
+                            type: str
+                            description:
+                              - ARN of the CloudWatch log group to send logs to.
+                        LogOutputFormat:
+                            type: str
+                            description:
+                              - Log format.
+                            choices: ["json", "text"]
+        StartupAction:
+            type: str
+            description:
+              - The action to take when establishing the tunnel.
+              - O(tunnel_options.StartupAction=add) means the customer gateway must initiate the IKE negotiation and bring up the tunnel.
+              - O(tunnel_options.StartupAction=start) means the AWS must initiate the IKE negotiation and bring up the tunnel.
+            choices: ["add", "start"]
+            version_added: 9.4.0
         TunnelInsideCidr:
             type: str
             description:


### PR DESCRIPTION
##### SUMMARY
Add additional VPN tunnel options: `StartupAction` and `LogOptions`.

More details can be found [here](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/ec2/client/modify_vpn_tunnel_options.html).

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Feature Pull Request

##### COMPONENT NAME
ec2_vpc_vpn

##### ADDITIONAL INFORMATION
Example execution:

```paste below
- name: Create a connection with tunnel options
  amazon.aws.ec2_vpc_vpn:
    customer_gateway_id: cgw-XXXXXXXX
    tunnel_options:
      - LogOptions:
          CloudWatchLogOptions:
            LogEnabled: true
            LogGroupArn: "arn:aws:logs:us-east-1:123412341234:log-group:/aws/vpn/example:*
            LogOutputFormat: json
        TunnelInsideCidr: 169.254.160.108/30
      - LogOptions:
          CloudWatchLogOptions:
            LogEnabled: true
            LogGroupArn: "arn:aws:logs:us-east-1:123412341234:log-group:/aws/vpn/example:*
            LogOutputFormat: json
        TunnelInsideCidr: 169.254.104.228/30
```