### PR TITLE
s3_bucket - Fix error when configuring non-KMS encryption and explicitly setting `bucket_key_encryption=False`

### DIFF
--- a/changelogs/fragments/2734-AES_explicit_bucket_key.yml
+++ b/changelogs/fragments/2734-AES_explicit_bucket_key.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- s3_bucket - fix error when configuring AES256 bucket encryption with ``bucket_key_enabled`` explicitly set to ``false`` (https://github.com/ansible-collections/amazon.aws/issues/2734).

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -861,9 +861,11 @@ def _handle_bucket_key_encryption(
     current_encryption_algorithm = current_encryption.get("SSEAlgorithm") if current_encryption else None
 
     if current_encryption_algorithm != "aws:kms":
-        raise AnsibleS3Error(
-            f'Unable to set bucket key: current encryption algorith ("{current_encryption_algorithm}") is not "aws:kms"'
-        )
+        if bucket_key_enabled:
+            raise AnsibleS3Error(
+                f'Unable to set bucket key: current encryption algorithm ("{current_encryption_algorithm}") is not "aws:kms"'
+            )
+        return False, current_encryption
 
     if get_bucket_key_enabled(s3_client, name) == bucket_key_enabled:
         return False, current_encryption

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_bucket_key.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_bucket_key.yml
@@ -37,6 +37,7 @@
         that:
           - output.changed
           - output.encryption != {}
+          - output.encryption.SSEAlgorithm == 'aws:kms'
 
     - name: Re-enable bucket key for bucket with aws:kms encryption (idempotent)
       amazon.aws.s3_bucket:
@@ -50,38 +51,37 @@
         that:
           - not output.changed
           - output.encryption != {}
+          - output.encryption.SSEAlgorithm == 'aws:kms'
 
-    ## # ============================================================
-    ##
-    ## AWS S3 no longer supports disabling S3 encryption
-    ## https://docs.aws.amazon.com/AmazonS3/latest/userguide/default-encryption-faq.html
-    ##
-    ## - name: Disable encryption from bucket
-    ##   amazon.aws.s3_bucket:
-    ##     name: "{{ local_bucket_name }}"
-    ##     encryption: none
-    ##     bucket_key_enabled: false
-    ##   register: output
-    ##
-    ## - name: Assert for 'Disable encryption from bucket'
-    ##   assert:
-    ##     that:
-    ##       - output.changed
-    ##       - not output.encryption
-    ##
-    ## - name: Disable encryption from bucket (idempotent)
-    ##   amazon.aws.s3_bucket:
-    ##     name: "{{ local_bucket_name }}"
-    ##     bucket_key_enabled: true
-    ##   register: output
-    ##
-    ## - name: Assert for 'Disable encryption from bucket (idempotent)'
-    ##   assert:
-    ##     that:
-    ##       - output is not changed
-    ##       - not output.encryption
-    ##
-    ## # ============================================================
+    # ============================================================
+
+    - name: Disable bucket key for bucket with aws:kms encryption
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        bucket_key_enabled: false
+      register: output
+
+    - name: Assert for 'Disable bucket key for bucket with aws:kms encryption'
+      assert:
+        that:
+          - output.changed
+          - output.encryption != {}
+          - output.encryption.SSEAlgorithm == 'aws:kms'
+
+    - name:  Disable bucket key for bucket with aws:kms encryption (idempotent)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        bucket_key_enabled: false
+      register: output
+
+    - name: Assert for 'Disable bucket key for bucket with aws:kms encryption (idempotent)'
+      assert:
+        that:
+          - output is not changed
+          - output.encryption != {}
+          - output.encryption.SSEAlgorithm == 'aws:kms'
+
+    # ============================================================
 
     - name: Delete encryption test s3 bucket
       amazon.aws.s3_bucket:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_sse.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/encryption_sse.yml
@@ -43,6 +43,20 @@
           - output.encryption != {}
           - output.encryption.SSEAlgorithm == 'AES256'
 
+    - name: Re-enable AES256 encryption with bucket_key_enabled=False (Issue 2734)
+      amazon.aws.s3_bucket:
+        name: "{{ local_bucket_name }}"
+        state: present
+        encryption: AES256
+        bucket_key_enabled: false
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - not output.changed
+          - output.encryption != {}
+          - output.encryption.SSEAlgorithm == 'AES256'
+
     ## # ============================================================
     ##
     ## AWS S3 no longer supports disabling S3 encryption


### PR DESCRIPTION
##### SUMMARY

Fixes: #2734 

"Bucket Key" encryption (the use of a single data key for the whole bucket, instead of per-object data keys), can only be enabled when using KMS encryption.  The test to prevent people from enabling the feature when using a different encryption mode was too broad and would throw an error if `bucket_key_encryption` was explicitly set to false, rather than just not set.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

s3_bucket

##### ADDITIONAL INFORMATION