### PR TITLE
ci: improve test infrastructure and add coverage tooling

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -94,6 +94,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
         job-id: ${{ fromJson(needs.splitter.outputs.jobs) }}
     name: "${{ matrix.job-id }}"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ target-version = ['py38', 'py39']
 extend-exclude = '''
 /(
   | plugins/module_utils/_version.py
+  | \.tox
+  | tests/output
 )/
 '''
 
@@ -21,6 +23,7 @@ src = [
 profile = "black"
 force_single_line = true
 line_length = 120
+skip = [".tox", "tests/output"]
 
 src_paths = [
     "plugins",
@@ -38,6 +41,8 @@ known_ansible_community_aws = ["ansible_collections.community.aws"]
 transform-joins = true
 exclude = [
     "ec2_metadata_facts",
+    ".tox",
+    "tests/output",
 ]
 
 [tool.flake8]
@@ -46,18 +51,23 @@ show-source = true
 ignore = ["E123", "E125", "E203", "E402", "E501", "E741", "F401", "F811", "F841", "W503"]
 max-line-length = 160
 builtins = "_"
+exclude = [".tox", "tests/output"]
 
 [tool.mypy]
 disable_error_code = ["import-untyped"]
 
 [tool.ruff]
 line-length = 120
+exclude = [".tox", "tests/output"]
 
 [tool.ruff.lint]
 # "F401" - unused-imports - We use these imports to maintain historic Interfaces
 # "E402" - import not at top of file - General Ansible style puts the documentation at the top.
 unfixable = ["F401"]
 ignore = ["F401", "E402"]
+
+[tool.pylint.main]
+ignore = [".tox", "tests/output"]
 
 [tool.pytest.ini_options]
 xfail_strict = true

--- a/tox.ini
+++ b/tox.ini
@@ -213,19 +213,18 @@ description = Use pylint to evaluate McCabe cyclomatic complexity (fail if >15, 
 deps =
   pylint
 change_dir = {toxinidir}
-commands_pre =
 commands =
   # Warn if complexity > 10
   -pylint \
     --load-plugins=pylint.extensions.mccabe \
-    --disable R,C,W,E \
+    --disable=all \
     --enable too-complex \
     --max-complexity=10 \
     {posargs:{[common]lint_dirs}}
   # Fail if complexity > 15
   pylint \
     --load-plugins=pylint.extensions.mccabe \
-    --disable R,C,W,E \
+    --disable=all \
     --enable too-complex \
     --max-complexity=15 \
     {posargs:{[common]lint_dirs}}

--- a/tox.ini
+++ b/tox.ini
@@ -232,7 +232,7 @@ commands =
 
 [testenv:flake8-cognitive-complexity]
 labels = complexity
-description = Check cognitive complexity using flake8
+description = Check cognitive complexity using flake8 (fail if >15, warn if >10)
 deps =
   flake8
   flake8-pyproject
@@ -240,6 +240,12 @@ deps =
 change_dir = {toxinidir}
 commands_pre =
 commands =
+  # Warn if complexity > 10
+  -flake8 \
+    --select=CCR001 \
+    --max-cognitive-complexity=10 \
+    {posargs:{[common]lint_dirs}}
+  # Fail if complexity > 15
   flake8 \
     --select=CCR001 \
     --max-cognitive-complexity=15 \

--- a/tox.ini
+++ b/tox.ini
@@ -80,6 +80,30 @@ commands =
     find .tox -name coverage.xml -delete
     rm -rf tests/output/ htmlcov/ .mypy_cache/ complexity/ .ruff_cache/
 
+[testenv:diff-cover]
+description = Check coverage on new code against origin/main (requires prior unit test run)
+labels = coverage
+deps =
+    diff-cover
+allowlist_externals = sh
+passenv = DIFF_COMPARE_BRANCH
+set_env =
+    DIFF_COMPARE_BRANCH={env:DIFF_COMPARE_BRANCH:origin/main}
+change_dir = {toxinidir}
+commands_pre =
+commands =
+    sh -c 'COVERAGE_FILE=$(find .tox -path "*/ansible_collections/amazon/aws/coverage.xml" -type f -printf "%T@ %p\n" | sort -rn | head -1 | cut -d" " -f2-); \
+           if [ -z "$COVERAGE_FILE" ]; then \
+               echo "Error: No coverage.xml found. Run unit tests first (e.g., tox -m unit-newest)"; \
+               exit 1; \
+           fi; \
+           echo "Comparing against: $DIFF_COMPARE_BRANCH"; \
+           diff-cover \
+               --compare-branch="$DIFF_COMPARE_BRANCH" \
+               --fail-under=80 \
+               --format html:diff-coverage.html \
+               "$COVERAGE_FILE"'
+
 [testenv:complexity-report]
 labels = future-lint
 description = Generate a HTML complexity report in the complexity directory
@@ -107,6 +131,7 @@ commands_pre =
 commands =
   ansible-lint \
         --skip-list=name[missing],yaml[line-length],args[module],run-once[task],ignore-errors,sanity[cannot-ignore],run-once[play] \
+        --exclude=.tox/ --exclude=tests/output/ \
         {posargs:{[common]lint_dirs}}
 
 [testenv:black]
@@ -182,6 +207,45 @@ commands_pre =
 commands =
   flake8 {posargs:{[common]format_dirs}}
 
+[testenv:pylint-cyclomatic-complexity]
+labels = complexity
+description = Use pylint to evaluate McCabe cyclomatic complexity (fail if >15, warn if >10)
+deps =
+  pylint
+change_dir = {toxinidir}
+commands_pre =
+commands =
+  # Warn if complexity > 10
+  -pylint \
+    --load-plugins=pylint.extensions.mccabe \
+    --disable R,C,W,E \
+    --enable too-complex \
+    --max-complexity=10 \
+    {posargs:{[common]lint_dirs}}
+  # Fail if complexity > 15
+  pylint \
+    --load-plugins=pylint.extensions.mccabe \
+    --disable R,C,W,E \
+    --enable too-complex \
+    --max-complexity=15 \
+    {posargs:{[common]lint_dirs}}
+
+[testenv:flake8-cognitive-complexity]
+labels = complexity
+description = Check cognitive complexity using flake8
+deps =
+  flake8
+  flake8-pyproject
+  flake8-cognitive-complexity
+change_dir = {toxinidir}
+commands_pre =
+commands =
+  flake8 \
+    --select=CCR001 \
+    --max-cognitive-complexity=15 \
+    {posargs:{[common]lint_dirs}}
+
+
 [testenv:pylint-lint]
 labels = lint
 description = Run pylint tests that are disabled by the default Ansible sanity tests
@@ -217,7 +281,7 @@ commands =
 
 [testenv:ruff-lint]
 description = lint source code
-labels = lint-future
+labels = future-lint
 deps =
     ruff
 change_dir = {toxinidir}

--- a/tox.ini
+++ b/tox.ini
@@ -90,7 +90,6 @@ passenv = DIFF_COMPARE_BRANCH
 set_env =
     DIFF_COMPARE_BRANCH={env:DIFF_COMPARE_BRANCH:origin/main}
 change_dir = {toxinidir}
-commands_pre =
 commands =
     sh -c 'COVERAGE_FILE=$(find .tox -path "*/ansible_collections/amazon/aws/coverage.xml" -type f -printf "%T@ %p\n" | sort -rn | head -1 | cut -d" " -f2-); \
            if [ -z "$COVERAGE_FILE" ]; then \


### PR DESCRIPTION
## Summary

CI/test infrastructure improvements:

1. **Integration test throttling**: Limit parallel integration jobs to 8 to reduce AWS API pressure
2. **diff-cover tox environment**: Verify test coverage on changed code
3. **Complexity testing environments**: Add cyclomatic and cognitive complexity checks with warning thresholds
4. **pyproject.toml**: Add explicit `.tox` and `tests/output` exclusions for linters/formatters
5. **tox.ini**: Add ansible-lint exclusions and fix ruff-lint label

## Changes

### Integration workflow throttling (.github/workflows/integration.yml)
- Add `max-parallel: 8` to integration test strategy matrix
- Tests still split into 24 jobs for granular distribution
- Reduces concurrent AWS API load and prevents IAM permission conflicts

### New tox environment: diff-cover
```bash
tox -m unit-newest    # Generate coverage.xml
tox -e diff-cover     # Check coverage on new code

# Custom comparison branch:
DIFF_COMPARE_BRANCH=abc123 tox -e diff-cover
```

Features:
- Auto-finds most recent coverage.xml from any tox test run
- Compares against origin/main by default (configurable via `DIFF_COMPARE_BRANCH` env var)
- Fails if new code coverage < 80%
- Generates HTML report at `diff-coverage.html`

### New tox environments: complexity testing
**pylint-cyclomatic-complexity**
- Warns (non-failing) if cyclomatic complexity > 10
- Fails if cyclomatic complexity > 15

**flake8-cognitive-complexity**  (This locally mirrors the test SonarCloud is running)
- Warns (non-failing) if cognitive complexity > 10  
- Fails if cognitive complexity > 15

Both use two-tier thresholds to provide early warnings before hitting hard limits.

### pyproject.toml
Add explicit `.tox` and `tests/output` exclusions to:
- `[tool.black]` extend-exclude
- `[tool.isort]` skip
- `[tool.flynt]` exclude
- `[tool.flake8]` exclude
- `[tool.ruff]` exclude
- `[tool.pylint.main]` ignore

These directories are in `.gitignore` but explicit exclusions improve performance and clarity.

### tox.ini fixes
- Add `--exclude=.tox/ --exclude=tests/output/` to ansible-lint environment
- Fix `ruff-lint` label from `lint-future` to `future-lint` (matches convention)

## Test plan

- [x] Integration workflow: validated YAML syntax
- [x] diff-cover: tested locally, generates reports correctly
- [x] Complexity environments: run without errors

## Notes

Test/CI configuration only - no changelog fragments required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)