### PR TITLE
Replace deprecated datetime.utcnow() in ec2_vpc modules

### DIFF
--- a/changelogs/fragments/utcnow-deprecation.yml
+++ b/changelogs/fragments/utcnow-deprecation.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - ec2_vpc_nat_gateway - replace deprecated ``datetime.utcnow()`` with timezone-aware ``datetime.now(datetime.timezone.utc)``.
+  - ec2_vpc_endpoint - replace deprecated ``datetime.utcnow()`` with timezone-aware ``datetime.now(datetime.timezone.utc)``.

--- a/changelogs/fragments/utcnow-deprecation.yml
+++ b/changelogs/fragments/utcnow-deprecation.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - ec2_vpc_nat_gateway - replace deprecated ``datetime.utcnow()`` with timezone-aware ``datetime.now(datetime.timezone.utc)``.
-  - ec2_vpc_endpoint - replace deprecated ``datetime.utcnow()`` with timezone-aware ``datetime.now(datetime.timezone.utc)``.
+  - ec2_vpc_nat_gateway - replace deprecated ``datetime.utcnow()`` with timezone-aware ``datetime.now(datetime.timezone.utc)`` (https://github.com/ansible-collections/amazon.aws/pull/2866).
+  - ec2_vpc_endpoint - replace deprecated ``datetime.utcnow()`` with timezone-aware ``datetime.now(datetime.timezone.utc)`` (https://github.com/ansible-collections/amazon.aws/pull/2866).

--- a/plugins/modules/ec2_vpc_endpoint.py
+++ b/plugins/modules/ec2_vpc_endpoint.py
@@ -369,7 +369,7 @@ def create_aws_vpc_endpoint(client, module: AnsibleAWSModule) -> Tuple[bool, Dic
 
     if module.params.get("client_token"):
         token_provided = True
-        request_time = datetime.datetime.utcnow()
+        request_time = datetime.datetime.now(datetime.timezone.utc)
         params["ClientToken"] = module.params.get("client_token")
 
     policy = None

--- a/plugins/modules/ec2_vpc_nat_gateway.py
+++ b/plugins/modules/ec2_vpc_nat_gateway.py
@@ -609,7 +609,7 @@ def create(client, module: AnsibleAWSModule, allocation_id: Optional[str]) -> Tu
     if connectivity_type == "public":
         params.update({"AllocationId": allocation_id})
 
-    request_time = datetime.datetime.utcnow()
+    request_time = datetime.datetime.now(datetime.timezone.utc)
     changed = False
     token_provided = False
     result: dict[str, Any] = {}


### PR DESCRIPTION
##### SUMMARY
Replaced deprecated `datetime.utcnow()` calls with timezone-aware `datetime.now(datetime.timezone.utc)` in `ec2_vpc_nat_gateway` and `ec2_vpc_endpoint` modules to address Python deprecation warnings.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
ec2_vpc_nat_gateway, ec2_vpc_endpoint

##### ADDITIONAL INFORMATION
The `datetime.utcnow()` method has been deprecated in Python 3.12 in favor of timezone-aware datetime operations. This change ensures compatibility with newer Python versions and follows best practices for datetime handling.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>