### PR TITLE
Pin GitHub Actions dependencies to commit SHA

### DIFF
--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   changelog-labeller:
-    uses: ansible-network/github_actions/.github/workflows/backport-labeller.yml@main
+    uses: ansible-network/github_actions/.github/workflows/backport-labeller.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25
     with:
       label_minor_release: backport-11
       label_bugfix_release: backport-10

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,4 +19,4 @@ on:
       - "*"
 jobs:
   changelog:
-    uses: ansible-network/github_actions/.github/workflows/changelog.yml@main
+    uses: ansible-network/github_actions/.github/workflows/changelog.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     name: Validate Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@main
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
     with:
       init-lenient: false
       init-fail-on-error: true
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: read
     name: Build Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@main
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
     with:
       init-lenient: true
       init-fail-on-error: false
@@ -46,7 +46,7 @@ jobs:
     name: PR comments
     steps:
       - name: PR comment
-        uses: ansible-community/github-docs-build/actions/ansible-docs-build-comment@main
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-comment@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
         with:
           body-includes: "## Docs Build"
           reactions: heart

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     name: Build Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@main
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
     with:
       init-lenient: false
       init-fail-on-error: true
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     needs: [build-docs]
     name: Publish Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-gh-pages.yml@main
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-gh-pages.yml@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
     with:
       artifact-name: ${{ needs.build-docs.outputs.artifact-name }}
       publish-gh-pages-branch: true

--- a/.github/workflows/label-new-issues.yaml
+++ b/.github/workflows/label-new-issues.yaml
@@ -13,6 +13,6 @@ jobs:
       contents: write
       issues: write
     steps:
-      - uses: actions-ecosystem/action-add-labels@v1
+      - uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
         with:
           labels: needs_triage

--- a/.github/workflows/label-new-prs.yaml
+++ b/.github/workflows/label-new-prs.yaml
@@ -16,13 +16,13 @@ jobs:
       pull-requests: write
     steps:
       - name: Add 'needs_triage' label if the pr is not a draft
-        uses: actions-ecosystem/action-add-labels@v1
+        uses: actions-ecosystem/action-add-labels@18f1af5e3544586314bbe15c0273249c770b2daf # v1
         if: github.event.pull_request.draft == false
         with:
           labels: needs_triage
 
       - name: Remove 'needs_triage' label if the pr is a draft
-        uses: actions-ecosystem/action-remove-labels@v1
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1
         if: github.event.pull_request.draft == true
         with:
           labels: needs_triage

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -5,7 +5,7 @@ on: [workflow_call] # allow this workflow to be called from other workflows
 
 jobs:
   linters:
-    uses: ansible-network/github_actions/.github/workflows/tox.yml@main
+    uses: ansible-network/github_actions/.github/workflows/tox.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25
     with:
       envname: ""
       labelname: lint

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -5,7 +5,7 @@ on: [workflow_call] # allow this workflow to be called from other workflows
 
 jobs:
   sanity:
-    uses: ansible-network/github_actions/.github/workflows/sanity.yml@main
+    uses: ansible-network/github_actions/.github/workflows/sanity.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25
     with:
       matrix_exclude: >-
           [

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -89,7 +89,8 @@ jobs:
           echo "SONAR_ARGS=${SONAR_ARGS}" >> $GITHUB_ENV
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v7
+        # a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 (v7)
+        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
         env:
           SONAR_TOKEN: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}
         with:

--- a/.github/workflows/units.yml
+++ b/.github/workflows/units.yml
@@ -5,7 +5,7 @@ on: [workflow_call] # allow this workflow to be called from other workflows
 
 jobs:
   unit-source:
-    uses: ansible-network/github_actions/.github/workflows/unit_source.yml@main
+    uses: ansible-network/github_actions/.github/workflows/unit_source.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25
     with:
       matrix_exclude: >-
           [

--- a/.github/workflows/update-variables.yml
+++ b/.github/workflows/update-variables.yml
@@ -13,4 +13,4 @@ on:
   pull_request_target:
 jobs:
   update-variables:
-    uses: ansible-network/github_actions/.github/workflows/update_aws_variables.yml@main
+    uses: ansible-network/github_actions/.github/workflows/update_aws_variables.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25


### PR DESCRIPTION
##### SUMMARY
Pin external GitHub Actions dependencies to specific commit SHAs to improve supply chain security and address SonarCloud security hotspots.

This change pins the following external dependencies:
- ansible-network/github_actions workflows → 446d458
- ansible-community/github-docs-build workflows → ea28abe  
- actions-ecosystem/action-add-labels → 18f1af5
- actions-ecosystem/action-remove-labels → 2ce5d41
- SonarSource/sonarqube-scan-action → a31c939

Local actions (ansible-collections/amazon.aws/.github/actions/*@main) remain unpinned as they're part of this repository.

Addresses 16 SonarCloud security hotspots (rule githubactions:S7637: Use full commit SHA hash for dependencies).

##### ISSUE TYPE
Docs Pull Request

##### COMPONENT NAME
GitHub Actions workflows

##### ADDITIONAL INFORMATION
Each pinned SHA is annotated with a comment indicating the original reference (e.g., `# @main as of 2026-03-25`) to aid future updates.

SonarCloud hotspot keys: AZx2vrrtBuzFI9Zt1PTR, AZx2vrpBBuzFI9Zt1PTE, AZx2vro5BuzFI9Zt1PTB, AZx2vro5BuzFI9Zt1PTC, AZx2vro5BuzFI9Zt1PTD, AZx2vrreBuzFI9Zt1PTO, AZx2vrreBuzFI9Zt1PTP, AZx2vrrOBuzFI9Zt1PTM, AZx2vrpZBuzFI9Zt1PTK, AZx2vrpZBuzFI9Zt1PTL, AZx2vrrlBuzFI9Zt1PTQ, AZx2vrpJBuzFI9Zt1PTF, AZx2vrpJBuzFI9Zt1PTG, AZx2vrpSBuzFI9Zt1PTH, AZx2vrpSBuzFI9Zt1PTI, AZx2vrrWBuzFI9Zt1PTN, AZx2vrooBuzFI9Zt1PS_, AZx2vroxBuzFI9Zt1PTA, AZyu4kYxQuZLKMUlry5p

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>