### PR TITLE
fix: Use github.actor instead of event payload for trust decision

### DIFF
--- a/.github/workflows/label-new-prs.yaml
+++ b/.github/workflows/label-new-prs.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   add_label:
-    if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+    if: ${{ github.actor == 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
##### SUMMARY
Replaces the use of `github.event.pull_request.user.login` with `github.actor` in the label-new-prs workflow to follow GitHub's security best practices for `pull_request_target` workflows.

`github.actor` is a trusted runtime context value that cannot be forged, whereas event payload values are considered less secure. This change resolves the SonarCloud security warning about relying on forgeable GitHub context values in workflows with elevated permissions.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
`.github/workflows/label-new-prs.yaml`

##### ADDITIONAL INFORMATION
The workflow functionality remains unchanged - it still only applies to dependabot PRs. The security improvement is that the trust decision now relies on a server-side runtime value rather than the webhook event payload.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>