### PR TITLE
Drop py3.11 support in unit and sanity tests

### DIFF
--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -11,6 +11,14 @@ jobs:
           [
             {
               "ansible-version": "devel",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "devel",
               "python-version": "3.10"
             },
             {

--- a/.github/workflows/units.yml
+++ b/.github/workflows/units.yml
@@ -11,6 +11,14 @@ jobs:
           [
             {
               "ansible-version": "devel",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "milestone",
+              "python-version": "3.11"
+            },
+            {
+              "ansible-version": "devel",
               "python-version": "3.10"
             },
             {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

This PR drops Python 3.11 support for devel and milestone

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
