### PR TITLE
Remove deprecated disable_lookups parameter from template calls

### DIFF
--- a/changelogs/fragments/template_disable_lookups_cleanup.yml
+++ b/changelogs/fragments/template_disable_lookups_cleanup.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - aws_ec2 - remove explicit ``disable_lookups=False`` parameter from template calls as it is deprecated and False is the default value.
+  - aws_inventory_base - remove explicit ``disable_lookups=False`` parameter from template calls as it is deprecated and False is the default value.

--- a/changelogs/fragments/template_disable_lookups_cleanup.yml
+++ b/changelogs/fragments/template_disable_lookups_cleanup.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - aws_ec2 - remove explicit ``disable_lookups=False`` parameter from template calls as it is deprecated and False is the default value.
-  - aws_inventory_base - remove explicit ``disable_lookups=False`` parameter from template calls as it is deprecated and False is the default value.
+  - aws_ec2 - remove explicit ``disable_lookups=False`` parameter from template calls as it is deprecated and False is the default value (https://github.com/ansible-collections/amazon.aws/pull/2864).
+  - aws_inventory_base - remove explicit ``disable_lookups=False`` parameter from template calls as it is deprecated and False is the default value (https://github.com/ansible-collections/amazon.aws/pull/2864).

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -675,7 +675,7 @@ class InventoryModule(AWSInventoryBase):
                 template_var = "{{%s|%s}}" % (hostname, jinja2_filter)
             if trust_as_template:
                 template_var = trust_as_template(template_var)
-            hostname = self.templar.template(variable=template_var, disable_lookups=False)
+            hostname = self.templar.template(variable=template_var)
         if isinstance(hostname, list) and return_single_hostname:
             hostname = hostname[0] if hostname else None
         return hostname

--- a/plugins/plugin_utils/inventory.py
+++ b/plugins/plugin_utils/inventory.py
@@ -56,14 +56,14 @@ class AWSInventoryBase(BaseInventoryPlugin, Constructable, Cacheable, AWSPluginB
                 return value
 
             if isinstance(value, dict):
-                return {k: self.templar.template(variable=v, disable_lookups=False) for k, v in value.items()}
+                return {k: self.templar.template(variable=v) for k, v in value.items()}
             if isinstance(value, list):
-                return [self.templar.template(variable=v, disable_lookups=False) for v in value]
+                return [self.templar.template(variable=v) for v in value]
 
             if not self.templar.is_template(value):
                 return value
 
-            return self.templar.template(variable=value, disable_lookups=False)
+            return self.templar.template(variable=value)
 
     def get_options(self, *args):
         return self.TemplatedOptions(self.templar, super().get_options(*args))

--- a/tests/unit/plugins/plugin_utils/inventory/test_inventory_base.py
+++ b/tests/unit/plugins/plugin_utils/inventory/test_inventory_base.py
@@ -90,7 +90,7 @@ class AwsUnitTestTemplar:
                     return True
         return False
 
-    def template(self, variable, disable_lookups):
+    def template(self, variable):
         for k, v in self.config.items():
             variable = re.sub("{{([ ]*%s[ ]*)}}" % k, v, variable)
         if self.is_template_string(variable):


### PR DESCRIPTION
##### SUMMARY
Remove the deprecated `disable_lookups` parameter from `templar.template()` calls in inventory plugins.

The `disable_lookups` parameter is deprecated in Ansible's templating engine and has a default value of `False`. This change removes the explicit `disable_lookups=False` argument from all template() calls, simplifying the code while maintaining the same behavior.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- aws_ec2 inventory plugin
- aws_inventory_base plugin utility

##### ADDITIONAL INFORMATION
The changes affect:
- `plugins/inventory/aws_ec2.py` - 1 occurrence
- `plugins/plugin_utils/inventory.py` - 3 occurrences  
- `tests/unit/plugins/plugin_utils/inventory/test_inventory_base.py` - 1 occurrence in mock

All unit tests (1811) and linting checks pass.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>