### PR TITLE
Add S3 Account Regional Namespace Support

### DIFF
--- a/changelogs/fragments/s3_bucket-account_regional.yml
+++ b/changelogs/fragments/s3_bucket-account_regional.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - s3_bucket - Added O(account_regional) parameter to support creating buckets in the account-regional namespace. Requires at least botocore version 1.42.67 (https://github.com/ansible-collections/amazon.aws/pull/XXXX).

--- a/changelogs/fragments/s3_bucket-account_regional.yml
+++ b/changelogs/fragments/s3_bucket-account_regional.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - s3_bucket - Added O(account_regional) parameter to support creating buckets in the account-regional namespace. Requires at least botocore version 1.42.67 (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - s3_bucket - Added O(account_regional) parameter to support creating buckets in the account-regional namespace. Requires at least botocore version 1.42.67 (https://github.com/ansible-collections/amazon.aws/pull/2960).

--- a/plugins/module_utils/s3.py
+++ b/plugins/module_utils/s3.py
@@ -1405,6 +1405,50 @@ def validate_bucket_name(name: str) -> Optional[str]:
     return None
 
 
+def validate_account_regional_bucket_name(name: str, region: Optional[str] = None) -> Optional[str]:
+    """
+    Validate S3 bucket name for account-regional namespace.
+
+    Account-regional bucket names must follow the format:
+    prefix-{accountId}-{region}-an
+
+    Parameters:
+        name (str): The bucket name to validate.
+        region (str): The AWS region (optional, used for validation if provided).
+
+    Returns:
+        Error message string if validation fails, or None if valid.
+    """
+    import re
+
+    if len(name) < 3:
+        return "account-regional bucket name must be at least 3 characters"
+    if len(name) > 63:
+        return "account-regional bucket name cannot exceed 63 characters"
+
+    if not name.endswith("-an"):
+        return "account-regional bucket name must end with '-an'"
+
+    pattern = r"^(.+)-(\d{12})-([a-z]{2}-[a-z]+-\d)-an$"
+    match = re.match(pattern, name)
+
+    if not match:
+        return "account-regional bucket name must follow format: prefix-{12-digit-account-id}-{region}-an"
+
+    prefix, account_id, bucket_region = match.groups()
+
+    if not prefix:
+        return "account-regional bucket name must have a prefix before the account ID"
+
+    if len(account_id) != 12:
+        return "account ID in bucket name must be exactly 12 digits"
+
+    if region and bucket_region != region:
+        return f"bucket name region '{bucket_region}' does not match the bucket's configured region '{region}'"
+
+    return None
+
+
 # Spot special case of fakes3.
 def is_fakes3(url: Optional[str]) -> bool:
     """Return True if endpoint_url has scheme fakes3://"""

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -49,6 +49,7 @@ options:
       - When V(true), the bucket name must follow the format C(prefix-accountId-region-an).
       - Can only be set during bucket creation. Cannot be changed for existing buckets.
       - Not supported for directory buckets.
+      - Requires botocore >= 1.42.67
     type: bool
     version_added: 11.3.0
   requester_pays:

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -45,12 +45,12 @@ options:
     default: false
   account_regional:
     description:
-      - Whether to create the bucket in the account-regional namespace instead of the global namespace.                          
-      - When V(true), the bucket name must follow the format C(prefix-accountId-region-an).                                      
-      - Can only be set during bucket creation. Cannot be changed for existing buckets.                                          
-      - Not supported for directory buckets.                                                                                     
-    type: bool                                                                                                                   
-    version_added: 11.3.0           
+      - Whether to create the bucket in the account-regional namespace instead of the global namespace.
+      - When V(true), the bucket name must follow the format C(prefix-accountId-region-an).
+      - Can only be set during bucket creation. Cannot be changed for existing buckets.
+      - Not supported for directory buckets.
+    type: bool
+    version_added: 11.3.0
   requester_pays:
     description:
       - With Requester Pays buckets, the requester instead of the bucket owner pays the cost
@@ -294,12 +294,11 @@ EXAMPLES = r"""
     endpoint_url: http://your-ceph-rados-gateway-server.xxx
     ceph: true
 
-# Create a bucket with account-regional namespace                                                                              
-  - amazon.aws.s3_bucket:                                                                                                        
-      name: my-bucket-111122223333-us-east-1-an                                                                                  
-      state: present                                                                                                             
-      account_regional: true
-      
+# Create a bucket with account-regional namespace
+- amazon.aws.s3_bucket:
+    name: my-bucket-111122223333-us-east-1-an
+    state: present
+    account_regional: true
 # Remove an S3 bucket and any keys it contains
 - amazon.aws.s3_bucket:
     name: mys3bucket
@@ -1295,7 +1294,11 @@ def _create_bucket(s3_client: ClientType, **params) -> bool:
 
 
 def create_bucket(
-    s3_client: ClientType, bucket_name: str, location: str, object_lock_enabled: Optional[bool] = False, account_regional: Optional[bool] = None
+    s3_client: ClientType,
+    bucket_name: str,
+    location: str,
+    object_lock_enabled: Optional[bool] = False,
+    account_regional: Optional[bool] = None,
 ) -> bool:
     """
     Create an S3 bucket.

--- a/plugins/modules/s3_bucket.py
+++ b/plugins/modules/s3_bucket.py
@@ -43,6 +43,14 @@ options:
     aliases: ['rgw']
     type: bool
     default: false
+  account_regional:
+    description:
+      - Whether to create the bucket in the account-regional namespace instead of the global namespace.                          
+      - When V(true), the bucket name must follow the format C(prefix-accountId-region-an).                                      
+      - Can only be set during bucket creation. Cannot be changed for existing buckets.                                          
+      - Not supported for directory buckets.                                                                                     
+    type: bool                                                                                                                   
+    version_added: 11.3.0           
   requester_pays:
     description:
       - With Requester Pays buckets, the requester instead of the bucket owner pays the cost
@@ -286,6 +294,12 @@ EXAMPLES = r"""
     endpoint_url: http://your-ceph-rados-gateway-server.xxx
     ceph: true
 
+# Create a bucket with account-regional namespace                                                                              
+  - amazon.aws.s3_bucket:                                                                                                        
+      name: my-bucket-111122223333-us-east-1-an                                                                                  
+      state: present                                                                                                             
+      account_regional: true
+      
 # Remove an S3 bucket and any keys it contains
 - amazon.aws.s3_bucket:
     name: mys3bucket
@@ -603,6 +617,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.s3 import put_s3_object
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_acl_to_name
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_bucket_exists
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import s3_extra_params
+from ansible_collections.amazon.aws.plugins.module_utils.s3 import validate_account_regional_bucket_name
 from ansible_collections.amazon.aws.plugins.module_utils.s3 import validate_bucket_name
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import scrub_none_parameters
 
@@ -1191,7 +1206,8 @@ def create_or_update_bucket(s3_client: ClientType, module: AnsibleAWSModule) -> 
     bucket_is_present = s3_bucket_exists(s3_client, name)
 
     if not bucket_is_present:
-        changed = create_bucket(s3_client, name, location, object_lock_enabled)
+        account_regional = module.params.get("account_regional")
+        changed = create_bucket(s3_client, name, location, object_lock_enabled, account_regional)
         waiter = get_s3_waiter(s3_client, "bucket_exists")
         S3ErrorHandler.common_error_handler(f"wait for bucket {name} to be created")(waiter.wait)(Bucket=name)
 
@@ -1279,7 +1295,7 @@ def _create_bucket(s3_client: ClientType, **params) -> bool:
 
 
 def create_bucket(
-    s3_client: ClientType, bucket_name: str, location: str, object_lock_enabled: Optional[bool] = False
+    s3_client: ClientType, bucket_name: str, location: str, object_lock_enabled: Optional[bool] = False, account_regional: Optional[bool] = None
 ) -> bool:
     """
     Create an S3 bucket.
@@ -1288,6 +1304,7 @@ def create_bucket(
         bucket_name (str): The name of the bucket to create.
         location (str): The AWS region where the bucket should be created. If None, it defaults to "us-east-1".
         object_lock_enabled (bool): Whether to enable object lock for the bucket. Defaults to False.
+        account_regional (bool): Whether to create the bucket in the account-regional namespace. Defaults to None (global namespace).
     Returns:
         True if the bucket was successfully created, False otherwise.
     """
@@ -1302,7 +1319,8 @@ def create_bucket(
 
     if object_lock_enabled is not None:
         params["ObjectLockEnabledForBucket"] = object_lock_enabled
-
+    if account_regional:
+        params["BucketNamespace"] = "account-regional"
     return _create_bucket(s3_client, **params)
 
 
@@ -1705,6 +1723,7 @@ def main():
         dualstack=dict(default=False, type="bool"),
         state=dict(default="present", choices=["present", "absent"]),
         ceph=dict(default=False, type="bool", aliases=["rgw"]),
+        account_regional=dict(type="bool"),
         # ** Warning **
         # we support non-AWS implementations, only force/purge options should have a
         # default set for any top-level option.  We need to be able to identify
@@ -1825,6 +1844,13 @@ def main():
 
     if module.params.get("validate_bucket_name"):
         err = validate_bucket_name(module.params["name"])
+        if err:
+            module.fail_json(msg=err)
+
+    account_regional = module.params.get("account_regional")
+    if account_regional:
+        region = module.params.get("region") or module.region
+        err = validate_account_regional_bucket_name(module.params["name"], region)
         if err:
             module.fail_json(msg=err)
 

--- a/tests/integration/targets/s3_bucket/inventory
+++ b/tests/integration/targets/s3_bucket/inventory
@@ -14,6 +14,7 @@ object_lock
 accelerate
 default_retention
 inventory
+account_regional
 
 [all:vars]
 ansible_connection=local

--- a/tests/integration/targets/s3_bucket/meta/main.yml
+++ b/tests/integration/targets/s3_bucket/meta/main.yml
@@ -1,5 +1,6 @@
 ---
 dependencies:
+# Beware this is actually needed in roles/s3_bucket/meta too
   - role: setup_botocore_pip
     vars:
       boto3_version: "1.42.67"

--- a/tests/integration/targets/s3_bucket/meta/main.yml
+++ b/tests/integration/targets/s3_bucket/meta/main.yml
@@ -1,2 +1,6 @@
 ---
-dependencies: []
+dependencies:
+  - role: setup_botocore_pip
+    vars:
+      boto3_version: "1.42.67"
+      botocore_version: "1.42.67"

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/meta/main.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/meta/main.yml
@@ -1,2 +1,6 @@
 ---
-dependencies: []
+dependencies:
+  - role: setup_botocore_pip
+    vars:
+      boto3_version: "1.42.67"
+      botocore_version: "1.42.67"

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/account_regional.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/account_regional.yml
@@ -1,5 +1,7 @@
 ---
 - name: Run account-regional bucket tests
+  vars:
+    ansible_python_interpreter: "{{ botocore_virtualenv_interpreter }}"
   block:
     - name: Get AWS caller identity
       amazon.aws.aws_caller_info:

--- a/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/account_regional.yml
+++ b/tests/integration/targets/s3_bucket/roles/s3_bucket/tasks/account_regional.yml
@@ -1,0 +1,100 @@
+---
+- name: Run account-regional bucket tests
+  block:
+    - name: Get AWS caller identity
+      amazon.aws.aws_caller_info:
+      register: caller_info
+
+    - ansible.builtin.set_fact:
+        account_regional_bucket_name: "{{ (s3_bucket_name | hash('md5'))[:10] }}-{{ caller_info.account }}-{{ aws_region }}-an"
+        invalid_bucket_name: "{{ (s3_bucket_name | hash('md5'))[:10] }}-invalid-bucket"
+
+    # ============================================================
+    - name: Try to create account-regional bucket with invalid name format
+      amazon.aws.s3_bucket:
+        name: "{{ invalid_bucket_name }}"
+        state: present
+        account_regional: true
+      register: output
+      ignore_errors: true
+
+    - ansible.builtin.assert:
+        that:
+          - output is failed
+          - "'account-regional bucket name must' in output.msg"
+
+    # ============================================================
+    - name: Create a bucket with account-regional namespace
+      amazon.aws.s3_bucket:
+        name: "{{ account_regional_bucket_name }}"
+        state: present
+        account_regional: true
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output is success
+          - output is changed
+          - output.name == account_regional_bucket_name
+
+    # ============================================================
+    - name: Re-create account-regional bucket (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ account_regional_bucket_name }}"
+        state: present
+        account_regional: true
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output is success
+          - output is not changed
+          - output.name == account_regional_bucket_name
+
+    # ============================================================
+    - name: Update account-regional bucket with tags
+      amazon.aws.s3_bucket:
+        name: "{{ account_regional_bucket_name }}"
+        state: present
+        tags:
+          test: value
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output is success
+          - output is changed
+          - output.name == account_regional_bucket_name
+          - output.tags.test == 'value'
+
+    # ============================================================
+    - name: Delete account-regional bucket
+      amazon.aws.s3_bucket:
+        name: "{{ account_regional_bucket_name }}"
+        state: absent
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output is success
+          - output is changed
+
+    # ============================================================
+    - name: Re-delete account-regional bucket (idempotency)
+      amazon.aws.s3_bucket:
+        name: "{{ account_regional_bucket_name }}"
+        state: absent
+      register: output
+
+    - ansible.builtin.assert:
+        that:
+          - output is success
+          - output is not changed
+
+  # ============================================================
+  always:
+    - name: Ensure all test buckets are deleted
+      amazon.aws.s3_bucket:
+        name: "{{ account_regional_bucket_name }}"
+        state: absent
+      ignore_errors: true

--- a/tests/unit/plugins/module_utils/s3/test_validate_account_regional_bucket_name.py
+++ b/tests/unit/plugins/module_utils/s3/test_validate_account_regional_bucket_name.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+import pytest
+
+from ansible_collections.amazon.aws.plugins.module_utils import s3
+
+
+@pytest.mark.parametrize(
+    "bucket_name,region,result",
+    [
+        # Valid account-regional bucket names
+        ("my-bucket-111122223333-us-east-1-an", None, None),
+        ("my-bucket-111122223333-us-east-1-an", "us-east-1", None),
+        ("test-bucket-123456789012-eu-west-1-an", "eu-west-1", None),
+        ("prefix-999888777666-ap-south-1-an", None, None),
+        ("a-111122223333-us-west-2-an", None, None),  # Minimal prefix
+        # Invalid: too short
+        ("ab", None, "account-regional bucket name must be at least 3 characters"),
+        # Invalid: too long (>63 characters)
+        (
+            "this-is-a-very-long-bucket-name-prefix-111122223333-us-east-1-an",
+            None,
+            "account-regional bucket name cannot exceed 63 characters",
+        ),
+        # Invalid: doesn't end with -an
+        ("my-bucket-111122223333-us-east-1", None, "account-regional bucket name must end with '-an'"),
+        ("my-bucket-111122223333-us-east-1-xx", None, "account-regional bucket name must end with '-an'"),
+        # Invalid: wrong format
+        (
+            "nobucketname-an",
+            None,
+            "account-regional bucket name must follow format: prefix-{12-digit-account-id}-{region}-an",
+        ),
+        (
+            "prefix-12345-us-east-1-an",
+            None,
+            "account-regional bucket name must follow format: prefix-{12-digit-account-id}-{region}-an",
+        ),
+        (
+            "prefix-1234567890123-us-east-1-an",
+            None,
+            "account-regional bucket name must follow format: prefix-{12-digit-account-id}-{region}-an",
+        ),
+        # Invalid: no prefix (regex won't match)
+        (
+            "-111122223333-us-east-1-an",
+            None,
+            "account-regional bucket name must follow format: prefix-{12-digit-account-id}-{region}-an",
+        ),
+        # Invalid: region mismatch
+        (
+            "my-bucket-111122223333-us-east-1-an",
+            "us-west-2",
+            "bucket name region 'us-east-1' does not match the bucket's configured region 'us-west-2'",
+        ),
+        (
+            "test-bucket-123456789012-eu-west-1-an",
+            "eu-central-1",
+            "bucket name region 'eu-west-1' does not match the bucket's configured region 'eu-central-1'",
+        ),
+    ],
+)
+def test_validate_account_regional_bucket_name(bucket_name, region, result):
+    assert result == s3.validate_account_regional_bucket_name(bucket_name, region)


### PR DESCRIPTION
##### SUMMARY

Added feature to support account regional S3 bucket namespaces, including validation in module_utils and integration testing. This feature requires at least boto3 v1.42.67 to work (https://github.com/boto/boto3/blob/99980e56797d83ffdbd04ee6f9633ffd8396329c/CHANGELOG.rst#L471-L480)

Feedback on this is welcome!

Meant to address https://github.com/ansible-collections/amazon.aws/issues/2935.

https://redhat.atlassian.net/browse/ACA-6066.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
s3_bucket

##### ADDITIONAL INFORMATION

Since this is a new feature in AWS, I was only able to test this locally with boto v1.42.67.

Assisted-by:Claude Sonnet 4.5
