### PR TITLE
[stable-9][backport]sanity/devel - remove use of module ansible.module_utils.six (#2727)

### DIFF
--- a/changelogs/fragments/20250924-sanity-fixes.yml
+++ b/changelogs/fragments/20250924-sanity-fixes.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - Remove ``ansible.module_utils.six`` imports to avoid warnings (https://github.com/ansible-collections/amazon.aws/pull/2727).

--- a/plugins/lookup/secretsmanager_secret.py
+++ b/plugins/lookup/secretsmanager_secret.py
@@ -126,7 +126,6 @@ except ImportError:
 
 from ansible.errors import AnsibleLookupError
 from ansible.module_utils._text import to_native
-from ansible.module_utils.six import string_types
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message
@@ -156,19 +155,19 @@ class LookupModule(AWSLookupBase):
 
         # validate arguments 'on_missing' and 'on_denied'
         if on_missing is not None and (
-            not isinstance(on_missing, string_types) or on_missing.lower() not in ["error", "warn", "skip"]
+            not isinstance(on_missing, str) or on_missing.lower() not in ["error", "warn", "skip"]
         ):
             raise AnsibleLookupError(
                 f'"on_missing" must be a string and one of "error", "warn" or "skip", not {on_missing}'
             )
         if on_denied is not None and (
-            not isinstance(on_denied, string_types) or on_denied.lower() not in ["error", "warn", "skip"]
+            not isinstance(on_denied, str) or on_denied.lower() not in ["error", "warn", "skip"]
         ):
             raise AnsibleLookupError(
                 f'"on_denied" must be a string and one of "error", "warn" or "skip", not {on_denied}'
             )
         if on_deleted is not None and (
-            not isinstance(on_deleted, string_types) or on_deleted.lower() not in ["error", "warn", "skip"]
+            not isinstance(on_deleted, str) or on_deleted.lower() not in ["error", "warn", "skip"]
         ):
             raise AnsibleLookupError(
                 f'"on_deleted" must be a string and one of "error", "warn" or "skip", not {on_deleted}'

--- a/plugins/lookup/ssm_parameter.py
+++ b/plugins/lookup/ssm_parameter.py
@@ -146,7 +146,6 @@ except ImportError:
 
 from ansible.errors import AnsibleLookupError
 from ansible.module_utils._text import to_native
-from ansible.module_utils.six import string_types
 from ansible.utils.display import Display
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
@@ -173,13 +172,13 @@ class LookupModule(AWSLookupBase):
 
         # validate arguments 'on_missing' and 'on_denied'
         if on_missing is not None and (
-            not isinstance(on_missing, string_types) or on_missing.lower() not in ["error", "warn", "skip"]
+            not isinstance(on_missing, str) or on_missing.lower() not in ["error", "warn", "skip"]
         ):
             raise AnsibleLookupError(
                 f'"on_missing" must be a string and one of "error", "warn" or "skip", not {on_missing}'
             )
         if on_denied is not None and (
-            not isinstance(on_denied, string_types) or on_denied.lower() not in ["error", "warn", "skip"]
+            not isinstance(on_denied, str) or on_denied.lower() not in ["error", "warn", "skip"]
         ):
             raise AnsibleLookupError(
                 f'"on_denied" must be a string and one of "error", "warn" or "skip", not {on_denied}'

--- a/plugins/module_utils/botocore.py
+++ b/plugins/module_utils/botocore.py
@@ -79,8 +79,6 @@ except ImportError:
 from ansible.module_utils._text import to_native
 from ansible.module_utils.ansible_release import __version__
 from ansible.module_utils.basic import missing_required_lib
-from ansible.module_utils.six import binary_type
-from ansible.module_utils.six import text_type
 
 from .common import get_collection_info
 from .exceptions import AnsibleBotocoreError
@@ -291,8 +289,8 @@ def _aws_connection_info(params: Dict) -> Tuple[Optional[str], Optional[str], Di
         boto_params["aws_config"] = botocore.config.Config(**config)
 
     for param, value in boto_params.items():
-        if isinstance(value, binary_type):
-            boto_params[param] = text_type(value, "utf-8", "strict")
+        if isinstance(value, bytes):
+            boto_params[param] = str(value, "utf-8", "strict")
 
     return region, endpoint_url, boto_params
 

--- a/plugins/module_utils/ec2.py
+++ b/plugins/module_utils/ec2.py
@@ -53,8 +53,6 @@ from ansible.module_utils.common.dict_transformations import _camel_to_snake  # 
 from ansible.module_utils.common.dict_transformations import _snake_to_camel  # pylint: disable=unused-import
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict  # pylint: disable=unused-import
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict  # pylint: disable=unused-import
-from ansible.module_utils.six import integer_types
-from ansible.module_utils.six import string_types
 
 # Used to live here, moved into ansible_collections.amazon.aws.plugins.module_utils.arn
 from .arn import is_outpost_arn as is_outposts_arn  # pylint: disable=unused-import
@@ -1534,7 +1532,7 @@ def get_ec2_security_group_ids_from_names(sec_group_list, ec2_connection, vpc_id
 
     sec_group_id_list = []
 
-    if isinstance(sec_group_list, string_types):
+    if isinstance(sec_group_list, str):
         sec_group_list = [sec_group_list]
 
     # Get all security groups
@@ -1763,7 +1761,7 @@ def normalize_ec2_vpc_dhcp_config(option_config: List[Dict[str, Any]]) -> Dict[s
     for config_item in option_config:
         # Handle single value keys
         if config_item["Key"] == "netbios-node-type":
-            if isinstance(config_item["Values"], integer_types):
+            if isinstance(config_item["Values"], int):
                 config_data["netbios-node-type"] = str((config_item["Values"]))
             elif isinstance(config_item["Values"], list):
                 config_data["netbios-node-type"] = str((config_item["Values"][0]["Value"]))
@@ -1849,7 +1847,7 @@ def describe_ec2_mac_dedicated_hosts(
 @AWSRetry.jittered_backoff()
 def release_ec2_dedicated_host(client, host_id: Union[str, List[str]]) -> bool:
     host_ids = host_id
-    if isinstance(host_id, string_types):
+    if isinstance(host_id, str):
         host_ids = [host_id]
     client.release_hosts(HostIds=host_ids)
     return True
@@ -1871,6 +1869,6 @@ def modify_ec2_dedicated_hosts(
     **params: Dict[str, Union[List[str], List[Dict[str, Union[str, List[str]]]]]],
 ) -> Dict[str, Any]:
     host_ids = host_id
-    if isinstance(host_id, string_types):
+    if isinstance(host_id, str):
         host_ids = [host_id]
     return client.modify_hosts(HostIds=host_ids, **params)

--- a/plugins/module_utils/policy.py
+++ b/plugins/module_utils/policy.py
@@ -31,8 +31,6 @@
 from functools import cmp_to_key
 
 from ansible.module_utils._text import to_text
-from ansible.module_utils.six import binary_type
-from ansible.module_utils.six import string_types
 
 
 def _canonify_root_arn(arn):
@@ -91,7 +89,7 @@ def _hashable_policy(policy, policy_list):
             hashed_policy = _hashable_policy(each, [])
             tupleified = _tuplify_list(hashed_policy)
             policy_list.append(tupleified)
-    elif isinstance(policy, string_types) or isinstance(policy, binary_type):
+    elif isinstance(policy, str) or isinstance(policy, bytes):
         policy = to_text(policy)
         # convert root account ARNs to just account IDs
         policy = _canonify_root_arn(policy)

--- a/plugins/module_utils/tagging.py
+++ b/plugins/module_utils/tagging.py
@@ -30,7 +30,6 @@
 
 from ansible.module_utils._text import to_native
 from ansible.module_utils._text import to_text
-from ansible.module_utils.six import string_types
 
 
 def boto3_tag_list_to_ansible_dict(tags_list, tag_name_key_name=None, tag_value_key_name=None):
@@ -170,7 +169,7 @@ def boto3_tag_specifications(tags_dict, types=None):
         specifications.append(dict(Tags=tag_list))
         return specifications
 
-    if isinstance(types, string_types):
+    if isinstance(types, str):
         types = [types]
 
     for type_name in types:

--- a/plugins/module_utils/transformation.py
+++ b/plugins/module_utils/transformation.py
@@ -39,8 +39,6 @@ from typing import Sequence
 from typing import Union
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-from ansible.module_utils.six import integer_types
-from ansible.module_utils.six import string_types
 
 from .botocore import normalize_boto3_result
 from .tagging import boto3_tag_list_to_ansible_dict
@@ -78,9 +76,9 @@ def ansible_dict_to_boto3_filter_list(filters_dict):
         filter_dict = {"Name": k}
         if isinstance(v, bool):
             filter_dict["Values"] = [str(v).lower()]
-        elif isinstance(v, integer_types):
+        elif isinstance(v, int):
             filter_dict["Values"] = [str(v)]
-        elif isinstance(v, string_types):
+        elif isinstance(v, str):
             filter_dict["Values"] = [v]
         else:
             filter_dict["Values"] = v

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1338,7 +1338,6 @@ except ImportError:
 from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
-from ansible.module_utils.six import string_types
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleEC2Error
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import associate_iam_instance_profile
@@ -1580,7 +1579,7 @@ def build_network_spec(client, module: AnsibleAWSModule) -> List[Dict[str, Any]]
         # handle list of `network.interfaces` options
         interfaces.extend(
             [
-                {"DeviceIndex": idx, "NetworkInterfaceId": inty if isinstance(inty, string_types) else inty.get("id")}
+                {"DeviceIndex": idx, "NetworkInterfaceId": inty if isinstance(inty, str) else inty.get("id")}
                 for idx, inty in enumerate(network.get("interfaces", []))
             ]
         )
@@ -2634,7 +2633,7 @@ def build_filters(client, module: AnsibleAWSModule) -> Dict[str, Any]:
     instance_state_names = ["pending", "running", "stopping", "stopped"]
     filters = {}
     instance_ids = module.params.get("instance_ids")
-    if isinstance(instance_ids, string_types):
+    if isinstance(instance_ids, str):
         filters = {"instance-id": [instance_ids], "instance-state-name": instance_state_names}
     elif isinstance(instance_ids, list) and len(instance_ids):
         filters = {"instance-id": instance_ids, "instance-state-name": instance_state_names}

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -581,7 +581,6 @@ from ansible.module_utils._text import to_text
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.network import to_ipv6_subnet
 from ansible.module_utils.common.network import to_subnet
-from ansible.module_utils.six import string_types
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleEC2Error
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import authorize_security_group_egress
@@ -1326,10 +1325,10 @@ def get_diff_final_resource(client, module, security_group):
                 format_rule.pop("from_port")
                 format_rule.pop("to_port")
             elif rule.get("ports"):
-                if rule.get("ports") and (isinstance(rule["ports"], string_types) or isinstance(rule["ports"], int)):
+                if rule.get("ports") and (isinstance(rule["ports"], str) or isinstance(rule["ports"], int)):
                     rule["ports"] = [rule["ports"]]
                 for port in rule.get("ports"):
-                    if isinstance(port, string_types) and "-" in port:
+                    if isinstance(port, str) and "-" in port:
                         format_rule["from_port"], format_rule["to_port"] = port.split("-")
                     else:
                         format_rule["from_port"] = format_rule["to_port"] = port
@@ -1428,7 +1427,7 @@ def flatten_nested_targets(module, rules):
                     collection_name="amazon.aws",
                 )
                 yield from _flatten(target)
-            elif isinstance(target, string_types):
+            elif isinstance(target, str):
                 yield target
 
     if rules is not None:

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -261,7 +261,6 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-from ansible.module_utils.six import string_types
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import normalize_boto3_result
@@ -430,7 +429,7 @@ def setup_removal(client, module: AnsibleAWSModule) -> Tuple[bool, Dict[str, Any
         return changed, result
 
     vpc_endpoint_ids = module.params.get("vpc_endpoint_id")
-    if isinstance(vpc_endpoint_ids, string_types):
+    if isinstance(vpc_endpoint_ids, str):
         vpc_endpoint_ids = [vpc_endpoint_ids]
 
     try:

--- a/plugins/modules/iam_policy.py
+++ b/plugins/modules/iam_policy.py
@@ -162,7 +162,6 @@ try:
 except ImportError:
     pass
 
-from ansible.module_utils.six import string_types
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
@@ -248,7 +247,7 @@ class Policy:
         return None
 
     def get_policy_from_json(self):
-        if isinstance(self.policy_json, string_types):
+        if isinstance(self.policy_json, str):
             pdoc = json.loads(self.policy_json)
         else:
             pdoc = self.policy_json

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -889,7 +889,6 @@ from typing import Optional
 
 from ansible.module_utils._text import to_text
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-from ansible.module_utils.six import string_types
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
@@ -1306,7 +1305,7 @@ def get_changing_options_with_inconsistent_keys(
                 elif set(desired_option) <= set(current_option):
                     # Desired option set is entirely contained within current option set and purge is False, nothing to change
                     continue
-            elif isinstance(desired_option, string_types):
+            elif isinstance(desired_option, str):
                 # Current option is a list and desired option is a string
                 if desired_option in current_option:
                     # Desired option is in current options, nothing to change

--- a/plugins/modules/rds_instance_param_group.py
+++ b/plugins/modules/rds_instance_param_group.py
@@ -113,7 +113,6 @@ except ImportError:
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.parsing.convert_bool import BOOLEANS_TRUE
-from ansible.module_utils.six import string_types
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
@@ -146,7 +145,7 @@ def convert_parameter(param, value):
     converted_value = value
 
     if param["DataType"] == "integer":
-        if isinstance(value, string_types):
+        if isinstance(value, str):
             try:
                 for name, modifier in INT_MODIFIERS.items():
                     if value.endswith(name):
@@ -159,7 +158,7 @@ def convert_parameter(param, value):
             converted_value = 1 if value else 0
 
     elif param["DataType"] == "boolean":
-        if isinstance(value, string_types):
+        if isinstance(value, str):
             converted_value = value in BOOLEANS_TRUE
         # convert True/False to 1/0
         converted_value = 1 if converted_value else 0

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -555,7 +555,6 @@ except ImportError:
 
 from ansible.module_utils.basic import to_text
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
-from ansible.module_utils.six import string_types
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
@@ -758,7 +757,7 @@ def handle_bucket_policy(s3_client, module: AnsibleAWSModule, name: str) -> Tupl
         module.fail_json_aws(e, msg="Failed to get bucket policy")
     else:
         if policy is not None:
-            if isinstance(policy, string_types):
+            if isinstance(policy, str):
                 policy = json.loads(policy)
 
             if not policy and current_policy:

--- a/tests/integration/targets/rds_cluster_snapshot/tasks/main.yml
+++ b/tests/integration/targets/rds_cluster_snapshot/tasks/main.yml
@@ -224,10 +224,13 @@
         that:
           - _result_delete_snapshot.changed
 
-    - name: Get info of the existing DB cluster
+    - name: Ensure DB cluster is in available state
       amazon.aws.rds_cluster_info:
         cluster_id: "{{ cluster_id }}"
       register: _result_cluster_info
+      retries: 30
+      delay: 5
+      until: _result_cluster_info.clusters[0].status == "available"
 
     - ansible.builtin.assert:
         that:

--- a/tests/unit/plugins/module_utils/conftest.py
+++ b/tests/unit/plugins/module_utils/conftest.py
@@ -14,8 +14,6 @@ import ansible.module_utils.basic
 import ansible.module_utils.common
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
-from ansible.module_utils.six import PY3
-from ansible.module_utils.six import string_types
 
 
 @pytest.fixture(name="stdin")
@@ -33,7 +31,7 @@ def fixture_stdin(mocker, request):
             # No need to reset the value
             warnings.warn("deprecated")
 
-    if isinstance(request.param, string_types):
+    if isinstance(request.param, str):
         args = request.param
     elif isinstance(request.param, MutableMapping):
         if "ANSIBLE_MODULE_ARGS" not in request.param:
@@ -47,11 +45,8 @@ def fixture_stdin(mocker, request):
         raise Exception("Malformed data to the stdin pytest fixture")
 
     fake_stdin = BytesIO(to_bytes(args, errors="surrogate_or_strict"))
-    if PY3:
-        mocker.patch("ansible.module_utils.basic.sys.stdin", mocker.MagicMock())
-        mocker.patch("ansible.module_utils.basic.sys.stdin.buffer", fake_stdin)
-    else:
-        mocker.patch("ansible.module_utils.basic.sys.stdin", fake_stdin)
+    mocker.patch("ansible.module_utils.basic.sys.stdin", mocker.MagicMock())
+    mocker.patch("ansible.module_utils.basic.sys.stdin.buffer", fake_stdin)
 
     yield fake_stdin
 

--- a/tests/unit/plugins/modules/conftest.py
+++ b/tests/unit/plugins/modules/conftest.py
@@ -9,12 +9,11 @@ import pytest
 
 from ansible.module_utils._text import to_bytes
 from ansible.module_utils.common._collections_compat import MutableMapping
-from ansible.module_utils.six import string_types
 
 
 @pytest.fixture
 def patch_ansible_module(request, mocker):
-    if isinstance(request.param, string_types):
+    if isinstance(request.param, str):
         args = request.param
     elif isinstance(request.param, MutableMapping):
         if "ANSIBLE_MODULE_ARGS" not in request.param:

--- a/tests/unit/plugins/plugin_utils/inventory/test_inventory_base.py
+++ b/tests/unit/plugins/plugin_utils/inventory/test_inventory_base.py
@@ -13,7 +13,6 @@ import pytest
 
 import ansible.plugins.inventory as base_inventory
 from ansible.errors import AnsibleError
-from ansible.module_utils.six import string_types
 
 import ansible_collections.amazon.aws.plugins.plugin_utils.inventory as utils_inventory
 
@@ -79,7 +78,7 @@ class AwsUnitTestTemplar:
         return bool(m)
 
     def is_template(self, data):
-        if isinstance(data, string_types):
+        if isinstance(data, str):
             return self.is_template_string(data)
         elif isinstance(data, (list, tuple)):
             for v in data:


### PR DESCRIPTION
SUMMARY

Remove use of  ansible.module_utils.six library

ISSUE TYPE

Bugfix Pull Request

COMPONENT NAME

CI

Reviewed-by: Bianca Henderson <beeankha@gmail.com>
Reviewed-by: Alina Buzachis
(cherry picked from commit d056b1259079286e8def78f42a8bfe3649e372e1)

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
