### PR TITLE
Fix iam user info issues

### DIFF
--- a/changelogs/fragments/2567-iam-user-info-add-missing-tags.yml
+++ b/changelogs/fragments/2567-iam-user-info-add-missing-tags.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - iam_user_info - Add tags to ListUsers or GetGroup results (https://github.com/ansible-collections/amazon.aws/pull/2567).

--- a/changelogs/fragments/2567-iam-user-info-fix-get-user-condition.yml
+++ b/changelogs/fragments/2567-iam-user-info-fix-get-user-condition.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - iam_user_info - Actually call GetUser when only user name is supplied instead of listing and filtering from all users (https://github.com/ansible-collections/amazon.aws/pull/2567).

--- a/changelogs/fragments/2567-iam-user-info-fix-path-prefix-condition.yml
+++ b/changelogs/fragments/2567-iam-user-info-fix-path-prefix-condition.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - iam_user_info - Actually filter users by path prefix when one is provided (https://github.com/ansible-collections/amazon.aws/pull/2567).

--- a/changelogs/fragments/2567-iam-user-info-handle-non-existant-group.yml
+++ b/changelogs/fragments/2567-iam-user-info-handle-non-existant-group.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - iam_user_info - Return empty user list when invalid group name is provided instead of python error (https://github.com/ansible-collections/amazon.aws/pull/2567).

--- a/plugins/module_utils/iam.py
+++ b/plugins/module_utils/iam.py
@@ -160,9 +160,11 @@ def get_iam_access_keys(client, user):
 
 @IAMErrorHandler.list_error_handler("get user")
 @AWSRetry.jittered_backoff()
-def get_iam_user(client, user):
+def get_iam_user(client, user, normalize=True):
     results = client.get_user(UserName=user)
-    return normalize_iam_user(results.get("User", []))
+    if normalize:
+        return normalize_iam_user(results.get("User", []))
+    return results.get("User", [])
 
 
 @IAMErrorHandler.list_error_handler("get user tags")

--- a/plugins/module_utils/iam.py
+++ b/plugins/module_utils/iam.py
@@ -165,6 +165,13 @@ def get_iam_user(client, user):
     return normalize_iam_user(results.get("User", []))
 
 
+@IAMErrorHandler.list_error_handler("get user tags")
+@AWSRetry.jittered_backoff()
+def list_iam_user_tags(client, user):
+    results = client.list_user_tags(UserName=user)
+    return results.get("Tags", [])
+
+
 def find_iam_managed_policy_by_name(client, name):
     policies = list_iam_managed_policies(client)
     for policy in policies:

--- a/plugins/module_utils/iam.py
+++ b/plugins/module_utils/iam.py
@@ -95,7 +95,7 @@ def list_iam_role_attached_policies(client, role_name):
 @AWSRetry.jittered_backoff()
 def list_iam_users(client, path=None):
     args = {}
-    if path is None:
+    if path is not None:
         args = {"PathPrefix": path}
     paginator = client.get_paginator("list_users")
     return paginator.paginate(**args).build_full_result()["Users"]

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -129,6 +129,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.iam import AnsibleIAMEr
 from ansible_collections.amazon.aws.plugins.module_utils.iam import IAMErrorHandler
 from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_group
 from ansible_collections.amazon.aws.plugins.module_utils.iam import get_iam_user
+from ansible_collections.amazon.aws.plugins.module_utils.iam import list_iam_user_tags
 from ansible_collections.amazon.aws.plugins.module_utils.iam import list_iam_users
 from ansible_collections.amazon.aws.plugins.module_utils.iam import normalize_iam_user
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
@@ -157,6 +158,9 @@ def _list_users(connection, name, group, path):
     # filter by name when a path or group was specified
     if name:
         iam_users = [u for u in iam_users if u["UserName"] == name]
+
+    for user in iam_users:
+        user["Tags"] = list_iam_user_tags(connection, user["UserName"])
 
     return iam_users
 
@@ -187,6 +191,7 @@ def main():
     path = module.params.get("path_prefix")
 
     connection = module.client("iam")
+
     try:
         module.exit_json(changed=False, iam_users=list_users(connection, name, group, path))
     except AnsibleIAMError as e:

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -147,8 +147,12 @@ def _list_users(connection, name, group, path):
     if name and not (path or group):
         return [get_iam_user(connection, name)]
 
+    iam_users = []
+
     if group:
-        iam_users = get_iam_group(connection, group)["Users"]
+        iam_group = get_iam_group(connection, group)
+        if iam_group:
+            iam_users = iam_group["Users"]
     else:
         iam_users = list_iam_users(connection, path=path)
 

--- a/plugins/modules/iam_user_info.py
+++ b/plugins/modules/iam_user_info.py
@@ -144,8 +144,8 @@ def check_console_access(connection, user_name):
 
 def _list_users(connection, name, group, path):
     # name but not path or group
-    if name and not (path or group):
-        return [get_iam_user(connection, name)]
+    if name and path == "/" and not group:
+        return [get_iam_user(connection, name, normalize=False)]
 
     iam_users = []
 

--- a/tests/integration/targets/iam_user/tasks/path.yml
+++ b/tests/integration/targets/iam_user/tasks/path.yml
@@ -29,6 +29,31 @@
       - iam_user.iam_user.user.user_name == test_user
       - iam_user.iam_user.user.path == test_path2
 
+- name: Add tag to test user
+  amazon.aws.iam_user:
+    name: "{{ test_user }}"
+    state: present
+    tags:
+      TagA: ValueA
+
+- name: List users by path
+  amazon.aws.iam_user_info:
+    path: "{{ test_path2 }}"
+  register: iam_user_info
+- name: Assert user found by path
+  ansible.builtin.assert:
+    that:
+      - iam_user_info.iam_users | length == 1
+      - iam_user_info.iam_users[0].user_name == test_user
+      - iam_user_info.iam_users[0].tags | length == 1
+      - iam_user_info.iam_users[0].tags.TagA == "ValueA"
+
+- name: Remove tag from test user
+  amazon.aws.iam_user:
+    name: "{{ test_user }}"
+    state: present
+    tags: {}
+
 - name: Retry set path (check_mode)
   amazon.aws.iam_user:
     name: "{{ test_user }}"

--- a/tests/integration/targets/iam_user/tasks/search_group.yml
+++ b/tests/integration/targets/iam_user/tasks/search_group.yml
@@ -13,6 +13,13 @@
       - iam_group.changed
       - iam_group.iam_group.users
 
+- name: Add tag to test user
+  amazon.aws.iam_user:
+    name: "{{ test_user }}"
+    state: present
+    tags:
+      TagA: ValueA
+
 - name: Get info on IAM user(s) in group
   amazon.aws.iam_user_info:
     group: "{{ test_group }}"
@@ -27,7 +34,14 @@
       - iam_user_info.iam_users[0].path == test_iam_user.path
       - iam_user_info.iam_users[0].user_id == test_iam_user.user_id
       - iam_user_info.iam_users[0].user_name == test_iam_user.user_name
-      - iam_user_info.iam_users[0].tags | length == 0
+      - iam_user_info.iam_users[0].tags | length == 1
+      - iam_user_info.iam_users[0].tags.TagA == "ValueA"
+
+- name: Remove tag from test user
+  amazon.aws.iam_user:
+    name: "{{ test_user }}"
+    state: present
+    tags: {}
 
 - name: Remove user from group
   amazon.aws.iam_group:

--- a/tests/integration/targets/iam_user/tasks/search_group.yml
+++ b/tests/integration/targets/iam_user/tasks/search_group.yml
@@ -149,3 +149,12 @@
   ansible.builtin.assert:
     that:
       - not iam_group.changed
+
+- name: Get info on non existent group
+  amazon.aws.iam_user_info:
+    group: "non-existent-group"
+  register: iam_user_info
+- name: Assert empty list of users for non existant group are returned
+  ansible.builtin.assert:
+    that:
+      - iam_user_info.iam_users | length == 0

--- a/tests/integration/targets/iam_user/tasks/tags.yml
+++ b/tests/integration/targets/iam_user/tasks/tags.yml
@@ -30,6 +30,18 @@
       - '"TagA" in iam_user.iam_user.user.tags'
       - iam_user.iam_user.user.tags.TagA == "ValueA"
 
+- name: Get info on IAM user
+  amazon.aws.iam_user_info:
+    name: "{{ test_user }}"
+  register: iam_user_info
+- name: Assert tag present in user info
+  ansible.builtin.assert:
+    that:
+      - iam_user_info.iam_users | length == 1
+      - iam_user_info.iam_users[0].arn == iam_user.iam_user.user.arn
+      - iam_user_info.iam_users[0].tags | length == 1
+      - iam_user_info.iam_users[0].tags.TagA == "ValueA"
+
 - name: Add Tag (no change - check mode)
   amazon.aws.iam_user:
     name: "{{ test_user }}"


### PR DESCRIPTION
##### SUMMARY
Few fixes to iam_user_info module (separate commits):

1. list_users and get_group does not return any tag info, ask them separately
2. With invalid group name, module failed with python error `'NoneType' object is not subscriptable`, handle this gracefully instead by returning empty user list
3. Fix path prefix conditional so the filter would actually apply
4. Fix condition to call get_user when only user name is supplied

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
iam_user_info

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Fixes https://github.com/ansible-collections/amazon.aws/issues/2565

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
