### PR TITLE
[Manual Backport][Stable-11]feat: add waiter support for Route53 DNSSEC operations (#2982)

### DIFF
--- a/changelogs/fragments/2981-route53_zone-wait-dnssec.yml
+++ b/changelogs/fragments/2981-route53_zone-wait-dnssec.yml
@@ -1,0 +1,3 @@
+---
+minor_changes:
+  - route53_zone - add support for ``wait`` and ``wait_timeout`` parameters to wait for DNSSEC state changes to propagate (https://github.com/ansible-collections/amazon.aws/issues/2981).

--- a/plugins/modules/route53_zone.py
+++ b/plugins/modules/route53_zone.py
@@ -67,8 +67,19 @@ options:
         description:
             - Enables DNSSEC signing in a specific hosted zone.
         type: bool
-        default: false
         version_added: 9.2.0
+    wait:
+        description:
+            - Wait until the DNSSEC changes have been replicated.
+        type: bool
+        default: false
+        version_added: 11.4.0
+    wait_timeout:
+        description:
+            - How long to wait for the DNSSEC changes to be replicated, in seconds.
+        default: 300
+        type: int
+        version_added: 11.4.0
 extends_documentation_fragment:
     - amazon.aws.common.modules
     - amazon.aws.region.modules
@@ -128,6 +139,13 @@ EXAMPLES = r"""
     tags:
       Support: Ansible Community
     purge_tags: true
+
+- name: enable DNSSEC signing and wait for changes to propagate
+  amazon.aws.route53_zone:
+    zone: example.com
+    dnssec: true
+    wait: true
+    wait_timeout: 600
 """
 
 RETURN = r"""
@@ -289,10 +307,12 @@ from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.route53 import AnsibleRoute53Error
 from ansible_collections.amazon.aws.plugins.module_utils.route53 import get_tags
 from ansible_collections.amazon.aws.plugins.module_utils.route53 import manage_tags
+from ansible_collections.amazon.aws.plugins.module_utils.waiters import get_waiter
 
 try:
     from botocore.exceptions import BotoCoreError
     from botocore.exceptions import ClientError
+    from botocore.exceptions import WaiterError
 except ImportError:
     pass  # caught by AnsibleAWSModule
 
@@ -328,18 +348,36 @@ def get_dnssec(hosted_zone_id: str) -> Dict[str, Any]:
         module.fail_json_aws(e, msg=f"Could not get dnssec details about hosted zone {hosted_zone_id}")
 
 
-def enable_hosted_zone_dnssec(zone_id: str) -> None:
+def enable_hosted_zone_dnssec(zone_id: str) -> Dict[str, Any]:
     try:
-        client.enable_hosted_zone_dnssec(HostedZoneId=zone_id)
+        return client.enable_hosted_zone_dnssec(HostedZoneId=zone_id)
     except (BotoCoreError, ClientError) as e:
         module.fail_json_aws(e, msg=f"Could not enable DNSSEC for {zone_id}")
 
 
-def disable_hosted_zone_dnssec(zone_id: str) -> None:
+def disable_hosted_zone_dnssec(zone_id: str) -> Dict[str, Any]:
     try:
-        client.disable_hosted_zone_dnssec(HostedZoneId=zone_id)
+        return client.disable_hosted_zone_dnssec(HostedZoneId=zone_id)
     except (BotoCoreError, ClientError) as e:
         module.fail_json_aws(e, msg=f"Could not enable DNSSEC for {zone_id}")
+
+
+def wait_for_dnssec_change(change_id: str) -> None:
+    """Wait for DNSSEC changes to propagate using Route53 change waiter."""
+    if not module.params.get("wait"):
+        return
+
+    try:
+        waiter = get_waiter(client, "resource_record_sets_changed")
+        waiter.wait(
+            Id=change_id,
+            WaiterConfig=dict(
+                Delay=5,
+                MaxAttempts=module.params.get("wait_timeout") // 5,
+            ),
+        )
+    except WaiterError as e:
+        module.fail_json_aws(e, msg="Timeout waiting for DNSSEC changes to be replicated")
 
 
 def get_hosted_zone(hosted_zone_id: str) -> Dict[str, Any]:
@@ -363,7 +401,8 @@ def ensure_dnssec(zone_id: str) -> bool:
         if dnssec_status == "NOT_SIGNING":
             # Enable DNSSEC
             if not module.check_mode:
-                enable_hosted_zone_dnssec(zone_id)
+                result = enable_hosted_zone_dnssec(zone_id)
+                wait_for_dnssec_change(result["ChangeInfo"]["Id"])
             changed = True
         elif dnssec_status == "DELETING":
             # DNSSEC signing is in the process of being removed for the hosted zone.
@@ -375,7 +414,8 @@ def ensure_dnssec(zone_id: str) -> bool:
         if dnssec_status == "SIGNING":
             # Disable DNSSEC
             if not module.check_mode:
-                disable_hosted_zone_dnssec(zone_id)
+                result = disable_hosted_zone_dnssec(zone_id)
+                wait_for_dnssec_change(result["ChangeInfo"]["Id"])
             changed = True
         # if dnssec_status == "DELETING":
         # DNSSEC signing is in the process of being removed for the hosted zone.
@@ -662,7 +702,9 @@ def main():
         delegation_set_id=dict(),
         tags=dict(type="dict", aliases=["resource_tags"]),
         purge_tags=dict(type="bool", default=True),
-        dnssec=dict(type="bool", default=False),
+        dnssec=dict(type="bool"),
+        wait=dict(type="bool", default=False),
+        wait_timeout=dict(type="int", default=300),
     )
 
     mutually_exclusive = [

--- a/tests/integration/targets/route53_key_signing_key/tasks/main.yml
+++ b/tests/integration/targets/route53_key_signing_key/tasks/main.yml
@@ -156,6 +156,8 @@
         zone: "{{ resource_prefix }}.public"
         state: present
         dnssec: true
+        wait: true
+        wait_timeout: 600
       check_mode: true
       register: _hosted_zone_dnssec
 
@@ -170,6 +172,8 @@
         zone: "{{ resource_prefix }}.public"
         state: present
         dnssec: true
+        wait: true
+        wait_timeout: 600
       register: _hosted_zone_dnssec
 
     - name: Assert success
@@ -177,12 +181,15 @@
         that:
           - _hosted_zone_dnssec is successful
           - _hosted_zone_dnssec.changed
+          - _hosted_zone_dnssec.dnssec is defined
 
     - name: Disable DNSSEC for Route53 public zone (check_mode)
       amazon.aws.route53_zone:
         zone: "{{ resource_prefix }}.public"
         state: present
         dnssec: false
+        wait: true
+        wait_timeout: 600
       check_mode: true
       register: _hosted_zone_dnssec
 
@@ -197,6 +204,8 @@
         zone: "{{ resource_prefix }}.public"
         state: present
         dnssec: false
+        wait: true
+        wait_timeout: 600
       register: _hosted_zone_dnssec
 
     - name: Assert success
@@ -204,6 +213,7 @@
         that:
           - _hosted_zone_dnssec is successful
           - _hosted_zone_dnssec.changed
+          - _hosted_zone_dnssec.dnssec is defined
 
     - name: Delete the Route53 public zone (expected to fail)
       amazon.aws.route53_zone:

--- a/tests/unit/plugins/modules/test_route53_zone.py
+++ b/tests/unit/plugins/modules/test_route53_zone.py
@@ -1,0 +1,214 @@
+# (c) 2026 Red Hat Inc.
+
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+module_name = "ansible_collections.amazon.aws.plugins.modules.route53_zone"
+
+
+class TestWaitForDnssecChange:
+    """Test the wait_for_dnssec_change function"""
+
+    @patch(f"{module_name}.get_waiter")
+    def test_wait_enabled(self, mock_get_waiter):
+        """Test waiter is called when wait=True"""
+        # Import the module to get access to the module variable
+        from ansible_collections.amazon.aws.plugins.modules import route53_zone
+
+        # Mock the module params
+        route53_zone.module = MagicMock()
+        route53_zone.module.params.get.side_effect = {
+            "wait": True,
+            "wait_timeout": 300,
+        }.get
+
+        # Mock the client and waiter
+        route53_zone.client = MagicMock()
+        mock_waiter = MagicMock()
+        mock_get_waiter.return_value = mock_waiter
+
+        # Call the function
+        change_id = "/change/C1234567890ABC"
+        route53_zone.wait_for_dnssec_change(change_id)
+
+        # Verify waiter was called with correct parameters
+        mock_get_waiter.assert_called_once_with(route53_zone.client, "resource_record_sets_changed")
+        mock_waiter.wait.assert_called_once_with(
+            Id=change_id,
+            WaiterConfig=dict(
+                Delay=5,
+                MaxAttempts=60,  # 300 // 5
+            ),
+        )
+
+    @patch(f"{module_name}.get_waiter")
+    def test_wait_disabled(self, mock_get_waiter):
+        """Test waiter is NOT called when wait=False"""
+        from ansible_collections.amazon.aws.plugins.modules import route53_zone
+
+        # Mock the module params with wait=False
+        route53_zone.module = MagicMock()
+        route53_zone.module.params.get.side_effect = {
+            "wait": False,
+            "wait_timeout": 300,
+        }.get
+
+        # Call the function
+        change_id = "/change/C1234567890ABC"
+        route53_zone.wait_for_dnssec_change(change_id)
+
+        # Verify waiter was NOT called
+        mock_get_waiter.assert_not_called()
+
+    @patch(f"{module_name}.get_waiter")
+    def test_wait_timeout_calculation(self, mock_get_waiter):
+        """Test timeout is correctly calculated"""
+        from ansible_collections.amazon.aws.plugins.modules import route53_zone
+
+        # Mock the module params with custom timeout
+        route53_zone.module = MagicMock()
+        route53_zone.module.params.get.side_effect = {
+            "wait": True,
+            "wait_timeout": 600,  # 10 minutes
+        }.get
+
+        route53_zone.client = MagicMock()
+        mock_waiter = MagicMock()
+        mock_get_waiter.return_value = mock_waiter
+
+        # Call the function
+        change_id = "/change/C1234567890ABC"
+        route53_zone.wait_for_dnssec_change(change_id)
+
+        # Verify MaxAttempts is 600 // 5 = 120
+        mock_waiter.wait.assert_called_once_with(
+            Id=change_id,
+            WaiterConfig=dict(
+                Delay=5,
+                MaxAttempts=120,  # 600 // 5
+            ),
+        )
+
+    @patch(f"{module_name}.get_waiter")
+    def test_wait_waiter_error(self, mock_get_waiter):
+        """Test WaiterError is handled correctly"""
+        from botocore.exceptions import WaiterError
+
+        from ansible_collections.amazon.aws.plugins.modules import route53_zone
+
+        # Mock the module params
+        route53_zone.module = MagicMock()
+        route53_zone.module.params.get.side_effect = {
+            "wait": True,
+            "wait_timeout": 300,
+        }.get
+
+        route53_zone.client = MagicMock()
+        mock_waiter = MagicMock()
+        mock_get_waiter.return_value = mock_waiter
+
+        # Make waiter raise WaiterError
+        waiter_error = WaiterError(
+            name="resource_record_sets_changed",
+            reason="Max attempts exceeded",
+            last_response={},
+        )
+        mock_waiter.wait.side_effect = waiter_error
+
+        # Call the function
+        change_id = "/change/C1234567890ABC"
+        route53_zone.wait_for_dnssec_change(change_id)
+
+        # Verify fail_json_aws was called
+        route53_zone.module.fail_json_aws.assert_called_once_with(
+            waiter_error, msg="Timeout waiting for DNSSEC changes to be replicated"
+        )
+
+
+class TestEnsureDnssec:
+    """Test the ensure_dnssec function with wait support"""
+
+    @patch(f"{module_name}.wait_for_dnssec_change")
+    @patch(f"{module_name}.enable_hosted_zone_dnssec")
+    @patch(f"{module_name}.get_dnssec")
+    def test_enable_dnssec_with_wait(self, mock_get_dnssec, mock_enable_dnssec, mock_wait):
+        """Test enabling DNSSEC calls waiter when wait=True"""
+        from ansible_collections.amazon.aws.plugins.modules import route53_zone
+
+        # Mock module params
+        route53_zone.module = MagicMock()
+        route53_zone.module.params.get.side_effect = {
+            "dnssec": True,
+            "wait": True,
+        }.get
+        route53_zone.module.check_mode = False
+
+        # Mock get_dnssec to return NOT_SIGNING
+        mock_get_dnssec.return_value = {
+            "Status": {"ServeSignature": "NOT_SIGNING"},
+        }
+
+        # Mock enable_hosted_zone_dnssec to return ChangeInfo
+        mock_enable_dnssec.return_value = {
+            "ChangeInfo": {
+                "Id": "/change/C1234567890ABC",
+                "Status": "PENDING",
+            }
+        }
+
+        # Call the function
+        zone_id = "Z1234567890ABC"
+        changed = route53_zone.ensure_dnssec(zone_id)
+
+        # Verify enable was called
+        mock_enable_dnssec.assert_called_once_with(zone_id)
+
+        # Verify waiter was called with the change ID
+        mock_wait.assert_called_once_with("/change/C1234567890ABC")
+
+        # Verify changed is True
+        assert changed is True
+
+    @patch(f"{module_name}.wait_for_dnssec_change")
+    @patch(f"{module_name}.disable_hosted_zone_dnssec")
+    @patch(f"{module_name}.get_dnssec")
+    def test_disable_dnssec_with_wait(self, mock_get_dnssec, mock_disable_dnssec, mock_wait):
+        """Test disabling DNSSEC calls waiter when wait=True"""
+        from ansible_collections.amazon.aws.plugins.modules import route53_zone
+
+        # Mock module params
+        route53_zone.module = MagicMock()
+        route53_zone.module.params.get.side_effect = {
+            "dnssec": False,
+            "wait": True,
+        }.get
+        route53_zone.module.check_mode = False
+
+        # Mock get_dnssec to return SIGNING
+        mock_get_dnssec.return_value = {
+            "Status": {"ServeSignature": "SIGNING"},
+        }
+
+        # Mock disable_hosted_zone_dnssec to return ChangeInfo
+        mock_disable_dnssec.return_value = {
+            "ChangeInfo": {
+                "Id": "/change/C9876543210ABC",
+                "Status": "PENDING",
+            }
+        }
+
+        # Call the function
+        zone_id = "Z1234567890ABC"
+        changed = route53_zone.ensure_dnssec(zone_id)
+
+        # Verify disable was called
+        mock_disable_dnssec.assert_called_once_with(zone_id)
+
+        # Verify waiter was called with the change ID
+        mock_wait.assert_called_once_with("/change/C9876543210ABC")
+
+        # Verify changed is True
+        assert changed is True


### PR DESCRIPTION
Add wait and wait_timeout parameters to route53_zone module to wait for DNSSEC state changes to propagate using the Route53 resource_record_sets_changed waiter. Summary
This PR adds support for waiting for DNSSEC operations to complete, addressing the eventual consistency issues when enabling/disabling DNSSEC on Route53 hosted zones. Changes

Added wait parameter (boolean, default: false) to enable waiting Added wait_timeout parameter (int, default: 300 seconds) to configure wait time Modified enable_hosted_zone_dnssec() to return ChangeInfo Modified disable_hosted_zone_dnssec() to return ChangeInfo Added wait_for_dnssec_change() function using Route53 waiter Added 6 unit tests covering wait functionality
Added 6 integration tests covering enable/disable DNSSEC with wait

Testing

Unit tests verify waiter invocation and timeout calculation Integration tests verify actual DNSSEC operations with wait parameter Tests cover check mode, actual operations, and idempotence

Closes #2981

Reviewed-by: Mark Chappell
(cherry picked from commit 01c23a428b14886c64cf81f7e67b12b5acccee4b)

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module/Plugin Pull Request
- Refactoring Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Integration tests should also be included where practical (tests/integration/targets) -->

<!--- Contributions created with the assistance of AI must include an 'Assisted-by: ...' declaration -->
<!--- Assisted-by: <AI model and version> -->
