### PR TITLE
Add f-string parameter interpolation to error handlers

### DIFF
--- a/changelogs/fragments/error-handler-format-strings.yml
+++ b/changelogs/fragments/error-handler-format-strings.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - module_utils/errors - Add support for f-string style parameter interpolation in error handler descriptions to provide more detailed error messages (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - module_utils/errors - Add support for f-string style parameter interpolation in error handler descriptions to provide more detailed error messages (https://github.com/ansible-collections/amazon.aws/pull/2944).

--- a/changelogs/fragments/error-handler-format-strings.yml
+++ b/changelogs/fragments/error-handler-format-strings.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - module_utils/errors - Add support for f-string style parameter interpolation in error handler descriptions to provide more detailed error messages (https://github.com/ansible-collections/amazon.aws/pull/XXXX).

--- a/plugins/module_utils/errors.py
+++ b/plugins/module_utils/errors.py
@@ -4,6 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 import functools
+import inspect
 
 try:
     import botocore
@@ -32,17 +33,33 @@ class AWSErrorHandler:
                             Exception raised will include a message of
                             f"Timeout trying to {description}" or
                             f"Failed to {description}"
+                            Supports format string placeholders matching function parameters,
+                            e.g., "get role {name}" will interpolate the 'name' parameter.
         """
 
         def wrapper(func):
+            # Unwrap nested decorators to find the original function signature
+            original_func = func
+            while hasattr(original_func, "__wrapped__"):
+                original_func = original_func.__wrapped__
+            sig = inspect.signature(original_func)
+
             @functools.wraps(func)
             def handler(*args, **kwargs):
                 try:
+                    bound = sig.bind(*args, **kwargs)
+                    bound.apply_defaults()
+                    desc = description.format(**bound.arguments)
+                except (KeyError, ValueError, AttributeError) as format_error:
+                    # Formatting failed - append a note to help debug the issue
+                    desc = f"{description} (error formatting message: {format_error})"
+
+                try:
                     return func(*args, **kwargs)
                 except botocore.exceptions.WaiterError as e:
-                    raise cls._CUSTOM_EXCEPTION(message=f"Timeout trying to {description}", exception=e) from e
+                    raise cls._CUSTOM_EXCEPTION(message=f"Timeout trying to {desc}", exception=e) from e
                 except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                    raise cls._CUSTOM_EXCEPTION(message=f"Failed to {description}", exception=e) from e
+                    raise cls._CUSTOM_EXCEPTION(message=f"Failed to {desc}", exception=e) from e
 
             return handler
 
@@ -59,13 +76,15 @@ class AWSErrorHandler:
                             Exception raised will include a message of
                             f"Timeout trying to {description}" or
                             f"Failed to {description}"
+                            Supports format string placeholders matching function parameters,
+                            e.g., "get role {name}" will interpolate the 'name' parameter.
         param: default_value: the value to return if no matching
                             resources are returned.  Defaults to None
         """
 
         def wrapper(func):
-            @functools.wraps(func)
             @cls.common_error_handler(description)
+            @functools.wraps(func)
             def handler(*args, **kwargs):
                 try:
                     return func(*args, **kwargs)
@@ -87,11 +106,13 @@ class AWSErrorHandler:
                             Exception raised will include a message of
                             f"Timeout trying to {description}" or
                             f"Failed to {description}"
+                            Supports format string placeholders matching function parameters,
+                            e.g., "delete role {name}" will interpolate the 'name' parameter.
         """
 
         def wrapper(func):
-            @functools.wraps(func)
             @cls.common_error_handler(description)
+            @functools.wraps(func)
             def handler(*args, **kwargs):
                 try:
                     return func(*args, **kwargs)

--- a/tests/unit/plugins/module_utils/errors/aws_error_handler/test_common_handler.py
+++ b/tests/unit/plugins/module_utils/errors/aws_error_handler/test_common_handler.py
@@ -85,3 +85,93 @@ class TestAwsCommonHandler:
         assert isinstance(raised.exception, botocore.exceptions.ClientError)
         assert "do something" in raised.message
         assert "Something bad" in str(raised.exception)
+
+    def test_format_string_single_param(self):
+        self.counter = 0
+        err_response = {"Error": {"Code": "MalformedPolicyDocument"}}
+
+        @AWSErrorHandler.common_error_handler("get role {name}")
+        def raise_client_error(name):
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Something bad")
+
+        with pytest.raises(AnsibleAWSError) as e_info:
+            raise_client_error("test-role")
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "get role test-role" in raised.message
+        assert "Something bad" in str(raised.exception)
+
+    def test_format_string_multiple_params(self):
+        self.counter = 0
+        err_response = {"Error": {"Code": "MalformedPolicyDocument"}}
+
+        @AWSErrorHandler.common_error_handler("attach policy {policy} to role {role}")
+        def raise_client_error(client, role, policy):
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Something bad")
+
+        with pytest.raises(AnsibleAWSError) as e_info:
+            raise_client_error(None, "test-role", "test-policy")
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "attach policy test-policy to role test-role" in raised.message
+
+    def test_format_string_kwargs(self):
+        self.counter = 0
+        err_response = {"Error": {"Code": "MalformedPolicyDocument"}}
+
+        @AWSErrorHandler.common_error_handler("update role {name}")
+        def raise_client_error(client, name=None):
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Something bad")
+
+        with pytest.raises(AnsibleAWSError) as e_info:
+            raise_client_error(None, name="my-role")
+        assert self.counter == 1
+        raised = e_info.value
+        assert "update role my-role" in raised.message
+
+    def test_format_string_fallback_on_invalid_param(self):
+        self.counter = 0
+        err_response = {"Error": {"Code": "MalformedPolicyDocument"}}
+
+        @AWSErrorHandler.common_error_handler("get role {nonexistent}")
+        def raise_client_error(name):
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Something bad")
+
+        with pytest.raises(AnsibleAWSError) as e_info:
+            raise_client_error("test-role")
+        assert self.counter == 1
+        raised = e_info.value
+        # Should fall back to original description with error note when format fails
+        assert "get role {nonexistent}" in raised.message
+        assert "error formatting message" in raised.message
+
+    def test_format_string_no_params(self):
+        self.counter = 0
+
+        @AWSErrorHandler.common_error_handler("list all roles")
+        def no_failures():
+            self.counter += 1
+
+        no_failures()
+        assert self.counter == 1
+
+    def test_format_string_waiter_error(self):
+        self.counter = 0
+
+        @AWSErrorHandler.common_error_handler("wait for role {name}")
+        def raise_waiter_error(name):
+            self.counter += 1
+            raise botocore.exceptions.WaiterError("RoleExists", "Max attempts exceeded", {})
+
+        with pytest.raises(AnsibleAWSError) as e_info:
+            raise_waiter_error("test-role")
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.WaiterError)
+        assert "Timeout trying to wait for role test-role" in raised.message

--- a/tests/unit/plugins/module_utils/errors/aws_error_handler/test_deletion_handler.py
+++ b/tests/unit/plugins/module_utils/errors/aws_error_handler/test_deletion_handler.py
@@ -123,3 +123,32 @@ class TestAWSDeletionHandler:
         assert isinstance(raised.exception, botocore.exceptions.ClientError)
         assert "do something" in raised.message
         assert "Something bad" in str(raised.exception)
+
+    def test_format_string_with_params(self):
+        self.counter = 0
+        err_response = {"Error": {"Code": "MalformedPolicyDocument"}}
+
+        @AWSErrorHandler.deletion_error_handler("delete role {role_name}")
+        def raise_client_error(client, role_name):
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Something bad")
+
+        with pytest.raises(AnsibleAWSError) as e_info:
+            raise_client_error(None, "test-role")
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "delete role test-role" in raised.message
+
+    def test_format_string_missing_entity(self):
+        self.counter = 0
+        err_response = {"Error": {"Code": "NoSuchEntity"}}
+
+        @AWSExampleErrorHandler.deletion_error_handler("delete role {role_name}")
+        def raise_client_error(client, role_name):
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Role not found")
+
+        ret_val = raise_client_error(None, "missing-role")
+        assert self.counter == 1
+        assert ret_val is False

--- a/tests/unit/plugins/module_utils/errors/aws_error_handler/test_list_handler.py
+++ b/tests/unit/plugins/module_utils/errors/aws_error_handler/test_list_handler.py
@@ -126,3 +126,45 @@ class TestAWSListHandler:
         assert isinstance(raised.exception, botocore.exceptions.ClientError)
         assert "do something" in raised.message
         assert "Something bad" in str(raised.exception)
+
+    def test_format_string_with_params(self):
+        self.counter = 0
+        err_response = {"Error": {"Code": "MalformedPolicyDocument"}}
+
+        @AWSErrorHandler.list_error_handler("list policies for role {role_name}")
+        def raise_client_error(client, role_name):
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Something bad")
+
+        with pytest.raises(AnsibleAWSError) as e_info:
+            raise_client_error(None, "test-role")
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "list policies for role test-role" in raised.message
+
+    def test_format_string_missing_entity(self):
+        self.counter = 0
+        err_response = {"Error": {"Code": "NoSuchEntity"}}
+
+        @AWSExampleErrorHandler.list_error_handler("list policies for role {role_name}")
+        def raise_client_error(client, role_name):
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Role not found")
+
+        ret_val = raise_client_error(None, "missing-role")
+        assert self.counter == 1
+        assert ret_val is None
+
+    def test_format_string_missing_entity_custom_default(self):
+        self.counter = 0
+        err_response = {"Error": {"Code": "NoSuchEntity"}}
+
+        @AWSExampleErrorHandler.list_error_handler("get role {name}", default_value=[])
+        def raise_client_error(name):
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Role not found")
+
+        ret_val = raise_client_error("missing-role")
+        assert self.counter == 1
+        assert ret_val == []


### PR DESCRIPTION
##### SUMMARY
Enable dynamic message formatting in error handler decorators by supporting f-string style placeholders that match function parameters. This allows error messages to include specific values like resource names for better debugging.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
module_utils/errors

##### ADDITIONAL INFORMATION
This enhancement applies to all error handler decorators (common_error_handler, list_error_handler, deletion_error_handler), enabling more informative error messages across all modules that use these handlers.

Assisted-by: Claude Sonnet 4.5 <noreply@anthropic.com>