### PR TITLE
chore(s3_bucket): add location parameter to fix the issue 2214 | usin…

### DIFF
--- a/plugins/module_utils/s3.py
+++ b/plugins/module_utils/s3.py
@@ -201,5 +201,6 @@ def list_bucket_object_keys(client, bucket, prefix=None, max_keys=None, start_af
 
 def get_s3_bucket_location(module):
     if module.params.get("ceph") is True:
-        return module.params.get("region")
+        # Use location parameter if provided, otherwise fall back to region parameter
+        return module.params.get("location") or module.params.get("region")
     return module.region or "us-east-1"

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -41,6 +41,13 @@ options:
     aliases: ['rgw']
     type: bool
     default: false
+  location:
+    description:
+      - The LocationConstraint for the S3 bucket.
+      - When O(ceph=true), this parameter is used as the LocationConstraint instead of the region parameter.
+      - If not specified when O(ceph=true), it will fall back to the region parameter.
+    type: str
+    version_added: 1.0.0
   requester_pays:
     description:
       - With Requester Pays buckets, the requester instead of the bucket owner pays the cost
@@ -2211,6 +2218,7 @@ def main():
         dualstack=dict(default=False, type="bool"),
         state=dict(default="present", choices=["present", "absent"]),
         ceph=dict(default=False, type="bool", aliases=["rgw"]),
+        location=dict(type="str"),
         # ** Warning **
         # we support non-AWS implementations, only force/purge options should have a
         # default set for any top-level option.  We need to be able to identify


### PR DESCRIPTION
##### SUMMARY
Adds a new `location` parameter to the `s3_bucket` module to allow specifying a separate LocationConstraint when using Ceph RGW. Previously, when `ceph=true`, the module would use the `region` parameter as the LocationConstraint. This change allows users to specify a dedicated `location` parameter for the LocationConstraint while keeping the `region` parameter for its original purpose (AWS region configuration).

The implementation maintains backward compatibility by falling back to the `region` parameter if `location` is not specified when `ceph=true`.

##### ISSUE TYPE
- Feature Pull Request
- It was first introduced on https://github.com/ansible-collections/amazon.aws/issues/2214

##### COMPONENT NAME
amazon.aws.s3_bucket

##### ADDITIONAL INFORMATION
**Changes:**
- Added `location` parameter to `s3_bucket` module argument specification
- Updated `get_s3_bucket_location()` function in `module_utils/s3.py` to prioritize `location` parameter when `ceph=true`, with fallback to `region` parameter
- Added documentation for the new `location` parameter

**Use Case:**
When working with Ceph RGW, users may need to specify a LocationConstraint that differs from the AWS region parameter. This is particularly useful in multi-region Ceph deployments or when the region parameter is used for other AWS-specific configurations.

**Backward Compatibility:**
The change is fully backward compatible. If `location` is not specified, the module will continue to use the `region` parameter as before, maintaining existing behavior.

**Example Usage:**
- name: Create S3 bucket on Ceph with custom location
  amazon.aws.s3_bucket:
    name: mybucket
    endpoint_url: http://ceph-rgw.example.com
    ceph: true
    location: "default:default-placement"
    state: present