### PR TITLE
Fix: Improve aws_ssm documentation examples

### DIFF
--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -232,22 +232,20 @@ EXAMPLES = r"""
       raw: yum install -y awscli
       tags: aws-cli
 
-# Optionally, you can show some tag as hostname instead of InstanceID
+# Alternatively, you can use a tag (eg. Name) as hostname instead of InstanceID.
+# However,  "ansible_host" must still be set to the instance_id
 # =======================================
 # # aws_ec2.yml (Dynamic Inventory - Linux)
 # plugin: aws_ec2
 # regions:
 #   - us-east-1
-# # This will return the Instances with the tag "SSMTag" set to "ssmlinux"
-# filters:
-#   tag:SSMTag: ssmlinux
 # hostnames:
 #   - tag:Name # will return `tag:Name` for hostname
 # compose:
 #   ansible_host: instance_id # but connection will be done to InstanceID
 ---
 
-# Execution: ansible-playbook linux.yaml -i aws_ec2.yml
+# Execution: ansible-playbook windows.yaml -i aws_ec2.yml
 # =====================================================
 # # aws_ec2.yml (Dynamic Inventory - Windows)
 # plugin: aws_ec2

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -232,6 +232,19 @@ EXAMPLES = r"""
       raw: yum install -y awscli
       tags: aws-cli
 
+# Optionally, you can show some tag as hostname instead of InstanceID
+# =======================================
+# # aws_ec2.yml (Dynamic Inventory - Linux)
+# plugin: aws_ec2
+# regions:
+#   - us-east-1
+# # This will return the Instances with the tag "SSMTag" set to "ssmlinux"
+# filters:
+#   tag:SSMTag: ssmlinux
+# hostnames:
+#   - tag:Name # will return `tag:Name` for hostname
+# compose:
+#   ansible_host: instance_id # but connection will be done to InstanceID
 ---
 
 # Execution: ansible-playbook linux.yaml -i aws_ec2.yml


### PR DESCRIPTION
##### SUMMARY

I noticed that unlike [aws_ec2](https://docs.ansible.com/ansible/latest/collections/amazon/aws/aws_ec2_inventory.html) docs, aws_ssm connection plugin documentation doesn't mention ability to use compose to show one hostname, but connect to instance_id.

I think it would be useful to add this.

Fixes: #2652

##### ISSUE TYPE

- Docs Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION

None
