### PR TITLE
Migrate from deprecated ansible.module_utils._text to ansible.module_utils.common.text.converters

### DIFF
--- a/changelogs/fragments/20260225-migrate-text-converters.yml
+++ b/changelogs/fragments/20260225-migrate-text-converters.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - Various modules and utilities - migrated from deprecated ``ansible.module_utils._text`` to ``ansible.module_utils.common.text.converters`` (https://github.com/ansible-collections/amazon.aws/pull/2860).

--- a/plugins/action/s3_object.py
+++ b/plugins/action/s3_object.py
@@ -10,7 +10,7 @@ from ansible.errors import AnsibleAction
 from ansible.errors import AnsibleActionFail
 from ansible.errors import AnsibleError
 from ansible.errors import AnsibleFileNotFound
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 from ansible.plugins.action import ActionBase
 from ansible.utils.vars import merge_hash
 

--- a/plugins/callback/aws_resource_actions.py
+++ b/plugins/callback/aws_resource_actions.py
@@ -27,7 +27,7 @@ sample output: >
   #               's3:ListObjectsV2', 's3:HeadBucket', 's3:UploadPart', 's3:PutObject']
 """
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.plugins.callback import CallbackBase
 
 

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -347,7 +347,7 @@ from typing import Dict
 from typing import List
 from typing import Set
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 try:
     from ansible.template import trust_as_template

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -86,8 +86,8 @@ except ImportError:
     pass  # will be captured by imported HAS_BOTO3
 
 from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -54,7 +54,7 @@ except ImportError:
     pass  # Handled by AWSLookupBase
 
 from ansible.errors import AnsibleLookupError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import AWSLookupBase

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -51,7 +51,7 @@ import json
 import ansible.module_utils.six.moves.urllib.error
 import ansible.module_utils.urls
 from ansible.errors import AnsibleLookupError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.plugins.lookup import LookupBase
 
 

--- a/plugins/lookup/secretsmanager_secret.py
+++ b/plugins/lookup/secretsmanager_secret.py
@@ -125,7 +125,7 @@ except ImportError:
     pass  # Handled by AWSLookupBase
 
 from ansible.errors import AnsibleLookupError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message

--- a/plugins/lookup/ssm_parameter.py
+++ b/plugins/lookup/ssm_parameter.py
@@ -145,7 +145,7 @@ except ImportError:
     pass  # Handled by AWSLookupBase
 
 from ansible.errors import AnsibleLookupError
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.utils.display import Display
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code

--- a/plugins/module_utils/acm.py
+++ b/plugins/module_utils/acm.py
@@ -21,8 +21,8 @@ try:
 except ImportError:
     pass
 
-from ansible.module_utils._text import to_bytes
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.common.text.converters import to_bytes
 
 from .botocore import is_boto3_error_code
 from .retries import AWSRetry

--- a/plugins/module_utils/botocore.py
+++ b/plugins/module_utils/botocore.py
@@ -78,9 +78,9 @@ try:
 except ImportError:
     HAS_PACKAGING = False
 
-from ansible.module_utils._text import to_native
 from ansible.module_utils.ansible_release import __version__
 from ansible.module_utils.basic import missing_required_lib
+from ansible.module_utils.common.text.converters import to_native
 
 from .common import get_collection_info
 from .exceptions import AnsibleBotocoreError

--- a/plugins/module_utils/exceptions.py
+++ b/plugins/module_utils/exceptions.py
@@ -3,7 +3,7 @@
 # (c) 2022 Red Hat Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 
 class AnsibleAWSError(Exception):

--- a/plugins/module_utils/iam.py
+++ b/plugins/module_utils/iam.py
@@ -10,7 +10,7 @@ try:
 except ImportError:
     pass  # Modules are responsible for handling this.
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from .arn import parse_aws_arn
 from .arn import validate_aws_arn

--- a/plugins/module_utils/modules.py
+++ b/plugins/module_utils/modules.py
@@ -46,12 +46,12 @@ from typing import Dict
 from typing import NoReturn
 from typing import Optional
 
-from ansible.module_utils._text import to_native
 from ansible.module_utils.ansible_release import __version__ as _ANSIBLE_CORE_VERSION
 from ansible.module_utils.basic import AnsibleModule
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.common.text.converters import to_native
 
 from .botocore import boto3_at_least
 from .botocore import boto3_conn

--- a/plugins/module_utils/policy.py
+++ b/plugins/module_utils/policy.py
@@ -30,7 +30,7 @@
 
 from functools import cmp_to_key
 
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_text
 
 
 def _canonify_root_arn(arn):

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -18,9 +18,9 @@ try:
 except ImportError:
     pass
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
+from ansible.module_utils.common.text.converters import to_text
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import get_boto3_client_method_parameters
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code

--- a/plugins/module_utils/tagging.py
+++ b/plugins/module_utils/tagging.py
@@ -28,8 +28,8 @@
 # LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
 # USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-from ansible.module_utils._text import to_native
-from ansible.module_utils._text import to_text
+from ansible.module_utils.common.text.converters import to_native
+from ansible.module_utils.common.text.converters import to_text
 
 
 def boto3_tag_list_to_ansible_dict(tags_list, tag_name_key_name=None, tag_value_key_name=None):

--- a/plugins/module_utils/tower.py
+++ b/plugins/module_utils/tower.py
@@ -6,7 +6,7 @@
 import string
 import textwrap
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 from ansible.module_utils.six.moves.urllib import parse as urlparse
 
 

--- a/plugins/modules/autoscaling_group.py
+++ b/plugins/modules/autoscaling_group.py
@@ -691,9 +691,9 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import describe_target_groups

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -338,8 +338,8 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils._text import to_bytes
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_bytes
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import boto_exception
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -1324,9 +1324,9 @@ except ImportError:
     pass  # caught by AnsibleAWSModule
 
 
-from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleEC2Error
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import associate_iam_instance_profile

--- a/plugins/modules/ec2_key.py
+++ b/plugins/modules/ec2_key.py
@@ -164,7 +164,7 @@ key:
 import os
 import uuid
 
-from ansible.module_utils._text import to_bytes
+from ansible.module_utils.common.text.converters import to_bytes
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleEC2Error
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import create_key_pair

--- a/plugins/modules/ec2_launch_template.py
+++ b/plugins/modules/ec2_launch_template.py
@@ -1134,9 +1134,9 @@ from typing import Optional
 from typing import Tuple
 from uuid import uuid4
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
+from ansible.module_utils.common.text.converters import to_text
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import normalize_boto3_result
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleEC2Error

--- a/plugins/modules/ec2_metadata_facts.py
+++ b/plugins/modules/ec2_metadata_facts.py
@@ -459,8 +459,8 @@ import socket
 import time
 import zlib
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.basic import AnsibleModule
+from ansible.module_utils.common.text.converters import to_text
 from ansible.module_utils.six.moves.urllib.parse import quote
 from ansible.module_utils.urls import fetch_url
 

--- a/plugins/modules/ec2_security_group.py
+++ b/plugins/modules/ec2_security_group.py
@@ -569,10 +569,10 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 from ansible.module_utils.common.network import to_ipv6_subnet
 from ansible.module_utils.common.network import to_subnet
+from ansible.module_utils.common.text.converters import to_text
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleEC2Error
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import authorize_security_group_egress

--- a/plugins/modules/ec2_vpc_vpn.py
+++ b/plugins/modules/ec2_vpc_vpn.py
@@ -438,8 +438,8 @@ from typing import Optional
 from typing import Tuple
 from typing import Union
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.common.text.converters import to_text
 
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import AnsibleEC2Error
 from ansible_collections.amazon.aws.plugins.module_utils.ec2 import create_vpn_connection

--- a/plugins/modules/iam_managed_policy.py
+++ b/plugins/modules/iam_managed_policy.py
@@ -193,7 +193,7 @@ policy:
 
 import json
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.iam import AnsibleIAMError

--- a/plugins/modules/lambda_policy.py
+++ b/plugins/modules/lambda_policy.py
@@ -126,7 +126,7 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
-from ansible.module_utils._text import to_native
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule

--- a/plugins/modules/rds_instance.py
+++ b/plugins/modules/rds_instance.py
@@ -888,8 +888,8 @@ from typing import Dict
 from typing import List
 from typing import Optional
 
-from ansible.module_utils._text import to_text
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.common.text.converters import to_text
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -498,9 +498,9 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils._text import to_native
 from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule


### PR DESCRIPTION
##### SUMMARY

Migrate from deprecated \`ansible.module_utils._text\` to \`ansible.module_utils.common.text.converters\` across various modules and utilities.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
Various modules and utilities

##### ADDITIONAL INFORMATION
This change updates import statements across the codebase to use the non-deprecated text converters module.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>