### PR TITLE
stable-9: manual backport - module_utils/modules.py - call to deprecate should specified argument…

### DIFF
--- a/changelogs/fragments/20250506-module_utils-modules-fix-sanity-with-devel.yml
+++ b/changelogs/fragments/20250506-module_utils-modules-fix-sanity-with-devel.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - module_utils/modules.py - call to ``deprecate()`` without specifying ``collection_name``, ``version`` or ``date`` arguments raises a sanity errors (https://github.com/ansible-collections/amazon.aws/pull/2607).

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -185,8 +185,10 @@ class AnsibleAWSModule:
     def warn(self, *args, **kwargs) -> None:
         return self._module.warn(*args, **kwargs)
 
-    def deprecate(self, *args, **kwargs) -> None:
-        return self._module.deprecate(*args, **kwargs)
+    def __getattr__(self, attr):
+        if hasattr(self._module, attr):
+            return getattr(self._module, attr)
+        raise AttributeError(f"AnsibleAWSModule has no attribute '{attr}'")
 
     def boolean(self, *args, **kwargs) -> bool:
         return self._module.boolean(*args, **kwargs)

--- a/tests/integration/targets/ec2_vpc_nacl/tasks/ipv6.yml
+++ b/tests/integration/targets/ec2_vpc_nacl/tasks/ipv6.yml
@@ -23,7 +23,7 @@
     - name: Assert that module returned the Network ACL id
       ansible.builtin.assert:
         that:
-          - nacl.nacl_id
+          - nacl.nacl_id != ""
 
     - name: Set fact for Network ACL ID
       ansible.builtin.set_fact:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/public_access.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/public_access.yml
@@ -80,7 +80,7 @@
     - ansible.builtin.assert:
         that:
           - output is changed
-          - not output.public_access_block|bool
+          - not output.public_access_block
 
     - name: Delete public access block configuration (idempotency)
       amazon.aws.s3_bucket:
@@ -92,7 +92,7 @@
     - ansible.builtin.assert:
         that:
           - output is not changed
-          - not output.public_access_block|bool
+          - not output.public_access_block
 
     # ============================================================
 


### PR DESCRIPTION
…s (#2607)

SUMMARY

call to deprecate() should specified method arguments collection_name, version and date arguments

Reviewed-by: Mandar Kulkarni <mandar242@gmail.com>
Reviewed-by: Alina Buzachis
Reviewed-by: Bianca Henderson <beeankha@gmail.com>
(cherry picked from commit c0f969b61756b9e4ca18f8cd7ea5ab48c7411806)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
