### PR TITLE
Fixed ReferenceError in aws_ssm destructor (Fixes #2728)

### DIFF
--- a/changelogs/fragments/2728-reference_error_ssm_destructor.yml
+++ b/changelogs/fragments/2728-reference_error_ssm_destructor.yml
@@ -1,0 +1,2 @@
+bugfixes:
+- connection/aws_ssm - fixed ReferenceError in aws_ssm connection plugin destructor during interpreter shutdown (https://github.com/ansible-collections/amazon.aws/issues/2728).

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -499,7 +499,10 @@ class Connection(ConnectionBase, AwsConnectionPluginBase):
         self._instance_id = instance_id
 
     def __del__(self) -> None:
-        self.close()
+        try:
+            self.close()
+        except Exception:
+            pass
 
     def _connect(self) -> Any:
         """connect to the host via ssm"""

--- a/plugins/plugin_utils/ssm/sessionmanager.py
+++ b/plugins/plugin_utils/ssm/sessionmanager.py
@@ -192,5 +192,8 @@ class SSMSessionManager:
         if self._process_mgr:
             self._process_mgr.terminate()
         if self._session_id and self._client:
-            self._client.terminate_session(SessionId=self._session_id)
+            try:
+                self._client.terminate_session(SessionId=self._session_id)
+            except Exception:
+                pass
             self._session_id = None

--- a/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
@@ -144,6 +144,12 @@ class TestConnectionBaseClass:
             session_manager.terminate.assert_not_called()
         assert loaded_aws_ssm.session_manager is None
 
+    def test_plugins_connection_aws_ssm_del_handles_exceptions(self, loaded_aws_ssm):
+        """Test that __del__ handles exceptions gracefully during shutdown"""
+        loaded_aws_ssm.close = MagicMock(side_effect=ReferenceError("weakly-referenced object no longer exists"))
+        loaded_aws_ssm.__del__()
+        loaded_aws_ssm.close.assert_called_once()
+
     @pytest.mark.parametrize("level", ["invalid value", 5, -1])
     @patch("ansible_collections.amazon.aws.plugins.connection.aws_ssm.display")
     def test_verbosity_diplay_invalid_level(self, mock_display, loaded_aws_ssm, level):


### PR DESCRIPTION
##### SUMMARY
Fixed ReferenceError in aws_ssm connection plugin destructor during interpreter shutdown.

The `__del__` method in the aws_ssm connection plugin was calling `close()`, which attempted to terminate the SSM session via boto3. During Python interpreter shutdown, weakly-referenced objects may already be garbage collected, causing a `ReferenceError: weakly-referenced object no longer exists` that produced noisy tracebacks even though functionality worked correctly.

This fix adds exception handling in both the `Connection.__del__` method and `SSMSessionManager.terminate` method to suppress exceptions during shutdown, following Python best practices for destructor methods. A unit test was added to verify the destructor handles exceptions gracefully.

Fixes #2728 

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_ssm (connection plugin)

##### ADDITIONAL INFORMATION
**Changes made:**
1. Wrapped `self.close()` in `Connection.__del__` with try-except to suppress exceptions during shutdown
2. Added defensive exception handling in `SSMSessionManager.terminate` to catch exceptions when the boto3 client is invalidated
3. Added unit test `test_plugins_connection_aws_ssm_del_handles_exceptions` to verify the fix

**Testing:**
- All existing unit tests pass
- New test verifies that `__del__` handles ReferenceError exceptions gracefully
- No linter errors introduced

**Before:**
```
Exception ignored in: <function Connection.del at 0x...>
Traceback (most recent call last):
File ".../aws_ssm.py", line 502, in del
self.close()
...
ReferenceError: weakly-referenced object no longer exists
```

**After:**
No exceptions are raised during interpreter shutdown.