### PR TITLE
Fix: skip unopted-in AWS regions in aws_ec2 inventory plugin

### DIFF
--- a/changelogs/fragments/skip-disabled-regions.yml
+++ b/changelogs/fragments/skip-disabled-regions.yml
@@ -1,0 +1,4 @@
+---
+bugfixes:
+  - gracefully skip AWS regions that are not opted-in (fix misleading AuthFailure) in aws_ec2 inventory plugin
+


### PR DESCRIPTION
### Summary

This pull request improves the robustness of the `amazon.aws.aws_ec2` dynamic inventory plugin by gracefully skipping AWS regions that are not opted-in or enabled in the account.

Currently, if a user includes disabled/not enabled regions on their aws account like `ap-east-1` or `me-south-1` in the `regions:` list of their inventory config, the plugin throws a misleading `AuthFailure` error, even though the credentials are valid.

This PR introduces a targeted `ClientError` handler that:
- Checks if the error is an `AuthFailure`
- Logs a clear warning
- Skips the region instead of failing the entire inventory load

### Before

```
[WARNING]: * Failed to parse inventory/aws_ec2.yml with auto plugin: Failed to describe instances: An error occurred (AuthFailure) when calling the DescribeInstances operation: AWS was not able to validate the provided access credentials
```
and no inventory was rendered because having not activated/disabled regions in the regions list.

### After

```
[WARNING]: Region 'ap-east-1' is not enabled for this AWS account. Skipping.
```

### Changelog

- bugfixes:
  - gracefully skip AWS regions that are not opted-in (fix misleading AuthFailure) in aws_ec2 inventory plugin

### Related

Fixes UX issue related to #1518 and improves region support edge cases.
