### PR TITLE
Release v10.3.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,21 @@ amazon.aws Release Notes
 
 .. contents:: Topics
 
+v10.3.1
+=======
+
+Release Summary
+---------------
+
+This patch release includes bugfixes for the ``s3_object_info``, ``autoscaling_group``, and ``kms_key`` modules, addressing duplicate dictionary key assignments and improving reliability. It also fixes a TypeError in CloudFront module utilities.
+
+Bugfixes
+--------
+
+- autoscaling_group - Fixed duplicate default_cooldown assignment in properties dict (https://github.com/ansible-collections/amazon.aws/pull/2923).
+- kms_key - Fixed parameter reassignment by using passed alias parameter instead of re-fetching from module params (https://github.com/ansible-collections/amazon.aws/pull/2923).
+- module_utils/cloudfront_facts - fix TypeError in CloudFrontFactsServiceManager.describe_cloudfront_property (https://github.com/ansible-collections/community.aws/issues/1915).
+- s3_object_info - Fixed duplicate dictionary key assignments when retrieving object facts (https://github.com/ansible-collections/amazon.aws/pull/2923).
 
 v10.3.0
 =======
@@ -117,7 +132,6 @@ Release Summary
 This major release introduces new support with the ``aws_ssm`` connection plugin, which has been promoted from ``community.aws``, several bugfixes, minor changes and deprecated features.
 Additionally, this release increases the minimum required versions of ``boto3`` and ``botocore`` to 1.34.0 to align with updated AWS SDK support and support for ansible-core < 2.17 has been dropped.
 Due to the AWS SDKs announcing the end of support for Python less than 3.8 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/), support for Python less than 3.8 by this collection was deprecated in 9.0.0 release and is removed in this 10.0.0 release.
-
 
 Major Changes
 -------------
@@ -1040,7 +1054,6 @@ Release Summary
 This release is the last planned minor release of ``amazon.aws`` prior to the release of 7.0.0.
 It includes documentation fixes as well as minor changes and bug fixes for the ``ec2_ami`` and ``elb_application_lb_info`` modules.
 
-
 Minor Changes
 -------------
 
@@ -1372,7 +1385,6 @@ Release Summary
 
 This release brings few bugfixes.
 
-
 Bugfixes
 --------
 
@@ -1392,7 +1404,6 @@ Release Summary
 ---------------
 
 This release contains a number of bugfixes, new features and new modules.  This is the last planned minor release prior to the release of version 6.0.0.
-
 
 Minor Changes
 -------------
@@ -1487,7 +1498,6 @@ Release Summary
 ---------------
 
 A minor release containing bugfixes for the ``ec2_eni_info`` module and the ``aws_rds`` inventory plugin, as well as improvements to the ``rds_instance`` module.
-
 
 Minor Changes
 -------------
@@ -1712,7 +1722,6 @@ Release Summary
 
 This release contains a minor bugfix for the ``ec2_vol`` module, some minor work on the ``ec2_key`` module, and various documentation fixes.  This is the last planned release of the 4.x series.
 
-
 Minor Changes
 -------------
 
@@ -1751,7 +1760,6 @@ Release Summary
 The amazon.aws 4.3.0 release includes a number of minor bug fixes and improvements.
 Following the release of amazon.aws 5.0.0, backports to the 4.x series will be limited to
 security issues and bugfixes.
-
 
 Minor Changes
 -------------
@@ -1906,7 +1914,6 @@ Release Summary
 ---------------
 
 Following the release of amazon.aws 5.0.0, 3.5.0 is a bugfix release and the final planned release for the 3.x series.
-
 
 Minor Changes
 -------------

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -312,6 +312,258 @@ releases:
     - 460-pylint.yml
     - 486-ec2_vol_fixed_returned_changed_var.yml
     release_date: '2021-09-09'
+  10.0.0:
+    changes:
+      breaking_changes:
+      - amazon.aws collection - Support for ansible-core < 2.17 has been dropped (https://github.com/ansible-collections/amazon.aws/pull/2601).
+      - amazon.aws collection - Support for the ``EC2_ACCESS_KEY`` environment variable
+        was deprecated in release ``6.0.0`` and has now been removed.  Please use
+        the ``access_key`` parameter or ``AWS_ACCESS_KEY_ID`` environment variable
+        instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - Support for the ``EC2_REGION`` environment variable
+        was deprecated in release ``6.0.0`` and has now been removed.  Please use
+        the ``region`` parameter or ``AWS_REGION`` environment variable instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - Support for the ``EC2_SECRET_KEY`` environment variable
+        was deprecated in release ``6.0.0`` and has now been removed.  Please use
+        the ``secret_key`` parameter or ``AWS_SECRET_ACCESS_KEY`` environment variable
+        instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - Support for the ``EC2_SECURITY_TOKEN`` and ``AWS_SECURITY_TOKEN``
+        environment variables were deprecated in release ``6.0.0`` and have now been
+        removed.  Please use the ``session_token`` parameter or ``AWS_SESSION_TOKEN``
+        environment variable instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - Support for the ``EC2_URL`` and ``S3_URL`` environment
+        variables were deprecated in release ``6.0.0`` and have now been removed.  Please
+        use the ``endpoint_url`` parameter or ``AWS_URL`` environment variable instead
+        (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - The ``access_token``, ``aws_security_token`` and ``security_token``
+        aliases for the ``session_token`` parameter were deprecated in release ``6.0.0``
+        and have now been removed.  Please use the ``session_token`` name instead
+        (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - The ``boto_profile`` alias for the ``profile`` parameter
+        was deprecated in release ``6.0.0`` and has now been removed.  Please use
+        the ``profile`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - The ``ec2_access_key`` alias for the ``access_key``
+        parameter was deprecated in release ``6.0.0`` and has now been removed.  Please
+        use the ``access_key`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - The ``ec2_region`` alias for the ``region`` parameter
+        was deprecated in release ``6.0.0`` and has now been removed.  Please use
+        the ``region`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - The ``ec2_secret_key`` alias for the ``secret_key``
+        parameter was deprecated in release ``6.0.0`` and has now been removed.  Please
+        use the ``secret_key`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - The ``endpoint``, ``ec2_url`` and ``s3_url`` aliases
+        for the ``endpoint_url`` parameter were deprecated in release ``6.0.0`` and
+        have now been removed.  Please use the ``region`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - docs_fragments - The previously deprecated ``amazon.aws.aws_credentials``
+        docs fragment has been removed please use ``amazon.aws.common.plugins`` instead
+        (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - docs_fragments - The previously deprecated ``amazon.aws.aws_region`` docs
+        fragment has been removed please use ``amazon.aws.region.plugins`` instead
+        (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - docs_fragments - The previously deprecated ``amazon.aws.aws`` docs fragment
+        has been removed please use ``amazon.aws.common.modules`` instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - docs_fragments - The previously deprecated ``amazon.aws.ec2`` docs fragment
+        has been removed please use ``amazon.aws.region.modules`` instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - ec2_vpc_peering_info - the ``result`` key has been removed from the return
+        value. ``vpc_peering_connections`` should be used instead (https://github.com/ansible-collections/amazon.aws/pull/2618).
+      - module_utils.botocore - drop deprecated ``boto3`` parameter for ``get_aws_region()``
+        and ``get_aws_connection_info()``, this parameter has had no effect since
+        release 4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/2443).
+      - module_utils.ec2 - drop deprecated ``boto3`` parameter for ``get_ec2_security_group_ids_from_names()``
+        and ``get_aws_connection_info()``, this parameter has had no effect since
+        release 4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/2603).
+      - rds_param_group - the redirect has been removed and playbooks should be updated
+        to use rds_instance_param_group (https://github.com/ansible-collections/amazon.aws/pull/2618).
+      bugfixes:
+      - s3_bucket - bucket ACLs now consistently returned (https://github.com/ansible-collections/amazon.aws/pull/2478).
+      - s3_bucket - fixed idempotency when setting bucket ACLs (https://github.com/ansible-collections/amazon.aws/pull/2478).
+      major_changes:
+      - amazon.aws collection - The amazon.aws collection has dropped support for
+        ``botocore<1.34.0`` and ``boto3<1.34.0``. Most modules will continue to work
+        with older versions of the AWS SDK, however compatibility with older versions
+        of the SDK is not guaranteed and will not be tested. When using older versions
+        of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/2426).
+      - amazon.aws collection - due to the AWS SDKs announcing the end of support
+        for Python less than 3.8 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/),
+        support for Python less than 3.8 by this collection was deprecated in release
+        6.0.0 and removed in release 10.0.0. (https://github.com/ansible-collections/amazon.aws/pull/2426).
+      - connection/aws_ssm - The module has been migrated from the ``community.aws``
+        collection. Playbooks using the Fully Qualified Collection Name for this module
+        should be updated to use ``amazon.aws.aws_ssm``.
+      minor_changes:
+      - module_utils.s3 - added "501" to the list of error codes thrown by S3 replacements
+        (https://github.com/ansible-collections/amazon.aws/issues/2447).
+      - module_utils/s3 - add initial ErrorHandler for S3 modules (https://github.com/ansible-collections/amazon.aws/pull/2060).
+      - s3_bucket - migrated to use updated error handlers for better handling of
+        non-AWS errors (https://github.com/ansible-collections/amazon.aws/pull/2478).
+      release_summary: 'This major release introduces new support with the ``aws_ssm``
+        connection plugin, which has been promoted from ``community.aws``, several
+        bugfixes, minor changes and deprecated features.
+
+        Additionally, this release increases the minimum required versions of ``boto3``
+        and ``botocore`` to 1.34.0 to align with updated AWS SDK support and support
+        for ansible-core < 2.17 has been dropped.
+
+        Due to the AWS SDKs announcing the end of support for Python less than 3.8
+        (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/),
+        support for Python less than 3.8 by this collection was deprecated in 9.0.0
+        release and is removed in this 10.0.0 release.
+
+        '
+    fragments:
+    - 10.0.0-increase-ansible-core-version.yml
+    - 10.0.0.yml
+    - 20241029-main-10.0.0.yml
+    - 20250117-s3_bucket-error_handler.yml
+    - 20250508-update-docs.yml
+    - 2060-s3_error_handler.yml
+    - 2443-boto-final-clean.yml
+    - 2527-module_aliases.yml
+    - 2618-remove-rds-param-group.yml
+    - boto3-cleanup.yml
+    - botocore.yml
+    - migrate_aws_ssm.yml
+    - s3_bucket-501.yml
+    - skip_ansible-core_2.16.yml
+    release_date: '2025-05-13'
+  10.1.0:
+    changes:
+      minor_changes:
+      - inventory/aws_ec2 - Adding support for ``Route53`` as hostname (https://github.com/ansible-collections/amazon.aws/pull/2580).
+      release_summary: This minor release adds support for ``Route53`` as a hostname.
+    fragments:
+    - 20250321-inventory_aws_ec2-add-support-for-route53.yml
+    release_date: '2025-06-03'
+  10.1.1:
+    changes:
+      bugfixes:
+      - ec2_instance - corrected typo for InsufficientInstanceCapacity. Fix now will
+        retry Ec2 creation when InsufficientInstanceCapacity error occurs (https://github.com/ansible-collections/amazon.aws/issues/1038).
+      release_summary: This release includes a bugfix and a documentation update.
+    fragments:
+    - 10.1.1.yml
+    - 2674-fix-errorcode-typo.yml
+    release_date: '2025-08-06'
+  10.1.2:
+    changes:
+      bugfixes:
+      - Remove ``ansible.module_utils.six`` imports to avoid warnings (https://github.com/ansible-collections/amazon.aws/pull/2727).
+      - amazon.aws.autoscaling_instance - setting the state to ``terminated`` had
+        no effect. The fix implements missing instance termination state (https://github.com/ansible-collections/amazon.aws/issues/2719).
+      - ec2_vpc_nacl - Fix issue when trying to update existing Network ACL rule (https://github.com/ansible-collections/amazon.aws/issues/2592).
+      - s3_object - Honor headers for content and content_base64 uploads by promoting
+        supported keys (e.g. ContentType, ContentDisposition, CacheControl) to top-level
+        S3 arguments and placing remaining keys under Metadata. This makes content
+        uploads consistent with src uploads. (https://github.com/ansible-collections/amazon.aws)
+      release_summary: This release includes multiple bug fixes.
+    fragments:
+    - 10.1.2_summary.yaml
+    - 20250513-ec2_vpc_nacl-fix-issue-when-updating-rules.yml
+    - 20250924-sanity-fixes.yml
+    - 2720-autoscaling_instance-implements-missing-instance-termination-state.yaml
+    - s3_object-content-headers.yml
+    release_date: '2025-10-07'
+  10.2.0:
+    changes:
+      bugfixes:
+      - connection/aws_ssm - fixed ReferenceError in aws_ssm connection plugin destructor
+        during interpreter shutdown (https://github.com/ansible-collections/amazon.aws/issues/2728).
+      - lambda_info - fixed invalid return value documentation that used dot notation
+        (``function.TheName``) which cannot be used in Jinja2 templates (https://github.com/ansible-collections/amazon.aws/pull/2772).
+      - s3_bucket - fix error when configuring AES256 bucket encryption with ``bucket_key_enabled``
+        explicitly set to ``false`` (https://github.com/ansible-collections/amazon.aws/issues/2734).
+      deprecated_features:
+      - ec2_vpc_dhcp_option - the ``dhcp_config`` return value has been deprecated
+        and will be removed in a release after 2026-12-01. Use ``dhcp_options`` instead
+        (https://github.com/ansible-collections/amazon.aws/pull/2772).
+      - ec2_vpc_dhcp_option_info - the ``dhcp_config`` return value has been deprecated
+        and will be removed in a release after 2026-12-01. Use ``dhcp_options`` instead
+        (https://github.com/ansible-collections/amazon.aws/pull/2772).
+      - route53 - the ``values`` key in the ``resource_record_sets`` return value
+        has been deprecated in favor of ``record_values`` for Jinja2 compatibility.
+        The ``values`` key will be removed in a release after 2026-12-01 (https://github.com/ansible-collections/amazon.aws/pull/2772).
+      minor_changes:
+      - Add support for the io2 storage type for RDS (https://github.com/ansible-collections/amazon.aws/pull/2748).
+      - ec2_launch_template - increase GP3 volume ``throughput`` limits in line with
+        updated AWS limits (https://github.com/ansible-collections/amazon.aws/pull/2749).
+      - ec2_vol - increase ``throughput`` and ``iops`` limits for GP3 volumes in line
+        with updated AWS limits (https://github.com/ansible-collections/amazon.aws/pull/2749).
+      - module_utils.s3 - added "501" to the list of error codes thrown by S3 replacements
+        (https://github.com/ansible-collections/amazon.aws/issues/2447).
+      - module_utils/_s3/common - use ``is_boto3_error_httpstatus`` to handle HTTP
+        403 and 501 status codes from S3-compatible services (https://github.com/ansible-collections/amazon.aws/pull/2776).
+      - module_utils/botocore - add ``is_boto3_error_httpstatus`` helper function
+        to catch boto3 exceptions based on HTTP status codes (https://github.com/ansible-collections/amazon.aws/pull/2776).
+      - route53 - added ``record_values`` key to ``resource_record_sets`` return value
+        that can be accessed using Jinja2 dot notation (https://github.com/ansible-collections/amazon.aws/pull/2772).
+      - sts_assume_role - improve error handling for ``MalformedPolicyDocument`` errors
+        by providing a clearer error message when an invalid policy document is provided
+        (https://github.com/ansible-collections/amazon.aws/pull/2778).
+      release_summary: This release adds support for the io2 storage type for RDS
+        as well as other minor changes, several bugfixes and deprecated features.
+    fragments:
+    - 2728-reference_error_ssm_destructor.yml
+    - 2734-AES_explicit_bucket_key.yml
+    - 2748-io2_storage_support.yml
+    - 2749-gp3-limits.yml
+    - fix-bad-return-value-keys.yml
+    - is_boto3_error_httpstatus.yml
+    - s3_bucket-501.yml
+    - sts_assume_role-malformed_policy.yml
+    release_date: '2026-01-13'
+  10.3.0:
+    changes:
+      bugfixes:
+      - aws_ssm - Fixed connection being re-established on every loop iteration. The
+        plugin now properly establishes a single connection for a loop (https://github.com/ansible-collections/amazon.aws/pull/2869).
+      - elb_application_lb - fixed comparison of multi-rule default actions to properly
+        handle the ``Order`` field when determining if listener modifications are
+        needed (https://github.com/ansible-collections/amazon.aws/issues/2537).
+      - 'elb_application_lb - fixed error where creating a new application load balancer
+        with listener rules would fail with ``Parameter validation failed: Invalid
+        type for parameter ListenerArn, value: None`` (https://github.com/ansible-collections/amazon.aws/issues/2400).'
+      - s3_object - fixed error when using PUT with an empty ``content`` string (https://github.com/ansible-collections/amazon.aws/pull/2810)
+      minor_changes:
+      - meta/runtime.yml - Lowered the ``ansible-core`` minimum version to ``2.16``.
+        This expands compatibility and does not change or remove existing functionality.
+      release_summary: This minor release includes several bug fixes across ALB, S3,
+        and the SSM connection plugin, security hardening for ARN parsing, and expanded
+        compatibility with ansible-core >= 2.16.
+      security_fixes:
+      - arn - fix potential ReDoS vulnerability in ARN parsing regex by using negated
+        character class instead of non-greedy quantifier (https://github.com/ansible-collections/amazon.aws/pull/2884).
+      - ec2_security_group - fix potential ReDoS vulnerability in security group ID
+        parsing regex by using negated character classes and adding end anchor (https://github.com/ansible-collections/amazon.aws/pull/2884).
+    fragments:
+    - 2773-elb-application-lb-listener-rules.yml
+    - 2810-fix-put-empty-content.yml
+    - 2869_aws_ssm_connection_fix.yml
+    - relax_ansible_core_version.yml
+    - release_summary.yml
+    - sonarcloud_regex.yml
+    - unittests-boto3-credentials.yml
+    release_date: '2026-03-16'
+  10.3.1:
+    changes:
+      bugfixes:
+      - autoscaling_group - Fixed duplicate default_cooldown assignment in properties
+        dict (https://github.com/ansible-collections/amazon.aws/pull/2923).
+      - kms_key - Fixed parameter reassignment by using passed alias parameter instead
+        of re-fetching from module params (https://github.com/ansible-collections/amazon.aws/pull/2923).
+      - module_utils/cloudfront_facts - fix TypeError in CloudFrontFactsServiceManager.describe_cloudfront_property
+        (https://github.com/ansible-collections/community.aws/issues/1915).
+      - s3_object_info - Fixed duplicate dictionary key assignments when retrieving
+        object facts (https://github.com/ansible-collections/amazon.aws/pull/2923).
+      release_summary: This patch release includes bugfixes for the ``s3_object_info``,
+        ``autoscaling_group``, and ``kms_key`` modules, addressing duplicate dictionary
+        key assignments and improving reliability. It also fixes a TypeError in CloudFront
+        module utilities.
+    fragments:
+    - 10.3.1.yml
+    - 1915-cloudfront_distribution_info-TypeError.yml
+    - ansible-test-gh-action-migration.yml
+    - reliability-duplicate-assignments.yml
+    release_date: '2026-05-05'
   2.0.0:
     changes:
       breaking_changes:
@@ -3780,234 +4032,3 @@ releases:
     - 9.5.2.yml
     - s3_object-content-headers.yml
     release_date: '2025-10-07'
-  10.0.0:
-    changes:
-      breaking_changes:
-      - amazon.aws collection - Support for ansible-core < 2.17 has been dropped (https://github.com/ansible-collections/amazon.aws/pull/2601).
-      - amazon.aws collection - Support for the ``EC2_ACCESS_KEY`` environment variable
-        was deprecated in release ``6.0.0`` and has now been removed.  Please use
-        the ``access_key`` parameter or ``AWS_ACCESS_KEY_ID`` environment variable
-        instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - Support for the ``EC2_REGION`` environment variable
-        was deprecated in release ``6.0.0`` and has now been removed.  Please use
-        the ``region`` parameter or ``AWS_REGION`` environment variable instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - Support for the ``EC2_SECRET_KEY`` environment variable
-        was deprecated in release ``6.0.0`` and has now been removed.  Please use
-        the ``secret_key`` parameter or ``AWS_SECRET_ACCESS_KEY`` environment variable
-        instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - Support for the ``EC2_SECURITY_TOKEN`` and ``AWS_SECURITY_TOKEN``
-        environment variables were deprecated in release ``6.0.0`` and have now been
-        removed.  Please use the ``session_token`` parameter or ``AWS_SESSION_TOKEN``
-        environment variable instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - Support for the ``EC2_URL`` and ``S3_URL`` environment
-        variables were deprecated in release ``6.0.0`` and have now been removed.  Please
-        use the ``endpoint_url`` parameter or ``AWS_URL`` environment variable instead
-        (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - The ``access_token``, ``aws_security_token`` and ``security_token``
-        aliases for the ``session_token`` parameter were deprecated in release ``6.0.0``
-        and have now been removed.  Please use the ``session_token`` name instead
-        (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - The ``boto_profile`` alias for the ``profile`` parameter
-        was deprecated in release ``6.0.0`` and has now been removed.  Please use
-        the ``profile`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - The ``ec2_access_key`` alias for the ``access_key``
-        parameter was deprecated in release ``6.0.0`` and has now been removed.  Please
-        use the ``access_key`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - The ``ec2_region`` alias for the ``region`` parameter
-        was deprecated in release ``6.0.0`` and has now been removed.  Please use
-        the ``region`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - The ``ec2_secret_key`` alias for the ``secret_key``
-        parameter was deprecated in release ``6.0.0`` and has now been removed.  Please
-        use the ``secret_key`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - The ``endpoint``, ``ec2_url`` and ``s3_url`` aliases
-        for the ``endpoint_url`` parameter were deprecated in release ``6.0.0`` and
-        have now been removed.  Please use the ``region`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - docs_fragments - The previously deprecated ``amazon.aws.aws_credentials``
-        docs fragment has been removed please use ``amazon.aws.common.plugins`` instead
-        (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - docs_fragments - The previously deprecated ``amazon.aws.aws_region`` docs
-        fragment has been removed please use ``amazon.aws.region.plugins`` instead
-        (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - docs_fragments - The previously deprecated ``amazon.aws.aws`` docs fragment
-        has been removed please use ``amazon.aws.common.modules`` instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - docs_fragments - The previously deprecated ``amazon.aws.ec2`` docs fragment
-        has been removed please use ``amazon.aws.region.modules`` instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - ec2_vpc_peering_info - the ``result`` key has been removed from the return
-        value. ``vpc_peering_connections`` should be used instead (https://github.com/ansible-collections/amazon.aws/pull/2618).
-      - module_utils.botocore - drop deprecated ``boto3`` parameter for ``get_aws_region()``
-        and ``get_aws_connection_info()``, this parameter has had no effect since
-        release 4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/2443).
-      - module_utils.ec2 - drop deprecated ``boto3`` parameter for ``get_ec2_security_group_ids_from_names()``
-        and ``get_aws_connection_info()``, this parameter has had no effect since
-        release 4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/2603).
-      - rds_param_group - the redirect has been removed and playbooks should be updated
-        to use rds_instance_param_group (https://github.com/ansible-collections/amazon.aws/pull/2618).
-      bugfixes:
-      - s3_bucket - bucket ACLs now consistently returned (https://github.com/ansible-collections/amazon.aws/pull/2478).
-      - s3_bucket - fixed idempotency when setting bucket ACLs (https://github.com/ansible-collections/amazon.aws/pull/2478).
-      major_changes:
-      - amazon.aws collection - The amazon.aws collection has dropped support for
-        ``botocore<1.34.0`` and ``boto3<1.34.0``. Most modules will continue to work
-        with older versions of the AWS SDK, however compatibility with older versions
-        of the SDK is not guaranteed and will not be tested. When using older versions
-        of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/2426).
-      - amazon.aws collection - due to the AWS SDKs announcing the end of support
-        for Python less than 3.8 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/),
-        support for Python less than 3.8 by this collection was deprecated in release
-        6.0.0 and removed in release 10.0.0. (https://github.com/ansible-collections/amazon.aws/pull/2426).
-      - connection/aws_ssm - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.aws_ssm``.
-      minor_changes:
-      - module_utils.s3 - added "501" to the list of error codes thrown by S3 replacements
-        (https://github.com/ansible-collections/amazon.aws/issues/2447).
-      - module_utils/s3 - add initial ErrorHandler for S3 modules (https://github.com/ansible-collections/amazon.aws/pull/2060).
-      - s3_bucket - migrated to use updated error handlers for better handling of
-        non-AWS errors (https://github.com/ansible-collections/amazon.aws/pull/2478).
-      release_summary: 'This major release introduces new support with the ``aws_ssm``
-        connection plugin, which has been promoted from ``community.aws``, several
-        bugfixes, minor changes and deprecated features.
-
-        Additionally, this release increases the minimum required versions of ``boto3``
-        and ``botocore`` to 1.34.0 to align with updated AWS SDK support and support
-        for ansible-core < 2.17 has been dropped.
-
-        Due to the AWS SDKs announcing the end of support for Python less than 3.8
-        (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/),
-        support for Python less than 3.8 by this collection was deprecated in 9.0.0
-        release and is removed in this 10.0.0 release.
-
-        '
-    fragments:
-    - 10.0.0-increase-ansible-core-version.yml
-    - 10.0.0.yml
-    - 20241029-main-10.0.0.yml
-    - 20250117-s3_bucket-error_handler.yml
-    - 20250508-update-docs.yml
-    - 2060-s3_error_handler.yml
-    - 2443-boto-final-clean.yml
-    - 2527-module_aliases.yml
-    - 2618-remove-rds-param-group.yml
-    - boto3-cleanup.yml
-    - botocore.yml
-    - migrate_aws_ssm.yml
-    - s3_bucket-501.yml
-    - skip_ansible-core_2.16.yml
-    release_date: '2025-05-13'
-  10.1.0:
-    changes:
-      minor_changes:
-      - inventory/aws_ec2 - Adding support for ``Route53`` as hostname (https://github.com/ansible-collections/amazon.aws/pull/2580).
-      release_summary: This minor release adds support for ``Route53`` as a hostname.
-    fragments:
-    - 20250321-inventory_aws_ec2-add-support-for-route53.yml
-    release_date: '2025-06-03'
-  10.1.1:
-    changes:
-      bugfixes:
-      - ec2_instance - corrected typo for InsufficientInstanceCapacity. Fix now will
-        retry Ec2 creation when InsufficientInstanceCapacity error occurs (https://github.com/ansible-collections/amazon.aws/issues/1038).
-      release_summary: This release includes a bugfix and a documentation update.
-    fragments:
-    - 10.1.1.yml
-    - 2674-fix-errorcode-typo.yml
-    release_date: '2025-08-06'
-  10.1.2:
-    changes:
-      bugfixes:
-      - Remove ``ansible.module_utils.six`` imports to avoid warnings (https://github.com/ansible-collections/amazon.aws/pull/2727).
-      - amazon.aws.autoscaling_instance - setting the state to ``terminated`` had
-        no effect. The fix implements missing instance termination state (https://github.com/ansible-collections/amazon.aws/issues/2719).
-      - ec2_vpc_nacl - Fix issue when trying to update existing Network ACL rule (https://github.com/ansible-collections/amazon.aws/issues/2592).
-      - s3_object - Honor headers for content and content_base64 uploads by promoting
-        supported keys (e.g. ContentType, ContentDisposition, CacheControl) to top-level
-        S3 arguments and placing remaining keys under Metadata. This makes content
-        uploads consistent with src uploads. (https://github.com/ansible-collections/amazon.aws)
-      release_summary: This release includes multiple bug fixes.
-    fragments:
-    - 10.1.2_summary.yaml
-    - 20250513-ec2_vpc_nacl-fix-issue-when-updating-rules.yml
-    - 20250924-sanity-fixes.yml
-    - 2720-autoscaling_instance-implements-missing-instance-termination-state.yaml
-    - s3_object-content-headers.yml
-    release_date: '2025-10-07'
-  10.2.0:
-    changes:
-      bugfixes:
-      - connection/aws_ssm - fixed ReferenceError in aws_ssm connection plugin destructor
-        during interpreter shutdown (https://github.com/ansible-collections/amazon.aws/issues/2728).
-      - lambda_info - fixed invalid return value documentation that used dot notation
-        (``function.TheName``) which cannot be used in Jinja2 templates (https://github.com/ansible-collections/amazon.aws/pull/2772).
-      - s3_bucket - fix error when configuring AES256 bucket encryption with ``bucket_key_enabled``
-        explicitly set to ``false`` (https://github.com/ansible-collections/amazon.aws/issues/2734).
-      deprecated_features:
-      - ec2_vpc_dhcp_option - the ``dhcp_config`` return value has been deprecated
-        and will be removed in a release after 2026-12-01. Use ``dhcp_options`` instead
-        (https://github.com/ansible-collections/amazon.aws/pull/2772).
-      - ec2_vpc_dhcp_option_info - the ``dhcp_config`` return value has been deprecated
-        and will be removed in a release after 2026-12-01. Use ``dhcp_options`` instead
-        (https://github.com/ansible-collections/amazon.aws/pull/2772).
-      - route53 - the ``values`` key in the ``resource_record_sets`` return value
-        has been deprecated in favor of ``record_values`` for Jinja2 compatibility.
-        The ``values`` key will be removed in a release after 2026-12-01 (https://github.com/ansible-collections/amazon.aws/pull/2772).
-      minor_changes:
-      - Add support for the io2 storage type for RDS (https://github.com/ansible-collections/amazon.aws/pull/2748).
-      - ec2_launch_template - increase GP3 volume ``throughput`` limits in line with
-        updated AWS limits (https://github.com/ansible-collections/amazon.aws/pull/2749).
-      - ec2_vol - increase ``throughput`` and ``iops`` limits for GP3 volumes in line
-        with updated AWS limits (https://github.com/ansible-collections/amazon.aws/pull/2749).
-      - module_utils.s3 - added "501" to the list of error codes thrown by S3 replacements
-        (https://github.com/ansible-collections/amazon.aws/issues/2447).
-      - module_utils/_s3/common - use ``is_boto3_error_httpstatus`` to handle HTTP
-        403 and 501 status codes from S3-compatible services (https://github.com/ansible-collections/amazon.aws/pull/2776).
-      - module_utils/botocore - add ``is_boto3_error_httpstatus`` helper function
-        to catch boto3 exceptions based on HTTP status codes (https://github.com/ansible-collections/amazon.aws/pull/2776).
-      - route53 - added ``record_values`` key to ``resource_record_sets`` return value
-        that can be accessed using Jinja2 dot notation (https://github.com/ansible-collections/amazon.aws/pull/2772).
-      - sts_assume_role - improve error handling for ``MalformedPolicyDocument`` errors
-        by providing a clearer error message when an invalid policy document is provided
-        (https://github.com/ansible-collections/amazon.aws/pull/2778).
-      release_summary: This release adds support for the io2 storage type for RDS
-        as well as other minor changes, several bugfixes and deprecated features.
-    fragments:
-    - 2728-reference_error_ssm_destructor.yml
-    - 2734-AES_explicit_bucket_key.yml
-    - 2748-io2_storage_support.yml
-    - 2749-gp3-limits.yml
-    - fix-bad-return-value-keys.yml
-    - is_boto3_error_httpstatus.yml
-    - s3_bucket-501.yml
-    - sts_assume_role-malformed_policy.yml
-    release_date: '2026-01-13'
-  10.3.0:
-    changes:
-      bugfixes:
-      - aws_ssm - Fixed connection being re-established on every loop iteration. The
-        plugin now properly establishes a single connection for a loop (https://github.com/ansible-collections/amazon.aws/pull/2869).
-      - elb_application_lb - fixed comparison of multi-rule default actions to properly
-        handle the ``Order`` field when determining if listener modifications are
-        needed (https://github.com/ansible-collections/amazon.aws/issues/2537).
-      - 'elb_application_lb - fixed error where creating a new application load balancer
-        with listener rules would fail with ``Parameter validation failed: Invalid
-        type for parameter ListenerArn, value: None`` (https://github.com/ansible-collections/amazon.aws/issues/2400).'
-      - s3_object - fixed error when using PUT with an empty ``content`` string (https://github.com/ansible-collections/amazon.aws/pull/2810)
-      minor_changes:
-      - meta/runtime.yml - Lowered the ``ansible-core`` minimum version to ``2.16``.
-        This expands compatibility and does not change or remove existing functionality.
-      release_summary: This minor release includes several bug fixes across ALB, S3,
-        and the SSM connection plugin, security hardening for ARN parsing, and expanded
-        compatibility with ansible-core >= 2.16.
-      security_fixes:
-      - arn - fix potential ReDoS vulnerability in ARN parsing regex by using negated
-        character class instead of non-greedy quantifier (https://github.com/ansible-collections/amazon.aws/pull/2884).
-      - ec2_security_group - fix potential ReDoS vulnerability in security group ID
-        parsing regex by using negated character classes and adding end anchor (https://github.com/ansible-collections/amazon.aws/pull/2884).
-    fragments:
-    - 2773-elb-application-lb-listener-rules.yml
-    - 2810-fix-put-empty-content.yml
-    - 2869_aws_ssm_connection_fix.yml
-    - relax_ansible_core_version.yml
-    - release_summary.yml
-    - sonarcloud_regex.yml
-    - unittests-boto3-credentials.yml
-    release_date: '2026-03-16'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -312,258 +312,6 @@ releases:
     - 460-pylint.yml
     - 486-ec2_vol_fixed_returned_changed_var.yml
     release_date: '2021-09-09'
-  10.0.0:
-    changes:
-      breaking_changes:
-      - amazon.aws collection - Support for ansible-core < 2.17 has been dropped (https://github.com/ansible-collections/amazon.aws/pull/2601).
-      - amazon.aws collection - Support for the ``EC2_ACCESS_KEY`` environment variable
-        was deprecated in release ``6.0.0`` and has now been removed.  Please use
-        the ``access_key`` parameter or ``AWS_ACCESS_KEY_ID`` environment variable
-        instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - Support for the ``EC2_REGION`` environment variable
-        was deprecated in release ``6.0.0`` and has now been removed.  Please use
-        the ``region`` parameter or ``AWS_REGION`` environment variable instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - Support for the ``EC2_SECRET_KEY`` environment variable
-        was deprecated in release ``6.0.0`` and has now been removed.  Please use
-        the ``secret_key`` parameter or ``AWS_SECRET_ACCESS_KEY`` environment variable
-        instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - Support for the ``EC2_SECURITY_TOKEN`` and ``AWS_SECURITY_TOKEN``
-        environment variables were deprecated in release ``6.0.0`` and have now been
-        removed.  Please use the ``session_token`` parameter or ``AWS_SESSION_TOKEN``
-        environment variable instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - Support for the ``EC2_URL`` and ``S3_URL`` environment
-        variables were deprecated in release ``6.0.0`` and have now been removed.  Please
-        use the ``endpoint_url`` parameter or ``AWS_URL`` environment variable instead
-        (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - The ``access_token``, ``aws_security_token`` and ``security_token``
-        aliases for the ``session_token`` parameter were deprecated in release ``6.0.0``
-        and have now been removed.  Please use the ``session_token`` name instead
-        (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - The ``boto_profile`` alias for the ``profile`` parameter
-        was deprecated in release ``6.0.0`` and has now been removed.  Please use
-        the ``profile`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - The ``ec2_access_key`` alias for the ``access_key``
-        parameter was deprecated in release ``6.0.0`` and has now been removed.  Please
-        use the ``access_key`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - The ``ec2_region`` alias for the ``region`` parameter
-        was deprecated in release ``6.0.0`` and has now been removed.  Please use
-        the ``region`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - The ``ec2_secret_key`` alias for the ``secret_key``
-        parameter was deprecated in release ``6.0.0`` and has now been removed.  Please
-        use the ``secret_key`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - amazon.aws collection - The ``endpoint``, ``ec2_url`` and ``s3_url`` aliases
-        for the ``endpoint_url`` parameter were deprecated in release ``6.0.0`` and
-        have now been removed.  Please use the ``region`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - docs_fragments - The previously deprecated ``amazon.aws.aws_credentials``
-        docs fragment has been removed please use ``amazon.aws.common.plugins`` instead
-        (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - docs_fragments - The previously deprecated ``amazon.aws.aws_region`` docs
-        fragment has been removed please use ``amazon.aws.region.plugins`` instead
-        (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - docs_fragments - The previously deprecated ``amazon.aws.aws`` docs fragment
-        has been removed please use ``amazon.aws.common.modules`` instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - docs_fragments - The previously deprecated ``amazon.aws.ec2`` docs fragment
-        has been removed please use ``amazon.aws.region.modules`` instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
-      - ec2_vpc_peering_info - the ``result`` key has been removed from the return
-        value. ``vpc_peering_connections`` should be used instead (https://github.com/ansible-collections/amazon.aws/pull/2618).
-      - module_utils.botocore - drop deprecated ``boto3`` parameter for ``get_aws_region()``
-        and ``get_aws_connection_info()``, this parameter has had no effect since
-        release 4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/2443).
-      - module_utils.ec2 - drop deprecated ``boto3`` parameter for ``get_ec2_security_group_ids_from_names()``
-        and ``get_aws_connection_info()``, this parameter has had no effect since
-        release 4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/2603).
-      - rds_param_group - the redirect has been removed and playbooks should be updated
-        to use rds_instance_param_group (https://github.com/ansible-collections/amazon.aws/pull/2618).
-      bugfixes:
-      - s3_bucket - bucket ACLs now consistently returned (https://github.com/ansible-collections/amazon.aws/pull/2478).
-      - s3_bucket - fixed idempotency when setting bucket ACLs (https://github.com/ansible-collections/amazon.aws/pull/2478).
-      major_changes:
-      - amazon.aws collection - The amazon.aws collection has dropped support for
-        ``botocore<1.34.0`` and ``boto3<1.34.0``. Most modules will continue to work
-        with older versions of the AWS SDK, however compatibility with older versions
-        of the SDK is not guaranteed and will not be tested. When using older versions
-        of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/2426).
-      - amazon.aws collection - due to the AWS SDKs announcing the end of support
-        for Python less than 3.8 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/),
-        support for Python less than 3.8 by this collection was deprecated in release
-        6.0.0 and removed in release 10.0.0. (https://github.com/ansible-collections/amazon.aws/pull/2426).
-      - connection/aws_ssm - The module has been migrated from the ``community.aws``
-        collection. Playbooks using the Fully Qualified Collection Name for this module
-        should be updated to use ``amazon.aws.aws_ssm``.
-      minor_changes:
-      - module_utils.s3 - added "501" to the list of error codes thrown by S3 replacements
-        (https://github.com/ansible-collections/amazon.aws/issues/2447).
-      - module_utils/s3 - add initial ErrorHandler for S3 modules (https://github.com/ansible-collections/amazon.aws/pull/2060).
-      - s3_bucket - migrated to use updated error handlers for better handling of
-        non-AWS errors (https://github.com/ansible-collections/amazon.aws/pull/2478).
-      release_summary: 'This major release introduces new support with the ``aws_ssm``
-        connection plugin, which has been promoted from ``community.aws``, several
-        bugfixes, minor changes and deprecated features.
-
-        Additionally, this release increases the minimum required versions of ``boto3``
-        and ``botocore`` to 1.34.0 to align with updated AWS SDK support and support
-        for ansible-core < 2.17 has been dropped.
-
-        Due to the AWS SDKs announcing the end of support for Python less than 3.8
-        (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/),
-        support for Python less than 3.8 by this collection was deprecated in 9.0.0
-        release and is removed in this 10.0.0 release.
-
-        '
-    fragments:
-    - 10.0.0-increase-ansible-core-version.yml
-    - 10.0.0.yml
-    - 20241029-main-10.0.0.yml
-    - 20250117-s3_bucket-error_handler.yml
-    - 20250508-update-docs.yml
-    - 2060-s3_error_handler.yml
-    - 2443-boto-final-clean.yml
-    - 2527-module_aliases.yml
-    - 2618-remove-rds-param-group.yml
-    - boto3-cleanup.yml
-    - botocore.yml
-    - migrate_aws_ssm.yml
-    - s3_bucket-501.yml
-    - skip_ansible-core_2.16.yml
-    release_date: '2025-05-13'
-  10.1.0:
-    changes:
-      minor_changes:
-      - inventory/aws_ec2 - Adding support for ``Route53`` as hostname (https://github.com/ansible-collections/amazon.aws/pull/2580).
-      release_summary: This minor release adds support for ``Route53`` as a hostname.
-    fragments:
-    - 20250321-inventory_aws_ec2-add-support-for-route53.yml
-    release_date: '2025-06-03'
-  10.1.1:
-    changes:
-      bugfixes:
-      - ec2_instance - corrected typo for InsufficientInstanceCapacity. Fix now will
-        retry Ec2 creation when InsufficientInstanceCapacity error occurs (https://github.com/ansible-collections/amazon.aws/issues/1038).
-      release_summary: This release includes a bugfix and a documentation update.
-    fragments:
-    - 10.1.1.yml
-    - 2674-fix-errorcode-typo.yml
-    release_date: '2025-08-06'
-  10.1.2:
-    changes:
-      bugfixes:
-      - Remove ``ansible.module_utils.six`` imports to avoid warnings (https://github.com/ansible-collections/amazon.aws/pull/2727).
-      - amazon.aws.autoscaling_instance - setting the state to ``terminated`` had
-        no effect. The fix implements missing instance termination state (https://github.com/ansible-collections/amazon.aws/issues/2719).
-      - ec2_vpc_nacl - Fix issue when trying to update existing Network ACL rule (https://github.com/ansible-collections/amazon.aws/issues/2592).
-      - s3_object - Honor headers for content and content_base64 uploads by promoting
-        supported keys (e.g. ContentType, ContentDisposition, CacheControl) to top-level
-        S3 arguments and placing remaining keys under Metadata. This makes content
-        uploads consistent with src uploads. (https://github.com/ansible-collections/amazon.aws)
-      release_summary: This release includes multiple bug fixes.
-    fragments:
-    - 10.1.2_summary.yaml
-    - 20250513-ec2_vpc_nacl-fix-issue-when-updating-rules.yml
-    - 20250924-sanity-fixes.yml
-    - 2720-autoscaling_instance-implements-missing-instance-termination-state.yaml
-    - s3_object-content-headers.yml
-    release_date: '2025-10-07'
-  10.2.0:
-    changes:
-      bugfixes:
-      - connection/aws_ssm - fixed ReferenceError in aws_ssm connection plugin destructor
-        during interpreter shutdown (https://github.com/ansible-collections/amazon.aws/issues/2728).
-      - lambda_info - fixed invalid return value documentation that used dot notation
-        (``function.TheName``) which cannot be used in Jinja2 templates (https://github.com/ansible-collections/amazon.aws/pull/2772).
-      - s3_bucket - fix error when configuring AES256 bucket encryption with ``bucket_key_enabled``
-        explicitly set to ``false`` (https://github.com/ansible-collections/amazon.aws/issues/2734).
-      deprecated_features:
-      - ec2_vpc_dhcp_option - the ``dhcp_config`` return value has been deprecated
-        and will be removed in a release after 2026-12-01. Use ``dhcp_options`` instead
-        (https://github.com/ansible-collections/amazon.aws/pull/2772).
-      - ec2_vpc_dhcp_option_info - the ``dhcp_config`` return value has been deprecated
-        and will be removed in a release after 2026-12-01. Use ``dhcp_options`` instead
-        (https://github.com/ansible-collections/amazon.aws/pull/2772).
-      - route53 - the ``values`` key in the ``resource_record_sets`` return value
-        has been deprecated in favor of ``record_values`` for Jinja2 compatibility.
-        The ``values`` key will be removed in a release after 2026-12-01 (https://github.com/ansible-collections/amazon.aws/pull/2772).
-      minor_changes:
-      - Add support for the io2 storage type for RDS (https://github.com/ansible-collections/amazon.aws/pull/2748).
-      - ec2_launch_template - increase GP3 volume ``throughput`` limits in line with
-        updated AWS limits (https://github.com/ansible-collections/amazon.aws/pull/2749).
-      - ec2_vol - increase ``throughput`` and ``iops`` limits for GP3 volumes in line
-        with updated AWS limits (https://github.com/ansible-collections/amazon.aws/pull/2749).
-      - module_utils.s3 - added "501" to the list of error codes thrown by S3 replacements
-        (https://github.com/ansible-collections/amazon.aws/issues/2447).
-      - module_utils/_s3/common - use ``is_boto3_error_httpstatus`` to handle HTTP
-        403 and 501 status codes from S3-compatible services (https://github.com/ansible-collections/amazon.aws/pull/2776).
-      - module_utils/botocore - add ``is_boto3_error_httpstatus`` helper function
-        to catch boto3 exceptions based on HTTP status codes (https://github.com/ansible-collections/amazon.aws/pull/2776).
-      - route53 - added ``record_values`` key to ``resource_record_sets`` return value
-        that can be accessed using Jinja2 dot notation (https://github.com/ansible-collections/amazon.aws/pull/2772).
-      - sts_assume_role - improve error handling for ``MalformedPolicyDocument`` errors
-        by providing a clearer error message when an invalid policy document is provided
-        (https://github.com/ansible-collections/amazon.aws/pull/2778).
-      release_summary: This release adds support for the io2 storage type for RDS
-        as well as other minor changes, several bugfixes and deprecated features.
-    fragments:
-    - 2728-reference_error_ssm_destructor.yml
-    - 2734-AES_explicit_bucket_key.yml
-    - 2748-io2_storage_support.yml
-    - 2749-gp3-limits.yml
-    - fix-bad-return-value-keys.yml
-    - is_boto3_error_httpstatus.yml
-    - s3_bucket-501.yml
-    - sts_assume_role-malformed_policy.yml
-    release_date: '2026-01-13'
-  10.3.0:
-    changes:
-      bugfixes:
-      - aws_ssm - Fixed connection being re-established on every loop iteration. The
-        plugin now properly establishes a single connection for a loop (https://github.com/ansible-collections/amazon.aws/pull/2869).
-      - elb_application_lb - fixed comparison of multi-rule default actions to properly
-        handle the ``Order`` field when determining if listener modifications are
-        needed (https://github.com/ansible-collections/amazon.aws/issues/2537).
-      - 'elb_application_lb - fixed error where creating a new application load balancer
-        with listener rules would fail with ``Parameter validation failed: Invalid
-        type for parameter ListenerArn, value: None`` (https://github.com/ansible-collections/amazon.aws/issues/2400).'
-      - s3_object - fixed error when using PUT with an empty ``content`` string (https://github.com/ansible-collections/amazon.aws/pull/2810)
-      minor_changes:
-      - meta/runtime.yml - Lowered the ``ansible-core`` minimum version to ``2.16``.
-        This expands compatibility and does not change or remove existing functionality.
-      release_summary: This minor release includes several bug fixes across ALB, S3,
-        and the SSM connection plugin, security hardening for ARN parsing, and expanded
-        compatibility with ansible-core >= 2.16.
-      security_fixes:
-      - arn - fix potential ReDoS vulnerability in ARN parsing regex by using negated
-        character class instead of non-greedy quantifier (https://github.com/ansible-collections/amazon.aws/pull/2884).
-      - ec2_security_group - fix potential ReDoS vulnerability in security group ID
-        parsing regex by using negated character classes and adding end anchor (https://github.com/ansible-collections/amazon.aws/pull/2884).
-    fragments:
-    - 2773-elb-application-lb-listener-rules.yml
-    - 2810-fix-put-empty-content.yml
-    - 2869_aws_ssm_connection_fix.yml
-    - relax_ansible_core_version.yml
-    - release_summary.yml
-    - sonarcloud_regex.yml
-    - unittests-boto3-credentials.yml
-    release_date: '2026-03-16'
-  10.3.1:
-    changes:
-      bugfixes:
-      - autoscaling_group - Fixed duplicate default_cooldown assignment in properties
-        dict (https://github.com/ansible-collections/amazon.aws/pull/2923).
-      - kms_key - Fixed parameter reassignment by using passed alias parameter instead
-        of re-fetching from module params (https://github.com/ansible-collections/amazon.aws/pull/2923).
-      - module_utils/cloudfront_facts - fix TypeError in CloudFrontFactsServiceManager.describe_cloudfront_property
-        (https://github.com/ansible-collections/community.aws/issues/1915).
-      - s3_object_info - Fixed duplicate dictionary key assignments when retrieving
-        object facts (https://github.com/ansible-collections/amazon.aws/pull/2923).
-      release_summary: This patch release includes bugfixes for the ``s3_object_info``,
-        ``autoscaling_group``, and ``kms_key`` modules, addressing duplicate dictionary
-        key assignments and improving reliability. It also fixes a TypeError in CloudFront
-        module utilities.
-    fragments:
-    - 10.3.1.yml
-    - 1915-cloudfront_distribution_info-TypeError.yml
-    - ansible-test-gh-action-migration.yml
-    - reliability-duplicate-assignments.yml
-    release_date: '2026-05-05'
   2.0.0:
     changes:
       breaking_changes:
@@ -4032,3 +3780,255 @@ releases:
     - 9.5.2.yml
     - s3_object-content-headers.yml
     release_date: '2025-10-07'
+  10.0.0:
+    changes:
+      breaking_changes:
+      - amazon.aws collection - Support for ansible-core < 2.17 has been dropped (https://github.com/ansible-collections/amazon.aws/pull/2601).
+      - amazon.aws collection - Support for the ``EC2_ACCESS_KEY`` environment variable
+        was deprecated in release ``6.0.0`` and has now been removed.  Please use
+        the ``access_key`` parameter or ``AWS_ACCESS_KEY_ID`` environment variable
+        instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - Support for the ``EC2_REGION`` environment variable
+        was deprecated in release ``6.0.0`` and has now been removed.  Please use
+        the ``region`` parameter or ``AWS_REGION`` environment variable instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - Support for the ``EC2_SECRET_KEY`` environment variable
+        was deprecated in release ``6.0.0`` and has now been removed.  Please use
+        the ``secret_key`` parameter or ``AWS_SECRET_ACCESS_KEY`` environment variable
+        instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - Support for the ``EC2_SECURITY_TOKEN`` and ``AWS_SECURITY_TOKEN``
+        environment variables were deprecated in release ``6.0.0`` and have now been
+        removed.  Please use the ``session_token`` parameter or ``AWS_SESSION_TOKEN``
+        environment variable instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - Support for the ``EC2_URL`` and ``S3_URL`` environment
+        variables were deprecated in release ``6.0.0`` and have now been removed.  Please
+        use the ``endpoint_url`` parameter or ``AWS_URL`` environment variable instead
+        (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - The ``access_token``, ``aws_security_token`` and ``security_token``
+        aliases for the ``session_token`` parameter were deprecated in release ``6.0.0``
+        and have now been removed.  Please use the ``session_token`` name instead
+        (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - The ``boto_profile`` alias for the ``profile`` parameter
+        was deprecated in release ``6.0.0`` and has now been removed.  Please use
+        the ``profile`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - The ``ec2_access_key`` alias for the ``access_key``
+        parameter was deprecated in release ``6.0.0`` and has now been removed.  Please
+        use the ``access_key`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - The ``ec2_region`` alias for the ``region`` parameter
+        was deprecated in release ``6.0.0`` and has now been removed.  Please use
+        the ``region`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - The ``ec2_secret_key`` alias for the ``secret_key``
+        parameter was deprecated in release ``6.0.0`` and has now been removed.  Please
+        use the ``secret_key`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - amazon.aws collection - The ``endpoint``, ``ec2_url`` and ``s3_url`` aliases
+        for the ``endpoint_url`` parameter were deprecated in release ``6.0.0`` and
+        have now been removed.  Please use the ``region`` name instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - docs_fragments - The previously deprecated ``amazon.aws.aws_credentials``
+        docs fragment has been removed please use ``amazon.aws.common.plugins`` instead
+        (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - docs_fragments - The previously deprecated ``amazon.aws.aws_region`` docs
+        fragment has been removed please use ``amazon.aws.region.plugins`` instead
+        (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - docs_fragments - The previously deprecated ``amazon.aws.aws`` docs fragment
+        has been removed please use ``amazon.aws.common.modules`` instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - docs_fragments - The previously deprecated ``amazon.aws.ec2`` docs fragment
+        has been removed please use ``amazon.aws.region.modules`` instead (https://github.com/ansible-collections/amazon.aws/pull/2527).
+      - ec2_vpc_peering_info - the ``result`` key has been removed from the return
+        value. ``vpc_peering_connections`` should be used instead (https://github.com/ansible-collections/amazon.aws/pull/2618).
+      - module_utils.botocore - drop deprecated ``boto3`` parameter for ``get_aws_region()``
+        and ``get_aws_connection_info()``, this parameter has had no effect since
+        release 4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/2443).
+      - module_utils.ec2 - drop deprecated ``boto3`` parameter for ``get_ec2_security_group_ids_from_names()``
+        and ``get_aws_connection_info()``, this parameter has had no effect since
+        release 4.0.0 (https://github.com/ansible-collections/amazon.aws/pull/2603).
+      - rds_param_group - the redirect has been removed and playbooks should be updated
+        to use rds_instance_param_group (https://github.com/ansible-collections/amazon.aws/pull/2618).
+      bugfixes:
+      - s3_bucket - bucket ACLs now consistently returned (https://github.com/ansible-collections/amazon.aws/pull/2478).
+      - s3_bucket - fixed idempotency when setting bucket ACLs (https://github.com/ansible-collections/amazon.aws/pull/2478).
+      major_changes:
+      - amazon.aws collection - The amazon.aws collection has dropped support for
+        ``botocore<1.34.0`` and ``boto3<1.34.0``. Most modules will continue to work
+        with older versions of the AWS SDK, however compatibility with older versions
+        of the SDK is not guaranteed and will not be tested. When using older versions
+        of the SDK a warning will be emitted by Ansible (https://github.com/ansible-collections/amazon.aws/pull/2426).
+      - amazon.aws collection - due to the AWS SDKs announcing the end of support
+        for Python less than 3.8 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/),
+        support for Python less than 3.8 by this collection was deprecated in release
+        6.0.0 and removed in release 10.0.0. (https://github.com/ansible-collections/amazon.aws/pull/2426).
+      - connection/aws_ssm - The module has been migrated from the ``community.aws``
+        collection. Playbooks using the Fully Qualified Collection Name for this module
+        should be updated to use ``amazon.aws.aws_ssm``.
+      minor_changes:
+      - module_utils.s3 - added "501" to the list of error codes thrown by S3 replacements
+        (https://github.com/ansible-collections/amazon.aws/issues/2447).
+      - module_utils/s3 - add initial ErrorHandler for S3 modules (https://github.com/ansible-collections/amazon.aws/pull/2060).
+      - s3_bucket - migrated to use updated error handlers for better handling of
+        non-AWS errors (https://github.com/ansible-collections/amazon.aws/pull/2478).
+      release_summary: 'This major release introduces new support with the ``aws_ssm``
+        connection plugin, which has been promoted from ``community.aws``, several
+        bugfixes, minor changes and deprecated features.
+
+        Additionally, this release increases the minimum required versions of ``boto3``
+        and ``botocore`` to 1.34.0 to align with updated AWS SDK support and support
+        for ansible-core < 2.17 has been dropped.
+
+        Due to the AWS SDKs announcing the end of support for Python less than 3.8
+        (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/),
+        support for Python less than 3.8 by this collection was deprecated in 9.0.0
+        release and is removed in this 10.0.0 release.
+
+        '
+    fragments:
+    - 10.0.0-increase-ansible-core-version.yml
+    - 10.0.0.yml
+    - 20241029-main-10.0.0.yml
+    - 20250117-s3_bucket-error_handler.yml
+    - 20250508-update-docs.yml
+    - 2060-s3_error_handler.yml
+    - 2443-boto-final-clean.yml
+    - 2527-module_aliases.yml
+    - 2618-remove-rds-param-group.yml
+    - boto3-cleanup.yml
+    - botocore.yml
+    - migrate_aws_ssm.yml
+    - s3_bucket-501.yml
+    - skip_ansible-core_2.16.yml
+    release_date: '2025-05-13'
+  10.1.0:
+    changes:
+      minor_changes:
+      - inventory/aws_ec2 - Adding support for ``Route53`` as hostname (https://github.com/ansible-collections/amazon.aws/pull/2580).
+      release_summary: This minor release adds support for ``Route53`` as a hostname.
+    fragments:
+    - 20250321-inventory_aws_ec2-add-support-for-route53.yml
+    release_date: '2025-06-03'
+  10.1.1:
+    changes:
+      bugfixes:
+      - ec2_instance - corrected typo for InsufficientInstanceCapacity. Fix now will
+        retry Ec2 creation when InsufficientInstanceCapacity error occurs (https://github.com/ansible-collections/amazon.aws/issues/1038).
+      release_summary: This release includes a bugfix and a documentation update.
+    fragments:
+    - 10.1.1.yml
+    - 2674-fix-errorcode-typo.yml
+    release_date: '2025-08-06'
+  10.1.2:
+    changes:
+      bugfixes:
+      - Remove ``ansible.module_utils.six`` imports to avoid warnings (https://github.com/ansible-collections/amazon.aws/pull/2727).
+      - amazon.aws.autoscaling_instance - setting the state to ``terminated`` had
+        no effect. The fix implements missing instance termination state (https://github.com/ansible-collections/amazon.aws/issues/2719).
+      - ec2_vpc_nacl - Fix issue when trying to update existing Network ACL rule (https://github.com/ansible-collections/amazon.aws/issues/2592).
+      - s3_object - Honor headers for content and content_base64 uploads by promoting
+        supported keys (e.g. ContentType, ContentDisposition, CacheControl) to top-level
+        S3 arguments and placing remaining keys under Metadata. This makes content
+        uploads consistent with src uploads. (https://github.com/ansible-collections/amazon.aws)
+      release_summary: This release includes multiple bug fixes.
+    fragments:
+    - 10.1.2_summary.yaml
+    - 20250513-ec2_vpc_nacl-fix-issue-when-updating-rules.yml
+    - 20250924-sanity-fixes.yml
+    - 2720-autoscaling_instance-implements-missing-instance-termination-state.yaml
+    - s3_object-content-headers.yml
+    release_date: '2025-10-07'
+  10.2.0:
+    changes:
+      bugfixes:
+      - connection/aws_ssm - fixed ReferenceError in aws_ssm connection plugin destructor
+        during interpreter shutdown (https://github.com/ansible-collections/amazon.aws/issues/2728).
+      - lambda_info - fixed invalid return value documentation that used dot notation
+        (``function.TheName``) which cannot be used in Jinja2 templates (https://github.com/ansible-collections/amazon.aws/pull/2772).
+      - s3_bucket - fix error when configuring AES256 bucket encryption with ``bucket_key_enabled``
+        explicitly set to ``false`` (https://github.com/ansible-collections/amazon.aws/issues/2734).
+      deprecated_features:
+      - ec2_vpc_dhcp_option - the ``dhcp_config`` return value has been deprecated
+        and will be removed in a release after 2026-12-01. Use ``dhcp_options`` instead
+        (https://github.com/ansible-collections/amazon.aws/pull/2772).
+      - ec2_vpc_dhcp_option_info - the ``dhcp_config`` return value has been deprecated
+        and will be removed in a release after 2026-12-01. Use ``dhcp_options`` instead
+        (https://github.com/ansible-collections/amazon.aws/pull/2772).
+      - route53 - the ``values`` key in the ``resource_record_sets`` return value
+        has been deprecated in favor of ``record_values`` for Jinja2 compatibility.
+        The ``values`` key will be removed in a release after 2026-12-01 (https://github.com/ansible-collections/amazon.aws/pull/2772).
+      minor_changes:
+      - Add support for the io2 storage type for RDS (https://github.com/ansible-collections/amazon.aws/pull/2748).
+      - ec2_launch_template - increase GP3 volume ``throughput`` limits in line with
+        updated AWS limits (https://github.com/ansible-collections/amazon.aws/pull/2749).
+      - ec2_vol - increase ``throughput`` and ``iops`` limits for GP3 volumes in line
+        with updated AWS limits (https://github.com/ansible-collections/amazon.aws/pull/2749).
+      - module_utils.s3 - added "501" to the list of error codes thrown by S3 replacements
+        (https://github.com/ansible-collections/amazon.aws/issues/2447).
+      - module_utils/_s3/common - use ``is_boto3_error_httpstatus`` to handle HTTP
+        403 and 501 status codes from S3-compatible services (https://github.com/ansible-collections/amazon.aws/pull/2776).
+      - module_utils/botocore - add ``is_boto3_error_httpstatus`` helper function
+        to catch boto3 exceptions based on HTTP status codes (https://github.com/ansible-collections/amazon.aws/pull/2776).
+      - route53 - added ``record_values`` key to ``resource_record_sets`` return value
+        that can be accessed using Jinja2 dot notation (https://github.com/ansible-collections/amazon.aws/pull/2772).
+      - sts_assume_role - improve error handling for ``MalformedPolicyDocument`` errors
+        by providing a clearer error message when an invalid policy document is provided
+        (https://github.com/ansible-collections/amazon.aws/pull/2778).
+      release_summary: This release adds support for the io2 storage type for RDS
+        as well as other minor changes, several bugfixes and deprecated features.
+    fragments:
+    - 2728-reference_error_ssm_destructor.yml
+    - 2734-AES_explicit_bucket_key.yml
+    - 2748-io2_storage_support.yml
+    - 2749-gp3-limits.yml
+    - fix-bad-return-value-keys.yml
+    - is_boto3_error_httpstatus.yml
+    - s3_bucket-501.yml
+    - sts_assume_role-malformed_policy.yml
+    release_date: '2026-01-13'
+  10.3.0:
+    changes:
+      bugfixes:
+      - aws_ssm - Fixed connection being re-established on every loop iteration. The
+        plugin now properly establishes a single connection for a loop (https://github.com/ansible-collections/amazon.aws/pull/2869).
+      - elb_application_lb - fixed comparison of multi-rule default actions to properly
+        handle the ``Order`` field when determining if listener modifications are
+        needed (https://github.com/ansible-collections/amazon.aws/issues/2537).
+      - 'elb_application_lb - fixed error where creating a new application load balancer
+        with listener rules would fail with ``Parameter validation failed: Invalid
+        type for parameter ListenerArn, value: None`` (https://github.com/ansible-collections/amazon.aws/issues/2400).'
+      - s3_object - fixed error when using PUT with an empty ``content`` string (https://github.com/ansible-collections/amazon.aws/pull/2810)
+      minor_changes:
+      - meta/runtime.yml - Lowered the ``ansible-core`` minimum version to ``2.16``.
+        This expands compatibility and does not change or remove existing functionality.
+      release_summary: This minor release includes several bug fixes across ALB, S3,
+        and the SSM connection plugin, security hardening for ARN parsing, and expanded
+        compatibility with ansible-core >= 2.16.
+      security_fixes:
+      - arn - fix potential ReDoS vulnerability in ARN parsing regex by using negated
+        character class instead of non-greedy quantifier (https://github.com/ansible-collections/amazon.aws/pull/2884).
+      - ec2_security_group - fix potential ReDoS vulnerability in security group ID
+        parsing regex by using negated character classes and adding end anchor (https://github.com/ansible-collections/amazon.aws/pull/2884).
+    fragments:
+    - 2773-elb-application-lb-listener-rules.yml
+    - 2810-fix-put-empty-content.yml
+    - 2869_aws_ssm_connection_fix.yml
+    - relax_ansible_core_version.yml
+    - release_summary.yml
+    - sonarcloud_regex.yml
+    - unittests-boto3-credentials.yml
+    release_date: '2026-03-16'
+  10.3.1:
+    changes:
+      bugfixes:
+      - autoscaling_group - Fixed duplicate default_cooldown assignment in properties
+        dict (https://github.com/ansible-collections/amazon.aws/pull/2923).
+      - kms_key - Fixed parameter reassignment by using passed alias parameter instead
+        of re-fetching from module params (https://github.com/ansible-collections/amazon.aws/pull/2923).
+      - module_utils/cloudfront_facts - fix TypeError in CloudFrontFactsServiceManager.describe_cloudfront_property
+        (https://github.com/ansible-collections/community.aws/issues/1915).
+      - s3_object_info - Fixed duplicate dictionary key assignments when retrieving
+        object facts (https://github.com/ansible-collections/amazon.aws/pull/2923).
+      release_summary: This patch release includes bugfixes for the ``s3_object_info``,
+        ``autoscaling_group``, and ``kms_key`` modules, addressing duplicate dictionary
+        key assignments and improving reliability. It also fixes a TypeError in CloudFront
+        module utilities.
+    fragments:
+    - 10.3.1.yml
+    - 1915-cloudfront_distribution_info-TypeError.yml
+    - ansible-test-gh-action-migration.yml
+    - reliability-duplicate-assignments.yml
+    release_date: '2026-05-06'

--- a/changelogs/fragments/1915-cloudfront_distribution_info-TypeError.yml
+++ b/changelogs/fragments/1915-cloudfront_distribution_info-TypeError.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - module_utils/cloudfront_facts - fix TypeError in CloudFrontFactsServiceManager.describe_cloudfront_property (https://github.com/ansible-collections/community.aws/issues/1915).

--- a/changelogs/fragments/ansible-test-gh-action-migration.yml
+++ b/changelogs/fragments/ansible-test-gh-action-migration.yml
@@ -1,2 +1,0 @@
-trivial:
-  - Migrate CI workflows to use ansible-community/ansible-test-gh-action for unified sanity and unit testing (https://github.com/ansible-collections/amazon.aws/pull/2927).

--- a/changelogs/fragments/reliability-duplicate-assignments.yml
+++ b/changelogs/fragments/reliability-duplicate-assignments.yml
@@ -1,4 +1,0 @@
-bugfixes:
-  - s3_object_info - Fixed duplicate dictionary key assignments when retrieving object facts (https://github.com/ansible-collections/amazon.aws/pull/2923).
-  - autoscaling_group - Fixed duplicate default_cooldown assignment in properties dict (https://github.com/ansible-collections/amazon.aws/pull/2923).
-  - kms_key - Fixed parameter reassignment by using passed alias parameter instead of re-fetching from module params (https://github.com/ansible-collections/amazon.aws/pull/2923).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: amazon
 name: aws
-version: 10.3.0
+version: 10.3.1
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 AMAZON_AWS_COLLECTION_NAME = "amazon.aws"
-AMAZON_AWS_COLLECTION_VERSION = "10.3.0"
+AMAZON_AWS_COLLECTION_VERSION = "10.3.1"
 
 
 _collection_info_context = {


### PR DESCRIPTION
## Release v10.3.1

This PR prepares the v10.3.1 release for the amazon.aws collection from stable-10.

### Changes
- Updated galaxy.yml to v10.3.1
- Generated changelog from fragments
- Deleted processed changelog fragments

### Changelog Summary
This patch release includes bugfixes for the ``s3_object_info``, ``autoscaling_group``, and ``kms_key`` modules, addressing duplicate dictionary key assignments and improving reliability. It also fixes a TypeError in CloudFront module utilities.

### Quality Checks
- ✅ Lint: All Python linters passed (black, isort, flynt, flake8, pylint)
- ✅ Sanity: All tests passed (4 changed files, Python 3.12 + ansible-core 2.20)

### Checklist
- [x] Version updated in galaxy.yml
- [x] Changelog generated
- [x] Lint checks passed
- [x] Sanity tests passed

---
*Generated by Ansible Release Orchestrator*
*Reference: https://github.com/ansible-collections/cloud-content-handbook*