### PR TITLE
sts_assume_role - Improve error handling for MalformedPolicyDocument

### DIFF
--- a/changelogs/fragments/sts_assume_role-malformed_policy.yml
+++ b/changelogs/fragments/sts_assume_role-malformed_policy.yml
@@ -1,0 +1,2 @@
+minor_changes:
+- sts_assume_role - improve error handling for ``MalformedPolicyDocument`` errors by providing a clearer error message when an invalid policy document is provided (https://github.com/ansible-collections/amazon.aws/pull/2778).

--- a/plugins/modules/sts_assume_role.py
+++ b/plugins/modules/sts_assume_role.py
@@ -109,6 +109,7 @@ except ImportError:
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 
 
@@ -143,6 +144,8 @@ def assume_role_policy(connection, module):
     try:
         response = connection.assume_role(**kwargs)
         changed = True
+    except is_boto3_error_code("MalformedPolicyDocument") as e:
+        module.fail_json_aws(e, msg="Invalid policy document provided")
     except (ClientError, ParamValidationError) as e:
         module.fail_json_aws(e)
 

--- a/tests/integration/targets/sts_assume_role/tasks/main.yml
+++ b/tests/integration/targets/sts_assume_role/tasks/main.yml
@@ -89,15 +89,8 @@
       ansible.builtin.assert:
         that:
           - result.failed
-          - "'The policy is not in the valid JSON format.' in result.msg"
+          - "'Invalid policy document provided' in result.msg"
       when: result.module_stderr is not defined
-
-    - name: Assert assume role with invalid policy
-      ansible.builtin.assert:
-        that:
-          - result.failed
-          - "'The policy is not in the valid JSON format.' in result.module_stderr"
-      when: result.module_stderr is defined
 
     # ============================================================
     - name: Test assume role with invalid duration seconds


### PR DESCRIPTION
##### SUMMARY

Add specific error handling for MalformedPolicyDocument error code using is_boto3_error_code, providing a clearer error message when an invalid policy document is provided to assume_role.

We used to test based on the error message returned by AWS, however it appears that the error message has become much less user-friendly:

```
Unexpected character ('i' (code 105)): expected a valid value (number, String, array, object, 'true', 'false' or 'null')\n at [Source: java.io.StringReader@52b5743d; line: 1, column: 2]
```

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

sts_assume_role

##### ADDITIONAL INFORMATION

Assisted-by: Claude Sonnet 4.5