### PR TITLE
[tests] Update ELB access log S3 bucket policies to use service principal

### DIFF
--- a/changelogs/fragments/elb_logging_service_principal.yml
+++ b/changelogs/fragments/elb_logging_service_principal.yml
@@ -1,0 +1,3 @@
+trivial:
+  - elb_application_lb - integration tests now use service principal ``logdelivery.elasticloadbalancing.amazonaws.com`` for S3 bucket policies instead of legacy region-specific AWS account IDs, following current AWS best practices.
+  - elb_classic_lb - integration tests now use service principal ``logdelivery.elasticloadbalancing.amazonaws.com`` for S3 bucket policies instead of legacy region-specific AWS account IDs, following current AWS best practices.

--- a/tests/integration/targets/elb_application_lb/defaults/main.yml
+++ b/tests/integration/targets/elb_application_lb/defaults/main.yml
@@ -15,21 +15,6 @@ public_subnet_cidr_1: 10.{{ 256 | random(seed=resource_prefix) }}.3.0/24
 public_subnet_cidr_2: 10.{{ 256 | random(seed=resource_prefix) }}.4.0/24
 s3_bucket_name: alb-test-{{ resource_short }}
 
-# Amazon's SDKs don't provide the list of account ID's.  Amazon only provide a
-# web page.  If you want to run the tests outside the US regions you'll need to
-# update this.
-# https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
-elb_access_log_account_id_map:
-  us-east-1: "127311923021"
-  us-east-2: "033677994240"
-  us-west-1: "027434742980"
-  us-west-2: "797873946194"
-  us-gov-east-1: "190560391635"
-  us-gov-west-1: "048591011584"
-  eu-west-1: "156460612806"
-
-elb_account_id: "{{ elb_access_log_account_id_map[aws_region] }}"
-
 local_certs:
   - priv_key: "{{ remote_tmp_dir }}/private-1.pem"
     cert: "{{ remote_tmp_dir }}/public-1.pem"

--- a/tests/integration/targets/elb_application_lb/templates/policy.json
+++ b/tests/integration/targets/elb_application_lb/templates/policy.json
@@ -4,7 +4,7 @@
         {
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::{{ elb_account_id}}:root"
+                "Service": "logdelivery.elasticloadbalancing.amazonaws.com"
             },
             "Action": "s3:PutObject",
             "Resource": "arn:aws:s3:::{{ s3_bucket_name }}/alb-logs/AWSLogs/{{ aws_account }}/*"

--- a/tests/integration/targets/elb_classic_lb/defaults/main.yml
+++ b/tests/integration/targets/elb_classic_lb/defaults/main.yml
@@ -141,20 +141,6 @@ updated_lb_stickiness:
   type: loadbalancer
   expiration: 600
 
-# Amazon's SDKs don't provide the list of account ID's.  Amazon only provide a
-# web page.  If you want to run the tests outside the US regions you'll need to
-# update this.
-# https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html
-access_log_account_id_map:
-  us-east-1: "127311923021"
-  us-east-2: "033677994240"
-  us-west-1: "027434742980"
-  us-west-2: "797873946194"
-  us-gov-west-1: "048591011584"
-  us-gov-east-1: "190560391635"
-
-access_log_account_id: "{{ access_log_account_id_map[aws_region] }}"
-
 s3_logging_bucket_a: ansible-test-{{ tiny_prefix }}-a
 s3_logging_bucket_b: ansible-test-{{ tiny_prefix }}-b
 default_logging_prefix: logs

--- a/tests/integration/targets/elb_classic_lb/tasks/setup_s3.yml
+++ b/tests/integration/targets/elb_classic_lb/tasks/setup_s3.yml
@@ -1,4 +1,12 @@
 ---
+- name: Get ARN of calling user
+  amazon.aws.aws_caller_info:
+  register: aws_caller_info
+
+- name: Register account id
+  ansible.builtin.set_fact:
+    aws_account: "{{ aws_caller_info.account }}"
+
 - name: Create S3 bucket for access logs
   vars:
     s3_logging_bucket: "{{ s3_logging_bucket_a }}"

--- a/tests/integration/targets/elb_classic_lb/templates/s3_policy.j2
+++ b/tests/integration/targets/elb_classic_lb/templates/s3_policy.j2
@@ -9,7 +9,11 @@
                 "Service": "logdelivery.elasticloadbalancing.amazonaws.com"
             },
             "Action": "s3:PutObject",
-            "Resource": "arn:aws:s3:::{{ s3_logging_bucket }}/AWSLogs/{{ aws_account }}/*"
+            "Resource": [
+                "arn:aws:s3:::{{ s3_logging_bucket }}/AWSLogs/{{ aws_account }}/*",
+                "arn:aws:s3:::{{ s3_logging_bucket }}/{{ default_logging_prefix }}/AWSLogs/{{ aws_account }}/*",
+                "arn:aws:s3:::{{ s3_logging_bucket }}/{{ updated_logging_prefix }}/AWSLogs/{{ aws_account }}/*"
+            ]
         }
     ]
 }

--- a/tests/integration/targets/elb_classic_lb/templates/s3_policy.j2
+++ b/tests/integration/targets/elb_classic_lb/templates/s3_policy.j2
@@ -6,10 +6,10 @@
             "Sid": "ELB-Logging",
             "Effect": "Allow",
             "Principal": {
-                "AWS": "arn:aws:iam::{{ access_log_account_id }}:root"
+                "Service": "logdelivery.elasticloadbalancing.amazonaws.com"
             },
             "Action": "s3:PutObject",
-            "Resource": "arn:aws:s3:::{{ s3_logging_bucket }}/*"
+            "Resource": "arn:aws:s3:::{{ s3_logging_bucket }}/AWSLogs/{{ aws_account }}/*"
         }
     ]
 }


### PR DESCRIPTION
##### SUMMARY
    
Replace legacy region-specific AWS account ID approach with the
recommended service principal method for both Classic and Application
Load Balancers. This simplifies the bucket policies and allows tests
to run in any AWS region without maintaining a region-to-account-id
mapping.

See also: https://docs.aws.amazon.com/elasticloadbalancing/latest/application/enable-access-logging.html
and #2773
    
##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

elb_application_lb
elb_classic_lb

##### ADDITIONAL INFORMATION

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>