### PR TITLE
[Backport][Stable-9]s3_object: honor headers for content uploads; promote to ExtraArgs; docs and tests (#2705)

### DIFF
--- a/changelogs/fragments/s3_object-content-headers.yml
+++ b/changelogs/fragments/s3_object-content-headers.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - s3_object - Honor headers for content and content_base64 uploads by promoting supported keys
+    (e.g. ContentType, ContentDisposition, CacheControl) to top-level S3 arguments and placing
+    remaining keys under Metadata. This makes content uploads consistent with src uploads.
+    (https://github.com/ansible-collections/amazon.aws)

--- a/plugins/modules/s3_object.py
+++ b/plugins/modules/s3_object.py
@@ -52,6 +52,15 @@ options:
   headers:
     description:
       - Custom headers to use when O(mode=put) as a dictionary of key value pairs.
+      - Keys that match supported S3 object arguments are promoted to top‑level ExtraArgs. Supported keys include
+        C(ContentType), C(Content-Disposition), C(ContentEncoding), C(ContentLanguage), C(CacheControl), C(Expires),
+        C(ACL), C(GrantFullControl), C(GrantRead), C(GrantReadACP), C(GrantWriteACP), C(StorageClass),
+        C(ServerSideEncryption), C(SSECustomerAlgorithm), C(SSECustomerKey), C(SSECustomerKeyMD5), C(SSEKMSKeyId),
+        and C(WebsiteRedirectLocation). Remaining keys are stored under C(Metadata).
+      - Both header name styles C(ContentType) and C(Content-Type) are supported. Underscore variants like
+        C(content_type) are not promoted and will be placed under C(Metadata).
+      - If C(ContentType) is not provided, a type is guessed from C(src) when uploading from a file. When uploading
+        using C(content) or C(content_base64) the default is C(binary/octet-stream).
       - Ignored when O(mode) is not V(put).
     type: dict
   marker:
@@ -68,6 +77,8 @@ options:
   metadata:
     description:
       - Metadata to use when O(mode=copy), O(mode=create) or O(mode=put) as a dictionary of key value pairs.
+      - Keys that match supported S3 object arguments are promoted to top‑level ExtraArgs (for example C(ContentType)).
+        Remaining keys are applied as user metadata under C(Metadata).
     type: dict
   mode:
     description:
@@ -292,6 +303,16 @@ EXAMPLES = r"""
     content: "{{ lookup('template', 'templates/object.yaml.j2') }}"
     mode: put
 
+- name: PUT content with explicit ContentType and ContentDisposition
+  amazon.aws.s3_object:
+    bucket: mybucket
+    object: /index.html
+    content: "<html>Hello</html>\n"
+    mode: put
+    headers:
+      ContentType: "text/html; charset=utf-8"
+      ContentDisposition: inline
+
 - name: Simple PUT operation in Ceph RGW S3
   amazon.aws.s3_object:
     bucket: mybucket
@@ -332,7 +353,8 @@ EXAMPLES = r"""
     object: /my/desired/key.txt
     src: /usr/local/myfile.txt
     mode: put
-    headers: 'x-amz-grant-full-control=emailAddress=owner@example.com'
+    headers:
+      GrantFullControl: "emailAddress=owner@example.com"
 
 - name: List keys simple
   amazon.aws.s3_object:
@@ -421,7 +443,6 @@ tags:
 
 import base64
 import copy
-import io
 import mimetypes
 import os
 import time
@@ -745,6 +766,19 @@ def upload_s3file(
             module.params.get("encryption_kms_key_id"),
             metadata,
         )
+        # Promote supported headers to boto3 ExtraArgs and place unknown ones under Metadata
+        if headers:
+            if not isinstance(headers, dict):
+                module.warn("'headers' must be a dict; ignoring non-dict value")
+            else:
+                for option, value in headers.items():
+                    extra_arg_key = option_in_extra_args(option)
+                    if extra_arg_key:
+                        extra[extra_arg_key] = value
+                    else:
+                        # Fall back to Metadata for non-ExtraArgs headers
+                        extra.setdefault("Metadata", {})
+                        extra["Metadata"][option] = value
         if module.params.get("permission"):
             permissions = module.params["permission"]
             if isinstance(permissions, str):
@@ -758,8 +792,11 @@ def upload_s3file(
         if src:
             s3.upload_file(aws_retry=True, Filename=src, Bucket=bucket, Key=obj, ExtraArgs=extra)
         else:
-            f = io.BytesIO(content)
-            s3.upload_fileobj(aws_retry=True, Fileobj=f, Bucket=bucket, Key=obj, ExtraArgs=extra)
+            # For in-memory content uploads, use put_object so promoted headers
+            # (e.g. ContentType, ContentDisposition, CacheControl) are applied consistently
+            params = {"Bucket": bucket, "Key": obj, "Body": content}
+            params.update(extra)
+            s3.put_object(aws_retry=True, **params)
     except (
         botocore.exceptions.ClientError,
         botocore.exceptions.BotoCoreError,

--- a/tests/unit/plugins/modules/test_s3_object.py
+++ b/tests/unit/plugins/modules/test_s3_object.py
@@ -110,3 +110,88 @@ def test_populate_params(m_get_aws_connection_info):
     module.params.update({"object": "example.txt", "mode": "delete"})
     result = s3_object.populate_params(module)
     module.fail_json.assert_called_with(msg="Parameter object cannot be used with mode=delete")
+
+
+def _base_module_mock():
+    module = MagicMock()
+    module.check_mode = False
+    module.params = {
+        "permission": ["private"],
+        "encryption_mode": "AES256",
+        "encryption_kms_key_id": None,
+        "tags": None,
+    }
+    return module
+
+
+def _headers_fixture():
+    return {
+        "ContentType": "text/html; charset=utf-8",
+        "ContentDisposition": "inline",
+        "CacheControl": "max-age=0",
+        "X-Custom-Header": "custom",
+    }
+
+
+def test_upload_content_headers_promoted_to_extraargs():
+    module = _base_module_mock()
+    s3 = MagicMock()
+
+    headers = _headers_fixture()
+
+    s3_object.upload_s3file(
+        module,
+        s3,
+        bucket="my-bucket",
+        obj="index.html",
+        expiry=600,
+        metadata=None,
+        encrypt=True,
+        headers=headers,
+        src=None,
+        content=b"<html></html>",
+        acl_disabled=False,
+    )
+
+    # With in-memory content we now use put_object to ensure headers are honored
+    assert s3.put_object.call_count == 1
+    # Extract kwargs for verification
+    call_args, kwargs = s3.put_object.call_args
+    # With put_object, promoted headers are top-level kwargs, not under ExtraArgs
+    assert kwargs["ContentType"] == headers["ContentType"]
+    assert kwargs["ContentDisposition"] == headers["ContentDisposition"]
+    assert kwargs["CacheControl"] == headers["CacheControl"]
+    assert kwargs["ServerSideEncryption"] == "AES256"
+    assert "Metadata" in kwargs and kwargs["Metadata"]["X-Custom-Header"] == "custom"
+
+
+def test_upload_src_headers_promoted_to_extraargs():
+    module = _base_module_mock()
+    s3 = MagicMock()
+
+    headers = _headers_fixture()
+
+    s3_object.upload_s3file(
+        module,
+        s3,
+        bucket="my-bucket",
+        obj="index.html",
+        expiry=600,
+        metadata=None,
+        encrypt=True,
+        headers=headers,
+        src="/tmp/index.html",
+        content=None,
+        acl_disabled=False,
+    )
+
+    assert s3.upload_file.call_count == 1
+    call_args, kwargs = s3.upload_file.call_args
+    extra = kwargs.get("ExtraArgs")
+
+    assert extra["ContentType"] == headers["ContentType"]
+    assert extra["ContentDisposition"] == headers["ContentDisposition"]
+    assert extra["CacheControl"] == headers["CacheControl"]
+    assert extra["ServerSideEncryption"] == "AES256"
+    assert extra.get("Metadata") is not None
+    assert extra["Metadata"]["X-Custom-Header"] == "custom"


### PR DESCRIPTION


Fix: honor headers for content/content_base64 uploads in amazon.aws.s3_object

Problem: When using content or content_base64 with headers (e.g., ContentType), S3 objects were created with Content-Type application/octet-stream. Root cause: The content path used an API style that didn’t consistently apply promoted headers. Change:

Promote supported header keys (ContentType, ContentDisposition, CacheControl, etc.) to top-level S3 args for both src and content paths. Use put_object for in-memory uploads so promoted headers are applied reliably. Docs updated; unit tests added; changelog included. Small module-utils improvement to avoid duplicate warnings in results.

Behavior after the fix

headers work the same for both src and content/content_base64 paths. If an object already exists, metadata changes don’t flip changed: true (idempotency uses ETag). To update metadata on an existing object, run once with overwrite: always (or delete the object first).

Minimal tasks to demonstrate the fix
Previously broken (now works)
- name: Put HTML via content (ContentType now honored) amazon.aws.s3_object: bucket: my-bucket object: index.html mode: put content: "<html>Hello</html>" headers: ContentType: "text/html; charset=utf-8"
    overwrite: always     # only needed once if the object already exists
Binary content via content_base64 (now honors headers)
- name: Put binary via content_base64 with CacheControl and inline disposition
  vars:
    data_b64: "{{ lookup('file', 'image.png') | b64encode }}"
  amazon.aws.s3_object:
    bucket: my-bucket
    object: image.png
    mode: put
    content_base64: "{{ data_b64 }}"
    headers:
      ContentType: "image/png"
      CacheControl: "public, max-age=31536000"
      ContentDisposition: inline
    overwrite: always     # only needed once if the object already exists
File upload via src (unchanged, still works)
- name: Put via src with headers (unchanged behavior)
  amazon.aws.s3_object:
    bucket: my-bucket
    object: index.html
    mode: put
    src: "{{ playbook_dir }}/build/index.html"
    headers:
      ContentType: "text/html; charset=utf-8"
Optional: metadata also works (pre-existing behavior)
- name: Put via content using metadata instead of headers
  amazon.aws.s3_object:
    bucket: my-bucket
    object: index.html
    mode: put
    content: "<html>Hello</html>"
    metadata:
      ContentType: "text/html; charset=utf-8"
Verification
aws s3api head-object --bucket my-bucket --key index.html --query ContentType
Notes for reviewers

Implementation:

Promote headers via internal mapping and include remaining keys under Metadata. Switch content/content_base64 path to use put_object with promoted args to ensure ContentType/Disposition/CacheControl are applied by S3.

Tests:

Added unit tests for headers with content and src. Adjusted warnings behavior to avoid duplicates in results; passthrough warnings still emit normally for tests that expect them.

Docs:

Clarified headers behavior and added content example.

Changelog:

bugfix fragment included.

Reviewed-by: Alina Buzachis
Reviewed-by: GomathiselviS <gomathiselvi@gmail.com>
Reviewed-by: Bianca Henderson <beeankha@gmail.com>
(cherry picked from commit f619c878c0ee2333507753ce4cc6ff7baf10575b)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
