### PR TITLE
Refactor lookup plugins to reduce cognitive complexity

### DIFF
--- a/changelogs/fragments/lookup-error-handler-refactor.yml
+++ b/changelogs/fragments/lookup-error-handler-refactor.yml
@@ -1,0 +1,8 @@
+minor_changes:
+  - lookup plugins - created centralised LookupErrorHandler decorator pattern to reduce code duplication and cognitive complexity in lookup plugins. (https://github.com/ansible-collections/amazon.aws/pull/2914)
+  - secretsmanager_secret - refactored to use LookupErrorHandler decorator, reducing cognitive complexity from 36 to <15. (https://github.com/ansible-collections/amazon.aws/pull/2914)
+  - ssm_parameter - refactored to use LookupErrorHandler decorator, reducing cognitive complexity from 28 to <15. (https://github.com/ansible-collections/amazon.aws/pull/2914)
+  - aws_account_attribute - added ``on_denied`` parameter to control behaviour when access to account attributes is denied, supporting error (default), skip, and warn modes. (https://github.com/ansible-collections/amazon.aws/pull/2914)
+  - lookup plugins - updated deprecated text converter imports from ``ansible.module_utils._text`` to ``ansible.module_utils.common.text.converters`` to avoid deprecation warnings. (https://github.com/ansible-collections/amazon.aws/pull/2914)
+bugfixes:
+  - secretsmanager_secret - fixed bug where falsy values (0, empty string, False) were incorrectly filtered when on_missing/on_denied was set to skip or warn. Now only None values are filtered. (https://github.com/ansible-collections/amazon.aws/pull/2914)

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -58,6 +58,8 @@ _raw:
       (or all attributes if one is not specified).
 """
 
+from ansible.module_utils.common.text.converters import to_native
+
 from ansible_collections.amazon.aws.plugins.plugin_utils._lookup.common import LookupErrorHandler
 from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import AWSLookupBase
 
@@ -135,6 +137,8 @@ class LookupModule(AWSLookupBase):
 
         # Pass attribute name as term for error messages
         term = attribute or "all attributes"
+        self.v_log(3, f"aws_account_attribute lookup term: {term} in region: {self.region}")
+
         result = self._describe_account_attributes(term=term, **params)
 
         # Handle case where access was denied with on_denied=warn/skip
@@ -144,12 +148,18 @@ class LookupModule(AWSLookupBase):
         response = result["AccountAttributes"]
 
         if check_ec2_classic:
-            return [self._process_response_for_ec2_classic(response)]
+            ret = [self._process_response_for_ec2_classic(response)]
+            self.v_log(4, f"aws_account_attribute lookup returning: {to_native(ret)}")
+            return ret
 
         if attribute:
-            return self._process_response_for_attribute(response)
+            ret = self._process_response_for_attribute(response)
+            self.v_log(4, f"aws_account_attribute lookup returning: {to_native(ret)}")
+            return ret
 
-        return [self._process_response_for_all_attributes(response)]
+        ret = [self._process_response_for_all_attributes(response)]
+        self.v_log(4, f"aws_account_attribute lookup returning: {to_native(ret)}")
+        return ret
 
     @LookupErrorHandler.handle_lookup_errors("account attribute")
     def _describe_account_attributes(self, term, **params):

--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -22,6 +22,16 @@ options:
       - max-elastic-ips
       - vpc-max-elastic-ips
       - has-ec2-classic
+  on_denied:
+    description:
+      - Action to take if access to the account attribute is denied.
+      - V(error) will raise a fatal error when access to the account attribute is denied.
+      - V(skip) will silently ignore the denied account attribute.
+      - V(warn) will skip over the denied account attribute but issue a warning.
+    default: error
+    type: str
+    choices: ["error", "skip", "warn"]
+    version_added: "11.3.0"
 extends_documentation_fragment:
   - amazon.aws.boto3
   - amazon.aws.common.plugins
@@ -48,51 +58,100 @@ _raw:
       (or all attributes if one is not specified).
 """
 
-try:
-    import botocore
-except ImportError:
-    pass  # Handled by AWSLookupBase
-
-from ansible.errors import AnsibleLookupError
-from ansible.module_utils.common.text.converters import to_native
-
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.plugin_utils._lookup.common import LookupErrorHandler
 from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import AWSLookupBase
 
 
-def _describe_account_attributes(client, **params):
-    return client.describe_account_attributes(aws_retry=True, **params)
-
-
 class LookupModule(AWSLookupBase):
-    def run(self, terms, variables, **kwargs):
-        super().run(terms, variables, **kwargs)
+    _SERVICE = "ec2"
 
-        client = self.client("ec2", AWSRetry.jittered_backoff())
+    def _build_api_params(self, attribute):
+        """
+        Build API parameters for describe_account_attributes call.
 
-        attribute = kwargs.get("attribute")
+        Args:
+            attribute: The attribute name to query, or None for all attributes
+
+        Returns:
+            Tuple of (params dict, check_ec2_classic boolean)
+        """
         params = {"AttributeNames": []}
         check_ec2_classic = False
-        if "has-ec2-classic" == attribute:
+
+        if attribute == "has-ec2-classic":
             check_ec2_classic = True
             params["AttributeNames"] = ["supported-platforms"]
         elif attribute:
             params["AttributeNames"] = [attribute]
 
-        try:
-            response = _describe_account_attributes(client, **params)["AccountAttributes"]
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            raise AnsibleLookupError(f"Failed to describe account attributes: {to_native(e)}")
+        return params, check_ec2_classic
 
-        if check_ec2_classic:
-            attr = response[0]
-            return [any(value["AttributeValue"] == "EC2" for value in attr["AttributeValues"])]
+    def _process_response_for_ec2_classic(self, response):
+        """
+        Process response to check if account has EC2-Classic support.
 
-        if attribute:
-            attr = response[0]
-            return [value["AttributeValue"] for value in attr["AttributeValues"]]
+        Args:
+            response: List of account attributes from AWS API
 
+        Returns:
+            Boolean indicating if EC2-Classic is supported
+        """
+        attr = response[0]
+        return any(value["AttributeValue"] == "EC2" for value in attr["AttributeValues"])
+
+    def _process_response_for_attribute(self, response):
+        """
+        Process response to extract values for a specific attribute.
+
+        Args:
+            response: List of account attributes from AWS API
+
+        Returns:
+            List of attribute values
+        """
+        attr = response[0]
+        return [value["AttributeValue"] for value in attr["AttributeValues"]]
+
+    def _process_response_for_all_attributes(self, response):
+        """
+        Process response to extract all account attributes as a dictionary.
+
+        Args:
+            response: List of account attributes from AWS API
+
+        Returns:
+            Dictionary mapping attribute names to lists of values
+        """
         flattened = {}
         for k_v_dict in response:
             flattened[k_v_dict["AttributeName"]] = [value["AttributeValue"] for value in k_v_dict["AttributeValues"]]
-        return [flattened]
+        return flattened
+
+    def run(self, terms, variables, **kwargs):
+        super().run(terms, variables, **kwargs)
+
+        attribute = kwargs.get("attribute")
+        params, check_ec2_classic = self._build_api_params(attribute)
+
+        # Pass attribute name as term for error messages
+        term = attribute or "all attributes"
+        result = self._describe_account_attributes(term=term, **params)
+
+        # Handle case where access was denied with on_denied=warn/skip
+        if result is None:
+            return result
+
+        response = result["AccountAttributes"]
+
+        if check_ec2_classic:
+            return [self._process_response_for_ec2_classic(response)]
+
+        if attribute:
+            return self._process_response_for_attribute(response)
+
+        return [self._process_response_for_all_attributes(response)]
+
+    @LookupErrorHandler.handle_lookup_errors("account attribute")
+    def _describe_account_attributes(self, term, **params):
+        """Describe EC2 account attributes"""
+        return self.aws_client.describe_account_attributes(aws_retry=True, **params)

--- a/plugins/lookup/aws_collection_constants.py
+++ b/plugins/lookup/aws_collection_constants.py
@@ -3,6 +3,8 @@
 # (c) 2023 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 DOCUMENTATION = r"""
 name: aws_collection_constants
 author:
@@ -34,6 +36,11 @@ _raw:
   type: str
 """
 
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+
 from ansible.errors import AnsibleLookupError
 from ansible.plugins.lookup import LookupBase
 
@@ -49,7 +56,14 @@ except ImportError:
 
 
 class LookupModule(LookupBase):
-    def lookup_constant(self, name):  # pylint: disable=too-many-return-statements
+    def _validate_terms(self, terms: list[str]) -> None:
+        """Validate that exactly one term is provided"""
+        if not terms:
+            raise AnsibleLookupError("Constant name not provided")
+        if len(terms) > 1:
+            raise AnsibleLookupError("Multiple constant names provided")
+
+    def lookup_constant(self, name: str) -> str | bool | None:  # pylint: disable=too-many-return-statements
         if name == "MINIMUM_BOTOCORE_VERSION":
             return botocore_utils.MINIMUM_BOTOCORE_VERSION
         if name == "MINIMUM_BOTO3_VERSION":
@@ -71,12 +85,9 @@ class LookupModule(LookupBase):
                 raise AnsibleLookupError("Unable to load ansible_collections.community.aws.plugins.module_utils.common")
             return community_utils.COMMUNITY_AWS_COLLECTION_NAME
 
-    def run(self, terms, variables, **kwargs):
+    def run(self, terms: list[str], variables: dict[str, Any], **kwargs: Any) -> list[str | bool]:
         self.set_options(var_options=variables, direct=kwargs)
-        if not terms:
-            raise AnsibleLookupError("Constant name not provided")
-        if len(terms) > 1:
-            raise AnsibleLookupError("Multiple constant names provided")
+        self._validate_terms(terms)
         name = terms[0].upper()
 
         return [self.lookup_constant(name)]

--- a/plugins/lookup/aws_service_ip_ranges.py
+++ b/plugins/lookup/aws_service_ip_ranges.py
@@ -4,6 +4,8 @@
 # (c) 2017 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 DOCUMENTATION = r"""
 name: aws_service_ip_ranges
 author:
@@ -46,6 +48,12 @@ _raw:
   description: Comma-separated list of CIDR ranges.
 """
 
+import typing
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Iterator
+    from typing import Any
+
 import json
 
 import ansible.module_utils.six.moves.urllib.error
@@ -56,14 +64,34 @@ from ansible.plugins.lookup import LookupBase
 
 
 class LookupModule(LookupBase):
-    def run(self, terms, variables, **kwargs):
-        if "ipv6_prefixes" in kwargs and kwargs["ipv6_prefixes"]:
-            prefixes_label = "ipv6_prefixes"
-            ip_prefix_label = "ipv6_prefix"
-        else:
-            prefixes_label = "prefixes"
-            ip_prefix_label = "ip_prefix"
+    def _determine_prefix_labels(self, use_ipv6: bool) -> tuple[str, str]:
+        """
+        Determine the JSON field names for IP prefix data.
 
+        Args:
+            use_ipv6: Boolean indicating whether to use IPv6 prefixes
+
+        Returns:
+            Tuple of (prefixes_label, ip_prefix_label)
+        """
+        if use_ipv6:
+            return ("ipv6_prefixes", "ipv6_prefix")
+        else:
+            return ("prefixes", "ip_prefix")
+
+    def _fetch_ip_ranges(self, prefixes_label: str) -> list[dict[str, str]]:
+        """
+        Fetch and parse IP ranges from AWS.
+
+        Args:
+            prefixes_label: The JSON field name to extract from the response
+
+        Returns:
+            List of IP range dictionaries from AWS
+
+        Raises:
+            AnsibleLookupError: If fetching or parsing fails
+        """
         try:
             resp = ansible.module_utils.urls.open_url("https://ip-ranges.amazonaws.com/ip-ranges.json")
             amazon_response = json.load(resp)[prefixes_label]
@@ -79,12 +107,57 @@ class LookupModule(LookupBase):
             raise AnsibleLookupError(f"Failed look up IP range service: {to_native(e)}")
         except ansible.module_utils.urls.ConnectionError as e:
             raise AnsibleLookupError(f"Error connecting to IP range service: {to_native(e)}")
+        return amazon_response
+
+    def _filter_by_region(self, ip_ranges: Iterator[dict[str, str]], region: str) -> Iterator[dict[str, str]]:
+        """
+        Filter IP ranges by AWS region.
+
+        Args:
+            ip_ranges: Iterator or list of IP range dictionaries
+            region: AWS region string to filter by
+
+        Returns:
+            Generator of IP ranges matching the region
+        """
+        return (item for item in ip_ranges if item["region"] == region)
+
+    def _filter_by_service(self, ip_ranges: Iterator[dict[str, str]], service: str) -> Iterator[dict[str, str]]:
+        """
+        Filter IP ranges by AWS service.
+
+        Args:
+            ip_ranges: Iterator or list of IP range dictionaries
+            service: AWS service name to filter by (case-insensitive)
+
+        Returns:
+            Generator of IP ranges matching the service
+        """
+        service_upper = str.upper(service)
+        return (item for item in ip_ranges if item["service"] == service_upper)
+
+    def _extract_ip_addresses(self, ip_ranges: Iterator[dict[str, str]], ip_prefix_label: str) -> list[str]:
+        """
+        Extract IP address strings from IP range dictionaries.
+
+        Args:
+            ip_ranges: Iterator or list of IP range dictionaries
+            ip_prefix_label: The field name containing the IP prefix
+
+        Returns:
+            List of IP address/CIDR strings
+        """
+        return [item[ip_prefix_label] for item in ip_ranges]
+
+    def run(self, terms: list[str], variables: dict[str, Any], **kwargs: Any) -> list[str]:
+        prefixes_label, ip_prefix_label = self._determine_prefix_labels(kwargs.get("ipv6_prefixes", False))
+
+        amazon_response = self._fetch_ip_ranges(prefixes_label)
 
         if "region" in kwargs:
-            region = kwargs["region"]
-            amazon_response = (item for item in amazon_response if item["region"] == region)
+            amazon_response = self._filter_by_region(amazon_response, kwargs["region"])
         if "service" in kwargs:
-            service = str.upper(kwargs["service"])
-            amazon_response = (item for item in amazon_response if item["service"] == service)
-        iprange = [item[ip_prefix_label] for item in amazon_response]
+            amazon_response = self._filter_by_service(amazon_response, kwargs["service"])
+
+        iprange = self._extract_ip_addresses(amazon_response, ip_prefix_label)
         return iprange

--- a/plugins/lookup/secretsmanager_secret.py
+++ b/plugins/lookup/secretsmanager_secret.py
@@ -120,10 +120,11 @@ _raw:
 import json
 
 from ansible.errors import AnsibleLookupError
+from ansible.module_utils.common.text.converters import to_native
 
 from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import AWSLookupBase
 from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import LookupErrorHandler
-from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import NestedKeyNotFoundError
+from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import LookupResourceNotFoundError
 
 
 class LookupModule(AWSLookupBase):
@@ -179,16 +180,19 @@ class LookupModule(AWSLookupBase):
         """Lookup secrets by path"""
         secrets = {}
         for term in terms:
+            self.v_log(3, f"secretsmanager_secret path lookup term: {term} in region: {self.region}")
             secret_list = self._fetch_secret_list(term)
             for secret_obj in secret_list:
                 value = self.get_secret_value(secret_obj["Name"])
                 if value is not None:
                     secrets[secret_obj["Name"]] = value
 
+        self.v_log(4, f"secretsmanager_secret path lookup returning: {to_native(secrets)}")
         return [secrets] if secrets else []
 
     def _lookup_by_name(self, terms):
         """Lookup secrets by name"""
+        self.v_log(3, f"secretsmanager_secret name lookup term: {terms}")
         secrets = []
         for term in terms:
             value = self.get_secret_value(
@@ -201,8 +205,11 @@ class LookupModule(AWSLookupBase):
                 secrets.append(value)
 
         if self.get_option("join"):
-            return ["".join(secrets)]
+            joined = ["".join(secrets)]
+            self.v_log(4, f"secretsmanager_secret name lookup returning (joined): {to_native(joined)}")
+            return joined
 
+        self.v_log(4, f"secretsmanager_secret name lookup returning: {to_native(secrets)}")
         return secrets
 
     @LookupErrorHandler.handle_lookup_errors("secret")
@@ -258,7 +265,7 @@ class LookupModule(AWSLookupBase):
         """
         Extract nested value from secret JSON.
 
-        Raises NestedKeyNotFoundError if any key in the path is not found,
+        Raises LookupResourceNotFoundError if any key in the path is not found,
         which is caught by the @handle_lookup_errors decorator.
         """
         query = term.split(".")[1:]
@@ -273,6 +280,6 @@ class LookupModule(AWSLookupBase):
             except (KeyError, TypeError) as e:
                 # KeyError: key not in dict
                 # TypeError: trying to access a non-dict (e.g., string) as a dict
-                raise NestedKeyNotFoundError(path) from e
+                raise LookupResourceNotFoundError(path) from e
 
         return str(ret_val)

--- a/plugins/lookup/secretsmanager_secret.py
+++ b/plugins/lookup/secretsmanager_secret.py
@@ -119,26 +119,16 @@ _raw:
 
 import json
 
-try:
-    import botocore
-except ImportError:
-    pass  # Handled by AWSLookupBase
-
 from ansible.errors import AnsibleLookupError
-from ansible.module_utils.common.text.converters import to_native
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import AWSLookupBase
-
-
-def _list_secrets(client, term):
-    paginator = client.get_paginator("list_secrets")
-    return paginator.paginate(Filters=[{"Key": "name", "Values": [term]}])
+from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import LookupErrorHandler
+from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import NestedKeyNotFoundError
 
 
 class LookupModule(AWSLookupBase):
+    _SERVICE = "secretsmanager"
+
     def run(self, terms, variables, **kwargs):
         """
         :arg terms: a list of lookups to run.
@@ -149,89 +139,98 @@ class LookupModule(AWSLookupBase):
 
         super().run(terms, variables, **kwargs)
 
-        on_missing = self.get_option("on_missing")
-        on_denied = self.get_option("on_denied")
-        on_deleted = self.get_option("on_deleted")
-
-        # validate arguments 'on_missing' and 'on_denied'
-        if on_missing is not None and (
-            not isinstance(on_missing, str) or on_missing.lower() not in ["error", "warn", "skip"]
-        ):
-            raise AnsibleLookupError(
-                f'"on_missing" must be a string and one of "error", "warn" or "skip", not {on_missing}'
-            )
-        if on_denied is not None and (
-            not isinstance(on_denied, str) or on_denied.lower() not in ["error", "warn", "skip"]
-        ):
-            raise AnsibleLookupError(
-                f'"on_denied" must be a string and one of "error", "warn" or "skip", not {on_denied}'
-            )
-        if on_deleted is not None and (
-            not isinstance(on_deleted, str) or on_deleted.lower() not in ["error", "warn", "skip"]
-        ):
-            raise AnsibleLookupError(
-                f'"on_deleted" must be a string and one of "error", "warn" or "skip", not {on_deleted}'
-            )
-
-        client = self.client("secretsmanager", AWSRetry.jittered_backoff())
+        self._validate_options()
 
         if self.get_option("bypath"):
-            secrets = {}
-            for term in terms:
-                try:
-                    for secret_wrapper in _list_secrets(client, term):
-                        if "SecretList" in secret_wrapper:
-                            for secret_obj in secret_wrapper["SecretList"]:
-                                secrets.update(
-                                    {
-                                        secret_obj["Name"]: self.get_secret_value(
-                                            secret_obj["Name"], client, on_missing=on_missing, on_denied=on_denied
-                                        )
-                                    }
-                                )
-                    secrets = [secrets]
-
-                except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                    raise AnsibleLookupError(f"Failed to retrieve secret: {to_native(e)}")
+            return self._lookup_by_path(terms)
         else:
-            secrets = []
-            for term in terms:
-                value = self.get_secret_value(
-                    term,
-                    client,
-                    version_stage=self.get_option("version_stage"),
-                    version_id=self.get_option("version_id"),
-                    on_missing=on_missing,
-                    on_denied=on_denied,
-                    on_deleted=on_deleted,
-                    nested=self.get_option("nested"),
-                )
-                if value:
-                    secrets.append(value)
-            if self.get_option("join"):
-                joined_secret = []
-                joined_secret.append("".join(secrets))
-                return joined_secret
+            return self._lookup_by_name(terms)
+
+    def _validate_options(self):
+        """Validate on_missing, on_denied and on_deleted options"""
+        if self.on_missing.lower() not in ["error", "warn", "skip"]:
+            raise AnsibleLookupError(
+                f'"on_missing" must be a string and one of "error", "warn" or "skip", not {self.on_missing}'
+            )
+        if self.on_denied.lower() not in ["error", "warn", "skip"]:
+            raise AnsibleLookupError(
+                f'"on_denied" must be a string and one of "error", "warn" or "skip", not {self.on_denied}'
+            )
+        if self.on_deleted.lower() not in ["error", "warn", "skip"]:
+            raise AnsibleLookupError(
+                f'"on_deleted" must be a string and one of "error", "warn" or "skip", not {self.on_deleted}'
+            )
+
+    @LookupErrorHandler.handle_lookup_errors("secret path", default_value=[])
+    def _fetch_secret_list(self, term):
+        """
+        Fetch list of secrets matching term.
+
+        Note: on_missing and on_denied are read by the decorator from self.on_missing/self.on_denied.
+        """
+        paginator = self.aws_client.get_paginator("list_secrets")
+        results = []
+        for page in paginator.paginate(Filters=[{"Key": "name", "Values": [term]}]):
+            if "SecretList" in page:
+                results.extend(page["SecretList"])
+        return results
+
+    def _lookup_by_path(self, terms):
+        """Lookup secrets by path"""
+        secrets = {}
+        for term in terms:
+            secret_list = self._fetch_secret_list(term)
+            for secret_obj in secret_list:
+                value = self.get_secret_value(secret_obj["Name"])
+                if value is not None:
+                    secrets[secret_obj["Name"]] = value
+
+        return [secrets] if secrets else []
+
+    def _lookup_by_name(self, terms):
+        """Lookup secrets by name"""
+        secrets = []
+        for term in terms:
+            value = self.get_secret_value(
+                term,
+                version_stage=self.get_option("version_stage"),
+                version_id=self.get_option("version_id"),
+                nested=self.get_option("nested"),
+            )
+            if value is not None:
+                secrets.append(value)
+
+        if self.get_option("join"):
+            return ["".join(secrets)]
 
         return secrets
 
+    @LookupErrorHandler.handle_lookup_errors("secret")
     def get_secret_value(
         self,
         term,
-        client,
         version_stage=None,
         version_id=None,
-        on_missing=None,
-        on_denied=None,
-        on_deleted=None,
         nested=False,
     ):
-        params = {}
-        params["SecretId"] = term
+        """
+        Retrieve a secret value from AWS Secrets Manager.
+
+        Note: on_missing, on_denied, and on_deleted are read by the decorator from self.on_missing/self.on_denied/self.on_deleted properties.
+        """
+        params = self._build_secret_params(term, version_id, version_stage, nested)
+        response = self.aws_client.get_secret_value(aws_retry=True, **params)
+        return self._process_secret_response(response, term, nested)
+
+    def _build_secret_params(self, term, version_id, version_stage, nested):
+        """Build parameters for get_secret_value API call"""
+        params = {"SecretId": term}
+
         if version_id:
             params["VersionId"] = version_id
         if version_stage:
             params["VersionStage"] = version_stage
+
         if nested:
             if len(term.split(".")) < 2:
                 raise AnsibleLookupError(
@@ -240,52 +239,40 @@ class LookupModule(AWSLookupBase):
             secret_name = term.split(".")[0]
             params["SecretId"] = secret_name
 
-        try:
-            response = client.get_secret_value(aws_retry=True, **params)
-            if "SecretBinary" in response:
-                return response["SecretBinary"]
-            if "SecretString" in response:
-                if nested:
-                    query = term.split(".")[1:]
-                    path = None
-                    secret_string = json.loads(response["SecretString"])
-                    ret_val = secret_string
-                    while query:
-                        key = query.pop(0)
-                        path = key if not path else path + "." + key
-                        if key in ret_val:
-                            ret_val = ret_val[key]
-                        elif on_missing == "warn":
-                            self._display.warning(
-                                f"Skipping, Successfully retrieved secret but there exists no key {path} in the secret"
-                            )
-                            return None
-                        elif on_missing == "error":
-                            raise AnsibleLookupError(
-                                f"Successfully retrieved secret but there exists no key {path} in the secret"
-                            )
-                    return str(ret_val)
-                else:
-                    return response["SecretString"]
-        except is_boto3_error_message("marked for deletion"):
-            if on_deleted == "error":
-                raise AnsibleLookupError(f"Failed to find secret {term} (marked for deletion)")
-            elif on_deleted == "warn":
-                self._display.warning(f"Skipping, did not find secret (marked for deletion) {term}")
-        except is_boto3_error_code("ResourceNotFoundException"):  # pylint: disable=duplicate-except
-            if on_missing == "error":
-                raise AnsibleLookupError(f"Failed to find secret {term} (ResourceNotFound)")
-            elif on_missing == "warn":
-                self._display.warning(f"Skipping, did not find secret {term}")
-        except is_boto3_error_code("AccessDeniedException"):  # pylint: disable=duplicate-except
-            if on_denied == "error":
-                raise AnsibleLookupError(f"Failed to access secret {term} (AccessDenied)")
-            elif on_denied == "warn":
-                self._display.warning(f"Skipping, access denied for secret {term}")
-        except (
-            botocore.exceptions.ClientError,
-            botocore.exceptions.BotoCoreError,
-        ) as e:  # pylint: disable=duplicate-except
-            raise AnsibleLookupError(f"Failed to retrieve secret: {to_native(e)}")
+        return params
+
+    def _process_secret_response(self, response, term, nested):
+        """Process the secret response from AWS"""
+        if "SecretBinary" in response:
+            return response["SecretBinary"]
+
+        if "SecretString" in response:
+            if nested:
+                return self._extract_nested_value(response["SecretString"], term)
+            else:
+                return response["SecretString"]
 
         return None
+
+    def _extract_nested_value(self, secret_string, term):
+        """
+        Extract nested value from secret JSON.
+
+        Raises NestedKeyNotFoundError if any key in the path is not found,
+        which is caught by the @handle_lookup_errors decorator.
+        """
+        query = term.split(".")[1:]
+        secret_data = json.loads(secret_string)
+        ret_val = secret_data
+        path = None
+
+        for key in query:
+            path = key if not path else path + "." + key
+            try:
+                ret_val = ret_val[key]
+            except (KeyError, TypeError) as e:
+                # KeyError: key not in dict
+                # TypeError: trying to access a non-dict (e.g., string) as a dict
+                raise NestedKeyNotFoundError(path) from e
+
+        return str(ret_val)

--- a/plugins/lookup/ssm_parameter.py
+++ b/plugins/lookup/ssm_parameter.py
@@ -141,13 +141,11 @@ EXAMPLES = r"""
 
 from ansible.errors import AnsibleLookupError
 from ansible.module_utils.common.text.converters import to_native
-from ansible.utils.display import Display
 
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import AWSLookupBase
 from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import LookupErrorHandler
-
-display = Display()
+from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import LookupResourceNotFoundError
 
 
 class LookupModule(AWSLookupBase):
@@ -202,21 +200,21 @@ class LookupModule(AWSLookupBase):
         ret = []
 
         for term in terms:
-            display.vvv(f"AWS_ssm path lookup term: {term} in region: {self.region}")
+            self.v_log(3, f"AWS_ssm path lookup term: {term} in region: {self.region}")
 
             paramlist = self.get_path_parameters(term, ssm_dict)
             self._process_parameter_names(paramlist, term)
 
-            display.vvvv(f"aws_ssm path lookup returned: {to_native(paramlist)}")
+            self.v_log(4, f"aws_ssm path lookup returned: {to_native(paramlist)}")
 
             ret.append(boto3_tag_list_to_ansible_dict(paramlist, tag_name_key_name="Name", tag_value_key_name="Value"))
 
-        display.vvvv(f"aws_ssm path lookup returning: {to_native(ret)} ")
+        self.v_log(4, f"aws_ssm path lookup returning: {to_native(ret)} ")
         return ret
 
     def _lookup_by_name(self, ssm_dict, terms):
         """Lookup SSM parameters by name"""
-        display.vvv(f"aws_ssm name lookup term: {terms}")
+        self.v_log(3, f"aws_ssm name lookup term: {terms}")
         ret = []
 
         for term in terms:
@@ -228,7 +226,7 @@ class LookupModule(AWSLookupBase):
         if ret and all(v is None for v in ret):
             ret = []
 
-        display.vvvv(f"aws_ssm path lookup returning: {to_native(ret)} ")
+        self.v_log(4, f"aws_ssm name lookup returning: {to_native(ret)} ")
         return ret
 
     @LookupErrorHandler.handle_lookup_errors("SSM parameter path", default_value=[{}])
@@ -244,11 +242,12 @@ class LookupModule(AWSLookupBase):
 
         # Handle empty results (API call succeeded but no parameters found)
         if not paramlist:
-            on_missing = self.on_missing
-            if on_missing == "error":
-                raise AnsibleLookupError(f"Failed to find SSM parameter path {term} (ResourceNotFound)")
-            elif on_missing == "warn":
-                self.warn(f"Skipping, did not find SSM parameter path {term}")
+            raise LookupResourceNotFoundError(
+                path=term,
+                error_template="Failed to find SSM parameter path {term} (ResourceNotFound)",
+                warn_template="Skipping, did not find SSM parameter path {term}",
+                default_value=[],
+            )
 
         return paramlist
 

--- a/plugins/lookup/ssm_parameter.py
+++ b/plugins/lookup/ssm_parameter.py
@@ -139,24 +139,20 @@ EXAMPLES = r"""
   ansible.builtin.debug: msg="{{ lookup('amazon.aws.aws_ssm', 'missing-parameter', on_denied="warn" ) }}"
 """
 
-try:
-    import botocore
-except ImportError:
-    pass  # Handled by AWSLookupBase
-
 from ansible.errors import AnsibleLookupError
 from ansible.module_utils.common.text.converters import to_native
 from ansible.utils.display import Display
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import AWSLookupBase
+from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import LookupErrorHandler
 
 display = Display()
 
 
 class LookupModule(AWSLookupBase):
+    _SERVICE = "ssm"
+
     def run(self, terms, variables, **kwargs):
         """
         :arg terms: a list of lookups to run.
@@ -167,81 +163,88 @@ class LookupModule(AWSLookupBase):
 
         super().run(terms, variables, **kwargs)
 
-        on_missing = self.get_option("on_missing")
-        on_denied = self.get_option("on_denied")
+        self._validate_options()
 
-        # validate arguments 'on_missing' and 'on_denied'
-        if on_missing is not None and (
-            not isinstance(on_missing, str) or on_missing.lower() not in ["error", "warn", "skip"]
-        ):
+        ssm_dict = {"WithDecryption": self.get_option("decrypt")}
+
+        if self.get_option("bypath"):
+            return self._lookup_by_path(ssm_dict, terms)
+        else:
+            return self._lookup_by_name(ssm_dict, terms)
+
+    def _validate_options(self):
+        """Validate on_missing, on_denied, shortnames and droppath options"""
+        if self.on_missing.lower() not in ["error", "warn", "skip"]:
             raise AnsibleLookupError(
-                f'"on_missing" must be a string and one of "error", "warn" or "skip", not {on_missing}'
+                f'"on_missing" must be a string and one of "error", "warn" or "skip", not {self.on_missing}'
             )
-        if on_denied is not None and (
-            not isinstance(on_denied, str) or on_denied.lower() not in ["error", "warn", "skip"]
-        ):
+        if self.on_denied.lower() not in ["error", "warn", "skip"]:
             raise AnsibleLookupError(
-                f'"on_denied" must be a string and one of "error", "warn" or "skip", not {on_denied}'
+                f'"on_denied" must be a string and one of "error", "warn" or "skip", not {self.on_denied}'
             )
 
         if self.get_option("shortnames") and self.get_option("droppath"):
             raise AnsibleLookupError("shortnames and droppath are mutually exclusive. They cannot both be set to true.")
 
+    def _process_parameter_names(self, paramlist, path):
+        """Process parameter names based on shortnames/droppath options"""
+        if self.get_option("shortnames"):
+            for param in paramlist:
+                param["Name"] = param["Name"][param["Name"].rfind("/") + 1:]  # fmt: skip
+
+        if self.get_option("droppath"):
+            for param in paramlist:
+                param["Name"] = param["Name"].replace(path, "")
+
+    def _lookup_by_path(self, ssm_dict, terms):
+        """Lookup SSM parameters by path"""
+        ssm_dict["Recursive"] = self.get_option("recursive")
         ret = []
-        ssm_dict = {}
 
-        client = self.client("ssm", AWSRetry.jittered_backoff())
+        for term in terms:
+            display.vvv(f"AWS_ssm path lookup term: {term} in region: {self.region}")
 
-        ssm_dict["WithDecryption"] = self.get_option("decrypt")
+            paramlist = self.get_path_parameters(term, ssm_dict)
+            self._process_parameter_names(paramlist, term)
 
-        # Lookup by path
-        if self.get_option("bypath"):
-            ssm_dict["Recursive"] = self.get_option("recursive")
-            for term in terms:
-                display.vvv(f"AWS_ssm path lookup term: {term} in region: {self.region}")
+            display.vvvv(f"aws_ssm path lookup returned: {to_native(paramlist)}")
 
-                paramlist = self.get_path_parameters(client, ssm_dict, term, on_missing.lower(), on_denied.lower())
-                # Shorten parameter names. Yes, this will return
-                # duplicate names with different values.
-                if self.get_option("shortnames"):
-                    for x in paramlist:
-                        x["Name"] = x["Name"][x["Name"].rfind("/") + 1:]  # fmt: skip
+            ret.append(boto3_tag_list_to_ansible_dict(paramlist, tag_name_key_name="Name", tag_value_key_name="Value"))
 
-                if self.get_option("droppath"):
-                    for x in paramlist:
-                        x["Name"] = x["Name"].replace(ssm_dict["Path"], "")
-
-                display.vvvv(f"aws_ssm path lookup returned: {to_native(paramlist)}")
-
-                ret.append(
-                    boto3_tag_list_to_ansible_dict(paramlist, tag_name_key_name="Name", tag_value_key_name="Value")
-                )
-        # Lookup by parameter name - always returns a list with one or
-        # no entry.
-        else:
-            display.vvv(f"aws_ssm name lookup term: {terms}")
-            for term in terms:
-                ret.append(self.get_parameter_value(client, ssm_dict, term, on_missing.lower(), on_denied.lower()))
         display.vvvv(f"aws_ssm path lookup returning: {to_native(ret)} ")
         return ret
 
-    def get_path_parameters(self, client, ssm_dict, term, on_missing, on_denied):
-        ssm_dict["Path"] = term
-        paginator = client.get_paginator("get_parameters_by_path")
-        try:
-            paramlist = paginator.paginate(**ssm_dict).build_full_result()["Parameters"]
-        except is_boto3_error_code("AccessDeniedException"):
-            if on_denied == "error":
-                raise AnsibleLookupError(f"Failed to access SSM parameter path {term} (AccessDenied)")
-            elif on_denied == "warn":
-                self.warn(f"Skipping, access denied for SSM parameter path {term}")
-                paramlist = [{}]
-            elif on_denied == "skip":
-                paramlist = [{}]
-        except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
-            raise AnsibleLookupError(f"SSM lookup exception: {to_native(e)}")
+    def _lookup_by_name(self, ssm_dict, terms):
+        """Lookup SSM parameters by name"""
+        display.vvv(f"aws_ssm name lookup term: {terms}")
+        ret = []
 
-        if not len(paramlist):
+        for term in terms:
+            value = self.get_parameter_value(term, ssm_dict)
+            ret.append(value)
+
+        # Filter out None values only if ALL values are None
+        # This handles the case where all parameters are missing/denied with on_missing=skip/on_denied=skip
+        if ret and all(v is None for v in ret):
+            ret = []
+
+        display.vvvv(f"aws_ssm path lookup returning: {to_native(ret)} ")
+        return ret
+
+    @LookupErrorHandler.handle_lookup_errors("SSM parameter path", default_value=[{}])
+    def get_path_parameters(self, term, ssm_dict):
+        """
+        Retrieve SSM parameters by path.
+
+        Note: on_missing and on_denied are read by the decorator from self.on_missing/self.on_denied properties.
+        """
+        ssm_dict["Path"] = term
+        paginator = self.aws_client.get_paginator("get_parameters_by_path")
+        paramlist = paginator.paginate(**ssm_dict).build_full_result()["Parameters"]
+
+        # Handle empty results (API call succeeded but no parameters found)
+        if not paramlist:
+            on_missing = self.on_missing
             if on_missing == "error":
                 raise AnsibleLookupError(f"Failed to find SSM parameter path {term} (ResourceNotFound)")
             elif on_missing == "warn":
@@ -249,21 +252,13 @@ class LookupModule(AWSLookupBase):
 
         return paramlist
 
-    def get_parameter_value(self, client, ssm_dict, term, on_missing, on_denied):
+    @LookupErrorHandler.handle_lookup_errors("SSM parameter")
+    def get_parameter_value(self, term, ssm_dict):
+        """
+        Retrieve a single SSM parameter value.
+
+        Note: on_missing and on_denied are read by the decorator from self.on_missing/self.on_denied properties.
+        """
         ssm_dict["Name"] = term
-        try:
-            response = client.get_parameter(aws_retry=True, **ssm_dict)
-            return response["Parameter"]["Value"]
-        except is_boto3_error_code("ParameterNotFound"):
-            if on_missing == "error":
-                raise AnsibleLookupError(f"Failed to find SSM parameter {term} (ResourceNotFound)")
-            elif on_missing == "warn":
-                self.warn(f"Skipping, did not find SSM parameter {term}")
-        except is_boto3_error_code("AccessDeniedException"):  # pylint: disable=duplicate-except
-            if on_denied == "error":
-                raise AnsibleLookupError(f"Failed to access SSM parameter {term} (AccessDenied)")
-            elif on_denied == "warn":
-                self.warn(f"Skipping, access denied for SSM parameter {term}")
-        except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
-            raise AnsibleLookupError(f"SSM lookup exception: {to_native(e)}")
-        return None
+        response = self.aws_client.get_parameter(aws_retry=True, **ssm_dict)
+        return response["Parameter"]["Value"]

--- a/plugins/plugin_utils/_lookup/common.py
+++ b/plugins/plugin_utils/_lookup/common.py
@@ -66,6 +66,66 @@ class LookupErrorHandler:
     """
 
     @staticmethod
+    def _build_error_messages(resource_type: str, error_type: str) -> tuple[str, str]:
+        """
+        Build error and warning message templates for a given error type.
+
+        Parameters:
+            resource_type: Description of the resource (e.g., "secret", "SSM parameter")
+            error_type: Type of error ("missing", "denied", "deleted")
+
+        Returns:
+            Tuple of (error_template, warn_template) with {term} placeholder
+        """
+        templates = {
+            "missing": (
+                f"Failed to find {resource_type} {{term}} (ResourceNotFound)",
+                f"Skipping, did not find {resource_type} {{term}}",
+            ),
+            "denied": (
+                f"Failed to access {resource_type} {{term}} (AccessDenied)",
+                f"Skipping, access denied for {resource_type} {{term}}",
+            ),
+            "deleted": (
+                f"Failed to find {resource_type} {{term}} (marked for deletion)",
+                f"Skipping, did not find {resource_type} (marked for deletion) {{term}}",
+            ),
+        }
+        return templates[error_type]
+
+    @staticmethod
+    def _resolve_default_value(exception_default: Any, decorator_default: Any) -> Any:
+        """
+        Resolve which default value to use.
+
+        Parameters:
+            exception_default: Default value from exception (or ... if not set)
+            decorator_default: Default value from decorator
+
+        Returns:
+            The appropriate default value to use
+        """
+        return exception_default if exception_default is not ... else decorator_default
+
+    @staticmethod
+    def _extract_term(args: tuple, kwargs: dict) -> Any:
+        """
+        Extract the term parameter from function arguments.
+
+        The term is expected to be either:
+        - A keyword argument named 'term'
+        - The first positional argument (after self)
+
+        Parameters:
+            args: Positional arguments (not including self)
+            kwargs: Keyword arguments
+
+        Returns:
+            The term value, or None if not found
+        """
+        return kwargs.get("term") or (args[0] if len(args) > 0 else None)
+
+    @staticmethod
     def handle_lookup_errors(resource_type: str, default_value: Any = None) -> Callable:
         """
         Decorator for handling AWS lookup errors based on runtime error handling parameters.
@@ -113,54 +173,32 @@ class LookupErrorHandler:
                 on_denied = self.on_denied
                 on_deleted = self.on_deleted
 
-                # term is typically the first positional argument after self
-                term = kwargs.get("term") or (args[0] if len(args) > 0 else None)
+                # Extract term from arguments
+                term = LookupErrorHandler._extract_term(args, kwargs)
 
                 try:
                     return func(self, *args, **kwargs)
                 except is_boto3_error_message("marked for deletion"):
+                    error_msg, warn_msg = LookupErrorHandler._build_error_messages(resource_type, "deleted")
                     return LookupErrorHandler._handle_response(
-                        self,
-                        on_deleted,
-                        term,
-                        resource_type,
-                        f"Failed to find {resource_type} {{term}} (marked for deletion)",
-                        f"Skipping, did not find {resource_type} (marked for deletion) {{term}}",
-                        default_value,
+                        self, on_deleted, term, resource_type, error_msg, warn_msg, default_value
                     )
                 except is_boto3_error_code(
                     ["ResourceNotFoundException", "ParameterNotFound"]
                 ):  # pylint: disable=duplicate-except
+                    error_msg, warn_msg = LookupErrorHandler._build_error_messages(resource_type, "missing")
                     return LookupErrorHandler._handle_response(
-                        self,
-                        on_missing,
-                        term,
-                        resource_type,
-                        f"Failed to find {resource_type} {{term}} (ResourceNotFound)",
-                        f"Skipping, did not find {resource_type} {{term}}",
-                        default_value,
+                        self, on_missing, term, resource_type, error_msg, warn_msg, default_value
                     )
                 except LookupResourceNotFoundError as e:
-                    # Use exception's default_value if provided, otherwise use decorator's default_value
-                    value_to_return = e.default_value if e.default_value is not ... else default_value
+                    value_to_return = LookupErrorHandler._resolve_default_value(e.default_value, default_value)
                     return LookupErrorHandler._handle_response(
-                        self,
-                        on_missing,
-                        e.path,
-                        "key",
-                        e.error_template,
-                        e.warn_template,
-                        value_to_return,
+                        self, on_missing, e.path, "key", e.error_template, e.warn_template, value_to_return
                     )
                 except is_boto3_error_code("AccessDeniedException"):  # pylint: disable=duplicate-except
+                    error_msg, warn_msg = LookupErrorHandler._build_error_messages(resource_type, "denied")
                     return LookupErrorHandler._handle_response(
-                        self,
-                        on_denied,
-                        term,
-                        resource_type,
-                        f"Failed to access {resource_type} {{term}} (AccessDenied)",
-                        f"Skipping, access denied for {resource_type} {{term}}",
-                        default_value,
+                        self, on_denied, term, resource_type, error_msg, warn_msg, default_value
                     )
                 except (
                     botocore.exceptions.ClientError,

--- a/plugins/plugin_utils/_lookup/common.py
+++ b/plugins/plugin_utils/_lookup/common.py
@@ -1,0 +1,201 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import functools
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+    from typing import Callable
+
+try:
+    import botocore
+except ImportError:
+    pass  # Handled by the calling module
+
+from ansible.errors import AnsibleLookupError
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message
+
+
+class NestedKeyNotFoundError(KeyError):
+    """
+    KeyError that includes the full nested path that failed lookup.
+
+    Used when traversing nested dictionaries/JSON structures to preserve
+    the key path for error messages. Optionally carries custom error and
+    warning message templates.
+
+    Parameters:
+        path: The full dotted path that failed (e.g., "root.child.missing_key")
+        error_template: Template for error messages (default: standard nested key message)
+        warn_template: Template for warning messages (default: standard nested key message)
+
+    Templates should include a {term} placeholder for the path.
+    """
+
+    def __init__(
+        self,
+        path: str,
+        error_template: str | None = None,
+        warn_template: str | None = None,
+    ) -> None:
+        self.path = path
+        self.error_template = (
+            error_template or "Successfully retrieved secret but there exists no key {term} in the secret"
+        )
+        self.warn_template = (
+            warn_template or "Skipping, Successfully retrieved secret but there exists no key {term} in the secret"
+        )
+        super().__init__(path)
+
+
+class LookupErrorHandler:
+    """
+    Error handler for AWS lookup plugins with support for on_missing, on_denied, and on_deleted parameters.
+
+    Provides decorators for handling common AWS lookup error patterns where the error handling
+    behavior (error/warn/skip) is read from cached properties on the lookup instance.
+    """
+
+    @staticmethod
+    def handle_lookup_errors(resource_type: str, default_value: Any = None) -> Callable:
+        """
+        Decorator for handling AWS lookup errors based on runtime error handling parameters.
+
+        Handles common AWS error codes and defers to on_missing, on_denied, and on_deleted
+        parameters to determine whether to raise an exception, log a warning, or silently skip.
+
+        The decorator extracts the 'term' parameter for use in error messages. The term should
+        be the first positional argument after 'self', or passed as a keyword argument 'term'.
+
+        Error Handling Behavior:
+            - Reads on_missing, on_denied, on_deleted from cached properties on the lookup instance
+            - Catches boto3 ClientError/BotoCoreError and handles based on error code
+            - Catches NestedKeyNotFoundError for nested dictionary traversal failures
+            - ResourceNotFoundException/ParameterNotFound -> delegates to on_missing
+            - AccessDeniedException -> delegates to on_denied
+            - Error message containing "marked for deletion" -> delegates to on_deleted
+            - All other ClientError/BotoCoreError -> raises AnsibleLookupError
+
+        Parameters:
+            resource_type: Description of the resource type (e.g., "secret", "SSM parameter")
+            default_value: Value to return when warn/skip is triggered (default: None)
+
+        Decorated Function Convention:
+            The first positional argument after 'self' should be 'term' (the resource identifier).
+            This is used in error messages. Example signatures:
+                def get_secret_value(self, term, **kwargs)
+                def get_parameter(self, term, version_id=None)
+
+        Usage:
+            @LookupErrorHandler.handle_lookup_errors("secret")
+            def get_secret_value(self, term, version_stage=None, version_id=None):
+                return self.aws_client.get_secret_value(SecretId=term)
+
+            @LookupErrorHandler.handle_lookup_errors("SSM parameter path", default_value=[{}])
+            def get_path_parameters(self, term):
+                return self.aws_client.get_parameters_by_path(Path=term)
+        """
+
+        def decorator(func: Callable) -> Callable:
+            @functools.wraps(func)
+            def wrapper(self: Any, *args: Any, **kwargs: Any) -> Any:
+                # Read error handling parameters from cached properties on the lookup instance
+                on_missing = self.on_missing
+                on_denied = self.on_denied
+                on_deleted = self.on_deleted
+
+                # term is typically the first positional argument after self
+                term = kwargs.get("term") or (args[0] if len(args) > 0 else None)
+
+                try:
+                    return func(self, *args, **kwargs)
+                except is_boto3_error_message("marked for deletion"):
+                    return LookupErrorHandler._handle_response(
+                        self,
+                        on_deleted,
+                        term,
+                        resource_type,
+                        f"Failed to find {resource_type} {{term}} (marked for deletion)",
+                        f"Skipping, did not find {resource_type} (marked for deletion) {{term}}",
+                        default_value,
+                    )
+                except is_boto3_error_code(
+                    ["ResourceNotFoundException", "ParameterNotFound"]
+                ):  # pylint: disable=duplicate-except
+                    return LookupErrorHandler._handle_response(
+                        self,
+                        on_missing,
+                        term,
+                        resource_type,
+                        f"Failed to find {resource_type} {{term}} (ResourceNotFound)",
+                        f"Skipping, did not find {resource_type} {{term}}",
+                        default_value,
+                    )
+                except NestedKeyNotFoundError as e:  # pylint: disable=duplicate-except
+                    return LookupErrorHandler._handle_response(
+                        self,
+                        on_missing,
+                        e.path,
+                        "key",
+                        e.error_template,
+                        e.warn_template,
+                        default_value,
+                    )
+                except is_boto3_error_code("AccessDeniedException"):  # pylint: disable=duplicate-except
+                    return LookupErrorHandler._handle_response(
+                        self,
+                        on_denied,
+                        term,
+                        resource_type,
+                        f"Failed to access {resource_type} {{term}} (AccessDenied)",
+                        f"Skipping, access denied for {resource_type} {{term}}",
+                        default_value,
+                    )
+                except (
+                    botocore.exceptions.ClientError,
+                    botocore.exceptions.BotoCoreError,
+                ) as e:  # pylint: disable=duplicate-except
+                    raise AnsibleLookupError(f"Failed to retrieve {resource_type}: {e}") from e
+
+            return wrapper
+
+        return decorator
+
+    @staticmethod
+    def _handle_response(
+        lookup_instance: Any,
+        action: str,
+        term: str,
+        resource_type: str,
+        error_msg: str,
+        warn_msg: str,
+        default_value: Any = None,
+    ) -> Any:
+        """
+        Handle the response based on the action parameter (error/warn/skip).
+
+        Parameters:
+            lookup_instance: The lookup plugin instance (for accessing _display)
+            action: The action to take ("error", "warn", or "skip")
+            term: The resource identifier
+            resource_type: Description of the resource type
+            error_msg: Message template for error (should contain {term} placeholder)
+            warn_msg: Message template for warning (should contain {term} placeholder)
+            default_value: Value to return for warn/skip (default: None)
+
+        Returns:
+            default_value for warn/skip, raises exception for error
+        """
+        if action == "error":
+            raise AnsibleLookupError(error_msg.format(term=term))
+        elif action == "warn":
+            lookup_instance._display.warning(warn_msg.format(term=term))
+        # For "skip" or "warn", return the default value
+        return default_value

--- a/plugins/plugin_utils/_lookup/common.py
+++ b/plugins/plugin_utils/_lookup/common.py
@@ -23,18 +23,18 @@ from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_message
 
 
-class NestedKeyNotFoundError(KeyError):
+class LookupResourceNotFoundError(KeyError):
     """
-    KeyError that includes the full nested path that failed lookup.
+    Exception for lookup resources that were not found.
 
-    Used when traversing nested dictionaries/JSON structures to preserve
-    the key path for error messages. Optionally carries custom error and
-    warning message templates.
+    Used when a resource (parameter, secret, nested key, etc.) is not found during lookup.
+    Carries custom error and warning message templates that can be used by the error handler.
 
     Parameters:
-        path: The full dotted path that failed (e.g., "root.child.missing_key")
-        error_template: Template for error messages (default: standard nested key message)
-        warn_template: Template for warning messages (default: standard nested key message)
+        path: The resource identifier or path that failed (e.g., "parameter-name", "secret.key.path")
+        error_template: Template for error messages (default: standard not found message)
+        warn_template: Template for warning messages (default: standard not found message)
+        default_value: Value to return for warn/skip (overrides decorator's default_value if provided)
 
     Templates should include a {term} placeholder for the path.
     """
@@ -44,6 +44,7 @@ class NestedKeyNotFoundError(KeyError):
         path: str,
         error_template: str | None = None,
         warn_template: str | None = None,
+        default_value: Any = ...,
     ) -> None:
         self.path = path
         self.error_template = (
@@ -52,6 +53,7 @@ class NestedKeyNotFoundError(KeyError):
         self.warn_template = (
             warn_template or "Skipping, Successfully retrieved secret but there exists no key {term} in the secret"
         )
+        self.default_value = default_value
         super().__init__(path)
 
 
@@ -77,7 +79,7 @@ class LookupErrorHandler:
         Error Handling Behavior:
             - Reads on_missing, on_denied, on_deleted from cached properties on the lookup instance
             - Catches boto3 ClientError/BotoCoreError and handles based on error code
-            - Catches NestedKeyNotFoundError for nested dictionary traversal failures
+            - Catches LookupResourceNotFoundError for custom resource not found cases
             - ResourceNotFoundException/ParameterNotFound -> delegates to on_missing
             - AccessDeniedException -> delegates to on_denied
             - Error message containing "marked for deletion" -> delegates to on_deleted
@@ -138,7 +140,9 @@ class LookupErrorHandler:
                         f"Skipping, did not find {resource_type} {{term}}",
                         default_value,
                     )
-                except NestedKeyNotFoundError as e:  # pylint: disable=duplicate-except
+                except LookupResourceNotFoundError as e:
+                    # Use exception's default_value if provided, otherwise use decorator's default_value
+                    value_to_return = e.default_value if e.default_value is not ... else default_value
                     return LookupErrorHandler._handle_response(
                         self,
                         on_missing,
@@ -146,7 +150,7 @@ class LookupErrorHandler:
                         "key",
                         e.error_template,
                         e.warn_template,
-                        default_value,
+                        value_to_return,
                     )
                 except is_boto3_error_code("AccessDeniedException"):  # pylint: disable=duplicate-except
                     return LookupErrorHandler._handle_response(
@@ -196,6 +200,6 @@ class LookupErrorHandler:
         if action == "error":
             raise AnsibleLookupError(error_msg.format(term=term))
         elif action == "warn":
-            lookup_instance._display.warning(warn_msg.format(term=term))
+            lookup_instance.warn(warn_msg.format(term=term))
         # For "skip" or "warn", return the default value
         return default_value

--- a/plugins/plugin_utils/lookup.py
+++ b/plugins/plugin_utils/lookup.py
@@ -3,21 +3,115 @@
 # (c) 2022 Red Hat Inc.
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+    from typing import NoReturn
+
+    from ansible_collections.amazon.aws.plugins.module_utils.botocore import ClientType
+
 from ansible.errors import AnsibleLookupError
 from ansible.plugins.lookup import LookupBase
 
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.plugin_utils._lookup import common as _lookup_common
 from ansible_collections.amazon.aws.plugins.plugin_utils.base import AWSPluginBase
+
+LookupErrorHandler = _lookup_common.LookupErrorHandler
+NestedKeyNotFoundError = _lookup_common.NestedKeyNotFoundError
 
 
 class AWSLookupBase(AWSPluginBase, LookupBase):
-    def _do_fail(self, message):
-        raise AnsibleLookupError(message)
+    """
+    Base class for AWS lookup plugins.
 
-    def __init__(self, *args, **kwargs):
+    Subclasses should define:
+        _SERVICE: AWS service name (e.g., "secretsmanager", "ssm")
+    """
+
+    _SERVICE: str | None = None
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         # Lookup plugins don't have a host context
         self.host = None
+        self._cached_client: ClientType | None = None
+        self._cached_on_missing: str | None = None
+        self._cached_on_denied: str | None = None
+        self._cached_on_deleted: str | None = None
 
-    def run(self, terms, variables, botocore_version=None, boto3_version=None, **kwargs):
+    @property
+    def aws_client(self) -> ClientType:
+        """
+        Cached AWS client for the service defined by _SERVICE.
+
+        Creates and caches the client on first access. Subclasses must define
+        the _SERVICE class attribute.
+        """
+        if self._cached_client is None:
+            if self._SERVICE is None:
+                raise NotImplementedError(f"{self.__class__.__name__} must define _SERVICE class attribute")
+            self._cached_client = self.client(self._SERVICE, AWSRetry.jittered_backoff())
+        return self._cached_client
+
+    @property
+    def on_missing(self) -> str:
+        """
+        Cached error handling behavior for missing resources.
+
+        Returns 'error', 'warn', or 'skip' based on plugin configuration.
+        Defaults to 'error' if the option is not defined by the plugin.
+        """
+        if self._cached_on_missing is None:
+            try:
+                self._cached_on_missing = str(self.get_option("on_missing") or "error")
+            except (KeyError, AttributeError):
+                self._cached_on_missing = "error"
+        return self._cached_on_missing
+
+    @property
+    def on_denied(self) -> str:
+        """
+        Cached error handling behavior for access denied errors.
+
+        Returns 'error', 'warn', or 'skip' based on plugin configuration.
+        Defaults to 'error' if the option is not defined by the plugin.
+        """
+        if self._cached_on_denied is None:
+            try:
+                self._cached_on_denied = str(self.get_option("on_denied") or "error")
+            except (KeyError, AttributeError):
+                self._cached_on_denied = "error"
+        return self._cached_on_denied
+
+    @property
+    def on_deleted(self) -> str:
+        """
+        Cached error handling behavior for deleted resources.
+
+        Returns 'error', 'warn', or 'skip' based on plugin configuration.
+        Defaults to 'error' if the option is not defined by the plugin.
+        """
+        if self._cached_on_deleted is None:
+            try:
+                self._cached_on_deleted = str(self.get_option("on_deleted") or "error")
+            except (KeyError, AttributeError):
+                self._cached_on_deleted = "error"
+        return self._cached_on_deleted
+
+    def _do_fail(self, message: str) -> NoReturn:
+        raise AnsibleLookupError(message)
+
+    def run(
+        self,
+        terms: list[str],
+        variables: dict[str, Any],
+        botocore_version: str | None = None,
+        boto3_version: str | None = None,
+        **kwargs: Any,
+    ) -> None:
         self.require_aws_sdk(botocore_version=botocore_version, boto3_version=boto3_version)
         self.set_options(var_options=variables, direct=kwargs)

--- a/plugins/plugin_utils/lookup.py
+++ b/plugins/plugin_utils/lookup.py
@@ -21,7 +21,7 @@ from ansible_collections.amazon.aws.plugins.plugin_utils._lookup import common a
 from ansible_collections.amazon.aws.plugins.plugin_utils.base import AWSPluginBase
 
 LookupErrorHandler = _lookup_common.LookupErrorHandler
-NestedKeyNotFoundError = _lookup_common.NestedKeyNotFoundError
+LookupResourceNotFoundError = _lookup_common.LookupResourceNotFoundError
 
 
 class AWSLookupBase(AWSPluginBase, LookupBase):

--- a/tests/integration/targets/lookup_ssm_parameter/tasks/main.yml
+++ b/tests/integration/targets/lookup_ssm_parameter/tasks/main.yml
@@ -59,7 +59,8 @@
       register: lookup_missing
     - ansible.builtin.assert:
         that:
-          - lookup_value is none
+          - lookup_value is defined
+          - lookup_value | list | length == 0
 
     - name: Lookup a single missing key (skip)
       ansible.builtin.set_fact:
@@ -67,7 +68,8 @@
       register: lookup_missing
     - ansible.builtin.assert:
         that:
-          - lookup_value is none
+          - lookup_value is defined
+          - lookup_value | list | length == 0
 
     - name: Create key/value pair in aws parameter store
       community.aws.ssm_parameter:

--- a/tests/unit/plugins/lookup/test_aws_account_attribute.py
+++ b/tests/unit/plugins/lookup/test_aws_account_attribute.py
@@ -17,6 +17,7 @@ from ansible_collections.amazon.aws.plugins.lookup.aws_account_attribute import 
 def fixture_lookup_plugin():
     lookup = LookupModule()
     lookup._display = MagicMock()
+    lookup.warn = MagicMock()
     lookup.set_options = MagicMock()
     # Mock the cached client instead of the property
     lookup._cached_client = MagicMock()
@@ -253,9 +254,9 @@ class TestRun:
             result = lookup_plugin.run([], {}, attribute="default-vpc")
 
         assert result is None
-        lookup_plugin._display.warning.assert_called_once()
+        lookup_plugin.warn.assert_called_once()
         assert (
-            "access denied for account attribute default-vpc" in lookup_plugin._display.warning.call_args[0][0].lower()
+            "access denied for account attribute default-vpc" in lookup_plugin.warn.call_args[0][0].lower()
         )
 
     def test_run_access_denied_skip(self, lookup_plugin):
@@ -272,7 +273,7 @@ class TestRun:
             result = lookup_plugin.run([], {}, attribute="default-vpc")
 
         assert result is None
-        lookup_plugin._display.warning.assert_not_called()
+        lookup_plugin.warn.assert_not_called()
 
     def test_run_other_client_error(self, lookup_plugin):
         """Test run with other ClientError from AWS"""

--- a/tests/unit/plugins/lookup/test_aws_account_attribute.py
+++ b/tests/unit/plugins/lookup/test_aws_account_attribute.py
@@ -19,6 +19,7 @@ def fixture_lookup_plugin():
     lookup._display = MagicMock()
     lookup.warn = MagicMock()
     lookup.set_options = MagicMock()
+    lookup._load_name = "aws_account_attribute"
     # Mock the cached client instead of the property
     lookup._cached_client = MagicMock()
     return lookup
@@ -255,9 +256,7 @@ class TestRun:
 
         assert result is None
         lookup_plugin.warn.assert_called_once()
-        assert (
-            "access denied for account attribute default-vpc" in lookup_plugin.warn.call_args[0][0].lower()
-        )
+        assert "access denied for account attribute default-vpc" in lookup_plugin.warn.call_args[0][0].lower()
 
     def test_run_access_denied_skip(self, lookup_plugin):
         """Test run with AccessDeniedException - on_denied=skip"""

--- a/tests/unit/plugins/lookup/test_aws_account_attribute.py
+++ b/tests/unit/plugins/lookup/test_aws_account_attribute.py
@@ -1,0 +1,327 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from ansible.errors import AnsibleLookupError
+
+from ansible_collections.amazon.aws.plugins.lookup.aws_account_attribute import LookupModule
+
+
+@pytest.fixture(name="lookup_plugin")
+def fixture_lookup_plugin():
+    lookup = LookupModule()
+    lookup._display = MagicMock()
+    lookup.set_options = MagicMock()
+    # Mock the cached client instead of the property
+    lookup._cached_client = MagicMock()
+    return lookup
+
+
+class TestBuildApiParams:
+    """Unit tests for _build_api_params method"""
+
+    def test_build_params_has_ec2_classic(self, lookup_plugin):
+        """Test building parameters for has-ec2-classic attribute"""
+        params, check_ec2_classic = lookup_plugin._build_api_params("has-ec2-classic")
+        assert params == {"AttributeNames": ["supported-platforms"]}
+        assert check_ec2_classic is True
+
+    def test_build_params_specific_attribute(self, lookup_plugin):
+        """Test building parameters for a specific attribute"""
+        params, check_ec2_classic = lookup_plugin._build_api_params("default-vpc")
+        assert params == {"AttributeNames": ["default-vpc"]}
+        assert check_ec2_classic is False
+
+    def test_build_params_all_attributes(self, lookup_plugin):
+        """Test building parameters for all attributes (None)"""
+        params, check_ec2_classic = lookup_plugin._build_api_params(None)
+        assert params == {"AttributeNames": []}
+        assert check_ec2_classic is False
+
+    def test_build_params_max_instances(self, lookup_plugin):
+        """Test building parameters for max-instances attribute"""
+        params, check_ec2_classic = lookup_plugin._build_api_params("max-instances")
+        assert params == {"AttributeNames": ["max-instances"]}
+        assert check_ec2_classic is False
+
+    def test_build_params_returns_tuple(self, lookup_plugin):
+        """Test that the method returns a tuple"""
+        result = lookup_plugin._build_api_params("default-vpc")
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+
+class TestProcessResponseForEc2Classic:
+    """Unit tests for _process_response_for_ec2_classic method"""
+
+    def test_ec2_classic_supported(self, lookup_plugin):
+        """Test when EC2-Classic is supported"""
+        response = [
+            {
+                "AttributeName": "supported-platforms",
+                "AttributeValues": [{"AttributeValue": "EC2"}, {"AttributeValue": "VPC"}],
+            }
+        ]
+        result = lookup_plugin._process_response_for_ec2_classic(response)
+        assert result is True
+
+    def test_ec2_classic_not_supported(self, lookup_plugin):
+        """Test when EC2-Classic is not supported"""
+        response = [{"AttributeName": "supported-platforms", "AttributeValues": [{"AttributeValue": "VPC"}]}]
+        result = lookup_plugin._process_response_for_ec2_classic(response)
+        assert result is False
+
+    def test_ec2_classic_only_ec2(self, lookup_plugin):
+        """Test when only EC2 is supported (unlikely but valid)"""
+        response = [{"AttributeName": "supported-platforms", "AttributeValues": [{"AttributeValue": "EC2"}]}]
+        result = lookup_plugin._process_response_for_ec2_classic(response)
+        assert result is True
+
+    def test_ec2_classic_empty_values(self, lookup_plugin):
+        """Test when no platforms are returned"""
+        response = [{"AttributeName": "supported-platforms", "AttributeValues": []}]
+        result = lookup_plugin._process_response_for_ec2_classic(response)
+        assert result is False
+
+
+class TestProcessResponseForAttribute:
+    """Unit tests for _process_response_for_attribute method"""
+
+    def test_single_value(self, lookup_plugin):
+        """Test extracting a single attribute value"""
+        response = [{"AttributeName": "default-vpc", "AttributeValues": [{"AttributeValue": "vpc-12345678"}]}]
+        result = lookup_plugin._process_response_for_attribute(response)
+        assert result == ["vpc-12345678"]
+
+    def test_multiple_values(self, lookup_plugin):
+        """Test extracting multiple attribute values"""
+        response = [
+            {
+                "AttributeName": "supported-platforms",
+                "AttributeValues": [{"AttributeValue": "EC2"}, {"AttributeValue": "VPC"}],
+            }
+        ]
+        result = lookup_plugin._process_response_for_attribute(response)
+        assert result == ["EC2", "VPC"]
+
+    def test_numeric_value(self, lookup_plugin):
+        """Test extracting numeric attribute values"""
+        response = [{"AttributeName": "max-instances", "AttributeValues": [{"AttributeValue": "20"}]}]
+        result = lookup_plugin._process_response_for_attribute(response)
+        assert result == ["20"]
+
+    def test_empty_values(self, lookup_plugin):
+        """Test extracting from empty attribute values"""
+        response = [{"AttributeName": "default-vpc", "AttributeValues": []}]
+        result = lookup_plugin._process_response_for_attribute(response)
+        assert result == []
+
+
+class TestProcessResponseForAllAttributes:
+    """Unit tests for _process_response_for_all_attributes method"""
+
+    def test_multiple_attributes(self, lookup_plugin):
+        """Test flattening multiple attributes"""
+        response = [
+            {"AttributeName": "default-vpc", "AttributeValues": [{"AttributeValue": "vpc-12345678"}]},
+            {"AttributeName": "max-instances", "AttributeValues": [{"AttributeValue": "20"}]},
+            {
+                "AttributeName": "supported-platforms",
+                "AttributeValues": [{"AttributeValue": "EC2"}, {"AttributeValue": "VPC"}],
+            },
+        ]
+        result = lookup_plugin._process_response_for_all_attributes(response)
+        assert result == {
+            "default-vpc": ["vpc-12345678"],
+            "max-instances": ["20"],
+            "supported-platforms": ["EC2", "VPC"],
+        }
+
+    def test_single_attribute(self, lookup_plugin):
+        """Test flattening a single attribute"""
+        response = [{"AttributeName": "default-vpc", "AttributeValues": [{"AttributeValue": "vpc-12345678"}]}]
+        result = lookup_plugin._process_response_for_all_attributes(response)
+        assert result == {"default-vpc": ["vpc-12345678"]}
+
+    def test_empty_response(self, lookup_plugin):
+        """Test flattening empty response"""
+        response = []
+        result = lookup_plugin._process_response_for_all_attributes(response)
+        assert result == {}
+
+    def test_attribute_with_multiple_values(self, lookup_plugin):
+        """Test flattening attribute with multiple values"""
+        response = [
+            {"AttributeName": "max-elastic-ips", "AttributeValues": [{"AttributeValue": "5"}]},
+            {"AttributeName": "vpc-max-elastic-ips", "AttributeValues": [{"AttributeValue": "5"}]},
+        ]
+        result = lookup_plugin._process_response_for_all_attributes(response)
+        assert result == {"max-elastic-ips": ["5"], "vpc-max-elastic-ips": ["5"]}
+
+
+class TestRun:
+    """Unit tests for run method integration"""
+
+    def test_run_has_ec2_classic_true(self, lookup_plugin):
+        """Test run with has-ec2-classic attribute returning true"""
+        lookup_plugin._cached_client.describe_account_attributes.return_value = {
+            "AccountAttributes": [
+                {
+                    "AttributeName": "supported-platforms",
+                    "AttributeValues": [{"AttributeValue": "EC2"}, {"AttributeValue": "VPC"}],
+                }
+            ]
+        }
+
+        with patch.object(lookup_plugin, "run", wraps=lookup_plugin.run):
+            result = lookup_plugin.run([], {}, attribute="has-ec2-classic")
+
+        assert result == [True]
+
+    def test_run_has_ec2_classic_false(self, lookup_plugin):
+        """Test run with has-ec2-classic attribute returning false"""
+        lookup_plugin._cached_client.describe_account_attributes.return_value = {
+            "AccountAttributes": [
+                {"AttributeName": "supported-platforms", "AttributeValues": [{"AttributeValue": "VPC"}]}
+            ]
+        }
+
+        with patch.object(lookup_plugin, "run", wraps=lookup_plugin.run):
+            result = lookup_plugin.run([], {}, attribute="has-ec2-classic")
+
+        assert result == [False]
+
+    def test_run_specific_attribute(self, lookup_plugin):
+        """Test run with a specific attribute"""
+        lookup_plugin._cached_client.describe_account_attributes.return_value = {
+            "AccountAttributes": [
+                {"AttributeName": "default-vpc", "AttributeValues": [{"AttributeValue": "vpc-12345678"}]}
+            ]
+        }
+
+        with patch.object(lookup_plugin, "run", wraps=lookup_plugin.run):
+            result = lookup_plugin.run([], {}, attribute="default-vpc")
+
+        assert result == ["vpc-12345678"]
+
+    def test_run_all_attributes(self, lookup_plugin):
+        """Test run with no attribute specified (all attributes)"""
+        lookup_plugin._cached_client.describe_account_attributes.return_value = {
+            "AccountAttributes": [
+                {"AttributeName": "default-vpc", "AttributeValues": [{"AttributeValue": "vpc-12345678"}]},
+                {"AttributeName": "max-instances", "AttributeValues": [{"AttributeValue": "20"}]},
+            ]
+        }
+
+        with patch.object(lookup_plugin, "run", wraps=lookup_plugin.run):
+            result = lookup_plugin.run([], {})
+
+        assert result == [{"default-vpc": ["vpc-12345678"], "max-instances": ["20"]}]
+
+    def test_run_access_denied_error(self, lookup_plugin):
+        """Test run with AccessDeniedException - on_denied defaults to error"""
+        import botocore.exceptions
+
+        error = botocore.exceptions.ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "Access denied"}}, "DescribeAccountAttributes"
+        )
+        lookup_plugin._cached_client.describe_account_attributes.side_effect = error
+
+        with patch.object(lookup_plugin, "run", wraps=lookup_plugin.run):
+            with pytest.raises(AnsibleLookupError) as exc_info:
+                lookup_plugin.run([], {}, attribute="default-vpc")
+
+        assert "Failed to access account attribute default-vpc" in str(exc_info.value)
+
+    def test_run_access_denied_warn(self, lookup_plugin):
+        """Test run with AccessDeniedException - on_denied=warn"""
+        import botocore.exceptions
+
+        error = botocore.exceptions.ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "Access denied"}}, "DescribeAccountAttributes"
+        )
+        lookup_plugin._cached_client.describe_account_attributes.side_effect = error
+        lookup_plugin._cached_on_denied = "warn"
+
+        with patch.object(lookup_plugin, "run", wraps=lookup_plugin.run):
+            result = lookup_plugin.run([], {}, attribute="default-vpc")
+
+        assert result is None
+        lookup_plugin._display.warning.assert_called_once()
+        assert (
+            "access denied for account attribute default-vpc" in lookup_plugin._display.warning.call_args[0][0].lower()
+        )
+
+    def test_run_access_denied_skip(self, lookup_plugin):
+        """Test run with AccessDeniedException - on_denied=skip"""
+        import botocore.exceptions
+
+        error = botocore.exceptions.ClientError(
+            {"Error": {"Code": "AccessDeniedException", "Message": "Access denied"}}, "DescribeAccountAttributes"
+        )
+        lookup_plugin._cached_client.describe_account_attributes.side_effect = error
+        lookup_plugin._cached_on_denied = "skip"
+
+        with patch.object(lookup_plugin, "run", wraps=lookup_plugin.run):
+            result = lookup_plugin.run([], {}, attribute="default-vpc")
+
+        assert result is None
+        lookup_plugin._display.warning.assert_not_called()
+
+    def test_run_other_client_error(self, lookup_plugin):
+        """Test run with other ClientError from AWS"""
+        import botocore.exceptions
+
+        error = botocore.exceptions.ClientError(
+            {"Error": {"Code": "UnauthorizedOperation", "Message": "Not authorized"}}, "DescribeAccountAttributes"
+        )
+        lookup_plugin._cached_client.describe_account_attributes.side_effect = error
+
+        with patch.object(lookup_plugin, "run", wraps=lookup_plugin.run):
+            with pytest.raises(AnsibleLookupError) as exc_info:
+                lookup_plugin.run([], {}, attribute="default-vpc")
+
+        assert "Failed to retrieve account attribute" in str(exc_info.value)
+
+    def test_run_botocore_error(self, lookup_plugin):
+        """Test run with BotoCoreError from AWS"""
+        import botocore.exceptions
+
+        error = botocore.exceptions.BotoCoreError()
+        lookup_plugin._cached_client.describe_account_attributes.side_effect = error
+
+        with patch.object(lookup_plugin, "run", wraps=lookup_plugin.run):
+            with pytest.raises(AnsibleLookupError) as exc_info:
+                lookup_plugin.run([], {}, attribute="default-vpc")
+
+        assert "Failed to retrieve account attribute" in str(exc_info.value)
+
+    def test_run_calls_describe_with_correct_params(self, lookup_plugin):
+        """Test that run calls describe_account_attributes with correct parameters"""
+        lookup_plugin._cached_client.describe_account_attributes.return_value = {
+            "AccountAttributes": [{"AttributeName": "max-instances", "AttributeValues": [{"AttributeValue": "20"}]}]
+        }
+
+        with patch.object(
+            lookup_plugin, "_describe_account_attributes", wraps=lookup_plugin._describe_account_attributes
+        ) as mock_describe:
+            lookup_plugin.run([], {}, attribute="max-instances")
+
+        mock_describe.assert_called_once_with(term="max-instances", AttributeNames=["max-instances"])
+
+    def test_run_all_attributes_empty_params(self, lookup_plugin):
+        """Test that run calls describe_account_attributes with empty AttributeNames for all attributes"""
+        lookup_plugin._cached_client.describe_account_attributes.return_value = {"AccountAttributes": []}
+
+        with patch.object(
+            lookup_plugin, "_describe_account_attributes", wraps=lookup_plugin._describe_account_attributes
+        ) as mock_describe:
+            lookup_plugin.run([], {})
+
+        mock_describe.assert_called_once_with(term="all attributes", AttributeNames=[])

--- a/tests/unit/plugins/lookup/test_aws_collection_constants.py
+++ b/tests/unit/plugins/lookup/test_aws_collection_constants.py
@@ -1,0 +1,172 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from ansible.errors import AnsibleLookupError
+
+from ansible_collections.amazon.aws.plugins.lookup.aws_collection_constants import LookupModule
+
+
+@pytest.fixture(name="lookup_plugin")
+def fixture_lookup_plugin():
+    lookup = LookupModule()
+    lookup._display = MagicMock()
+    return lookup
+
+
+class TestValidateTerms:
+    """Unit tests for _validate_terms helper method"""
+
+    def test_validate_single_term(self, lookup_plugin):
+        """Test that single term is valid"""
+        # Should not raise
+        lookup_plugin._validate_terms(["MINIMUM_BOTOCORE_VERSION"])
+
+    def test_validate_empty_terms(self, lookup_plugin):
+        """Test that empty terms raises error"""
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin._validate_terms([])
+        assert "Constant name not provided" in str(exc_info.value)
+
+    def test_validate_multiple_terms(self, lookup_plugin):
+        """Test that multiple terms raises error"""
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin._validate_terms(["MINIMUM_BOTOCORE_VERSION", "HAS_BOTO3"])
+        assert "Multiple constant names provided" in str(exc_info.value)
+
+
+class TestLookupConstant:
+    """Unit tests for lookup_constant method"""
+
+    def test_lookup_minimum_botocore_version(self, lookup_plugin):
+        """Test looking up MINIMUM_BOTOCORE_VERSION"""
+        result = lookup_plugin.lookup_constant("MINIMUM_BOTOCORE_VERSION")
+        assert result is not None
+        assert isinstance(result, str)
+
+    def test_lookup_minimum_boto3_version(self, lookup_plugin):
+        """Test looking up MINIMUM_BOTO3_VERSION"""
+        result = lookup_plugin.lookup_constant("MINIMUM_BOTO3_VERSION")
+        assert result is not None
+        assert isinstance(result, str)
+
+    def test_lookup_has_boto3(self, lookup_plugin):
+        """Test looking up HAS_BOTO3"""
+        result = lookup_plugin.lookup_constant("HAS_BOTO3")
+        assert result is not None
+        assert isinstance(result, bool)
+
+    def test_lookup_amazon_aws_collection_version(self, lookup_plugin):
+        """Test looking up AMAZON_AWS_COLLECTION_VERSION"""
+        result = lookup_plugin.lookup_constant("AMAZON_AWS_COLLECTION_VERSION")
+        assert result is not None
+        assert isinstance(result, str)
+
+    def test_lookup_amazon_aws_collection_name(self, lookup_plugin):
+        """Test looking up AMAZON_AWS_COLLECTION_NAME"""
+        result = lookup_plugin.lookup_constant("AMAZON_AWS_COLLECTION_NAME")
+        assert result is not None
+        assert isinstance(result, str)
+
+    def test_lookup_community_aws_collection_version_when_available(self, lookup_plugin):
+        """Test looking up COMMUNITY_AWS_COLLECTION_VERSION when community collection is available"""
+        import ansible_collections.amazon.aws.plugins.lookup.aws_collection_constants as constants_module
+
+        mock_utils = MagicMock()
+        mock_utils.COMMUNITY_AWS_COLLECTION_VERSION = "1.0.0"
+
+        # Set the attribute before patching since it may not exist
+        setattr(constants_module, "community_utils", mock_utils)
+        try:
+            with patch.object(constants_module, "HAS_COMMUNITY", True):
+                result = lookup_plugin.lookup_constant("COMMUNITY_AWS_COLLECTION_VERSION")
+                assert result == "1.0.0"
+        finally:
+            # Clean up the attribute
+            if hasattr(constants_module, "community_utils"):
+                delattr(constants_module, "community_utils")
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_collection_constants.HAS_COMMUNITY", False)
+    def test_lookup_community_aws_collection_version_when_unavailable(self, lookup_plugin):
+        """Test looking up COMMUNITY_AWS_COLLECTION_VERSION when community collection is not available"""
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin.lookup_constant("COMMUNITY_AWS_COLLECTION_VERSION")
+        assert "Unable to load ansible_collections.community.aws" in str(exc_info.value)
+
+    def test_lookup_community_aws_collection_name_when_available(self, lookup_plugin):
+        """Test looking up COMMUNITY_AWS_COLLECTION_NAME when community collection is available"""
+        import ansible_collections.amazon.aws.plugins.lookup.aws_collection_constants as constants_module
+
+        mock_utils = MagicMock()
+        mock_utils.COMMUNITY_AWS_COLLECTION_NAME = "community.aws"
+
+        # Set the attribute before patching since it may not exist
+        setattr(constants_module, "community_utils", mock_utils)
+        try:
+            with patch.object(constants_module, "HAS_COMMUNITY", True):
+                result = lookup_plugin.lookup_constant("COMMUNITY_AWS_COLLECTION_NAME")
+                assert result == "community.aws"
+        finally:
+            # Clean up the attribute
+            if hasattr(constants_module, "community_utils"):
+                delattr(constants_module, "community_utils")
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_collection_constants.HAS_COMMUNITY", False)
+    def test_lookup_community_aws_collection_name_when_unavailable(self, lookup_plugin):
+        """Test looking up COMMUNITY_AWS_COLLECTION_NAME when community collection is not available"""
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin.lookup_constant("COMMUNITY_AWS_COLLECTION_NAME")
+        assert "Unable to load ansible_collections.community.aws" in str(exc_info.value)
+
+    def test_lookup_invalid_constant(self, lookup_plugin):
+        """Test that looking up an invalid constant returns None"""
+        result = lookup_plugin.lookup_constant("INVALID_CONSTANT")
+        assert result is None
+
+
+class TestRun:
+    """Unit tests for run method"""
+
+    def test_run_with_valid_constant(self, lookup_plugin):
+        """Test run with a valid constant name"""
+        lookup_plugin.set_options = MagicMock()
+        result = lookup_plugin.run(["MINIMUM_BOTOCORE_VERSION"], {})
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0] is not None
+
+    def test_run_normalizes_case(self, lookup_plugin):
+        """Test that run normalizes constant name to uppercase"""
+        lookup_plugin.set_options = MagicMock()
+        result = lookup_plugin.run(["minimum_botocore_version"], {})
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0] is not None
+
+    def test_run_with_no_terms(self, lookup_plugin):
+        """Test that run raises error when no terms provided"""
+        lookup_plugin.set_options = MagicMock()
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin.run([], {})
+        assert "Constant name not provided" in str(exc_info.value)
+
+    def test_run_with_multiple_terms(self, lookup_plugin):
+        """Test that run raises error when multiple terms provided"""
+        lookup_plugin.set_options = MagicMock()
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin.run(["MINIMUM_BOTOCORE_VERSION", "MINIMUM_BOTO3_VERSION"], {})
+        assert "Multiple constant names provided" in str(exc_info.value)
+
+    def test_run_calls_set_options(self, lookup_plugin):
+        """Test that run calls set_options with correct parameters"""
+        lookup_plugin.set_options = MagicMock()
+        variables = {"var1": "value1"}
+        kwargs = {"key1": "value1"}
+        lookup_plugin.run(["HAS_BOTO3"], variables, **kwargs)
+        lookup_plugin.set_options.assert_called_once_with(var_options=variables, direct=kwargs)

--- a/tests/unit/plugins/lookup/test_aws_service_ip_ranges.py
+++ b/tests/unit/plugins/lookup/test_aws_service_ip_ranges.py
@@ -1,0 +1,365 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from ansible.errors import AnsibleLookupError
+
+from ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges import LookupModule
+
+
+@pytest.fixture(name="lookup_plugin")
+def fixture_lookup_plugin():
+    lookup = LookupModule()
+    lookup._display = MagicMock()
+    return lookup
+
+
+class TestDeterminePrefixLabels:
+    """Unit tests for _determine_prefix_labels method"""
+
+    def test_determine_ipv4_labels(self, lookup_plugin):
+        """Test that IPv4 labels are returned when use_ipv6 is False"""
+        prefixes_label, ip_prefix_label = lookup_plugin._determine_prefix_labels(False)
+        assert prefixes_label == "prefixes"
+        assert ip_prefix_label == "ip_prefix"
+
+    def test_determine_ipv6_labels(self, lookup_plugin):
+        """Test that IPv6 labels are returned when use_ipv6 is True"""
+        prefixes_label, ip_prefix_label = lookup_plugin._determine_prefix_labels(True)
+        assert prefixes_label == "ipv6_prefixes"
+        assert ip_prefix_label == "ipv6_prefix"
+
+    def test_determine_labels_returns_tuple(self, lookup_plugin):
+        """Test that the method returns a tuple"""
+        result = lookup_plugin._determine_prefix_labels(False)
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+
+
+class TestFetchIpRanges:
+    """Unit tests for _fetch_ip_ranges method"""
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.ansible.module_utils.urls.open_url")
+    def test_fetch_ip_ranges_success_ipv4(self, mock_open_url, lookup_plugin):
+        """Test successful fetch of IPv4 IP ranges"""
+        mock_response = MagicMock()
+        mock_response.read.return_value = (
+            '{"prefixes": [{"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"}]}'
+        )
+        mock_open_url.return_value = mock_response
+
+        with patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.json.load") as mock_json_load:
+            mock_json_load.return_value = {
+                "prefixes": [{"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"}]
+            }
+            result = lookup_plugin._fetch_ip_ranges("prefixes")
+
+        assert result == [{"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"}]
+        mock_open_url.assert_called_once_with("https://ip-ranges.amazonaws.com/ip-ranges.json")
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.ansible.module_utils.urls.open_url")
+    def test_fetch_ip_ranges_success_ipv6(self, mock_open_url, lookup_plugin):
+        """Test successful fetch of IPv6 IP ranges"""
+        mock_response = MagicMock()
+        mock_open_url.return_value = mock_response
+
+        with patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.json.load") as mock_json_load:
+            mock_json_load.return_value = {
+                "ipv6_prefixes": [{"ipv6_prefix": "2001:db8::/32", "region": "us-east-1", "service": "EC2"}]
+            }
+            result = lookup_plugin._fetch_ip_ranges("ipv6_prefixes")
+
+        assert result == [{"ipv6_prefix": "2001:db8::/32", "region": "us-east-1", "service": "EC2"}]
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.ansible.module_utils.urls.open_url")
+    def test_fetch_ip_ranges_json_decode_error(self, mock_open_url, lookup_plugin):
+        """Test that JSON decode errors are properly handled"""
+        import json
+
+        mock_response = MagicMock()
+        mock_open_url.return_value = mock_response
+
+        # Use the appropriate exception type (JSONDecodeError in Python 3+, ValueError in Python 2)
+        json_error = getattr(json.decoder, "JSONDecodeError", ValueError)
+
+        with patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.json.load") as mock_json_load:
+            mock_json_load.side_effect = json_error("Invalid JSON", "", 0)
+            with pytest.raises(AnsibleLookupError) as exc_info:
+                lookup_plugin._fetch_ip_ranges("prefixes")
+
+        assert "Could not decode AWS IP ranges" in str(exc_info.value)
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.ansible.module_utils.urls.open_url")
+    def test_fetch_ip_ranges_http_error(self, mock_open_url, lookup_plugin):
+        """Test that HTTP errors are properly handled"""
+        import ansible.module_utils.six.moves.urllib.error as urllib_error
+
+        mock_open_url.side_effect = urllib_error.HTTPError("url", 404, "Not Found", {}, None)
+
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin._fetch_ip_ranges("prefixes")
+
+        assert "Received HTTP error while pulling IP ranges" in str(exc_info.value)
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.ansible.module_utils.urls.open_url")
+    def test_fetch_ip_ranges_ssl_error(self, mock_open_url, lookup_plugin):
+        """Test that SSL validation errors are properly handled"""
+        import ansible.module_utils.urls
+
+        mock_open_url.side_effect = ansible.module_utils.urls.SSLValidationError("SSL Error")
+
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin._fetch_ip_ranges("prefixes")
+
+        assert "Error validating the server's certificate" in str(exc_info.value)
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.ansible.module_utils.urls.open_url")
+    def test_fetch_ip_ranges_url_error(self, mock_open_url, lookup_plugin):
+        """Test that URL errors are properly handled"""
+        import ansible.module_utils.six.moves.urllib.error as urllib_error
+
+        mock_open_url.side_effect = urllib_error.URLError("Connection refused")
+
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin._fetch_ip_ranges("prefixes")
+
+        assert "Failed look up IP range service" in str(exc_info.value)
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.ansible.module_utils.urls.open_url")
+    def test_fetch_ip_ranges_connection_error(self, mock_open_url, lookup_plugin):
+        """Test that connection errors are properly handled"""
+        import ansible.module_utils.urls
+
+        mock_open_url.side_effect = ansible.module_utils.urls.ConnectionError("Connection failed")
+
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin._fetch_ip_ranges("prefixes")
+
+        assert "Error connecting to IP range service" in str(exc_info.value)
+
+
+class TestFilterByRegion:
+    """Unit tests for _filter_by_region method"""
+
+    def test_filter_by_region_single_match(self, lookup_plugin):
+        """Test filtering with a single matching region"""
+        ip_ranges = [
+            {"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"},
+            {"ip_prefix": "198.51.100.0/24", "region": "eu-west-1", "service": "EC2"},
+        ]
+        result = list(lookup_plugin._filter_by_region(ip_ranges, "us-east-1"))
+        assert len(result) == 1
+        assert result[0]["region"] == "us-east-1"
+
+    def test_filter_by_region_multiple_matches(self, lookup_plugin):
+        """Test filtering with multiple matching regions"""
+        ip_ranges = [
+            {"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"},
+            {"ip_prefix": "198.51.100.0/24", "region": "us-east-1", "service": "S3"},
+            {"ip_prefix": "203.0.113.0/24", "region": "eu-west-1", "service": "EC2"},
+        ]
+        result = list(lookup_plugin._filter_by_region(ip_ranges, "us-east-1"))
+        assert len(result) == 2
+        assert all(item["region"] == "us-east-1" for item in result)
+
+    def test_filter_by_region_no_matches(self, lookup_plugin):
+        """Test filtering with no matching regions"""
+        ip_ranges = [
+            {"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"},
+            {"ip_prefix": "198.51.100.0/24", "region": "eu-west-1", "service": "EC2"},
+        ]
+        result = list(lookup_plugin._filter_by_region(ip_ranges, "ap-southeast-1"))
+        assert len(result) == 0
+
+    def test_filter_by_region_empty_input(self, lookup_plugin):
+        """Test filtering with empty input"""
+        result = list(lookup_plugin._filter_by_region([], "us-east-1"))
+        assert len(result) == 0
+
+
+class TestFilterByService:
+    """Unit tests for _filter_by_service method"""
+
+    def test_filter_by_service_single_match(self, lookup_plugin):
+        """Test filtering with a single matching service"""
+        ip_ranges = [
+            {"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"},
+            {"ip_prefix": "198.51.100.0/24", "region": "us-east-1", "service": "S3"},
+        ]
+        result = list(lookup_plugin._filter_by_service(ip_ranges, "EC2"))
+        assert len(result) == 1
+        assert result[0]["service"] == "EC2"
+
+    def test_filter_by_service_case_insensitive(self, lookup_plugin):
+        """Test that service filtering is case-insensitive"""
+        ip_ranges = [
+            {"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"},
+            {"ip_prefix": "198.51.100.0/24", "region": "us-east-1", "service": "S3"},
+        ]
+        result = list(lookup_plugin._filter_by_service(ip_ranges, "ec2"))
+        assert len(result) == 1
+        assert result[0]["service"] == "EC2"
+
+    def test_filter_by_service_multiple_matches(self, lookup_plugin):
+        """Test filtering with multiple matching services"""
+        ip_ranges = [
+            {"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"},
+            {"ip_prefix": "198.51.100.0/24", "region": "eu-west-1", "service": "EC2"},
+            {"ip_prefix": "203.0.113.0/24", "region": "us-east-1", "service": "S3"},
+        ]
+        result = list(lookup_plugin._filter_by_service(ip_ranges, "EC2"))
+        assert len(result) == 2
+        assert all(item["service"] == "EC2" for item in result)
+
+    def test_filter_by_service_no_matches(self, lookup_plugin):
+        """Test filtering with no matching services"""
+        ip_ranges = [
+            {"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"},
+            {"ip_prefix": "198.51.100.0/24", "region": "us-east-1", "service": "S3"},
+        ]
+        result = list(lookup_plugin._filter_by_service(ip_ranges, "CLOUDFRONT"))
+        assert len(result) == 0
+
+    def test_filter_by_service_empty_input(self, lookup_plugin):
+        """Test filtering with empty input"""
+        result = list(lookup_plugin._filter_by_service([], "EC2"))
+        assert len(result) == 0
+
+
+class TestExtractIpAddresses:
+    """Unit tests for _extract_ip_addresses method"""
+
+    def test_extract_ipv4_addresses(self, lookup_plugin):
+        """Test extracting IPv4 addresses"""
+        ip_ranges = [
+            {"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"},
+            {"ip_prefix": "198.51.100.0/24", "region": "us-east-1", "service": "S3"},
+        ]
+        result = lookup_plugin._extract_ip_addresses(ip_ranges, "ip_prefix")
+        assert result == ["192.0.2.0/24", "198.51.100.0/24"]
+
+    def test_extract_ipv6_addresses(self, lookup_plugin):
+        """Test extracting IPv6 addresses"""
+        ip_ranges = [
+            {"ipv6_prefix": "2001:db8::/32", "region": "us-east-1", "service": "EC2"},
+            {"ipv6_prefix": "2001:db8:1::/48", "region": "us-east-1", "service": "S3"},
+        ]
+        result = lookup_plugin._extract_ip_addresses(ip_ranges, "ipv6_prefix")
+        assert result == ["2001:db8::/32", "2001:db8:1::/48"]
+
+    def test_extract_addresses_empty_input(self, lookup_plugin):
+        """Test extracting addresses from empty input"""
+        result = lookup_plugin._extract_ip_addresses([], "ip_prefix")
+        assert result == []
+
+    def test_extract_addresses_single_item(self, lookup_plugin):
+        """Test extracting addresses from single item"""
+        ip_ranges = [{"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"}]
+        result = lookup_plugin._extract_ip_addresses(ip_ranges, "ip_prefix")
+        assert result == ["192.0.2.0/24"]
+
+
+class TestRun:
+    """Unit tests for run method integration"""
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.ansible.module_utils.urls.open_url")
+    def test_run_ipv4_no_filters(self, mock_open_url, lookup_plugin):
+        """Test run method with IPv4 and no filters"""
+        lookup_plugin.set_options = MagicMock()
+        mock_response = MagicMock()
+        mock_open_url.return_value = mock_response
+
+        with patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.json.load") as mock_json_load:
+            mock_json_load.return_value = {
+                "prefixes": [
+                    {"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"},
+                    {"ip_prefix": "198.51.100.0/24", "region": "eu-west-1", "service": "S3"},
+                ]
+            }
+            result = lookup_plugin.run([], {})
+
+        assert len(result) == 2
+        assert "192.0.2.0/24" in result
+        assert "198.51.100.0/24" in result
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.ansible.module_utils.urls.open_url")
+    def test_run_ipv6(self, mock_open_url, lookup_plugin):
+        """Test run method with IPv6"""
+        lookup_plugin.set_options = MagicMock()
+        mock_response = MagicMock()
+        mock_open_url.return_value = mock_response
+
+        with patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.json.load") as mock_json_load:
+            mock_json_load.return_value = {
+                "ipv6_prefixes": [
+                    {"ipv6_prefix": "2001:db8::/32", "region": "us-east-1", "service": "EC2"},
+                ]
+            }
+            result = lookup_plugin.run([], {}, ipv6_prefixes=True)
+
+        assert len(result) == 1
+        assert "2001:db8::/32" in result
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.ansible.module_utils.urls.open_url")
+    def test_run_filter_by_region(self, mock_open_url, lookup_plugin):
+        """Test run method with region filter"""
+        lookup_plugin.set_options = MagicMock()
+        mock_response = MagicMock()
+        mock_open_url.return_value = mock_response
+
+        with patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.json.load") as mock_json_load:
+            mock_json_load.return_value = {
+                "prefixes": [
+                    {"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"},
+                    {"ip_prefix": "198.51.100.0/24", "region": "eu-west-1", "service": "EC2"},
+                ]
+            }
+            result = lookup_plugin.run([], {}, region="us-east-1")
+
+        assert len(result) == 1
+        assert "192.0.2.0/24" in result
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.ansible.module_utils.urls.open_url")
+    def test_run_filter_by_service(self, mock_open_url, lookup_plugin):
+        """Test run method with service filter"""
+        lookup_plugin.set_options = MagicMock()
+        mock_response = MagicMock()
+        mock_open_url.return_value = mock_response
+
+        with patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.json.load") as mock_json_load:
+            mock_json_load.return_value = {
+                "prefixes": [
+                    {"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"},
+                    {"ip_prefix": "198.51.100.0/24", "region": "us-east-1", "service": "S3"},
+                ]
+            }
+            result = lookup_plugin.run([], {}, service="EC2")
+
+        assert len(result) == 1
+        assert "192.0.2.0/24" in result
+
+    @patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.ansible.module_utils.urls.open_url")
+    def test_run_filter_by_both(self, mock_open_url, lookup_plugin):
+        """Test run method with both region and service filters"""
+        lookup_plugin.set_options = MagicMock()
+        mock_response = MagicMock()
+        mock_open_url.return_value = mock_response
+
+        with patch("ansible_collections.amazon.aws.plugins.lookup.aws_service_ip_ranges.json.load") as mock_json_load:
+            mock_json_load.return_value = {
+                "prefixes": [
+                    {"ip_prefix": "192.0.2.0/24", "region": "us-east-1", "service": "EC2"},
+                    {"ip_prefix": "198.51.100.0/24", "region": "us-east-1", "service": "S3"},
+                    {"ip_prefix": "203.0.113.0/24", "region": "eu-west-1", "service": "EC2"},
+                ]
+            }
+            result = lookup_plugin.run([], {}, region="us-east-1", service="EC2")
+
+        assert len(result) == 1
+        assert "192.0.2.0/24" in result

--- a/tests/unit/plugins/lookup/test_secretsmanager_secret.py
+++ b/tests/unit/plugins/lookup/test_secretsmanager_secret.py
@@ -234,24 +234,24 @@ class TestExtractNestedValue:
         assert "localhost" in result
 
     def test_extract_missing_key_raises_nested_error(self, lookup_plugin):
-        """Test that missing keys raise NestedKeyNotFoundError"""
-        from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import NestedKeyNotFoundError
+        """Test that missing keys raise LookupResourceNotFoundError"""
+        from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import LookupResourceNotFoundError
 
         secret_string = '{"db": {"prod": {"password": "secret123"}}}'
 
-        with pytest.raises(NestedKeyNotFoundError) as exc_info:
+        with pytest.raises(LookupResourceNotFoundError) as exc_info:
             lookup_plugin._extract_nested_value(secret_string, "my-secret.db.staging.password")
 
         assert exc_info.value.path == "db.staging"
 
     def test_extract_key_from_non_dict_raises_nested_error(self, lookup_plugin):
-        """Test that trying to traverse a non-dict raises NestedKeyNotFoundError"""
-        from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import NestedKeyNotFoundError
+        """Test that trying to traverse a non-dict raises LookupResourceNotFoundError"""
+        from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import LookupResourceNotFoundError
 
         secret_string = '{"password": "secret123"}'
 
         # Trying to access password.nested when password is a string, not a dict
-        with pytest.raises(NestedKeyNotFoundError) as exc_info:
+        with pytest.raises(LookupResourceNotFoundError) as exc_info:
             lookup_plugin._extract_nested_value(secret_string, "my-secret.password.nested")
 
         assert exc_info.value.path == "password.nested"

--- a/tests/unit/plugins/lookup/test_secretsmanager_secret.py
+++ b/tests/unit/plugins/lookup/test_secretsmanager_secret.py
@@ -4,17 +4,13 @@
 # This file is part of Ansible
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-import random
-from unittest.mock import ANY
 from unittest.mock import MagicMock
-from unittest.mock import call
 
 import pytest
 from botocore.exceptions import ClientError
 
 from ansible.errors import AnsibleLookupError
 
-# from ansible_collections.amazon.aws.plugins.lookup.secretsmanager_secret import AnsibleLookupError
 from ansible_collections.amazon.aws.plugins.lookup.secretsmanager_secret import LookupModule
 
 
@@ -30,14 +26,9 @@ def fixture_lookup_plugin():
 
     lookup.get_option.side_effect = _get_option
     lookup.client = MagicMock()
+    lookup._display = MagicMock()
 
     return lookup
-
-
-def pick_from_list(elements=None):
-    if elements is None:
-        elements = ["error", "warn", "skip"]
-    return random.choice(elements)
 
 
 def _raise_boto_clienterror(code, msg):
@@ -48,301 +39,377 @@ def _raise_boto_clienterror(code, msg):
     return ClientError(params, "get_secret_value")
 
 
-class TestLookupModuleRun:
+class TestValidateOptions:
+    """Unit tests for _validate_options helper method"""
+
     @pytest.mark.parametrize(
-        "params,err",
+        "on_missing,expected_error",
         [
-            ({"on_missing": "test"}, '"on_missing" must be a string and one of "error", "warn" or "skip", not test'),
-            ({"on_denied": "return"}, '"on_denied" must be a string and one of "error", "warn" or "skip", not return'),
-            (
-                {"on_deleted": "delete"},
-                '"on_deleted" must be a string and one of "error", "warn" or "skip", not delete',
-            ),
-            (
-                {"on_missing": ["warn"]},
-                '"on_missing" must be a string and one of "error", "warn" or "skip", not [\'warn\']',
-            ),
-            ({"on_denied": True}, '"on_denied" must be a string and one of "error", "warn" or "skip", not True'),
-            (
-                {"on_deleted": {"error": True}},
-                '"on_deleted" must be a string and one of "error", "warn" or "skip", not {\'error\': True}',
-            ),
+            ("invalid", '"on_missing" must be a string and one of "error", "warn" or "skip", not invalid'),
         ],
     )
-    def test_run_invalid_parameters(self, lookup_plugin, mocker, params, err):
-        aws_lookup_base_run = mocker.patch(
-            "ansible_collections.amazon.aws.plugins.lookup.secretsmanager_secret.AWSLookupBase.run"
-        )
-        aws_lookup_base_run.return_value = True
-        m_list_secrets = mocker.patch(
-            "ansible_collections.amazon.aws.plugins.lookup.secretsmanager_secret._list_secrets"
-        )
-        m_list_secrets.return_value = {"SecretList": []}
-
-        lookup_plugin.params = params
+    def test_validate_invalid_on_missing(self, lookup_plugin, on_missing, expected_error):
+        """Test that invalid on_missing values raise errors"""
+        lookup_plugin.params = {"on_missing": on_missing, "on_denied": "error", "on_deleted": "error"}
         with pytest.raises(AnsibleLookupError) as exc_info:
-            lookup_plugin.run(terms=["testing_secret"], variables=[])
-        assert err == str(exc_info.value)
+            lookup_plugin._validate_options()
+        assert expected_error == str(exc_info.value)
 
-    def test_run_by_path(self, lookup_plugin, mocker):
-        aws_lookup_base_run = mocker.patch(
-            "ansible_collections.amazon.aws.plugins.lookup.secretsmanager_secret.AWSLookupBase.run"
-        )
-        aws_lookup_base_run.return_value = True
-        m_list_secrets = mocker.patch(
-            "ansible_collections.amazon.aws.plugins.lookup.secretsmanager_secret._list_secrets"
-        )
-        secrets_lists = [{"Name": "secret-0"}, {"Name": "secret-1"}, {"Name": "secret-2"}]
-        m_list_secrets.return_value = [{"SecretList": secrets_lists}]
-
-        params = {
-            "on_missing": pick_from_list(),
-            "on_denied": pick_from_list(),
-            "on_deleted": pick_from_list(),
-            "bypath": True,
-        }
-        lookup_plugin.params = params
-
-        lookup_plugin.get_secret_value = MagicMock()
-        secrets_values = {
-            "secret-0": "value-0",
-            "secret-1": "value-1",
-            "secret-2": "value-2",
-        }
-        lookup_plugin.get_secret_value.side_effect = lambda x, client, **kwargs: secrets_values.get(x)
-
-        secretsmanager_client = MagicMock()
-        lookup_plugin.client.return_value = secretsmanager_client
-
-        term = "term0"
-        assert [secrets_values] == lookup_plugin.run(terms=[term], variables=[])
-
-        m_list_secrets.assert_called_once_with(secretsmanager_client, term)
-        lookup_plugin.client.assert_called_once_with("secretsmanager", ANY)
-        lookup_plugin.get_secret_value.assert_has_calls(
-            [
-                call(
-                    "secret-0",
-                    secretsmanager_client,
-                    on_missing=params.get("on_missing"),
-                    on_denied=params.get("on_denied"),
-                ),
-                call(
-                    "secret-1",
-                    secretsmanager_client,
-                    on_missing=params.get("on_missing"),
-                    on_denied=params.get("on_denied"),
-                ),
-                call(
-                    "secret-2",
-                    secretsmanager_client,
-                    on_missing=params.get("on_missing"),
-                    on_denied=params.get("on_denied"),
-                ),
-            ]
-        )
-
-    @pytest.mark.parametrize("join_secrets", [True, False])
     @pytest.mark.parametrize(
-        "terms", [["secret-0"], ["secret-0", "secret-1"], ["secret-0", "secret-1", "secret-0", "secret-2"]]
+        "on_denied,expected_error",
+        [
+            ("invalid", '"on_denied" must be a string and one of "error", "warn" or "skip", not invalid'),
+        ],
     )
-    def test_run(self, lookup_plugin, mocker, join_secrets, terms):
-        aws_lookup_base_run = mocker.patch(
-            "ansible_collections.amazon.aws.plugins.lookup.secretsmanager_secret.AWSLookupBase.run"
-        )
-        aws_lookup_base_run.return_value = True
+    def test_validate_invalid_on_denied(self, lookup_plugin, on_denied, expected_error):
+        """Test that invalid on_denied values raise errors"""
+        lookup_plugin.params = {"on_missing": "error", "on_denied": on_denied, "on_deleted": "error"}
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin._validate_options()
+        assert expected_error == str(exc_info.value)
 
-        params = {
-            "on_missing": pick_from_list(),
-            "on_denied": pick_from_list(),
-            "on_deleted": pick_from_list(),
-            "bypath": False,
-            "version_stage": MagicMock(),
-            "version_id": MagicMock(),
-            "nested": pick_from_list([True, False]),
-            "join": join_secrets,
-        }
-        lookup_plugin.params = params
+    @pytest.mark.parametrize(
+        "on_deleted,expected_error",
+        [
+            ("delete", '"on_deleted" must be a string and one of "error", "warn" or "skip", not delete'),
+        ],
+    )
+    def test_validate_invalid_on_deleted(self, lookup_plugin, on_deleted, expected_error):
+        """Test that invalid on_deleted values raise errors"""
+        lookup_plugin.params = {"on_missing": "error", "on_denied": "error", "on_deleted": on_deleted}
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin._validate_options()
+        assert expected_error == str(exc_info.value)
 
-        lookup_plugin.get_secret_value = MagicMock()
-        secrets_values = {
-            "secret-0": "value-0",
-            "secret-1": "value-1",
-        }
-        lookup_plugin.get_secret_value.side_effect = lambda x, client, **kwargs: secrets_values.get(x)
-
-        secretsmanager_client = MagicMock()
-        lookup_plugin.client.return_value = secretsmanager_client
-
-        expected_secrets = [secrets_values.get(x) for x in terms if secrets_values.get(x) is not None]
-        if join_secrets:
-            expected_secrets = ["".join(expected_secrets)]
-
-        assert expected_secrets == lookup_plugin.run(terms=terms, variables=[])
-
-        lookup_plugin.client.assert_called_once_with("secretsmanager", ANY)
-        lookup_plugin.get_secret_value.assert_has_calls(
-            [
-                call(
-                    x,
-                    secretsmanager_client,
-                    version_stage=params.get("version_stage"),
-                    version_id=params.get("version_id"),
-                    on_missing=params.get("on_missing"),
-                    on_denied=params.get("on_denied"),
-                    on_deleted=params.get("on_deleted"),
-                    nested=params.get("nested"),
-                )
-                for x in terms
-            ]
-        )
+    def test_validate_valid_options(self, lookup_plugin):
+        """Test that valid options don't raise errors"""
+        # Should not raise
+        lookup_plugin.params = {"on_missing": "error", "on_denied": "warn", "on_deleted": "skip"}
+        lookup_plugin._validate_options()
+        lookup_plugin.params = {"on_missing": "warn", "on_denied": "skip", "on_deleted": "error"}
+        lookup_plugin._validate_options()
+        lookup_plugin.params = {"on_missing": "skip", "on_denied": "error", "on_deleted": "warn"}
+        lookup_plugin._validate_options()
 
 
 class TestLookupModuleGetSecretValue:
-    def test_get_secret__invalid_nested_value(self, lookup_plugin):
-        params = {
-            "version_stage": MagicMock(),
-            "version_id": MagicMock(),
-            "on_missing": None,
-            "on_denied": None,
-            "on_deleted": None,
-        }
-        with pytest.raises(AnsibleLookupError) as exc_info:
-            client = MagicMock()
-            lookup_plugin.get_secret_value("aws_invalid_nested_secret", client, nested=True, **params)
-        assert "Nested query must use the following syntax: `aws_secret_name.<key_name>.<key_name>" == str(
-            exc_info.value
+    """Integration tests for get_secret_value - tests full flow with decorator"""
+
+    def test_get_secret_value_integration(self, lookup_plugin):
+        """Test complete get_secret_value flow"""
+        client = MagicMock()
+        client.get_secret_value = MagicMock()
+        client.get_secret_value.return_value = {"SecretString": "my-secret-value"}
+        lookup_plugin._cached_client = client
+
+        result = lookup_plugin.get_secret_value("my-secret", version_stage="AWSCURRENT", version_id="v123")
+
+        assert result == "my-secret-value"
+        client.get_secret_value.assert_called_once_with(
+            aws_retry=True, SecretId="my-secret", VersionStage="AWSCURRENT", VersionId="v123"
         )
 
-    @pytest.mark.parametrize("versionId", [None, MagicMock()])
-    @pytest.mark.parametrize("versionStage", [None, MagicMock()])
-    @pytest.mark.parametrize(
-        "term,nested,secretId",
-        [
-            ("secret0", False, "secret0"),
-            ("secret0.child", False, "secret0.child"),
-            ("secret0.child", True, "secret0"),
-            ("secret0.root.child", False, "secret0.root.child"),
-            ("secret0.root.child", True, "secret0"),
-        ],
-    )
-    def test_get_secret__binary_secret(self, lookup_plugin, versionId, versionStage, term, nested, secretId):
-        params = {
-            "version_stage": versionStage,
-            "version_id": versionId,
-            "on_missing": None,
-            "on_denied": None,
-            "on_deleted": None,
-        }
-
+    def test_get_secret_value_nested_integration(self, lookup_plugin):
+        """Test nested value extraction integration"""
         client = MagicMock()
         client.get_secret_value = MagicMock()
-        bin_secret_value = b"binary_value"
-        client.get_secret_value.return_value = {"SecretBinary": bin_secret_value}
-
-        assert bin_secret_value == lookup_plugin.get_secret_value(term, client, nested=nested, **params)
-        api_params = {"SecretId": secretId}
-        if versionId is not None:
-            api_params["VersionId"] = versionId
-        if versionStage:
-            api_params["VersionStage"] = versionStage
-        client.get_secret_value.assert_called_once_with(aws_retry=True, **api_params)
-
-    @pytest.mark.parametrize("on_missing", ["warn", "error"])
-    @pytest.mark.parametrize(
-        "term,missing_key",
-        [
-            ("secret_name.root.child1", "root.child1"),
-            ("secret_name.root.child1.nested", "root.child1"),
-            ("secret_name.root.child.nested1", "root.child.nested1"),
-            ("secret_name.root.child.nested.value", "root.child.nested.value"),
-        ],
-    )
-    def test_get_secret__missing_nested_secret(self, lookup_plugin, on_missing, term, missing_key):
-        client = MagicMock()
-        client.get_secret_value = MagicMock()
-        json_secret = '{"root": {"child": {"nested": "ansible-test-secret-0"}}}'
+        json_secret = '{"db": {"password": "secret123"}}'
         client.get_secret_value.return_value = {"SecretString": json_secret}
+        lookup_plugin._cached_client = client
 
-        if on_missing == "error":
-            with pytest.raises(AnsibleLookupError) as exc_info:
-                lookup_plugin.get_secret_value(term, client, nested=True, on_missing=on_missing)
-            assert f"Successfully retrieved secret but there exists no key {missing_key} in the secret" == str(
-                exc_info.value
-            )
-        else:
-            lookup_plugin._display = MagicMock()
-            lookup_plugin._display.warning = MagicMock()
-            assert lookup_plugin.get_secret_value(term, client, nested=True, on_missing=on_missing) is None
-            lookup_plugin._display.warning.assert_called_once_with(
-                f"Skipping, Successfully retrieved secret but there exists no key {missing_key} in the secret"
-            )
+        result = lookup_plugin.get_secret_value("my-secret.db.password", nested=True)
 
-    def test_get_secret__missing_secret(self, lookup_plugin):
-        client = MagicMock()
-        client.get_secret_value = MagicMock()
-        client.get_secret_value.side_effect = _raise_boto_clienterror("UnexpecteError", "unable to retrieve Secret")
+        assert result == "secret123"
+        # Nested=True extracts just the secret name for the API call
+        client.get_secret_value.assert_called_once_with(aws_retry=True, SecretId="my-secret")
 
+
+class TestBuildSecretParams:
+    """Unit tests for _build_secret_params helper method"""
+
+    def test_build_params_simple_term(self, lookup_plugin):
+        """Test building params with just a term"""
+        params = lookup_plugin._build_secret_params("my-secret", None, None, False)
+        assert params == {"SecretId": "my-secret"}
+
+    def test_build_params_with_version_id(self, lookup_plugin):
+        """Test building params with version_id"""
+        params = lookup_plugin._build_secret_params("my-secret", "version-123", None, False)
+        assert params == {"SecretId": "my-secret", "VersionId": "version-123"}
+
+    def test_build_params_with_version_stage(self, lookup_plugin):
+        """Test building params with version_stage"""
+        params = lookup_plugin._build_secret_params("my-secret", None, "AWSCURRENT", False)
+        assert params == {"SecretId": "my-secret", "VersionStage": "AWSCURRENT"}
+
+    def test_build_params_with_both_versions(self, lookup_plugin):
+        """Test building params with both version_id and version_stage"""
+        params = lookup_plugin._build_secret_params("my-secret", "version-123", "AWSCURRENT", False)
+        assert params == {"SecretId": "my-secret", "VersionId": "version-123", "VersionStage": "AWSCURRENT"}
+
+    def test_build_params_nested_extracts_secret_name(self, lookup_plugin):
+        """Test that nested=True extracts secret name from dotted path"""
+        params = lookup_plugin._build_secret_params("my-secret.root.child", None, None, True)
+        assert params == {"SecretId": "my-secret"}
+
+    def test_build_params_nested_with_versions(self, lookup_plugin):
+        """Test nested with version parameters"""
+        params = lookup_plugin._build_secret_params("my-secret.root.child", "version-123", "AWSCURRENT", True)
+        assert params == {"SecretId": "my-secret", "VersionId": "version-123", "VersionStage": "AWSCURRENT"}
+
+    def test_build_params_nested_invalid_raises_error(self, lookup_plugin):
+        """Test that nested=True with no dots raises error"""
         with pytest.raises(AnsibleLookupError) as exc_info:
-            lookup_plugin.get_secret_value(MagicMock(), client)
-        assert (
-            "Failed to retrieve secret: An error occurred (UnexpecteError) when calling the get_secret_value operation: unable to retrieve Secret"
-            == str(exc_info.value)
-        )
+            lookup_plugin._build_secret_params("my-secret", None, None, True)
+        assert "Nested query must use the following syntax" in str(exc_info.value)
 
-    @pytest.mark.parametrize("on_denied", ["warn", "error"])
-    def test_get_secret__on_denied(self, lookup_plugin, on_denied):
+
+class TestProcessSecretResponse:
+    """Unit tests for _process_secret_response helper method"""
+
+    def test_process_binary_response(self, lookup_plugin):
+        """Test processing response with SecretBinary"""
+        response = {"SecretBinary": b"binary-data"}
+        result = lookup_plugin._process_secret_response(response, "my-secret", False)
+        assert result == b"binary-data"
+
+    def test_process_string_response_non_nested(self, lookup_plugin):
+        """Test processing response with SecretString (non-nested)"""
+        response = {"SecretString": "my-secret-value"}
+        result = lookup_plugin._process_secret_response(response, "my-secret", False)
+        assert result == "my-secret-value"
+
+    def test_process_string_response_nested(self, lookup_plugin, mocker):
+        """Test processing response with SecretString (nested)"""
+        response = {"SecretString": '{"key": "value"}'}
+        mock_extract = mocker.patch.object(lookup_plugin, "_extract_nested_value", return_value="extracted-value")
+
+        result = lookup_plugin._process_secret_response(response, "my-secret.key", True)
+
+        assert result == "extracted-value"
+        mock_extract.assert_called_once_with('{"key": "value"}', "my-secret.key")
+
+    def test_process_empty_response(self, lookup_plugin):
+        """Test processing response with neither SecretBinary nor SecretString"""
+        response = {"ARN": "arn:aws:secretsmanager:us-east-1:123456789012:secret:my-secret"}
+        result = lookup_plugin._process_secret_response(response, "my-secret", False)
+        assert result is None
+
+
+class TestExtractNestedValue:
+    """Unit tests for _extract_nested_value helper method"""
+
+    def test_extract_single_key(self, lookup_plugin):
+        """Test extracting a single nested key"""
+        secret_string = '{"password": "secret123"}'
+        result = lookup_plugin._extract_nested_value(secret_string, "my-secret.password")
+        assert result == "secret123"
+
+    def test_extract_nested_keys(self, lookup_plugin):
+        """Test extracting deeply nested keys"""
+        secret_string = '{"db": {"prod": {"password": "secret123"}}}'
+        result = lookup_plugin._extract_nested_value(secret_string, "my-secret.db.prod.password")
+        assert result == "secret123"
+
+    def test_extract_number_converts_to_string(self, lookup_plugin):
+        """Test that numeric values are converted to strings"""
+        secret_string = '{"port": 5432}'
+        result = lookup_plugin._extract_nested_value(secret_string, "my-secret.port")
+        assert result == "5432"
+        assert isinstance(result, str)
+
+    def test_extract_boolean_converts_to_string(self, lookup_plugin):
+        """Test that boolean values are converted to strings"""
+        secret_string = '{"enabled": true}'
+        result = lookup_plugin._extract_nested_value(secret_string, "my-secret.enabled")
+        assert result == "True"
+        assert isinstance(result, str)
+
+    def test_extract_object_converts_to_string(self, lookup_plugin):
+        """Test that object values are converted to strings"""
+        secret_string = '{"config": {"host": "localhost", "port": 5432}}'
+        result = lookup_plugin._extract_nested_value(secret_string, "my-secret.config")
+        # Python dict str representation
+        assert "host" in result
+        assert "localhost" in result
+
+    def test_extract_missing_key_raises_nested_error(self, lookup_plugin):
+        """Test that missing keys raise NestedKeyNotFoundError"""
+        from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import NestedKeyNotFoundError
+
+        secret_string = '{"db": {"prod": {"password": "secret123"}}}'
+
+        with pytest.raises(NestedKeyNotFoundError) as exc_info:
+            lookup_plugin._extract_nested_value(secret_string, "my-secret.db.staging.password")
+
+        assert exc_info.value.path == "db.staging"
+
+    def test_extract_key_from_non_dict_raises_nested_error(self, lookup_plugin):
+        """Test that trying to traverse a non-dict raises NestedKeyNotFoundError"""
+        from ansible_collections.amazon.aws.plugins.plugin_utils.lookup import NestedKeyNotFoundError
+
+        secret_string = '{"password": "secret123"}'
+
+        # Trying to access password.nested when password is a string, not a dict
+        with pytest.raises(NestedKeyNotFoundError) as exc_info:
+            lookup_plugin._extract_nested_value(secret_string, "my-secret.password.nested")
+
+        assert exc_info.value.path == "password.nested"
+
+
+class TestFetchSecretList:
+    """Unit tests for _fetch_secret_list helper method"""
+
+    def test_fetch_single_page(self, lookup_plugin):
+        """Test fetching secrets from a single page"""
         client = MagicMock()
-        client.get_secret_value = MagicMock()
-        client.get_secret_value.side_effect = _raise_boto_clienterror(
-            "AccessDeniedException", "Access denied to Secret"
-        )
-        term = "ansible-test-secret-0123"
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {"SecretList": [{"Name": "secret-1", "ARN": "arn:1"}, {"Name": "secret-2", "ARN": "arn:2"}]}
+        ]
+        client.get_paginator.return_value = paginator
+        lookup_plugin._cached_client = client
 
-        if on_denied == "error":
-            with pytest.raises(AnsibleLookupError) as exc_info:
-                lookup_plugin.get_secret_value(term, client, on_denied=on_denied)
-            assert f"Failed to access secret {term} (AccessDenied)" == str(exc_info.value)
-        else:
-            lookup_plugin._display = MagicMock()
-            lookup_plugin._display.warning = MagicMock()
-            assert lookup_plugin.get_secret_value(term, client, on_denied=on_denied) is None
-            lookup_plugin._display.warning.assert_called_once_with(f"Skipping, access denied for secret {term}")
+        result = lookup_plugin._fetch_secret_list("/app/prod/*")
 
-    @pytest.mark.parametrize("on_missing", ["warn", "error"])
-    def test_get_secret__on_missing(self, lookup_plugin, on_missing):
+        assert len(result) == 2
+        assert result[0]["Name"] == "secret-1"
+        assert result[1]["Name"] == "secret-2"
+        client.get_paginator.assert_called_once_with("list_secrets")
+        paginator.paginate.assert_called_once_with(Filters=[{"Key": "name", "Values": ["/app/prod/*"]}])
+
+    def test_fetch_multiple_pages(self, lookup_plugin):
+        """Test fetching secrets across multiple pages"""
         client = MagicMock()
-        client.get_secret_value = MagicMock()
-        client.get_secret_value.side_effect = _raise_boto_clienterror("ResourceNotFoundException", "secret not found")
-        term = "ansible-test-secret-4561"
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {"SecretList": [{"Name": "secret-1"}, {"Name": "secret-2"}]},
+            {"SecretList": [{"Name": "secret-3"}]},
+            {"SecretList": [{"Name": "secret-4"}, {"Name": "secret-5"}]},
+        ]
+        client.get_paginator.return_value = paginator
+        lookup_plugin._cached_client = client
 
-        if on_missing == "error":
-            with pytest.raises(AnsibleLookupError) as exc_info:
-                lookup_plugin.get_secret_value(term, client, on_missing=on_missing)
-            assert f"Failed to find secret {term} (ResourceNotFound)" == str(exc_info.value)
-        else:
-            lookup_plugin._display = MagicMock()
-            lookup_plugin._display.warning = MagicMock()
-            assert lookup_plugin.get_secret_value(term, client, on_missing=on_missing) is None
-            lookup_plugin._display.warning.assert_called_once_with(f"Skipping, did not find secret {term}")
+        result = lookup_plugin._fetch_secret_list("/app/*")
 
-    @pytest.mark.parametrize("on_deleted", ["warn", "error"])
-    def test_get_secret__on_deleted(self, lookup_plugin, on_deleted):
+        assert len(result) == 5
+        assert [s["Name"] for s in result] == ["secret-1", "secret-2", "secret-3", "secret-4", "secret-5"]
+
+    def test_fetch_empty_results(self, lookup_plugin):
+        """Test fetching when no secrets match"""
         client = MagicMock()
-        client.get_secret_value = MagicMock()
-        client.get_secret_value.side_effect = _raise_boto_clienterror(
-            "ResourceMarkedForDeletion", "marked for deletion"
-        )
-        term = "ansible-test-secret-8790"
+        paginator = MagicMock()
+        paginator.paginate.return_value = [{"SecretList": []}]
+        client.get_paginator.return_value = paginator
+        lookup_plugin._cached_client = client
+        lookup_plugin._cached_on_missing = "skip"
 
-        if on_deleted == "error":
-            with pytest.raises(AnsibleLookupError) as exc_info:
-                lookup_plugin.get_secret_value(term, client, on_deleted=on_deleted)
-            assert f"Failed to find secret {term} (marked for deletion)" == str(exc_info.value)
-        else:
-            lookup_plugin._display = MagicMock()
-            lookup_plugin._display.warning = MagicMock()
-            assert lookup_plugin.get_secret_value(term, client, on_deleted=on_deleted) is None
-            lookup_plugin._display.warning.assert_called_once_with(
-                f"Skipping, did not find secret (marked for deletion) {term}"
-            )
+        result = lookup_plugin._fetch_secret_list("/nonexistent/*")
+
+        assert result == []
+
+    def test_fetch_page_without_secret_list(self, lookup_plugin):
+        """Test handling pages without SecretList key"""
+        client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value = [
+            {"SecretList": [{"Name": "secret-1"}]},
+            {"NextToken": "token123"},  # Page without SecretList
+            {"SecretList": [{"Name": "secret-2"}]},
+        ]
+        client.get_paginator.return_value = paginator
+        lookup_plugin._cached_client = client
+
+        result = lookup_plugin._fetch_secret_list("/app/*")
+
+        assert len(result) == 2
+        assert result[0]["Name"] == "secret-1"
+        assert result[1]["Name"] == "secret-2"
+
+
+class TestLookupByPath:
+    """Unit tests for _lookup_by_path orchestration"""
+
+    def test_lookup_by_path_single_term(self, lookup_plugin):
+        """Test path lookup with single term"""
+        lookup_plugin._fetch_secret_list = MagicMock(return_value=[{"Name": "secret-1"}, {"Name": "secret-2"}])
+        lookup_plugin.get_secret_value = MagicMock(side_effect=lambda name: f"value-{name}")
+
+        result = lookup_plugin._lookup_by_path(["/app/prod/*"])
+
+        assert result == [{"secret-1": "value-secret-1", "secret-2": "value-secret-2"}]
+        lookup_plugin._fetch_secret_list.assert_called_once_with("/app/prod/*")
+
+    def test_lookup_by_path_multiple_terms(self, lookup_plugin):
+        """Test path lookup with multiple terms"""
+        lookup_plugin._fetch_secret_list = MagicMock(
+            side_effect=[
+                [{"Name": "secret-1"}],
+                [{"Name": "secret-2"}],
+            ]
+        )
+        lookup_plugin.get_secret_value = MagicMock(side_effect=lambda name: f"value-{name}")
+
+        result = lookup_plugin._lookup_by_path(["/app/prod/*", "/app/staging/*"])
+
+        assert result == [{"secret-1": "value-secret-1", "secret-2": "value-secret-2"}]
+
+    def test_lookup_by_path_skips_none_values(self, lookup_plugin):
+        """Test that None values are skipped (on_missing/on_denied='skip')"""
+        lookup_plugin._fetch_secret_list = MagicMock(
+            return_value=[{"Name": "secret-1"}, {"Name": "secret-2"}, {"Name": "secret-3"}]
+        )
+        # Simulate skip behavior: some return None
+        lookup_plugin.get_secret_value = MagicMock(side_effect=["value-1", None, "value-3"])
+
+        result = lookup_plugin._lookup_by_path(["/app/*"])
+
+        assert result == [{"secret-1": "value-1", "secret-3": "value-3"}]
+
+    def test_lookup_by_path_all_none_returns_empty(self, lookup_plugin):
+        """Test that all None values returns empty list"""
+        lookup_plugin._fetch_secret_list = MagicMock(return_value=[{"Name": "secret-1"}, {"Name": "secret-2"}])
+        lookup_plugin.get_secret_value = MagicMock(return_value=None)
+
+        result = lookup_plugin._lookup_by_path(["/app/*"])
+
+        assert result == []
+
+    def test_lookup_by_path_empty_secret_list(self, lookup_plugin):
+        """Test path lookup when no secrets found"""
+        lookup_plugin._fetch_secret_list = MagicMock(return_value=[])
+
+        result = lookup_plugin._lookup_by_path(["/nonexistent/*"])
+
+        assert result == []
+
+
+class TestLookupByName:
+    """Unit tests for _lookup_by_name orchestration"""
+
+    def test_lookup_by_name_filters_none_values(self, lookup_plugin):
+        """Test that None values are filtered in non-join mode"""
+        lookup_plugin.params = {"join": False, "version_stage": None, "version_id": None, "nested": False}
+        lookup_plugin.get_secret_value = MagicMock(side_effect=["value-1", None, "value-3"])
+
+        result = lookup_plugin._lookup_by_name(["secret-1", "secret-2", "secret-3"])
+
+        assert result == ["value-1", "value-3"]
+
+    def test_lookup_by_name_all_none_returns_empty(self, lookup_plugin):
+        """Test that all None values returns empty list in non-join mode"""
+        lookup_plugin.params = {"join": False, "version_stage": None, "version_id": None, "nested": False}
+        lookup_plugin.get_secret_value = MagicMock(return_value=None)
+
+        result = lookup_plugin._lookup_by_name(["secret-1", "secret-2"])
+
+        assert result == []
+
+    def test_lookup_by_name_join_mode(self, lookup_plugin):
+        """Test join mode concatenates non-None values"""
+        lookup_plugin.params = {"join": True, "version_stage": None, "version_id": None, "nested": False}
+        lookup_plugin.get_secret_value = MagicMock(side_effect=["part1", None, "part2"])
+
+        result = lookup_plugin._lookup_by_name(["secret-1", "secret-2", "secret-3"])
+
+        assert result == ["part1part2"]

--- a/tests/unit/plugins/lookup/test_secretsmanager_secret.py
+++ b/tests/unit/plugins/lookup/test_secretsmanager_secret.py
@@ -27,6 +27,7 @@ def fixture_lookup_plugin():
     lookup.get_option.side_effect = _get_option
     lookup.client = MagicMock()
     lookup._display = MagicMock()
+    lookup._load_name = "secretsmanager_secret"
 
     return lookup
 

--- a/tests/unit/plugins/lookup/test_ssm_parameter.py
+++ b/tests/unit/plugins/lookup/test_ssm_parameter.py
@@ -1,0 +1,270 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ansible.errors import AnsibleLookupError
+
+from ansible_collections.amazon.aws.plugins.lookup.ssm_parameter import LookupModule
+
+
+@pytest.fixture(name="lookup_plugin")
+def fixture_lookup_plugin():
+    lookup = LookupModule()
+    lookup.params = {}
+
+    lookup.get_option = MagicMock()
+
+    def _get_option(x):
+        return lookup.params.get(x)
+
+    lookup.get_option.side_effect = _get_option
+    lookup.client = MagicMock()
+    lookup._display = MagicMock()
+
+    return lookup
+
+
+class TestValidateOptions:
+    """Unit tests for _validate_options helper method"""
+
+    def test_validate_valid_options(self, lookup_plugin):
+        """Test that valid options don't raise errors"""
+        # Should not raise
+        lookup_plugin.params = {"on_missing": "error", "on_denied": "warn"}
+        lookup_plugin._validate_options()
+        lookup_plugin.params = {"on_missing": "warn", "on_denied": "skip"}
+        lookup_plugin._validate_options()
+        lookup_plugin.params = {"on_missing": "skip", "on_denied": "error"}
+        lookup_plugin._validate_options()
+
+    @pytest.mark.parametrize(
+        "on_missing,expected_error",
+        [
+            ("invalid", '"on_missing" must be a string and one of "error", "warn" or "skip", not invalid'),
+        ],
+    )
+    def test_validate_invalid_on_missing(self, lookup_plugin, on_missing, expected_error):
+        """Test that invalid on_missing values raise errors"""
+        lookup_plugin.params = {"on_missing": on_missing, "on_denied": "error"}
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin._validate_options()
+        assert expected_error == str(exc_info.value)
+
+    @pytest.mark.parametrize(
+        "on_denied,expected_error",
+        [
+            ("invalid", '"on_denied" must be a string and one of "error", "warn" or "skip", not invalid'),
+        ],
+    )
+    def test_validate_invalid_on_denied(self, lookup_plugin, on_denied, expected_error):
+        """Test that invalid on_denied values raise errors"""
+        lookup_plugin.params = {"on_missing": "error", "on_denied": on_denied}
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin._validate_options()
+        assert expected_error == str(exc_info.value)
+
+    def test_validate_shortnames_droppath_mutually_exclusive(self, lookup_plugin):
+        """Test that shortnames and droppath cannot both be True"""
+        lookup_plugin.params = {"shortnames": True, "droppath": True, "on_missing": "error", "on_denied": "error"}
+
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin._validate_options()
+        assert "shortnames and droppath are mutually exclusive" in str(exc_info.value)
+
+    def test_validate_shortnames_only(self, lookup_plugin):
+        """Test that shortnames=True alone is valid"""
+        lookup_plugin.params = {"shortnames": True, "droppath": False, "on_missing": "error", "on_denied": "error"}
+        # Should not raise
+        lookup_plugin._validate_options()
+
+    def test_validate_droppath_only(self, lookup_plugin):
+        """Test that droppath=True alone is valid"""
+        lookup_plugin.params = {"shortnames": False, "droppath": True, "on_missing": "error", "on_denied": "error"}
+        # Should not raise
+        lookup_plugin._validate_options()
+
+
+class TestProcessParameterNames:
+    """Unit tests for _process_parameter_names helper method"""
+
+    def test_process_no_options(self, lookup_plugin):
+        """Test that parameters are unchanged when no options are set"""
+        lookup_plugin.params = {"shortnames": False, "droppath": False}
+        paramlist = [
+            {"Name": "/app/prod/database/password", "Value": "secret1"},
+            {"Name": "/app/prod/database/username", "Value": "admin"},
+        ]
+
+        lookup_plugin._process_parameter_names(paramlist, "/app/prod/")
+
+        assert paramlist[0]["Name"] == "/app/prod/database/password"
+        assert paramlist[1]["Name"] == "/app/prod/database/username"
+
+    def test_process_shortnames(self, lookup_plugin):
+        """Test that shortnames extracts the final path component"""
+        lookup_plugin.params = {"shortnames": True, "droppath": False}
+        paramlist = [
+            {"Name": "/app/prod/database/password", "Value": "secret1"},
+            {"Name": "/app/prod/database/username", "Value": "admin"},
+            {"Name": "/app/prod/api/key", "Value": "key123"},
+        ]
+
+        lookup_plugin._process_parameter_names(paramlist, "/app/prod/")
+
+        assert paramlist[0]["Name"] == "password"
+        assert paramlist[1]["Name"] == "username"
+        assert paramlist[2]["Name"] == "key"
+
+    def test_process_shortnames_no_slash(self, lookup_plugin):
+        """Test shortnames with parameter name that has no slashes"""
+        lookup_plugin.params = {"shortnames": True, "droppath": False}
+        paramlist = [{"Name": "simple-name", "Value": "value1"}]
+
+        lookup_plugin._process_parameter_names(paramlist, "/app/")
+
+        # rfind returns -1 when not found, so [-1+1:] gives the whole string
+        assert paramlist[0]["Name"] == "simple-name"
+
+    def test_process_droppath(self, lookup_plugin):
+        """Test that droppath removes the specified path prefix"""
+        lookup_plugin.params = {"shortnames": False, "droppath": True}
+        paramlist = [
+            {"Name": "/app/prod/database/password", "Value": "secret1"},
+            {"Name": "/app/prod/database/username", "Value": "admin"},
+            {"Name": "/app/prod/api/key", "Value": "key123"},
+        ]
+
+        lookup_plugin._process_parameter_names(paramlist, "/app/prod/")
+
+        assert paramlist[0]["Name"] == "database/password"
+        assert paramlist[1]["Name"] == "database/username"
+        assert paramlist[2]["Name"] == "api/key"
+
+    def test_process_droppath_no_match(self, lookup_plugin):
+        """Test droppath when the path doesn't match"""
+        lookup_plugin.params = {"shortnames": False, "droppath": True}
+        paramlist = [{"Name": "/other/path/param", "Value": "value1"}]
+
+        lookup_plugin._process_parameter_names(paramlist, "/app/prod/")
+
+        # Path not in name, so it remains unchanged
+        assert paramlist[0]["Name"] == "/other/path/param"
+
+    def test_process_empty_paramlist(self, lookup_plugin):
+        """Test processing an empty parameter list"""
+        lookup_plugin.params = {"shortnames": True, "droppath": False}
+        paramlist = []
+
+        # Should not raise
+        lookup_plugin._process_parameter_names(paramlist, "/app/prod/")
+
+        assert paramlist == []
+
+
+class TestGetPathParameters:
+    """Unit tests for get_path_parameters method"""
+
+    def test_get_path_parameters_empty_list_error(self, lookup_plugin):
+        """Test that empty paramlist with on_missing='error' raises error"""
+        lookup_plugin.params = {"on_missing": "error"}
+        lookup_plugin._cached_on_missing = "error"
+
+        client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value.build_full_result.return_value = {"Parameters": []}
+        client.get_paginator.return_value = paginator
+        lookup_plugin._cached_client = client
+
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            lookup_plugin.get_path_parameters("/app/missing/", {})
+
+        assert "Failed to find SSM parameter path /app/missing/ (ResourceNotFound)" == str(exc_info.value)
+
+    def test_get_path_parameters_empty_list_warn(self, lookup_plugin):
+        """Test that empty paramlist with on_missing='warn' returns empty and warns"""
+        lookup_plugin.params = {"on_missing": "warn"}
+        lookup_plugin._cached_on_missing = "warn"
+        lookup_plugin.warn = MagicMock()
+
+        client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value.build_full_result.return_value = {"Parameters": []}
+        client.get_paginator.return_value = paginator
+        lookup_plugin._cached_client = client
+
+        result = lookup_plugin.get_path_parameters("/app/missing/", {})
+
+        assert result == []
+        lookup_plugin.warn.assert_called_once_with("Skipping, did not find SSM parameter path /app/missing/")
+
+    def test_get_path_parameters_empty_list_skip(self, lookup_plugin):
+        """Test that empty paramlist with on_missing='skip' returns empty silently"""
+        lookup_plugin.params = {"on_missing": "skip"}
+        lookup_plugin._cached_on_missing = "skip"
+        lookup_plugin.warn = MagicMock()
+
+        client = MagicMock()
+        paginator = MagicMock()
+        paginator.paginate.return_value.build_full_result.return_value = {"Parameters": []}
+        client.get_paginator.return_value = paginator
+        lookup_plugin._cached_client = client
+
+        result = lookup_plugin.get_path_parameters("/app/missing/", {})
+
+        assert result == []
+        lookup_plugin.warn.assert_not_called()
+
+    def test_get_path_parameters_with_results(self, lookup_plugin):
+        """Test that non-empty paramlist is returned successfully"""
+        lookup_plugin.params = {"on_missing": "error"}
+        lookup_plugin._cached_on_missing = "error"
+
+        client = MagicMock()
+        paginator = MagicMock()
+        expected_params = [
+            {"Name": "/app/prod/db/password", "Value": "secret1"},
+            {"Name": "/app/prod/db/username", "Value": "admin"},
+        ]
+        paginator.paginate.return_value.build_full_result.return_value = {"Parameters": expected_params}
+        client.get_paginator.return_value = paginator
+        lookup_plugin._cached_client = client
+
+        result = lookup_plugin.get_path_parameters("/app/prod/", {})
+
+        assert result == expected_params
+
+
+class TestLookupByName:
+    """Unit tests for _lookup_by_name orchestration"""
+
+    def test_lookup_by_name_preserves_none_values(self, lookup_plugin):
+        """Test that None values are preserved (on_missing/on_denied='skip')"""
+        lookup_plugin.params = {"recursive": False}
+        lookup_plugin.get_parameter_value = MagicMock(side_effect=["value-1", None, "value-3"])
+
+        result = lookup_plugin._lookup_by_name({}, ["param-1", "param-2", "param-3"])
+
+        assert result == ["value-1", None, "value-3"]
+
+    def test_lookup_by_name_all_none_returns_empty_list(self, lookup_plugin):
+        """Test that all None values returns empty list (all params missing/denied)"""
+        lookup_plugin.params = {"recursive": False}
+        lookup_plugin.get_parameter_value = MagicMock(return_value=None)
+
+        result = lookup_plugin._lookup_by_name({}, ["param-1", "param-2"])
+
+        assert result == []
+
+    def test_lookup_by_name_successful(self, lookup_plugin):
+        """Test successful parameter lookups"""
+        lookup_plugin.params = {"recursive": False}
+        lookup_plugin.get_parameter_value = MagicMock(side_effect=["value-1", "value-2"])
+
+        result = lookup_plugin._lookup_by_name({}, ["param-1", "param-2"])
+
+        assert result == ["value-1", "value-2"]

--- a/tests/unit/plugins/plugin_utils/_lookup/test_error_handler.py
+++ b/tests/unit/plugins/plugin_utils/_lookup/test_error_handler.py
@@ -11,7 +11,7 @@ from botocore.exceptions import ClientError
 from ansible.errors import AnsibleLookupError
 
 from ansible_collections.amazon.aws.plugins.plugin_utils._lookup.common import LookupErrorHandler
-from ansible_collections.amazon.aws.plugins.plugin_utils._lookup.common import NestedKeyNotFoundError
+from ansible_collections.amazon.aws.plugins.plugin_utils._lookup.common import LookupResourceNotFoundError
 
 
 def _raise_boto_clienterror(code, msg):
@@ -28,6 +28,7 @@ class MockLookup:
 
     def __init__(self):
         self._display = MagicMock()
+        self.warn = MagicMock()
         self.aws_client = MagicMock()
         # Set default values for cached properties
         self.on_missing = "error"
@@ -67,7 +68,7 @@ class TestHandleResponse:
         )
 
         assert result is None
-        lookup_instance._display.warning.assert_called_once_with("Skipping test-resource")
+        lookup_instance.warn.assert_called_once_with("Skipping test-resource")
 
     def test_handle_response_skip_action(self):
         """Test _handle_response returns None for 'skip' action"""
@@ -155,7 +156,7 @@ class TestLookupErrorHandler:
             result = get_value(mock_lookup, "missing-resource")
             assert result is None
             if on_missing == "warn":
-                mock_lookup._display.warning.assert_called_once_with(
+                mock_lookup.warn.assert_called_once_with(
                     "Skipping, did not find test resource missing-resource"
                 )
 
@@ -180,7 +181,7 @@ class TestLookupErrorHandler:
             result = get_value(mock_lookup, "missing-param")
             assert result is None
             if on_missing == "warn":
-                mock_lookup._display.warning.assert_called_once_with(
+                mock_lookup.warn.assert_called_once_with(
                     "Skipping, did not find SSM parameter missing-param"
                 )
 
@@ -203,7 +204,7 @@ class TestLookupErrorHandler:
             result = get_value(mock_lookup, "denied-secret")
             assert result is None
             if on_denied == "warn":
-                mock_lookup._display.warning.assert_called_once_with("Skipping, access denied for secret denied-secret")
+                mock_lookup.warn.assert_called_once_with("Skipping, access denied for secret denied-secret")
 
     @pytest.mark.parametrize("on_deleted", ["error", "warn", "skip"])
     def test_handle_marked_for_deletion(self, on_deleted):
@@ -226,7 +227,7 @@ class TestLookupErrorHandler:
             result = get_value(mock_lookup, "deleted-secret")
             assert result is None
             if on_deleted == "warn":
-                mock_lookup._display.warning.assert_called_once_with(
+                mock_lookup.warn.assert_called_once_with(
                     "Skipping, did not find secret (marked for deletion) deleted-secret"
                 )
 
@@ -275,14 +276,14 @@ class TestLookupErrorHandler:
 
     @pytest.mark.parametrize("on_missing", ["error", "warn", "skip"])
     def test_handle_nested_key_not_found(self, on_missing):
-        """Test decorator handles NestedKeyNotFoundError correctly"""
+        """Test decorator handles LookupResourceNotFoundError correctly"""
         mock_lookup = MockLookup()
         mock_lookup.on_missing = on_missing
 
         @LookupErrorHandler.handle_lookup_errors("secret")
         def extract_value(self, term):
             # Simulate nested key traversal that fails
-            raise NestedKeyNotFoundError("root.child.missing_key")
+            raise LookupResourceNotFoundError("root.child.missing_key")
 
         if on_missing == "error":
             with pytest.raises(AnsibleLookupError) as exc_info:
@@ -294,20 +295,20 @@ class TestLookupErrorHandler:
             result = extract_value(mock_lookup, "secret.root.child.missing_key")
             assert result is None
             if on_missing == "warn":
-                mock_lookup._display.warning.assert_called_once_with(
+                mock_lookup.warn.assert_called_once_with(
                     "Skipping, Successfully retrieved secret but there exists no key root.child.missing_key in the secret"
                 )
 
     @pytest.mark.parametrize("on_missing", ["error", "warn", "skip"])
     def test_handle_nested_key_not_found_custom_templates(self, on_missing):
-        """Test decorator handles NestedKeyNotFoundError with custom templates"""
+        """Test decorator handles LookupResourceNotFoundError with custom templates"""
         mock_lookup = MockLookup()
         mock_lookup.on_missing = on_missing
 
         @LookupErrorHandler.handle_lookup_errors("parameter")
         def extract_value(self, term):
             # Simulate nested key traversal with custom error messages
-            raise NestedKeyNotFoundError(
+            raise LookupResourceNotFoundError(
                 "config.database.port",
                 error_template="SSM parameter retrieved but nested key {term} is missing",
                 warn_template="Skipping nested key {term} in SSM parameter",
@@ -321,7 +322,7 @@ class TestLookupErrorHandler:
             result = extract_value(mock_lookup, "parameter.config.database.port")
             assert result is None
             if on_missing == "warn":
-                mock_lookup._display.warning.assert_called_once_with(
+                mock_lookup.warn.assert_called_once_with(
                     "Skipping nested key config.database.port in SSM parameter"
                 )
 
@@ -372,7 +373,7 @@ class TestLookupErrorHandler:
 
         result = get_value(mock_lookup, "missing-secret")
         assert result == default_dict
-        mock_lookup._display.warning.assert_called_once()
+        mock_lookup.warn.assert_called_once()
 
     def test_default_value_with_access_denied(self):
         """Test decorator returns default_value when access is denied"""

--- a/tests/unit/plugins/plugin_utils/_lookup/test_error_handler.py
+++ b/tests/unit/plugins/plugin_utils/_lookup/test_error_handler.py
@@ -1,0 +1,404 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+
+import pytest
+from botocore.exceptions import ClientError
+
+from ansible.errors import AnsibleLookupError
+
+from ansible_collections.amazon.aws.plugins.plugin_utils._lookup.common import LookupErrorHandler
+from ansible_collections.amazon.aws.plugins.plugin_utils._lookup.common import NestedKeyNotFoundError
+
+
+def _raise_boto_clienterror(code, msg):
+    """Helper to create a ClientError"""
+    params = {
+        "Error": {"Code": code, "Message": msg},
+        "ResponseMetadata": {"RequestId": "01234567-89ab-cdef-0123-456789abcdef"},
+    }
+    return ClientError(params, "test_operation")
+
+
+class MockLookup:
+    """Mock lookup class for testing the decorator"""
+
+    def __init__(self):
+        self._display = MagicMock()
+        self.aws_client = MagicMock()
+        # Set default values for cached properties
+        self.on_missing = "error"
+        self.on_denied = "error"
+        self.on_deleted = "error"
+
+
+class TestHandleResponse:
+    """Unit tests for _handle_response static method"""
+
+    def test_handle_response_error_action(self):
+        """Test _handle_response raises error for 'error' action"""
+        lookup_instance = MagicMock()
+
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            LookupErrorHandler._handle_response(
+                lookup_instance,
+                action="error",
+                term="test-resource",
+                resource_type="secret",
+                error_msg="Failed to find secret {term}",
+                warn_msg="Skipping {term}",
+            )
+        assert "Failed to find secret test-resource" in str(exc_info.value)
+
+    def test_handle_response_warn_action(self):
+        """Test _handle_response logs warning for 'warn' action"""
+        lookup_instance = MagicMock()
+
+        result = LookupErrorHandler._handle_response(
+            lookup_instance,
+            action="warn",
+            term="test-resource",
+            resource_type="secret",
+            error_msg="Failed",
+            warn_msg="Skipping {term}",
+        )
+
+        assert result is None
+        lookup_instance._display.warning.assert_called_once_with("Skipping test-resource")
+
+    def test_handle_response_skip_action(self):
+        """Test _handle_response returns None for 'skip' action"""
+        lookup_instance = MagicMock()
+
+        result = LookupErrorHandler._handle_response(
+            lookup_instance,
+            action="skip",
+            term="test-resource",
+            resource_type="secret",
+            error_msg="Failed",
+            warn_msg="Skipping {term}",
+        )
+
+        assert result is None
+        lookup_instance._display.warning.assert_not_called()
+
+    def test_handle_response_default_value(self):
+        """Test _handle_response returns default_value for skip/warn"""
+        lookup_instance = MagicMock()
+        default_value = [{"test": "value"}]
+
+        result = LookupErrorHandler._handle_response(
+            lookup_instance,
+            action="skip",
+            term="test-resource",
+            resource_type="secret",
+            error_msg="Failed",
+            warn_msg="Skipping",
+            default_value=default_value,
+        )
+
+        assert result == default_value
+
+    def test_handle_response_message_formatting(self):
+        """Test message templates are formatted correctly"""
+        lookup_instance = MagicMock()
+
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            LookupErrorHandler._handle_response(
+                lookup_instance,
+                action="error",
+                term="my-secret",
+                resource_type="secret",
+                error_msg="Cannot access secret '{term}' (AccessDenied)",
+                warn_msg="Skipping",
+            )
+        assert "Cannot access secret 'my-secret' (AccessDenied)" == str(exc_info.value)
+
+
+class TestLookupErrorHandler:
+    """Tests for the LookupErrorHandler decorator"""
+
+    def test_handle_lookup_errors_success(self):
+        """Test decorator allows successful calls to pass through"""
+        mock_lookup = MockLookup()
+        mock_lookup.aws_client.get_value.return_value = {"Value": "test-value"}
+
+        @LookupErrorHandler.handle_lookup_errors("test resource")
+        def get_value(self, term, on_missing=None, on_denied=None, on_deleted=None):
+            return self.aws_client.get_value(Name=term)
+
+        result = get_value(mock_lookup, "test-term")
+        assert result == {"Value": "test-value"}
+        mock_lookup.aws_client.get_value.assert_called_once_with(Name="test-term")
+
+    @pytest.mark.parametrize("on_missing", ["error", "warn", "skip"])
+    def test_handle_resource_not_found(self, on_missing):
+        """Test decorator handles ResourceNotFoundException correctly"""
+        mock_lookup = MockLookup()
+        mock_lookup.on_missing = on_missing
+        mock_lookup.aws_client.get_value.side_effect = _raise_boto_clienterror(
+            "ResourceNotFoundException", "Resource not found"
+        )
+
+        @LookupErrorHandler.handle_lookup_errors("test resource")
+        def get_value(self, term):
+            return self.aws_client.get_value(Name=term)
+
+        if on_missing == "error":
+            with pytest.raises(AnsibleLookupError) as exc_info:
+                get_value(mock_lookup, "missing-resource")
+            assert "Failed to find test resource missing-resource (ResourceNotFound)" == str(exc_info.value)
+        else:
+            result = get_value(mock_lookup, "missing-resource")
+            assert result is None
+            if on_missing == "warn":
+                mock_lookup._display.warning.assert_called_once_with(
+                    "Skipping, did not find test resource missing-resource"
+                )
+
+    @pytest.mark.parametrize("on_missing", ["error", "warn", "skip"])
+    def test_handle_parameter_not_found(self, on_missing):
+        """Test decorator handles ParameterNotFound correctly"""
+        mock_lookup = MockLookup()
+        mock_lookup.on_missing = on_missing
+        mock_lookup.aws_client.get_value.side_effect = _raise_boto_clienterror(
+            "ParameterNotFound", "Parameter not found"
+        )
+
+        @LookupErrorHandler.handle_lookup_errors("SSM parameter")
+        def get_value(self, term):
+            return self.aws_client.get_value(Name=term)
+
+        if on_missing == "error":
+            with pytest.raises(AnsibleLookupError) as exc_info:
+                get_value(mock_lookup, "missing-param")
+            assert "Failed to find SSM parameter missing-param (ResourceNotFound)" == str(exc_info.value)
+        else:
+            result = get_value(mock_lookup, "missing-param")
+            assert result is None
+            if on_missing == "warn":
+                mock_lookup._display.warning.assert_called_once_with(
+                    "Skipping, did not find SSM parameter missing-param"
+                )
+
+    @pytest.mark.parametrize("on_denied", ["error", "warn", "skip"])
+    def test_handle_access_denied(self, on_denied):
+        """Test decorator handles AccessDeniedException correctly"""
+        mock_lookup = MockLookup()
+        mock_lookup.on_denied = on_denied
+        mock_lookup.aws_client.get_value.side_effect = _raise_boto_clienterror("AccessDeniedException", "Access denied")
+
+        @LookupErrorHandler.handle_lookup_errors("secret")
+        def get_value(self, term):
+            return self.aws_client.get_value(Name=term)
+
+        if on_denied == "error":
+            with pytest.raises(AnsibleLookupError) as exc_info:
+                get_value(mock_lookup, "denied-secret")
+            assert "Failed to access secret denied-secret (AccessDenied)" == str(exc_info.value)
+        else:
+            result = get_value(mock_lookup, "denied-secret")
+            assert result is None
+            if on_denied == "warn":
+                mock_lookup._display.warning.assert_called_once_with("Skipping, access denied for secret denied-secret")
+
+    @pytest.mark.parametrize("on_deleted", ["error", "warn", "skip"])
+    def test_handle_marked_for_deletion(self, on_deleted):
+        """Test decorator handles marked for deletion correctly"""
+        mock_lookup = MockLookup()
+        mock_lookup.on_deleted = on_deleted
+        # Using error message match pattern
+        error = _raise_boto_clienterror("ResourceMarkedForDeletion", "marked for deletion")
+        mock_lookup.aws_client.get_value.side_effect = error
+
+        @LookupErrorHandler.handle_lookup_errors("secret")
+        def get_value(self, term):
+            return self.aws_client.get_value(Name=term)
+
+        if on_deleted == "error":
+            with pytest.raises(AnsibleLookupError) as exc_info:
+                get_value(mock_lookup, "deleted-secret")
+            assert "Failed to find secret deleted-secret (marked for deletion)" == str(exc_info.value)
+        else:
+            result = get_value(mock_lookup, "deleted-secret")
+            assert result is None
+            if on_deleted == "warn":
+                mock_lookup._display.warning.assert_called_once_with(
+                    "Skipping, did not find secret (marked for deletion) deleted-secret"
+                )
+
+    def test_handle_unexpected_client_error(self):
+        """Test decorator re-raises unexpected ClientErrors"""
+        mock_lookup = MockLookup()
+        mock_lookup.aws_client.get_value.side_effect = _raise_boto_clienterror(
+            "UnexpectedError", "Something went wrong"
+        )
+
+        @LookupErrorHandler.handle_lookup_errors("resource")
+        def get_value(self, term):
+            return self.aws_client.get_value(Name=term)
+
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            get_value(mock_lookup, "test-resource")
+        assert "Failed to retrieve resource:" in str(exc_info.value)
+        assert "UnexpectedError" in str(exc_info.value)
+
+    def test_default_value_parameter(self):
+        """Test decorator returns default_value when specified"""
+        mock_lookup = MockLookup()
+        mock_lookup.on_missing = "skip"
+        mock_lookup.aws_client.get_value.side_effect = _raise_boto_clienterror("ResourceNotFoundException", "Not found")
+
+        @LookupErrorHandler.handle_lookup_errors("parameter", default_value=[{}])
+        def get_value(self, term):
+            return self.aws_client.get_value(Name=term)
+
+        result = get_value(mock_lookup, "missing")
+        assert result == [{}]
+
+    def test_term_extraction_from_kwargs(self):
+        """Test decorator extracts term from kwargs correctly"""
+        mock_lookup = MockLookup()
+        mock_lookup.on_missing = "error"
+        mock_lookup.aws_client.get_value.side_effect = _raise_boto_clienterror("ResourceNotFoundException", "Not found")
+
+        @LookupErrorHandler.handle_lookup_errors("resource")
+        def get_value(self, term):
+            return self.aws_client.get_value(Name=term)
+
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            get_value(mock_lookup, term="my-resource")
+        assert "Failed to find resource my-resource (ResourceNotFound)" == str(exc_info.value)
+
+    @pytest.mark.parametrize("on_missing", ["error", "warn", "skip"])
+    def test_handle_nested_key_not_found(self, on_missing):
+        """Test decorator handles NestedKeyNotFoundError correctly"""
+        mock_lookup = MockLookup()
+        mock_lookup.on_missing = on_missing
+
+        @LookupErrorHandler.handle_lookup_errors("secret")
+        def extract_value(self, term):
+            # Simulate nested key traversal that fails
+            raise NestedKeyNotFoundError("root.child.missing_key")
+
+        if on_missing == "error":
+            with pytest.raises(AnsibleLookupError) as exc_info:
+                extract_value(mock_lookup, "secret.root.child.missing_key")
+            assert "Successfully retrieved secret but there exists no key root.child.missing_key in the secret" == str(
+                exc_info.value
+            )
+        else:
+            result = extract_value(mock_lookup, "secret.root.child.missing_key")
+            assert result is None
+            if on_missing == "warn":
+                mock_lookup._display.warning.assert_called_once_with(
+                    "Skipping, Successfully retrieved secret but there exists no key root.child.missing_key in the secret"
+                )
+
+    @pytest.mark.parametrize("on_missing", ["error", "warn", "skip"])
+    def test_handle_nested_key_not_found_custom_templates(self, on_missing):
+        """Test decorator handles NestedKeyNotFoundError with custom templates"""
+        mock_lookup = MockLookup()
+        mock_lookup.on_missing = on_missing
+
+        @LookupErrorHandler.handle_lookup_errors("parameter")
+        def extract_value(self, term):
+            # Simulate nested key traversal with custom error messages
+            raise NestedKeyNotFoundError(
+                "config.database.port",
+                error_template="SSM parameter retrieved but nested key {term} is missing",
+                warn_template="Skipping nested key {term} in SSM parameter",
+            )
+
+        if on_missing == "error":
+            with pytest.raises(AnsibleLookupError) as exc_info:
+                extract_value(mock_lookup, "parameter.config.database.port")
+            assert "SSM parameter retrieved but nested key config.database.port is missing" == str(exc_info.value)
+        else:
+            result = extract_value(mock_lookup, "parameter.config.database.port")
+            assert result is None
+            if on_missing == "warn":
+                mock_lookup._display.warning.assert_called_once_with(
+                    "Skipping nested key config.database.port in SSM parameter"
+                )
+
+    def test_handle_botocore_error(self):
+        """Test decorator handles BotoCoreError (not ClientError)"""
+        from botocore.exceptions import BotoCoreError
+
+        mock_lookup = MockLookup()
+
+        # Create a BotoCoreError
+        botocore_error = BotoCoreError()
+        mock_lookup.aws_client.get_value.side_effect = botocore_error
+
+        @LookupErrorHandler.handle_lookup_errors("secret")
+        def get_value(self, term):
+            return self.aws_client.get_value(Name=term)
+
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            get_value(mock_lookup, "test-secret")
+        assert "Failed to retrieve secret:" in str(exc_info.value)
+
+    def test_term_extraction_from_positional_args(self):
+        """Test decorator extracts term from positional args when not in kwargs"""
+        mock_lookup = MockLookup()
+        mock_lookup.on_missing = "error"
+        mock_lookup.aws_client.get_value.side_effect = _raise_boto_clienterror("ResourceNotFoundException", "Not found")
+
+        @LookupErrorHandler.handle_lookup_errors("parameter")
+        def get_value(self, term):
+            return self.aws_client.get_value(Name=term)
+
+        # Call with positional arg (not kwargs)
+        with pytest.raises(AnsibleLookupError) as exc_info:
+            get_value(mock_lookup, "my-param")
+        assert "Failed to find parameter my-param (ResourceNotFound)" == str(exc_info.value)
+
+    def test_default_value_with_warn_action(self):
+        """Test decorator returns default_value with warn action"""
+        mock_lookup = MockLookup()
+        mock_lookup.on_missing = "warn"
+        mock_lookup.aws_client.get_value.side_effect = _raise_boto_clienterror("ResourceNotFoundException", "Not found")
+
+        default_dict = {"default": "value"}
+
+        @LookupErrorHandler.handle_lookup_errors("secret", default_value=default_dict)
+        def get_value(self, term):
+            return self.aws_client.get_value(Name=term)
+
+        result = get_value(mock_lookup, "missing-secret")
+        assert result == default_dict
+        mock_lookup._display.warning.assert_called_once()
+
+    def test_default_value_with_access_denied(self):
+        """Test decorator returns default_value when access is denied"""
+        mock_lookup = MockLookup()
+        mock_lookup.on_denied = "skip"
+        mock_lookup.aws_client.get_value.side_effect = _raise_boto_clienterror("AccessDeniedException", "Access denied")
+
+        default_list = [{"default": "item"}]
+
+        @LookupErrorHandler.handle_lookup_errors("secret", default_value=default_list)
+        def get_value(self, term):
+            return self.aws_client.get_value(Name=term)
+
+        result = get_value(mock_lookup, "denied-secret")
+        assert result == default_list
+
+    def test_default_value_with_deleted_resource(self):
+        """Test decorator returns default_value for deleted resources"""
+        mock_lookup = MockLookup()
+        mock_lookup.on_deleted = "skip"
+        error = _raise_boto_clienterror("InvalidParameterValue", "marked for deletion")
+        mock_lookup.aws_client.get_value.side_effect = error
+
+        @LookupErrorHandler.handle_lookup_errors("secret", default_value=[])
+        def get_value(self, term):
+            return self.aws_client.get_value(Name=term)
+
+        result = get_value(mock_lookup, "deleted-secret")
+        assert result == []

--- a/tests/unit/plugins/plugin_utils/_lookup/test_error_handler.py
+++ b/tests/unit/plugins/plugin_utils/_lookup/test_error_handler.py
@@ -156,9 +156,7 @@ class TestLookupErrorHandler:
             result = get_value(mock_lookup, "missing-resource")
             assert result is None
             if on_missing == "warn":
-                mock_lookup.warn.assert_called_once_with(
-                    "Skipping, did not find test resource missing-resource"
-                )
+                mock_lookup.warn.assert_called_once_with("Skipping, did not find test resource missing-resource")
 
     @pytest.mark.parametrize("on_missing", ["error", "warn", "skip"])
     def test_handle_parameter_not_found(self, on_missing):
@@ -181,9 +179,7 @@ class TestLookupErrorHandler:
             result = get_value(mock_lookup, "missing-param")
             assert result is None
             if on_missing == "warn":
-                mock_lookup.warn.assert_called_once_with(
-                    "Skipping, did not find SSM parameter missing-param"
-                )
+                mock_lookup.warn.assert_called_once_with("Skipping, did not find SSM parameter missing-param")
 
     @pytest.mark.parametrize("on_denied", ["error", "warn", "skip"])
     def test_handle_access_denied(self, on_denied):
@@ -322,9 +318,7 @@ class TestLookupErrorHandler:
             result = extract_value(mock_lookup, "parameter.config.database.port")
             assert result is None
             if on_missing == "warn":
-                mock_lookup.warn.assert_called_once_with(
-                    "Skipping nested key config.database.port in SSM parameter"
-                )
+                mock_lookup.warn.assert_called_once_with("Skipping nested key config.database.port in SSM parameter")
 
     def test_handle_botocore_error(self):
         """Test decorator handles BotoCoreError (not ClientError)"""

--- a/tests/unit/plugins/plugin_utils/_lookup/test_error_handler.py
+++ b/tests/unit/plugins/plugin_utils/_lookup/test_error_handler.py
@@ -390,6 +390,30 @@ class TestLookupErrorHandler:
         result = get_value(mock_lookup, "denied-secret")
         assert result == default_list
 
+    @pytest.mark.parametrize("on_missing", ["warn", "skip"])
+    def test_exception_default_value_overrides_decorator_default(self, on_missing):
+        """Test LookupResourceNotFoundError default_value overrides decorator's default_value"""
+        mock_lookup = MockLookup()
+        mock_lookup.on_missing = on_missing
+
+        decorator_default = [{"decorator": "default"}]
+        exception_default = []
+
+        @LookupErrorHandler.handle_lookup_errors("parameter", default_value=decorator_default)
+        def get_value(self, term):
+            # Raise exception with its own default_value
+            raise LookupResourceNotFoundError(
+                path=term,
+                error_template="Parameter {term} not found",
+                warn_template="Skipping parameter {term}",
+                default_value=exception_default,
+            )
+
+        result = get_value(mock_lookup, "/missing/path")
+        # Should use exception's default_value, not decorator's
+        assert result == exception_default
+        assert result != decorator_default
+
     def test_default_value_with_deleted_resource(self):
         """Test decorator returns default_value for deleted resources"""
         mock_lookup = MockLookup()

--- a/tests/unit/plugins/plugin_utils/_lookup/test_error_handler.py
+++ b/tests/unit/plugins/plugin_utils/_lookup/test_error_handler.py
@@ -421,3 +421,82 @@ class TestLookupErrorHandler:
 
         result = get_value(mock_lookup, "deleted-secret")
         assert result == []
+
+
+class TestHelperMethods:
+    """Unit tests for LookupErrorHandler helper methods"""
+
+    @pytest.mark.parametrize(
+        "error_type,expected",
+        [
+            (
+                "missing",
+                (
+                    "Failed to find test resource {term} (ResourceNotFound)",
+                    "Skipping, did not find test resource {term}",
+                ),
+            ),
+            (
+                "denied",
+                (
+                    "Failed to access test resource {term} (AccessDenied)",
+                    "Skipping, access denied for test resource {term}",
+                ),
+            ),
+            (
+                "deleted",
+                (
+                    "Failed to find test resource {term} (marked for deletion)",
+                    "Skipping, did not find test resource (marked for deletion) {term}",
+                ),
+            ),
+        ],
+    )
+    def test_build_error_messages(self, error_type, expected):
+        """Test _build_error_messages returns correct templates"""
+        error_msg, warn_msg = LookupErrorHandler._build_error_messages("test resource", error_type)
+        assert error_msg == expected[0]
+        assert warn_msg == expected[1]
+
+    def test_resolve_default_value_uses_exception_default(self):
+        """Test _resolve_default_value prefers exception default when set"""
+        exception_default = []
+        decorator_default = [{"default": "value"}]
+        result = LookupErrorHandler._resolve_default_value(exception_default, decorator_default)
+        assert result == exception_default
+        assert result != decorator_default
+
+    def test_resolve_default_value_uses_decorator_default(self):
+        """Test _resolve_default_value uses decorator default when exception default is not set"""
+        exception_default = ...
+        decorator_default = [{"default": "value"}]
+        result = LookupErrorHandler._resolve_default_value(exception_default, decorator_default)
+        assert result == decorator_default
+
+    def test_extract_term_from_kwargs(self):
+        """Test _extract_term extracts term from kwargs"""
+        args = ()
+        kwargs = {"term": "my-term", "other": "value"}
+        result = LookupErrorHandler._extract_term(args, kwargs)
+        assert result == "my-term"
+
+    def test_extract_term_from_args(self):
+        """Test _extract_term extracts term from first positional argument"""
+        args = ("my-term", "other-arg")
+        kwargs = {}
+        result = LookupErrorHandler._extract_term(args, kwargs)
+        assert result == "my-term"
+
+    def test_extract_term_prefers_kwargs(self):
+        """Test _extract_term prefers kwargs over args"""
+        args = ("arg-term",)
+        kwargs = {"term": "kwarg-term"}
+        result = LookupErrorHandler._extract_term(args, kwargs)
+        assert result == "kwarg-term"
+
+    def test_extract_term_returns_none_when_missing(self):
+        """Test _extract_term returns None when term not found"""
+        args = ()
+        kwargs = {}
+        result = LookupErrorHandler._extract_term(args, kwargs)
+        assert result is None

--- a/tests/unit/plugins/plugin_utils/lookup/test_lookup_base.py
+++ b/tests/unit/plugins/plugin_utils/lookup/test_lookup_base.py
@@ -52,3 +52,135 @@ def test_run(monkeypatch):
         botocore_version=sentinel.PARAM_BOTOCORE, boto3_version=sentinel.PARAM_BOTO3
     )
     assert set_options.call_args == call(var_options=sentinel.PARAM_VARS, direct=kwargs)
+
+
+def test_on_missing_property_with_option():
+    """Test on_missing property when get_option returns a value"""
+    lookup_plugin = utils_lookup.AWSLookupBase()
+    lookup_plugin.get_option = MagicMock(return_value="warn")
+
+    assert lookup_plugin.on_missing == "warn"
+    lookup_plugin.get_option.assert_called_once_with("on_missing")
+
+
+def test_on_missing_property_without_option():
+    """Test on_missing property when get_option raises KeyError (option not defined)"""
+    lookup_plugin = utils_lookup.AWSLookupBase()
+    lookup_plugin.get_option = MagicMock(side_effect=KeyError("on_missing"))
+
+    # Should default to "error" when option doesn't exist
+    assert lookup_plugin.on_missing == "error"
+
+
+def test_on_denied_property_with_option():
+    """Test on_denied property when get_option returns a value"""
+    lookup_plugin = utils_lookup.AWSLookupBase()
+    lookup_plugin.get_option = MagicMock(return_value="skip")
+
+    assert lookup_plugin.on_denied == "skip"
+    lookup_plugin.get_option.assert_called_once_with("on_denied")
+
+
+def test_on_denied_property_without_option():
+    """Test on_denied property when get_option raises KeyError (option not defined)"""
+    lookup_plugin = utils_lookup.AWSLookupBase()
+    lookup_plugin.get_option = MagicMock(side_effect=KeyError("on_denied"))
+
+    # Should default to "error" when option doesn't exist
+    assert lookup_plugin.on_denied == "error"
+
+
+def test_on_deleted_property_with_option():
+    """Test on_deleted property when get_option returns a value"""
+    lookup_plugin = utils_lookup.AWSLookupBase()
+    lookup_plugin.get_option = MagicMock(return_value="warn")
+
+    assert lookup_plugin.on_deleted == "warn"
+    lookup_plugin.get_option.assert_called_once_with("on_deleted")
+
+
+def test_on_deleted_property_without_option():
+    """Test on_deleted property when get_option raises KeyError (option not defined)"""
+    lookup_plugin = utils_lookup.AWSLookupBase()
+    lookup_plugin.get_option = MagicMock(side_effect=KeyError("on_deleted"))
+
+    # Should default to "error" when option doesn't exist
+    assert lookup_plugin.on_deleted == "error"
+
+
+def test_aws_client_without_service_defined():
+    """Test aws_client property raises NotImplementedError when _SERVICE is None"""
+    lookup_plugin = utils_lookup.AWSLookupBase()
+    # AWSLookupBase has _SERVICE = None by default
+
+    with pytest.raises(NotImplementedError) as exc_info:
+        _client = lookup_plugin.aws_client
+
+    assert "must define _SERVICE class attribute" in str(exc_info.value)
+
+
+def test_aws_client_caching():
+    """Test aws_client property caches the client after first call"""
+
+    class TestLookup(utils_lookup.AWSLookupBase):
+        _SERVICE = "s3"
+
+    lookup_plugin = TestLookup()
+    lookup_plugin.client = MagicMock(return_value=sentinel.CLIENT)
+
+    # First call should create client
+    client1 = lookup_plugin.aws_client
+    assert client1 == sentinel.CLIENT
+
+    # Second call should return cached client
+    client2 = lookup_plugin.aws_client
+    assert client2 == sentinel.CLIENT
+
+    # client() should only be called once due to caching
+    lookup_plugin.client.assert_called_once()
+
+
+def test_on_missing_with_attribute_error():
+    """Test on_missing property handles AttributeError (not just KeyError)"""
+    lookup_plugin = utils_lookup.AWSLookupBase()
+    lookup_plugin.get_option = MagicMock(side_effect=AttributeError("'NoneType' object has no attribute 'on_missing'"))
+
+    # Should default to "error" when AttributeError is raised
+    assert lookup_plugin.on_missing == "error"
+
+
+def test_on_denied_with_attribute_error():
+    """Test on_denied property handles AttributeError (not just KeyError)"""
+    lookup_plugin = utils_lookup.AWSLookupBase()
+    lookup_plugin.get_option = MagicMock(side_effect=AttributeError("'NoneType' object has no attribute 'on_denied'"))
+
+    # Should default to "error" when AttributeError is raised
+    assert lookup_plugin.on_denied == "error"
+
+
+def test_on_deleted_with_attribute_error():
+    """Test on_deleted property handles AttributeError (not just KeyError)"""
+    lookup_plugin = utils_lookup.AWSLookupBase()
+    lookup_plugin.get_option = MagicMock(side_effect=AttributeError("'NoneType' object has no attribute 'on_deleted'"))
+
+    # Should default to "error" when AttributeError is raised
+    assert lookup_plugin.on_deleted == "error"
+
+
+def test_property_caching():
+    """Test that on_missing/on_denied/on_deleted properties cache their values"""
+    lookup_plugin = utils_lookup.AWSLookupBase()
+    lookup_plugin.get_option = MagicMock(return_value="warn")
+
+    # Access each property twice
+    assert lookup_plugin.on_missing == "warn"
+    assert lookup_plugin.on_missing == "warn"
+
+    assert lookup_plugin.on_denied == "warn"
+    assert lookup_plugin.on_denied == "warn"
+
+    assert lookup_plugin.on_deleted == "warn"
+    assert lookup_plugin.on_deleted == "warn"
+
+    # get_option should only be called once per property (caching works)
+    assert lookup_plugin.get_option.call_count == 3


### PR DESCRIPTION
##### SUMMARY
Refactored lookup plugins to reduce cognitive complexity, improve testability, and expand test coverage. This PR introduces a centralised error handling pattern, adds comprehensive unit tests for previously untested lookup plugins, and fixes several issues discovered during testing.

**Main achievements:**
- Reduced cognitive complexity in secretsmanager_secret (36 → <15) and ssm_parameter (28 → <15)
- Increased lookup plugin test coverage from ~50% to 91.33% average
- Added unit tests for 3 previously untested lookup plugins (0% → 95-100% coverage)
- Added on_denied parameter support to aws_account_attribute lookup
- Fixed ssm_parameter None value handling for skip/warn scenarios
- Updated deprecated text converter imports

##### ISSUE TYPE
- Bugfix Pull Request
- Feature Pull Request

##### COMPONENT NAME
- plugins/lookup/secretsmanager_secret
- plugins/lookup/ssm_parameter
- plugins/lookup/aws_account_attribute
- plugins/lookup/aws_collection_constants
- plugins/lookup/aws_service_ip_ranges
- plugins/plugin_utils/lookup
- plugins/plugin_utils/_lookup/common

##### ADDITIONAL INFORMATION

**Error Handling Refactor:**
- Created `plugins/plugin_utils/_lookup/common.py` with `LookupErrorHandler` decorator and `NestedKeyNotFoundError` exception
- Added cached properties (`on_missing`, `on_denied`, `on_deleted`) to `AWSLookupBase` following existing aws_client pattern
- Applied `@handle_lookup_errors` decorator to `get_secret_value()`, `get_parameter_value()`, and `_describe_account_attributes()`
- Refactored `_extract_nested_value()` to raise `NestedKeyNotFoundError` instead of duplicating error handling

**Test Coverage Improvements:**
- **aws_collection_constants**: 0% → 95.24% (18 new tests)
- **aws_service_ip_ranges**: 0% → 100% (28 new tests)
- **aws_account_attribute**: 0% → 100% (28 new tests)
- **ssm_parameter**: Added 25 new unit tests
- **LookupErrorHandler**: 32 new tests for decorator behaviour
- **AWSLookupBase**: 14 new tests for cached properties

**Testability Refactoring:**
Extracted helper methods from monolithic `run()` methods to enable unit testing:
- `aws_collection_constants`: `_validate_terms()`
- `aws_service_ip_ranges`: `_determine_prefix_labels()`, `_fetch_ip_ranges()`, `_filter_by_region()`, `_filter_by_service()`, `_extract_ip_addresses()`
- `aws_account_attribute`: `_build_api_params()`, `_process_response_for_ec2_classic()`, `_process_response_for_attribute()`, `_process_response_for_all_attributes()`

**New Features:**
- Added `on_denied` parameter to aws_account_attribute lookup (version_added: 11.3.0)
- Supports error/skip/warn modes for handling AccessDeniedException

**Bug Fixes:**
- Fixed ssm_parameter to correctly handle None values when on_missing=skip/on_denied=skip:
  - All parameters missing → returns `[]` (empty list)
  - Some parameters missing → preserves `None` in list (maintains position)
- Fixed lookup plugins to filter None values correctly when some parameters succeed
- Updated text converter imports from deprecated `ansible.module_utils._text` to `ansible.module_utils.common.text.converters`

**Testing:**
- All 2165 unit tests passing
- Pylint score: 10.00/10
- All formatting and linting checks pass

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>