### PR TITLE
Release v10.3.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,14 @@ amazon.aws Release Notes
 
 .. contents:: Topics
 
+v10.3.2
+=======
+
+Bugfixes
+--------
+
+- Add retry state for 404 in S3 waiters to avoid failure on s3 bucket 404 if bucket is not immediately visible (https://github.com/ansible-collections/amazon.aws/issues/2984#issuecomment-4603538914) (https://github.com/ansible-collections/amazon.aws/pull/2987)
+
 v10.3.1
 =======
 

--- a/changelogs/changelog.yaml
+++ b/changelogs/changelog.yaml
@@ -4032,3 +4032,12 @@ releases:
     - ansible-test-gh-action-migration.yml
     - reliability-duplicate-assignments.yml
     release_date: '2026-05-06'
+  10.3.2:
+    changes:
+      bugfixes:
+      - Add retry state for 404 in S3 waiters to avoid failure on s3 bucket 404 if
+        bucket is not immediately visible (https://github.com/ansible-collections/amazon.aws/issues/2984#issuecomment-4603538914)
+        (https://github.com/ansible-collections/amazon.aws/pull/2987)
+    fragments:
+    - 2987-s3bucket-waiter-retry-404.yml
+    release_date: '2026-06-16'

--- a/changelogs/fragments/2987-s3bucket-waiter-retry-404.yml
+++ b/changelogs/fragments/2987-s3bucket-waiter-retry-404.yml
@@ -1,2 +1,0 @@
-bugfixes:
-  - Add retry state for 404 in S3 waiters to avoid failure on s3 bucket 404 if bucket is not immediately visible (https://github.com/ansible-collections/amazon.aws/issues/2984#issuecomment-4603538914) (https://github.com/ansible-collections/amazon.aws/pull/2987)

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -1,7 +1,7 @@
 ---
 namespace: amazon
 name: aws
-version: 10.3.1
+version: 10.3.2
 readme: README.md
 authors:
   - Ansible (https://github.com/ansible)

--- a/plugins/module_utils/common.py
+++ b/plugins/module_utils/common.py
@@ -4,7 +4,7 @@
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
 AMAZON_AWS_COLLECTION_NAME = "amazon.aws"
-AMAZON_AWS_COLLECTION_VERSION = "10.3.1"
+AMAZON_AWS_COLLECTION_VERSION = "10.3.2"
 
 
 _collection_info_context = {


### PR DESCRIPTION
## Summary

Release v10.3.2 of amazon.aws collection.

**Release date**: 2026-06-16

### Changes included

**Bugfixes:**
- Add retry state for 404 in S3 waiters to avoid failure on s3 bucket 404 if bucket is not immediately visible (#2987)

### Checklist

- [x] Version bumped in `galaxy.yml` (10.3.1 → 10.3.2)
- [x] Changelog generated with `antsibull-changelog release`
- [x] Changelog fragment consumed
- [x] CHANGELOG.rst updated
- [x] Sanity tests pass

---

🤖 Generated with [Claude Code](https://claude.ai/code)