### PR TITLE
Also treat `NotSupported` error as a `501` in v9

### DIFF
--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -688,7 +688,7 @@ def handle_bucket_public_access_config(s3_client, module: AnsibleAWSModule, name
 
     try:
         current_public_access = get_bucket_public_access(s3_client, name)
-    except is_boto3_error_code(["NotImplemented", "XNotImplemented"]) as e:
+    except is_boto3_error_code(["NotImplemented", "XNotImplemented", "NotSupported"]) as e:
         if public_access is not None:
             module.fail_json_aws(e, msg="Bucket public access settings are not supported by the current S3 Endpoint")
     except is_boto3_error_code("AccessDenied") as e:


### PR DESCRIPTION
##### SUMMARY
Accept `NotSupported` (added by S3 Express and AIStor) as an alternative to `NotImplemented` code when calling `s3_client.get_public_access_block`. Note that this is for v9 (v10 already has a fix via #2478).

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`s3_bucket`

##### ADDITIONAL INFORMATION
This PR was submitted, because of the discussion in https://github.com/ansible-collections/amazon.aws/pull/2478#issuecomment-3551568042.