### PR TITLE
Fix unit tests for pytest_ansible compatibility

### DIFF
--- a/changelogs/fragments/pytest-ansible-compatibility.yml
+++ b/changelogs/fragments/pytest-ansible-compatibility.yml
@@ -1,0 +1,2 @@
+trivial:
+  - tests - fix unit tests to work correctly when run using pytest_ansible plugin.

--- a/changelogs/fragments/pytest-ansible-compatibility.yml
+++ b/changelogs/fragments/pytest-ansible-compatibility.yml
@@ -1,2 +1,5 @@
+minor_changes:
+  - aws_cloudtrail - replace deprecated ``datetime.utcnow()`` with timezone-aware ``datetime.now(tz=timezone.utc)`` (https://github.com/ansible-collections/amazon.aws/pull/2858).
+
 trivial:
   - tests - fix unit tests to work correctly when run using pytest_ansible plugin (https://github.com/ansible-collections/amazon.aws/pull/2858).

--- a/changelogs/fragments/pytest-ansible-compatibility.yml
+++ b/changelogs/fragments/pytest-ansible-compatibility.yml
@@ -1,2 +1,2 @@
 trivial:
-  - tests - fix unit tests to work correctly when run using pytest_ansible plugin.
+  - tests - fix unit tests to work correctly when run using pytest_ansible plugin (https://github.com/ansible-collections/amazon.aws/pull/2858).

--- a/extensions/eda/plugins/event_source/aws_cloudtrail.py
+++ b/extensions/eda/plugins/event_source/aws_cloudtrail.py
@@ -1,6 +1,6 @@
 import asyncio
+import datetime
 import json
-from datetime import datetime
 from typing import TYPE_CHECKING, Any, cast
 
 from aiobotocore.session import get_session
@@ -132,7 +132,7 @@ async def main(queue: asyncio.Queue[Any], args: dict[str, Any]) -> None:
         if args.get(key) is not None:
             params[value] = args.get(key)
 
-    params["StartTime"] = datetime.utcnow()  # noqa: DTZ003
+    params["StartTime"] = datetime.datetime.now(tz=datetime.timezone.utc)
 
     async with session.create_client("cloudtrail", **connection_args(args)) as client:
         event_time = None

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -7,24 +7,3 @@
 # isn't as agressive as the ansible_test._util.target.pytest.plugins.ansible_pytest_collections plugin
 # when it comes to rewriting the import paths and as such we can't import fixtures via their
 # absolute import path or across collections.
-
-import asyncio
-from typing import Any
-
-import pytest
-
-
-class ListQueue(asyncio.Queue[Any]):
-    def __init__(self) -> None:
-        self.queue: list[Any] = []
-
-    async def put(self, item: Any) -> None:
-        self.queue.append(item)
-
-    def put_nowait(self, item: Any) -> None:
-        self.queue.append(item)
-
-
-@pytest.fixture
-def eda_queue() -> ListQueue:
-    return ListQueue()

--- a/tests/unit/event_source/conftest.py
+++ b/tests/unit/event_source/conftest.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+
+from ansible_collections.amazon.aws.tests.unit.utils.event import ListQueue
+
+
+@pytest.fixture
+def eda_queue() -> ListQueue:
+    return ListQueue()

--- a/tests/unit/event_source/test_aws_cloudtrail.py
+++ b/tests/unit/event_source/test_aws_cloudtrail.py
@@ -3,12 +3,13 @@ from unittest.mock import patch
 
 import pytest
 from asyncmock import AsyncMock
-from extensions.eda.plugins.event_source.aws_cloudtrail import _cloudtrail_event_to_dict
-from extensions.eda.plugins.event_source.aws_cloudtrail import _get_events
-from extensions.eda.plugins.event_source.aws_cloudtrail import connection_args
-from extensions.eda.plugins.event_source.aws_cloudtrail import main as cloudtrail_main
 from mock import MagicMock
-from tests.unit.conftest import ListQueue
+
+from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_cloudtrail import _cloudtrail_event_to_dict
+from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_cloudtrail import _get_events
+from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_cloudtrail import connection_args
+from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_cloudtrail import main as cloudtrail_main
+from ansible_collections.amazon.aws.tests.unit.utils.event import ListQueue
 
 
 @pytest.mark.asyncio
@@ -31,7 +32,7 @@ async def test_receive_from_cloudtrail(eda_queue: ListQueue) -> None:
         ]
     }
     with patch(
-        "extensions.eda.plugins.event_source.aws_cloudtrail.get_session",  # noqa: E501
+        "ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_cloudtrail.get_session",
         return_value=session,
     ):
         iterator = AsyncMock()

--- a/tests/unit/event_source/test_aws_sqs_queue.py
+++ b/tests/unit/event_source/test_aws_sqs_queue.py
@@ -2,15 +2,16 @@ from unittest.mock import patch
 
 import pytest
 from asyncmock import AsyncMock
-from extensions.eda.plugins.event_source.aws_sqs_queue import main as sqs_main
-from tests.unit.conftest import ListQueue
+
+from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue import main as sqs_main
+from ansible_collections.amazon.aws.tests.unit.utils.event import ListQueue
 
 
 @pytest.mark.asyncio
 async def test_receive_from_sqs(eda_queue: ListQueue) -> None:
     session = AsyncMock()
     with patch(
-        "extensions.eda.plugins.event_source.aws_sqs_queue.get_session",  # noqa: E501
+        "ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue.get_session",
         return_value=session,
     ):
         client = AsyncMock()

--- a/tests/unit/plugins/module_utils/conftest.py
+++ b/tests/unit/plugins/module_utils/conftest.py
@@ -6,14 +6,14 @@
 import json
 import sys
 import warnings
+from collections.abc import MutableMapping
 from io import BytesIO
 
 import pytest
 
 import ansible.module_utils.basic
 import ansible.module_utils.common
-from ansible.module_utils._text import to_bytes
-from ansible.module_utils.common._collections_compat import MutableMapping
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 @pytest.fixture(name="stdin")

--- a/tests/unit/plugins/modules/conftest.py
+++ b/tests/unit/plugins/modules/conftest.py
@@ -4,11 +4,11 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import json
+from collections.abc import MutableMapping
 
 import pytest
 
-from ansible.module_utils._text import to_bytes
-from ansible.module_utils.common._collections_compat import MutableMapping
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 @pytest.fixture

--- a/tests/unit/plugins/modules/test_ec2_key.py
+++ b/tests/unit/plugins/modules/test_ec2_key.py
@@ -10,7 +10,7 @@ import botocore
 import pytest
 from dateutil.tz import tzutc
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.amazon.aws.plugins.modules import ec2_key
 

--- a/tests/unit/plugins/modules/utils.py
+++ b/tests/unit/plugins/modules/utils.py
@@ -3,7 +3,7 @@ import unittest
 from unittest.mock import patch
 
 from ansible.module_utils import basic
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 
 def set_module_args(args):

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -4,5 +4,6 @@ boto3
 
 placebo
 # For testing event source plugins
+aiobotocore
 asyncmock
 pytest-asyncio

--- a/tests/unit/utils/event.py
+++ b/tests/unit/utils/event.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import asyncio
+from typing import Any
+
+
+class ListQueue(asyncio.Queue[Any]):
+    def __init__(self) -> None:
+        self.queue: list[Any] = []
+
+    async def put(self, item: Any) -> None:
+        self.queue.append(item)
+
+    def put_nowait(self, item: Any) -> None:
+        self.queue.append(item)


### PR DESCRIPTION
##### SUMMARY
Fix unit tests to work correctly when run using the pytest_ansible plugin. The pytest_ansible plugin isn't as aggressive as the ansible_test plugin when it comes to rewriting import paths.

This is a follow-up to #2816.

Changes include:
- Move shared test code to tests/unit/utils to avoid namespace pollution
- Use fully qualified imports throughout test files
- Update unit test requirements
- Clean up deprecated imports

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests

##### ADDITIONAL INFORMATION
This change ensures that unit tests can be run using pytest_ansible without import errors. The tests were previously relying on import path rewriting that was specific to the ansible_test plugin.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>