### PR TITLE
ACA-6003 Bump minimum boto3/botocore requirements to support the `aiobotocore` requirement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,23 +11,25 @@ The Ansible Amazon AWS collection includes a variety of Ansible content to help 
 
 ## Contents
 
-- [Description](#description)
-- [Communication](#communication)
-- [Requirements](#requirements)
-  - [Ansible version compatibility](#ansible-version-compatibility)
-  - [Python version compatibility](#python-version-compatibility)
-  - [AWS SDK version compatibility](#aws-sdk-version-compatibility)
-  - [Event source plugin compatibility](#event-source-plugin-compatibility)
-- [Included content](#included-content)
-- [Installation](#installation)
-- [Use Cases](#use-cases)
-- [Testing](#testing)
-- [Contributing to this collection](#contributing-to-this-collection)
-  - [More information about contributing](#more-information-about-contributing)
-- [Support](#support)
-- [Release notes](#release-notes)
-- [Related Information](#related-information)
-- [License Information](#license-information)
+- [Amazon AWS Collection](#amazon-aws-collection)
+  - [Contents](#contents)
+  - [Description](#description)
+  - [Communication](#communication)
+  - [Requirements](#requirements)
+    - [Ansible version compatibility](#ansible-version-compatibility)
+    - [Python version compatibility](#python-version-compatibility)
+    - [AWS SDK version compatibility](#aws-sdk-version-compatibility)
+    - [Event source plugin compatibility](#event-source-plugin-compatibility)
+  - [Included content](#included-content)
+  - [Installation](#installation)
+  - [Use Cases](#use-cases)
+  - [Testing](#testing)
+  - [Contributing to this collection](#contributing-to-this-collection)
+    - [More information about contributing](#more-information-about-contributing)
+  - [Support](#support)
+  - [Release notes](#release-notes)
+  - [Related Information](#related-information)
+  - [License Information](#license-information)
 
 ## Description
 
@@ -87,7 +89,7 @@ As such, support for Python versions below 3.10 will be removed in a release aft
 
 Starting with the 2.0.0 releases of amazon.aws and community.aws, the collection's policy is generally to support the versions of `botocore` and `boto3` that were released within 12 months prior to the most recent major collection release, following semantic versioning (for example, 2.0.0, 3.0.0).
 
-Version 12.0.0 of this collection supports `boto3 >= 1.38.0` and `botocore >= 1.38.0`
+Version 12.0.0 of this collection supports `boto3 >= 1.38.23` and `botocore >= 1.38.23`
 
 All support for the original AWS SDK `boto` was removed in release 4.0.0.
 

--- a/changelogs/fragments/2952_boto3-botocore-13823_aiobotocore_requirements.yml
+++ b/changelogs/fragments/2952_boto3-botocore-13823_aiobotocore_requirements.yml
@@ -1,0 +1,5 @@
+breaking_changes:
+  - Collection - Minimum supported boto3 version is now 1.38.23 (https://github.com/ansible-collections/amazon.aws/pull/2952).
+  - Collection - Minimum supported botocore version is now 1.38.23 (https://github.com/ansible-collections/amazon.aws/pull/2952).
+minor_changes:
+  - Collection - Add aiobotocore version 2.23.0 as a dependency for the event source plugins (https://github.com/ansible-collections/amazon.aws/pull/2952).

--- a/plugins/module_utils/botocore.py
+++ b/plugins/module_utils/botocore.py
@@ -86,8 +86,8 @@ from .common import get_collection_info
 from .exceptions import AnsibleBotocoreError
 from .retries import AWSRetry
 
-MINIMUM_BOTOCORE_VERSION = "1.38.0"
-MINIMUM_BOTO3_VERSION = "1.38.0"
+MINIMUM_BOTOCORE_VERSION = "1.38.23"
+MINIMUM_BOTO3_VERSION = "1.38.23"
 
 
 def _get_user_agent_string():

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,5 @@
 # - tests/integration/constraints.txt
 botocore>=1.38.0
 boto3>=1.38.0
-# aiobotocore doesn't play nice:
-# - it's got very specific botocore requirements and rarely supports a.b.0
-# aiobotocore>=2.14.0
+# required for eda event source plugins
+aiobotocore[botocore]>=2.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # When updating the minimal requirements please also update
 # - tests/unit/constraints.txt
 # - tests/integration/constraints.txt
-botocore>=1.38.0
-boto3>=1.38.0
+botocore>=1.38.23
+boto3>=1.38.23
 # required for eda event source plugins
 aiobotocore[botocore]>=2.23.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -19,3 +19,4 @@ cryptography
 # For testing event source plugins
 asyncmock
 pytest-asyncio
+aiobotocore[botocore]

--- a/tests/integration/constraints.txt
+++ b/tests/integration/constraints.txt
@@ -1,7 +1,8 @@
 # Specifically run tests against the oldest versions that we support
-botocore==1.38.0
-boto3==1.38.0
+botocore==1.38.23
+boto3==1.38.23
+aiobotocore==2.23.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.39.0
+awscli==1.40.22

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -16,3 +16,4 @@ jq
 # Used for event source AWS integration tests
 ansible-rulebook
 ansible-runner
+aiobotocore[botocore]

--- a/tests/integration/targets/ec2_vol/meta/main.yml
+++ b/tests/integration/targets/ec2_vol/meta/main.yml
@@ -1,6 +1,3 @@
 ---
 dependencies:
   - role: setup_ec2_facts
-  - role: setup_botocore_pip
-    vars:
-      botocore_version: "1.38.10"

--- a/tests/integration/targets/ec2_vol/tasks/main.yml
+++ b/tests/integration/targets/ec2_vol/tasks/main.yml
@@ -216,8 +216,6 @@
           ResourcePrefix: "{{ resource_prefix }}"
       check_mode: true
       register: volume4_check_mode
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Check task return attributes
       ansible.builtin.assert:
@@ -235,8 +233,6 @@
         tags:
           ResourcePrefix: "{{ resource_prefix }}"
       register: volume4
-      vars:
-        ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
 
     - name: Check task return attributes
       ansible.builtin.assert:

--- a/tests/unit/constraints.txt
+++ b/tests/unit/constraints.txt
@@ -1,9 +1,9 @@
 # Specifically run tests against the oldest versions that we support
-botocore==1.38.0
-boto3==1.38.0
+botocore==1.38.23
+boto3==1.38.23
 # aiobotocore doesn't play nice:
 # - it's got very specific botocore requirements and rarely supports a.b.0
-# aiobotocore==2.23.0
+aiobotocore==2.23.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.

--- a/tests/unit/constraints.txt
+++ b/tests/unit/constraints.txt
@@ -7,4 +7,4 @@ aiobotocore==2.23.0
 
 # AWS CLI has `botocore==` dependencies, provide the one that matches botocore
 # to avoid needing to download over a years worth of awscli wheels.
-awscli==1.39.0
+awscli==1.40.22

--- a/tests/unit/event_source/test_aws_cloudtrail.py
+++ b/tests/unit/event_source/test_aws_cloudtrail.py
@@ -5,7 +5,6 @@ import pytest
 from asyncmock import AsyncMock
 from mock import MagicMock
 
-
 from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_cloudtrail import _cloudtrail_event_to_dict
 from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_cloudtrail import _get_events
 from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_cloudtrail import connection_args

--- a/tests/unit/event_source/test_aws_cloudtrail.py
+++ b/tests/unit/event_source/test_aws_cloudtrail.py
@@ -5,7 +5,6 @@ import pytest
 from asyncmock import AsyncMock
 from mock import MagicMock
 
-pytest.importorskip("aiobotocore")
 
 from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_cloudtrail import _cloudtrail_event_to_dict
 from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_cloudtrail import _get_events

--- a/tests/unit/event_source/test_aws_sqs_queue.py
+++ b/tests/unit/event_source/test_aws_sqs_queue.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import pytest
 from asyncmock import AsyncMock
 
-pytest.importorskip("aiobotocore")
 
 from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue import main as sqs_main
 from ansible_collections.amazon.aws.tests.unit.utils.event import ListQueue

--- a/tests/unit/event_source/test_aws_sqs_queue.py
+++ b/tests/unit/event_source/test_aws_sqs_queue.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 import pytest
 from asyncmock import AsyncMock
 
-
 from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue import main as sqs_main
 from ansible_collections.amazon.aws.tests.unit.utils.event import ListQueue
 

--- a/tests/unit/plugins/module_utils/modules/ansible_aws_module/test_minimal_versions.py
+++ b/tests/unit/plugins/module_utils/modules/ansible_aws_module/test_minimal_versions.py
@@ -26,8 +26,8 @@ class TestMinimalVersionTestSuite:
     # Prepare some data for use in our testing
     # ========================================================
     def setup_method(self):
-        self.MINIMAL_BOTO3 = "1.38.0"
-        self.MINIMAL_BOTOCORE = "1.38.0"
+        self.MINIMAL_BOTO3 = "1.38.23"
+        self.MINIMAL_BOTOCORE = "1.38.23"
         self.OLD_BOTO3 = "1.37.999"
         self.OLD_BOTOCORE = "1.37.999"
 

--- a/tests/unit/requirements.txt
+++ b/tests/unit/requirements.txt
@@ -3,6 +3,8 @@ botocore
 boto3
 
 placebo
+# For testing eda event source plugins
+aiobotocore[botocore]
 
 asyncmock
 pytest-asyncio

--- a/tox.ini
+++ b/tox.ini
@@ -55,7 +55,6 @@ deps =
   ansible2.19: ansible-core>2.19,<2.20
   ansible2.20: ansible-core>2.20,<2.21
   with_constraints: -rtests/unit/constraints.txt
-  without_constraints: aiobotocore
 allowlist_externals = rsync
 change_dir = {[common]full_collection_path}
 commands_pre =


### PR DESCRIPTION


##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Note: This PR is in preparation for a forecast release of version 12.0.0 in early May 2026.

Bump minimum requirements  boto3 1.38.23, and botocore 1.38.23 to support aiobotocore requirement.

boto3 and botocore 1.38.23 were released on 2025-05-23.

Adding back `aiobotocore` dependency as a mandatory requirement for EDA event source plugins.

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

Breaking changes:

Minimum boto3 version: 1.38.23 (was 1.38.0)
Minimum botocore version: 1.38.23 (was 1.38.0)

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Breaking Change Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

Fixes #2922 issue that removed `aiobotocore` dependency, since it got very specific botocore requirements and rarely supports a.b.0.
Enables EDA event source unit tests.

Files modified:

requirements.txt - Updated minimum versions, and add aiobotocore.
tests/unit/constraints.txt - Updated oldest supported versions (boto3==1.38.23, botocore==1.38.23, awscli==1.40.22, aiobotocore==2.23.0).
tests/unit/requirements.txt - Add aiobotocore requirement.
tests/integration/constraints.txt - Updated oldest supported versions
tests/integration/requirements.txt - Add aiobotocore requirement.
plugins/module_utils/botocore.py - Updated MINIMUM_BOTO3_VERSION and MINIMUM_BOTOCORE_VERSION constants
README.md - Updated boto3 and botocore version compatibility documentation
Changelog fragment - Added breaking changes