### PR TITLE
ec2_instance - Remove placement_group and tenancy parameters

### DIFF
--- a/changelogs/fragments/ec2-instance-remove-overdue-deprecations.yml
+++ b/changelogs/fragments/ec2-instance-remove-overdue-deprecations.yml
@@ -1,3 +1,3 @@
 breaking_changes:
-  - ec2_instance - removed the ``placement_group`` parameter. The parameter was deprecated in release 7.0.0. Use ``placement.group_name`` instead (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
-  - ec2_instance - removed the ``tenancy`` parameter. The parameter was deprecated in release 7.0.0. Use ``placement.tenancy`` instead (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - ec2_instance - removed the ``placement_group`` parameter. The parameter was deprecated in release 7.0.0. Use ``placement.group_name`` instead (https://github.com/ansible-collections/amazon.aws/pull/2937).
+  - ec2_instance - removed the ``tenancy`` parameter. The parameter was deprecated in release 7.0.0. Use ``placement.tenancy`` instead (https://github.com/ansible-collections/amazon.aws/pull/2937).

--- a/changelogs/fragments/ec2-instance-remove-overdue-deprecations.yml
+++ b/changelogs/fragments/ec2-instance-remove-overdue-deprecations.yml
@@ -1,0 +1,3 @@
+breaking_changes:
+  - ec2_instance - removed the ``placement_group`` parameter. The parameter was deprecated in release 7.0.0. Use ``placement.group_name`` instead (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - ec2_instance - removed the ``tenancy`` parameter. The parameter was deprecated in release 7.0.0. Use ``placement.tenancy`` instead (https://github.com/ansible-collections/amazon.aws/pull/XXXX).

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -354,12 +354,6 @@ options:
       - Whether to stop or terminate an instance upon shutdown.
     choices: ['stop', 'terminate']
     type: str
-  tenancy:
-    description:
-      - What type of tenancy to allow an instance to use. Default is V(shared) tenancy. Dedicated tenancy will incur additional charges.
-      - This field is deprecated and will be removed in a release after 2025-12-01, use O(placement) instead.
-    choices: ['dedicated', 'default']
-    type: str
   termination_protection:
     description:
       - Whether to enable termination protection.
@@ -422,11 +416,6 @@ options:
       - If no full ARN is provided, the role with a matching name will be used from the active AWS account.
     type: str
     aliases: ['instance_role']
-  placement_group:
-    description:
-      - The placement group that needs to be assigned to the instance.
-      - This field is deprecated and will be removed in a release after 2025-12-01, use O(placement) instead.
-    type: str
   placement:
     description:
       - The location where the instance launched, if applicable.
@@ -1712,13 +1701,6 @@ def build_top_level_options(module: AnsibleAWSModule) -> Dict[str, Any]:
         spec["Monitoring"] = {"Enabled": True}
     if params.get("cpu_credit_specification") is not None:
         spec["CreditSpecification"] = {"CpuCredits": params.get("cpu_credit_specification")}
-    if params.get("tenancy") is not None:
-        spec["Placement"] = {"Tenancy": params.get("tenancy")}
-    if params.get("placement_group"):
-        if "Placement" in spec:
-            spec["Placement"]["GroupName"] = str(params.get("placement_group"))
-        else:
-            spec.setdefault("Placement", {"GroupName": str(params.get("placement_group"))})
     if params.get("placement") is not None:
         spec["Placement"] = {}
         if params.get("placement").get("availability_zone") is not None:
@@ -2730,8 +2712,6 @@ def main():
                 threads_per_core=dict(type="int", choices=[1, 2], required=True),
             ),
         ),
-        tenancy=dict(type="str", choices=["dedicated", "default"]),
-        placement_group=dict(type="str"),
         placement=dict(
             type="dict",
             options=dict(
@@ -2802,8 +2782,6 @@ def main():
             ["image_id", "image"],
             ["exact_count", "count"],
             ["exact_count", "instance_ids"],
-            ["tenancy", "placement"],
-            ["placement_group", "placement"],
             ["network", "network_interfaces"],
             ["network", "network_interfaces_ids"],
             ["security_group", "network_interfaces_ids"],
@@ -2832,20 +2810,6 @@ def main():
             module.warn(
                 "the source_dest_check option has been set therefore network.source_dest_check will be ignored."
             )
-
-    if module.params.get("placement_group"):
-        module.deprecate(
-            "The placement_group parameter has been deprecated, please use placement.group_name instead.",
-            date="2025-12-01",
-            collection_name="amazon.aws",
-        )
-
-    if module.params.get("tenancy"):
-        module.deprecate(
-            "The tenancy parameter has been deprecated, please use placement.tenancy instead.",
-            date="2025-12-01",
-            collection_name="amazon.aws",
-        )
 
     state = module.params.get("state")
 

--- a/plugins/modules/ec2_instance.py
+++ b/plugins/modules/ec2_instance.py
@@ -449,7 +449,7 @@ options:
       tenancy:
         description:
           - Type of tenancy to allow an instance to use. Default is shared tenancy. Dedicated tenancy will incur additional charges.
-          - Support for O(tenancy=host) was added in amazon.aws 7.6.0.
+          - Support for O(placement.tenancy=host) was added in amazon.aws 7.6.0.
         type: str
         required: false
         choices: ['dedicated', 'default', 'host']


### PR DESCRIPTION
##### SUMMARY
Removes two deprecations from the ec2_instance module that were deprecated in release 7.0.0 with a scheduled removal date of 2025-12-01 (122 days overdue):

- **placement_group parameter**: Users must use `placement.group_name` instead
- **tenancy parameter**: Users must use `placement.tenancy` instead

Both features had their deprecation period end on 2025-12-01. Users should have migrated to the new `placement` parameter structure as documented in the deprecation warnings.

This is part of the deprecation cleanup effort for the anticipated May 2026 major release.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
ec2_instance

##### ADDITIONAL INFORMATION
- All module documentation, argument specifications, mutually exclusive constraints, and implementation code for the deprecated parameters have been removed
- Integration tests already use the new `placement` parameter syntax and require no updates
- All precommit and prepush checks passed (format, lint, unit tests newest/oldest, sanity tests)

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>