### PR TITLE
Deprecate use_contrib_script_compatible_ec2_tag_keys and use_contrib_script_compatible_sanitization

### DIFF
--- a/changelogs/fragments/2854-deprecate-legacy-script-options.yml
+++ b/changelogs/fragments/2854-deprecate-legacy-script-options.yml
@@ -1,5 +1,7 @@
 deprecated_features:
   - aws_ec2 - the ``use_contrib_script_compatible_ec2_tag_keys`` option has been deprecated and will be removed in a release after 2026-12-01.
-    We advise to migrate to the ``ec2_tags`` structure instead.
+    Use the ``ec2_tags`` structure instead.
+    (https://github.com/ansible-collections/amazon.aws/pull/2854)
   - aws_ec2 - the ``use_contrib_script_compatible_sanitization`` option has been deprecated and will be removed in a release after 2026-12-01.
-    We advise to remove this option and migrate to Ansible's default group name sanitization instead.
+    Use Ansible's default group name sanitization instead.
+     (https://github.com/ansible-collections/amazon.aws/pull/2854)

--- a/docs/docsite/rst/aws_ec2_guide.rst
+++ b/docs/docsite/rst/aws_ec2_guide.rst
@@ -331,11 +331,11 @@ Some examples are shown below:
 
 .. deprecated:: 11.2.0
    The ``use_contrib_script_compatible_ec2_tag_keys`` option is deprecated and will be removed in a release after 2026-12-01.
-   We advise to migrate to the ``ec2_tags`` structure (e.g. use ``ec2_tags.TAGNAME`` instead of ``ec2_tag_TAGNAME``).
+   Use the ``ec2_tags`` structure instead (e.g. ``ec2_tags.TAGNAME`` rather than ``ec2_tag_TAGNAME``).
 
 .. deprecated:: 11.2.0
    The ``use_contrib_script_compatible_sanitization`` option is deprecated and will be removed in a release after 2026-12-01.
-   We advise to remove this option and migrate to Ansible's default group name sanitization instead.
+   Use Ansible's default group name sanitization instead.
 
 ``use_contrib_script_compatible_ec2_tag_keys`` exposes the host tags with ec2_tag_TAGNAME keys like the old ec2.py inventory script when it's True.
 

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -23,9 +23,9 @@ notes:
     Use C(ec2_tags) instead to avoid conflicts with Ansible reserved variable names.
   - The C(ec2_tags) host variable was added in version 11.2.0.
   - The C(use_contrib_script_compatible_ec2_tag_keys) option is deprecated and will be removed in a release after 2026-12-01.
-    We advise to migrate to the C(ec2_tags) structure (e.g. use C(ec2_tags.TAGNAME) instead of C(ec2_tag_TAGNAME)).
+    Use the C(ec2_tags) structure instead (e.g. use C(ec2_tags.TAGNAME) rather than C(ec2_tag_TAGNAME)).
   - The C(use_contrib_script_compatible_sanitization) option is deprecated and will be removed in a release after 2026-12-01.
-    We advise to remove this option and migrate to Ansible's default group name sanitization instead.
+    Use Ansible's default group name sanitization instead.
 author:
   - Sloane Hertel (@s-hertel)
 options:
@@ -119,14 +119,14 @@ options:
       - This is not the default as such names break certain functionality as not all characters are valid Python identifiers
         which group names end up being used as.
       - The use of this feature is deprecated and will be removed in a release after 2026-12-01.
-        We advise to remove this option and migrate to Ansible's default group name sanitization instead.
+        Use Ansible's default group name sanitization instead.
     type: bool
     default: false
   use_contrib_script_compatible_ec2_tag_keys:
     description:
       - Expose the host tags with C(ec2_tag_TAGNAME) keys like the old C(ec2.py) inventory script.
       - The use of this feature is deprecated and will be removed in a release after 2026-12-01.
-        We advise to migrate to the C(ec2_tags) structure (e.g. use C(ec2_tags.TAGNAME) instead of C(ec2_tag_TAGNAME)).
+        Use the C(ec2_tags) structure instead (e.g. use C(ec2_tags.TAGNAME) rather than C(ec2_tag_TAGNAME)).
     type: bool
     default: false
     version_added: 1.5.0
@@ -977,7 +977,7 @@ class InventoryModule(AWSInventoryBase):
         if use_contrib_script_compatible_sanitization:
             self.display.deprecated(
                 "The 'use_contrib_script_compatible_sanitization' option is deprecated. "
-                "We advise to remove this option and migrate to Ansible's default group name sanitization instead.",
+                "Use Ansible's default group name sanitization instead.",
                 date="2026-12-01",
                 collection_name="amazon.aws",
             )
@@ -987,7 +987,7 @@ class InventoryModule(AWSInventoryBase):
         if use_contrib_script_compatible_ec2_tag_keys:
             self.display.deprecated(
                 "The 'use_contrib_script_compatible_ec2_tag_keys' option is deprecated. "
-                "We advise to migrate to the 'ec2_tags' structure.",
+                "Use the 'ec2_tags' structure instead.",
                 date="2026-12-01",
                 collection_name="amazon.aws",
             )


### PR DESCRIPTION
##### SUMMARY
[ACA-5079](https://issues.redhat.com/browse/ACA-5079)

This pr deprecates the `use_contrib_script_compatible_ec2_tag_keys` and `use_contrib_script_compatible_sanitization` options. 

The `use_contrib_script_compatible_ec2_tag_keys` option creates individual `ec2_tag_TAGNAME` host variables matching the behavior of the old ec2.py script. This creates non-standard host variables. Users should access tags via the standard dictionary structure (`ec2_tags.TAGNAME` ) instead.

The `use_contrib_script_compatible_sanitization` option provides legacy group name sanitization that preserves hyphens in group names while converting other invalid characters to underscores, matching the behavior of the old ec2.py script when replace_dash_in_groups = False. Users should remove this option and rely on Ansible's default group name sanitization. 

##### COMPONENT NAME
`aws_ec2`
