### PR TITLE
Fix MD5/SHA1 hashing for FIPS mode compatibility

### DIFF
--- a/changelogs/fragments/fips-hashing-compatibility.yml
+++ b/changelogs/fragments/fips-hashing-compatibility.yml
@@ -1,3 +1,3 @@
 bugfixes:
-  - module_utils/s3 - Fix MD5 hashing for FIPS mode compatibility by adding usedforsecurity=False parameter to support Python running in FIPS-enabled environments (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
-  - cloudformation - Fix SHA1 hashing for FIPS mode compatibility by adding usedforsecurity=False parameter to support Python running in FIPS-enabled environments (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - module_utils/s3 - Fix MD5 hashing for FIPS mode compatibility by adding usedforsecurity=False parameter to support Python running in FIPS-enabled environments (https://github.com/ansible-collections/amazon.aws/pull/2921).
+  - cloudformation - Fix SHA1 hashing for FIPS mode compatibility by adding usedforsecurity=False parameter to support Python running in FIPS-enabled environments (https://github.com/ansible-collections/amazon.aws/pull/2921).

--- a/changelogs/fragments/fips-hashing-compatibility.yml
+++ b/changelogs/fragments/fips-hashing-compatibility.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - module_utils/s3 - Fix MD5 hashing for FIPS mode compatibility by adding usedforsecurity=False parameter to support Python running in FIPS-enabled environments (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - cloudformation - Fix SHA1 hashing for FIPS mode compatibility by adding usedforsecurity=False parameter to support Python running in FIPS-enabled environments (https://github.com/ansible-collections/amazon.aws/pull/XXXX).

--- a/plugins/module_utils/s3.py
+++ b/plugins/module_utils/s3.py
@@ -1270,10 +1270,10 @@ def calculate_checksum_with_file(
     digests = []
     with open(filename, "rb") as f:
         for head in s3_head_objects(client, parts, bucket, obj, versionId):
-            digests.append(md5(f.read(int(head["ContentLength"]))).digest())
+            digests.append(md5(f.read(int(head["ContentLength"])), usedforsecurity=False).digest())
 
     digest_squared = b"".join(digests)
-    return f'"{md5(digest_squared).hexdigest()}-{len(digests)}"'
+    return f'"{md5(digest_squared, usedforsecurity=False).hexdigest()}-{len(digests)}"'
 
 
 def calculate_checksum_with_content(
@@ -1297,11 +1297,11 @@ def calculate_checksum_with_content(
     offset = 0
     for head in s3_head_objects(client, parts, bucket, obj, versionId):
         length = int(head["ContentLength"])
-        digests.append(md5(content[offset:offset + length]).digest())  # fmt: skip
+        digests.append(md5(content[offset:offset + length], usedforsecurity=False).digest())  # fmt: skip
         offset += length
 
     digest_squared = b"".join(digests)
-    return f'"{md5(digest_squared).hexdigest()}-{len(digests)}"'
+    return f'"{md5(digest_squared, usedforsecurity=False).hexdigest()}-{len(digests)}"'
 
 
 def calculate_etag(
@@ -1377,7 +1377,7 @@ def calculate_etag_content(
         except (botocore.exceptions.BotoCoreError, botocore.exceptions.ClientError) as e:
             raise AnsibleS3Error(message="Failed to calculate object ETag", exception=e) from e
     else:  # Compute the MD5 sum normally
-        return f'"{md5(content).hexdigest()}"'
+        return f'"{md5(content, usedforsecurity=False).hexdigest()}"'
 
 
 def validate_bucket_name(name: str) -> Optional[str]:

--- a/plugins/modules/cloudformation.py
+++ b/plugins/modules/cloudformation.py
@@ -591,7 +591,7 @@ def build_changeset_name(stack_params):
 
     json_params = json.dumps(stack_params, sort_keys=True)
 
-    changeset_sha = sha1(to_bytes(json_params, errors="surrogate_or_strict")).hexdigest()
+    changeset_sha = sha1(to_bytes(json_params, errors="surrogate_or_strict"), usedforsecurity=False).hexdigest()
     return f"Ansible-{stack_params['StackName']}-{changeset_sha}"
 
 


### PR DESCRIPTION
##### SUMMARY
Fix MD5 and SHA1 hashing to support Python running in FIPS mode by adding the usedforsecurity=False parameter.

When Python runs in FIPS mode (common on RHEL, GovCloud systems), hashlib.md5() and hashlib.sha1() raise ValueError by default unless explicitly marked as non-cryptographic use. This breaks S3 operations and CloudFormation changeset creation.

AWS S3 ETags are MD5-based by design. FIPS 140-2 allows MD5/SHA1 for non-cryptographic purposes (data integrity, checksums). The usedforsecurity=False parameter indicates these hashes are used for data integrity verification only, not cryptographic security.

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
module_utils/s3, cloudformation

##### ADDITIONAL INFORMATION
**Changes:**
- `plugins/module_utils/s3.py`: Add usedforsecurity=False to 5 MD5 calls used for S3 ETag calculation (lines 1273, 1276, 1300, 1304, 1380)
- `plugins/modules/cloudformation.py`: Add usedforsecurity=False to SHA1 call used for changeset name generation (line 594)

**Python version requirement:**
This change uses the `usedforsecurity` parameter which requires Python 3.9+. Python 3.8 support is being dropped in the next major release after 2026-05-01.

**SonarCloud hotspots addressed:** 6 (rule python:S4790)
SonarCloud hotspot keys: AZx2vqmkBuzFI9Zt1Oss, AZx2vqmkBuzFI9Zt1Ost, AZx2vqmkBuzFI9Zt1Osv, AZx2vqmkBuzFI9Zt1Osw, AZx2vqmkBuzFI9Zt1Osx, AZx2vqoABuzFI9Zt1Ott

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>