### PR TITLE
Remove deprecated method disable_lookups as no longer supported in ansible-core 2.19/Ansible 12

### DIFF
--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -670,7 +670,7 @@ class InventoryModule(AWSInventoryBase):
                 template_var = "{{%s|%s}}" % (hostname, jinja2_filter)
             if trust_as_template:
                 template_var = trust_as_template(template_var)
-            hostname = self.templar.template(variable=template_var, disable_lookups=False)
+            hostname = self.templar.template(variable=template_var)
         if isinstance(hostname, list) and return_single_hostname:
             hostname = hostname[0] if hostname else None
         return hostname

--- a/plugins/plugin_utils/inventory.py
+++ b/plugins/plugin_utils/inventory.py
@@ -56,14 +56,14 @@ class AWSInventoryBase(BaseInventoryPlugin, Constructable, Cacheable, AWSPluginB
                 return value
 
             if isinstance(value, dict):
-                return {k: self.templar.template(variable=v, disable_lookups=False) for k, v in value.items()}
+                return {k: self.templar.template(variable=v) for k, v in value.items()}
             if isinstance(value, list):
-                return [self.templar.template(variable=v, disable_lookups=False) for v in value]
+                return [self.templar.template(variable=v) for v in value]
 
             if not self.templar.is_template(value):
                 return value
 
-            return self.templar.template(variable=value, disable_lookups=False)
+            return self.templar.template(variable=value)
 
     def get_options(self, *args):
         return self.TemplatedOptions(self.templar, super().get_options(*args))


### PR DESCRIPTION
In ansible-core 2.19/Ansible 12, the inventory plugins throws unwanted deprecated warning for disable_lookups, as it is not supported anymore to pass to the template.

##### SUMMARY
In ansible-core 2.19/Ansible 12, the inventory plugins throws unwanted warnings due to use of disable_lookups=False, hence this warning appears in every ansible command that is run using amazon.aws collection. 

In the docs: https://docs.ansible.com/ansible/latest/porting_guides/porting_guide_12.html
`templating - The disable_lookups option has no effect, since plugins must be updated to apply trust before any templating can be performed.`

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/template_lookup.html

After the removal of disable_lookup the warning disappear, tested both using Ansible 11.11.0 and Ansible 12.1.0

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
- Bugfix Pull Request


##### COMPONENT NAME
`plugins/inventory/aws-rds.py`
`plugins/inventory/aws-ec2.py`

##### ADDITIONAL INFORMATION
Getting warning initially like: 

[WARNING]: Deprecation warnings can be disabled by setting `deprecation_warnings=False` in ansible.cfg.
[DEPRECATION WARNING]: Passing `disable_lookups` to `template` is deprecated. This feature will be removed from ansible-core version 2.23.

After the fix the warning goes away.

