### PR TITLE
bugfix: filter deprecated max-instances from aws_account_attribute lo…

### DIFF
--- a/plugins/lookup/aws_account_attribute.py
+++ b/plugins/lookup/aws_account_attribute.py
@@ -17,7 +17,6 @@ options:
     choices:
       - supported-platforms
       - default-vpc
-      - max-instances
       - vpc-max-security-groups-per-interface
       - max-elastic-ips
       - vpc-max-elastic-ips
@@ -47,8 +46,8 @@ vars:
   # vpc-xxxxxxxx | none
 
   account_details: "{{ lookup('aws_account_attribute', wantlist='true') }}"
-  # {'default-vpc': ['vpc-xxxxxxxx'], 'max-elastic-ips': ['5'], 'max-instances': ['20'],
-  #  'supported-platforms': ['VPC', 'EC2'], 'vpc-max-elastic-ips': ['5'], 'vpc-max-security-groups-per-interface': ['5']}
+  # {'default-vpc': ['vpc-xxxxxxxx'], 'max-elastic-ips': ['5'], 'supported-platforms': ['VPC', 'EC2'],
+  #  'vpc-max-elastic-ips': ['5'], 'vpc-max-security-groups-per-interface': ['5']}
 """
 
 RETURN = r"""
@@ -126,6 +125,8 @@ class LookupModule(AWSLookupBase):
         """
         flattened = {}
         for k_v_dict in response:
+            if k_v_dict["AttributeName"] == "max-instances":
+                continue
             flattened[k_v_dict["AttributeName"]] = [value["AttributeValue"] for value in k_v_dict["AttributeValues"]]
         return flattened
 

--- a/tests/integration/targets/lookup_aws_account_attribute/tasks/main.yaml
+++ b/tests/integration/targets/lookup_aws_account_attribute/tasks/main.yaml
@@ -39,8 +39,6 @@
           - '"default-vpc" in account_attrs[0]'
           - '"max-elastic-ips" in account_attrs[0]'
           - account_attrs[0]['max-elastic-ips'][0] | int | string == account_attrs[0]['max-elastic-ips'][0]
-          - '"max-instances" in account_attrs[0]'
-          - account_attrs[0]['max-instances'][0] | int | string == account_attrs[0]['max-instances'][0]
           # EC2 and VPC are both valid values, but we can't guarantee which are available
           - '"supported-platforms" in account_attrs[0]'
           - account_attrs[0]['supported-platforms'] | difference(['VPC', 'EC2']) | length == 0
@@ -58,7 +56,6 @@
         that:
           - '"default-vpc" in account_attrs'
           - '"max-elastic-ips" in account_attrs'
-          - '"max-instances" in account_attrs'
           - '"supported-platforms" in account_attrs'
           - '"vpc-max-elastic-ips" in account_attrs'
           - '"vpc-max-security-groups-per-interface" in account_attrs'
@@ -76,13 +73,6 @@
     - ansible.builtin.assert:
         that:
           - max_eips | int | string == max_eips
-
-    - name: Check for maximum number of Instances (max-instances)
-      ansible.builtin.set_fact:
-        max_instances: "{{ lookup('amazon.aws.aws_account_attribute', attribute='max-instances', **connection_args) }}"
-    - ansible.builtin.assert:
-        that:
-          - max_instances | int | string == max_instances
 
     - name: Check for maximum number of EIPs in a VPC (vpc-max-elastic-ips)
       ansible.builtin.set_fact:


### PR DESCRIPTION
##### SUMMARY
As discussed in the issue, AWS has deprecated the `max-instances` attribute, and the returned API value no longer reflects actual vCPU limits. 

This PR resolves the issue by:
1. Filtering `max-instances` out of the dictionary returned when fetching all attributes in `_process_response_for_all_attributes`.
2. Removing `max-instances` from the `choices` array in the `DOCUMENTATION` block.
3. Updating the `EXAMPLES` return block to accurately reflect the correct dictionary output.

Fixes #1092

##### ISSUE TYPE
- Bugfix Pull Request
- Docs Pull Request

##### COMPONENT NAME
aws_account_attribute

##### ADDITIONAL INFORMATION
This ensures the lookup plugin stops returning stale/inaccurate data for the deprecated `max-instances` limit. 

Assisted-by: Google Gemini