### PR TITLE
Update sanity ignore files for core-2.21 branching

### DIFF
--- a/tests/sanity/ignore-2.15.txt
+++ b/tests/sanity/ignore-2.15.txt
@@ -1,2 +1,0 @@
-plugins/inventory/aws_ec2.py yamllint:unparsable-with-libyaml # bug in ansible-test - https://github.com/ansible/ansible/issues/82353
-plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this

--- a/tests/sanity/ignore-2.22.txt
+++ b/tests/sanity/ignore-2.22.txt
@@ -1,0 +1,4 @@
+plugins/modules/ec2_vpc_dhcp_option.py validate-modules:bad-return-value-key # deprecated hyphenated keys kept for backward compatibility until 2026-12-01
+plugins/modules/ec2_vpc_dhcp_option_info.py validate-modules:bad-return-value-key # deprecated hyphenated keys kept for backward compatibility until 2026-12-01
+plugins/modules/route53.py validate-modules:parameter-state-invalid-choice # route53_info needs improvements before we can deprecate this
+plugins/modules/route53.py validate-modules:bad-return-value-key # deprecated 'values' key kept for backward compatibility until 2026-12-01


### PR DESCRIPTION
##### SUMMARY

With ansible-core 2.21 having branched, the devel branch is now 2.22 and we need a 2.22 ignore file.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

tests/sanity/

##### ADDITIONAL INFORMATION

https://github.com/ansible-collections/amazon.aws/actions/runs/24144497382/job/70454664765?pr=2938
https://github.com/ansible/ansible/pull/86784