### PR TITLE
Release v11.3.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,34 @@ amazon.aws Release Notes
 
 .. contents:: Topics
 
+v11.3.0
+=======
+
+Release Summary
+---------------
+
+This minor release adds new features and improvements to the ``autoscaling_group``, ``elb_application_lb``, ``elb_application_lb_info``, ``elb_classic_lb``, ``event_source_aws_cloudtrail``, ``kms_key``, ``s3_bucket``, ``s3_object_info`` module(s).
+
+Minor Changes
+-------------
+
+- Various modules and utilities - migrated from deprecated ``ansible.module_utils._text`` to ``ansible.module_utils.common.text.converters`` (https://github.com/ansible-collections/amazon.aws/pull/2860).
+- amazon.aws.cloudformation - Fixed an issue where creating a changeset in check mode would fail if the stack is not in a ready state (e.g., UPDATE_IN_PROGRESS). The module now waits for the stack to be in a ready state (UPDATE_COMPLETE) before creating the changeset (https://github.com/ansible-collections/amazon.aws/pull/1910)
+- elb_application_lb_info - Fixed return value documentation to correctly reflect actual types and added missing fields (https://github.com/ansible-collections/amazon.aws/issues/2939).
+- extensions/eda/plugins/event_source/aws_sqs_queue.py - Added optional support for feedback so that the event can be removed from the SQS Queue on receipt of acknowledgement from ansible-rulebook.
+- module_utils/errors - Add support for f-string style parameter interpolation in error handler descriptions to provide more detailed error messages (https://github.com/ansible-collections/amazon.aws/pull/2944).
+- s3_bucket - Added O(account_regional) parameter to support creating buckets in the account-regional namespace. Requires at least botocore version 1.42.67 (https://github.com/ansible-collections/amazon.aws/pull/2960).
+- s3_bucket - Added support for managing bucket logging configuration (https://github.com/ansible-collections/amazon.aws/pull/2855).
+
+Bugfixes
+--------
+
+- autoscaling_group - Fixed duplicate default_cooldown assignment in properties dict (https://github.com/ansible-collections/amazon.aws/pull/2923).
+- elb_application_lb - Listener rules are now returned sorted by priority with the default rule appearing last (https://github.com/ansible-collections/amazon.aws/issues/2939).
+- elb_application_lb_info - Listener rules are now returned sorted by priority with the default rule appearing last (https://github.com/ansible-collections/amazon.aws/issues/2939).
+- kms_key - Fixed parameter reassignment by using passed alias parameter instead of re-fetching from module params (https://github.com/ansible-collections/amazon.aws/pull/2923).
+- module_utils/cloudfront_facts - fix TypeError in CloudFrontFactsServiceManager.describe_cloudfront_property (https://github.com/ansible-collections/community.aws/issues/1915).
+- s3_object_info - Fixed duplicate dictionary key assignments when retrieving object facts (https://github.com/ansible-collections/amazon.aws/pull/2923).
 
 v11.2.0
 =======
@@ -14,7 +42,6 @@ Release Summary
 This release introduces several new features and improvements across the collection. Notable additions include support for the ``volume_initialization_rate`` parameter in ``ec2_vol`` to enable Provisioned Initialization Rate when creating volumes from snapshots, and a new ``protected_from_scale_in`` option in ``autoscaling_group`` to control scale-in protection for instances. Route53 modules have been enhanced with new parameters for latency-based routing, including ``routing_region`` and a temporary ``aws_region`` option to support the transition away from the deprecated ``region`` parameter.
 The release also includes security fixes addressing potential ReDoS vulnerabilities in ARN and EC2 security group ID parsing, as well as several internal improvements and refactorings to improve code maintainability, error handling, and testability across modules and plugin utilities.
 Several deprecations were introduced in inventory plugins to avoid conflicts with Ansible reserved variable names and modernize configuration options. In addition, the release includes code modernization updates such as replacing deprecated ``datetime.utcnow()`` usage with timezone-aware alternatives, improvements to inventory plugin utilities, and various testing and internal maintenance updates.
-
 
 Minor Changes
 -------------
@@ -230,7 +257,6 @@ Release Summary
 This major release introduces new support with the ``aws_ssm`` connection plugin, which has been promoted from ``community.aws``, several bugfixes, minor changes and deprecated features.
 Additionally, this release increases the minimum required versions of ``boto3`` and ``botocore`` to 1.34.0 to align with updated AWS SDK support and support for ansible-core < 2.17 has been dropped.
 Due to the AWS SDKs announcing the end of support for Python less than 3.8 (https://aws.amazon.com/blogs/developer/python-support-policy-updates-for-aws-sdks-and-tools/), support for Python less than 3.8 by this collection was deprecated in 9.0.0 release and is removed in this 10.0.0 release.
-
 
 Major Changes
 -------------
@@ -898,7 +924,6 @@ Bugfixes
 - cloudwatchevent_rule - Fix to avoid adding quotes to JSON input for provided input_template (https://github.com/ansible-collections/amazon.aws/pull/1883).
 - lookup/secretsmanager_secret - fix the issue when the nested secret is missing and on_missing is set to warn, the lookup was raising an error instead of a warning message (https://github.com/ansible-collections/amazon.aws/issues/1781).
 - module_utils/elbv2 - Fix issue when creating or modifying Load balancer rule type authenticate-oidc using ``ClientSecret`` parameter and ``UseExistingClientSecret=true`` (https://github.com/ansible-collections/amazon.aws/issues/1877).
-- amazon.aws.cloudformation - Fixed an issue where creating a changeset in check mode would fail if the stack is not in a ready state (e.g., UPDATE_IN_PROGRESS). The module now waits for the stack to be in a ready state (UPDATE_COMPLETE) before creating the changeset (https://github.com/ansible-collections/amazon.aws/pull/1910)
 
 v7.3.0
 ======
@@ -1153,7 +1178,6 @@ Release Summary
 
 This release is the last planned minor release of ``amazon.aws`` prior to the release of 7.0.0.
 It includes documentation fixes as well as minor changes and bug fixes for the ``ec2_ami`` and ``elb_application_lb_info`` modules.
-
 
 Minor Changes
 -------------
@@ -1486,7 +1510,6 @@ Release Summary
 
 This release brings few bugfixes.
 
-
 Bugfixes
 --------
 
@@ -1506,7 +1529,6 @@ Release Summary
 ---------------
 
 This release contains a number of bugfixes, new features and new modules.  This is the last planned minor release prior to the release of version 6.0.0.
-
 
 Minor Changes
 -------------
@@ -1601,7 +1623,6 @@ Release Summary
 ---------------
 
 A minor release containing bugfixes for the ``ec2_eni_info`` module and the ``aws_rds`` inventory plugin, as well as improvements to the ``rds_instance`` module.
-
 
 Minor Changes
 -------------
@@ -1826,7 +1847,6 @@ Release Summary
 
 This release contains a minor bugfix for the ``ec2_vol`` module, some minor work on the ``ec2_key`` module, and various documentation fixes.  This is the last planned release of the 4.x series.
 
-
 Minor Changes
 -------------
 
@@ -1865,7 +1885,6 @@ Release Summary
 The amazon.aws 4.3.0 release includes a number of minor bug fixes and improvements.
 Following the release of amazon.aws 5.0.0, backports to the 4.x series will be limited to
 security issues and bugfixes.
-
 
 Minor Changes
 -------------
@@ -2020,7 +2039,6 @@ Release Summary
 ---------------
 
 Following the release of amazon.aws 5.0.0, 3.5.0 is a bugfix release and the final planned release for the 3.x series.
-
 
 Minor Changes
 -------------

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -4258,4 +4258,4 @@ releases:
     - reliability-duplicate-assignments.yml
     - s3_bucket-account_regional.yml
     - s3_bucket_logging.yml
-    release_date: '2026-05-07'
+    release_date: '2026-05-08'

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -4207,3 +4207,55 @@ releases:
     - unittests-common.yml
     - utcnow-deprecation.yml
     release_date: '2026-03-17'
+  11.3.0:
+    changes:
+      bugfixes:
+      - autoscaling_group - Fixed duplicate default_cooldown assignment in properties
+        dict (https://github.com/ansible-collections/amazon.aws/pull/2923).
+      - elb_application_lb - Listener rules are now returned sorted by priority with
+        the default rule appearing last (https://github.com/ansible-collections/amazon.aws/issues/2939).
+      - elb_application_lb_info - Listener rules are now returned sorted by priority
+        with the default rule appearing last (https://github.com/ansible-collections/amazon.aws/issues/2939).
+      - kms_key - Fixed parameter reassignment by using passed alias parameter instead
+        of re-fetching from module params (https://github.com/ansible-collections/amazon.aws/pull/2923).
+      - module_utils/cloudfront_facts - fix TypeError in CloudFrontFactsServiceManager.describe_cloudfront_property
+        (https://github.com/ansible-collections/community.aws/issues/1915).
+      - s3_object_info - Fixed duplicate dictionary key assignments when retrieving
+        object facts (https://github.com/ansible-collections/amazon.aws/pull/2923).
+      minor_changes:
+      - Various modules and utilities - migrated from deprecated ``ansible.module_utils._text``
+        to ``ansible.module_utils.common.text.converters`` (https://github.com/ansible-collections/amazon.aws/pull/2860).
+      - amazon.aws.cloudformation - Fixed an issue where creating a changeset in check
+        mode would fail if the stack is not in a ready state (e.g., UPDATE_IN_PROGRESS).
+        The module now waits for the stack to be in a ready state (UPDATE_COMPLETE)
+        before creating the changeset (https://github.com/ansible-collections/amazon.aws/pull/1910)
+      - elb_application_lb_info - Fixed return value documentation to correctly reflect
+        actual types and added missing fields (https://github.com/ansible-collections/amazon.aws/issues/2939).
+      - extensions/eda/plugins/event_source/aws_sqs_queue.py - Added optional support
+        for feedback so that the event can be removed from the SQS Queue on receipt
+        of acknowledgement from ansible-rulebook.
+      - module_utils/errors - Add support for f-string style parameter interpolation
+        in error handler descriptions to provide more detailed error messages (https://github.com/ansible-collections/amazon.aws/pull/2944).
+      - s3_bucket - Added O(account_regional) parameter to support creating buckets
+        in the account-regional namespace. Requires at least botocore version 1.42.67
+        (https://github.com/ansible-collections/amazon.aws/pull/2960).
+      - s3_bucket - Added support for managing bucket logging configuration (https://github.com/ansible-collections/amazon.aws/pull/2855).
+      release_summary: This minor release adds new features and improvements to the
+        ``autoscaling_group``, ``elb_application_lb``, ``elb_application_lb_info``,
+        ``elb_classic_lb``, ``event_source_aws_cloudtrail``, ``kms_key``, ``s3_bucket``,
+        ``s3_object_info`` module(s).
+    fragments:
+    - 11.3.0.yml
+    - 1910-check_stack_change_set.yml
+    - 1915-cloudfront_distribution_info-TypeError.yml
+    - 20260225-migrate-text-converters.yml
+    - 2868_event_source_aws_cloudtrail_integration_tests.yaml
+    - 2939-elb-rules-sorting.yml
+    - ansible-test-gh-action-migration.yml
+    - elb_logging_service_principal.yml
+    - error-handler-format-strings.yml
+    - feedback_eda_sqs_source_plugin.yml
+    - reliability-duplicate-assignments.yml
+    - s3_bucket-account_regional.yml
+    - s3_bucket_logging.yml
+    release_date: '2026-05-07'

--- a/changelogs/fragments/1910-check_stack_change_set.yml
+++ b/changelogs/fragments/1910-check_stack_change_set.yml
@@ -1,3 +1,0 @@
----
-minor_changes:
-  - amazon.aws.cloudformation - Fixed an issue where creating a changeset in check mode would fail if the stack is not in a ready state (e.g., UPDATE_IN_PROGRESS). The module now waits for the stack to be in a ready state (UPDATE_COMPLETE) before creating the changeset (https://github.com/ansible-collections/amazon.aws/pull/1910)

--- a/changelogs/fragments/1915-cloudfront_distribution_info-TypeError.yml
+++ b/changelogs/fragments/1915-cloudfront_distribution_info-TypeError.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - module_utils/cloudfront_facts - fix TypeError in CloudFrontFactsServiceManager.describe_cloudfront_property (https://github.com/ansible-collections/community.aws/issues/1915).

--- a/changelogs/fragments/20260225-migrate-text-converters.yml
+++ b/changelogs/fragments/20260225-migrate-text-converters.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - Various modules and utilities - migrated from deprecated ``ansible.module_utils._text`` to ``ansible.module_utils.common.text.converters`` (https://github.com/ansible-collections/amazon.aws/pull/2860).

--- a/changelogs/fragments/2868_event_source_aws_cloudtrail_integration_tests.yaml
+++ b/changelogs/fragments/2868_event_source_aws_cloudtrail_integration_tests.yaml
@@ -1,3 +1,0 @@
-trivial:
-  - event_source_aws_cloudtrail - add event source aws cloudtrail integration tests. (https://github.com/ansible-collections/amazon.aws/pull/2868)
-  - event_source_aws_cloudtrail - add test system and python dependencies for event source aws cloudtrail integration tests. (https://github.com/ansible-collections/amazon.aws/pull/2868)

--- a/changelogs/fragments/2939-elb-rules-sorting.yml
+++ b/changelogs/fragments/2939-elb-rules-sorting.yml
@@ -1,5 +1,0 @@
-bugfixes:
-  - elb_application_lb - Listener rules are now returned sorted by priority with the default rule appearing last (https://github.com/ansible-collections/amazon.aws/issues/2939).
-  - elb_application_lb_info - Listener rules are now returned sorted by priority with the default rule appearing last (https://github.com/ansible-collections/amazon.aws/issues/2939).
-minor_changes:
-  - elb_application_lb_info - Fixed return value documentation to correctly reflect actual types and added missing fields (https://github.com/ansible-collections/amazon.aws/issues/2939).

--- a/changelogs/fragments/ansible-test-gh-action-migration.yml
+++ b/changelogs/fragments/ansible-test-gh-action-migration.yml
@@ -1,2 +1,0 @@
-trivial:
-  - Migrate CI workflows to use ansible-community/ansible-test-gh-action for unified sanity and unit testing (https://github.com/ansible-collections/amazon.aws/pull/2927).

--- a/changelogs/fragments/elb_logging_service_principal.yml
+++ b/changelogs/fragments/elb_logging_service_principal.yml
@@ -1,3 +1,0 @@
-trivial:
-  - elb_application_lb - integration tests now use service principal ``logdelivery.elasticloadbalancing.amazonaws.com`` for S3 bucket policies instead of legacy region-specific AWS account IDs, following current AWS best practices.
-  - elb_classic_lb - integration tests now use service principal ``logdelivery.elasticloadbalancing.amazonaws.com`` for S3 bucket policies instead of legacy region-specific AWS account IDs, following current AWS best practices.

--- a/changelogs/fragments/error-handler-format-strings.yml
+++ b/changelogs/fragments/error-handler-format-strings.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - module_utils/errors - Add support for f-string style parameter interpolation in error handler descriptions to provide more detailed error messages (https://github.com/ansible-collections/amazon.aws/pull/2944).

--- a/changelogs/fragments/feedback_eda_sqs_source_plugin.yml
+++ b/changelogs/fragments/feedback_eda_sqs_source_plugin.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - extensions/eda/plugins/event_source/aws_sqs_queue.py - Added optional support for feedback so that the event can be removed from the SQS Queue on receipt of acknowledgement from ansible-rulebook.

--- a/changelogs/fragments/reliability-duplicate-assignments.yml
+++ b/changelogs/fragments/reliability-duplicate-assignments.yml
@@ -1,4 +1,0 @@
-bugfixes:
-  - s3_object_info - Fixed duplicate dictionary key assignments when retrieving object facts (https://github.com/ansible-collections/amazon.aws/pull/2923).
-  - autoscaling_group - Fixed duplicate default_cooldown assignment in properties dict (https://github.com/ansible-collections/amazon.aws/pull/2923).
-  - kms_key - Fixed parameter reassignment by using passed alias parameter instead of re-fetching from module params (https://github.com/ansible-collections/amazon.aws/pull/2923).

--- a/changelogs/fragments/s3_bucket-account_regional.yml
+++ b/changelogs/fragments/s3_bucket-account_regional.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - s3_bucket - Added O(account_regional) parameter to support creating buckets in the account-regional namespace. Requires at least botocore version 1.42.67 (https://github.com/ansible-collections/amazon.aws/pull/2960).

--- a/changelogs/fragments/s3_bucket_logging.yml
+++ b/changelogs/fragments/s3_bucket_logging.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - s3_bucket - Added support for managing bucket logging configuration (https://github.com/ansible-collections/amazon.aws/pull/2855).

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: amazon
 name: aws
-version: 11.2.0
+version: 11.3.0
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 AMAZON_AWS_COLLECTION_NAME = "amazon.aws"
-AMAZON_AWS_COLLECTION_VERSION = "11.2.0"
+AMAZON_AWS_COLLECTION_VERSION = "11.3.0"
 
 
 _collection_info_context = {


### PR DESCRIPTION
## Release v11.3.0

This PR prepares the v11.3.0 release for the amazon.aws collection.

### Changes
- Updated galaxy.yml to v11.3.0
- Generated changelog from fragments
- Release date: 2026-05-07

### Quality Checks
- ✅ Lint: All checks passed (5/5 linters)
- ⏸️ Sanity: Skipped (will run in CI)

### Checklist
- [x] Version updated in galaxy.yml
- [x] Changelog generated with custom release date
- [x] Lint checks passed
- [x] Release summary uses proper backticks for module names
- [x] Folded scalar (>) used to avoid blank lines

---
*Generated by Ansible Release Orchestrator*
*Reference: https://github.com/ansible-collections/cloud-content-handbook*