### PR TITLE
Refactor inventory error handling and address SonarCloud issues

### DIFF
--- a/changelogs/fragments/aws_ec2-availability-zone-id.yml
+++ b/changelogs/fragments/aws_ec2-availability-zone-id.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - aws_ec2 inventory plugin - Added availability_zone_id to the placement block in host variables (https://github.com/ansible-collections/amazon.aws/issues/1550).

--- a/changelogs/fragments/sonarcloud-inventory-fixes.yml
+++ b/changelogs/fragments/sonarcloud-inventory-fixes.yml
@@ -1,6 +1,6 @@
 minor_changes:
-  - plugin_utils/inventory - Refactored error handling to use centralised InventoryErrorHandler following S3ErrorHandler pattern (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
-  - aws_ec2 inventory plugin - Addressed SonarCloud code-smells by reducing cognitive complexity in hostname processing methods (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - plugin_utils/inventory - Refactored error handling to use centralised InventoryErrorHandler following S3ErrorHandler pattern (https://github.com/ansible-collections/amazon.aws/pull/2936).
+  - aws_ec2 inventory plugin - Addressed SonarCloud code-smells by reducing cognitive complexity in hostname processing methods (https://github.com/ansible-collections/amazon.aws/pull/2936).
 trivial:
-  - aws_ec2 and aws_rds inventory plugins - Cleaned up retry decorator usage by removing redundant retries from paginated functions (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
-  - aws_ec2 and aws_rds inventory plugins - Added type hints and docstrings to helper functions (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - aws_ec2 and aws_rds inventory plugins - Cleaned up retry decorator usage by removing redundant retries from paginated functions (https://github.com/ansible-collections/amazon.aws/pull/2936).
+  - aws_ec2 and aws_rds inventory plugins - Added type hints and docstrings to helper functions (https://github.com/ansible-collections/amazon.aws/pull/2936).

--- a/changelogs/fragments/sonarcloud-inventory-fixes.yml
+++ b/changelogs/fragments/sonarcloud-inventory-fixes.yml
@@ -1,0 +1,6 @@
+minor_changes:
+  - plugin_utils/inventory - Refactored error handling to use centralised InventoryErrorHandler following S3ErrorHandler pattern (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - aws_ec2 inventory plugin - Addressed SonarCloud code-smells by reducing cognitive complexity in hostname processing methods (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+trivial:
+  - aws_ec2 and aws_rds inventory plugins - Cleaned up retry decorator usage by removing redundant retries from paginated functions (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - aws_ec2 and aws_rds inventory plugins - Added type hints and docstrings to helper functions (https://github.com/ansible-collections/amazon.aws/pull/XXXX).

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -347,6 +347,7 @@ from typing import Dict
 from typing import List
 from typing import Set
 
+from ansible.errors import AnsibleError
 from ansible.module_utils._text import to_text
 
 try:
@@ -356,6 +357,7 @@ except ImportError:
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.common import get_collection_info
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
@@ -614,7 +616,7 @@ def _remove_trailing_dot(data: str) -> str:
 
 
 class InventoryModule(AWSInventoryBase):
-    NAME = "amazon.aws.aws_ec2"
+    NAME = f"{get_collection_info()['name']}.aws_ec2"
     INVENTORY_FILE_SUFFIXES = ("aws_ec2.yml", "aws_ec2.yaml")
 
     def __init__(self):
@@ -691,6 +693,28 @@ class InventoryModule(AWSInventoryBase):
     def route53_enabled(self) -> bool:
         return self.get_option("route53_enabled")
 
+    def _process_hostname_dict_preference(self, instance, preference):
+        """
+        Process a dict preference to construct a hostname.
+
+        :param instance: an instance dict returned by boto3 ec2 describe_instances()
+        :param preference: a dict containing 'name', optional 'prefix', and optional 'separator'
+        :return: constructed hostname or None
+        """
+        if "name" not in preference:
+            raise AnsibleError("A 'name' key must be defined in a hostnames dictionary.")
+
+        hostname = self._get_preferred_hostname(instance, [preference["name"]])
+        if "prefix" not in preference:
+            return hostname
+
+        hostname_from_prefix = self._get_preferred_hostname(instance, [preference["prefix"]])
+        if not (hostname and hostname_from_prefix):
+            return hostname
+
+        separator = preference.get("separator", "_")
+        return hostname_from_prefix + separator + hostname
+
     def _get_preferred_hostname(self, instance, hostnames):
         """
         :param instance: an instance dict returned by boto3 ec2 describe_instances()
@@ -706,24 +730,51 @@ class InventoryModule(AWSInventoryBase):
         if not hostnames:
             hostnames = ["dns-name", "private-dns-name"]
 
-        hostname = None
         for preference in hostnames:
             if isinstance(preference, dict):
-                if "name" not in preference:
-                    self.fail_aws("A 'name' key must be defined in a hostnames dictionary.")
-                hostname = self._get_preferred_hostname(instance, [preference["name"]])
-                hostname_from_prefix = None
-                if "prefix" in preference:
-                    hostname_from_prefix = self._get_preferred_hostname(instance, [preference["prefix"]])
-                separator = preference.get("separator", "_")
-                if hostname and hostname_from_prefix and "prefix" in preference:
-                    hostname = hostname_from_prefix + separator + hostname
+                hostname = self._process_hostname_dict_preference(instance, preference)
             else:
                 hostname = self._get_hostname_with_jinja2_filter(instance, preference, return_single_hostname=True)
+
             if hostname:
-                break
-        if hostname:
-            return self._sanitize_hostname(hostname)
+                return self._sanitize_hostname(hostname)
+
+        return None
+
+    def _process_all_hostnames_dict_preference(self, instance, preference):
+        """
+        Process a dict preference to construct a hostname for the all hostnames case.
+
+        :param instance: an instance dict returned by boto3 ec2 describe_instances()
+        :param preference: a dict containing 'name', optional 'prefix', and optional 'separator'
+        :return: constructed hostname (string or list) or None
+        """
+        if "name" not in preference:
+            raise AnsibleError("A 'name' key must be defined in a hostnames dictionary.")
+
+        hostname = self._get_all_hostnames(instance, [preference["name"]])
+        if "prefix" not in preference:
+            return hostname
+
+        hostname_from_prefix = self._get_all_hostnames(instance, [preference["prefix"]])
+        if not (hostname and hostname_from_prefix):
+            return hostname
+
+        separator = preference.get("separator", "_")
+        return hostname_from_prefix[0] + separator + hostname[0]
+
+    def _add_hostname_to_list(self, hostname_list, hostname):
+        """
+        Add a hostname to the list, handling both string and list types.
+
+        :param hostname_list: the list to add to
+        :param hostname: the hostname(s) to add (string or list)
+        """
+        if isinstance(hostname, list):
+            for host in hostname:
+                hostname_list.append(self._sanitize_hostname(host))
+        elif isinstance(hostname, str):
+            hostname_list.append(self._sanitize_hostname(hostname))
 
     def _get_all_hostnames(self, instance, hostnames):
         """
@@ -738,27 +789,14 @@ class InventoryModule(AWSInventoryBase):
         if not hostnames:
             hostnames = ["dns-name", "private-dns-name"]
 
-        hostname = None
         for preference in hostnames:
             if isinstance(preference, dict):
-                if "name" not in preference:
-                    self.fail_aws("A 'name' key must be defined in a hostnames dictionary.")
-                hostname = self._get_all_hostnames(instance, [preference["name"]])
-                hostname_from_prefix = None
-                if "prefix" in preference:
-                    hostname_from_prefix = self._get_all_hostnames(instance, [preference["prefix"]])
-                separator = preference.get("separator", "_")
-                if hostname and hostname_from_prefix and "prefix" in preference:
-                    hostname = hostname_from_prefix[0] + separator + hostname[0]
+                hostname = self._process_all_hostnames_dict_preference(instance, preference)
             else:
                 hostname = self._get_hostname_with_jinja2_filter(instance, preference)
 
             if hostname:
-                if isinstance(hostname, list):
-                    for host in hostname:
-                        hostname_list.append(self._sanitize_hostname(host))
-                elif isinstance(hostname, str):
-                    hostname_list.append(self._sanitize_hostname(hostname))
+                self._add_hostname_to_list(hostname_list, hostname)
 
         return hostname_list
 
@@ -957,7 +995,7 @@ class InventoryModule(AWSInventoryBase):
         self.display.deprecated(
             "The 'tags' host variable is deprecated. Use 'ec2_tags' instead.",
             date="2026-12-01",
-            collection_name="amazon.aws",
+            collection_name=get_collection_info()["name"],
         )
 
         # get user specifications
@@ -979,7 +1017,7 @@ class InventoryModule(AWSInventoryBase):
                 "The 'use_contrib_script_compatible_sanitization' option is deprecated. "
                 "Use Ansible's default group name sanitization instead.",
                 date="2026-12-01",
-                collection_name="amazon.aws",
+                collection_name=get_collection_info()["name"],
             )
 
             self._sanitize_group_name = self._legacy_script_compatible_group_sanitization
@@ -989,7 +1027,7 @@ class InventoryModule(AWSInventoryBase):
                 "The 'use_contrib_script_compatible_ec2_tag_keys' option is deprecated. "
                 "Use the 'ec2_tags' structure instead.",
                 date="2026-12-01",
-                collection_name="amazon.aws",
+                collection_name=get_collection_info()["name"],
             )
 
         if not all(isinstance(element, (dict, str)) for element in hostnames):

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -347,6 +347,7 @@ from typing import Dict
 from typing import List
 from typing import Set
 
+from ansible.errors import AnsibleError
 from ansible.module_utils.common.text.converters import to_text
 
 try:
@@ -356,6 +357,7 @@ except ImportError:
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.common import get_collection_info
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
@@ -614,7 +616,7 @@ def _remove_trailing_dot(data: str) -> str:
 
 
 class InventoryModule(AWSInventoryBase):
-    NAME = "amazon.aws.aws_ec2"
+    NAME = f"{get_collection_info()['name']}.aws_ec2"
     INVENTORY_FILE_SUFFIXES = ("aws_ec2.yml", "aws_ec2.yaml")
 
     def __init__(self):
@@ -691,6 +693,28 @@ class InventoryModule(AWSInventoryBase):
     def route53_enabled(self) -> bool:
         return self.get_option("route53_enabled")
 
+    def _process_hostname_dict_preference(self, instance, preference):
+        """
+        Process a dict preference to construct a hostname.
+
+        :param instance: an instance dict returned by boto3 ec2 describe_instances()
+        :param preference: a dict containing 'name', optional 'prefix', and optional 'separator'
+        :return: constructed hostname or None
+        """
+        if "name" not in preference:
+            raise AnsibleError("A 'name' key must be defined in a hostnames dictionary.")
+
+        hostname = self._get_preferred_hostname(instance, [preference["name"]])
+        if "prefix" not in preference:
+            return hostname
+
+        hostname_from_prefix = self._get_preferred_hostname(instance, [preference["prefix"]])
+        if not (hostname and hostname_from_prefix):
+            return hostname
+
+        separator = preference.get("separator", "_")
+        return hostname_from_prefix + separator + hostname
+
     def _get_preferred_hostname(self, instance, hostnames):
         """
         :param instance: an instance dict returned by boto3 ec2 describe_instances()
@@ -706,24 +730,51 @@ class InventoryModule(AWSInventoryBase):
         if not hostnames:
             hostnames = ["dns-name", "private-dns-name"]
 
-        hostname = None
         for preference in hostnames:
             if isinstance(preference, dict):
-                if "name" not in preference:
-                    self.fail_aws("A 'name' key must be defined in a hostnames dictionary.")
-                hostname = self._get_preferred_hostname(instance, [preference["name"]])
-                hostname_from_prefix = None
-                if "prefix" in preference:
-                    hostname_from_prefix = self._get_preferred_hostname(instance, [preference["prefix"]])
-                separator = preference.get("separator", "_")
-                if hostname and hostname_from_prefix and "prefix" in preference:
-                    hostname = hostname_from_prefix + separator + hostname
+                hostname = self._process_hostname_dict_preference(instance, preference)
             else:
                 hostname = self._get_hostname_with_jinja2_filter(instance, preference, return_single_hostname=True)
+
             if hostname:
-                break
-        if hostname:
-            return self._sanitize_hostname(hostname)
+                return self._sanitize_hostname(hostname)
+
+        return None
+
+    def _process_all_hostnames_dict_preference(self, instance, preference):
+        """
+        Process a dict preference to construct a hostname for the all hostnames case.
+
+        :param instance: an instance dict returned by boto3 ec2 describe_instances()
+        :param preference: a dict containing 'name', optional 'prefix', and optional 'separator'
+        :return: constructed hostname (string or list) or None
+        """
+        if "name" not in preference:
+            raise AnsibleError("A 'name' key must be defined in a hostnames dictionary.")
+
+        hostname = self._get_all_hostnames(instance, [preference["name"]])
+        if "prefix" not in preference:
+            return hostname
+
+        hostname_from_prefix = self._get_all_hostnames(instance, [preference["prefix"]])
+        if not (hostname and hostname_from_prefix):
+            return hostname
+
+        separator = preference.get("separator", "_")
+        return hostname_from_prefix[0] + separator + hostname[0]
+
+    def _add_hostname_to_list(self, hostname_list, hostname):
+        """
+        Add a hostname to the list, handling both string and list types.
+
+        :param hostname_list: the list to add to
+        :param hostname: the hostname(s) to add (string or list)
+        """
+        if isinstance(hostname, list):
+            for host in hostname:
+                hostname_list.append(self._sanitize_hostname(host))
+        elif isinstance(hostname, str):
+            hostname_list.append(self._sanitize_hostname(hostname))
 
     def _get_all_hostnames(self, instance, hostnames):
         """
@@ -738,27 +789,14 @@ class InventoryModule(AWSInventoryBase):
         if not hostnames:
             hostnames = ["dns-name", "private-dns-name"]
 
-        hostname = None
         for preference in hostnames:
             if isinstance(preference, dict):
-                if "name" not in preference:
-                    self.fail_aws("A 'name' key must be defined in a hostnames dictionary.")
-                hostname = self._get_all_hostnames(instance, [preference["name"]])
-                hostname_from_prefix = None
-                if "prefix" in preference:
-                    hostname_from_prefix = self._get_all_hostnames(instance, [preference["prefix"]])
-                separator = preference.get("separator", "_")
-                if hostname and hostname_from_prefix and "prefix" in preference:
-                    hostname = hostname_from_prefix[0] + separator + hostname[0]
+                hostname = self._process_all_hostnames_dict_preference(instance, preference)
             else:
                 hostname = self._get_hostname_with_jinja2_filter(instance, preference)
 
             if hostname:
-                if isinstance(hostname, list):
-                    for host in hostname:
-                        hostname_list.append(self._sanitize_hostname(host))
-                elif isinstance(hostname, str):
-                    hostname_list.append(self._sanitize_hostname(hostname))
+                self._add_hostname_to_list(hostname_list, hostname)
 
         return hostname_list
 
@@ -957,7 +995,7 @@ class InventoryModule(AWSInventoryBase):
         self.display.deprecated(
             "The 'tags' host variable is deprecated. Use 'ec2_tags' instead.",
             date="2026-12-01",
-            collection_name="amazon.aws",
+            collection_name=get_collection_info()["name"],
         )
 
         # get user specifications
@@ -979,7 +1017,7 @@ class InventoryModule(AWSInventoryBase):
                 "The 'use_contrib_script_compatible_sanitization' option is deprecated. "
                 "Use Ansible's default group name sanitization instead.",
                 date="2026-12-01",
-                collection_name="amazon.aws",
+                collection_name=get_collection_info()["name"],
             )
 
             self._sanitize_group_name = self._legacy_script_compatible_group_sanitization
@@ -989,7 +1027,7 @@ class InventoryModule(AWSInventoryBase):
                 "The 'use_contrib_script_compatible_ec2_tag_keys' option is deprecated. "
                 "Use the 'ec2_tags' structure instead.",
                 date="2026-12-01",
-                collection_name="amazon.aws",
+                collection_name=get_collection_info()["name"],
             )
 
         if not all(isinstance(element, (dict, str)) for element in hostnames):

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -351,7 +351,6 @@ except ImportError:
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.common import get_collection_info
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AnsibleInventoryPermissionsError
@@ -593,7 +592,6 @@ def _get_ssm_information(client: Any, filters: List[Dict[str, Any]]) -> Dict[str
 
 
 @InventoryErrorHandler.common_error_handler("list Route53 hosted zones")
-@AWSRetry.jittered_backoff()
 def _list_hosted_zones(client: Any, **kwargs: Dict[str, Any]) -> List[Dict[str, Any]]:
     """
     List all hosted zones using the given boto3 Route53 client.
@@ -607,7 +605,6 @@ def _list_hosted_zones(client: Any, **kwargs: Dict[str, Any]) -> List[Dict[str, 
 
 
 @InventoryErrorHandler.common_error_handler("list Route53 resource record sets")
-@AWSRetry.jittered_backoff()
 def _list_resource_record_sets(client: Any, hosted_zone_id: str, **kwargs: Dict[str, Any]) -> List[Dict[str, Any]]:
     """
     Retrieve all resource record sets for a specific hosted zone in Route53.

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -1028,7 +1028,7 @@ class InventoryModule(AWSInventoryBase):
         self.display.deprecated(
             "The 'tags' host variable is deprecated. Use 'ec2_tags' instead.",
             date="2026-12-01",
-            collection_name=get_collection_info()["name"],
+            collection_name="amazon.aws",
         )
 
         # get user specifications
@@ -1050,7 +1050,7 @@ class InventoryModule(AWSInventoryBase):
                 "The 'use_contrib_script_compatible_sanitization' option is deprecated. "
                 "Use Ansible's default group name sanitization instead.",
                 date="2026-12-01",
-                collection_name=get_collection_info()["name"],
+                collection_name="amazon.aws",
             )
 
             self._sanitize_group_name = self._legacy_script_compatible_group_sanitization
@@ -1060,7 +1060,7 @@ class InventoryModule(AWSInventoryBase):
                 "The 'use_contrib_script_compatible_ec2_tag_keys' option is deprecated. "
                 "Use the 'ec2_tags' structure instead.",
                 date="2026-12-01",
-                collection_name=get_collection_info()["name"],
+                collection_name="amazon.aws",
             )
 
         if not all(isinstance(element, (dict, str)) for element in hostnames):

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -351,6 +351,7 @@ except ImportError:
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.common import get_collection_info
+from ansible_collections.amazon.aws.plugins.module_utils.ec2 import describe_availability_zones
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AnsibleInventoryPermissionsError
@@ -494,6 +495,7 @@ def _get_tag_hostname(preference: str, instance: Dict[str, Any]) -> Any:
 
 def _prepare_host_vars(
     original_host_vars: Dict[str, Any],
+    availability_zone_ids: Dict[str, str],
     hostvars_prefix: str = None,
     hostvars_suffix: str = None,
     use_contrib_script_compatible_ec2_tag_keys: bool = False,
@@ -505,6 +507,7 @@ def _prepare_host_vars(
     and applies optional prefixes/suffixes.
 
     :param original_host_vars: Raw EC2 instance data
+    :param availability_zone_ids: Dictionary mapping zone names to zone IDs
     :param hostvars_prefix: Optional prefix to add to all host variable names
     :param hostvars_suffix: Optional suffix to add to all host variable names
     :param use_contrib_script_compatible_ec2_tag_keys: If True, create ec2_tag_* variables
@@ -515,8 +518,11 @@ def _prepare_host_vars(
     # ec2_tags is the new key, tags is deprecated but kept for backward compatibility
     host_vars["tags"] = host_vars["ec2_tags"]
 
-    # Allow easier grouping by region
+    # Allow easier grouping by region or by AZ ID
     host_vars["placement"]["region"] = host_vars["placement"]["availability_zone"][:-1]
+    host_vars["placement"]["availability_zone_id"] = availability_zone_ids.get(
+        host_vars["placement"]["availability_zone"]
+    )
 
     if use_contrib_script_compatible_ec2_tag_keys:
         for k, v in host_vars["ec2_tags"].items():
@@ -657,6 +663,7 @@ class InventoryModule(AWSInventoryBase):
         super().__init__()
 
         self.group_prefix = "aws_ec2_"
+        self._availability_zone_cache = {}
 
     def _get_instances_by_region(self, regions, filters, strict_permissions):
         """
@@ -693,6 +700,43 @@ class InventoryModule(AWSInventoryBase):
             all_instances.extend(instances)
 
         return all_instances
+
+    def _describe_azs_by_region(self, region: str) -> Dict[str, Dict[str, Any]]:
+        """
+        Describe availability zones for a given region with caching.
+
+        :param region: AWS region name
+        :return: Dictionary mapping zone names to zone information
+        """
+        if region in self._availability_zone_cache:
+            return self._availability_zone_cache[region]
+
+        connection = self.client("ec2", region=region)
+        az_info = {az["ZoneName"]: az for az in describe_availability_zones(connection)}
+
+        self._availability_zone_cache[region] = az_info
+        return az_info
+
+    def _get_availability_zone_ids(self, strict_permissions: bool) -> Dict[str, str]:
+        """
+        Get availability zone ID mappings for all configured regions.
+
+        :param strict_permissions: Whether to fail or ignore 403 error codes
+        :return: Dictionary mapping zone names to zone IDs
+        """
+        availability_zone_ids = {}
+
+        for _connection, region in self.all_clients("ec2"):
+            try:
+                az_info = self._describe_azs_by_region(region)
+                for zone_name, zone_data in az_info.items():
+                    availability_zone_ids[zone_name] = zone_data["ZoneId"]
+            except AnsibleInventoryPermissionsError:
+                if strict_permissions:
+                    raise
+                continue
+
+        return availability_zone_ids
 
     def _sanitize_hostname(self, hostname):
         if ":" in to_text(hostname):
@@ -927,6 +971,7 @@ class InventoryModule(AWSInventoryBase):
         self,
         groups,
         hostnames,
+        availability_zone_ids,
         allow_duplicated_hosts=False,
         hostvars_prefix=None,
         hostvars_suffix=None,
@@ -938,6 +983,7 @@ class InventoryModule(AWSInventoryBase):
                 hosts=groups[group],
                 group=group,
                 hostnames=hostnames,
+                availability_zone_ids=availability_zone_ids,
                 allow_duplicated_hosts=allow_duplicated_hosts,
                 hostvars_prefix=hostvars_prefix,
                 hostvars_suffix=hostvars_suffix,
@@ -949,6 +995,7 @@ class InventoryModule(AWSInventoryBase):
         self,
         hosts,
         hostnames,
+        availability_zone_ids,
         allow_duplicated_hosts=False,
         hostvars_prefix=None,
         hostvars_suffix=None,
@@ -964,6 +1011,7 @@ class InventoryModule(AWSInventoryBase):
 
             host_vars = _prepare_host_vars(
                 host,
+                availability_zone_ids,
                 hostvars_prefix,
                 hostvars_suffix,
                 use_contrib_script_compatible_ec2_tag_keys,
@@ -976,6 +1024,7 @@ class InventoryModule(AWSInventoryBase):
         hosts,
         group,
         hostnames,
+        availability_zone_ids,
         allow_duplicated_hosts=False,
         hostvars_prefix=None,
         hostvars_suffix=None,
@@ -985,6 +1034,7 @@ class InventoryModule(AWSInventoryBase):
         :param hosts: a list of hosts to be added to a group
         :param group: the name of the group to which the hosts belong
         :param hostnames: a list of hostname destination variables in order of preference
+        :param availability_zone_ids: Dictionary mapping zone names to zone IDs
         :param bool allow_duplicated_hosts: if true, accept same host with different names
         :param str hostvars_prefix: starts the hostvars variable name with this prefix
         :param str hostvars_suffix: ends the hostvars variable name with this suffix
@@ -994,6 +1044,7 @@ class InventoryModule(AWSInventoryBase):
         for name, host_vars in self.iter_entry(
             hosts,
             hostnames,
+            availability_zone_ids,
             allow_duplicated_hosts=allow_duplicated_hosts,
             hostvars_prefix=hostvars_prefix,
             hostvars_suffix=hostvars_suffix,
@@ -1074,9 +1125,12 @@ class InventoryModule(AWSInventoryBase):
         if self.route53_enabled:
             self.route53_resource_record_mapping = self._map_route53_records()
 
+        availability_zone_ids = self._get_availability_zone_ids(strict_permissions)
+
         self._populate(
             results,
             hostnames,
+            availability_zone_ids,
             allow_duplicated_hosts=allow_duplicated_hosts,
             hostvars_prefix=hostvars_prefix,
             hostvars_suffix=hostvars_suffix,

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -460,7 +460,14 @@ instance_data_filter_to_boto_attr = {
 }
 
 
-def _get_tag_hostname(preference, instance):
+def _get_tag_hostname(preference: str, instance: Dict[str, Any]) -> Any:
+    """
+    Extract hostname from instance tags based on preference string.
+
+    :param preference: Tag preference string (e.g., "tag:Name" or "tag:Name,Environment")
+    :param instance: EC2 instance dictionary containing Tags
+    :return: Tag value(s) as string or list of strings
+    """
     tag_hostnames = preference.split("tag:", 1)[1]
     expected_single_value = False
     if "," in tag_hostnames:
@@ -486,11 +493,23 @@ def _get_tag_hostname(preference, instance):
 
 
 def _prepare_host_vars(
-    original_host_vars,
-    hostvars_prefix=None,
-    hostvars_suffix=None,
-    use_contrib_script_compatible_ec2_tag_keys=False,
-):
+    original_host_vars: Dict[str, Any],
+    hostvars_prefix: str = None,
+    hostvars_suffix: str = None,
+    use_contrib_script_compatible_ec2_tag_keys: bool = False,
+) -> Dict[str, Any]:
+    """
+    Transform EC2 instance data into Ansible host variables.
+
+    Converts camelCase keys to snake_case, processes tags, adds region info,
+    and applies optional prefixes/suffixes.
+
+    :param original_host_vars: Raw EC2 instance data
+    :param hostvars_prefix: Optional prefix to add to all host variable names
+    :param hostvars_suffix: Optional suffix to add to all host variable names
+    :param use_contrib_script_compatible_ec2_tag_keys: If True, create ec2_tag_* variables
+    :return: Dictionary of processed host variables
+    """
     host_vars = camel_dict_to_snake_dict(original_host_vars, ignore_list=["Tags"])
     host_vars["ec2_tags"] = boto3_tag_list_to_ansible_dict(original_host_vars.get("Tags", []))
     # ec2_tags is the new key, tags is deprecated but kept for backward compatibility
@@ -515,18 +534,20 @@ def _prepare_host_vars(
     return host_vars
 
 
-def _compile_values(obj, attr):
+def _compile_values(obj: Any, attr: str) -> Any:
     """
+    Recursively extract attribute values from nested lists/dicts.
+
     :param obj: A list or dict of instance attributes
-    :param attr: A key
-    :return The value(s) found via the attr
+    :param attr: A key to extract from the object
+    :return: The value(s) found via the attr
     """
     if obj is None:
         return
 
     temp_obj = []
 
-    if isinstance(obj, list) or isinstance(obj, tuple):
+    if isinstance(obj, (list, tuple)):
         for each in obj:
             value = _compile_values(each, attr)
             if value:
@@ -534,17 +555,20 @@ def _compile_values(obj, attr):
     else:
         temp_obj = obj.get(attr)
 
-    has_indexes = any([isinstance(temp_obj, list), isinstance(temp_obj, tuple)])
+    has_indexes = any([isinstance(temp_obj, (list, tuple))])
     if has_indexes and len(temp_obj) == 1:
         return temp_obj[0]
 
     return temp_obj
 
 
-def _get_boto_attr_chain(filter_name, instance):
+def _get_boto_attr_chain(filter_name: str, instance: Dict[str, Any]) -> Any:
     """
-    :param filter_name: The filter
-    :param instance: instance dict returned by boto3 ec2 describe_instances()
+    Resolve filter name to instance attribute value by following boto3 attribute chain.
+
+    :param filter_name: Filter name (e.g., 'dns-name', 'private-ip-address')
+    :param instance: Instance dict returned by boto3 ec2 describe_instances()
+    :return: Attribute value from instance, or filter_name as literal if not recognized
     """
     allowed_filters = sorted(
         list(instance_data_filter_to_boto_attr.keys()) + list(instance_meta_filter_to_boto_attr.keys())

--- a/plugins/inventory/aws_ec2.py
+++ b/plugins/inventory/aws_ec2.py
@@ -335,12 +335,6 @@ route53_excluded_zones:
 """
 
 import re
-
-try:
-    import botocore
-except ImportError:
-    pass  # will be captured by imported HAS_BOTO3
-
 from collections import defaultdict
 from typing import Any
 from typing import Dict
@@ -356,12 +350,13 @@ except ImportError:
     trust_as_template = None
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.common import get_collection_info
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AnsibleInventoryPermissionsError
 from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AWSInventoryBase
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import InventoryErrorHandler
 
 # The mappings give an array of keys to get from the filter name to the value
 # returned by boto3's EC2 describe_instances method.
@@ -571,16 +566,33 @@ def _get_boto_attr_chain(filter_name, instance):
     return instance_value
 
 
-def _describe_ec2_instances(connection, filters):
+@InventoryErrorHandler.common_error_handler("describe EC2 instances")
+def _describe_ec2_instances(connection: Any, filters: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Describe EC2 instances using the given boto3 EC2 client.
+
+    :param connection: boto3 client for EC2
+    :param filters: List of filters to apply to the describe operation
+    :return: Dictionary containing reservations and instance data
+    """
     paginator = connection.get_paginator("describe_instances")
     return paginator.paginate(Filters=filters).build_full_result()
 
 
-def _get_ssm_information(client, filters):
+@InventoryErrorHandler.common_error_handler("get SSM inventory information")
+def _get_ssm_information(client: Any, filters: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """
+    Retrieve SSM inventory information using the given boto3 SSM client.
+
+    :param client: boto3 client for SSM
+    :param filters: List of filters to apply to the inventory query
+    :return: Dictionary containing inventory entities and metadata
+    """
     paginator = client.get_paginator("get_inventory")
     return paginator.paginate(Filters=filters).build_full_result()
 
 
+@InventoryErrorHandler.common_error_handler("list Route53 hosted zones")
 @AWSRetry.jittered_backoff()
 def _list_hosted_zones(client: Any, **kwargs: Dict[str, Any]) -> List[Dict[str, Any]]:
     """
@@ -594,6 +606,7 @@ def _list_hosted_zones(client: Any, **kwargs: Dict[str, Any]) -> List[Dict[str, 
     return paginator.paginate(**kwargs).build_full_result()["HostedZones"]
 
 
+@InventoryErrorHandler.common_error_handler("list Route53 resource record sets")
 @AWSRetry.jittered_backoff()
 def _list_resource_record_sets(client: Any, hosted_zone_id: str, **kwargs: Dict[str, Any]) -> List[Dict[str, Any]]:
     """
@@ -639,23 +652,22 @@ class InventoryModule(AWSInventoryBase):
         for connection, _region in self.all_clients("ec2"):
             try:
                 reservations = _describe_ec2_instances(connection, filters).get("Reservations")
-                instances = []
-                for r in reservations:
-                    new_instances = r["Instances"]
-                    reservation_details = {
-                        "OwnerId": r["OwnerId"],
-                        "RequesterId": r.get("RequesterId", ""),
-                        "ReservationId": r["ReservationId"],
-                    }
-                    for instance in new_instances:
-                        instance.update(reservation_details)
-                    instances.extend(new_instances)
-            except is_boto3_error_code("UnauthorizedOperation") as e:
-                if not strict_permissions:
-                    continue
-                self.fail_aws("Failed to describe instances", exception=e)
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                self.fail_aws("Failed to describe instances", exception=e)
+            except AnsibleInventoryPermissionsError:
+                if strict_permissions:
+                    raise
+                continue
+
+            instances = []
+            for r in reservations:
+                new_instances = r["Instances"]
+                reservation_details = {
+                    "OwnerId": r["OwnerId"],
+                    "RequesterId": r.get("RequesterId", ""),
+                    "ReservationId": r["ReservationId"],
+                }
+                for instance in new_instances:
+                    instance.update(reservation_details)
+                instances.extend(new_instances)
 
             all_instances.extend(instances)
 

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -80,19 +80,13 @@ hostvars_prefix: aws_
 hostvars_suffix: _rds
 """
 
-try:
-    import botocore
-except ImportError:
-    pass  # will be captured by imported HAS_BOTO3
-
-from ansible.errors import AnsibleError
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-from ansible.module_utils.common.text.converters import to_native
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AnsibleInventoryPermissionsError
 from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AWSInventoryBase
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import InventoryErrorHandler
 
 
 def _find_hosts_with_valid_statuses(hosts, statuses):
@@ -114,7 +108,26 @@ def _get_rds_hostname(host):
         return host["DBClusterIdentifier"]
 
 
+@InventoryErrorHandler.list_error_handler("list tags for RDS resource", default_value=[])
+def _get_tags_for_resource(connection, resource_arn):
+    """
+    Retrieve tags for an RDS resource.
+
+    :param connection: boto3 client for RDS
+    :param resource_arn: ARN of the RDS resource
+    :return: List of tags (empty list if resource not found)
+    """
+    return connection.list_tags_for_resource(ResourceName=resource_arn)["TagList"]
+
+
 def _add_tags_for_rds_hosts(connection, hosts, strict):
+    """
+    Add tags to RDS hosts, handling permission errors based on strict mode.
+
+    :param connection: boto3 client for RDS
+    :param hosts: List of RDS host dictionaries
+    :param strict: If True, raise on permission errors; if False, set empty tags
+    """
     for host in hosts:
         if "DBInstanceArn" in host:
             resource_arn = host["DBInstanceArn"]
@@ -122,16 +135,22 @@ def _add_tags_for_rds_hosts(connection, hosts, strict):
             resource_arn = host["DBClusterArn"]
 
         try:
-            tags = connection.list_tags_for_resource(ResourceName=resource_arn)["TagList"]
-        except is_boto3_error_code("AccessDenied") as e:
-            if not strict:
-                tags = []
-            else:
-                raise e
+            tags = _get_tags_for_resource(connection, resource_arn)
+        except AnsibleInventoryPermissionsError:
+            if strict:
+                raise
+            tags = []
+
         host["Tags"] = tags
 
 
 def describe_resource_with_tags(func):
+    """
+    Decorator that extracts DB instances/clusters from API results and adds tags.
+
+    Handles permission errors from describe operations based on strict mode.
+    """
+
     def describe_wrapper(connection, filters, strict=False):
         try:
             results = func(connection=connection, filters=filters)
@@ -140,15 +159,10 @@ def describe_resource_with_tags(func):
             else:
                 results = results["DBClusters"]
             _add_tags_for_rds_hosts(connection, results, strict)
-        except is_boto3_error_code("AccessDenied") as e:  # pylint: disable=duplicate-except
+        except AnsibleInventoryPermissionsError:
             if not strict:
                 return []
-            raise AnsibleError(f"Failed to query RDS: {to_native(e)}")
-        except (
-            botocore.exceptions.BotoCoreError,
-            botocore.exceptions.ClientError,
-        ) as e:  # pylint: disable=duplicate-except
-            raise AnsibleError(f"Failed to query RDS: {to_native(e)}")
+            raise
 
         return results
 
@@ -156,13 +170,29 @@ def describe_resource_with_tags(func):
 
 
 @describe_resource_with_tags
+@InventoryErrorHandler.common_error_handler("describe RDS DB instances")
 def _describe_db_instances(connection, filters):
+    """
+    Describe RDS DB instances using the given boto3 RDS client.
+
+    :param connection: boto3 client for RDS
+    :param filters: List of filters to apply to the describe operation
+    :return: Dictionary containing DB instances
+    """
     paginator = connection.get_paginator("describe_db_instances")
     return paginator.paginate(Filters=filters).build_full_result()
 
 
 @describe_resource_with_tags
+@InventoryErrorHandler.common_error_handler("describe RDS DB clusters")
 def _describe_db_clusters(connection, filters):
+    """
+    Describe RDS DB clusters using the given boto3 RDS client.
+
+    :param connection: boto3 client for RDS
+    :param filters: List of filters to apply to the describe operation
+    :return: Dictionary containing DB clusters
+    """
     return connection.describe_db_clusters(Filters=filters)
 
 

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -3,6 +3,8 @@
 # Copyright (c) 2018 Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from __future__ import annotations
+
 DOCUMENTATION = r"""
 name: aws_rds
 short_description: RDS instance inventory source
@@ -80,6 +82,12 @@ hostvars_prefix: aws_
 hostvars_suffix: _rds
 """
 
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+    from typing import Callable
+
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
@@ -90,7 +98,14 @@ from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AWSInv
 from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import InventoryErrorHandler
 
 
-def _find_hosts_with_valid_statuses(hosts, statuses):
+def _find_hosts_with_valid_statuses(hosts: list, statuses: list) -> list:
+    """
+    Filter RDS hosts by their current status.
+
+    :param hosts: List of RDS DB instances or clusters
+    :param statuses: List of desired statuses (or ['all'] for all hosts)
+    :return: Filtered list of hosts matching the desired statuses
+    """
     if "all" in statuses:
         return hosts
     valid_hosts = []
@@ -102,11 +117,16 @@ def _find_hosts_with_valid_statuses(hosts, statuses):
     return valid_hosts
 
 
-def _get_rds_hostname(host):
+def _get_rds_hostname(host: dict) -> str:
+    """
+    Extract the hostname identifier from an RDS host.
+
+    :param host: RDS DB instance or cluster dictionary
+    :return: DBInstanceIdentifier for instances or DBClusterIdentifier for clusters
+    """
     if host.get("DBInstanceIdentifier"):
         return host["DBInstanceIdentifier"]
-    else:
-        return host["DBClusterIdentifier"]
+    return host["DBClusterIdentifier"]
 
 
 @InventoryErrorHandler.list_error_handler("list tags for RDS resource", default_value=[])
@@ -122,7 +142,7 @@ def _get_tags_for_resource(connection, resource_arn):
     return connection.list_tags_for_resource(ResourceName=resource_arn)["TagList"]
 
 
-def _add_tags_for_rds_hosts(connection, hosts, strict):
+def _add_tags_for_rds_hosts(connection: Any, hosts: list, strict: bool) -> None:
     """
     Add tags to RDS hosts, handling permission errors based on strict mode.
 
@@ -146,14 +166,17 @@ def _add_tags_for_rds_hosts(connection, hosts, strict):
         host["Tags"] = tags
 
 
-def describe_resource_with_tags(func):
+def describe_resource_with_tags(func: Callable) -> Callable:
     """
     Decorator that extracts DB instances/clusters from API results and adds tags.
 
     Handles permission errors from describe operations based on strict mode.
+
+    :param func: Function that returns describe_db_instances or describe_db_clusters result
+    :return: Wrapped function that extracts list and adds tags
     """
 
-    def describe_wrapper(connection, filters, strict=False):
+    def describe_wrapper(connection: Any, filters: Any, strict: bool = False) -> list:
         try:
             results = func(connection=connection, filters=filters)
             if "DBInstances" in results:

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -80,19 +80,13 @@ hostvars_prefix: aws_
 hostvars_suffix: _rds
 """
 
-try:
-    import botocore
-except ImportError:
-    pass  # will be captured by imported HAS_BOTO3
-
-from ansible.errors import AnsibleError
-from ansible.module_utils._text import to_native
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AnsibleInventoryPermissionsError
 from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AWSInventoryBase
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import InventoryErrorHandler
 
 
 def _find_hosts_with_valid_statuses(hosts, statuses):
@@ -114,7 +108,26 @@ def _get_rds_hostname(host):
         return host["DBClusterIdentifier"]
 
 
+@InventoryErrorHandler.list_error_handler("list tags for RDS resource", default_value=[])
+def _get_tags_for_resource(connection, resource_arn):
+    """
+    Retrieve tags for an RDS resource.
+
+    :param connection: boto3 client for RDS
+    :param resource_arn: ARN of the RDS resource
+    :return: List of tags (empty list if resource not found)
+    """
+    return connection.list_tags_for_resource(ResourceName=resource_arn)["TagList"]
+
+
 def _add_tags_for_rds_hosts(connection, hosts, strict):
+    """
+    Add tags to RDS hosts, handling permission errors based on strict mode.
+
+    :param connection: boto3 client for RDS
+    :param hosts: List of RDS host dictionaries
+    :param strict: If True, raise on permission errors; if False, set empty tags
+    """
     for host in hosts:
         if "DBInstanceArn" in host:
             resource_arn = host["DBInstanceArn"]
@@ -122,16 +135,22 @@ def _add_tags_for_rds_hosts(connection, hosts, strict):
             resource_arn = host["DBClusterArn"]
 
         try:
-            tags = connection.list_tags_for_resource(ResourceName=resource_arn)["TagList"]
-        except is_boto3_error_code("AccessDenied") as e:
-            if not strict:
-                tags = []
-            else:
-                raise e
+            tags = _get_tags_for_resource(connection, resource_arn)
+        except AnsibleInventoryPermissionsError:
+            if strict:
+                raise
+            tags = []
+
         host["Tags"] = tags
 
 
 def describe_resource_with_tags(func):
+    """
+    Decorator that extracts DB instances/clusters from API results and adds tags.
+
+    Handles permission errors from describe operations based on strict mode.
+    """
+
     def describe_wrapper(connection, filters, strict=False):
         try:
             results = func(connection=connection, filters=filters)
@@ -140,15 +159,10 @@ def describe_resource_with_tags(func):
             else:
                 results = results["DBClusters"]
             _add_tags_for_rds_hosts(connection, results, strict)
-        except is_boto3_error_code("AccessDenied") as e:  # pylint: disable=duplicate-except
+        except AnsibleInventoryPermissionsError:
             if not strict:
                 return []
-            raise AnsibleError(f"Failed to query RDS: {to_native(e)}")
-        except (
-            botocore.exceptions.BotoCoreError,
-            botocore.exceptions.ClientError,
-        ) as e:  # pylint: disable=duplicate-except
-            raise AnsibleError(f"Failed to query RDS: {to_native(e)}")
+            raise
 
         return results
 
@@ -156,13 +170,29 @@ def describe_resource_with_tags(func):
 
 
 @describe_resource_with_tags
+@InventoryErrorHandler.common_error_handler("describe RDS DB instances")
 def _describe_db_instances(connection, filters):
+    """
+    Describe RDS DB instances using the given boto3 RDS client.
+
+    :param connection: boto3 client for RDS
+    :param filters: List of filters to apply to the describe operation
+    :return: Dictionary containing DB instances
+    """
     paginator = connection.get_paginator("describe_db_instances")
     return paginator.paginate(Filters=filters).build_full_result()
 
 
 @describe_resource_with_tags
+@InventoryErrorHandler.common_error_handler("describe RDS DB clusters")
 def _describe_db_clusters(connection, filters):
+    """
+    Describe RDS DB clusters using the given boto3 RDS client.
+
+    :param connection: boto3 client for RDS
+    :param filters: List of filters to apply to the describe operation
+    :return: Dictionary containing DB clusters
+    """
     return connection.describe_db_clusters(Filters=filters)
 
 

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -82,6 +82,7 @@ hostvars_suffix: _rds
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AnsibleInventoryPermissionsError
@@ -109,6 +110,7 @@ def _get_rds_hostname(host):
 
 
 @InventoryErrorHandler.list_error_handler("list tags for RDS resource", default_value=[])
+@AWSRetry.jittered_backoff()
 def _get_tags_for_resource(connection, resource_arn):
     """
     Retrieve tags for an RDS resource.
@@ -185,6 +187,7 @@ def _describe_db_instances(connection, filters):
 
 @describe_resource_with_tags
 @InventoryErrorHandler.common_error_handler("describe RDS DB clusters")
+@AWSRetry.jittered_backoff()
 def _describe_db_clusters(connection, filters):
     """
     Describe RDS DB clusters using the given boto3 RDS client.

--- a/plugins/plugin_utils/_inventory/common.py
+++ b/plugins/plugin_utils/_inventory/common.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import functools
+import typing
+from typing import cast
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+    from typing import Callable
+
+from ansible.errors import AnsibleError
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_httpstatus
+from ansible_collections.amazon.aws.plugins.module_utils.errors import AWSErrorHandler
+
+
+class AnsibleInventoryAWSError(AnsibleError):
+    """
+    Exception for AWS inventory plugins that supports structured exception handling.
+
+    Extends AnsibleError to be compatible with inventory plugin exception handling
+    while supporting the same message/exception pattern as AnsibleAWSError.
+    """
+
+    def __init__(self, message=None, exception=None, **kwargs):
+        if not message and not exception:
+            super().__init__()
+        elif not message:
+            super().__init__(exception)
+        else:
+            super().__init__(message)
+
+        self.exception = exception
+        self.message = message
+
+
+class AnsibleInventoryPermissionsError(AnsibleInventoryAWSError):
+    """Exception raised for inventory permission/authorization errors."""
+
+    pass
+
+
+class InventoryErrorHandler(AWSErrorHandler):
+    """
+    Error handler for AWS inventory plugins.
+
+    Provides decorators for handling common AWS inventory error patterns,
+    converting boto3 exceptions to AnsibleError exceptions.
+    """
+
+    _CUSTOM_EXCEPTION = AnsibleInventoryAWSError
+
+    @classmethod
+    def _is_missing(cls) -> Callable:
+        """
+        Check if a boto3 exception indicates a missing/not found resource.
+
+        Returns:
+            A matcher function for boto3 error codes indicating missing resources.
+        """
+        return is_boto3_error_code(
+            [
+                "ResourceNotFoundException",
+                "NoSuchEntity",
+                "InvalidParameterValue",
+            ]
+        )
+
+    @classmethod
+    def common_error_handler(cls, description: str) -> Callable:
+        """
+        Decorator for inventory operations that provides error handling.
+
+        Catches boto3 exceptions and converts them to AnsibleInventoryAWSError exceptions.
+        Permission-related errors (UnauthorizedOperation, AccessDenied, 403) are converted to
+        AnsibleInventoryPermissionsError to allow graceful handling with strict_permissions.
+
+        Parameters:
+            description: Human-readable description of the operation for error messages.
+
+        Returns:
+            Decorated function with error handling.
+        """
+
+        def wrapper(func: Callable) -> Callable:
+            parent_class = cast(AWSErrorHandler, super(InventoryErrorHandler, cls))
+
+            @parent_class.common_error_handler(description)
+            @functools.wraps(func)
+            def handler(*args: Any, **kwargs: Any) -> Any:
+                try:
+                    return func(*args, **kwargs)
+                except is_boto3_error_code(["UnauthorizedOperation", "AccessDenied"]) as e:
+                    raise AnsibleInventoryPermissionsError(
+                        message=f"Failed to {description} (permission denied)", exception=e
+                    ) from e
+                except is_boto3_error_httpstatus(403) as e:  # pylint: disable=duplicate-except
+                    raise AnsibleInventoryPermissionsError(
+                        message=f"Failed to {description} (permission denied)", exception=e
+                    ) from e
+
+            return handler
+
+        return wrapper

--- a/plugins/plugin_utils/inventory.py
+++ b/plugins/plugin_utils/inventory.py
@@ -14,8 +14,13 @@ from ansible.plugins.inventory import Cacheable
 from ansible.plugins.inventory import Constructable
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.plugin_utils._inventory import common as _common
 from ansible_collections.amazon.aws.plugins.plugin_utils.base import AWSPluginBase
 from ansible_collections.amazon.aws.plugins.plugin_utils.botocore import AnsibleBotocoreError
+
+AnsibleInventoryAWSError = _common.AnsibleInventoryAWSError
+AnsibleInventoryPermissionsError = _common.AnsibleInventoryPermissionsError
+InventoryErrorHandler = _common.InventoryErrorHandler
 
 
 def _boto3_session(profile_name=None):

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory.yml
@@ -11,3 +11,13 @@
           - "'aws_ec2' in groups"
           - groups.aws_ec2 | length == 1
           - groups.aws_ec2.0 == resource_prefix
+
+    - name: Assert placement data is populated including availability zone ID
+      ansible.builtin.assert:
+        that:
+          - hostvars[resource_prefix]['placement'] is defined
+          - hostvars[resource_prefix]['placement']['availability_zone'] is defined
+          - hostvars[resource_prefix]['placement']['region'] is defined
+          - hostvars[resource_prefix]['placement']['availability_zone_id'] is defined
+          - hostvars[resource_prefix]['placement']['availability_zone_id'] is string
+          - hostvars[resource_prefix]['placement']['availability_zone_id'] | length > 0

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_constructed.yml
@@ -48,3 +48,11 @@
               - groups.arch_x86_64 | length == 1
               - groups.tag_with_name_key | length == 1
               - vars.hostvars[groups.aws_ec2.0]['test_compose_var_sum'] == 'value1value2'
+
+        - name: Assert placement data includes availability zone ID
+          ansible.builtin.assert:
+            that:
+              - vars.hostvars[groups.aws_ec2.0]['placement']['availability_zone'] is defined
+              - vars.hostvars[groups.aws_ec2.0]['placement']['availability_zone_id'] is defined
+              - vars.hostvars[groups.aws_ec2.0]['placement']['availability_zone_id'] is string
+              - vars.hostvars[groups.aws_ec2.0]['placement']['availability_zone_id'] | length > 0

--- a/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostvars_prefix_suffix.yml
+++ b/tests/integration/targets/inventory_aws_ec2/playbooks/test_populating_inventory_with_hostvars_prefix_suffix.yml
@@ -45,3 +45,35 @@
           vars:
             vars_prefix: "{{ hostvars_prefix | default('') }}"
             vars_suffix: "{{ hostvars_suffix | default('') }}"
+
+        - name: Assert placement data includes availability zone ID
+          ansible.builtin.assert:
+            that:
+              - hostvars[resource_prefix+'_1'][vars_prefix+'placement'+vars_suffix]['availability_zone'] is defined
+              - hostvars[resource_prefix+'_1'][vars_prefix+'placement'+vars_suffix]['availability_zone_id'] is defined
+              - hostvars[resource_prefix+'_1'][vars_prefix+'placement'+vars_suffix]['availability_zone_id'] is string
+              - hostvars[resource_prefix+'_1'][vars_prefix+'placement'+vars_suffix]['availability_zone_id'] | length > 0
+          vars:
+            vars_prefix: "{{ hostvars_prefix | default('') }}"
+            vars_suffix: "{{ hostvars_suffix | default('') }}"
+
+        - name: Get AZ information from AWS to verify correctness
+          amazon.aws.aws_az_info:
+            filters:
+              zone-name: "{{ hostvars[resource_prefix+'_1'][vars_prefix+'placement'+vars_suffix]['availability_zone'] }}"
+          register: az_info
+          vars:
+            vars_prefix: "{{ hostvars_prefix | default('') }}"
+            vars_suffix: "{{ hostvars_suffix | default('') }}"
+
+        - name: Assert availability zone ID matches AWS API
+          ansible.builtin.assert:
+            that:
+              - az_info['availability_zones'] | length == 1
+              - hostvars[resource_prefix+'_1'][vars_prefix+'placement'+vars_suffix]['availability_zone_id'] == az_info['availability_zones'][0]['zone_id']
+            fail_msg: >-
+              Expected AZ ID {{ az_info['availability_zones'][0]['zone_id'] }}
+              but got {{ hostvars[resource_prefix+'_1'][vars_prefix+'placement'+vars_suffix]['availability_zone_id'] }}
+          vars:
+            vars_prefix: "{{ hostvars_prefix | default('') }}"
+            vars_suffix: "{{ hostvars_suffix | default('') }}"

--- a/tests/unit/plugins/inventory/aws_ec2/test_hostname_helpers.py
+++ b/tests/unit/plugins/inventory/aws_ec2/test_hostname_helpers.py
@@ -1,0 +1,276 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from ansible.errors import AnsibleError
+
+from ansible_collections.amazon.aws.plugins.inventory.aws_ec2 import InventoryModule
+
+
+@pytest.fixture(name="inventory")
+def fixture_inventory():
+    """Create a basic inventory module instance for testing."""
+    inventory = InventoryModule()
+    inventory._options = {
+        "route53_enabled": False,
+    }
+    inventory.get_option = MagicMock()
+    inventory.get_option.side_effect = inventory._options.get
+    return inventory
+
+
+class TestProcessHostnameDictPreference:
+    """Tests for _process_hostname_dict_preference helper method."""
+
+    def test_missing_name_key_raises_error(self, inventory):
+        """Test that missing 'name' key raises AnsibleError."""
+        instance = {}
+        preference = {"prefix": "test"}
+
+        with pytest.raises(AnsibleError, match="A 'name' key must be defined in a hostnames dictionary"):
+            inventory._process_hostname_dict_preference(instance, preference)
+
+    def test_name_only_no_prefix(self, inventory, monkeypatch):
+        """Test processing with only 'name' key, no prefix."""
+        instance = {"InstanceId": "i-12345"}
+        preference = {"name": "instance-id"}
+
+        # Mock _get_preferred_hostname to return a hostname
+        def mock_get_preferred_hostname(inst, hostnames):
+            if hostnames == ["instance-id"]:
+                return "i-12345"
+            return None
+
+        monkeypatch.setattr(inventory, "_get_preferred_hostname", mock_get_preferred_hostname)
+
+        result = inventory._process_hostname_dict_preference(instance, preference)
+        assert result == "i-12345"
+
+    def test_name_with_prefix(self, inventory, monkeypatch):
+        """Test processing with both 'name' and 'prefix' keys."""
+        instance = {"InstanceId": "i-12345", "Tags": [{"Key": "Name", "Value": "web-server"}]}
+        preference = {"name": "tag:Name", "prefix": "instance-id"}
+
+        # Mock _get_preferred_hostname
+        def mock_get_preferred_hostname(inst, hostnames):
+            if hostnames == ["tag:Name"]:
+                return "web-server"
+            elif hostnames == ["instance-id"]:
+                return "i-12345"
+            return None
+
+        monkeypatch.setattr(inventory, "_get_preferred_hostname", mock_get_preferred_hostname)
+
+        result = inventory._process_hostname_dict_preference(instance, preference)
+        assert result == "i-12345_web-server"
+
+    def test_name_with_prefix_custom_separator(self, inventory, monkeypatch):
+        """Test processing with custom separator."""
+        instance = {"InstanceId": "i-12345", "Tags": [{"Key": "Name", "Value": "web-server"}]}
+        preference = {"name": "tag:Name", "prefix": "instance-id", "separator": "-"}
+
+        # Mock _get_preferred_hostname
+        def mock_get_preferred_hostname(inst, hostnames):
+            if hostnames == ["tag:Name"]:
+                return "web-server"
+            elif hostnames == ["instance-id"]:
+                return "i-12345"
+            return None
+
+        monkeypatch.setattr(inventory, "_get_preferred_hostname", mock_get_preferred_hostname)
+
+        result = inventory._process_hostname_dict_preference(instance, preference)
+        assert result == "i-12345-web-server"
+
+    def test_name_with_prefix_but_no_hostname(self, inventory, monkeypatch):
+        """Test when name returns None but prefix is specified."""
+        instance = {}
+        preference = {"name": "tag:Name", "prefix": "instance-id"}
+
+        # Mock _get_preferred_hostname to return None for name
+        def mock_get_preferred_hostname(inst, hostnames):
+            return None
+
+        monkeypatch.setattr(inventory, "_get_preferred_hostname", mock_get_preferred_hostname)
+
+        result = inventory._process_hostname_dict_preference(instance, preference)
+        assert result is None
+
+    def test_name_with_prefix_but_no_prefix_hostname(self, inventory, monkeypatch):
+        """Test when prefix returns None but name has a value."""
+        instance = {}
+        preference = {"name": "tag:Name", "prefix": "instance-id"}
+
+        # Mock _get_preferred_hostname to return None for prefix
+        def mock_get_preferred_hostname(inst, hostnames):
+            if hostnames == ["tag:Name"]:
+                return "web-server"
+            return None
+
+        monkeypatch.setattr(inventory, "_get_preferred_hostname", mock_get_preferred_hostname)
+
+        result = inventory._process_hostname_dict_preference(instance, preference)
+        assert result == "web-server"
+
+
+class TestProcessAllHostnamesDictPreference:
+    """Tests for _process_all_hostnames_dict_preference helper method."""
+
+    def test_missing_name_key_raises_error(self, inventory):
+        """Test that missing 'name' key raises AnsibleError."""
+        instance = {}
+        preference = {"prefix": "test"}
+
+        with pytest.raises(AnsibleError, match="A 'name' key must be defined in a hostnames dictionary"):
+            inventory._process_all_hostnames_dict_preference(instance, preference)
+
+    def test_name_only_returns_list(self, inventory, monkeypatch):
+        """Test processing with only 'name' key returns list."""
+        instance = {"PrivateIpAddress": "192.0.2.1"}
+        preference = {"name": "private-ip-address"}
+
+        # Mock _get_all_hostnames to return a list
+        def mock_get_all_hostnames(inst, hostnames):
+            if hostnames == ["private-ip-address"]:
+                return ["192.0.2.1"]
+            return []
+
+        monkeypatch.setattr(inventory, "_get_all_hostnames", mock_get_all_hostnames)
+
+        result = inventory._process_all_hostnames_dict_preference(instance, preference)
+        assert result == ["192.0.2.1"]
+
+    def test_name_with_prefix_constructs_combined(self, inventory, monkeypatch):
+        """Test processing with both name and prefix constructs combined hostname."""
+        instance = {"InstanceId": "i-12345", "Tags": [{"Key": "Name", "Value": "web-server"}]}
+        preference = {"name": "tag:Name", "prefix": "instance-id"}
+
+        # Mock _get_all_hostnames
+        def mock_get_all_hostnames(inst, hostnames):
+            if hostnames == ["tag:Name"]:
+                return ["web-server"]
+            elif hostnames == ["instance-id"]:
+                return ["i-12345"]
+            return []
+
+        monkeypatch.setattr(inventory, "_get_all_hostnames", mock_get_all_hostnames)
+
+        result = inventory._process_all_hostnames_dict_preference(instance, preference)
+        assert result == "i-12345_web-server"
+
+    def test_name_with_prefix_custom_separator(self, inventory, monkeypatch):
+        """Test processing with custom separator for all hostnames."""
+        instance = {"InstanceId": "i-12345", "Tags": [{"Key": "Name", "Value": "web-server"}]}
+        preference = {"name": "tag:Name", "prefix": "instance-id", "separator": "-"}
+
+        # Mock _get_all_hostnames
+        def mock_get_all_hostnames(inst, hostnames):
+            if hostnames == ["tag:Name"]:
+                return ["web-server"]
+            elif hostnames == ["instance-id"]:
+                return ["i-12345"]
+            return []
+
+        monkeypatch.setattr(inventory, "_get_all_hostnames", mock_get_all_hostnames)
+
+        result = inventory._process_all_hostnames_dict_preference(instance, preference)
+        assert result == "i-12345-web-server"
+
+    def test_name_with_prefix_but_empty_results(self, inventory, monkeypatch):
+        """Test when results are empty lists."""
+        instance = {}
+        preference = {"name": "tag:Name", "prefix": "instance-id"}
+
+        # Mock _get_all_hostnames to return empty lists
+        def mock_get_all_hostnames(inst, hostnames):
+            return []
+
+        monkeypatch.setattr(inventory, "_get_all_hostnames", mock_get_all_hostnames)
+
+        result = inventory._process_all_hostnames_dict_preference(instance, preference)
+        assert result == []
+
+
+class TestAddHostnameToList:
+    """Tests for _add_hostname_to_list helper method."""
+
+    def test_add_string_hostname(self, inventory, monkeypatch):
+        """Test adding a string hostname to the list."""
+        hostname_list = []
+        hostname = "test-host.example.com"
+
+        # Mock _sanitize_hostname
+        def mock_sanitize(name):
+            return name.replace(".", "-")
+
+        monkeypatch.setattr(inventory, "_sanitize_hostname", mock_sanitize)
+
+        inventory._add_hostname_to_list(hostname_list, hostname)
+        assert hostname_list == ["test-host-example-com"]
+
+    def test_add_list_of_hostnames(self, inventory, monkeypatch):
+        """Test adding a list of hostnames."""
+        hostname_list = []
+        hostnames = ["host1.example.com", "host2.example.com", "host3.example.com"]
+
+        # Mock _sanitize_hostname
+        def mock_sanitize(name):
+            return name.replace(".", "-")
+
+        monkeypatch.setattr(inventory, "_sanitize_hostname", mock_sanitize)
+
+        inventory._add_hostname_to_list(hostname_list, hostnames)
+        assert hostname_list == ["host1-example-com", "host2-example-com", "host3-example-com"]
+
+    def test_add_to_existing_list(self, inventory, monkeypatch):
+        """Test adding hostnames to an existing list."""
+        hostname_list = ["existing-host"]
+        hostname = "new-host.example.com"
+
+        # Mock _sanitize_hostname
+        def mock_sanitize(name):
+            return name.replace(".", "-")
+
+        monkeypatch.setattr(inventory, "_sanitize_hostname", mock_sanitize)
+
+        inventory._add_hostname_to_list(hostname_list, hostname)
+        assert hostname_list == ["existing-host", "new-host-example-com"]
+
+    def test_add_empty_list(self, inventory, monkeypatch):
+        """Test adding an empty list does nothing."""
+        hostname_list = ["existing-host"]
+        hostnames = []
+
+        # Mock _sanitize_hostname (shouldn't be called)
+        def mock_sanitize(name):
+            return name
+
+        monkeypatch.setattr(inventory, "_sanitize_hostname", mock_sanitize)
+
+        inventory._add_hostname_to_list(hostname_list, hostnames)
+        assert hostname_list == ["existing-host"]
+
+    def test_add_neither_string_nor_list(self, inventory, monkeypatch):
+        """Test that non-string, non-list types are ignored."""
+        hostname_list = []
+
+        # Mock _sanitize_hostname (shouldn't be called)
+        def mock_sanitize(name):
+            return name
+
+        monkeypatch.setattr(inventory, "_sanitize_hostname", mock_sanitize)
+
+        # Should not raise an error, just ignore
+        inventory._add_hostname_to_list(hostname_list, None)
+        assert hostname_list == []
+
+        inventory._add_hostname_to_list(hostname_list, 123)
+        assert hostname_list == []
+
+        inventory._add_hostname_to_list(hostname_list, {"key": "value"})
+        assert hostname_list == []

--- a/tests/unit/plugins/inventory/test_aws_ec2.py
+++ b/tests/unit/plugins/inventory/test_aws_ec2.py
@@ -37,6 +37,8 @@ from ansible_collections.amazon.aws.plugins.inventory.aws_ec2 import _get_boto_a
 from ansible_collections.amazon.aws.plugins.inventory.aws_ec2 import _get_tag_hostname
 from ansible_collections.amazon.aws.plugins.inventory.aws_ec2 import _prepare_host_vars
 from ansible_collections.amazon.aws.plugins.inventory.aws_ec2 import _remove_trailing_dot
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AnsibleInventoryAWSError
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AnsibleInventoryPermissionsError
 
 
 @pytest.fixture(name="inventory")
@@ -536,38 +538,41 @@ def test_inventory_get_instances_by_region(m_describe_ec2_instances, inventory, 
 @pytest.mark.parametrize(
     "error",
     [
-        botocore.exceptions.ClientError(
-            {"Error": {"Code": 1, "Message": "Something went wrong"}, "ResponseMetadata": {"HTTPStatusCode": 404}},
-            "some_botocore_client_error",
+        AnsibleInventoryAWSError(
+            message="Failed to describe EC2 instances",
+            exception=botocore.exceptions.ClientError(
+                {"Error": {"Code": 1, "Message": "Something went wrong"}, "ResponseMetadata": {"HTTPStatusCode": 404}},
+                "some_botocore_client_error",
+            ),
         ),
-        botocore.exceptions.ClientError(
-            {
-                "Error": {"Code": "UnauthorizedOperation", "Message": "Something went wrong"},
-                "ResponseMetadata": {"HTTPStatusCode": 403},
-            },
-            "some_botocore_client_error",
+        AnsibleInventoryPermissionsError(
+            message="Failed to describe EC2 instances (permission denied)",
+            exception=botocore.exceptions.ClientError(
+                {
+                    "Error": {"Code": "UnauthorizedOperation", "Message": "Something went wrong"},
+                    "ResponseMetadata": {"HTTPStatusCode": 403},
+                },
+                "some_botocore_client_error",
+            ),
         ),
-        botocore.exceptions.PaginationError(message="some pagination error"),
+        AnsibleInventoryAWSError(
+            message="Timeout trying to describe EC2 instances",
+            exception=botocore.exceptions.PaginationError(message="some pagination error"),
+        ),
     ],
 )
 @patch("ansible_collections.amazon.aws.plugins.inventory.aws_ec2._describe_ec2_instances")
 def test_inventory_get_instances_by_region_failures(m_describe_ec2_instances, inventory, strict, error):
     inventory.all_clients = MagicMock()
     inventory.all_clients.return_value = [(MagicMock(), "us-west-2")]
-    inventory.fail_aws = MagicMock()
-    inventory.fail_aws.side_effect = SystemExit(1)
 
     m_describe_ec2_instances.side_effect = error
     regions = ["us-east-2", "us-east-4"]
 
-    if (
-        isinstance(error, botocore.exceptions.ClientError)
-        and error.response["ResponseMetadata"]["HTTPStatusCode"] == 403
-        and not strict
-    ):
+    if isinstance(error, AnsibleInventoryPermissionsError) and not strict:
         assert inventory._get_instances_by_region(regions, [], strict) == []
     else:
-        with pytest.raises(SystemExit):
+        with pytest.raises((AnsibleInventoryAWSError, AnsibleInventoryPermissionsError)):
             inventory._get_instances_by_region(regions, [], strict)
 
 

--- a/tests/unit/plugins/inventory/test_aws_ec2.py
+++ b/tests/unit/plugins/inventory/test_aws_ec2.py
@@ -260,15 +260,16 @@ def test_sanitize_hostname_legacy(inventory):
 
 
 @pytest.mark.parametrize(
-    "hostvars_prefix,hostvars_suffix,use_contrib_script_compatible_ec2_tag_keys,expectation",
+    "hostvars_prefix,hostvars_suffix,use_contrib_script_compatible_ec2_tag_keys,availability_zone_ids,expectation",
     [
         (
             None,
             None,
             False,
+            {"us-east-1a": "use1-az1"},
             {
                 "my_var": 1,
-                "placement": {"availability_zone": "us-east-1a", "region": "us-east-1"},
+                "placement": {"availability_zone": "us-east-1a", "region": "us-east-1", "availability_zone_id": "use1-az1"},
                 "ec2_tags": {"Name": "my-name"},
                 "tags": {"Name": "my-name"},
             },
@@ -277,11 +278,13 @@ def test_sanitize_hostname_legacy(inventory):
             "pre",
             "post",
             False,
+            {"us-east-1a": "use1-az1"},
             {
                 "premy_varpost": 1,
                 "preplacementpost": {
                     "availability_zone": "us-east-1a",
                     "region": "us-east-1",
+                    "availability_zone_id": "use1-az1",
                 },
                 "preec2_tagspost": {"Name": "my-name"},
                 "pretagspost": {"Name": "my-name"},
@@ -291,10 +294,23 @@ def test_sanitize_hostname_legacy(inventory):
             None,
             None,
             True,
+            {"us-east-1a": "use1-az1"},
             {
                 "my_var": 1,
                 "ec2_tag_Name": "my-name",
-                "placement": {"availability_zone": "us-east-1a", "region": "us-east-1"},
+                "placement": {"availability_zone": "us-east-1a", "region": "us-east-1", "availability_zone_id": "use1-az1"},
+                "ec2_tags": {"Name": "my-name"},
+                "tags": {"Name": "my-name"},
+            },
+        ),
+        (
+            None,
+            None,
+            False,
+            {},
+            {
+                "my_var": 1,
+                "placement": {"availability_zone": "us-east-1a", "region": "us-east-1", "availability_zone_id": None},
                 "ec2_tags": {"Name": "my-name"},
                 "tags": {"Name": "my-name"},
             },
@@ -305,6 +321,7 @@ def test_prepare_host_vars(
     hostvars_prefix,
     hostvars_suffix,
     use_contrib_script_compatible_ec2_tag_keys,
+    availability_zone_ids,
     expectation,
 ):
     original_host_vars = {
@@ -315,6 +332,7 @@ def test_prepare_host_vars(
     assert (
         _prepare_host_vars(
             original_host_vars,
+            availability_zone_ids,
             hostvars_prefix,
             hostvars_suffix,
             use_contrib_script_compatible_ec2_tag_keys,
@@ -340,17 +358,21 @@ def test_iter_entry(inventory):
         },
     ]
 
-    entries = list(inventory.iter_entry(hosts, hostnames=[]))
+    availability_zone_ids = {"us-east-1a": "use1-az1"}
+
+    entries = list(inventory.iter_entry(hosts, hostnames=[], availability_zone_ids=availability_zone_ids))
     assert len(entries) == 2
     assert entries[0][0] == "first_host___"
     assert entries[1][0] == "second-host"
     assert entries[1][1]["ec2_tags"]["Name"] == "my-name"
     assert entries[1][1]["tags"]["Name"] == "my-name"
+    assert entries[1][1]["placement"]["availability_zone_id"] == "use1-az1"
 
     entries = list(
         inventory.iter_entry(
             hosts,
             hostnames=[],
+            availability_zone_ids=availability_zone_ids,
             hostvars_prefix="a_",
             hostvars_suffix="_b",
             use_contrib_script_compatible_ec2_tag_keys=True,
@@ -360,6 +382,7 @@ def test_iter_entry(inventory):
     assert entries[0][0] == "first_host___"
     assert entries[1][1]["a_ec2_tags_b"]["Name"] == "my-name"
     assert entries[1][1]["a_tags_b"]["Name"] == "my-name"
+    assert entries[1][1]["a_placement_b"]["availability_zone_id"] == "use1-az1"
 
 
 @pytest.mark.parametrize(
@@ -798,3 +821,121 @@ def test__get_instance_route53_hostnames(inventory, instance, hostnames):
     }
     result = inventory._get_instance_route53_hostnames(instance)
     assert sorted(hostnames) == sorted(result)
+
+
+@patch("ansible_collections.amazon.aws.plugins.inventory.aws_ec2.describe_availability_zones")
+def test_describe_azs_by_region(m_describe_availability_zones, inventory):
+    mock_client = MagicMock()
+    inventory.client = MagicMock(return_value=mock_client)
+
+    m_describe_availability_zones.return_value = [
+        {"ZoneName": "us-east-1a", "ZoneId": "use1-az1", "State": "available"},
+        {"ZoneName": "us-east-1b", "ZoneId": "use1-az2", "State": "available"},
+        {"ZoneName": "us-east-1c", "ZoneId": "use1-az3", "State": "available"},
+    ]
+
+    result = inventory._describe_azs_by_region("us-east-1")
+
+    assert result == {
+        "us-east-1a": {"ZoneName": "us-east-1a", "ZoneId": "use1-az1", "State": "available"},
+        "us-east-1b": {"ZoneName": "us-east-1b", "ZoneId": "use1-az2", "State": "available"},
+        "us-east-1c": {"ZoneName": "us-east-1c", "ZoneId": "use1-az3", "State": "available"},
+    }
+    inventory.client.assert_called_once_with("ec2", region="us-east-1")
+    m_describe_availability_zones.assert_called_once_with(mock_client)
+
+
+@patch("ansible_collections.amazon.aws.plugins.inventory.aws_ec2.describe_availability_zones")
+def test_describe_azs_by_region_caching(m_describe_availability_zones, inventory):
+    mock_client = MagicMock()
+    inventory.client = MagicMock(return_value=mock_client)
+
+    m_describe_availability_zones.return_value = [
+        {"ZoneName": "us-east-1a", "ZoneId": "use1-az1", "State": "available"},
+    ]
+
+    # First call
+    result1 = inventory._describe_azs_by_region("us-east-1")
+    # Second call should use cache
+    result2 = inventory._describe_azs_by_region("us-east-1")
+
+    assert result1 == result2
+    # describe_availability_zones should only be called once due to caching
+    m_describe_availability_zones.assert_called_once()
+    inventory.client.assert_called_once()
+
+
+@patch("ansible_collections.amazon.aws.plugins.inventory.aws_ec2.describe_availability_zones")
+def test_get_availability_zone_ids(m_describe_availability_zones, inventory):
+    inventory.all_clients = MagicMock()
+    inventory.all_clients.return_value = [
+        (MagicMock(), "us-east-1"),
+        (MagicMock(), "us-west-2"),
+    ]
+
+    m_describe_availability_zones.side_effect = [
+        [
+            {"ZoneName": "us-east-1a", "ZoneId": "use1-az1"},
+            {"ZoneName": "us-east-1b", "ZoneId": "use1-az2"},
+        ],
+        [
+            {"ZoneName": "us-west-2a", "ZoneId": "usw2-az1"},
+            {"ZoneName": "us-west-2b", "ZoneId": "usw2-az2"},
+        ],
+    ]
+
+    inventory.client = MagicMock(side_effect=lambda service, region: MagicMock())
+
+    result = inventory._get_availability_zone_ids(strict_permissions=False)
+
+    assert result == {
+        "us-east-1a": "use1-az1",
+        "us-east-1b": "use1-az2",
+        "us-west-2a": "usw2-az1",
+        "us-west-2b": "usw2-az2",
+    }
+    inventory.all_clients.assert_called_once_with("ec2")
+
+
+@patch("ansible_collections.amazon.aws.plugins.inventory.aws_ec2.describe_availability_zones")
+def test_get_availability_zone_ids_with_permissions_error(m_describe_availability_zones, inventory):
+    inventory.all_clients = MagicMock()
+    inventory.all_clients.return_value = [
+        (MagicMock(), "us-east-1"),
+        (MagicMock(), "us-west-2"),
+    ]
+
+    # First region succeeds, second fails with permissions error
+    def describe_side_effect(client):
+        if not hasattr(describe_side_effect, "call_count"):
+            describe_side_effect.call_count = 0
+        describe_side_effect.call_count += 1
+
+        if describe_side_effect.call_count == 1:
+            return [{"ZoneName": "us-east-1a", "ZoneId": "use1-az1"}]
+        else:
+            raise AnsibleInventoryPermissionsError(
+                message="Failed to describe availability zones (permission denied)",
+                exception=botocore.exceptions.ClientError(
+                    {
+                        "Error": {"Code": "UnauthorizedOperation", "Message": "Not authorized"},
+                        "ResponseMetadata": {"HTTPStatusCode": 403},
+                    },
+                    "describe_availability_zones",
+                ),
+            )
+
+    m_describe_availability_zones.side_effect = describe_side_effect
+    inventory.client = MagicMock(side_effect=lambda service, region: MagicMock())
+
+    # With strict_permissions=False, should continue on permissions errors
+    result = inventory._get_availability_zone_ids(strict_permissions=False)
+    assert result == {"us-east-1a": "use1-az1"}
+
+    # With strict_permissions=True, should raise
+    # Clear cache and reset side effect
+    inventory._availability_zone_cache = {}
+    m_describe_availability_zones.side_effect = describe_side_effect
+    describe_side_effect.call_count = 0
+    with pytest.raises(AnsibleInventoryPermissionsError):
+        inventory._get_availability_zone_ids(strict_permissions=True)

--- a/tests/unit/plugins/inventory/test_aws_ec2.py
+++ b/tests/unit/plugins/inventory/test_aws_ec2.py
@@ -269,7 +269,11 @@ def test_sanitize_hostname_legacy(inventory):
             {"us-east-1a": "use1-az1"},
             {
                 "my_var": 1,
-                "placement": {"availability_zone": "us-east-1a", "region": "us-east-1", "availability_zone_id": "use1-az1"},
+                "placement": {
+                    "availability_zone": "us-east-1a",
+                    "region": "us-east-1",
+                    "availability_zone_id": "use1-az1",
+                },
                 "ec2_tags": {"Name": "my-name"},
                 "tags": {"Name": "my-name"},
             },
@@ -298,7 +302,11 @@ def test_sanitize_hostname_legacy(inventory):
             {
                 "my_var": 1,
                 "ec2_tag_Name": "my-name",
-                "placement": {"availability_zone": "us-east-1a", "region": "us-east-1", "availability_zone_id": "use1-az1"},
+                "placement": {
+                    "availability_zone": "us-east-1a",
+                    "region": "us-east-1",
+                    "availability_zone_id": "use1-az1",
+                },
                 "ec2_tags": {"Name": "my-name"},
                 "tags": {"Name": "my-name"},
             },

--- a/tests/unit/plugins/inventory/test_aws_rds.py
+++ b/tests/unit/plugins/inventory/test_aws_rds.py
@@ -42,6 +42,8 @@ from ansible_collections.amazon.aws.plugins.inventory.aws_rds import _find_hosts
 from ansible_collections.amazon.aws.plugins.inventory.aws_rds import _get_rds_hostname
 from ansible_collections.amazon.aws.plugins.inventory.aws_rds import ansible_dict_to_boto3_filter_list
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AnsibleInventoryAWSError
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AnsibleInventoryPermissionsError
 
 if not HAS_BOTO3:
     pytestmark = pytest.mark.skip("test_aws_rds.py requires the python modules 'boto3' and 'botocore'")
@@ -314,7 +316,7 @@ def test_add_tags_for_rds_hosts_with_failure_strict(connection):
 
     connection.list_tags_for_resource.side_effect = make_clienterror_exception()
 
-    with pytest.raises(botocore.exceptions.ClientError):
+    with pytest.raises(AnsibleInventoryPermissionsError):
         _add_tags_for_rds_hosts(connection, hosts, strict=True)
 
 
@@ -352,7 +354,7 @@ def test_describe_db_clusters_with_access_denied(m_add_tags_for_rds_hosts, conne
     filters = generate_random_string(with_punctuation=False)
 
     if strict:
-        with pytest.raises(AnsibleError):
+        with pytest.raises(AnsibleInventoryPermissionsError):
             _describe_db_clusters(connection=connection, filters=filters, strict=strict)
     else:
         assert _describe_db_clusters(connection=connection, filters=filters, strict=strict) == []
@@ -365,7 +367,7 @@ def test_describe_db_clusters_with_client_error(m_add_tags_for_rds_hosts, connec
     connection.describe_db_clusters.side_effect = make_clienterror_exception(code="Unknown")
 
     filters = generate_random_string(with_punctuation=False)
-    with pytest.raises(AnsibleError):
+    with pytest.raises(AnsibleInventoryAWSError):
         _describe_db_clusters(connection=connection, filters=filters, strict=False)
 
     m_add_tags_for_rds_hosts.assert_not_called()

--- a/tests/unit/plugins/inventory/test_aws_rds.py
+++ b/tests/unit/plugins/inventory/test_aws_rds.py
@@ -32,8 +32,6 @@ except ImportError:
     # Handled by HAS_BOTO3
     pass
 
-from ansible.errors import AnsibleError
-
 from ansible_collections.amazon.aws.plugins.inventory.aws_rds import InventoryModule
 from ansible_collections.amazon.aws.plugins.inventory.aws_rds import _add_tags_for_rds_hosts
 from ansible_collections.amazon.aws.plugins.inventory.aws_rds import _describe_db_clusters

--- a/tests/unit/plugins/plugin_utils/inventory/test_inventory_error_handler.py
+++ b/tests/unit/plugins/plugin_utils/inventory/test_inventory_error_handler.py
@@ -1,0 +1,230 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+try:
+    import botocore
+except ImportError:
+    pass
+
+import pytest
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AnsibleInventoryAWSError
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import AnsibleInventoryPermissionsError
+from ansible_collections.amazon.aws.plugins.plugin_utils.inventory import InventoryErrorHandler
+
+if not HAS_BOTO3:
+    pytestmark = pytest.mark.skip("test_inventory_error_handler.py requires the python modules 'boto3' and 'botocore'")
+
+
+class TestInventoryCommonHandler:
+    def test_no_failures(self):
+        self.counter = 0
+
+        @InventoryErrorHandler.common_error_handler("no error")
+        def no_failures():
+            self.counter += 1
+
+        no_failures()
+        assert self.counter == 1
+
+    def test_client_error(self):
+        self.counter = 0
+        err_response = {
+            "Error": {
+                "Code": "InvalidParameterValue",
+                "Message": "Invalid parameter value",
+            }
+        }
+
+        @InventoryErrorHandler.common_error_handler("describe instances")
+        def raise_client_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "DescribeInstances")
+
+        with pytest.raises(AnsibleInventoryAWSError) as e_info:
+            raise_client_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "describe instances" in raised.message
+        assert "DescribeInstances" in str(raised.exception)
+
+    def test_waiter_error(self):
+        self.counter = 0
+
+        @InventoryErrorHandler.common_error_handler("wait for instances")
+        def raise_waiter_error():
+            self.counter += 1
+            raise botocore.exceptions.WaiterError(
+                name="InstanceRunning",
+                reason="Max attempts exceeded",
+                last_response={},
+            )
+
+        with pytest.raises(AnsibleInventoryAWSError) as e_info:
+            raise_waiter_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.WaiterError)
+        assert "Timeout trying to wait for instances" in raised.message
+
+    def test_permissions_error_unauthorized(self):
+        self.counter = 0
+        err_response = {
+            "Error": {
+                "Code": "UnauthorizedOperation",
+                "Message": "You are not authorized to perform this operation",
+            },
+            "ResponseMetadata": {"HTTPStatusCode": 403},
+        }
+
+        @InventoryErrorHandler.common_error_handler("describe instances")
+        def raise_client_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "DescribeInstances")
+
+        with pytest.raises(AnsibleInventoryPermissionsError) as e_info:
+            raise_client_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "describe instances" in raised.message
+        assert "permission denied" in raised.message
+        assert "DescribeInstances" in str(raised.exception)
+
+    def test_permissions_error_http_403(self):
+        """Test that HTTP 403 status code raises AnsibleInventoryPermissionsError"""
+        self.counter = 0
+        err_response = {
+            "Error": {
+                "Code": "AccessDenied",
+                "Message": "Access Denied",
+            },
+            "ResponseMetadata": {"HTTPStatusCode": 403},
+        }
+
+        @InventoryErrorHandler.common_error_handler("list hosted zones")
+        def raise_client_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "ListHostedZones")
+
+        with pytest.raises(AnsibleInventoryPermissionsError) as e_info:
+            raise_client_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "list hosted zones" in raised.message
+        assert "permission denied" in raised.message
+        assert "ListHostedZones" in str(raised.exception)
+
+    def test_botocore_error(self):
+        self.counter = 0
+
+        @InventoryErrorHandler.common_error_handler("connect to endpoint")
+        def raise_connection_error():
+            self.counter += 1
+            raise botocore.exceptions.EndpointConnectionError(endpoint_url="https://ec2.us-east-1.amazonaws.com")
+
+        with pytest.raises(AnsibleInventoryAWSError) as e_info:
+            raise_connection_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.BotoCoreError)
+        assert "connect to endpoint" in raised.message
+        assert "ec2.us-east-1.amazonaws.com" in str(raised.exception)
+
+
+class TestInventoryListHandler:
+    def test_no_failures(self):
+        self.counter = 0
+
+        @InventoryErrorHandler.list_error_handler("no error")
+        def no_failures():
+            self.counter += 1
+
+        no_failures()
+        assert self.counter == 1
+
+    def test_client_error(self):
+        self.counter = 0
+        err_response = {
+            "Error": {
+                "Code": "ValidationException",
+                "Message": "Validation failed",
+            }
+        }
+
+        @InventoryErrorHandler.list_error_handler("get inventory")
+        def raise_client_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "GetInventory")
+
+        with pytest.raises(AnsibleInventoryAWSError) as e_info:
+            raise_client_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "get inventory" in raised.message
+        assert "GetInventory" in str(raised.exception)
+
+    def test_list_error(self):
+        self.counter = 0
+        err_response = {
+            "Error": {
+                "Code": "ResourceNotFoundException",
+                "Message": "Resource not found",
+            }
+        }
+
+        @InventoryErrorHandler.list_error_handler("get hosted zone")
+        def raise_client_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "GetHostedZone")
+
+        ret_val = raise_client_error()
+        assert self.counter == 1
+        assert ret_val is None
+
+    def test_list_error_with_default(self):
+        self.counter = 0
+        err_response = {
+            "Error": {
+                "Code": "NoSuchEntity",
+                "Message": "Entity not found",
+            }
+        }
+
+        @InventoryErrorHandler.list_error_handler("list records", default_value=[])
+        def raise_client_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "ListResourceRecordSets")
+
+        ret_val = raise_client_error()
+        assert self.counter == 1
+        assert ret_val == []
+
+    def test_permissions_error_not_silenced(self):
+        """Test that permission errors are NOT silenced by list_error_handler"""
+        self.counter = 0
+        err_response = {
+            "Error": {
+                "Code": "UnauthorizedOperation",
+                "Message": "You are not authorized",
+            },
+            "ResponseMetadata": {"HTTPStatusCode": 403},
+        }
+
+        @InventoryErrorHandler.list_error_handler("describe instances")
+        def raise_client_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "DescribeInstances")
+
+        with pytest.raises(AnsibleInventoryPermissionsError) as e_info:
+            raise_client_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "permission denied" in raised.message


### PR DESCRIPTION
##### SUMMARY

This PR refactors the aws_ec2 and aws_rds inventory plugins to improve code quality and address SonarCloud code-smells:

- Introduces centralised `InventoryErrorHandler` following the S3ErrorHandler pattern for consistent error handling across inventory plugins
- Reduces cognitive complexity in aws_ec2 hostname processing methods by extracting helper methods
- Adds comprehensive unit tests for inventory error handling
- Cleans up retry decorator usage by removing redundant retries from paginated functions (paginators have built-in retry logic)
- Adds type hints and docstrings to inventory plugin helper functions for improved code documentation
- Adds availability zone name to placement information


##### ISSUE TYPE

Feature Pull Request

##### COMPONENT NAME

aws_ec2 and aws_rds inventory plugins

##### ADDITIONAL INFORMATION

Also pulls in #1651 
Fixes: #1550
Fixes: #1651

Additional thanks to @timchenko-a for the work in #1651

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>