### PR TITLE
Fix Windows S3 presigned URL handling in SSM connection plugin

### DIFF
--- a/plugins/plugin_utils/ssm/s3clientmanager.py
+++ b/plugins/plugin_utils/ssm/s3clientmanager.py
@@ -129,7 +129,7 @@ class S3ClientManager:
     ) -> Tuple[str, Optional[Dict[str, str]]]:
         """
         Generate commands for the specified bucket and configurations, S3 path, input path, and output path.
-        The function generates a curl/Invoke-WebRequest command to be executed on the managed node.
+        The function generates a curl/urllib.request command to be executed on the managed node.
         The method 'get' means the controller node wants to retrieve content from the managed node, the corresponding
         on the managed node is a 'put' command to updload content to the S3 bucket.
         The method 'put' means the controller node wants to upload content to the managed node, the corresponding


### PR DESCRIPTION
##### SUMMARY
# Problem
The SSM connection plugin fails to download files on Windows hosts when using S3 presigned URLs. The issue occurs because Invoke-WebRequest on Windows has problems parsing complex URLs with multiple query parameters and special characters that are common in S3 presigned URLs, resulting in 403 Forbidden errors.

# Root Cause
When running a win_shell on an EC2 windows host using the aws_ssm connection plugin, Windows/Invoke-WebRequest  incorrectly parses the S3 presigned URLs, this breaks the AWS signature validation, causing 403 Forbidden responses.
The same URL work correctly with curl on Linux hosts.

# Solution
Replace Invoke-WebRequest with Python's built-in urllib library on Windows hosts:
Download operations: Use urllib.request.urlretrieve()
Upload operations: Use urllib.request.Request() with PUT method
Path handling: Use raw strings (r'') to prevent Windows path escape sequence issues
No dependencies: urllib is part of Python's standard library

# Rationale
✅ Reliable S3 presigned URL handling on Windows
✅ No additional package dependencies required, python is already required on the target host
✅ Consistent behavior across platforms

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
amazon.aws.aws_ssm

##### ADDITIONAL INFORMATION
Verified on EC2 Windows hosts (AMI Windows_Server-2019-English-Full-Base-2026.01.14) where Invoke-WebRequest failed
Confirmed Python urllib successfully handles the same URLs while Invoke-WebRequest or curl fails. The same error can be reproduced by created a signed s3 url and run Invoke-WebRequest against that url, it works with urllib.request using the same url.

### Before
Failure
```
msg: >+
  failed to transfer file to
  /root/.ansible/tmp/ansible-local-10891rzqb0/tmp3wfry1tf
  C:\Windows\TEMP\ansible-tmp-1769004650.2997134-19-57705445779364\AnsiballZ_win_shell.ps1:

  Invoke-WebRequest : The remote server returned an error: (403) Forbidden.

  At line:2 char:1

  + Invoke-WebRequest 'https://s3.eu-west-1.amazonaws.com/....

  + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      + CategoryInfo          : InvalidOperation: (System.Net.HttpWebRequest:HttpWebRequest) [Invoke-WebRequest], WebException
      + FullyQualifiedErrorId : WebCmdletWebResponseException,Microsoft.PowerShell.Commands.InvokeWebRequestCommand
```
### After
Success
```
{
  "start": "2026-01-22 12:27:36.982004",
  "stdout": "\r\nStatus   Name               DisplayName                           \r\n------   ----               -----------                           \r\nRunning AmazonSSMAgent     Amazon SSM Agent                      \r\n\r\n\r\n",
  "cmd": "Get-Service -Name AmazonSSMAgent",
  "stderr": "",
  "changed": true,
  "rc": 0,
  "delta": "0:00:01.322428",
  "end": "2026-01-22 12:27:38.304433",
  "stdout_lines": [
    "",
    "Status   Name               DisplayName                           ",
    "------   ----               -----------                           ",
    "Running AmazonSSMAgent     Amazon SSM Agent                      ",
    "",
    ""
  ],
  "stderr_lines": [],
  "_ansible_no_log": false
}
```