### PR TITLE
ec2_vpc_nacl - fix issue occurring when updating existing NACL rule

### DIFF
--- a/changelogs/fragments/20250513-ec2_vpc_nacl-fix-issue-when-updating-rules.yml
+++ b/changelogs/fragments/20250513-ec2_vpc_nacl-fix-issue-when-updating-rules.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - ec2_vpc_nacl - Fix issue when trying to update existing Network ACL rule (https://github.com/ansible-collections/amazon.aws/issues/2592).

--- a/plugins/modules/ec2_vpc_nacl.py
+++ b/plugins/modules/ec2_vpc_nacl.py
@@ -298,6 +298,13 @@ def rules_changed(
     removed_rules = find_added_rules(aws_rules, ansible_rules)
 
     changed = False
+    # Removed Rules
+    for rule in removed_rules:
+        changed = True
+        if not check_mode:
+            delete_network_acl_entry(client, network_acl_id=nacl_id, rule_number=rule["RuleNumber"], egress=egress)
+
+    # Added Rules
     for rule in added_rules:
         changed = True
         if not check_mode:
@@ -314,12 +321,6 @@ def rules_changed(
                 rule_number=rule_number,
                 **rule,
             )
-
-    # Removed Rules
-    for rule in removed_rules:
-        changed = True
-        if not check_mode:
-            delete_network_acl_entry(client, network_acl_id=nacl_id, rule_number=rule["RuleNumber"], egress=egress)
 
     return changed
 

--- a/tests/integration/targets/ec2_vpc_nacl/tasks/ingress_and_egress.yml
+++ b/tests/integration/targets/ec2_vpc_nacl/tasks/ingress_and_egress.yml
@@ -147,6 +147,43 @@
 
   # ============================================================
 
+    - name: Update egress rule
+      amazon.aws.ec2_vpc_nacl:
+        vpc_id: "{{ vpc_id }}"
+        name: "{{ nacl_name }}"
+        subnets: "{{ subnet_ids }}"
+        tags:
+          Created_by: "Ansible test {{ resource_prefix }}"
+        ingress:
+          - [100, "tcp", "allow", "0.0.0.0/0", !!null "", !!null "", 22, 22]
+          - [200, "tcp", "allow", "0.0.0.0/0", !!null "", !!null "", 80, 80]
+        egress:
+          - [100, "tcp", "allow", "192.68.0.0/24", !!null "", !!null "", 22, 22]
+          - [200, "udp", "allow", "192.68.0.0/24", !!null "", !!null "", 443, 443]
+        state: "present"
+      register: nacl
+
+    - name: Assert the network acl changed
+      ansible.builtin.assert:
+        that:
+          - nacl.changed
+          - nacl.nacl_id.startswith('acl-')
+
+    - name: Get network ACL facts
+      amazon.aws.ec2_vpc_nacl_info:
+        nacl_ids:
+          - "{{ nacl.nacl_id }}"
+      register: nacl_facts
+
+    - name: Assert the nacl has the correct attributes
+      ansible.builtin.assert:
+        that:
+          - nacl_facts.nacls | length == 1
+          - nacl_facts.nacls[0].ingress | length == 2
+          - nacl_facts.nacls[0].egress | length == 2
+
+  # ============================================================
+
     - name: Remove the network ACL
       amazon.aws.ec2_vpc_nacl:
         vpc_id: "{{ vpc_id }}"


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Closes #2592 
`ec2_vpc_nacl` - Module fails when updating an existing NACL rule.
The module currently adds a new rule before removing the old ones. This generates the `NetworkAclEntryAlreadyExists` error when trying to update an existing rule. The way to fix that is to remove the rule before adding it.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
`ec2_vpc_nacl`
