### PR TITLE
Fixes assertion update cancel autoscaling instance refresh error message

### DIFF
--- a/changelogs/fragments/2582-cancel-autoscaling-instance-refresh-error-message.yml
+++ b/changelogs/fragments/2582-cancel-autoscaling-instance-refresh-error-message.yml
@@ -1,3 +1,3 @@
 ---
 trivial:
-  - Update assertion check of cancel autoscaling instace refresh error message (https://github.com/ansible-collections/amazon.aws/pull/2496).
+  - Update assertion check of cancel autoscaling instance refresh error message (https://github.com/ansible-collections/amazon.aws/pull/2582).

--- a/changelogs/fragments/2582-cancel-autoscaling-instance-refresh-error-message.yml
+++ b/changelogs/fragments/2582-cancel-autoscaling-instance-refresh-error-message.yml
@@ -1,0 +1,3 @@
+---
+trivial:
+  - Update assertion check of cancel autoscaling instace refresh error message (https://github.com/ansible-collections/amazon.aws/pull/2496).

--- a/tests/integration/targets/autoscaling_instance_refresh/tasks/start_cancel_instance_refresh.yml
+++ b/tests/integration/targets/autoscaling_instance_refresh/tasks/start_cancel_instance_refresh.yml
@@ -9,7 +9,7 @@
 - name: Assert that module failed with proper message
   ansible.builtin.assert:
     that:
-      - "'An error occurred (ActiveInstanceRefreshNotFound) when calling the CancelInstanceRefresh operation: No in progress, baking, or pending Instance Refresh found for 
+      - "'An error occurred (ActiveInstanceRefreshNotFound) when calling the CancelInstanceRefresh operation: No in progress, baking, or pending Instance Refresh found for
         Auto Scaling group ' ~ resource_prefix ~ '-asg' in result.msg"
 
 - name: Test starting a refresh with a valid ASG name - check_mode

--- a/tests/integration/targets/autoscaling_instance_refresh/tasks/start_cancel_instance_refresh.yml
+++ b/tests/integration/targets/autoscaling_instance_refresh/tasks/start_cancel_instance_refresh.yml
@@ -9,8 +9,8 @@
 - name: Assert that module failed with proper message
   ansible.builtin.assert:
     that:
-      - "'An error occurred (ActiveInstanceRefreshNotFound) when calling the CancelInstanceRefresh operation: No in progress, baking, or pending Instance Refresh found for
-        Auto Scaling group ' ~ resource_prefix ~ '-asg' in result.msg"
+      - "'An error occurred (ActiveInstanceRefreshNotFound) when calling the CancelInstanceRefresh operation: No in progress, baking, or pending Instance Refresh
+        found for Auto Scaling group ' ~ resource_prefix ~ '-asg' in result.msg"
 
 - name: Test starting a refresh with a valid ASG name - check_mode
   amazon.aws.autoscaling_instance_refresh:

--- a/tests/integration/targets/autoscaling_instance_refresh/tasks/start_cancel_instance_refresh.yml
+++ b/tests/integration/targets/autoscaling_instance_refresh/tasks/start_cancel_instance_refresh.yml
@@ -9,7 +9,7 @@
 - name: Assert that module failed with proper message
   ansible.builtin.assert:
     that:
-      - "'An error occurred (ActiveInstanceRefreshNotFound) when calling the CancelInstanceRefresh operation: No in progress or pending Instance Refresh found for
+      - "'An error occurred (ActiveInstanceRefreshNotFound) when calling the CancelInstanceRefresh operation: No in progress, baking, or pending Instance Refresh found for 
         Auto Scaling group ' ~ resource_prefix ~ '-asg' in result.msg"
 
 - name: Test starting a refresh with a valid ASG name - check_mode


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fix downstream integration test assertion failures when checking the error message of canceling the autoscaling instance refresh.
Update the assertion check error message with the new error message.

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
autoscaling_instance_refresh
##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
