### PR TITLE
Fix listener rule sorting in ELB modules

### DIFF
--- a/changelogs/fragments/2939-elb-rules-sorting.yml
+++ b/changelogs/fragments/2939-elb-rules-sorting.yml
@@ -1,0 +1,3 @@
+bugfixes:
+  - elb_application_lb - Listener rules are now returned sorted by priority with the default rule appearing last (https://github.com/ansible-collections/amazon.aws/issues/2939).
+  - elb_application_lb_info - Listener rules are now returned sorted by priority with the default rule appearing last (https://github.com/ansible-collections/amazon.aws/issues/2939).

--- a/changelogs/fragments/2939-elb-rules-sorting.yml
+++ b/changelogs/fragments/2939-elb-rules-sorting.yml
@@ -1,3 +1,5 @@
 bugfixes:
   - elb_application_lb - Listener rules are now returned sorted by priority with the default rule appearing last (https://github.com/ansible-collections/amazon.aws/issues/2939).
   - elb_application_lb_info - Listener rules are now returned sorted by priority with the default rule appearing last (https://github.com/ansible-collections/amazon.aws/issues/2939).
+minor_changes:
+  - elb_application_lb_info - Fixed return value documentation to correctly reflect actual types and added missing fields (https://github.com/ansible-collections/amazon.aws/issues/2939).

--- a/plugins/module_utils/_elbv2/transformations.py
+++ b/plugins/module_utils/_elbv2/transformations.py
@@ -46,18 +46,67 @@ def _normalize_attributes(attributes: BotoResourceList) -> Dict[str, str]:
     return {k.replace(".", "_"): v for k, v in attrs_dict.items()}
 
 
+def _sort_actions(actions: BotoResourceList) -> BotoResourceList:
+    """
+    Sort ELB listener actions by Order and Type.
+
+    Sorts actions by Order field (defaulting to 0), then by Type for stability.
+    This ensures consistent ordering and avoids comparing dict/None which causes TypeError.
+
+    Parameters:
+        actions (list): List of action dicts from boto3
+
+    Returns:
+        List of actions sorted by Order and Type
+    """
+    if not actions:
+        return actions
+
+    return sorted(
+        actions,
+        key=lambda x: (
+            x.get("Order", 0),
+            x.get("Type", ""),
+        ),
+    )
+
+
+def _normalize_listener_actions(actions: BotoResourceList) -> AnsibleAWSResourceList:
+    """
+    Normalize and sort ELB listener actions by Order and Type.
+
+    Converts actions from the CamelCase boto3 format to the snake_case Ansible format
+    and sorts them by Order (defaulting to 0) then Type for stability.
+
+    Parameters:
+        actions (list): List of listener actions from boto3
+
+    Returns:
+        List of actions in Ansible format, sorted by Order and Type
+    """
+    if not actions:
+        return actions
+
+    # Sort actions before conversion
+    sorted_actions = _sort_actions(actions)
+
+    # Convert to Ansible dict format (force_tags=False to prevent automatic tags field)
+    return boto3_resource_list_to_ansible_dict(sorted_actions, force_tags=False)
+
+
 def _normalize_listener_rules(rules: BotoResourceList) -> AnsibleAWSResourceList:
     """
     Normalize and sort ELB listener rules by priority.
 
     Converts listener rules from the CamelCase boto3 format to the snake_case Ansible format
     and sorts them numerically by priority, with the "default" rule appearing last.
+    Actions within each rule are also sorted by Order and Type.
 
     Parameters:
         rules (list): List of listener rules from boto3
 
     Returns:
-        List of rules in Ansible format, sorted by priority
+        List of rules in Ansible format, sorted by priority with sorted actions
     """
     if not rules:
         return rules
@@ -76,27 +125,36 @@ def _normalize_listener_rules(rules: BotoResourceList) -> AnsibleAWSResourceList
 
     sorted_rules = sorted(rules, key=sort_key)
 
-    # Convert to Ansible dict format (force_tags=False to prevent automatic tags field)
-    return boto3_resource_list_to_ansible_dict(sorted_rules, force_tags=False)
+    # Convert to Ansible dict format, also sorting Actions within each rule
+    # (force_tags=False to prevent automatic tags field)
+    transforms = {"Actions": _normalize_listener_actions}
+    return [
+        boto3_resource_to_ansible_dict(rule, nested_transforms=transforms, force_tags=False) for rule in sorted_rules
+    ]
 
 
 def _normalize_listeners(listeners: BotoResourceList) -> AnsibleAWSResourceList:
     """
     Normalize ELB listeners.
 
-    Converts listeners from boto3 format to Ansible format, applying rule sorting.
+    Converts listeners from boto3 format to Ansible format, applying action and rule sorting.
+    DefaultActions are sorted by Order and Type for consistent output.
 
     Parameters:
         listeners (list): List of listeners from boto3
 
     Returns:
-        List of listeners in Ansible format with sorted rules
+        List of listeners in Ansible format with sorted default actions and sorted rules
     """
     if not listeners:
         return listeners
 
-    # Transform each listener, applying nested transforms to Rules (force_tags=False to prevent automatic tags field)
-    transforms = {"Rules": _normalize_listener_rules}
+    # Transform each listener, applying nested transforms to DefaultActions and Rules
+    # (force_tags=False to prevent automatic tags field)
+    transforms = {
+        "DefaultActions": _normalize_listener_actions,
+        "Rules": _normalize_listener_rules,
+    }
     return [
         boto3_resource_to_ansible_dict(listener, nested_transforms=transforms, force_tags=False)
         for listener in listeners

--- a/plugins/module_utils/_elbv2/transformations.py
+++ b/plugins/module_utils/_elbv2/transformations.py
@@ -16,8 +16,34 @@ if typing.TYPE_CHECKING:
     from ..transformation import BotoResource
     from ..transformation import BotoResourceList
 
+from ..tagging import boto3_tag_list_to_ansible_dict
 from ..transformation import boto3_resource_list_to_ansible_dict
 from ..transformation import boto3_resource_to_ansible_dict
+
+
+def _normalize_attributes(attributes: BotoResourceList) -> Dict[str, str]:
+    """
+    Normalize ELB load balancer attributes from boto3 format to Ansible format.
+
+    Converts attributes from the list of Key/Value dicts returned by
+    describe_load_balancer_attributes to a flat dict with underscored keys.
+
+    Parameters:
+        attributes (list): List of attribute dicts from boto3, format:
+            [{"Key": "access_logs.s3.enabled", "Value": "true"}, ...]
+
+    Returns:
+        Dict with underscored keys and string values:
+            {"access_logs_s3_enabled": "true", ...}
+    """
+    if not attributes:
+        return {}
+
+    # Convert from boto3 format [{"Key": "...", "Value": "..."}] to dict
+    attrs_dict = boto3_tag_list_to_ansible_dict(attributes)
+
+    # Replace '.' with '_' in attribute keys to make it more Ansibley
+    return {k.replace(".", "_"): v for k, v in attrs_dict.items()}
 
 
 def _normalize_listener_rules(rules: BotoResourceList) -> AnsibleAWSResourceList:
@@ -71,7 +97,10 @@ def _normalize_listeners(listeners: BotoResourceList) -> AnsibleAWSResourceList:
 
     # Transform each listener, applying nested transforms to Rules (force_tags=False to prevent automatic tags field)
     transforms = {"Rules": _normalize_listener_rules}
-    return [boto3_resource_to_ansible_dict(listener, nested_transforms=transforms, force_tags=False) for listener in listeners]
+    return [
+        boto3_resource_to_ansible_dict(listener, nested_transforms=transforms, force_tags=False)
+        for listener in listeners
+    ]
 
 
 def normalize_application_load_balancer(alb: BotoResource) -> AnsibleAWSResource:
@@ -80,6 +109,9 @@ def normalize_application_load_balancer(alb: BotoResource) -> AnsibleAWSResource
 
     Handles conversion of the ALB and its nested listeners and rules. Listener rules
     are sorted by priority with the "default" rule appearing last.
+
+    If the ALB dict contains an "Attributes" key (from describe_load_balancer_attributes),
+    the attributes will be converted and merged as flat fields into the result.
 
     Parameters:
         alb (dict): Application Load Balancer dict in boto3 format
@@ -90,6 +122,20 @@ def normalize_application_load_balancer(alb: BotoResource) -> AnsibleAWSResource
     if not alb:
         return alb
 
+    # Make a copy to avoid modifying the original
+    alb_copy = alb.copy()
+
+    # Extract and normalize attributes separately (they get flattened into the result)
+    attributes = None
+    if "Attributes" in alb_copy:
+        attributes = _normalize_attributes(alb_copy.pop("Attributes"))
+
     # Transform the ALB, applying nested transforms to Listeners
     transforms = {"Listeners": _normalize_listeners}
-    return boto3_resource_to_ansible_dict(alb, nested_transforms=transforms)
+    result = boto3_resource_to_ansible_dict(alb_copy, nested_transforms=transforms)
+
+    # Merge normalized attributes as flat fields
+    if attributes:
+        result.update(attributes)
+
+    return result

--- a/plugins/module_utils/_elbv2/transformations.py
+++ b/plugins/module_utils/_elbv2/transformations.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import Dict
+    from typing import List
+
+    from ..transformation import AnsibleAWSResource
+    from ..transformation import AnsibleAWSResourceList
+    from ..transformation import BotoResource
+    from ..transformation import BotoResourceList
+
+from ..transformation import boto3_resource_list_to_ansible_dict
+from ..transformation import boto3_resource_to_ansible_dict
+
+
+def _normalize_listener_rules(rules: BotoResourceList) -> AnsibleAWSResourceList:
+    """
+    Normalize and sort ELB listener rules by priority.
+
+    Converts listener rules from the CamelCase boto3 format to the snake_case Ansible format
+    and sorts them numerically by priority, with the "default" rule appearing last.
+
+    Parameters:
+        rules (list): List of listener rules from boto3
+
+    Returns:
+        List of rules in Ansible format, sorted by priority
+    """
+    if not rules:
+        return rules
+
+    # First sort the rules by Priority (while still in CamelCase)
+    def sort_key(rule):
+        priority = rule.get("Priority", "default")
+        if priority == "default":
+            # Put default rule last by using a very large number
+            return float("inf")
+        try:
+            return int(priority)
+        except (ValueError, TypeError):
+            # Fallback for unexpected priority values
+            return float("inf")
+
+    sorted_rules = sorted(rules, key=sort_key)
+
+    # Convert to Ansible dict format (force_tags=False to prevent automatic tags field)
+    return boto3_resource_list_to_ansible_dict(sorted_rules, force_tags=False)
+
+
+def _normalize_listeners(listeners: BotoResourceList) -> AnsibleAWSResourceList:
+    """
+    Normalize ELB listeners.
+
+    Converts listeners from boto3 format to Ansible format, applying rule sorting.
+
+    Parameters:
+        listeners (list): List of listeners from boto3
+
+    Returns:
+        List of listeners in Ansible format with sorted rules
+    """
+    if not listeners:
+        return listeners
+
+    # Transform each listener, applying nested transforms to Rules (force_tags=False to prevent automatic tags field)
+    transforms = {"Rules": _normalize_listener_rules}
+    return [boto3_resource_to_ansible_dict(listener, nested_transforms=transforms, force_tags=False) for listener in listeners]
+
+
+def normalize_application_load_balancer(alb: BotoResource) -> AnsibleAWSResource:
+    """
+    Normalize an Application Load Balancer from boto3 format to Ansible format.
+
+    Handles conversion of the ALB and its nested listeners and rules. Listener rules
+    are sorted by priority with the "default" rule appearing last.
+
+    Parameters:
+        alb (dict): Application Load Balancer dict in boto3 format
+
+    Returns:
+        Normalized ALB dict in Ansible format
+    """
+    if not alb:
+        return alb
+
+    # Transform the ALB, applying nested transforms to Listeners
+    transforms = {"Listeners": _normalize_listeners}
+    return boto3_resource_to_ansible_dict(alb, nested_transforms=transforms)

--- a/plugins/module_utils/_elbv2/transformations.py
+++ b/plugins/module_utils/_elbv2/transformations.py
@@ -189,8 +189,9 @@ def normalize_application_load_balancer(alb: BotoResource) -> AnsibleAWSResource
         attributes = _normalize_attributes(alb_copy.pop("Attributes"))
 
     # Transform the ALB, applying nested transforms to Listeners
+    # force_tags=False because tags require a separate API call and should be added by caller
     transforms = {"Listeners": _normalize_listeners}
-    result = boto3_resource_to_ansible_dict(alb_copy, nested_transforms=transforms)
+    result = boto3_resource_to_ansible_dict(alb_copy, nested_transforms=transforms, force_tags=False)
 
     # Merge normalized attributes as flat fields
     if attributes:

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -208,22 +208,6 @@ def _append_use_existing_client_secretn(action: Dict[str, Any]) -> Dict[str, Any
     return action
 
 
-def _sort_actions(actions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    return sorted(actions, key=lambda x: x.get("Order", 0))
-
-
-def _sort_listener_actions(actions: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
-    # Sort by Order field (defaulting to 0), then by Type for stability.
-    # This avoids comparing dict/None which causes TypeError.
-    return sorted(
-        actions,
-        key=lambda x: (
-            x.get("Order", 0),
-            x.get("Type", ""),
-        ),
-    )
-
-
 class ElasticLoadBalancerV2:
     def __init__(self, connection: Any, module: AnsibleAWSModule) -> None:
         self.connection = connection
@@ -1122,8 +1106,8 @@ def _compare_rule_actions(current_actions: List[Dict[str, Any]], new_actions: Li
 
     # if actions have just one element, compare the contents and then update if
     # they're different
-    current_actions_sorted = _sort_actions(current_actions)
-    new_actions_sorted = _sort_actions(deepcopy(new_actions))
+    current_actions_sorted = _transformations._sort_actions(current_actions)
+    new_actions_sorted = _transformations._sort_actions(deepcopy(new_actions))
 
     new_current_actions_sorted = [_append_use_existing_client_secretn(i) for i in current_actions_sorted]
     new_actions_sorted_no_secret = [_prune_secret(i) for i in new_actions_sorted]

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -18,6 +18,8 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
+# Not intended for general re-use / re-import
+from ._elbv2 import transformations as _transformations
 from .ec2 import get_ec2_security_group_ids_from_names
 from .elb_utils import AnsibleELBv2Error
 from .elb_utils import add_listener_certificates
@@ -48,6 +50,9 @@ from .tagging import ansible_dict_to_boto3_tag_list
 from .tagging import boto3_tag_list_to_ansible_dict
 from .transformation import scrub_none_parameters
 from .waiters import get_waiter
+
+# Expose transformation functions
+normalize_application_load_balancer = _transformations.normalize_application_load_balancer
 
 
 def _simple_forward_config_arn(config: Dict[str, Any], parent_arn: Optional[str]) -> Optional[str]:

--- a/plugins/module_utils/elbv2.py
+++ b/plugins/module_utils/elbv2.py
@@ -55,6 +55,54 @@ from .waiters import get_waiter
 normalize_application_load_balancer = _transformations.normalize_application_load_balancer
 
 
+def build_application_load_balancer_description(
+    connection: Any,
+    load_balancer: Dict[str, Any],
+    include_attributes: bool = True,
+    include_listeners: bool = True,
+    include_listener_rules: bool = True,
+) -> Dict[str, Any]:
+    """
+    Build a complete ALB description with optional attributes, listeners, and rules.
+
+    Takes a base load balancer dict from describe_load_balancers and enriches it with
+    additional information based on the include_* parameters, then normalizes the result.
+
+    Args:
+        connection: boto3 elbv2 connection
+        load_balancer: Base ALB dict from describe_load_balancers (in CamelCase boto3 format)
+        include_attributes: Whether to fetch and attach load balancer attributes
+        include_listeners: Whether to fetch and attach listeners
+        include_listener_rules: Whether to fetch and attach rules to each listener
+
+    Returns:
+        Normalized ALB dict in snake_case Ansible format
+
+    Note:
+        This function does not fetch tags. Tags should be handled separately by the caller
+        as they require a separate API call and may be added before or after normalization
+        depending on the use case.
+    """
+    # Make a copy to avoid modifying the original
+    alb = load_balancer.copy()
+
+    # Optionally add attributes (in raw boto3 format, normalization will convert them)
+    if include_attributes:
+        alb["Attributes"] = describe_load_balancer_attributes(connection, alb["LoadBalancerArn"])
+
+    # Optionally add listeners
+    if include_listeners or include_listener_rules:
+        alb["Listeners"] = describe_listeners(connection, load_balancer_arn=alb["LoadBalancerArn"])
+
+        # Optionally add rules to each listener
+        if include_listener_rules:
+            for listener in alb["Listeners"]:
+                listener["Rules"] = describe_rules(connection, ListenerArn=listener["ListenerArn"])
+
+    # Normalize the entire ALB object (convert to snake_case, sort rules, convert tags)
+    return normalize_application_load_balancer(alb)
+
+
 def _simple_forward_config_arn(config: Dict[str, Any], parent_arn: Optional[str]) -> Optional[str]:
     config = deepcopy(config)
 

--- a/plugins/modules/elb_application_lb.py
+++ b/plugins/modules/elb_application_lb.py
@@ -950,6 +950,9 @@ def create_or_update_alb(alb_obj: ApplicationLoadBalancer) -> None:
     # Add ip address type
     alb["IpAddressType"] = alb_obj.get_elb_ip_address_type()
 
+    # Add tags (not included in describe_load_balancers response)
+    alb["Tags"] = alb_obj.get_elb_tags()
+
     # Normalize the entire ALB object (convert to snake_case, sort rules, convert tags)
     snaked_alb = normalize_application_load_balancer(alb)
 

--- a/plugins/modules/elb_application_lb.py
+++ b/plugins/modules/elb_application_lb.py
@@ -763,8 +763,6 @@ try:
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
-from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-
 from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import AnsibleELBv2Error
 from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import get_elb_listener_rules
 from ansible_collections.amazon.aws.plugins.module_utils.elbv2 import ApplicationLoadBalancer
@@ -772,6 +770,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.elbv2 import ELBListene
 from ansible_collections.amazon.aws.plugins.module_utils.elbv2 import ELBListenerRule
 from ansible_collections.amazon.aws.plugins.module_utils.elbv2 import ELBListenerRules
 from ansible_collections.amazon.aws.plugins.module_utils.elbv2 import ELBListeners
+from ansible_collections.amazon.aws.plugins.module_utils.elbv2 import normalize_application_load_balancer
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
@@ -937,20 +936,22 @@ def create_or_update_alb(alb_obj: ApplicationLoadBalancer) -> None:
     # Update the ALB attributes
     alb_obj.update_elb_attributes()
 
-    # Convert to snake_case and merge in everything we want to return to the user
-    snaked_alb = camel_dict_to_snake_dict(alb_obj.elb)
-    snaked_alb.update(camel_dict_to_snake_dict(alb_obj.elb_attributes))
-    snaked_alb["listeners"] = []
+    # Build the complete ALB object in CamelCase format
+    alb = alb_obj.elb.copy()
+    alb.update(alb_obj.elb_attributes)
+
+    # Attach listeners with their rules
+    alb["Listeners"] = []
     for listener in listeners_obj.current_listeners:
-        # For each listener, get listener rules
-        listener["rules"] = get_elb_listener_rules(alb_obj.connection, alb_obj.module, listener["ListenerArn"])
-        snaked_alb["listeners"].append(camel_dict_to_snake_dict(listener))
+        # For each listener, get listener rules (in CamelCase)
+        listener["Rules"] = get_elb_listener_rules(alb_obj.connection, alb_obj.module, listener["ListenerArn"])
+        alb["Listeners"].append(listener)
 
-    # Change tags to ansible friendly dict
-    snaked_alb["tags"] = boto3_tag_list_to_ansible_dict(snaked_alb["tags"])
+    # Add ip address type
+    alb["IpAddressType"] = alb_obj.get_elb_ip_address_type()
 
-    # ip address type
-    snaked_alb["ip_address_type"] = alb_obj.get_elb_ip_address_type()
+    # Normalize the entire ALB object (convert to snake_case, sort rules, convert tags)
+    snaked_alb = normalize_application_load_balancer(alb)
 
     alb_obj.exit_json(changed=alb_obj.changed, **snaked_alb)
 

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -406,29 +406,11 @@ except ImportError:
     pass  # Handled by AnsibleAWSModule
 
 from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import AnsibleELBv2Error
-from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import describe_listeners
-from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import describe_load_balancer_attributes
 from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import describe_load_balancers
-from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import describe_rules
 from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import describe_tags
-from ansible_collections.amazon.aws.plugins.module_utils.elbv2 import normalize_application_load_balancer
+from ansible_collections.amazon.aws.plugins.module_utils.elbv2 import build_application_load_balancer_description
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
-
-
-def get_load_balancer_attributes(connection, module: AnsibleAWSModule, load_balancer_arn: str) -> Dict[str, str]:
-    try:
-        attributes = describe_load_balancer_attributes(connection, load_balancer_arn)
-    except AnsibleELBv2Error as e:
-        module.fail_json_aws(e, msg="Failed to describe load balancer attributes")
-    load_balancer_attributes = boto3_tag_list_to_ansible_dict(attributes)
-
-    # Replace '.' with '_' in attribute key names to make it more Ansibley
-    for k, v in list(load_balancer_attributes.items()):
-        load_balancer_attributes[k.replace(".", "_")] = v
-        del load_balancer_attributes[k]
-
-    return load_balancer_attributes
 
 
 def get_load_balancer_tags(connection, load_balancer_arn: str) -> Dict[str, str]:
@@ -445,24 +427,18 @@ def list_load_balancers(connection, module: AnsibleAWSModule) -> None:
 
     try:
         load_balancers = describe_load_balancers(connection, load_balancer_arns=load_balancer_arns, names=names)
-        for load_balancer in load_balancers:
-            # Get the attributes for each alb
-            if include_attributes:
-                load_balancer.update(get_load_balancer_attributes(connection, module, load_balancer["LoadBalancerArn"]))
 
-            # Get the listeners for each alb
-            if include_listeners or include_listener_rules:
-                load_balancer["Listeners"] = describe_listeners(
-                    connection, load_balancer_arn=load_balancer["LoadBalancerArn"]
-                )
-
-            # For each listener, get listener rules
-            if include_listener_rules:
-                for listener in load_balancer["Listeners"]:
-                    listener["Rules"] = describe_rules(connection, ListenerArn=listener["ListenerArn"])
-
-        # Normalize each load balancer (convert to snake_case, sort rules, convert tags)
-        snaked_load_balancers = [normalize_application_load_balancer(lb) for lb in load_balancers]
+        # Build complete ALB descriptions with normalization
+        snaked_load_balancers = [
+            build_application_load_balancer_description(
+                connection,
+                lb,
+                include_attributes=include_attributes,
+                include_listeners=include_listeners,
+                include_listener_rules=include_listener_rules,
+            )
+            for lb in load_balancers
+        ]
 
         # Get tags for each load balancer (not included in the boto3 describe_load_balancers response)
         for snaked_load_balancer in snaked_load_balancers:

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -147,11 +147,31 @@ load_balancers:
             description: The date and time the load balancer was created.
             type: str
             sample: "2015-02-12T02:14:02+00:00"
+        client_keep_alive_seconds:
+            description: The client keep alive value, in seconds.
+            returned: when O(include_attributes=true)
+            type: str
+            sample: "3600"
+        connection_logs_s3_bucket:
+            description: The name of the S3 bucket for the connection logs.
+            returned: when O(include_attributes=true)
+            type: str
+            sample: ""
+        connection_logs_s3_enabled:
+            description: Indicates whether connection logs are enabled.
+            returned: when O(include_attributes=true)
+            type: str
+            sample: "false"
+        connection_logs_s3_prefix:
+            description: The prefix for the location in the S3 bucket for the connection logs.
+            returned: when O(include_attributes=true)
+            type: str
+            sample: ""
         deletion_protection_enabled:
             description: Indicates whether deletion protection is enabled.
             returned: when O(include_attributes=true)
-            type: bool
-            sample: true
+            type: str
+            sample: "true"
         dns_name:
             description: The public DNS name of the load balancer.
             type: str
@@ -159,12 +179,17 @@ load_balancers:
         idle_timeout_timeout_seconds:
             description: The idle timeout value, in seconds.
             returned: when O(include_attributes=true)
-            type: int
-            sample: 60
+            type: str
+            sample: "60"
         ip_address_type:
             description: The type of IP addresses used by the subnets for the load balancer.
             type: str
             sample: "ipv4"
+        ipv6_deny_all_igw_traffic:
+            description: Locks internet gateway (IGW) access to the load balancer.
+            returned: when O(include_attributes=true)
+            type: str
+            sample: "false"
         listeners:
             description: Information about the listeners.
             returned: when O(include_listeners=true) or O(include_listener_rules=true)
@@ -346,6 +371,13 @@ load_balancers:
             returned: when O(include_attributes=true)
             type: str
             sample: "false"
+        routing_http_preserve_host_header_enabled:
+            description:
+              - Indicates whether the Application Load Balancer should preserve the Host header in the HTTP request and send it to the target without any
+                change.
+            returned: when O(include_attributes=true)
+            type: str
+            sample: "false"
         routing_http_x_amzn_tls_version_and_cipher_suite_enabled:
             description: Indicates whether the two headers are added to the client request before sending it to the target.
             returned: when O(include_attributes=true)
@@ -356,6 +388,13 @@ load_balancers:
             returned: when O(include_attributes=true)
             type: str
             sample: "false"
+        routing_http_xff_header_processing_mode:
+            description:
+              - Enables you to modify, preserve, or remove the X-Forwarded-For header in the HTTP request before the Application Load Balancer sends the
+                request to the target.
+            returned: when O(include_attributes=true)
+            type: str
+            sample: "append"
         scheme:
             description: Internet-facing or internal load balancer.
             type: str

--- a/plugins/modules/elb_application_lb_info.py
+++ b/plugins/modules/elb_application_lb_info.py
@@ -405,14 +405,13 @@ try:
 except ImportError:
     pass  # Handled by AnsibleAWSModule
 
-from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-
 from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import AnsibleELBv2Error
 from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import describe_listeners
 from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import describe_load_balancer_attributes
 from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import describe_load_balancers
 from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import describe_rules
 from ansible_collections.amazon.aws.plugins.module_utils.elb_utils import describe_tags
+from ansible_collections.amazon.aws.plugins.module_utils.elbv2 import normalize_application_load_balancer
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
@@ -453,19 +452,19 @@ def list_load_balancers(connection, module: AnsibleAWSModule) -> None:
 
             # Get the listeners for each alb
             if include_listeners or include_listener_rules:
-                load_balancer["listeners"] = describe_listeners(
+                load_balancer["Listeners"] = describe_listeners(
                     connection, load_balancer_arn=load_balancer["LoadBalancerArn"]
                 )
 
             # For each listener, get listener rules
             if include_listener_rules:
-                for listener in load_balancer["listeners"]:
-                    listener["rules"] = describe_rules(connection, ListenerArn=listener["ListenerArn"])
+                for listener in load_balancer["Listeners"]:
+                    listener["Rules"] = describe_rules(connection, ListenerArn=listener["ListenerArn"])
 
-        # Turn the boto3 result in to ansible_friendly_snaked_names
-        snaked_load_balancers = [camel_dict_to_snake_dict(load_balancer) for load_balancer in load_balancers]
+        # Normalize each load balancer (convert to snake_case, sort rules, convert tags)
+        snaked_load_balancers = [normalize_application_load_balancer(lb) for lb in load_balancers]
 
-        # Get tags for each load balancer
+        # Get tags for each load balancer (not included in the boto3 describe_load_balancers response)
         for snaked_load_balancer in snaked_load_balancers:
             snaked_load_balancer["tags"] = get_load_balancer_tags(connection, snaked_load_balancer["load_balancer_arn"])
     except AnsibleELBv2Error as e:

--- a/tests/unit/plugins/module_utils/_elbv2/test_alb_transformations.py
+++ b/tests/unit/plugins/module_utils/_elbv2/test_alb_transformations.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations import _normalize_listener_rules
+from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations import _normalize_listeners
+from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations import (
+    normalize_application_load_balancer,
+)
+
+# The various normalize_ functions are based upon ..transformation.boto3_resource_to_ansible_dict
+# As such these tests will be relatively light touch.
+
+
+class TestNormalizeListenerRules:
+    def test_sort_listener_rules_by_priority(self):
+        """Test that listener rules are sorted numerically by priority"""
+        INPUT = [
+            {"RuleArn": "arn:aws:elasticloadbalancing:::rule/3", "Priority": "10", "IsDefault": False},
+            {"RuleArn": "arn:aws:elasticloadbalancing:::rule/1", "Priority": "1", "IsDefault": False},
+            {"RuleArn": "arn:aws:elasticloadbalancing:::rule/4", "Priority": "default", "IsDefault": True},
+            {"RuleArn": "arn:aws:elasticloadbalancing:::rule/2", "Priority": "5", "IsDefault": False},
+        ]
+        OUTPUT = [
+            {"rule_arn": "arn:aws:elasticloadbalancing:::rule/1", "priority": "1", "is_default": False},
+            {"rule_arn": "arn:aws:elasticloadbalancing:::rule/2", "priority": "5", "is_default": False},
+            {"rule_arn": "arn:aws:elasticloadbalancing:::rule/3", "priority": "10", "is_default": False},
+            {"rule_arn": "arn:aws:elasticloadbalancing:::rule/4", "priority": "default", "is_default": True},
+        ]
+
+        assert OUTPUT == _normalize_listener_rules(INPUT)
+
+    def test_default_rule_appears_last(self):
+        """Test that the default rule always appears last regardless of input order"""
+        INPUT = [
+            {"RuleArn": "arn:aws:elasticloadbalancing:::rule/1", "Priority": "default", "IsDefault": True},
+            {"RuleArn": "arn:aws:elasticloadbalancing:::rule/2", "Priority": "1", "IsDefault": False},
+            {"RuleArn": "arn:aws:elasticloadbalancing:::rule/3", "Priority": "2", "IsDefault": False},
+        ]
+        OUTPUT = [
+            {"rule_arn": "arn:aws:elasticloadbalancing:::rule/2", "priority": "1", "is_default": False},
+            {"rule_arn": "arn:aws:elasticloadbalancing:::rule/3", "priority": "2", "is_default": False},
+            {"rule_arn": "arn:aws:elasticloadbalancing:::rule/1", "priority": "default", "is_default": True},
+        ]
+
+        assert OUTPUT == _normalize_listener_rules(INPUT)
+
+    def test_empty_rules_list(self):
+        """Test that empty rules list is handled correctly"""
+        assert [] == _normalize_listener_rules([])
+
+    def test_none_rules_list(self):
+        """Test that None rules list is handled correctly"""
+        assert _normalize_listener_rules(None) is None
+
+
+class TestNormalizeListeners:
+    def test_normalize_listeners_with_rules(self):
+        """Test that listeners are normalized and rules are sorted"""
+        INPUT = [
+            {
+                "ListenerArn": "arn:aws:elasticloadbalancing:::listener/1",
+                "Port": 80,
+                "Protocol": "HTTP",
+                "Rules": [
+                    {"RuleArn": "arn:aws:elasticloadbalancing:::rule/2", "Priority": "5", "IsDefault": False},
+                    {"RuleArn": "arn:aws:elasticloadbalancing:::rule/1", "Priority": "1", "IsDefault": False},
+                    {"RuleArn": "arn:aws:elasticloadbalancing:::rule/3", "Priority": "default", "IsDefault": True},
+                ],
+            }
+        ]
+        OUTPUT = [
+            {
+                "listener_arn": "arn:aws:elasticloadbalancing:::listener/1",
+                "port": 80,
+                "protocol": "HTTP",
+                "rules": [
+                    {"rule_arn": "arn:aws:elasticloadbalancing:::rule/1", "priority": "1", "is_default": False},
+                    {"rule_arn": "arn:aws:elasticloadbalancing:::rule/2", "priority": "5", "is_default": False},
+                    {"rule_arn": "arn:aws:elasticloadbalancing:::rule/3", "priority": "default", "is_default": True},
+                ],
+            }
+        ]
+
+        assert OUTPUT == _normalize_listeners(INPUT)
+
+    def test_normalize_listeners_without_rules(self):
+        """Test that listeners without rules are handled correctly"""
+        INPUT = [
+            {
+                "ListenerArn": "arn:aws:elasticloadbalancing:::listener/1",
+                "Port": 443,
+                "Protocol": "HTTPS",
+            }
+        ]
+        OUTPUT = [
+            {
+                "listener_arn": "arn:aws:elasticloadbalancing:::listener/1",
+                "port": 443,
+                "protocol": "HTTPS",
+            }
+        ]
+
+        assert OUTPUT == _normalize_listeners(INPUT)
+
+
+class TestNormalizeApplicationLoadBalancer:
+    def test_normalize_application_load_balancer(self):
+        """Test complete ALB normalization with listeners and sorted rules"""
+        INPUT = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+            "IpAddressType": "ipv4",
+            "Tags": [
+                {"Key": "Name", "Value": "test-alb"},
+                {"Key": "Environment", "Value": "test"},
+            ],
+            "Listeners": [
+                {
+                    "ListenerArn": "arn:aws:elasticloadbalancing:::listener/1",
+                    "Port": 80,
+                    "Protocol": "HTTP",
+                    "Rules": [
+                        {"RuleArn": "arn:aws:elasticloadbalancing:::rule/3", "Priority": "default", "IsDefault": True},
+                        {"RuleArn": "arn:aws:elasticloadbalancing:::rule/1", "Priority": "1", "IsDefault": False},
+                        {"RuleArn": "arn:aws:elasticloadbalancing:::rule/2", "Priority": "10", "IsDefault": False},
+                    ],
+                }
+            ],
+        }
+        OUTPUT = {
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "load_balancer_name": "test-alb",
+            "ip_address_type": "ipv4",
+            "tags": {
+                "Name": "test-alb",
+                "Environment": "test",
+            },
+            "listeners": [
+                {
+                    "listener_arn": "arn:aws:elasticloadbalancing:::listener/1",
+                    "port": 80,
+                    "protocol": "HTTP",
+                    "rules": [
+                        {"rule_arn": "arn:aws:elasticloadbalancing:::rule/1", "priority": "1", "is_default": False},
+                        {"rule_arn": "arn:aws:elasticloadbalancing:::rule/2", "priority": "10", "is_default": False},
+                        {
+                            "rule_arn": "arn:aws:elasticloadbalancing:::rule/3",
+                            "priority": "default",
+                            "is_default": True,
+                        },
+                    ],
+                }
+            ],
+        }
+
+        assert OUTPUT == normalize_application_load_balancer(INPUT)
+
+    def test_normalize_alb_without_listeners(self):
+        """Test ALB normalization without listeners"""
+        INPUT = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+            "IpAddressType": "dualstack",
+        }
+        OUTPUT = {
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "load_balancer_name": "test-alb",
+            "ip_address_type": "dualstack",
+            "tags": {},
+        }
+
+        assert OUTPUT == normalize_application_load_balancer(INPUT)
+
+    def test_normalize_alb_with_empty_tags(self):
+        """Test ALB normalization with empty tags list converts to empty dict"""
+        INPUT = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+            "Tags": [],
+        }
+        OUTPUT = {
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "load_balancer_name": "test-alb",
+            "tags": {},
+        }
+
+        assert OUTPUT == normalize_application_load_balancer(INPUT)
+
+    def test_normalize_alb_without_tags(self):
+        """Test ALB normalization without Tags key"""
+        INPUT = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+        }
+        OUTPUT = {
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "load_balancer_name": "test-alb",
+            "tags": {},
+        }
+
+        assert OUTPUT == normalize_application_load_balancer(INPUT)
+
+    def test_normalize_none_alb(self):
+        """Test that None ALB is handled correctly"""
+        assert normalize_application_load_balancer(None) is None

--- a/tests/unit/plugins/module_utils/_elbv2/test_alb_transformations.py
+++ b/tests/unit/plugins/module_utils/_elbv2/test_alb_transformations.py
@@ -4,8 +4,10 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations import _normalize_attributes
+from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations import _normalize_listener_actions
 from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations import _normalize_listener_rules
 from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations import _normalize_listeners
+from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations import _sort_actions
 from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations import (
     normalize_application_load_balancer,
 )
@@ -39,6 +41,84 @@ class TestNormalizeAttributes:
     def test_normalize_attributes_handles_none(self):
         """Test that None attributes returns empty dict"""
         assert {} == _normalize_attributes(None)
+
+
+class TestSortActions:
+    def test_sort_actions_by_order(self):
+        """Test that actions are sorted by Order field"""
+        INPUT = [
+            {"Order": 3, "Type": "forward"},
+            {"Order": 1, "Type": "authenticate-oidc"},
+            {"Order": 2, "Type": "forward"},
+        ]
+        OUTPUT = [
+            {"Order": 1, "Type": "authenticate-oidc"},
+            {"Order": 2, "Type": "forward"},
+            {"Order": 3, "Type": "forward"},
+        ]
+
+        assert OUTPUT == _sort_actions(INPUT)
+
+    def test_sort_actions_by_order_and_type(self):
+        """Test that actions with same Order are sorted by Type for stability"""
+        INPUT = [
+            {"Order": 1, "Type": "forward"},
+            {"Order": 1, "Type": "authenticate-oidc"},
+            {"Order": 1, "Type": "fixed-response"},
+        ]
+        OUTPUT = [
+            {"Order": 1, "Type": "authenticate-oidc"},
+            {"Order": 1, "Type": "fixed-response"},
+            {"Order": 1, "Type": "forward"},
+        ]
+
+        assert OUTPUT == _sort_actions(INPUT)
+
+    def test_sort_actions_with_default_order(self):
+        """Test that actions without Order default to 0"""
+        INPUT = [
+            {"Type": "forward", "TargetGroupArn": "arn:aws:..."},
+            {"Order": 2, "Type": "authenticate-oidc"},
+            {"Order": 1, "Type": "fixed-response"},
+        ]
+        OUTPUT = [
+            {"Type": "forward", "TargetGroupArn": "arn:aws:..."},
+            {"Order": 1, "Type": "fixed-response"},
+            {"Order": 2, "Type": "authenticate-oidc"},
+        ]
+
+        assert OUTPUT == _sort_actions(INPUT)
+
+    def test_sort_actions_empty_list(self):
+        """Test that empty actions list is handled correctly"""
+        assert [] == _sort_actions([])
+
+    def test_sort_actions_none(self):
+        """Test that None actions list is handled correctly"""
+        assert _sort_actions(None) is None
+
+
+class TestNormalizeListenerActions:
+    def test_normalize_listener_actions_sorts_and_converts(self):
+        """Test that listener actions are sorted and converted to snake_case"""
+        INPUT = [
+            {"Order": 2, "Type": "forward", "TargetGroupArn": "arn:aws:...2"},
+            {"Order": 1, "Type": "authenticate-oidc", "AuthenticateOidcConfig": {}},
+        ]
+        OUTPUT = [
+            {"order": 1, "type": "authenticate-oidc", "authenticate_oidc_config": {}},
+            {"order": 2, "type": "forward", "target_group_arn": "arn:aws:...2"},
+        ]
+
+        assert OUTPUT == _normalize_listener_actions(INPUT)
+
+    def test_normalize_listener_actions_empty_list(self):
+        """Test that empty actions list is handled correctly"""
+        assert [] == _normalize_listener_actions([])
+
+    def test_normalize_listener_actions_none(self):
+        """Test that None actions list is handled correctly"""
+        assert _normalize_listener_actions(None) is None
 
 
 class TestNormalizeListenerRules:
@@ -127,6 +207,74 @@ class TestNormalizeListeners:
                 "listener_arn": "arn:aws:elasticloadbalancing:::listener/1",
                 "port": 443,
                 "protocol": "HTTPS",
+            }
+        ]
+
+        assert OUTPUT == _normalize_listeners(INPUT)
+
+    def test_normalize_listeners_with_default_actions(self):
+        """Test that DefaultActions are sorted by Order and Type"""
+        INPUT = [
+            {
+                "ListenerArn": "arn:aws:elasticloadbalancing:::listener/1",
+                "Port": 80,
+                "Protocol": "HTTP",
+                "DefaultActions": [
+                    {"Order": 2, "Type": "forward", "TargetGroupArn": "arn:aws:..."},
+                    {"Order": 1, "Type": "authenticate-oidc", "AuthenticateOidcConfig": {}},
+                ],
+            }
+        ]
+        OUTPUT = [
+            {
+                "listener_arn": "arn:aws:elasticloadbalancing:::listener/1",
+                "port": 80,
+                "protocol": "HTTP",
+                "default_actions": [
+                    {"order": 1, "type": "authenticate-oidc", "authenticate_oidc_config": {}},
+                    {"order": 2, "type": "forward", "target_group_arn": "arn:aws:..."},
+                ],
+            }
+        ]
+
+        assert OUTPUT == _normalize_listeners(INPUT)
+
+    def test_normalize_listeners_with_rules_containing_actions(self):
+        """Test that Actions within Rules are sorted by Order and Type"""
+        INPUT = [
+            {
+                "ListenerArn": "arn:aws:elasticloadbalancing:::listener/1",
+                "Port": 80,
+                "Protocol": "HTTP",
+                "Rules": [
+                    {
+                        "RuleArn": "arn:aws:elasticloadbalancing:::rule/1",
+                        "Priority": "1",
+                        "IsDefault": False,
+                        "Actions": [
+                            {"Order": 2, "Type": "forward", "TargetGroupArn": "arn:aws:..."},
+                            {"Order": 1, "Type": "authenticate-oidc", "AuthenticateOidcConfig": {}},
+                        ],
+                    },
+                ],
+            }
+        ]
+        OUTPUT = [
+            {
+                "listener_arn": "arn:aws:elasticloadbalancing:::listener/1",
+                "port": 80,
+                "protocol": "HTTP",
+                "rules": [
+                    {
+                        "rule_arn": "arn:aws:elasticloadbalancing:::rule/1",
+                        "priority": "1",
+                        "is_default": False,
+                        "actions": [
+                            {"order": 1, "type": "authenticate-oidc", "authenticate_oidc_config": {}},
+                            {"order": 2, "type": "forward", "target_group_arn": "arn:aws:..."},
+                        ],
+                    },
+                ],
             }
         ]
 

--- a/tests/unit/plugins/module_utils/_elbv2/test_alb_transformations.py
+++ b/tests/unit/plugins/module_utils/_elbv2/test_alb_transformations.py
@@ -3,6 +3,7 @@
 # Copyright: Contributors to the Ansible project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations import _normalize_attributes
 from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations import _normalize_listener_rules
 from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations import _normalize_listeners
 from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations import (
@@ -11,6 +12,33 @@ from ansible_collections.amazon.aws.plugins.module_utils._elbv2.transformations 
 
 # The various normalize_ functions are based upon ..transformation.boto3_resource_to_ansible_dict
 # As such these tests will be relatively light touch.
+
+
+class TestNormalizeAttributes:
+    def test_normalize_attributes_converts_format(self):
+        """Test that attributes are converted from boto3 format to dict with underscored keys"""
+        INPUT = [
+            {"Key": "access_logs.s3.enabled", "Value": "true"},
+            {"Key": "access_logs.s3.bucket", "Value": "my-bucket"},
+            {"Key": "deletion_protection.enabled", "Value": "false"},
+            {"Key": "idle_timeout.timeout_seconds", "Value": "60"},
+        ]
+        OUTPUT = {
+            "access_logs_s3_enabled": "true",
+            "access_logs_s3_bucket": "my-bucket",
+            "deletion_protection_enabled": "false",
+            "idle_timeout_timeout_seconds": "60",
+        }
+
+        assert OUTPUT == _normalize_attributes(INPUT)
+
+    def test_normalize_attributes_handles_empty_list(self):
+        """Test that empty attributes list returns empty dict"""
+        assert {} == _normalize_attributes([])
+
+    def test_normalize_attributes_handles_none(self):
+        """Test that None attributes returns empty dict"""
+        assert {} == _normalize_attributes(None)
 
 
 class TestNormalizeListenerRules:
@@ -205,3 +233,54 @@ class TestNormalizeApplicationLoadBalancer:
     def test_normalize_none_alb(self):
         """Test that None ALB is handled correctly"""
         assert normalize_application_load_balancer(None) is None
+
+    def test_normalize_alb_with_attributes(self):
+        """Test ALB normalization with attributes are flattened and converted"""
+        INPUT = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+            "Attributes": [
+                {"Key": "access_logs.s3.enabled", "Value": "true"},
+                {"Key": "access_logs.s3.bucket", "Value": "my-bucket"},
+                {"Key": "deletion_protection.enabled", "Value": "false"},
+            ],
+        }
+        OUTPUT = {
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "load_balancer_name": "test-alb",
+            "tags": {},
+            "access_logs_s3_enabled": "true",
+            "access_logs_s3_bucket": "my-bucket",
+            "deletion_protection_enabled": "false",
+        }
+
+        assert OUTPUT == normalize_application_load_balancer(INPUT)
+
+    def test_normalize_alb_without_attributes(self):
+        """Test ALB normalization without Attributes key"""
+        INPUT = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+        }
+        OUTPUT = {
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "load_balancer_name": "test-alb",
+            "tags": {},
+        }
+
+        assert OUTPUT == normalize_application_load_balancer(INPUT)
+
+    def test_normalize_alb_with_empty_attributes(self):
+        """Test ALB normalization with empty Attributes list"""
+        INPUT = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+            "Attributes": [],
+        }
+        OUTPUT = {
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "load_balancer_name": "test-alb",
+            "tags": {},
+        }
+
+        assert OUTPUT == normalize_application_load_balancer(INPUT)

--- a/tests/unit/plugins/module_utils/_elbv2/test_alb_transformations.py
+++ b/tests/unit/plugins/module_utils/_elbv2/test_alb_transformations.py
@@ -344,7 +344,6 @@ class TestNormalizeApplicationLoadBalancer:
             "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
             "load_balancer_name": "test-alb",
             "ip_address_type": "dualstack",
-            "tags": {},
         }
 
         assert OUTPUT == normalize_application_load_balancer(INPUT)
@@ -364,8 +363,29 @@ class TestNormalizeApplicationLoadBalancer:
 
         assert OUTPUT == normalize_application_load_balancer(INPUT)
 
+    def test_normalize_alb_with_tags(self):
+        """Test ALB normalization with tags are properly converted"""
+        INPUT = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+            "Tags": [
+                {"Key": "Name", "Value": "test-alb"},
+                {"Key": "Environment", "Value": "production"},
+            ],
+        }
+        OUTPUT = {
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "load_balancer_name": "test-alb",
+            "tags": {
+                "Name": "test-alb",
+                "Environment": "production",
+            },
+        }
+
+        assert OUTPUT == normalize_application_load_balancer(INPUT)
+
     def test_normalize_alb_without_tags(self):
-        """Test ALB normalization without Tags key"""
+        """Test ALB normalization without Tags key - tags should not be added"""
         INPUT = {
             "LoadBalancerArn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
             "LoadBalancerName": "test-alb",
@@ -373,7 +393,6 @@ class TestNormalizeApplicationLoadBalancer:
         OUTPUT = {
             "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
             "load_balancer_name": "test-alb",
-            "tags": {},
         }
 
         assert OUTPUT == normalize_application_load_balancer(INPUT)
@@ -396,10 +415,36 @@ class TestNormalizeApplicationLoadBalancer:
         OUTPUT = {
             "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
             "load_balancer_name": "test-alb",
-            "tags": {},
             "access_logs_s3_enabled": "true",
             "access_logs_s3_bucket": "my-bucket",
             "deletion_protection_enabled": "false",
+        }
+
+        assert OUTPUT == normalize_application_load_balancer(INPUT)
+
+    def test_normalize_alb_with_attributes_and_tags(self):
+        """Test ALB normalization with both attributes and tags"""
+        INPUT = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+            "Attributes": [
+                {"Key": "access_logs.s3.enabled", "Value": "true"},
+                {"Key": "deletion_protection.enabled", "Value": "false"},
+            ],
+            "Tags": [
+                {"Key": "Name", "Value": "test-alb"},
+                {"Key": "Owner", "Value": "devops"},
+            ],
+        }
+        OUTPUT = {
+            "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
+            "load_balancer_name": "test-alb",
+            "access_logs_s3_enabled": "true",
+            "deletion_protection_enabled": "false",
+            "tags": {
+                "Name": "test-alb",
+                "Owner": "devops",
+            },
         }
 
         assert OUTPUT == normalize_application_load_balancer(INPUT)
@@ -413,7 +458,6 @@ class TestNormalizeApplicationLoadBalancer:
         OUTPUT = {
             "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
             "load_balancer_name": "test-alb",
-            "tags": {},
         }
 
         assert OUTPUT == normalize_application_load_balancer(INPUT)
@@ -428,7 +472,6 @@ class TestNormalizeApplicationLoadBalancer:
         OUTPUT = {
             "load_balancer_arn": "arn:aws:elasticloadbalancing:::loadbalancer/app/test/123",
             "load_balancer_name": "test-alb",
-            "tags": {},
         }
 
         assert OUTPUT == normalize_application_load_balancer(INPUT)

--- a/tests/unit/plugins/module_utils/elbv2/test_elbv2.py
+++ b/tests/unit/plugins/module_utils/elbv2/test_elbv2.py
@@ -389,3 +389,315 @@ def testELBListenersInit(
     assert elb_listener.elb_arn == elb_arn
     assert elb_listener.module == module
     assert elb_listener.changed is False
+
+
+class TestBuildApplicationLoadBalancerDescription:
+    """Tests for build_application_load_balancer_description function"""
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.normalize_application_load_balancer")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_rules")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_listeners")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_load_balancer_attributes")
+    def test_with_all_includes(
+        self,
+        m_describe_attributes,
+        m_describe_listeners,
+        m_describe_rules,
+        m_normalize,
+    ):
+        """Test with all include flags set to True"""
+        connection = MagicMock()
+        load_balancer = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+        }
+
+        # Mock return values
+        mock_attributes = [{"Key": "deletion_protection.enabled", "Value": "true"}]
+        mock_listeners = [
+            {
+                "ListenerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:listener/app/test/123/abc",
+                "Port": 80,
+            }
+        ]
+        mock_rules = [{"RuleArn": "arn:aws:...rule/1", "Priority": "1"}]
+        mock_normalized = {"load_balancer_name": "test-alb"}
+
+        m_describe_attributes.return_value = mock_attributes
+        m_describe_listeners.return_value = mock_listeners
+        m_describe_rules.return_value = mock_rules
+        m_normalize.return_value = mock_normalized
+
+        result = elbv2.build_application_load_balancer_description(
+            connection,
+            load_balancer,
+            include_attributes=True,
+            include_listeners=True,
+            include_listener_rules=True,
+        )
+
+        # Verify all describe functions were called
+        m_describe_attributes.assert_called_once_with(connection, load_balancer["LoadBalancerArn"])
+        m_describe_listeners.assert_called_once_with(connection, load_balancer_arn=load_balancer["LoadBalancerArn"])
+        m_describe_rules.assert_called_once_with(connection, ListenerArn=mock_listeners[0]["ListenerArn"])
+
+        # Verify normalize was called with the enriched ALB
+        call_args = m_normalize.call_args[0][0]
+        assert call_args["Attributes"] == mock_attributes
+        assert call_args["Listeners"] == mock_listeners
+        assert call_args["Listeners"][0]["Rules"] == mock_rules
+
+        assert result == mock_normalized
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.normalize_application_load_balancer")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_rules")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_listeners")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_load_balancer_attributes")
+    def test_without_attributes(
+        self,
+        m_describe_attributes,
+        m_describe_listeners,
+        m_describe_rules,
+        m_normalize,
+    ):
+        """Test with include_attributes=False"""
+        connection = MagicMock()
+        load_balancer = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+        }
+
+        mock_listeners = [{"ListenerArn": "arn:aws:...listener/1", "Port": 80}]
+        mock_rules = [{"RuleArn": "arn:aws:...rule/1", "Priority": "1"}]
+        mock_normalized = {"load_balancer_name": "test-alb"}
+
+        m_describe_listeners.return_value = mock_listeners
+        m_describe_rules.return_value = mock_rules
+        m_normalize.return_value = mock_normalized
+
+        result = elbv2.build_application_load_balancer_description(
+            connection,
+            load_balancer,
+            include_attributes=False,
+            include_listeners=True,
+            include_listener_rules=True,
+        )
+
+        # Verify attributes were not fetched
+        m_describe_attributes.assert_not_called()
+
+        # Verify listeners and rules were fetched
+        m_describe_listeners.assert_called_once()
+        m_describe_rules.assert_called_once()
+
+        # Verify normalize was called without Attributes
+        call_args = m_normalize.call_args[0][0]
+        assert "Attributes" not in call_args
+        assert result == mock_normalized
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.normalize_application_load_balancer")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_rules")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_listeners")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_load_balancer_attributes")
+    def test_without_listeners(
+        self,
+        m_describe_attributes,
+        m_describe_listeners,
+        m_describe_rules,
+        m_normalize,
+    ):
+        """Test with include_listeners=False and include_listener_rules=False"""
+        connection = MagicMock()
+        load_balancer = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+        }
+
+        mock_attributes = [{"Key": "deletion_protection.enabled", "Value": "true"}]
+        mock_normalized = {"load_balancer_name": "test-alb"}
+
+        m_describe_attributes.return_value = mock_attributes
+        m_normalize.return_value = mock_normalized
+
+        result = elbv2.build_application_load_balancer_description(
+            connection,
+            load_balancer,
+            include_attributes=True,
+            include_listeners=False,
+            include_listener_rules=False,
+        )
+
+        # Verify listeners and rules were not fetched
+        m_describe_listeners.assert_not_called()
+        m_describe_rules.assert_not_called()
+
+        # Verify attributes were fetched
+        m_describe_attributes.assert_called_once()
+
+        # Verify normalize was called without Listeners
+        call_args = m_normalize.call_args[0][0]
+        assert "Listeners" not in call_args
+        assert result == mock_normalized
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.normalize_application_load_balancer")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_rules")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_listeners")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_load_balancer_attributes")
+    def test_with_listeners_but_without_rules(
+        self,
+        m_describe_attributes,
+        m_describe_listeners,
+        m_describe_rules,
+        m_normalize,
+    ):
+        """Test with include_listeners=True but include_listener_rules=False"""
+        connection = MagicMock()
+        load_balancer = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+        }
+
+        mock_listeners = [{"ListenerArn": "arn:aws:...listener/1", "Port": 80}]
+        mock_normalized = {"load_balancer_name": "test-alb"}
+
+        m_describe_listeners.return_value = mock_listeners
+        m_normalize.return_value = mock_normalized
+
+        result = elbv2.build_application_load_balancer_description(
+            connection,
+            load_balancer,
+            include_attributes=False,
+            include_listeners=True,
+            include_listener_rules=False,
+        )
+
+        # Verify listeners were fetched but rules were not
+        m_describe_listeners.assert_called_once()
+        m_describe_rules.assert_not_called()
+
+        # Verify normalize was called with listeners but without rules
+        call_args = m_normalize.call_args[0][0]
+        assert call_args["Listeners"] == mock_listeners
+        assert "Rules" not in call_args["Listeners"][0]
+        assert result == mock_normalized
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.normalize_application_load_balancer")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_rules")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_listeners")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_load_balancer_attributes")
+    def test_with_multiple_listeners(
+        self,
+        m_describe_attributes,
+        m_describe_listeners,
+        m_describe_rules,
+        m_normalize,
+    ):
+        """Test that rules are fetched for each listener"""
+        connection = MagicMock()
+        load_balancer = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+        }
+
+        mock_listeners = [
+            {"ListenerArn": "arn:aws:...listener/1", "Port": 80},
+            {"ListenerArn": "arn:aws:...listener/2", "Port": 443},
+        ]
+        mock_rules = [{"RuleArn": "arn:aws:...rule/1", "Priority": "1"}]
+        mock_normalized = {"load_balancer_name": "test-alb"}
+
+        m_describe_listeners.return_value = mock_listeners
+        m_describe_rules.return_value = mock_rules
+        m_normalize.return_value = mock_normalized
+
+        result = elbv2.build_application_load_balancer_description(
+            connection,
+            load_balancer,
+            include_attributes=False,
+            include_listeners=True,
+            include_listener_rules=True,
+        )
+
+        # Verify describe_rules was called for each listener
+        assert m_describe_rules.call_count == 2
+        m_describe_rules.assert_any_call(connection, ListenerArn="arn:aws:...listener/1")
+        m_describe_rules.assert_any_call(connection, ListenerArn="arn:aws:...listener/2")
+
+        # Verify both listeners have rules attached
+        call_args = m_normalize.call_args[0][0]
+        assert call_args["Listeners"][0]["Rules"] == mock_rules
+        assert call_args["Listeners"][1]["Rules"] == mock_rules
+        assert result == mock_normalized
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.normalize_application_load_balancer")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_rules")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_listeners")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_load_balancer_attributes")
+    def test_include_listener_rules_implies_listeners(
+        self,
+        m_describe_attributes,
+        m_describe_listeners,
+        m_describe_rules,
+        m_normalize,
+    ):
+        """Test that include_listener_rules=True implies fetching listeners even if include_listeners=False"""
+        connection = MagicMock()
+        load_balancer = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+        }
+
+        mock_listeners = [{"ListenerArn": "arn:aws:...listener/1", "Port": 80}]
+        mock_rules = [{"RuleArn": "arn:aws:...rule/1", "Priority": "1"}]
+        mock_normalized = {"load_balancer_name": "test-alb"}
+
+        m_describe_listeners.return_value = mock_listeners
+        m_describe_rules.return_value = mock_rules
+        m_normalize.return_value = mock_normalized
+
+        result = elbv2.build_application_load_balancer_description(
+            connection,
+            load_balancer,
+            include_attributes=False,
+            include_listeners=False,
+            include_listener_rules=True,
+        )
+
+        # Verify listeners were still fetched because rules were requested
+        m_describe_listeners.assert_called_once()
+        m_describe_rules.assert_called_once()
+
+        assert result == mock_normalized
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.normalize_application_load_balancer")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.elbv2.describe_load_balancer_attributes")
+    def test_does_not_modify_original_load_balancer(
+        self,
+        m_describe_attributes,
+        m_normalize,
+    ):
+        """Test that the original load_balancer dict is not modified"""
+        connection = MagicMock()
+        load_balancer = {
+            "LoadBalancerArn": "arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/test/123",
+            "LoadBalancerName": "test-alb",
+        }
+        original_load_balancer = load_balancer.copy()
+
+        mock_attributes = [{"Key": "deletion_protection.enabled", "Value": "true"}]
+        mock_normalized = {"load_balancer_name": "test-alb"}
+
+        m_describe_attributes.return_value = mock_attributes
+        m_normalize.return_value = mock_normalized
+
+        elbv2.build_application_load_balancer_description(
+            connection,
+            load_balancer,
+            include_attributes=True,
+            include_listeners=False,
+            include_listener_rules=False,
+        )
+
+        # Verify the original dict was not modified
+        assert load_balancer == original_load_balancer
+        assert "Attributes" not in load_balancer

--- a/tests/unit/plugins/module_utils/elbv2/test_prune.py
+++ b/tests/unit/plugins/module_utils/elbv2/test_prune.py
@@ -281,14 +281,3 @@ def test__simple_forward_config_arn(config, parent_arn, expected):
 )
 def test__append_use_existing_client_secretn(action, expected):
     assert elbv2._append_use_existing_client_secretn(action) == expected
-
-
-@pytest.mark.parametrize(
-    "actions,expected",
-    [
-        ([{"Order": 2}, {"Order": 1}], [{"Order": 1}, {"Order": 2}]),
-        ([{"Order": 2}, {}, {"Order": 1}], [{}, {"Order": 1}, {"Order": 2}]),
-    ],
-)
-def test__sort_actions(actions, expected):
-    assert elbv2._sort_actions(actions) == expected


### PR DESCRIPTION
##### SUMMARY
Fixes listener rule sorting in elb_application_lb and elb_application_lb_info modules. Listener rules are now returned sorted numerically by priority, with the default rule appearing last, ensuring consistent and predictable output.

Also includes refactoring to consolidate common ALB description building logic, reducing code duplication between the two modules.

Fixes #2939

Updated documentation to include missing return values (these aren't new, they just weren't documented, version_added isn't really possible because it's not version dependent it's AWS API dependent)

##### ISSUE TYPE
Bugfix Pull Request

##### COMPONENT NAME
elb_application_lb, elb_application_lb_info

##### ADDITIONAL INFORMATION
- Added transformation functions to normalize and sort listener rules
- Created module_utils/_elbv2/transformations module
- Added comprehensive unit tests for transformations and attribute handling
- Refactored elb_application_lb_info to use shared helper function

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>