### PR TITLE
test: fix aws_ssm connection plugin unit test issues

### DIFF
--- a/changelogs/fragments/ruff-unused-test-cleanup.yml
+++ b/changelogs/fragments/ruff-unused-test-cleanup.yml
@@ -1,0 +1,2 @@
+trivial:
+  - aws_ssm connection plugin - fix unit test parameter and remove unused variable (https://github.com/ansible-collections/amazon.aws/pull/XXXX).

--- a/changelogs/fragments/ruff-unused-test-cleanup.yml
+++ b/changelogs/fragments/ruff-unused-test-cleanup.yml
@@ -1,2 +1,2 @@
 trivial:
-  - aws_ssm connection plugin - fix unit test parameter and remove unused variable (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - aws_ssm connection plugin - fix unit test parameter and remove unused variable (https://github.com/ansible-collections/amazon.aws/pull/2999).

--- a/tests/unit/plugins/connection/aws_ssm/test_file_transfer_manager.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_file_transfer_manager.py
@@ -126,7 +126,7 @@ class TestFileTransferManager:
 
         mock_file_content = b"dummy content"
         mock_file = BytesIO(mock_file_content)
-        with patch("builtins.open", return_value=mock_file) as mocked_open:
+        with patch("builtins.open", return_value=mock_file):
             result = file_transfer_manager._handle_put(
                 "in_path", "out_path", [{"command": "test-cmd", "method": "get"}], "s3_path", {}
             )

--- a/tests/unit/plugins/connection/aws_ssm/test_ssm_session_manager.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_ssm_session_manager.py
@@ -241,7 +241,7 @@ class TestSSMSessionManager:
         session = SSMSessionManager(
             ssm_client=ssm_client,
             instance_id=instance_id,
-            ssm_timeout=instance_id,
+            ssm_timeout=ssm_timeout,
             verbosity_display=verbosity_display,
         )
 


### PR DESCRIPTION
##### SUMMARY
Fix incorrect ssm_timeout parameter in SSMSessionManager test and remove unused mocked_open variable from file transfer manager test.

##### ISSUE TYPE
Test Pull Request

##### COMPONENT NAME
aws_ssm connection plugin

Assisted-by: Claude Sonnet 4.5