### PR TITLE
Use exclude_also for coverage config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,9 +63,7 @@ ignore = ["F401", "E402"]
 xfail_strict = true
 
 [tool.coverage.report]
-exclude_lines = [
-    # Have to re-enable the standard pragma
-    "pragma: no cover",
+exclude_also = [
     # Don't complain if tests don't hit defensive assertion code:
     "raise NotImplementedError",
 ]


### PR DESCRIPTION
##### SUMMARY
Use `exclude_also` instead of `exclude_lines` for coverage configuration to preserve coverage.py's default exclusions. The defaults have been expanded to include patterns for type checking blocks and other common code structures.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
pyproject.toml

##### ADDITIONAL INFORMATION
The `exclude_lines` option overwrites coverage.py's defaults, while `exclude_also` appends to them. This ensures we benefit from coverage.py's evolving default exclusion patterns without having to manually maintain them.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>