### PR TITLE
ci(tox): use matching community.aws branch for unit tests

### DIFF
--- a/changelogs/fragments/3014-tox-community-aws-branch.yml
+++ b/changelogs/fragments/3014-tox-community-aws-branch.yml
@@ -1,0 +1,2 @@
+trivial:
+  - tox - Use matching community.aws branch for unit tests to fix dependency resolution on stable branches (https://github.com/ansible-collections/amazon.aws/pull/3014).

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,12 @@ collection_path = amazon/aws
 format_dirs = {toxinidir}/plugins {toxinidir}/tests
 lint_dirs = {toxinidir}/plugins {toxinidir}/tests
 
+community_aws_install = sh -c 'VERSION=$(grep "^version:" {toxinidir}/galaxy.yml | cut -d" " -f2); \
+       if echo "$VERSION" | grep -q -- "-dev"; then BRANCH="main"; \
+       else MAJOR=$(echo "$VERSION" | cut -d. -f1); BRANCH="stable-$MAJOR"; fi; \
+       ansible-galaxy collection install "git+https://github.com/ansible-collections/community.aws.git,$BRANCH" 2>/dev/null || \
+       ansible-galaxy collection install git+https://github.com/ansible-collections/community.aws.git'
+
 ansible_desc =
     ansible2.17: Ansible-core 2.17
     ansible2.18: Ansible-core 2.18
@@ -59,9 +65,7 @@ allowlist_externals = rsync, sh
 change_dir = {[common]full_collection_path}
 commands_pre =
   rsync --delete --filter=':- .gitignore' --exclude=/.git -qraugpo {toxinidir}/ {[common]full_collection_path}/
-  sh -c 'BRANCH=$(git -C {toxinidir} rev-parse --abbrev-ref HEAD 2>/dev/null || echo main); \
-         ansible-galaxy collection install "git+https://github.com/ansible-collections/community.aws.git,$BRANCH" 2>/dev/null || \
-         ansible-galaxy collection install git+https://github.com/ansible-collections/community.aws.git'
+  {[common]community_aws_install}
 commands =
     pytest \
         --cov \
@@ -335,9 +339,7 @@ deps =
   typing_extensions
 commands_pre =
   rsync --delete --filter=':- .gitignore' --exclude=/.git -qraugpo {toxinidir}/ {[common]full_collection_path}/
-  sh -c 'BRANCH=$(git -C {toxinidir} rev-parse --abbrev-ref HEAD 2>/dev/null || echo main); \
-         ansible-galaxy collection install "git+https://github.com/ansible-collections/community.aws.git,$BRANCH" 2>/dev/null || \
-         ansible-galaxy collection install git+https://github.com/ansible-collections/community.aws.git'
+  {[common]community_aws_install}
   ln -s {env_site_packages_dir}/ansible {[common]ansible_collections_path}/ansible
   ln -s {[common]ansible_home}/collections/ansible_collections {[common]ansible_home}/ansible_collections
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -55,11 +55,13 @@ deps =
   ansible2.19: ansible-core>2.19,<2.20
   ansible2.20: ansible-core>2.20,<2.21
   with_constraints: -rtests/unit/constraints.txt
-allowlist_externals = rsync
+allowlist_externals = rsync, sh
 change_dir = {[common]full_collection_path}
 commands_pre =
   rsync --delete --filter=':- .gitignore' --exclude=/.git -qraugpo {toxinidir}/ {[common]full_collection_path}/
-  ansible-galaxy collection install git+https://github.com/ansible-collections/community.aws.git
+  sh -c 'BRANCH=$(git -C {toxinidir} rev-parse --abbrev-ref HEAD 2>/dev/null || echo main); \
+         ansible-galaxy collection install "git+https://github.com/ansible-collections/community.aws.git,$BRANCH" 2>/dev/null || \
+         ansible-galaxy collection install git+https://github.com/ansible-collections/community.aws.git'
 commands =
     pytest \
         --cov \
@@ -316,7 +318,7 @@ commands =
   ansible-test sanity
 
 [testenv:mypy-lint]
-allowlist_externals = rsync,ln
+allowlist_externals = rsync, ln, sh
 labels = future-lint
 description = Run mypi type tests
 set_env =
@@ -333,7 +335,9 @@ deps =
   typing_extensions
 commands_pre =
   rsync --delete --filter=':- .gitignore' --exclude=/.git -qraugpo {toxinidir}/ {[common]full_collection_path}/
-  ansible-galaxy collection install git+https://github.com/ansible-collections/community.aws.git
+  sh -c 'BRANCH=$(git -C {toxinidir} rev-parse --abbrev-ref HEAD 2>/dev/null || echo main); \
+         ansible-galaxy collection install "git+https://github.com/ansible-collections/community.aws.git,$BRANCH" 2>/dev/null || \
+         ansible-galaxy collection install git+https://github.com/ansible-collections/community.aws.git'
   ln -s {env_site_packages_dir}/ansible {[common]ansible_collections_path}/ansible
   ln -s {[common]ansible_home}/collections/ansible_collections {[common]ansible_home}/ansible_collections
 commands =


### PR DESCRIPTION
## Summary
- Fix tox unit test dependency resolution for stable branches
- Detect current git branch and install matching community.aws branch
- Fall back to main if the branch doesn't exist in community.aws

## Problem
When running tox unit tests on stable branches (e.g., stable-11), the `ansible-galaxy collection install` command installs `community.aws` from main. However, `community.aws` main may require a newer `amazon.aws` version than the stable branch provides, causing dependency resolution failures:

```
[ERROR]: Failed to resolve the requested dependencies map. Could not satisfy the following requirements:
* amazon.aws:>=12.0.0-dev0 (dependency of community.aws:12.0.0-dev0)
```

## Solution
Use shell command to detect the current branch and install the matching `community.aws` branch:

```ini
sh -c 'BRANCH=$(git -C {toxinidir} rev-parse --abbrev-ref HEAD 2>/dev/null || echo main); \
       ansible-galaxy collection install "git+https://github.com/ansible-collections/community.aws.git,$BRANCH" 2>/dev/null || \
       ansible-galaxy collection install git+https://github.com/ansible-collections/community.aws.git'
```

This works generically across all branches without hardcoding branch names.

## Test plan
- [ ] Verify tox unit tests pass on main
- [ ] Verify tox unit tests pass on stable-11 after backport

🤖 Generated with [Claude Code](https://claude.com/claude-code)