### PR TITLE
Add cache format versioning to inventory plugins

### DIFF
--- a/changelogs/fragments/inventory-cache-versioning.yml
+++ b/changelogs/fragments/inventory-cache-versioning.yml
@@ -1,4 +1,5 @@
 minor_changes:
   - plugin_utils/inventory - add cache format versioning to automatically invalidate incompatible caches when inventory plugins change cache structure (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - aws_rds - cache raw RDS instance data instead of formatted inventory to allow configuration changes (hostvars_prefix/suffix, keyed_groups, compose) to take effect without clearing the cache (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
 trivial:
   - plugin_utils/inventory - add unit tests for cache versioning and fix aws_rds tests to properly mock base class cache methods (https://github.com/ansible-collections/amazon.aws/pull/XXXX).

--- a/changelogs/fragments/inventory-cache-versioning.yml
+++ b/changelogs/fragments/inventory-cache-versioning.yml
@@ -1,5 +1,5 @@
 minor_changes:
-  - plugin_utils/inventory - add cache format versioning to automatically invalidate incompatible caches when inventory plugins change cache structure (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
-  - aws_rds - cache raw RDS instance data instead of formatted inventory to allow configuration changes (hostvars_prefix/suffix, keyed_groups, compose) to take effect without clearing the cache (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - plugin_utils/inventory - add cache format versioning to automatically invalidate incompatible caches when inventory plugins change cache structure (https://github.com/ansible-collections/amazon.aws/pull/2998).
+  - aws_rds - cache raw RDS instance data instead of formatted inventory to allow configuration changes (hostvars_prefix/suffix, keyed_groups, compose) to take effect without clearing the cache (https://github.com/ansible-collections/amazon.aws/pull/2998).
 trivial:
-  - plugin_utils/inventory - add unit tests for cache versioning and fix aws_rds tests to properly mock base class cache methods (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - plugin_utils/inventory - add unit tests for cache versioning and fix aws_rds tests to properly mock base class cache methods (https://github.com/ansible-collections/amazon.aws/pull/2998).

--- a/changelogs/fragments/inventory-cache-versioning.yml
+++ b/changelogs/fragments/inventory-cache-versioning.yml
@@ -1,0 +1,4 @@
+minor_changes:
+  - plugin_utils/inventory - add cache format versioning to automatically invalidate incompatible caches when inventory plugins change cache structure (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+trivial:
+  - plugin_utils/inventory - add unit tests for cache versioning and fix aws_rds tests to properly mock base class cache methods (https://github.com/ansible-collections/amazon.aws/pull/XXXX).

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -225,6 +225,8 @@ def _describe_db_clusters(connection, filters):
 class InventoryModule(AWSInventoryBase):
     NAME = "amazon.aws.aws_rds"
     INVENTORY_FILE_SUFFIXES = ("aws_rds.yml", "aws_rds.yaml")
+    # Version 2: Cache raw data instead of formatted inventory
+    CACHE_FORMAT_VERSION = 2
 
     def __init__(self):
         super().__init__()
@@ -236,28 +238,6 @@ class InventoryModule(AWSInventoryBase):
         if hosts:
             self._add_hosts(hosts=hosts, group=group)
             self.inventory.add_child("all", group)
-
-    def _populate_from_source(self, source_data):
-        hostvars = source_data.pop("_meta", {}).get("hostvars", {})
-        for group in source_data:
-            if group == "all":
-                continue
-            self.inventory.add_group(group)
-            hosts = source_data[group].get("hosts", [])
-            for host in hosts:
-                self._populate_host_vars([host], hostvars.get(host, {}), group)
-            self.inventory.add_child("all", group)
-
-    def _format_inventory(self, hosts):
-        results = {"_meta": {"hostvars": {}}}
-        group = "aws_rds"
-        results[group] = {"hosts": []}
-        for host in hosts:
-            hostname = _get_rds_hostname(host)
-            results[group]["hosts"].append(hostname)
-            h = self.inventory.get_host(hostname)
-            results["_meta"]["hostvars"][h.name] = h.vars
-        return results
 
     def _add_hosts(self, hosts, group):
         """
@@ -341,21 +321,17 @@ class InventoryModule(AWSInventoryBase):
         if "db-cluster-id" in filters and include_clusters:
             cluster_filters = ansible_dict_to_boto3_filter_list({"db-cluster-id": filters["db-cluster-id"]})
 
-        result_was_cached, cached_result = self.get_cached_result(path, cache)
-        if result_was_cached:
-            self._populate_from_source(cached_result)
-            return
+        result_was_cached, results = self.get_cached_result(path, cache)
+        if not result_was_cached:
+            results = self._get_all_db_hosts(
+                regions,
+                instance_filters,
+                cluster_filters,
+                strict_permissions,
+                statuses,
+                include_clusters,
+            )
+            # Cache the raw data
+            self.update_cached_result(path, cache, results)
 
-        results = self._get_all_db_hosts(
-            regions,
-            instance_filters,
-            cluster_filters,
-            strict_permissions,
-            statuses,
-            include_clusters,
-        )
         self._populate(results)
-
-        # Update the cache once we're done
-        formatted_inventory = self._format_inventory(results)
-        self.update_cached_result(path, cache, formatted_inventory)

--- a/plugins/plugin_utils/inventory.py
+++ b/plugins/plugin_utils/inventory.py
@@ -30,6 +30,10 @@ def _boto3_session(profile_name=None):
 
 
 class AWSInventoryBase(BaseInventoryPlugin, Constructable, Cacheable, AWSPluginBase):
+    # Cache format version - increment when cache structure changes
+    # Version 1: Original cache format (varies by plugin)
+    CACHE_FORMAT_VERSION = 1
+
     class TemplatedOptions:
         # When someone looks up the TEMPLATABLE_OPTIONS using get() any templates
         # will be templated using the loader passed to parse.
@@ -211,6 +215,25 @@ class AWSInventoryBase(BaseInventoryPlugin, Constructable, Cacheable, AWSPluginB
             # if cache expires or cache file doesn"t exist
             return False, None
 
+        # Validate cache format version
+        if isinstance(cached_value, dict):
+            # Check if this is a versioned cache entry
+            if "_cache_format_version" in cached_value:
+                if cached_value["_cache_format_version"] != self.CACHE_FORMAT_VERSION:
+                    # Cache format has changed, invalidate it
+                    return False, None
+                # Return the actual data without the metadata
+                return True, cached_value["_data"]
+            else:
+                # Legacy cache without version metadata (assume version 1)
+                if self.CACHE_FORMAT_VERSION != 1:
+                    # Plugin expects a different version, invalidate legacy cache
+                    return False, None
+                return True, cached_value
+
+        # Non-dict cache (also legacy, assume version 1)
+        if self.CACHE_FORMAT_VERSION != 1:
+            return False, None
         return True, cached_value
 
     def update_cached_result(self, path, cache, result):
@@ -224,7 +247,9 @@ class AWSInventoryBase(BaseInventoryPlugin, Constructable, Cacheable, AWSPluginB
         if cache and cache_key in self._cache:
             return
 
-        self._cache[cache_key] = result
+        # Wrap result with cache format version
+        cache_value = {"_cache_format_version": self.CACHE_FORMAT_VERSION, "_data": result}
+        self._cache[cache_key] = cache_value
 
     def verify_file(self, path):
         """

--- a/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_cache.yml
+++ b/tests/integration/targets/inventory_aws_rds/playbooks/test_inventory_cache.yml
@@ -9,10 +9,14 @@
         that:
           - "'aws_rds' in groups"
           - groups.aws_rds | length == 1
+          - "'rds_mariadb' in groups"
+          - groups.rds_mariadb | length == 1
 
     - ansible.builtin.meta: refresh_inventory
     - name: Assert refresh_inventory updated the cache
       ansible.builtin.assert:
         that:
           - "'aws_rds' in groups"
+          - "'rds_mariadb' in groups"
           - not groups.aws_rds
+          - not groups.rds_mariadb

--- a/tests/integration/targets/inventory_aws_rds/templates/inventory_with_cache.j2
+++ b/tests/integration/targets/inventory_aws_rds/templates/inventory_with_cache.j2
@@ -9,5 +9,8 @@ session_token: '{{ security_token }}'
 {% endif %}
 regions:
   - '{{ aws_region }}'
+keyed_groups:
+  - key: engine
+    prefix: rds
 filters:
   db-instance-id: "{{ instance_id }}"

--- a/tests/unit/plugins/inventory/test_aws_rds.py
+++ b/tests/unit/plugins/inventory/test_aws_rds.py
@@ -176,36 +176,6 @@ def test_get_rds_hostname(host, expected):
     assert expected == _get_rds_hostname(host)
 
 
-@pytest.mark.parametrize("hosts", ["", "host1", "host2,host3", "host2,host3,host1"])
-@patch("ansible_collections.amazon.aws.plugins.inventory.aws_rds._get_rds_hostname")
-def test_inventory_format_inventory(m_get_rds_hostname, inventory, hosts):
-    hosts_vars = {
-        "host1": {"var10": "value10"},
-        "host2": {"var20": "value20", "var21": "value21"},
-        "host3": {"var30": "value30", "var31": "value31", "var32": "value32"},
-    }
-
-    m_get_rds_hostname.side_effect = lambda h: h["name"]
-
-    class _inventory_host(object):
-        def __init__(self, name, host_vars):
-            self.name = name
-            self.vars = host_vars
-
-    inventory.inventory = MagicMock()
-    inventory.inventory.get_host.side_effect = lambda x: _inventory_host(name=x, host_vars=hosts_vars.get(x))
-
-    hosts = [{"name": x} for x in hosts.split(",") if x]
-    expected = {
-        "_meta": {"hostvars": {x["name"]: hosts_vars.get(x["name"]) for x in hosts}},
-        "aws_rds": {"hosts": [x["name"] for x in hosts]},
-    }
-
-    assert expected == inventory._format_inventory(hosts)
-    if hosts == []:
-        m_get_rds_hostname.assert_not_called()
-
-
 @pytest.mark.parametrize("length", range(0, 10, 2))
 def test_inventory_populate(inventory, length):
     group = "aws_rds"
@@ -222,50 +192,6 @@ def test_inventory_populate(inventory, length):
     else:
         inventory._add_hosts.assert_called_with(hosts=hosts, group=group)
         inventory.inventory.add_child.assert_called_with("all", group)
-
-
-def test_inventory_populate_from_source(inventory):
-    source_data = {
-        "_meta": {
-            "hostvars": {
-                "host_1_0": {"var10": "value10"},
-                "host_2": {"var2": "value2"},
-                "host_3": {"var3": ["value30", "value31", "value32"]},
-            }
-        },
-        "all": {"hosts": ["host_1_0", "host_1_1", "host_2", "host_3"]},
-        "aws_host_1": {"hosts": ["host_1_0", "host_1_1"]},
-        "aws_host_2": {"hosts": ["host_2"]},
-        "aws_host_3": {"hosts": ["host_3"]},
-    }
-
-    inventory._populate_from_source(source_data)
-    inventory.inventory.add_group.assert_has_calls(
-        [
-            call("aws_host_1"),
-            call("aws_host_2"),
-            call("aws_host_3"),
-        ],
-        any_order=True,
-    )
-    inventory.inventory.add_child.assert_has_calls(
-        [
-            call("all", "aws_host_1"),
-            call("all", "aws_host_2"),
-            call("all", "aws_host_3"),
-        ],
-        any_order=True,
-    )
-
-    inventory._populate_host_vars.assert_has_calls(
-        [
-            call(["host_1_0"], {"var10": "value10"}, "aws_host_1"),
-            call(["host_1_1"], {}, "aws_host_1"),
-            call(["host_2"], {"var2": "value2"}, "aws_host_2"),
-            call(["host_3"], {"var3": ["value30", "value31", "value32"]}, "aws_host_3"),
-        ],
-        any_order=True,
-    )
 
 
 @pytest.mark.parametrize("strict", [True, False])
@@ -632,15 +558,7 @@ def test_inventory_parse(
     cache_key = path + generate_random_string()
     inventory.get_cache_key.return_value = cache_key
 
-    cache_key_value = generate_random_string()
-    # get_cached_result behavior depends on cache flags and whether there's a cache hit
-    if cache and user_cache_directive and cache_hit:
-        inventory.get_cached_result.return_value = (True, cache_key_value)
-    else:
-        inventory.get_cached_result.return_value = (False, None)
-
     inventory._populate = MagicMock()
-    inventory._populate_from_source = MagicMock()
     inventory._get_all_db_hosts = MagicMock()
     all_db_hosts = [
         {"host": f"host_{int(random.randint(1, 1000))}"},
@@ -650,9 +568,12 @@ def test_inventory_parse(
     ]
     inventory._get_all_db_hosts.return_value = all_db_hosts
 
-    format_cache_key_value = f"format_inventory_{all_db_hosts}"
-    inventory._format_inventory = MagicMock()
-    inventory._format_inventory.return_value = format_cache_key_value
+    # get_cached_result behavior depends on cache flags and whether there's a cache hit
+    # With v2 caching, we return raw host data (not formatted inventory)
+    if cache and user_cache_directive and cache_hit:
+        inventory.get_cached_result.return_value = (True, all_db_hosts)
+    else:
+        inventory.get_cached_result.return_value = (False, None)
 
     inventory.parse(inventory_data, loader, path, cache)
 
@@ -665,15 +586,15 @@ def test_inventory_parse(
             {"db-cluster-id": options["filters"]["db-cluster-id"]}
         )
 
-    # When get_cached_result returns True (cache hit), parse() uses cached data
+    # With v2 caching: always call _populate() with raw data (from cache or fresh fetch)
+    inventory._populate.assert_called_with(all_db_hosts)
+
+    # When there's a cache hit, we don't fetch or update cache
     if cache and user_cache_directive and cache_hit:
         inventory._get_all_db_hosts.assert_not_called()
-        inventory._populate.assert_not_called()
-        inventory._format_inventory.assert_not_called()
-        inventory._populate_from_source.assert_called_with(cache_key_value)
         inventory.update_cached_result.assert_not_called()
     else:
-        # No cache hit: fetch data, populate, format, and update cache
+        # No cache hit: fetch data and update cache with raw data
         inventory._get_all_db_hosts.assert_called_with(
             options["regions"],
             boto3_instance_filters,
@@ -682,8 +603,5 @@ def test_inventory_parse(
             options["statuses"],
             include_clusters,
         )
-        inventory._populate.assert_called_with(all_db_hosts)
-        inventory._format_inventory.assert_called_with(all_db_hosts)
-        inventory._populate_from_source.assert_not_called()
-        # update_cached_result is always called when there's no cache hit
-        inventory.update_cached_result.assert_called_with(path, cache, format_cache_key_value)
+        # Cache the raw host data
+        inventory.update_cached_result.assert_called_with(path, cache, all_db_hosts)

--- a/tests/unit/plugins/inventory/test_aws_rds.py
+++ b/tests/unit/plugins/inventory/test_aws_rds.py
@@ -73,6 +73,8 @@ def fixture_inventory():
     inventory._set_credentials = MagicMock()
 
     inventory.get_cache_key = MagicMock()
+    inventory.get_cached_result = MagicMock()
+    inventory.update_cached_result = MagicMock()
 
     inventory._cache = {}
     return inventory
@@ -631,8 +633,11 @@ def test_inventory_parse(
     inventory.get_cache_key.return_value = cache_key
 
     cache_key_value = generate_random_string()
-    if cache_hit:
-        inventory._cache[cache_key] = cache_key_value
+    # get_cached_result behavior depends on cache flags and whether there's a cache hit
+    if cache and user_cache_directive and cache_hit:
+        inventory.get_cached_result.return_value = (True, cache_key_value)
+    else:
+        inventory.get_cached_result.return_value = (False, None)
 
     inventory._populate = MagicMock()
     inventory._populate_from_source = MagicMock()
@@ -660,7 +665,15 @@ def test_inventory_parse(
             {"db-cluster-id": options["filters"]["db-cluster-id"]}
         )
 
-    if not cache or not user_cache_directive or (cache and user_cache_directive and not cache_hit):
+    # When get_cached_result returns True (cache hit), parse() uses cached data
+    if cache and user_cache_directive and cache_hit:
+        inventory._get_all_db_hosts.assert_not_called()
+        inventory._populate.assert_not_called()
+        inventory._format_inventory.assert_not_called()
+        inventory._populate_from_source.assert_called_with(cache_key_value)
+        inventory.update_cached_result.assert_not_called()
+    else:
+        # No cache hit: fetch data, populate, format, and update cache
         inventory._get_all_db_hosts.assert_called_with(
             options["regions"],
             boto3_instance_filters,
@@ -671,14 +684,6 @@ def test_inventory_parse(
         )
         inventory._populate.assert_called_with(all_db_hosts)
         inventory._format_inventory.assert_called_with(all_db_hosts)
-    else:
-        inventory._get_all_db_hosts.assert_not_called()
-        inventory._populate.assert_not_called()
-        inventory._format_inventory.assert_not_called()
-
-    if cache and user_cache_directive and cache_hit:
-        inventory._populate_from_source.assert_called_with(cache_key_value)
-
-    if cache and user_cache_directive and not cache_hit or (not cache and user_cache_directive):
-        # validate that cache was populated
-        assert inventory._cache[cache_key] == format_cache_key_value
+        inventory._populate_from_source.assert_not_called()
+        # update_cached_result is always called when there's no cache hit
+        inventory.update_cached_result.assert_called_with(path, cache, format_cache_key_value)

--- a/tests/unit/plugins/plugin_utils/inventory/test_inventory_base.py
+++ b/tests/unit/plugins/plugin_utils/inventory/test_inventory_base.py
@@ -133,3 +133,99 @@ def test_inventory_get_options_with_templar(aws_inventory_base, mocker):
 
     # Test get_option() also uses templar
     assert aws_inventory_base.get_option("region") == "us-east-1"
+
+
+def test_cache_format_version_default():
+    """Test that CACHE_FORMAT_VERSION defaults to 1."""
+    inventory = utils_inventory.AWSInventoryBase()
+    assert inventory.CACHE_FORMAT_VERSION == 1
+
+
+def test_update_cached_result_includes_version(aws_inventory_base, mocker):
+    """Test that update_cached_result wraps data with version metadata."""
+    aws_inventory_base._cache = {}
+    aws_inventory_base._options = {"cache": True}
+
+    mocker.patch.object(aws_inventory_base, "get_cache_key", return_value="test_key")
+
+    test_data = {"hosts": ["host1", "host2"], "vars": {"key": "value"}}
+    aws_inventory_base.update_cached_result("test_path", cache=False, result=test_data)
+
+    assert "test_key" in aws_inventory_base._cache
+    cached_value = aws_inventory_base._cache["test_key"]
+    assert isinstance(cached_value, dict)
+    assert "_cache_format_version" in cached_value
+    assert cached_value["_cache_format_version"] == 1
+    assert "_data" in cached_value
+    assert cached_value["_data"] == test_data
+
+
+def test_get_cached_result_validates_version(aws_inventory_base, mocker):
+    """Test that get_cached_result invalidates cache when version doesn't match."""
+    aws_inventory_base._options = {"cache": True}
+    mocker.patch.object(aws_inventory_base, "get_cache_key", return_value="test_key")
+
+    # Test with matching version
+    test_data = {"hosts": ["host1"]}
+    aws_inventory_base._cache = {"test_key": {"_cache_format_version": 1, "_data": test_data}}
+    result_was_cached, result = aws_inventory_base.get_cached_result("test_path", cache=True)
+    assert result_was_cached is True
+    assert result == test_data
+
+    # Test with mismatched version
+    aws_inventory_base._cache = {"test_key": {"_cache_format_version": 2, "_data": test_data}}
+    result_was_cached, result = aws_inventory_base.get_cached_result("test_path", cache=True)
+    assert result_was_cached is False
+    assert result is None
+
+
+def test_get_cached_result_assumes_version_1_for_legacy_cache(aws_inventory_base, mocker):
+    """Test that cache without version metadata is treated as version 1."""
+    aws_inventory_base._options = {"cache": True}
+    mocker.patch.object(aws_inventory_base, "get_cache_key", return_value="test_key")
+
+    # Legacy cache without version metadata (should be treated as version 1)
+    legacy_data = {"hosts": ["host1"], "vars": {"key": "value"}}
+    aws_inventory_base._cache = {"test_key": legacy_data}
+
+    result_was_cached, result = aws_inventory_base.get_cached_result("test_path", cache=True)
+    assert result_was_cached is True
+    assert result == legacy_data
+
+    # Legacy dict cache with _meta but no version (should default to version 1)
+    legacy_formatted = {"_meta": {"hostvars": {}}, "aws_rds": {"hosts": []}}
+    aws_inventory_base._cache = {"test_key": legacy_formatted}
+
+    result_was_cached, result = aws_inventory_base.get_cached_result("test_path", cache=True)
+    assert result_was_cached is True
+    assert result == legacy_formatted
+
+
+def test_get_cached_result_invalidates_legacy_cache_for_v2_plugin(aws_inventory_base, mocker):
+    """Test that legacy v1 cache is invalidated when plugin expects v2."""
+    aws_inventory_base.CACHE_FORMAT_VERSION = 2
+    aws_inventory_base._options = {"cache": True}
+    mocker.patch.object(aws_inventory_base, "get_cache_key", return_value="test_key")
+
+    # Legacy cache (implicitly v1) should be invalidated for v2 plugin
+    legacy_data = {"_meta": {"hostvars": {}}, "aws_rds": {"hosts": []}}
+    aws_inventory_base._cache = {"test_key": legacy_data}
+
+    result_was_cached, result = aws_inventory_base.get_cached_result("test_path", cache=True)
+    assert result_was_cached is False
+    assert result is None
+
+
+def test_update_cached_result_respects_existing_cache(aws_inventory_base, mocker):
+    """Test that update_cached_result doesn't overwrite existing cache when cache=True."""
+    aws_inventory_base._options = {"cache": True}
+    mocker.patch.object(aws_inventory_base, "get_cache_key", return_value="test_key")
+
+    existing_data = {"_cache_format_version": 1, "_data": {"existing": "data"}}
+    aws_inventory_base._cache = {"test_key": existing_data}
+
+    new_data = {"new": "data"}
+    aws_inventory_base.update_cached_result("test_path", cache=True, result=new_data)
+
+    # Should not update when cache=True and key exists
+    assert aws_inventory_base._cache["test_key"] == existing_data

--- a/tests/unit/plugins/plugin_utils/inventory/test_inventory_base.py
+++ b/tests/unit/plugins/plugin_utils/inventory/test_inventory_base.py
@@ -229,3 +229,33 @@ def test_update_cached_result_respects_existing_cache(aws_inventory_base, mocker
 
     # Should not update when cache=True and key exists
     assert aws_inventory_base._cache["test_key"] == existing_data
+
+
+def test_get_cached_result_non_dict_cache_v1_plugin(aws_inventory_base, mocker):
+    """Test that non-dict legacy cache works with version 1 plugin."""
+    aws_inventory_base.CACHE_FORMAT_VERSION = 1
+    aws_inventory_base._options = {"cache": True}
+    mocker.patch.object(aws_inventory_base, "get_cache_key", return_value="test_key")
+
+    # Non-dict cache (e.g., plain list) should work with v1 plugin
+    legacy_list_cache = ["host1", "host2", "host3"]
+    aws_inventory_base._cache = {"test_key": legacy_list_cache}
+
+    result_was_cached, result = aws_inventory_base.get_cached_result("test_path", cache=True)
+    assert result_was_cached is True
+    assert result == legacy_list_cache
+
+
+def test_get_cached_result_non_dict_cache_v2_plugin(aws_inventory_base, mocker):
+    """Test that non-dict legacy cache is invalidated for version 2+ plugin."""
+    aws_inventory_base.CACHE_FORMAT_VERSION = 2
+    aws_inventory_base._options = {"cache": True}
+    mocker.patch.object(aws_inventory_base, "get_cache_key", return_value="test_key")
+
+    # Non-dict cache should be invalidated when plugin expects v2
+    legacy_list_cache = ["host1", "host2", "host3"]
+    aws_inventory_base._cache = {"test_key": legacy_list_cache}
+
+    result_was_cached, result = aws_inventory_base.get_cached_result("test_path", cache=True)
+    assert result_was_cached is False
+    assert result is None


### PR DESCRIPTION
##### SUMMARY

Add cache format versioning to inventory plugins to automatically invalidate incompatible caches when the cache structure changes. This allows the aws_rds inventory plugin to cache raw RDS instance data instead of formatted inventory, enabling configuration changes (hostvars_prefix/suffix, keyed_groups, compose) to take effect without manually clearing the cache.

##### ISSUE TYPE
Feature Pull Request

##### COMPONENT NAME
plugin_utils/inventory, aws_rds

##### ADDITIONAL INFORMATION

The cache versioning system works by wrapping cached data with metadata containing a `_cache_format_version` field. Each inventory plugin declares its expected version via the `CACHE_FORMAT_VERSION` class attribute (defaults to 1 for backward compatibility).

When retrieving cached data:
- If the cached version matches the plugin's expected version, data is returned
- If versions mismatch, the cache is invalidated and fresh data is fetched
- Legacy caches without version metadata are assumed to be version 1

The aws_rds plugin now uses version 2, which caches raw RDS instance data rather than pre-formatted inventory. This means users can modify inventory configuration parameters and see the changes applied on the next run without needing to manually clear the cache.

Assisted-by: Claude Sonnet 4.5