### PR TITLE
route53_info - removes jijna delimiters from example using when

### DIFF
--- a/changelogs/fragments/2594-route53_info_docs.yml
+++ b/changelogs/fragments/2594-route53_info_docs.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+- route53_info - removes jijna delimiters from example using when (https://github.com/ansible-collections/amazon.aws/issues/2594).

--- a/plugins/modules/route53_info.py
+++ b/plugins/modules/route53_info.py
@@ -186,7 +186,7 @@ EXAMPLES = r"""
     query: hosted_zone
     next_marker: "{{ first_info.NextMarker }}"
     max_items: 1
-  when: "{{ 'NextMarker' in first_info }}"
+  when: "'NextMarker' in first_info"
 
 - name: retrieve host entries starting with host1.workshop.test.io
   block:


### PR DESCRIPTION
##### SUMMARY

fixes: #2594

The current example includes extra jinja delimiters which result in double-interpretation of the statement.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

route53_info

##### ADDITIONAL INFORMATION