### PR TITLE
feat: support for feedback in Amazon SQS EDA Plugin

### DIFF
--- a/changelogs/fragments/feedback_eda_sqs_source_plugin.yml
+++ b/changelogs/fragments/feedback_eda_sqs_source_plugin.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - extensions/eda/plugins/event_source/aws_sqs_queue.py - Added optional support for feedback so that the event can be removed from the SQS Queue on receipt of acknowledgement from ansible-rulebook.

--- a/extensions/eda/plugins/event_source/aws_sqs_queue.py
+++ b/extensions/eda/plugins/event_source/aws_sqs_queue.py
@@ -73,12 +73,14 @@ options:
         The source plugin should wait for the response to come
         back on this queue before it picks the next event from
         SQS queue.
+    version_added: 11.3.0
   feedback_timeout:
     type: int
     default: 120
     description:
       - Timeout in seconds to wait for feedback from the rule engine
         before raising an exception. Only applies when feedback is enabled.
+    version_added: 11.3.0
   eda_feedback_queue:
     description:
       - Provided automatically by ansible-rulebook when the feedback
@@ -86,6 +88,7 @@ options:
         It allows the system to wait for confirmation that an event has
         been safely persisted in the database before removing it from the
         event queue. Users do not need to provide a value for this manually.
+    version_added: 11.3.0
 """
 
 EXAMPLES = r"""

--- a/extensions/eda/plugins/event_source/aws_sqs_queue.py
+++ b/extensions/eda/plugins/event_source/aws_sqs_queue.py
@@ -1,7 +1,8 @@
 import asyncio
 import json
 import logging
-from typing import Any, TypedDict
+from typing import Any
+from typing import TypedDict
 
 import botocore.exceptions
 from aiobotocore.session import get_session
@@ -61,6 +62,30 @@ options:
         messages might be returned). Valid values are V(1) to V(10).
     type: int
     default: 1
+  feedback:
+    type: bool
+    default: false
+    description:
+      - Should the source plugin wait for feedback before
+        processing the next event from SQS Queue.
+        This flag allows ansible rulebook to pass in an asyncio
+        queue which is passed in the O(eda_feedback_queue).
+        The source plugin should wait for the response to come
+        back on this queue before it picks the next event from
+        SQS queue.
+  feedback_timeout:
+    type: int
+    default: 120
+    description:
+      - Timeout in seconds to wait for feedback from the rule engine
+        before raising an exception. Only applies when feedback is enabled.
+  eda_feedback_queue:
+    description:
+      - Provided automatically by ansible-rulebook when the feedback
+        parameter is enabled, this parameter utilizes an asyncio.Queue.
+        It allows the system to wait for confirmation that an event has
+        been safely persisted in the database before removing it from the
+        event queue. Users do not need to provide a value for this manually.
 """
 
 EXAMPLES = r"""
@@ -71,6 +96,9 @@ EXAMPLES = r"""
 """
 
 
+DEFAULT_FEEDBACK_TIMEOUT = 120
+
+
 class DeleteMessageBatchRequestEntryTypeDef(TypedDict):
     """Custom TypedDict for Delete Message Batch Request Entry."""
 
@@ -78,102 +106,255 @@ class DeleteMessageBatchRequestEntryTypeDef(TypedDict):
     ReceiptHandle: str
 
 
-# pylint: disable=too-many-locals
-async def main(  # noqa: C901, PLR0912
+class MessageDeletionException(Exception):
+    pass
+
+
+class QueueConfig(TypedDict):
+    """Configuration extracted from arguments."""
+
+    queue_name: str
+    wait_seconds: int
+    max_number_of_messages: int
+    queue_owner_aws_account_id: str | None
+    feedback_enabled: bool
+    feedback_timeout: int
+    eda_feedback_queue: asyncio.Queue[Any] | None
+
+
+def _validate_and_extract_config(args: dict[str, Any]) -> QueueConfig:
+    """Validate arguments and extract configuration.
+
+    Args:
+        args: Dictionary of arguments
+
+    Returns:
+        QueueConfig with validated configuration
+
+    Raises:
+        ValueError: If required arguments are missing or invalid
+    """
+    if "name" not in args:
+        msg = "Missing queue name"
+        raise ValueError(msg)
+
+    feedback_enabled = args.get("feedback", False)
+    eda_feedback_queue = args.get("eda_feedback_queue", None)
+
+    if feedback_enabled and eda_feedback_queue is None:
+        msg = (
+            "feedback: true was set but no feedback queue was provided. "
+            "This requires a compatible version of ansible-rulebook that "
+            "supports the feedback mechanism."
+        )
+        raise ValueError(msg)
+
+    return QueueConfig(
+        queue_name=str(args.get("name")),
+        wait_seconds=int(args.get("delay_seconds", 2)),
+        max_number_of_messages=int(args.get("max_number_of_messages", 1)),
+        queue_owner_aws_account_id=args.get("queue_owner_aws_account_id"),
+        feedback_enabled=feedback_enabled,
+        feedback_timeout=int(args.get("feedback_timeout", DEFAULT_FEEDBACK_TIMEOUT)),
+        eda_feedback_queue=eda_feedback_queue,
+    )
+
+
+async def _get_queue_url(
+    client,
+    queue_name: str,
+    queue_owner_aws_account_id: str | None,
+) -> str:
+    """Retrieve the SQS queue URL.
+
+    Args:
+        client: AWS SQS client
+        queue_name: Name of the queue
+        queue_owner_aws_account_id: Optional account ID of queue owner
+
+    Returns:
+        Queue URL
+
+    Raises:
+        ValueError: If queue does not exist
+    """
+    queue_args = {"QueueName": queue_name}
+    if queue_owner_aws_account_id:
+        queue_args["QueueOwnerAWSAccountId"] = queue_owner_aws_account_id
+
+    try:
+        response = await client.get_queue_url(**queue_args)
+    except botocore.exceptions.ClientError as err:
+        if err.response["Error"]["Code"] == "AWS.SimpleQueueService.NonExistentQueue":
+            msg = f"Queue {queue_name} does not exist"
+            raise ValueError(msg) from None
+        raise
+
+    return response["QueueUrl"]
+
+
+def _parse_message_body(entry: dict[str, Any]) -> Any:
+    """Parse the message body from JSON.
+
+    Args:
+        entry: SQS message entry
+
+    Returns:
+        Parsed message body or raw body if parsing fails
+    """
+    logger = logging.getLogger()
+
+    try:
+        return json.loads(entry["Body"])
+    except json.JSONDecodeError:
+        logger.error("JSON decode error, storing raw value")
+        return entry["Body"]
+    except UnicodeError:
+        logger.exception("Unicode error while decoding message body")
+        return None
+
+
+async def _handle_feedback_and_delete(
+    client,
+    queue_url: str,
+    delete_entry: DeleteMessageBatchRequestEntryTypeDef,
+    config: QueueConfig,
+) -> None:
+    """Handle feedback mechanism and message deletion.
+
+    Args:
+        client: AWS SQS client
+        queue_url: Queue URL
+        delete_entry: Message deletion entry
+        config: Queue configuration
+
+    Raises:
+        asyncio.TimeoutError: If feedback timeout is exceeded
+        MessageDeletionException: If message deletion fails
+    """
+    logger = logging.getLogger()
+
+    if config["feedback_enabled"] and config["eda_feedback_queue"]:
+        try:
+            await asyncio.wait_for(
+                config["eda_feedback_queue"].get(),
+                timeout=config["feedback_timeout"],
+            )
+            if not await _delete_messages(client, queue_url, [delete_entry]):
+                logger.exception("Failed to delete messages, exiting")
+                raise MessageDeletionException("Messages could not be deleted")
+        except asyncio.TimeoutError:
+            logger.exception("Timed out waiting for feedback")
+            raise
+    else:
+        await _delete_messages(client, queue_url, [delete_entry])
+
+
+async def _process_message(
+    entry: dict[str, Any],
+    queue: asyncio.Queue[Any],
+    client,
+    queue_url: str,
+    config: QueueConfig,
+) -> None:
+    """Process a single SQS message.
+
+    Args:
+        entry: SQS message entry
+        queue: Queue to put processed events
+        client: AWS SQS client
+        queue_url: Queue URL
+        config: Queue configuration
+
+    Raises:
+        ValueError: If message format is invalid
+    """
+    if not isinstance(entry, dict) or "MessageId" not in entry:  # pragma: no cover
+        err_msg = f"Unexpected response {entry}, missing MessageId."
+        raise ValueError(err_msg)
+
+    delete_entry = DeleteMessageBatchRequestEntryTypeDef(
+        Id=entry["MessageId"],
+        ReceiptHandle=entry["ReceiptHandle"],
+    )
+
+    meta = {
+        "MessageId": entry["MessageId"],
+        "event": {"uuid": entry["MessageId"]},
+    }
+
+    msg_body = _parse_message_body(entry)
+
+    await queue.put({"body": msg_body, "meta": meta})
+    await _handle_feedback_and_delete(client, queue_url, delete_entry, config)
+    await asyncio.sleep(0)
+
+
+async def _delete_messages(client, queue_url, entries) -> bool:
+    result = False
+    logger = logging.getLogger()
+    # Need to remove msg from queue or else it'll reappear
+    delete_results = await client.delete_message_batch(
+        QueueUrl=queue_url,
+        Entries=entries,
+    )
+
+    # Check if the deletion was successful
+    if "Successful" in delete_results:
+        result = True
+        for item in delete_results["Successful"]:
+            logger.debug(
+                "Message with ID %s deleted successfully",
+                item["Id"],
+            )
+    # Log a error if any message failed deletions
+    if "Failed" in delete_results:
+        result = False
+        for item in delete_results["Failed"]:
+            logger.error(
+                "Error deleting message with ID : %s Error Code: %s Error Message: %s SenderFault: %s",
+                item["Id"],
+                item["Code"],
+                item["Message"],
+                str(item["SenderFault"]),
+            )
+
+    return result
+
+
+async def main(
     queue: asyncio.Queue[Any],
     args: dict[str, Any],
 ) -> None:
     """Receive events via an AWS SQS queue."""
     logger = logging.getLogger()
 
-    if "name" not in args:
-        msg = "Missing queue name"
-        raise ValueError(msg)
-    queue_name = str(args.get("name"))
-    wait_seconds = int(args.get("delay_seconds", 2))
-    max_number_of_messages = int(args.get("max_number_of_messages", 1))
-    queue_owner_aws_account_id = args.get("queue_owner_aws_account_id")
+    # Validate arguments and extract configuration
+    config = _validate_and_extract_config(args)
 
     session = get_session()
 
-    queue_args = {"QueueName": queue_name}
-    if queue_owner_aws_account_id:
-        queue_args["QueueOwnerAWSAccountId"] = queue_owner_aws_account_id
-
     async with session.create_client("sqs", **connection_args(args)) as client:
-        try:
-            response = await client.get_queue_url(**queue_args)
-        except botocore.exceptions.ClientError as err:
-            if (
-                err.response["Error"]["Code"]
-                == "AWS.SimpleQueueService.NonExistentQueue"
-            ):
-                msg = f"Queue {queue_name} does not exist"
-                raise ValueError(msg) from None
-            raise
+        # Get the queue URL
+        queue_url = await _get_queue_url(
+            client,
+            config["queue_name"],
+            config["queue_owner_aws_account_id"],
+        )
 
-        queue_url = response["QueueUrl"]
-
+        # Main message processing loop
         while True:
             # This loop won't spin really fast as there is
             # essentially a sleep in the receive_message call
             response_msg = await client.receive_message(
                 QueueUrl=queue_url,
-                WaitTimeSeconds=wait_seconds,
-                MaxNumberOfMessages=max_number_of_messages,
+                WaitTimeSeconds=config["wait_seconds"],
+                MaxNumberOfMessages=config["max_number_of_messages"],
             )
 
             if "Messages" in response_msg:
-                entries = []
                 for entry in response_msg["Messages"]:
-                    if (
-                        not isinstance(entry, dict) or "MessageId" not in entry
-                    ):  # pragma: no cover
-                        err_msg = (
-                            f"Unexpected response {response_msg}, missing MessageId."
-                        )
-                        raise ValueError(err_msg)
-                    entries.append(
-                        DeleteMessageBatchRequestEntryTypeDef(
-                            Id=entry["MessageId"],
-                            ReceiptHandle=entry["ReceiptHandle"],
-                        ),
-                    )
-                    meta = {"MessageId": entry["MessageId"]}
-                    try:
-                        msg_body = json.loads(entry["Body"])
-                    except json.JSONDecodeError:
-                        msg_body = entry["Body"]
-
-                    await queue.put({"body": msg_body, "meta": meta})
-                    await asyncio.sleep(0)
-
-                # Need to remove msg from queue or else it'll reappear
-                delete_results = await client.delete_message_batch(
-                    QueueUrl=queue_url,
-                    Entries=entries,
-                )
-
-                # Check if the deletion was successful
-                if "Successful" in delete_results:
-                    for item in delete_results["Successful"]:
-                        logger.debug(
-                            "Message with ID %s deleted successfully",
-                            item["Id"],
-                        )
-                # Log a error if any message failed deletions
-                if "Failed" in delete_results:
-                    for item in delete_results["Failed"]:
-                        logger.error(
-                            "Error deleting message with ID : %s "
-                            "Error Code: %s "
-                            "Error Message: %s "
-                            "SenderFault: %s",
-                            item["Id"],
-                            item["Code"],
-                            item["Message"],
-                            str(item["SenderFault"]),
-                        )
+                    await _process_message(entry, queue, client, queue_url, config)
             else:
                 logger.debug("No messages in queue")
 
@@ -195,6 +376,7 @@ def connection_args(args: dict[str, Any]) -> dict[str, Any]:
         selected_args["endpoint_url"] = args["endpoint_url"]
     if "region" in args:
         selected_args["region_name"] = args["region"]
+
     return selected_args
 
 

--- a/extensions/eda/plugins/event_source/schemas/aws_sqs_queue.json
+++ b/extensions/eda/plugins/event_source/schemas/aws_sqs_queue.json
@@ -43,6 +43,18 @@
             "title": "Polling Interval",
             "type": "integer",
             "default": 2
+        },
+        "feedback": {
+            "description": "Should the source plugin wait for feedback before processing the next event from the SQS Queue.",
+            "type": "boolean",
+            "title": "Feedback",
+            "default": false
+        },
+        "feedback_timeout": {
+            "description": "Timeout in seconds to wait for feedback from the rule engine before raising an exception. Only applies when feedback is enabled.",
+            "type": "integer",
+            "title": "Feedback Timeout",
+            "default": 120
         }
     },
     "required": [

--- a/tests/unit/event_source/test_aws_sqs_queue.py
+++ b/tests/unit/event_source/test_aws_sqs_queue.py
@@ -1,8 +1,13 @@
+import asyncio
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
 from asyncmock import AsyncMock
 
+pytest.importorskip("aiobotocore")
+
+from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue import _delete_messages
 from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue import main as sqs_main
 from ansible_collections.amazon.aws.tests.unit.utils.event import ListQueue
 
@@ -61,9 +66,319 @@ async def test_receive_from_sqs(eda_queue: ListQueue) -> None:
                     "queue_owner_aws_account_id": "123456",
                 },
             )
-        assert eda_queue.queue[0] == {"body": "Hello World", "meta": {"MessageId": "1"}}
+        assert eda_queue.queue[0] == {
+            "body": "Hello World",
+            "meta": {"MessageId": "1", "event": {"uuid": "1"}},
+        }
         assert eda_queue.queue[1] == {
             "body": {"Say": "Hello World"},
-            "meta": {"MessageId": "2"},
+            "meta": {"MessageId": "2", "event": {"uuid": "2"}},
         }
         assert len(eda_queue.queue) == 2
+
+
+@pytest.mark.asyncio
+async def test_feedback_enabled_without_queue() -> None:
+    """Test that ValueError is raised when feedback is enabled but no feedback queue is provided."""
+    session = AsyncMock()
+    with patch(
+        "ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue.get_session",
+        return_value=session,
+    ):
+        eda_queue = ListQueue()
+        with pytest.raises(ValueError, match="feedback: true was set but no feedback queue was provided"):
+            await sqs_main(
+                eda_queue,
+                {
+                    "region": "us-east-1",
+                    "name": "eda",
+                    "feedback": True,
+                },
+            )
+
+
+@pytest.mark.asyncio
+async def test_feedback_mechanism(eda_queue: ListQueue) -> None:
+    """Test the feedback mechanism with a feedback queue."""
+    session = AsyncMock()
+    with patch(
+        "ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue.get_session",
+        return_value=session,
+    ):
+        client = AsyncMock()
+        client.get_queue_url.return_value = {"QueueUrl": "sqs_url"}
+
+        message1 = {
+            "MessageId": "1",
+            "Body": '{"test":"data"}',
+            "ReceiptHandle": "handle1",
+        }
+        response = {"Messages": [message1]}
+        delete_response = {
+            "Successful": [{"Id": "1", "ReceiptHandle": "handle1"}],
+        }
+
+        client.receive_message = AsyncMock(side_effect=[response, ValueError()])
+
+        # Create a manual tracking mock for delete_message_batch
+        delete_call_tracker = MagicMock()
+
+        async def mock_delete_batch(*args, **kwargs):
+            delete_call_tracker(*args, **kwargs)
+            return delete_response
+
+        client.delete_message_batch = mock_delete_batch
+
+        session.create_client.return_value = client
+        session.create_client.not_async = True
+
+        # Create a feedback queue and pre-populate with a response
+        feedback_queue = asyncio.Queue()
+        await feedback_queue.put({"status": "processed"})
+
+        with pytest.raises(ValueError):
+            await sqs_main(
+                eda_queue,
+                {
+                    "region": "us-east-1",
+                    "name": "eda",
+                    "delay_seconds": 1,
+                    "feedback": True,
+                    "feedback_timeout": 5,
+                    "eda_feedback_queue": feedback_queue,
+                },
+            )
+
+        # Verify the message was put in the queue
+        assert len(eda_queue.queue) == 1
+        assert eda_queue.queue[0]["body"] == {"test": "data"}
+        # Verify delete was called
+        delete_call_tracker.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_feedback_timeout(eda_queue: ListQueue) -> None:
+    """Test that TimeoutError is raised when feedback queue times out."""
+    session = AsyncMock()
+    with patch(
+        "ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue.get_session",
+        return_value=session,
+    ):
+        client = AsyncMock()
+        client.get_queue_url.return_value = {"QueueUrl": "sqs_url"}
+
+        message1 = {
+            "MessageId": "1",
+            "Body": '{"test":"data"}',
+            "ReceiptHandle": "handle1",
+        }
+        response = {"Messages": [message1]}
+
+        client.receive_message = AsyncMock(return_value=response)
+        client.delete_message_batch = AsyncMock()
+
+        session.create_client.return_value = client
+        session.create_client.not_async = True
+
+        # Create an empty feedback queue (nothing to get, will timeout)
+        feedback_queue = asyncio.Queue()
+
+        with pytest.raises(asyncio.TimeoutError):
+            await sqs_main(
+                eda_queue,
+                {
+                    "region": "us-east-1",
+                    "name": "eda",
+                    "delay_seconds": 1,
+                    "feedback": True,
+                    "feedback_timeout": 1,  # 1 second timeout
+                    "eda_feedback_queue": feedback_queue,
+                },
+            )
+
+        # Verify the message was put in the queue before timeout
+        assert len(eda_queue.queue) == 1
+
+
+@pytest.mark.asyncio
+async def test_delete_messages_success() -> None:
+    """Test _delete_messages with successful deletion."""
+    delete_response = {
+        "Successful": [
+            {"Id": "1"},
+            {"Id": "2"},
+        ],
+    }
+
+    # Create a manual tracking mock
+    call_tracker = MagicMock()
+
+    async def mock_delete_batch(*args, **kwargs):
+        call_tracker(*args, **kwargs)
+        return delete_response
+
+    client = AsyncMock()
+    client.delete_message_batch = mock_delete_batch
+    client.delete_message_batch.mock = call_tracker
+
+    entries = [
+        {"Id": "1", "ReceiptHandle": "handle1"},
+        {"Id": "2", "ReceiptHandle": "handle2"},
+    ]
+
+    result = await _delete_messages(client, "queue_url", entries)
+
+    assert result is True
+    call_tracker.assert_called_once_with(
+        QueueUrl="queue_url",
+        Entries=entries,
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_messages_failure() -> None:
+    """Test _delete_messages with failed deletion."""
+    client = AsyncMock()
+    delete_response = {
+        "Successful": [{"Id": "1"}],
+        "Failed": [
+            {
+                "Id": "2",
+                "Code": "500",
+                "Message": "Internal Error",
+                "SenderFault": False,
+            }
+        ],
+    }
+    client.delete_message_batch = AsyncMock(side_effect=[delete_response])
+
+    entries = [
+        {"Id": "1", "ReceiptHandle": "handle1"},
+        {"Id": "2", "ReceiptHandle": "handle2"},
+    ]
+
+    result = await _delete_messages(client, "queue_url", entries)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_delete_messages_all_failures() -> None:
+    """Test _delete_messages with all messages failing to delete."""
+    client = AsyncMock()
+    delete_response = {
+        "Failed": [
+            {
+                "Id": "1",
+                "Code": "500",
+                "Message": "Internal Error",
+                "SenderFault": True,
+            }
+        ],
+    }
+    client.delete_message_batch = AsyncMock(side_effect=[delete_response])
+
+    entries = [{"Id": "1", "ReceiptHandle": "handle1"}]
+
+    result = await _delete_messages(client, "queue_url", entries)
+
+    assert result is False
+
+
+@pytest.mark.asyncio
+async def test_unicode_error_handling(eda_queue: ListQueue) -> None:
+    """Test handling of UnicodeError when decoding message body."""
+    session = AsyncMock()
+    with patch(
+        "ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue.get_session",
+        return_value=session,
+    ):
+        client = AsyncMock()
+        client.get_queue_url.return_value = {"QueueUrl": "sqs_url"}
+
+        # Create a message with body that will raise UnicodeError when json.loads is called
+        message1 = {
+            "MessageId": "1",
+            "Body": "test",  # Will be patched to raise UnicodeError
+            "ReceiptHandle": "handle1",
+        }
+        response = {"Messages": [message1]}
+        delete_response = {"Successful": [{"Id": "1"}]}
+
+        client.receive_message = AsyncMock(side_effect=[response, ValueError()])
+        client.delete_message_batch = AsyncMock(side_effect=[delete_response])
+
+        session.create_client.return_value = client
+        session.create_client.not_async = True
+
+        # Patch json.loads to raise UnicodeError
+        with patch("json.loads", side_effect=UnicodeError("unicode error")):
+            with pytest.raises(ValueError):
+                await sqs_main(
+                    eda_queue,
+                    {
+                        "region": "us-east-1",
+                        "name": "eda",
+                        "delay_seconds": 1,
+                    },
+                )
+
+        # Verify the message was put in queue with None body
+        assert len(eda_queue.queue) == 1
+        assert eda_queue.queue[0]["body"] is None
+        assert eda_queue.queue[0]["meta"]["MessageId"] == "1"
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_in_feedback_mode(eda_queue: ListQueue) -> None:
+    """Test that exception is raised when deletion fails in feedback mode."""
+    session = AsyncMock()
+    with patch(
+        "ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue.get_session",
+        return_value=session,
+    ):
+        client = AsyncMock()
+        client.get_queue_url.return_value = {"QueueUrl": "sqs_url"}
+
+        message1 = {
+            "MessageId": "1",
+            "Body": '{"test":"data"}',
+            "ReceiptHandle": "handle1",
+        }
+        response = {"Messages": [message1]}
+        delete_response = {
+            "Failed": [
+                {
+                    "Id": "1",
+                    "Code": "500",
+                    "Message": "Delete failed",
+                    "SenderFault": False,
+                }
+            ],
+        }
+
+        client.receive_message = AsyncMock(side_effect=[response])
+        client.delete_message_batch = AsyncMock(side_effect=[delete_response])
+
+        session.create_client.return_value = client
+        session.create_client.not_async = True
+
+        # Create a feedback queue with a response
+        feedback_queue = asyncio.Queue()
+        await feedback_queue.put({"status": "processed"})
+
+        with pytest.raises(Exception, match="Messages could not be deleted"):
+            await sqs_main(
+                eda_queue,
+                {
+                    "region": "us-east-1",
+                    "name": "eda",
+                    "delay_seconds": 1,
+                    "feedback": True,
+                    "feedback_timeout": 5,
+                    "eda_feedback_queue": feedback_queue,
+                },
+            )
+
+        # Verify the message was put in the queue
+        assert len(eda_queue.queue) == 1


### PR DESCRIPTION
##### SUMMARY

EDA now supports a feedback mechanism so we can safely delete in flight events from the SQS Queue once we know that the event if needed has been safely stored in a database to survive process outages and restarts.
To safely delete events from the SQS Queue we need to provide a mechanism to indicate that the event if needed has been persisted and wont be lost if the process restarts

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Ansible EDA Source Plugin for SQS

##### ADDITIONAL INFORMATION
2 new optional arguments have been added

* feedback : bool : Default False
* feedback_timeout : int : Default 120 seconds

Also added dev scripts which can be used for testing these locally without having to use EDA Activation or ansible-rulebook.
