### PR TITLE
Fix unit tests following ansible/ansible#86771

### DIFF
--- a/tests/unit/plugins/module_utils/modules/ansible_aws_module/test_minimal_versions.py
+++ b/tests/unit/plugins/module_utils/modules/ansible_aws_module/test_minimal_versions.py
@@ -49,7 +49,6 @@ class TestMinimalVersionTestSuite:
         return_val = json.loads(out)
 
         assert return_val.get("exception") is None
-        assert return_val.get("invocation") is not None
         assert return_val.get("failed") is None
         assert return_val.get("error") is None
         assert return_val.get("warnings") is None
@@ -72,7 +71,6 @@ class TestMinimalVersionTestSuite:
         return_val = json.loads(out)
 
         assert return_val.get("exception") is None
-        assert return_val.get("invocation") is not None
         assert return_val.get("failed") is None
         assert return_val.get("error") is None
         assert return_val.get("warnings") is None
@@ -99,7 +97,6 @@ class TestMinimalVersionTestSuite:
         pprint(return_val)
 
         assert return_val.get("exception") is None
-        assert return_val.get("invocation") is not None
         assert return_val.get("failed") is None
         assert return_val.get("error") is None
         assert return_val.get("warnings") is not None
@@ -133,7 +130,6 @@ class TestMinimalVersionTestSuite:
         pprint(return_val)
 
         assert return_val.get("exception") is None
-        assert return_val.get("invocation") is not None
         assert return_val.get("failed") is None
         assert return_val.get("error") is None
         assert return_val.get("warnings") is not None
@@ -167,7 +163,6 @@ class TestMinimalVersionTestSuite:
         pprint(return_val)
 
         assert return_val.get("exception") is None
-        assert return_val.get("invocation") is not None
         assert return_val.get("failed") is None
         assert return_val.get("error") is None
         assert return_val.get("warnings") is not None

--- a/tests/unit/plugins/module_utils/modules/ansible_aws_module/test_require_at_least.py
+++ b/tests/unit/plugins/module_utils/modules/ansible_aws_module/test_require_at_least.py
@@ -107,7 +107,6 @@ class TestRequireAtLeastTestSuite:
         return_val = json.loads(out)
 
         assert return_val.get("exception") is None
-        assert return_val.get("invocation") is not None
         if at_least:
             assert return_val.get("failed") is None
         else:
@@ -142,7 +141,6 @@ class TestRequireAtLeastTestSuite:
         return_val = json.loads(out)
 
         assert return_val.get("exception") is None
-        assert return_val.get("invocation") is not None
         if at_least:
             assert return_val.get("failed") is None
         else:
@@ -181,7 +179,6 @@ class TestRequireAtLeastTestSuite:
         return_val = json.loads(out)
 
         assert return_val.get("exception") is None
-        assert return_val.get("invocation") is not None
         if at_least:
             assert return_val.get("failed") is None
         else:
@@ -221,7 +218,6 @@ class TestRequireAtLeastTestSuite:
         return_val = json.loads(out)
 
         assert return_val.get("exception") is None
-        assert return_val.get("invocation") is not None
         if at_least:
             assert return_val.get("failed") is None
         else:


### PR DESCRIPTION
##### SUMMARY

Fix unit tests following removal of invocation from the default return values

ansible/ansible#86771 just removed invocation from the default return values, no point in us checking it's there in these unit tests since we don't (deliberately) put anything into "invocation".

##### ISSUE TYPE

- Test Pull Request

##### COMPONENT NAME

tests/unit/plugins/module_utils/modules/ansible_aws_module/test_minimal_versions.py
tests/unit/plugins/module_utils/modules/ansible_aws_module/test_require_at_least.py

##### ADDITIONAL INFORMATION