### PR TITLE
Remove JDK from bindep

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -2,6 +2,8 @@
 openssl [test platform:rpm]
 gcc [test platform:rpm]
 python3-devel [test platform:rpm]
-# Needed by ansible-rulebook installation for event source EDA integration tests
-java-17-openjdk [test platform:rpm]
-openjdk-17-jdk [test platform:dpkg]
+
+## Needed by ansible-rulebook installation for event source EDA integration tests
+# XXX Currently fails to install in CI
+#java-17-openjdk [test platform:rpm]
+#openjdk-17-jdk [test platform:dpkg]


### PR DESCRIPTION
##### SUMMARY

CI is currently broken due to the new bindep from #2868 (which didn't actually run the tests)

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

bindep.txt

##### ADDITIONAL INFORMATION

See https://eaf0b25a497cbfe41947-2b9ff5f1c8949bb85064afe31c3be3cb.ssl.cf2.rackcdn.com/ansible/9fd9edd63dcc48e593d6983c0abedaa3/job-output.txt for an example