### PR TITLE
Improve ec2_vpc_route_table documentation

### DIFF
--- a/plugins/modules/ec2_vpc_route_table.py
+++ b/plugins/modules/ec2_vpc_route_table.py
@@ -57,7 +57,8 @@ options:
     description:
       - List of routes in the route table.
       - Routes are specified as dicts containing the keys V(dest) and one of V(gateway_id),
-        V(instance_id), V(network_interface_id), V(transit_gateway_id), or V(vpc_peering_connection_id).
+        V(instance_id), V(network_interface_id), V(transit_gateway_id), V(vpc_peering_connection_id)
+        or V(egress_only_internet_gateway_id).
       - The value of V(dest) is used for the destination match. It may be a IPv4 CIDR block
         or a IPv6 CIDR block.
       - If V(gateway_id) is specified, you can refer to the VPC's IGW by using the value V(igw).


### PR DESCRIPTION
##### SUMMARY
Add `egress_only_internet_gateway_id` as a possible `routes` keys.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Docs Pull Request

##### COMPONENT NAME
`ec2_vpc_route_table`

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
