### PR TITLE
add .github to ansible-lint exclude path

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,4 +3,5 @@ profile: production
 
 exclude_paths:
   - changelogs/changelog.yaml
+  - .github/
   - tests/integration


### PR DESCRIPTION
Found in PE review of this collection and attempting a quick fix PR for it. This will remove a few lining errors in the import log in automation hub.

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->

- Docs Pull Request



##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
