### PR TITLE
route53: Add routing_region parameter to resolve region parameter conflict

### DIFF
--- a/changelogs/fragments/route53-region-parameter-refactor.yml
+++ b/changelogs/fragments/route53-region-parameter-refactor.yml
@@ -1,0 +1,6 @@
+---
+deprecated_features:
+  - route53 - the ``region`` parameter for latency-based routing has been deprecated and will be removed in a release after 2027-06-01. The ``routing_region`` parameter behaves exactly as ``region`` behaves today and should be used instead (https://github.com/ansible-collections/amazon.aws/issues/2893).
+minor_changes:
+  - route53 - added ``routing_region`` parameter to explicitly specify the region for latency-based resource record sets (https://github.com/ansible-collections/amazon.aws/issues/2893).
+  - route53 - added temporary ``aws_region`` parameter to allow specifying the AWS region for API requests while the ``region`` parameter is being transitioned (https://github.com/ansible-collections/amazon.aws/issues/2893).

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -106,7 +106,7 @@ options:
         latency-based routing
       - Mutually exclusive with O(weight) and O(failover).
     type: str
-    version_added: 12.0.0
+    version_added: 11.2.0
   region:
     description:
       - Latency-based resource record sets only Among resource record sets
@@ -124,7 +124,7 @@ options:
       - See the AWS documentation U(https://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region) for more information.
       - When O(aws_region) is not specified, the module may also use a profile from your AWS configuration.
     type: str
-    version_added: 12.0.0
+    version_added: 11.2.0
   geo_location:
     description:
       - Allows to control how Amazon Route 53 responds to DNS queries based on the geographic origin of the query.
@@ -240,7 +240,7 @@ resource_record_sets:
       returned: always
       type: str
       sample: "us-west-2"
-      version_added: 12.0.0
+      version_added: 11.2.0
     region:
       description:
         - Which region this should be associated with for latency-based routing.

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -737,7 +737,7 @@ def main():
     # Handle backward compatibility for deprecated 'region' parameter
     if region_in:
         module.deprecate(
-            "The 'region' parameter for latency-based routing is deprecated. " "Please use 'routing_region' instead.",
+            "The 'region' parameter for latency-based routing is deprecated. Please use 'routing_region' instead.",
             date="2027-06-01",
             collection_name="amazon.aws",
         )

--- a/plugins/modules/route53.py
+++ b/plugins/modules/route53.py
@@ -96,9 +96,9 @@ options:
         have the same combination of DNS name and type, a value that
         determines what portion of traffic for the current resource record set
         is routed to the associated location.
-      - Mutually exclusive with O(region) and O(failover).
+      - Mutually exclusive with O(routing_region), O(region), and O(failover).
     type: int
-  region:
+  routing_region:
     description:
       - Latency-based resource record sets only Among resource record sets
         that have the same combination of DNS name and type, a value that
@@ -106,6 +106,25 @@ options:
         latency-based routing
       - Mutually exclusive with O(weight) and O(failover).
     type: str
+    version_added: 12.0.0
+  region:
+    description:
+      - Latency-based resource record sets only Among resource record sets
+        that have the same combination of DNS name and type, a value that
+        determines which region this should be associated with for the
+        latency-based routing
+      - Mutually exclusive with O(weight) and O(failover).
+      - This parameter has been deprecated and will be removed in a release after 2027-06-01.
+      - Please use O(routing_region) instead.
+    type: str
+  aws_region:
+    description:
+      - The AWS region to use for API requests.
+      - If not specified, the value of the E(AWS_REGION) or E(AWS_DEFAULT_REGION) environment variable is used.
+      - See the AWS documentation U(https://docs.aws.amazon.com/general/latest/gr/rande.html#ec2_region) for more information.
+      - When O(aws_region) is not specified, the module may also use a profile from your AWS configuration.
+    type: str
+    version_added: 12.0.0
   geo_location:
     description:
       - Allows to control how Amazon Route 53 responds to DNS queries based on the geographic origin of the query.
@@ -140,7 +159,7 @@ options:
     description:
       - Failover resource record sets only. Whether this is the primary or
         secondary resource record set. Allowed values are V(PRIMARY) and V(SECONDARY).
-      - Mutually exclusive with O(weight) and O(region).
+      - Mutually exclusive with O(weight), O(routing_region), and O(region).
     type: str
     choices: ['SECONDARY', 'PRIMARY']
   vpc_id:
@@ -216,8 +235,16 @@ resource_record_sets:
       returned: always
       type: str
       sample: "new.foo.com"
-    region:
+    routing_region:
       description: Which region this should be associated with for latency-based routing.
+      returned: always
+      type: str
+      sample: "us-west-2"
+      version_added: 12.0.0
+    region:
+      description:
+        - Which region this should be associated with for latency-based routing.
+        - This return value has been deprecated and will be removed in a release after 2027-06-01. Use RV(resource_record_sets.routing_region) instead.
       returned: always
       type: str
       sample: "us-west-2"
@@ -472,6 +499,7 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible.module_utils._text import to_native
+from ansible.module_utils.basic import env_fallback
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message
@@ -552,7 +580,8 @@ def format_record(record_in, zone_in, zone_id):
     record["ttl"] = record_in.get("TTL", None)
     record["identifier"] = record_in.get("SetIdentifier", None)
     record["weight"] = record_in.get("Weight", None)
-    record["region"] = record_in.get("Region", None)
+    record["routing_region"] = record_in.get("Region", None)
+    record["region"] = record_in.get("Region", None)  # Deprecated, kept for backward compatibility
     record["failover"] = record_in.get("Failover", None)
     record["health_check"] = record_in.get("HealthCheckId", None)
 
@@ -560,6 +589,8 @@ def format_record(record_in, zone_in, zone_id):
         record["ttl"] = str(record["ttl"])
     if record["weight"]:
         record["weight"] = str(record["weight"])
+    if record["routing_region"]:
+        record["routing_region"] = str(record["routing_region"])
     if record["region"]:
         record["region"] = str(record["region"])
 
@@ -616,7 +647,12 @@ def main():
         private_zone=dict(type="bool", default=False),
         identifier=dict(type="str"),
         weight=dict(type="int"),
+        routing_region=dict(type="str"),
         region=dict(type="str"),
+        aws_region=dict(
+            type="str",
+            fallback=(env_fallback, ["AWS_REGION", "AWS_DEFAULT_REGION"]),
+        ),
         geo_location=dict(
             type="dict",
             options=dict(
@@ -642,14 +678,15 @@ def main():
             ("state", "present", ["value"]),
             ("state", "create", ["value"]),
         ),
-        # failover, region and weight are mutually exclusive
+        # failover, routing_region, region and weight are mutually exclusive
         mutually_exclusive=[
-            ("failover", "region", "weight"),
+            ("failover", "routing_region", "region", "weight"),
             ("alias", "ttl"),
         ],
-        # failover, region, weight and geo_location require identifier
+        # failover, routing_region, region, weight and geo_location require identifier
         required_by=dict(
             failover=("identifier",),
+            routing_region=("identifier",),
             region=("identifier",),
             weight=("identifier",),
             geo_location=("identifier",),
@@ -687,13 +724,24 @@ def main():
 
     identifier_in = module.params.get("identifier")
     weight_in = module.params.get("weight")
-    region_in = module.params.get("region")
+    routing_region_in = module.params.get("routing_region")
+    region_in = module.params.get("region")  # Deprecated, for backward compatibility
     health_check_in = module.params.get("health_check")
     failover_in = module.params.get("failover")
     vpc_id_in = module.params.get("vpc_id")
     wait_in = module.params.get("wait")
     wait_timeout_in = module.params.get("wait_timeout")
     geo_location = module.params.get("geo_location")
+    aws_region_in = module.params.get("aws_region")
+
+    # Handle backward compatibility for deprecated 'region' parameter
+    if region_in:
+        module.deprecate(
+            "The 'region' parameter for latency-based routing is deprecated. " "Please use 'routing_region' instead.",
+            date="2027-06-01",
+            collection_name="amazon.aws",
+        )
+        routing_region_in = region_in
 
     if zone_in[-1:] != ".":
         zone_in += "."
@@ -705,11 +753,11 @@ def main():
         if alias_in and len(value_in) != 1:
             module.fail_json(msg="parameter 'value' must contain a single dns name for alias records")
         if (
-            weight_in is None and region_in is None and failover_in is None and geo_location is None
+            weight_in is None and routing_region_in is None and failover_in is None and geo_location is None
         ) and identifier_in is not None:
             module.fail_json(
                 msg=(
-                    "You have specified identifier which makes sense only if you specify one of: weight, region,"
+                    "You have specified identifier which makes sense only if you specify one of: weight, routing_region,"
                     " geo_location or failover."
                 )
             )
@@ -722,8 +770,12 @@ def main():
     )
 
     # connect to the route53 endpoint
+    # Use aws_region for API connection, not the deprecated latency-routing region parameter
     try:
-        route53 = module.client("route53", retry_decorator=retry_decorator)
+        client_params = {"retry_decorator": retry_decorator}
+        if aws_region_in:
+            client_params["region"] = aws_region_in
+        route53 = module.client("route53", **client_params)
     except botocore.exceptions.HTTPClientError as e:
         module.fail_json_aws(e, msg="Failed to connect to AWS")
 
@@ -742,7 +794,7 @@ def main():
             "Name": record_in,
             "Type": type_in,
             "Weight": weight_in,
-            "Region": region_in,
+            "Region": routing_region_in,
             "Failover": failover_in,
             "TTL": ttl_in,
             "ResourceRecords": [dict(Value=value) for value in value_in],

--- a/tests/integration/targets/route53/tasks/main.yml
+++ b/tests/integration/targets/route53/tasks/main.yml
@@ -956,10 +956,126 @@
           - create_geo_subdivision_idem_check is not failed
           - '"route53:ChangeResourceRecordSets" not in create_geo_subdivision_idem_check.resource_actions'
 
+    # Test Latency-based Routing - routing_region parameter
+    - name: Create a record with routing_region for latency-based routing (check_mode)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: latency-test.{{ zone_one }}
+        identifier: latencyhost@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        routing_region: us-east-1
+        region: "{{ omit }}"
+      check_mode: true
+      register: create_latency_routing_region_check_mode
+    - ansible.builtin.assert:
+        that:
+          - create_latency_routing_region_check_mode is changed
+          - create_latency_routing_region_check_mode is not failed
+          - '"route53:ChangeResourceRecordSets" not in create_latency_routing_region_check_mode.resource_actions'
+          - '"wait_id" in create_latency_routing_region_check_mode'
+          - create_latency_routing_region_check_mode.wait_id is none
+
+    - name: Create a record with routing_region for latency-based routing
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: latency-test.{{ zone_one }}
+        identifier: latencyhost@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        routing_region: us-east-1
+        region: "{{ omit }}"
+      register: create_latency_routing_region
+    - name: Get Route53 latency record information
+      amazon.aws.route53_info:
+        type: A
+        query: record_sets
+        hosted_zone_id: "{{ z1.zone_id }}"
+        start_record_name: latency-test.{{ zone_one }}
+        max_items: 1
+      register: latency_result
+
+    - ansible.builtin.assert:
+        that:
+          - create_latency_routing_region is changed
+          - create_latency_routing_region is not failed
+          - '"route53:ChangeResourceRecordSets" in create_latency_routing_region.resource_actions'
+          - latency_result.resource_record_sets[0].region == "us-east-1"
+          - latency_result.resource_record_sets[0].set_identifier == "latencyhost@www"
+
+    - name: Create a record with routing_region for latency-based routing (idempotency)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: latency-test.{{ zone_one }}
+        identifier: latencyhost@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        routing_region: us-east-1
+        region: "{{ omit }}"
+      register: create_latency_routing_region_idem
+    - ansible.builtin.assert:
+        that:
+          - create_latency_routing_region_idem is not changed
+          - create_latency_routing_region_idem is not failed
+          - '"route53:ChangeResourceRecordSets" not in create_latency_routing_region_idem.resource_actions'
+
+    - name: Create a record with routing_region for latency-based routing (idempotency - check_mode)
+      amazon.aws.route53:
+        state: present
+        zone: "{{ zone_one }}"
+        record: latency-test.{{ zone_one }}
+        identifier: latencyhost@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        routing_region: us-east-1
+        region: "{{ omit }}"
+      check_mode: true
+      register: create_latency_routing_region_idem_check
+
+    - ansible.builtin.assert:
+        that:
+          - create_latency_routing_region_idem_check is not changed
+          - create_latency_routing_region_idem_check is not failed
+          - '"route53:ChangeResourceRecordSets" not in create_latency_routing_region_idem_check.resource_actions'
+
+    # Test that get returns both routing_region and region (for backward compatibility)
+    - name: Get latency record and verify both region fields are returned
+      amazon.aws.route53:
+        state: get
+        zone: "{{ zone_one }}"
+        record: latency-test.{{ zone_one }}
+        type: A
+      register: get_latency_result
+    - ansible.builtin.assert:
+        that:
+          - get_latency_result.set.routing_region is defined
+          - get_latency_result.set.region is defined
+          - get_latency_result.set.routing_region == "us-east-1"
+          - get_latency_result.set.region == "us-east-1"
+
   # ------------------------------------------------------
   # Cleanup
 
   always:
+    - name: Delete latency-based routing record
+      amazon.aws.route53:
+        state: absent
+        zone: "{{ zone_one }}"
+        record: latency-test.{{ zone_one }}
+        identifier: latencyhost@www
+        type: A
+        value: 127.0.0.1
+        ttl: 30
+        routing_region: us-east-1
+      ignore_errors: true
+
     - name: Delete a record with geo_location - continent_code
       amazon.aws.route53:
         state: absent


### PR DESCRIPTION
## SUMMARY
Resolves the region parameter conflict in the route53 module where the module-specific `region` parameter for latency-based routing was overriding the standard AWS region parameter from `aws_argument_spec()`.

The `routing_region` parameter behaves exactly as `region` behaves today for latency-based routing. Full backward compatibility is maintained.

Fixes #2893

## ISSUE TYPE
- Bugfix Pull Request

## COMPONENT NAME
route53

## ADDITIONAL INFORMATION

### Changes
- Added new `routing_region` parameter for latency-based routing
- Deprecated `region` parameter for latency-based routing (removal after 2027-06-01)
- Added temporary `aws_region` parameter for AWS API region selection
- Updated all internal references from `region_in` to `routing_region_in`
- Both `routing_region` and `region` returned in output for backward compatibility

### Testing
- Added comprehensive integration tests for latency-based routing with `routing_region` parameter
- Tests cover: creation, check_mode, idempotency, and return values verification
- All linting passed with 10.00/10 score

### Backward Compatibility
✅ Fully backward compatible
- Existing playbooks using `region` for latency routing continue to work
- Deprecation warning shown when using old `region` parameter
- Both `routing_region` and `region` field names returned in module output

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>