### PR TITLE
ec2_vol.py - Check if instance is found, fail if not

### DIFF
--- a/plugins/modules/ec2_vol.py
+++ b/plugins/modules/ec2_vol.py
@@ -757,7 +757,7 @@ def ensure_present(ec2_conn, module: AnsibleAWSModule, volume: Optional[Dict[str
     if instance:
         inst = get_instance(module, ec2_conn, instance_id=instance)
         if not inst:
-          module.fail_json(msg="Could not find instance, make sure the region is correct") # TODO, print the region that we _think_ the instance is in to help the user see if they've entered the wrong region 
+          module.fail_json(msg="Could not find instance, make sure the region is correct")
         zone = inst["placement"]["availability_zone"]
 
         # Use platform attribute to guess whether the instance is Windows or Linux


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

Add check to see if we get nothing back from querying the instance and fail with a descriptive error message if we don't get what we expect.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
ec2_vol.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

I ran into this issue when testing, I had entered the wrong region and it was searching for the instance ID in the wrong region. Since it never checks if we got valid data back, when we try and get an element from the NoneType, we get an error "TypeError: 'NoneType' object is not subscriptable." It took a long time to diagnose this and would be easier if I had a more descriptive error message.

<!--- Paste verbatim command output below, e.g. before and after your change -->
BEFORE:
```
The full traceback is:
Traceback (most recent call last):
  File "/home/eduffy/.ansible/tmp/ansible-tmp-1762890595.753122-2769440-87527233413948/AnsiballZ_ec2_vol.py", line 107, in <module>
    _ansiballz_main()
    ~~~~~~~~~~~~~~~^^
  File "/home/eduffy/.ansible/tmp/ansible-tmp-1762890595.753122-2769440-87527233413948/AnsiballZ_ec2_vol.py", line 99, in _ansiballz_main
    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/eduffy/.ansible/tmp/ansible-tmp-1762890595.753122-2769440-87527233413948/AnsiballZ_ec2_vol.py", line 47, in invoke_module
    runpy.run_module(mod_name='ansible_collections.amazon.aws.plugins.modules.ec2_vol', init_globals=dict(_module_fqn='ansible_collections.amazon.aws.plugins.modules.ec2_vol', _modlib_path=modlib_path),
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                     run_name='__main__', alter_sys=True)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen runpy>", line 226, in run_module
  File "<frozen runpy>", line 98, in _run_module_code
  File "<frozen runpy>", line 88, in _run_code
  File "/tmp/ansible_amazon.aws.ec2_vol_payload_w3dsolga/ansible_amazon.aws.ec2_vol_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vol.py", line 916, in <module>
  File "/tmp/ansible_amazon.aws.ec2_vol_payload_w3dsolga/ansible_amazon.aws.ec2_vol_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vol.py", line 910, in main
  File "/tmp/ansible_amazon.aws.ec2_vol_payload_w3dsolga/ansible_amazon.aws.ec2_vol_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vol.py", line 759, in ensure_present
TypeError: 'NoneType' object is not subscriptable
failed: [eduffy-<laptop hostname> (item=i-***************) => {
    "ansible_loop_var": "item",
    "changed": false,
    "item": "i-****************",
    "module_stderr": "Traceback (most recent call last):\n  File \"/home/eduffy/.ansible/tmp/ansible-tmp-1762890595.753122-2769440-87527233413948/AnsiballZ_ec2_vol.py\", line 107, in <module>\n    _ansiballz_main()\n    ~~~~~~~~~~~~~~~^^\n  File \"/home/eduffy/.ansible/tmp/ansible-tmp-1762890595.753122-2769440-87527233413948/AnsiballZ_ec2_vol.py\", line 99, in _ansiballz_main\n    invoke_module(zipped_mod, temp_path, ANSIBALLZ_PARAMS)\n    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/home/eduffy/.ansible/tmp/ansible-tmp-1762890595.753122-2769440-87527233413948/AnsiballZ_ec2_vol.py\", line 47, in invoke_module\n    runpy.run_module(mod_name='ansible_collections.amazon.aws.plugins.modules.ec2_vol', init_globals=dict(_module_fqn='ansible_collections.amazon.aws.plugins.modules.ec2_vol', _modlib_path=modlib_path),\n    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n                     run_name='__main__', alter_sys=True)\n                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"<frozen runpy>\", line 226, in run_module\n  File \"<frozen runpy>\", line 98, in _run_module_code\n  File \"<frozen runpy>\", line 88, in _run_code\n  File \"/tmp/ansible_amazon.aws.ec2_vol_payload_w3dsolga/ansible_amazon.aws.ec2_vol_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vol.py\", line 916, in <module>\n  File \"/tmp/ansible_amazon.aws.ec2_vol_payload_w3dsolga/ansible_amazon.aws.ec2_vol_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vol.py\", line 910, in main\n  File \"/tmp/ansible_amazon.aws.ec2_vol_payload_w3dsolga/ansible_amazon.aws.ec2_vol_payload.zip/ansible_collections/amazon/aws/plugins/modules/ec2_vol.py\", line 759, in ensure_present\nTypeError: 'NoneType' object is not subscriptable\n",
    "module_stdout": "",
    "msg": "MODULE FAILURE: No start of json char found\nSee stdout/stderr for the exact error",
    "rc": 1
}
```
Confusing, does not point to the actual issue.

AFTER:
```
failed: [eduffy-<laptop hostname>] (item=i-******************) => {                                                                                                                                          
    "ansible_loop_var": "item",                                                                                                                                                                                     
    "changed": false,                                                                                                                                                                                               
    "invocation": {                                                                                                                                                                                                 
        "module_args": {
            "access_key": null,
            "availability_zone": "us-east-1a",
            "aws_ca_bundle": null,
            "aws_config": null,
            "debug_botocore_endpoint_logs": false,
            "delete_on_termination": false,
            "device_name": "/dev/sde",
            "encrypted": false,
            "endpoint_url": null,
            "id": null,
            "instance": "i-****************",
            "iops": 5000,
            "kms_key_id": null,
            "modify_volume": false,
            "multi_attach": null,
            "name": null,
            "outpost_arn": null,
            "profile": "default",
            "purge_tags": true,
            "region": "us-east-1",
            "secret_key": null,
            "session_token": null,
            "snapshot": null,
            "state": "present",
            "tags": {
                "Name": "ceph-ebs-i-**************"
            },
            "throughput": null,
            "validate_certs": true,
            "volume_size": 160,
            "volume_type": "io2",
            "zone": "us-east-1a"
        }
    },
    "item": "i-**************",
    "msg": "Could not find instance, make sure the region is correct"
}
```
Much more descriptive and points directly at the real issue.