### PR TITLE
Add retry state for 404 in S3 waiters

### DIFF
--- a/changelogs/fragments/2987-s3bucket-waiter-retry-404.yml
+++ b/changelogs/fragments/2987-s3bucket-waiter-retry-404.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - Add retry state for 404 in S3 waiters to avoid failure on s3 bucket 404 if bucket is not immediately visible (https://github.com/ansible-collections/amazon.aws/issues/2984#issuecomment-4603538914) (https://github.com/ansible-collections/amazon.aws/pull/2987)

--- a/plugins/module_utils/_s3/waiters.py
+++ b/plugins/module_utils/_s3/waiters.py
@@ -34,6 +34,7 @@ class S3WaiterFactory(BaseWaiterFactory):
                     dict(state="success", matcher="status", expected=200),
                     dict(state="success", matcher="status", expected=301),
                     dict(state="success", matcher="status", expected=403),
+                    dict(state="retry", matcher="status", expected=404),
                 ],
             ),
             bucket_not_exists=dict(


### PR DESCRIPTION
##### SUMMARY

Add retry state for 404 in S3 waiters. Otherwise it fails immediately if the bucket is not visible fast enough (depending on provider)
Needed because botocore 1.43.14 changed Waiter.wait() behavior.

Fixes #2984

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
s3_bucket