### PR TITLE
ci(certification.yml): use test workflow v2.0.0 with galaxy-importer bumped to 0.4.39 and ansible-lint 26.4.0

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -3,5 +3,6 @@ profile: production
 
 exclude_paths:
   - changelogs/changelog.yaml
+  - changelogs/fragments/
   - .github/
   - tests/integration

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -6,3 +6,4 @@ exclude_paths:
   - changelogs/fragments/
   - .github/
   - tests/integration
+  - meta/

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -1,0 +1,35 @@
+---
+# This workflow calls the latest version of the
+# reusable workflow.
+# You can copy this file into your respository if
+# you want to check against pinned versions of
+# Automation Hub tests.
+name: Run collection certification checks
+
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  schedule:
+    - cron: '0 6 * * *'
+
+concurrency:
+  group: cert-ver-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+
+# Files that are not related to the core functionality
+# of your collection can cause Ansible Lint to fail.
+# If this happens, add an .ansible-lint file that includes
+# those files and directories to the root of your
+# repository; for example:
+# https://github.com/ansible-collections/partner-certification-checker/blob/main/.ansible-lint
+# https://github.com/ansible-collections/partner-certification-checker/blob/main/.ansible-lint
+
+# If there are sanity test failures that cannot be fixed and are allowed to ignore
+# https://docs.ansible.com/projects/lint/rules/sanity/, create a sanity ignore file
+# https://docs.ansible.com/projects/ansible/devel/dev_guide/testing/sanity/ignores.html#ignore-file-location
+# for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
+jobs:
+  call:
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v0.1

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -32,7 +32,7 @@ concurrency:
 # for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 jobs:
   call:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v2.0.0
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@969d9148dd8e6f25efff65e9e2cb036d15a6ce04
     # If the minimal Ansible Core version your collection supports Ansible
     # is greater than 2.16.0, specify it below.
     # You might also have to specify Python version supported by that version,

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -32,7 +32,7 @@ concurrency:
 # for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 jobs:
   call:
-    uses: Andersson007/partner-certification-checker/.github/workflows/certification-reusable.yml@v2.0.0
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v2.0.0
     # If the minimal Ansible Core version your collection supports Ansible
     # is greater than 2.16.0, specify it below.
     # You might also have to specify Python version supported by that version,

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -32,7 +32,7 @@ concurrency:
 # for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 jobs:
   call:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@969d9148dd8e6f25efff65e9e2cb036d15a6ce04
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@db5a7f2ef20e9af0cbaf78796ff4b99c72da91a2
     # If the minimal Ansible Core version your collection supports Ansible
     # is greater than 2.16.0, specify it below.
     # You might also have to specify Python version supported by that version,

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -39,4 +39,4 @@ jobs:
     # see https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
     with:
       ansible-core-version: '2.17.0'
-      python-versions: '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'
+      python-versions: '["3.9", "3.10", "3.11", "3.12"]'

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -32,7 +32,7 @@ concurrency:
 # for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 jobs:
   call:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@main
+    uses: Andersson007/partner-certification-checker/.github/workflows/certification-reusable.yml@v2.0.0
     # If the minimal Ansible Core version your collection supports Ansible
     # is greater than 2.16.0, specify it below.
     # You might also have to specify Python version supported by that version,

--- a/.github/workflows/certification.yml
+++ b/.github/workflows/certification.yml
@@ -32,4 +32,11 @@ concurrency:
 # for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 jobs:
   call:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v0.1
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@main
+    # If the minimal Ansible Core version your collection supports Ansible
+    # is greater than 2.16.0, specify it below.
+    # You might also have to specify Python version supported by that version,
+    # see https://docs.ansible.com/projects/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix
+    with:
+      ansible-core-version: '2.17.0'
+      python-versions: '["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]'

--- a/changelogs/fragments/certification_wf_bump_ver.yml
+++ b/changelogs/fragments/certification_wf_bump_ver.yml
@@ -1,0 +1,2 @@
+trivial:
+  - .github/workflows/certification.yml - bump the reusable workflow version to v2.0.0


### PR DESCRIPTION
##### SUMMARY

ci(certification.yml): use test workflow v2.0.0 with galaxy-importer bumped to 0.4.39 and ansible-lint 26.4.0