### PR TITLE
2667-added feature for creating alt types when instance capacity issue occurs and added tests

### DIFF
--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -57,6 +57,14 @@ options:
       - When the instance is present and the O(instance_type) specified value is different from the current value,
         the instance will be stopped and the instance type will be updated.
     type: str
+  alternate_instance_types:
+    description:
+      - A list of alternate instance types to try if the primary O(instance_type) fails with V(InsufficientInstanceCapacity).
+      - The module will attempt to launch with each alternate type in order until one succeeds or all are exhausted.
+      - Only used when launching new instances, not when modifying existing instances.
+    type: list
+    elements: str
+    version_added: 8.3.0
   count:
     description:
       - Number of instances to launch.
@@ -641,6 +649,21 @@ EXAMPLES = r"""
           delete_on_termination: true
     instance_type: t2.micro
     image_id: ami-123456
+
+- name: start an instance with alternate instance types for capacity failures
+  amazon.aws.ec2_instance:
+    name: "resilient-instance"
+    vpc_subnet_id: subnet-5ca1ab1e
+    instance_type: t3.medium
+    alternate_instance_types:
+      - t3.small
+      - t2.medium
+      - t2.small
+    image_id: ami-123456
+    key_name: "prod-ssh-key"
+    security_group: default
+    tags:
+      Environment: Testing
 
 - name: add second ENI interface
   amazon.aws.ec2_instance:
@@ -1320,6 +1343,7 @@ instances:
 
 import time
 import uuid
+import copy
 from collections import namedtuple
 from typing import Any
 from typing import Dict
@@ -2518,7 +2542,7 @@ def ensure_present(
                 spec=instance_spec,
                 msg="Would have launched instances if not in check_mode.",
             )
-    instance_response = run_instances(client, **instance_spec)
+    instance_response = run_instances(client, module, **instance_spec)
     instances = instance_response["Instances"]
     instance_ids = [i["InstanceId"] for i in instances]
 
@@ -2579,14 +2603,95 @@ def ensure_present(
         )
 
 
-def run_instances(client, **instance_spec: Dict[str, Any]) -> Dict[str, Any]:
-    try:
-        return run_ec2_instances(client, **instance_spec)
-    except is_ansible_aws_error_message("Invalid IAM Instance Profile ARN"):
-        # If the instance profile has just been created, it takes some time to be visible by ec2
-        # So we wait 10 second and retry the run_instances
-        time.sleep(10)
-        return run_ec2_instances(client, **instance_spec)
+def run_instances(client, module: AnsibleAWSModule, **instance_spec: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Run EC2 instances with retry logic for InsufficientInstanceCapacity errors.
+    
+    If the primary instance type fails with InsufficientInstanceCapacity,
+    try alternate instance types specified in the module parameters.
+    """
+    # Get the primary instance type and alternate types
+    primary_instance_type = instance_spec.get("InstanceType")
+    alternate_instance_types = module.params.get("alternate_instance_types", [])
+    
+    # List of instance types to try (primary first, then alternates)
+    instance_types_to_try = [primary_instance_type] if primary_instance_type else []
+    if alternate_instance_types:
+        instance_types_to_try.extend(alternate_instance_types)
+    
+    # If no instance types to try, fallback to original behavior
+    if not instance_types_to_try:
+        try:
+            return run_ec2_instances(client, **instance_spec)
+        except is_ansible_aws_error_message("Invalid IAM Instance Profile ARN"):
+            # If the instance profile has just been created, it takes some time to be visible by ec2
+            # So we wait 10 second and retry the run_instances
+            time.sleep(10)
+            return run_ec2_instances(client, **instance_spec)
+    
+    last_error = None
+    
+    for i, instance_type in enumerate(instance_types_to_try):
+        # Create a copy of the instance spec with the current instance type
+        current_spec = copy.deepcopy(instance_spec)
+        current_spec["InstanceType"] = instance_type
+        
+        try:
+            result = run_ec2_instances(client, **current_spec)
+            
+            # If we successfully launched with an alternate instance type, update the module params
+            # to reflect the actually used instance type to prevent later modification attempts
+            if i > 0:
+                module.warn(f"Successfully launched instance with alternate instance type '{instance_type}' "
+                           f"after primary instance type '{primary_instance_type}' failed with InsufficientInstanceCapacity")
+                # Update the module parameters to reflect the actually used instance type
+                module.params["instance_type"] = instance_type
+            
+            return result
+            
+        except is_ansible_aws_error_message("Invalid IAM Instance Profile ARN"):
+            # If the instance profile has just been created, it takes some time to be visible by ec2
+            # So we wait 10 second and retry with the same instance type
+            time.sleep(10)
+            try:
+                result = run_ec2_instances(client, **current_spec)
+                
+                # If we successfully launched with an alternate instance type, update the module params
+                # to reflect the actually used instance type to prevent later modification attempts
+                if i > 0:
+                    module.warn(f"Successfully launched instance with alternate instance type '{instance_type}' "
+                               f"after primary instance type '{primary_instance_type}' failed with InsufficientInstanceCapacity")
+                    # Update the module parameters to reflect the actually used instance type
+                    module.params["instance_type"] = instance_type
+                
+                return result
+                
+            except is_ansible_aws_error_code("InsufficientInstanceCapacity") as e:
+                last_error = e
+                # If this is not the last instance type to try, continue to the next one
+                if i < len(instance_types_to_try) - 1:
+                    continue
+                else:
+                    # This was the last instance type to try, re-raise the error
+                    raise
+            except Exception as e:
+                # For any other error, re-raise immediately
+                raise
+                
+        except is_ansible_aws_error_code("InsufficientInstanceCapacity") as e:
+            last_error = e
+            # If this is not the last instance type to try, continue to the next one
+            if i < len(instance_types_to_try) - 1:
+                continue
+            else:
+                # This was the last instance type to try, re-raise the error
+                raise
+        except Exception as e:
+            # For any other error, re-raise immediately
+            raise
+    
+    # If we get here, all instance types failed with InsufficientInstanceCapacity
+    raise last_error
 
 
 def describe_default_subnet(client, module: AnsibleAWSModule, use_availability_zone: bool = True) -> str:
@@ -2680,6 +2785,7 @@ def main():
         ),
         image_id=dict(type="str"),
         instance_type=dict(type="str"),
+        alternate_instance_types=dict(type="list", elements="str"),
         user_data=dict(type="str"),
         aap_callback=dict(
             type="dict",

--- a/tests/integration/targets/ec2_instance/defaults/main.yml
+++ b/tests/integration/targets/ec2_instance/defaults/main.yml
@@ -1,0 +1,19 @@
+# Default variables for ec2_instance alternate types integration test
+
+# Instance type that is very unlikely to be available in most regions/AZs
+# This should trigger the alternate instance types fallback mechanism
+unlikely_instance_type: "x1e.xlarge"
+
+# Alternate instance types that should be commonly available
+# Listed in order of preference (first choice to last choice)
+backup_instance_type_1: "t3.micro"
+backup_instance_type_2: "t2.micro" 
+backup_instance_type_3: "t3.small"
+
+# Instance type that should definitely be available for control tests
+available_instance_type: "t3.micro"
+
+# Test configuration
+instance_wait_timeout: 300
+test_vpc_cidr: "10.0.0.0/16"
+test_subnet_cidr: "10.0.1.0/24"

--- a/tests/integration/targets/ec2_instance/meta/main.yml
+++ b/tests/integration/targets/ec2_instance/meta/main.yml
@@ -1,0 +1,3 @@
+dependencies:
+  - setup_ec2
+  - setup_remote_tmp_dir

--- a/tests/integration/targets/ec2_instance/tasks/main.yml
+++ b/tests/integration/targets/ec2_instance/tasks/main.yml
@@ -1,0 +1,287 @@
+---
+# Integration test for ec2_instance alternate_instance_types functionality
+# Tests the ability to fall back to alternate instance types when primary fails
+
+- name: Set up test environment
+  module_defaults:
+    group/aws:
+      access_key: "{{ aws_access_key }}"
+      secret_key: "{{ aws_secret_key }}"
+      session_token: "{{ aws_session_token | default(omit) }}"
+      region: "{{ aws_region }}"
+  block:
+    # Setup infrastructure
+    - name: Create VPC for testing
+      amazon.aws.ec2_vpc:
+        name: "{{ resource_prefix }}-vpc-alt-types"
+        cidr_block: 10.0.0.0/16
+        state: present
+        tags:
+          TestId: "{{ resource_prefix }}"
+          TestType: "alternate-instance-types"
+      register: test_vpc
+
+    - name: Create subnet
+      amazon.aws.ec2_vpc_subnet:
+        vpc_id: "{{ test_vpc.vpc.vpc_id }}"
+        cidr: 10.0.1.0/24
+        state: present
+        tags:
+          Name: "{{ resource_prefix }}-subnet-alt-types"
+          TestId: "{{ resource_prefix }}"
+      register: test_subnet
+
+    - name: Create security group
+      amazon.aws.ec2_security_group:
+        name: "{{ resource_prefix }}-sg-alt-types"
+        description: Security group for alternate instance types test
+        vpc_id: "{{ test_vpc.vpc.vpc_id }}"
+        rules:
+          - proto: tcp
+            ports: [22]
+            cidr_ip: 0.0.0.0/0
+        tags:
+          TestId: "{{ resource_prefix }}"
+        state: present
+      register: test_sg
+
+    # Test 1: Basic alternate instance types functionality
+    - name: "Test 1: Launch instance with alternate types (primary likely unavailable)"
+      amazon.aws.ec2_instance:
+        name: "{{ resource_prefix }}-test1-alternate"
+        image_id: "{{ ec2_ami_id }}"
+        instance_type: "{{ unlikely_instance_type }}"  # Likely to fail
+        alternate_instance_types:
+          - "{{ backup_instance_type_1 }}"
+          - "{{ backup_instance_type_2 }}"
+          - "{{ backup_instance_type_3 }}"
+        vpc_subnet_id: "{{ test_subnet.subnet.subnet_id }}"
+        security_groups:
+          - "{{ test_sg.group_id }}"
+        state: present
+        wait: true
+        wait_timeout: 300
+        tags:
+          TestId: "{{ resource_prefix }}"
+          TestCase: "alternate-fallback"
+      register: test1_result
+
+    - name: Verify Test 1 - Instance launched successfully
+      assert:
+        that:
+          - test1_result.changed
+          - test1_result.instances | length == 1
+          - test1_result.instances[0].state.name in ['running', 'pending']
+          - test1_result.instances[0].instance_type in [unlikely_instance_type, backup_instance_type_1, backup_instance_type_2, backup_instance_type_3]
+        fail_msg: "Test 1 failed: Instance was not launched successfully"
+
+    - name: Display Test 1 results
+      debug:
+        msg: |
+          Test 1 Results:
+          - Requested instance type: {{ unlikely_instance_type }}
+          - Actual instance type: {{ test1_result.instances[0].instance_type }}
+          - Alternate used: {{ test1_result.instances[0].instance_type != unlikely_instance_type }}
+
+    # Test 2: Primary instance type available (control test)
+    - name: "Test 2: Launch instance with available primary type"
+      amazon.aws.ec2_instance:
+        name: "{{ resource_prefix }}-test2-primary"
+        image_id: "{{ ec2_ami_id }}"
+        instance_type: "{{ available_instance_type }}"
+        alternate_instance_types:
+          - "{{ backup_instance_type_1 }}"
+          - "{{ backup_instance_type_2 }}"
+        vpc_subnet_id: "{{ test_subnet.subnet.subnet_id }}"
+        security_groups:
+          - "{{ test_sg.group_id }}"
+        state: present
+        wait: true
+        wait_timeout: 300
+        tags:
+          TestId: "{{ resource_prefix }}"
+          TestCase: "primary-available"
+      register: test2_result
+
+    - name: Verify Test 2 - Primary type used when available
+      assert:
+        that:
+          - test2_result.changed
+          - test2_result.instances | length == 1
+          - test2_result.instances[0].state.name in ['running', 'pending']
+          - test2_result.instances[0].instance_type == available_instance_type
+        fail_msg: "Test 2 failed: Primary instance type should have been used"
+
+    # Test 3: Idempotency check
+    - name: "Test 3: Verify idempotency (no changes on re-run)"
+      amazon.aws.ec2_instance:
+        name: "{{ resource_prefix }}-test1-alternate"
+        image_id: "{{ ec2_ami_id }}"
+        instance_type: "{{ unlikely_instance_type }}"
+        alternate_instance_types:
+          - "{{ backup_instance_type_1 }}"
+          - "{{ backup_instance_type_2 }}"
+          - "{{ backup_instance_type_3 }}"
+        vpc_subnet_id: "{{ test_subnet.subnet.subnet_id }}"
+        security_groups:
+          - "{{ test_sg.group_id }}"
+        state: present
+        wait: true
+        wait_timeout: 300
+        tags:
+          TestId: "{{ resource_prefix }}"
+          TestCase: "alternate-fallback"
+      register: test3_result
+
+    - name: Verify Test 3 - Idempotency maintained
+      assert:
+        that:
+          - not test3_result.changed
+          - test3_result.instances[0].instance_id == test1_result.instances[0].instance_id
+          - test3_result.instances[0].instance_type == test1_result.instances[0].instance_type
+        fail_msg: "Test 3 failed: Module should be idempotent after alternate type launch"
+
+    # Test 4: Multiple instances with exact_count
+    - name: "Test 4: Launch multiple instances with exact_count and alternates"
+      amazon.aws.ec2_instance:
+        image_id: "{{ ec2_ami_id }}"
+        instance_type: "{{ unlikely_instance_type }}"
+        alternate_instance_types:
+          - "{{ backup_instance_type_1 }}"
+          - "{{ backup_instance_type_2 }}"
+        vpc_subnet_id: "{{ test_subnet.subnet.subnet_id }}"
+        security_groups:
+          - "{{ test_sg.group_id }}"
+        exact_count: 2
+        filters:
+          tag:TestCase: "exact-count-alternate"
+          tag:TestId: "{{ resource_prefix }}"
+          instance-state-name: ["running", "pending"]
+        state: present
+        wait: true
+        wait_timeout: 300
+        tags:
+          TestId: "{{ resource_prefix }}"
+          TestCase: "exact-count-alternate"
+      register: test4_result
+
+    - name: Verify Test 4 - Exact count with alternates
+      assert:
+        that:
+          - test4_result.changed
+          - test4_result.instances | length == 2
+          - test4_result.instances | selectattr('state.name', 'in', ['running', 'pending']) | list | length == 2
+        fail_msg: "Test 4 failed: Should have launched exactly 2 instances"
+
+    # Test 5: Empty alternate list (should work normally)
+    - name: "Test 5: Launch with empty alternate_instance_types list"
+      amazon.aws.ec2_instance:
+        name: "{{ resource_prefix }}-test5-empty-alt"
+        image_id: "{{ ec2_ami_id }}"
+        instance_type: "{{ available_instance_type }}"
+        alternate_instance_types: []
+        vpc_subnet_id: "{{ test_subnet.subnet.subnet_id }}"
+        security_groups:
+          - "{{ test_sg.group_id }}"
+        state: present
+        wait: true
+        wait_timeout: 300
+        tags:
+          TestId: "{{ resource_prefix }}"
+          TestCase: "empty-alternates"
+      register: test5_result
+
+    - name: Verify Test 5 - Empty alternates list works
+      assert:
+        that:
+          - test5_result.changed
+          - test5_result.instances | length == 1
+          - test5_result.instances[0].instance_type == available_instance_type
+        fail_msg: "Test 5 failed: Empty alternate list should work normally"
+
+    # Test 6: No alternate_instance_types parameter (backward compatibility)
+    - name: "Test 6: Launch without alternate_instance_types parameter"
+      amazon.aws.ec2_instance:
+        name: "{{ resource_prefix }}-test6-no-alt"
+        image_id: "{{ ec2_ami_id }}"
+        instance_type: "{{ available_instance_type }}"
+        vpc_subnet_id: "{{ test_subnet.subnet.subnet_id }}"
+        security_groups:
+          - "{{ test_sg.group_id }}"
+        state: present
+        wait: true
+        wait_timeout: 300
+        tags:
+          TestId: "{{ resource_prefix }}"
+          TestCase: "no-alternates"
+      register: test6_result
+
+    - name: Verify Test 6 - Backward compatibility maintained
+      assert:
+        that:
+          - test6_result.changed
+          - test6_result.instances | length == 1
+          - test6_result.instances[0].instance_type == available_instance_type
+        fail_msg: "Test 6 failed: Backward compatibility broken"
+
+    # Summary
+    - name: Test Summary
+      debug:
+        msg: |
+          === Integration Test Results Summary ===
+          Test 1 (Alternate Fallback): {{ 'PASS' if test1_result.instances[0].state.name in ['running', 'pending'] else 'FAIL' }}
+            - Used instance type: {{ test1_result.instances[0].instance_type }}
+            - Alternate used: {{ test1_result.instances[0].instance_type != unlikely_instance_type }}
+          
+          Test 2 (Primary Available): {{ 'PASS' if test2_result.instances[0].instance_type == available_instance_type else 'FAIL' }}
+            - Used instance type: {{ test2_result.instances[0].instance_type }}
+          
+          Test 3 (Idempotency): {{ 'PASS' if not test3_result.changed else 'FAIL' }}
+            - Changes made: {{ test3_result.changed }}
+          
+          Test 4 (Exact Count): {{ 'PASS' if test4_result.instances | length == 2 else 'FAIL' }}
+            - Instances launched: {{ test4_result.instances | length }}
+          
+          Test 5 (Empty Alternates): {{ 'PASS' if test5_result.instances[0].instance_type == available_instance_type else 'FAIL' }}
+            - Used instance type: {{ test5_result.instances[0].instance_type }}
+          
+          Test 6 (No Alternates Param): {{ 'PASS' if test6_result.instances[0].instance_type == available_instance_type else 'FAIL' }}
+            - Used instance type: {{ test6_result.instances[0].instance_type }}
+
+  always:
+    # Cleanup
+    - name: Cleanup - Terminate all test instances
+      amazon.aws.ec2_instance:
+        filters:
+          tag:TestId: "{{ resource_prefix }}"
+          instance-state-name: ["running", "pending", "stopping", "stopped"]
+        state: terminated
+        wait: true
+        wait_timeout: 300
+      ignore_errors: true
+
+    - name: Cleanup - Delete security group
+      amazon.aws.ec2_security_group:
+        name: "{{ resource_prefix }}-sg-alt-types"
+        state: absent
+      ignore_errors: true
+
+    - name: Cleanup - Delete subnet
+      amazon.aws.ec2_vpc_subnet:
+        vpc_id: "{{ test_vpc.vpc.vpc_id }}"
+        cidr: 10.0.1.0/24
+        state: absent
+      ignore_errors: true
+      when: test_vpc is defined
+
+    - name: Cleanup - Delete VPC
+      amazon.aws.ec2_vpc:
+        name: "{{ resource_prefix }}-vpc-alt-types"
+        cidr_block: 10.0.0.0/16
+        state: absent
+      ignore_errors: true
+      when: test_vpc is defined
+
+    - name: Final cleanup status
+      debug:
+        msg: "Cleanup completed. All test resources should be removed."

--- a/tests/unit/plugins/modules/ec2_instance/test_alternate_instance_types.py
+++ b/tests/unit/plugins/modules/ec2_instance/test_alternate_instance_types.py
@@ -1,0 +1,147 @@
+#!/usr/bin/env python3
+
+"""
+Test script to verify the alternate instance types functionality.
+This script simulates the key parts of the retry logic.
+"""
+
+import copy
+from unittest.mock import Mock, MagicMock
+
+def simulate_run_instances(client, module, **instance_spec):
+    """
+    Simulate the run_instances function to test the retry logic.
+    """
+    
+    # Mock the exceptions for testing
+    def mock_is_ansible_aws_error_code(error_code):
+        def decorator(exception):
+            return exception.code == error_code
+        return decorator
+    
+    def mock_is_ansible_aws_error_message(error_message):
+        def decorator(exception):
+            return error_message in str(exception)
+        return decorator
+    
+    # Mock AWS exception
+    class MockAWSError(Exception):
+        def __init__(self, code, message):
+            self.code = code
+            self.message = message
+            super().__init__(message)
+    
+    # Mock run_ec2_instances function
+    def mock_run_ec2_instances(client, **spec):
+        instance_type = spec.get("InstanceType")
+        if instance_type == "t3.large":
+            raise MockAWSError("InsufficientInstanceCapacity", "Insufficient capacity for t3.large")
+        elif instance_type == "t3.medium":
+            raise MockAWSError("InsufficientInstanceCapacity", "Insufficient capacity for t3.medium")
+        elif instance_type == "t3.small":
+            # This one succeeds
+            return {"Instances": [{"InstanceId": "i-1234567890abcdef0", "InstanceType": "t3.small"}]}
+        else:
+            return {"Instances": [{"InstanceId": "i-1234567890abcdef0", "InstanceType": instance_type}]}
+    
+    # Get the primary instance type and alternate types
+    primary_instance_type = instance_spec.get("InstanceType")
+    alternate_instance_types = module.params.get("alternate_instance_types", [])
+    
+    # List of instance types to try (primary first, then alternates)
+    instance_types_to_try = [primary_instance_type] if primary_instance_type else []
+    if alternate_instance_types:
+        instance_types_to_try.extend(alternate_instance_types)
+    
+    # If no instance types to try, fallback to original behavior
+    if not instance_types_to_try:
+        return mock_run_ec2_instances(client, **instance_spec)
+    
+    last_error = None
+    
+    for i, instance_type in enumerate(instance_types_to_try):
+        # Create a copy of the instance spec with the current instance type
+        current_spec = copy.deepcopy(instance_spec)
+        current_spec["InstanceType"] = instance_type
+        
+        try:
+            result = mock_run_ec2_instances(client, **current_spec)
+            
+            # If we successfully launched with an alternate instance type, log a message
+            if i > 0:
+                print(f"Successfully launched instance with alternate instance type '{instance_type}' "
+                      f"after primary instance type '{primary_instance_type}' failed with InsufficientInstanceCapacity")
+            
+            return result
+            
+        except MockAWSError as e:
+            if e.code == "InsufficientInstanceCapacity":
+                last_error = e
+                # If this is not the last instance type to try, continue to the next one
+                if i < len(instance_types_to_try) - 1:
+                    print(f"Instance type '{instance_type}' failed with InsufficientInstanceCapacity, trying next alternate")
+                    continue
+                else:
+                    # This was the last instance type to try, re-raise the error
+                    raise
+            else:
+                # For any other error, re-raise immediately
+                raise
+    
+    # If we get here, all instance types failed with InsufficientInstanceCapacity
+    raise last_error
+
+# Test cases
+def test_alternate_instance_types():
+    print("Testing alternate instance types functionality...")
+    
+    # Test case 1: Primary instance type fails, alternate succeeds
+    print("\nTest case 1: Primary fails, alternate succeeds")
+    module = Mock()
+    module.params = {
+        "alternate_instance_types": ["t3.medium", "t3.small", "t2.micro"]
+    }
+    module.warn = Mock()
+    
+    instance_spec = {"InstanceType": "t3.large"}
+    
+    try:
+        result = simulate_run_instances(None, module, **instance_spec)
+        print("Success! Result:", result)
+    except Exception as e:
+        print("Failed:", e)
+    
+    # Test case 2: Primary instance type succeeds
+    print("\nTest case 2: Primary succeeds")
+    module = Mock()
+    module.params = {
+        "alternate_instance_types": ["t3.medium", "t3.small", "t2.micro"]
+    }
+    module.warn = Mock()
+    
+    instance_spec = {"InstanceType": "t2.micro"}
+    
+    try:
+        result = simulate_run_instances(None, module, **instance_spec)
+        print("Success! Result:", result)
+    except Exception as e:
+        print("Failed:", e)
+    
+    # Test case 3: All instance types fail
+    print("\nTest case 3: All instance types fail")
+    module = Mock()
+    module.params = {
+        "alternate_instance_types": ["t3.medium", "t3.large"]
+    }
+    module.warn = Mock()
+    
+    instance_spec = {"InstanceType": "t3.large"}
+    
+    try:
+        result = simulate_run_instances(None, module, **instance_spec)
+        print("Success! Result:", result)
+    except Exception as e:
+        print("Failed (expected):", e)
+
+if __name__ == "__main__":
+    test_alternate_instance_types()


### PR DESCRIPTION

##### SUMMARY
Adds feature for ec2_instance to retry with alternate instance types when instance insufficient capacity issue occurs
https://github.com/ansible-collections/amazon.aws/issues/2667

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
amazon.aws.ec2_instance

##### ADDITIONAL INFORMATION
https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/troubleshooting-launch.html#troubleshooting-launch-capacity
This PR resolves https://github.com/ansible-collections/amazon.aws/issues/2667
