### PR TITLE
Fix/aws rds cache keyed groups

### DIFF
--- a/changelogs/fragments/aws_rds-cache-keyed-groups.yml
+++ b/changelogs/fragments/aws_rds-cache-keyed-groups.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws-_rds inventory plugin - Fixed ``keyed_groups``, ``groups``, and ``compose`` being lost when inventory was served from cache due to method not running appropriate calls. (https://github.com/ansible-collections/amazon.aws/issues/2852).

--- a/changelogs/fragments/aws_rds-cache-keyed-groups.yml
+++ b/changelogs/fragments/aws_rds-cache-keyed-groups.yml
@@ -1,2 +1,2 @@
 bugfixes:
-  - aws-_rds inventory plugin - Fixed ``keyed_groups``, ``groups``, and ``compose`` being lost when inventory was served from cache due to method not running appropriate calls. (https://github.com/ansible-collections/amazon.aws/issues/2852).
+  - aws_rds inventory plugin - Fixed ``keyed_groups``, ``groups``, and ``compose`` being lost when inventory was served from cache due to method not running appropriate calls. (https://github.com/ansible-collections/amazon.aws/issues/2852).

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -246,6 +246,12 @@ class InventoryModule(AWSInventoryBase):
             hosts = source_data[group].get("hosts", [])
             for host in hosts:
                 self._populate_host_vars([host], hostvars.get(host, {}), group)
+                # Re-apply constructed groups from cache
+                strict = self.get_option("strict")
+                self._set_composite_vars(self.get_option("compose"), hostvars.get(host, {}), host, strict=strict)
+                self._add_host_to_composed_groups(self.get_option("groups"), hostvars.get(host, {}), host,
+  strict=strict)
+                self._add_host_to_keyed_groups(self.get_option("keyed_groups"), hostvars.get(host, {}), host, strict=strict)
             self.inventory.add_child("all", group)
 
     def _format_inventory(self, hosts):

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -249,8 +249,7 @@ class InventoryModule(AWSInventoryBase):
                 # Re-apply constructed groups from cache
                 strict = self.get_option("strict")
                 self._set_composite_vars(self.get_option("compose"), hostvars.get(host, {}), host, strict=strict)
-                self._add_host_to_composed_groups(self.get_option("groups"), hostvars.get(host, {}), host,
-  strict=strict)
+                self._add_host_to_composed_groups(self.get_option("groups"), hostvars.get(host, {}), host, strict=strict)
                 self._add_host_to_keyed_groups(self.get_option("keyed_groups"), hostvars.get(host, {}), host, strict=strict)
             self.inventory.add_child("all", group)
 


### PR DESCRIPTION
### SUMMARY
  
  The aws_rds inventory plugin loses keyed_groups, groups, and compose variables when serving inventory
  from cache.

  The cache-hit path (_populate_from_source()) restores hosts and variables but never calls
  _set_composite_vars, _add_host_to_composed_groups, or _add_host_to_keyed_groups. The cache-miss path
  (_add_hosts()) calls all three. Added the three missing calls to _populate_from_source().
  
**ISSUE TYPE**

  **Bugfix**: Fixes #2852
  
 **COMPONENT NAME**

  aws_rds inventory plugin

 **ADDITIONAL INFORMATION**

  Pre-fix behavior:

  First run (cache miss) — groups present:
  "all": {
      "children": ["ungrouped", "aws_rds", "rds_mariadb", "rds_us_east_1", "rds_aurora_postgresql",
  "rds_mysql"]
  }

  Second run (cache hit) — groups lost:
  "all": {
      "children": ["ungrouped", "aws_rds"]
  }

  Post-fix behavior:

  First run (cache miss):
  "all": {
      "children": ["ungrouped", "aws_rds", "rds_mariadb", "rds_us_east_1", "rds_aurora_postgresql",
  "rds_mysql"]
  }

  Second run (cache hit) — groups now preserved:
  "all": {
      "children": ["ungrouped", "aws_rds", "rds_mariadb", "rds_us_east_1", "rds_aurora_postgresql",
  "rds_mysql"]
  }

  _Assisted-by: Claude Code (claude-opus-4-6)_