### PR TITLE
Fix 8.2.3 changelog.yaml (MD syntax)

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -3215,8 +3215,8 @@ releases:
     changes:
       bugfixes:
       - ec2_instance - Fix issue where EC2 instance module failed to apply security
-        groups when both `network` and `vpc_subnet_id`` were specified, caused by
-        passing `None` to discover_security_groups() (https://github.com/ansible-collections/amazon.aws/pull/2488).
+        groups when both ``network`` and ``vpc_subnet_id`` were specified, caused by
+        passing ``None`` to discover_security_groups() (https://github.com/ansible-collections/amazon.aws/pull/2488).
       - s3_bucket - Do not use default region as location constraint when creating
         bucket on ceph cluster (https://github.com/ansible-collections/amazon.aws/issues/2420).
       release_summary: This release includes bugfixes for the  ``ec2_instance`` and


### PR DESCRIPTION
##### SUMMARY

The changelog for #2488 used `` ` `` in a few places instead of ` `` `, while this has been manually fixed in the generated RST, the issue is still there in changelog.yaml which is causing the RST to contain bad links when it's regenerated as part of the release process.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelog.yaml

##### ADDITIONAL INFORMATION

(deliberately split from #2572 to make the backports easier)