### PR TITLE
chore(CI): prevent patchback bot from labeling new PRs

### DIFF
--- a/.github/workflows/label-new-prs.yaml
+++ b/.github/workflows/label-new-prs.yaml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   add_label:
+    if: github.actor != 'patchback[bot]'
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
##### SUMMARY
Currently, the patchback bot creates PRs that get labeled as "needs_triage". This change prevents labeling PRs created by the patchback bot.

##### ISSUE TYPE
- CI Bugfix Pull Request

##### COMPONENT NAME
.github/workflows/label-new-prs.yaml

##### ADDITIONAL INFORMATION
Trivial CI-only change, no changelog is required.

Resolves #2808
Similar to ansible-collections/kubernetes.core#1062