### PR TITLE
Fix `label-new-prs.yml` workflow security issue

### DIFF
--- a/.github/workflows/label-new-prs.yaml
+++ b/.github/workflows/label-new-prs.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   add_label:
-    if: github.actor != 'patchback[bot]'
+    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
##### SUMMARY

Fixing a security issue reported in [SonarQube](https://sonarcloud.io/project/overview?id=ansible-collections_amazon.aws):

> Using `github.actor` or equivalent properties to check if the actor is a trusted principal on events like `pull_request_target` could be a security issue, because they do not always refer to the actual creator of the `commit` or the `pull request`.
> 
> The value represents the entity who triggered the workflow event, which may differ from the actual author of the commit or pull request. If a threat actor could force a trusted actor (such as a bot) into making a change that triggers the workflow, they can bypass the check.
> 
> #### What is the potential impact?
> Unauthorized access
> An attacker could trick the action to run sensitive jobs/commands with special permissions or secrets. For instance, an auto-merge workflow.
> 
>  #### Supply Chain Compromise
> If the sensitive code performs a merge or releases an artifact, an attacker can inject malicious code or publish malicious packages, potentially compromising the entire supply chain.
> 
> ### Resources
>
> #### Documentation
>
> GitHub Docs - [GitHub Context reference](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context)
> GitHub Security Lab - [Keeping your GitHub Actions and workflows secure Part 4: New vulnerability patterns and mitigation strategies](https://securitylab.github.com/resources/github-actions-new-patterns-and-mitigations/)
> 
> 