### PR TITLE
Improve unit test performance and move coverage configuration into pyproject.toml

### DIFF
--- a/.github/workflows/all_green_check.yml
+++ b/.github/workflows/all_green_check.yml
@@ -63,17 +63,6 @@ jobs:
           export COLLECTION_PATH=$(dirname "$COVERAGE_FILE")
           export COVERAGE_FILE
           echo "COVERAGE_FILE=$COVERAGE_FILE" >> $GITHUB_ENV
-          python3 -c "
-          import os
-          prefix = os.environ['COLLECTION_PATH'].rstrip('/') + '/'
-          path = os.environ['COVERAGE_FILE']
-          with open(path, 'r') as f:
-            content = f.read()
-          content = content.replace(prefix, '')
-          with open(path, 'w') as f:
-            f.write(content)
-          "
-
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:

--- a/changelogs/fragments/unittests-boto3-credentials.yml
+++ b/changelogs/fragments/unittests-boto3-credentials.yml
@@ -1,0 +1,3 @@
+trivial:
+  - tests - provide dummy AWS credentials to boto3.Session in placebo fixture to prevent connection delays to AWS Metadata service during unit tests.
+  - tests - centralize coverage configuration in pyproject.toml and simplify tox.ini.

--- a/changelogs/fragments/unittests-boto3-credentials.yml
+++ b/changelogs/fragments/unittests-boto3-credentials.yml
@@ -1,3 +1,3 @@
 trivial:
-  - tests - provide dummy AWS credentials to boto3.Session in placebo fixture to prevent connection delays to AWS Metadata service during unit tests.
-  - tests - centralize coverage configuration in pyproject.toml and simplify tox.ini.
+  - tests - provide dummy AWS credentials to boto3.Session in placebo fixture to prevent connection delays to AWS Metadata service during unit tests (https://github.com/ansible-collections/amazon.aws/pull/2889).
+  - tests - centralize coverage configuration in pyproject.toml and simplify tox.ini (https://github.com/ansible-collections/amazon.aws/pull/2889).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,8 +62,24 @@ ignore = ["F401", "E402"]
 [tool.pytest]
 xfail_strict = true
 
+[tool.coverage.run]
+source = [
+    "plugins/",
+    "extensions/",
+]
+relative_files = true
+
 [tool.coverage.report]
 exclude_also = [
     # Don't complain if tests don't hit defensive assertion code:
     "raise NotImplementedError",
+    # Handling for botocore not being available is performed by AnsibleAWSModule
+    "try:\n(    import botocore\n|    import boto3\n)*except ImportError:\n    pass",
 ]
+include_namespace_packages = true
+
+[tool.coverage.html]
+directory = "coverage-report"
+
+[tool.coverage.xml]
+output = "coverage.xml"

--- a/tests/unit/utils/amazon_placebo_fixtures.py
+++ b/tests/unit/utils/amazon_placebo_fixtures.py
@@ -45,7 +45,9 @@ def fixture_placeboify(request, monkeypatch):
     namespace `placebo_recordings/{testfile name}/{test function name}` to
     distinguish them.
     """
-    session = boto3.Session(region_name="us-west-2")
+    session = boto3.Session(
+        region_name="us-west-2", aws_access_key_id="EXAMPLE_KEY", aws_secret_access_key="EXAMPLE_SECRET"
+    )
 
     recordings_path = os.path.join(
         request.fspath.dirname,

--- a/tox.ini
+++ b/tox.ini
@@ -58,15 +58,9 @@ commands_pre =
   ansible-galaxy collection install git+https://github.com/ansible-collections/community.aws.git
 commands =
     pytest \
+        --cov \
         --cov-report html \
-        --cov-report xml:coverage.xml \
-        --cov plugins/callback \
-        --cov plugins/inventory \
-        --cov plugins/lookup \
-        --cov plugins/module_utils \
-        --cov plugins/modules \
-        --cov plugins/plugin_utils \
-        --cov plugins \
+        --cov-report xml \
         --ansible-host-pattern localhost \
         {posargs:tests/unit/}
 


### PR DESCRIPTION
##### SUMMARY
Fix unit test performance by providing dummy AWS credentials to boto3.Session in the placebo fixture. When boto3.Session is initialized without credentials, it attempts to connect to the AWS Metadata service, causing delays in unit tests where the fetched credentials won't be used anyway.

Centralizes coverage configuration in pyproject.toml and simplifies tox.ini :
- Enables XML reporting
- Adds missing coverage reporting for code in extensions/ (Event Driven Ansible plugins)
- ignores the generic boto3/botocore ImportError top-level handling (AnsibleAWSModule is responsible for this)
- Sets `include_namespace_packages=true` becuase we don't generally add `__init__.py` (coverage defaults to skipping directories if it's not there "it must be an executable that doesn't need coverage reporting")

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
tests/unit/utils/amazon_placebo_fixtures.py
pyproject.toml
tox.ini

##### ADDITIONAL INFORMATION
Before this change, each unit test using the placebo fixture would experience a delay as boto3 tried to contact the AWS Metadata service. By providing dummy credentials (EXAMPLE_KEY/EXAMPLE_SECRET), we prevent these unnecessary connection attempts during testing.

The coverage configuration consolidation moves settings to pyproject.toml (the standard location) and simplifies the tox.ini command line.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>