### PR TITLE
Move pull request template into repo

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,31 @@
+##### SUMMARY
+<!--- Describe the change below, including rationale and design decisions -->
+
+<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
+
+<!--- Please do not forget to include a changelog fragment:
+      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
+      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
+      Read about more details in CONTRIBUTING.md.
+      -->
+
+##### ISSUE TYPE
+<!--- Pick one or more below and delete the rest.
+      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
+- Bugfix Pull Request
+- Docs Pull Request
+- Feature Pull Request
+- New Module/Plugin Pull Request
+- Refactoring Pull Request
+- Test Pull Request
+
+##### COMPONENT NAME
+<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->
+
+##### ADDITIONAL INFORMATION
+<!--- Include additional information to help people understand the change here -->
+<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
+<!--- Integration tests should also be included where practical (tests/integration/targets) -->
+
+<!--- Contributions created with the assistance of AI must include an 'Assisted-by: ...' declaration -->
+<!--- Assisted-by: <AI model and version> -->


### PR DESCRIPTION
##### SUMMARY

Move the PR template into .github/ in the same way we have with the issue templates.  This also has the advantage that automated workflows can read the template when submitting a PR from the CLI.

##### ISSUE TYPE

- Feature Pull Request

##### COMPONENT NAME

.github/

##### ADDITIONAL INFORMATION