### PR TITLE
Fix duplicate assignments and parameter reassignment reliability issues

### DIFF
--- a/changelogs/fragments/reliability-duplicate-assignments.yml
+++ b/changelogs/fragments/reliability-duplicate-assignments.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - s3_object_info - Fixed duplicate dictionary key assignments when retrieving object facts (https://github.com/ansible-collections/amazon.aws/pull/2923).
+  - autoscaling_group - Fixed duplicate default_cooldown assignment in properties dict (https://github.com/ansible-collections/amazon.aws/pull/2923).
+  - kms_key - Fixed parameter reassignment by using passed alias parameter instead of re-fetching from module params (https://github.com/ansible-collections/amazon.aws/pull/2923).

--- a/plugins/modules/autoscaling_group.py
+++ b/plugins/modules/autoscaling_group.py
@@ -896,7 +896,6 @@ def get_properties(autoscaling_group):
     properties["default_cooldown"] = autoscaling_group.get("DefaultCooldown")
     properties["healthcheck_grace_period"] = autoscaling_group.get("HealthCheckGracePeriod")
     properties["healthcheck_type"] = autoscaling_group.get("HealthCheckType")
-    properties["default_cooldown"] = autoscaling_group.get("DefaultCooldown")
     properties["termination_policies"] = autoscaling_group.get("TerminationPolicies")
     properties["target_group_arns"] = autoscaling_group.get("TargetGroupARNs")
     properties["vpc_zone_identifier"] = autoscaling_group.get("VPCZoneIdentifier")

--- a/plugins/modules/kms_key.py
+++ b/plugins/modules/kms_key.py
@@ -931,7 +931,7 @@ def fetch_key_metadata(connection, module, key_id, alias):
     # Integration tests will wait for 10 seconds to combat this issue.
     # See https://github.com/ansible-collections/community.aws/pull/1052.
 
-    alias = canonicalize_alias_name(module.params.get("alias"))
+    alias = canonicalize_alias_name(alias)
 
     try:
         # Fetch by key_id where possible

--- a/plugins/modules/s3_object_info.py
+++ b/plugins/modules/s3_object_info.py
@@ -584,22 +584,16 @@ def get_object_details(
 
     for key in requested_facts:
         if key == "object_acl":
-            all_facts[key] = {}
             all_facts[key] = describe_s3_object_acl(connection, bucket_name, object_name)
         elif key == "object_attributes":
-            all_facts[key] = {}
             all_facts[key] = describe_s3_object_attributes(connection, module, bucket_name, object_name)
         elif key == "object_legal_hold":
-            all_facts[key] = {}
             all_facts[key] = describe_s3_object_legal_hold(connection, bucket_name, object_name)
         elif key == "object_lock_configuration":
-            all_facts[key] = {}
             all_facts[key] = describe_s3_object_lock_configuration(connection, bucket_name)
         elif key == "object_retention":
-            all_facts[key] = {}
             all_facts[key] = describe_s3_object_retention(connection, bucket_name, object_name)
         elif key == "object_tagging":
-            all_facts[key] = {}
             all_facts[key] = describe_s3_object_tagging(connection, bucket_name, object_name)
 
     return all_facts


### PR DESCRIPTION
##### SUMMARY
Fixed duplicate dictionary key assignments and parameter reassignment issues identified by SonarCloud reliability analysis.

- s3_object_info: Removed redundant empty dict assignments before overwriting with function results
- autoscaling_group: Removed duplicate default_cooldown assignment
- kms_key: Fixed parameter reassignment by using passed alias parameter instead of re-fetching from module params

Addresses 8 SonarCloud reliability issues (python:S4143, python:S1226).

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
autoscaling_group, kms_key, s3_object_info

##### ADDITIONAL INFORMATION
All precommit checks passed:
- Formatting: ✓
- Linting: 10.00/10
- Unit tests: 2157 passed

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>