### PR TITLE
Fix Windows SSM Connection module execution and facts gathering

### DIFF
--- a/changelogs/fragments/2990-Fix-Windows-SSM-module-execution-facts.yml
+++ b/changelogs/fragments/2990-Fix-Windows-SSM-module-execution-facts.yml
@@ -1,0 +1,2 @@
+bugfix:
+  - plugins/connection/aws_ssm.py - remove CRLF line termination to allow for proper JSON parsing

--- a/plugins/connection/aws_ssm.py
+++ b/plugins/connection/aws_ssm.py
@@ -847,6 +847,7 @@ class Connection(AWSConnectionBase):
             # If it looks like JSON remove any newlines
             if stdout.startswith("{"):
                 self.verbosity_display(5, "POST_PROCESS: Detected JSON output, removing newlines")
+                stdout = stdout.replace("\r\n", "")
                 stdout = stdout.replace("\n", "")
 
         self.verbosity_display(5, f"POST_PROCESS: Final stdout length: {len(stdout)} bytes")


### PR DESCRIPTION
##### SUMMARY
This one line change fixes the JSON parsing errors I am having while attempting to execute `ansible.windows.*` modules against windows hosts using the SSM connector. There are a variety of issues spread across community.aws and amazon.aws that seem tangentially related to this but do not show the precise errors I encounter.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_ssm connection plugin

##### ADDITIONAL INFORMATION
This fixes an issue that prevents the aws_ssm connection from being used to manage windows ec2 instances for anything other than `ansible.builtin.raw` or `ansible.builtin.shell` modules. Facts gathering was prevented as well as any invocation of the `ansible.windows.*` modules. aws_ssm.py didn't seem to be appropriately checking for the windows-specific `\r\n` line termination sequence and was only removing `\n`. I kept both the removal of `\r\n` and `\n` as removing the `\n` function seemed to break facts gathering.

The typical error that would result from, for example, attempting a playbook that used the `ansible.windows.win_shell` module, would look like the following:

```
[ERROR]: Task failed: Action failed: Module result deserialization failed: No start of json char found

Task failed: Action failed.
Origin: /Users/travis/src/tj-playbook-example/test-windows-ssm.yml:33:7

31
32     # Test 3: Win_command module
33     - name: Test 3 - Win_command module
         ^ column 7

<<< caused by >>>

Module result deserialization failed: No start of json char found See stdout/stderr for the returned output.

fatal: [i-XXXXXXXXXXXXXX]: FAILED! => {"changed": false, "module_stderr": "", "module_stdout": "ConvertFrom-Json : Cannot bind argument to parameter 'InputObject' because it is null.\nAt line:14 char:39\n+ $code = ConvertFrom-Json -InputObject $codeJson\n+                                       ~~~~~~~~~\n    + CategoryInfo          : InvalidData: (:) [ConvertFrom-Json], ParameterBindingValidationException\n    + FullyQualifiedErrorId : ParameterArgumentValidationErrorNullNotAllowed,Microsoft.PowerShell.Commands.ConvertFromJsonCommand\n \n", "msg": "Module result deserialization failed: No start of json char found", "rc": 0}
```

STEPS TO REPRODUCE:
My target architecture is RHEL10 using the amazon.aws 10.3.0 collection to connect out to a Windows Server 2025 instance with the preinstalled SSM agent, but the current testing is happening using the same version of the collection on a macbook which is directly running against the instance. I haven't migrated the code over to the control host to see if this runs any differently, but I suspect from the nature of the issue that it won't.

The inventory is a dynamic aws_ec2 inventory using tags to identify hosts.

The playbook I'm testing with is:
```
---
- name: Test Windows modules over SSM
  hosts: Role_WindowsNode
  gather_facts: true
  gather_subset:
    - min
  vars:
    ansible_connection: amazon.aws.aws_ssm
    ansible_aws_ssm_bucket_name: XXXXXXXXXXXXXXXXX
    ansible_aws_ssm_region: us-east-1
    ansible_aws_ssm_timeout: 3600
    ansible_shell_type: powershell

  tasks:
    - name: Test 1 - Raw module
      ansible.builtin.raw: |
        Write-Output "Raw module works: $env:COMPUTERNAME"
      register: test1
      changed_when: false
      ignore_errors: yes

    - debug: var=test1

    # Test 2: Win_shell module
    - name: Test 2 - Win_shell module
      ansible.windows.win_shell: |
        Write-Output "Win_shell works: $env:COMPUTERNAME"
      register: test2
      ignore_errors: yes

    - debug: var=test2

    # Test 3: Win_command module
    - name: Test 3 - Win_command module
      ansible.windows.win_command: powershell.exe -Command "Write-Output 'Win_command works'"
      register: test3
      ignore_errors: yes

    - debug: var=test3

    # Test 4: Win_ping module
    - name: Test 4 - Win_ping module
      ansible.windows.win_ping:
      register: test4
      ignore_errors: yes

    - debug: var=test4

    - name: Summary
      debug:
        msg:
          - "Test 1 (raw): {{ 'SUCCESS' if test1 is success else 'FAILED' }}"
          - "Test 2 (win_shell): {{ 'SUCCESS' if test2 is success else 'FAILED' }}"
          - "Test 3 (win_command): {{ 'SUCCESS' if test3 is success else 'FAILED' }}"
          - "Test 4 (win_ping): {{ 'SUCCESS' if test4 is success else 'FAILED' }}"
```  

I will attempt to set up integration tests and create changelog fragments after PR creation. I'm a first time contributor, so I'm still trying to figure out everything necessary to ensure this bugfix is solid and goes through the right process.

AI was used in the analysis and troubleshooting of this issue but not in the creation of this PR.
Assisted-By: Claude Sonnet 4.5