### PR TITLE
Fix/aws rds cache

### DIFF
--- a/changelogs/fragments/aws_rds-cache-keyed-groups.yml
+++ b/changelogs/fragments/aws_rds-cache-keyed-groups.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_rds inventory plugin - Fixed ``keyed_groups``, ``groups``, and ``compose`` being lost when inventory was served from cache due to not running appropriate calls within method. (https://github.com/ansible-collections/amazon.aws/issues/2852).

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -246,15 +246,6 @@ class InventoryModule(AWSInventoryBase):
             hosts = source_data[group].get("hosts", [])
             for host in hosts:
                 self._populate_host_vars([host], hostvars.get(host, {}), group)
-                # Re-apply constructed groups from cache
-                strict = self.get_option("strict")
-                self._set_composite_vars(self.get_option("compose"), hostvars.get(host, {}), host, strict=strict)
-                self._add_host_to_composed_groups(
-                    self.get_option("groups"), hostvars.get(host, {}), host, strict=strict
-                )
-                self._add_host_to_keyed_groups(
-                    self.get_option("keyed_groups"), hostvars.get(host, {}), host, strict=strict
-                )
             self.inventory.add_child("all", group)
 
     def _format_inventory(self, hosts):

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -246,6 +246,15 @@ class InventoryModule(AWSInventoryBase):
             hosts = source_data[group].get("hosts", [])
             for host in hosts:
                 self._populate_host_vars([host], hostvars.get(host, {}), group)
+                # Re-apply constructed groups from cache
+                strict = self.get_option("strict")
+                self._set_composite_vars(self.get_option("compose"), hostvars.get(host, {}), host, strict=strict)
+                self._add_host_to_composed_groups(
+                    self.get_option("groups"), hostvars.get(host, {}), host, strict=strict
+                )
+                self._add_host_to_keyed_groups(
+                    self.get_option("keyed_groups"), hostvars.get(host, {}), host, strict=strict
+                )
             self.inventory.add_child("all", group)
 
     def _format_inventory(self, hosts):

--- a/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_cache.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_cache.yml
@@ -10,6 +10,7 @@
           - "'aws_rds' in groups"
           - groups.aws_rds | length == 1
           - "'rds_mariadb' in groups"
+          - groups.rds_mariadb | length == 1
 
     - ansible.builtin.meta: refresh_inventory
     - name: Assert refresh_inventory updated the cache

--- a/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_cache.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_cache.yml
@@ -18,3 +18,4 @@
         that:
           - "'aws_rds' in groups"
           - not groups.aws_rds
+          - not groups.rds_mariadb

--- a/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_cache.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_cache.yml
@@ -9,6 +9,7 @@
         that:
           - "'aws_rds' in groups"
           - groups.aws_rds | length == 1
+          - "'rds_mariadb' in groups"
 
     - ansible.builtin.meta: refresh_inventory
     - name: Assert refresh_inventory updated the cache

--- a/tests/integration/targets/inventory_aws_rds/templates/inventory_with_cache.j2
+++ b/tests/integration/targets/inventory_aws_rds/templates/inventory_with_cache.j2
@@ -9,5 +9,8 @@ session_token: '{{ security_token }}'
 {% endif %}
 regions:
   - '{{ aws_region }}'
+keyed_groups:
+  - key: engine
+    prefix: rds
 filters:
   db-instance-id: "{{ instance_id }}"


### PR DESCRIPTION
### SUMMARY

The `aws_rds` inventory plugin loses `keyed_groups`, `groups`, and `compose` variables when serving inventory
from cache. Updated `aws_rds.py`, created changelog fragment and updated `test_inventory_cache.yml`, `inventory_with_cache.j2` to include check for cache hit

The cache-hit path (`_populate_from_source()`) restores hosts and variables but never calls
`_set_composite_vars`, `_add_host_to_composed_groups`, or `_add_host_to_keyed_groups.` The cache-miss path
(`_add_hosts()`) calls all three. Added the three missing calls to `_populate_from_source()`.

**ISSUE TYPE**

Bugfix: Fixes https://github.com/ansible-collections/amazon.aws/issues/2852

**COMPONENT NAME**

aws_rds inventory plugin

**ADDITIONAL INFORMATION**

Pre-fix behavior:

First run (cache miss) — groups present:
```
"all": {
"children": ["ungrouped", "aws_rds", "rds_mariadb", "rds_us_east_1", "rds_aurora_postgresql",
"rds_mysql"]
}

```
Second run (cache hit) — groups lost:
```
"all": {
"children": ["ungrouped", "aws_rds"]
}
```

**Post-fix behavior:**

First run (cache miss):
```
"all": {
"children": ["ungrouped", "aws_rds", "rds_mariadb", "rds_us_east_1", "rds_aurora_postgresql",
"rds_mysql"]
}
```

Second run (cache hit) — groups now preserved:
```
"all": {
"children": ["ungrouped", "aws_rds", "rds_mariadb", "rds_us_east_1", "rds_aurora_postgresql",
"rds_mysql"]
}
```

Assisted-by: Claude Code (claude-opus-4-6)