### PR TITLE
Fix 9.4.0 changelog.yaml (MD syntax)

### DIFF
--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -3619,8 +3619,8 @@ releases:
     changes:
       bugfixes:
       - ec2_instance - Fix issue where EC2 instance module failed to apply security
-        groups when both `network` and `vpc_subnet_id`` were specified, caused by
-        passing `None` to discover_security_groups() (https://github.com/ansible-collections/amazon.aws/pull/2488).
+        groups when both ``network`` and ``vpc_subnet_id`` were specified, caused by
+        passing ``None`` to discover_security_groups() (https://github.com/ansible-collections/amazon.aws/pull/2488).
       - ec2_vpc_nacl_info - Fix failure when listing NetworkACLs and no ACLs are found
         (https://github.com/ansible-collections/amazon.aws/issues/2425).
       - iam_access_key - add missing requirements checks (https://github.com/ansible-collections/amazon.aws/pull/2465).


### PR DESCRIPTION
##### SUMMARY

The changelog for #2488 used `` ` `` in a few places instead of ` `` `, while this has been manually fixed in the generated RST, the issue is still there in changelog.yaml which is causing the RST to contain bad links when it's regenerated as part of the release process.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

changelog.yaml

##### ADDITIONAL INFORMATION

(deliberately split from #2571 to make the backports easier)