### PR TITLE
module_utils/modules.py - Fix sanity error with devel

### DIFF
--- a/changelogs/fragments/20250506-module_utils-modules-fix-sanity-with-devel.yml
+++ b/changelogs/fragments/20250506-module_utils-modules-fix-sanity-with-devel.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - module_utils/modules.py - call to ``deprecate()`` without specifying ``collection_name``, ``version`` or ``date`` arguments raises a sanity errors (https://github.com/ansible-collections/amazon.aws/pull/2607).

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -153,10 +153,10 @@ class AnsibleAWSModule:
     def warn(self, *args, **kwargs) -> None:
         return self._module.warn(*args, **kwargs)
 
-    def deprecate(self, *args, **kwargs) -> None:
-        return self._module.deprecate(  # pylint: disable=ansible-deprecated-no-collection-name, ansible-deprecated-no-version
-            *args, **kwargs
-        )
+    def __getattr__(self, attr):
+        if hasattr(self._module, attr):
+            return getattr(self._module, attr)
+        raise AttributeError(f"AnsibleAWSModule has no attribute '{attr}'")
 
     def boolean(self, *args, **kwargs) -> bool:
         return self._module.boolean(*args, **kwargs)


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
call to `deprecate()` should specified method arguments `collection_name`, `version` and `date` arguments
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
