### PR TITLE
Fix variable quoting in SonarCloud workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -49,9 +49,9 @@ jobs:
         run: |
           SONAR_ARGS="-Dsonar.scm.revision=\"${COMMIT_SHA}\""
           if [[ "$EVENT_TYPE" == "pull_request" && -n "$PR_NUMBER" ]]; then
-            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.key=\"${PR_NUMBER}\""
-            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.branch=\"${PR_HEAD}\""
-            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.base=\"${PR_BASE}\""
+            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.key=${PR_NUMBER}"
+            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.branch=${PR_HEAD}"
+            SONAR_ARGS="${SONAR_ARGS} -Dsonar.pullrequest.base=${PR_BASE}"
           fi
           echo "SONAR_ARGS=${SONAR_ARGS}" >> $GITHUB_ENV
 


### PR DESCRIPTION
##### SUMMARY
Fix the quoting of variable expansions for sonar.pullrequest.* parameters in the SonarCloud workflow. The NodeJS-based SonarSource/sonarqube-scan-action@v7 action doesn't handle arguments the same way a bash-based argument would. Removing the quotes around the variable expansions ensures parameters are passed correctly to the scanner.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
.github/workflows/sonarcloud.yml

##### ADDITIONAL INFORMATION
The issue manifests because the NodeJS action processes arguments differently from bash. The difference is equivalent to:
- `sonar-scanner-8.0.1.6346-linux-x64/bin/sonar-scanner -Dsonar.projectBaseDir=. ${SONAR_ARGS}` (doesn't work with the original quoting)
- vs `sonar-scanner-8.0.1.6346-linux-x64/bin/sonar-scanner -Dsonar.projectBaseDir=. "${SONAR_ARGS}"` (works with the original quoting)

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>