### PR TITLE
refactor(kms): consolidate module_utils and improve error handling

### DIFF
--- a/changelogs/fragments/3000-kms-refactor.yml
+++ b/changelogs/fragments/3000-kms-refactor.yml
@@ -1,0 +1,9 @@
+---
+bugfixes:
+  - kms_key - fix incorrect ``changed`` status when policy comparison failed due to transient API errors. The module now properly retries policy fetches and only reports ``changed`` when policies actually differ.
+minor_changes:
+  - kms_key - refactored KMS module_utils to improve maintainability and consistency.
+  - kms_key - added warning when unable to fetch key rotation status due to permissions or unsupported key type.
+  - kms_key_info - refactored to use consolidated module_utils functions.
+  - module_utils.kms - created comprehensive KMS module_utils with error handling, retry logic, and data transformations.
+  - module_utils.transformation - added ``tagging_params`` parameter to ``boto3_resource_to_ansible_dict`` to support custom tag key names like ``TagKey``/``TagValue``.

--- a/changelogs/fragments/3000-kms-refactor.yml
+++ b/changelogs/fragments/3000-kms-refactor.yml
@@ -1,9 +1,9 @@
 ---
 bugfixes:
-  - kms_key - fix incorrect ``changed`` status when policy comparison failed due to transient API errors. The module now properly retries policy fetches and only reports ``changed`` when policies actually differ.
+  - kms_key - fix incorrect ``changed`` status when policy comparison failed due to transient API errors. The module now properly retries policy fetches and only reports ``changed`` when policies actually differ (https://github.com/ansible-collections/amazon.aws/pull/3016).
 minor_changes:
-  - kms_key - refactored KMS module_utils to improve maintainability and consistency.
-  - kms_key - added warning when unable to fetch key rotation status due to permissions or unsupported key type.
-  - kms_key_info - refactored to use consolidated module_utils functions.
-  - module_utils.kms - created comprehensive KMS module_utils with error handling, retry logic, and data transformations.
-  - module_utils.transformation - added ``tagging_params`` parameter to ``boto3_resource_to_ansible_dict`` to support custom tag key names like ``TagKey``/``TagValue``.
+  - kms_key - refactored KMS module_utils to improve maintainability and consistency (https://github.com/ansible-collections/amazon.aws/pull/3016).
+  - kms_key - added warning when unable to fetch key rotation status due to permissions or unsupported key type (https://github.com/ansible-collections/amazon.aws/pull/3016).
+  - kms_key_info - refactored to use consolidated module_utils functions (https://github.com/ansible-collections/amazon.aws/pull/3016).
+  - module_utils.kms - created comprehensive KMS module_utils with error handling, retry logic, and data transformations (https://github.com/ansible-collections/amazon.aws/pull/3016).
+  - module_utils.transformation - added ``tagging_params`` parameter to ``boto3_resource_to_ansible_dict`` to support custom tag key names like ``TagKey``/``TagValue`` (https://github.com/ansible-collections/amazon.aws/pull/3016).

--- a/plugins/module_utils/_kms/api.py
+++ b/plugins/module_utils/_kms/api.py
@@ -1,0 +1,203 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Minimal API wrappers for KMS operations with error handling and retries.
+
+This module contains thin wrappers around boto3 KMS client methods.
+Each function is decorated with:
+- KMSErrorHandler for consistent error handling and exception conversion
+- AWSRetry for automatic retry with exponential backoff
+
+Functions here should be minimal - parameter manipulation is acceptable,
+but complex business logic belongs in the parent kms.py module.
+"""
+
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from ansible_collections.amazon.aws.plugins.module_utils.botocore import ClientType
+
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+
+from .common import KMSErrorHandler
+
+# Key and alias listing
+
+
+@KMSErrorHandler.common_error_handler("list KMS keys")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def get_kms_keys(client: ClientType) -> dict:
+    paginator = client.get_paginator("list_keys")
+    return paginator.paginate().build_full_result()
+
+
+@KMSErrorHandler.common_error_handler("list KMS aliases")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def get_kms_aliases(client: ClientType) -> dict:
+    paginator = client.get_paginator("list_aliases")
+    return paginator.paginate().build_full_result()
+
+
+# Tag operations
+
+
+@KMSErrorHandler.common_error_handler("list KMS resource tags")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def get_kms_tags(client: ClientType, key_id: str) -> dict:
+    paginator = client.get_paginator("list_resource_tags")
+    return paginator.paginate(KeyId=key_id).build_full_result()
+
+
+@KMSErrorHandler.common_error_handler("list KMS resource tags")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def list_resource_tags(client: ClientType, key_id: str, **kwargs) -> dict:
+    return client.list_resource_tags(KeyId=key_id, **kwargs)
+
+
+@KMSErrorHandler.common_error_handler("tag resource")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def tag_resource(client: ClientType, key_id: str, tags: list[dict]) -> dict:
+    return client.tag_resource(KeyId=key_id, Tags=tags)
+
+
+@KMSErrorHandler.common_error_handler("untag resource")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def untag_resource(client: ClientType, key_id: str, tag_keys: list[str]) -> dict:
+    return client.untag_resource(KeyId=key_id, TagKeys=tag_keys)
+
+
+# Grant operations
+
+
+@KMSErrorHandler.common_error_handler("list KMS grants")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def get_kms_grants(client: ClientType, key_id: str, grant_tokens: list[str] | None = None) -> dict:
+    params = {"KeyId": key_id}
+    if grant_tokens:
+        params["GrantTokens"] = grant_tokens
+    paginator = client.get_paginator("list_grants")
+    return paginator.paginate(**params).build_full_result()
+
+
+@KMSErrorHandler.common_error_handler("create grant")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def create_grant(client: ClientType, **params) -> dict:
+    return client.create_grant(**params)
+
+
+@KMSErrorHandler.common_error_handler("retire grant")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def retire_grant(client: ClientType, key_id: str, grant_id: str) -> dict:
+    return client.retire_grant(KeyId=key_id, GrantId=grant_id)
+
+
+# Key metadata and details
+
+
+@KMSErrorHandler.list_error_handler("describe KMS key", default_value=None)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def get_kms_metadata(client: ClientType, key_id: str) -> dict | None:
+    result = client.describe_key(KeyId=key_id)
+    return result.get("KeyMetadata") if result else None
+
+
+# Policy operations
+
+
+@KMSErrorHandler.common_error_handler("list key policies")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def list_key_policies(client: ClientType, key_id: str) -> dict:
+    paginator = client.get_paginator("list_key_policies")
+    return paginator.paginate(KeyId=key_id).build_full_result()
+
+
+@KMSErrorHandler.list_error_handler("get key policy", default_value=None)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def get_key_policy(client: ClientType, key_id: str, policy_name: str) -> dict | None:
+    return client.get_key_policy(KeyId=key_id, PolicyName=policy_name)
+
+
+@KMSErrorHandler.common_error_handler("put key policy")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def put_key_policy(client: ClientType, key_id: str, policy_name: str, policy: str) -> dict:
+    return client.put_key_policy(KeyId=key_id, PolicyName=policy_name, Policy=policy)
+
+
+# Key rotation operations
+
+
+@KMSErrorHandler.common_error_handler("get key rotation status")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def get_key_rotation_status(client: ClientType, key_id: str) -> dict:
+    return client.get_key_rotation_status(KeyId=key_id)
+
+
+@KMSErrorHandler.common_error_handler("enable key rotation")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def enable_key_rotation(client: ClientType, key_id: str) -> dict:
+    return client.enable_key_rotation(KeyId=key_id)
+
+
+@KMSErrorHandler.common_error_handler("disable key rotation")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def disable_key_rotation(client: ClientType, key_id: str) -> dict:
+    return client.disable_key_rotation(KeyId=key_id)
+
+
+# Key state operations
+
+
+@KMSErrorHandler.common_error_handler("enable key")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def enable_key(client: ClientType, key_id: str) -> dict:
+    return client.enable_key(KeyId=key_id)
+
+
+@KMSErrorHandler.common_error_handler("disable key")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def disable_key(client: ClientType, key_id: str) -> dict:
+    return client.disable_key(KeyId=key_id)
+
+
+@KMSErrorHandler.common_error_handler("schedule key deletion")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def schedule_key_deletion(client: ClientType, key_id: str, pending_window_in_days: int | None = None) -> dict:
+    params = {"KeyId": key_id}
+    if pending_window_in_days is not None:
+        params["PendingWindowInDays"] = pending_window_in_days
+    return client.schedule_key_deletion(**params)
+
+
+@KMSErrorHandler.common_error_handler("cancel key deletion")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def cancel_key_deletion(client: ClientType, key_id: str) -> dict:
+    return client.cancel_key_deletion(KeyId=key_id)
+
+
+# Key creation and modification
+
+
+@KMSErrorHandler.common_error_handler("create key")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def create_key(client: ClientType, **params) -> dict:
+    return client.create_key(**params)
+
+
+@KMSErrorHandler.common_error_handler("update key description")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def update_key_description(client: ClientType, key_id: str, description: str) -> dict:
+    return client.update_key_description(KeyId=key_id, Description=description)
+
+
+# Alias operations
+
+
+@KMSErrorHandler.common_error_handler("create alias")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def create_alias(client: ClientType, alias_name: str, target_key_id: str) -> dict:
+    return client.create_alias(AliasName=alias_name, TargetKeyId=target_key_id)

--- a/plugins/module_utils/_kms/common.py
+++ b/plugins/module_utils/_kms/common.py
@@ -1,0 +1,29 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import typing
+
+if typing.TYPE_CHECKING:
+    from typing import Callable
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.errors import AWSErrorHandler
+from ansible_collections.amazon.aws.plugins.module_utils.exceptions import AnsibleAWSError
+
+
+class AnsibleKMSError(AnsibleAWSError):
+    pass
+
+
+class KMSErrorHandler(AWSErrorHandler):
+    _CUSTOM_EXCEPTION = AnsibleKMSError
+
+    @classmethod
+    def _is_missing(cls) -> Callable:
+        # KMS uses service-specific NotFoundException exception
+        # Also handle InvalidKeyId for key lookup failures
+        return is_boto3_error_code(["NotFoundException", "InvalidKeyId"])

--- a/plugins/module_utils/_kms/common.py
+++ b/plugins/module_utils/_kms/common.py
@@ -3,8 +3,24 @@
 # Copyright: Contributors to the Ansible project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+"""
+Error handling infrastructure for KMS operations.
+
+This module defines KMS-specific exception classes and error handlers that
+provide consistent error handling across all KMS operations.
+
+Exception hierarchy:
+- AnsibleKMSError (base)
+  - AnsibleKMSPermissionsError (AccessDeniedException)
+  - AnsibleKMSUnsupportedError (UnsupportedOperationException)
+
+The KMSErrorHandler decorator automatically converts boto3 exceptions to
+these typed exceptions with helpful error messages.
+"""
+
 from __future__ import annotations
 
+import functools
 import typing
 
 if typing.TYPE_CHECKING:
@@ -19,6 +35,18 @@ class AnsibleKMSError(AnsibleAWSError):
     pass
 
 
+class AnsibleKMSPermissionsError(AnsibleKMSError):
+    """Exception raised for KMS permission/authorization errors."""
+
+    pass
+
+
+class AnsibleKMSUnsupportedError(AnsibleKMSError):
+    """Exception raised when a KMS operation is not supported (e.g., key rotation on asymmetric keys)."""
+
+    pass
+
+
 class KMSErrorHandler(AWSErrorHandler):
     _CUSTOM_EXCEPTION = AnsibleKMSError
 
@@ -27,3 +55,34 @@ class KMSErrorHandler(AWSErrorHandler):
         # KMS uses service-specific NotFoundException exception
         # Also handle InvalidKeyId for key lookup failures
         return is_boto3_error_code(["NotFoundException", "InvalidKeyId"])
+
+    @classmethod
+    def common_error_handler(cls, description: str):
+        """
+        Decorator for common error handling, including permissions and unsupported operation errors.
+
+        Catches and converts boto3 exceptions to appropriate AnsibleKMS exceptions:
+        - AccessDeniedException -> raises AnsibleKMSPermissionsError
+        - UnsupportedOperationException -> raises AnsibleKMSUnsupportedError
+        """
+
+        def wrapper(func: Callable) -> Callable:
+            parent_decorator = super(KMSErrorHandler, cls).common_error_handler(description)
+
+            @parent_decorator
+            @functools.wraps(func)
+            def handler(*args, **kwargs):
+                try:
+                    return func(*args, **kwargs)
+                except is_boto3_error_code("AccessDeniedException") as e:
+                    raise AnsibleKMSPermissionsError(
+                        message=f"Failed to {description} (permission denied)", exception=e
+                    ) from e
+                except is_boto3_error_code("UnsupportedOperationException") as e:  # pylint: disable=duplicate-except
+                    raise AnsibleKMSUnsupportedError(
+                        message=f"Failed to {description} (operation not supported)", exception=e
+                    ) from e
+
+            return handler
+
+        return wrapper

--- a/plugins/module_utils/_kms/grants.py
+++ b/plugins/module_utils/_kms/grants.py
@@ -1,0 +1,60 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Grant comparison and diff logic for idempotent grant management.
+
+This module provides functions to compare existing grants with desired grants
+and determine which grants need to be added or removed. Supports purge_grants
+parameter for controlling whether unspecified grants should be removed.
+
+Grant comparison considers:
+- Grantee principal
+- Retiring principal
+- Operations (order-independent)
+- Constraints (encryption context)
+"""
+
+from __future__ import annotations
+
+
+def different_grant(existing_grant: dict, desired_grant: dict) -> bool:
+    """Check if two grants differ in any way"""
+    if existing_grant.get("grantee_principal") != desired_grant.get("grantee_principal"):
+        return True
+    if existing_grant.get("retiring_principal") != desired_grant.get("retiring_principal"):
+        return True
+    if set(existing_grant.get("operations", [])) != set(desired_grant.get("operations", [])):
+        return True
+    if existing_grant.get("constraints") != desired_grant.get("constraints"):
+        return True
+    return False
+
+
+def compare_grants(
+    existing_grants: list[dict], desired_grants: list[dict], purge_grants: bool = False
+) -> tuple[list[dict], list[dict]]:
+    """
+    Compare existing and desired grants to determine which to add/remove.
+
+    Returns:
+        tuple: (grants_to_add, grants_to_remove)
+    """
+    existing_dict = {eg["name"]: eg for eg in existing_grants}
+    desired_dict = {dg["name"]: dg for dg in desired_grants}
+    to_add_keys = set(desired_dict.keys()) - set(existing_dict.keys())
+    if purge_grants:
+        to_remove_keys = set(existing_dict.keys()) - set(desired_dict.keys())
+    else:
+        to_remove_keys = set()
+    to_change_candidates = set(existing_dict.keys()) & set(desired_dict.keys())
+    for candidate in to_change_candidates:
+        if different_grant(existing_dict[candidate], desired_dict[candidate]):
+            to_add_keys.add(candidate)
+            to_remove_keys.add(candidate)
+
+    to_add = [desired_dict[key] for key in to_add_keys]
+    to_remove = [existing_dict[key] for key in to_remove_keys]
+    return to_add, to_remove

--- a/plugins/module_utils/_kms/transformations.py
+++ b/plugins/module_utils/_kms/transformations.py
@@ -1,0 +1,156 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""
+Data transformation functions for converting boto3 responses to Ansible format.
+
+This module handles transformation of KMS resources from AWS API format
+(CamelCase, boto3-specific structures) to Ansible format (snake_case,
+simplified dictionaries). Uses boto3_resource_to_ansible_dict for consistent
+transformation patterns across the collection.
+
+Key transformations:
+- Grant constraints with encryption context preservation
+- Policy document JSON parsing
+- Complete key details normalization
+- Alias name canonicalization
+"""
+
+from __future__ import annotations
+
+import json
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+from ansible_collections.amazon.aws.plugins.module_utils.transformation import boto3_resource_to_ansible_dict
+
+
+def canonicalize_alias_name(alias: str | None) -> str | None:
+    """
+    Normalize KMS alias name to always include 'alias/' prefix.
+
+    Args:
+        alias: Alias name with or without 'alias/' prefix, or None
+
+    Returns:
+        Alias name with 'alias/' prefix, or None if input was None
+
+    Examples:
+        >>> canonicalize_alias_name("myalias")
+        'alias/myalias'
+        >>> canonicalize_alias_name("alias/myalias")
+        'alias/myalias'
+        >>> canonicalize_alias_name(None)
+        None
+    """
+    if alias is None:
+        return None
+    if alias.startswith("alias/"):
+        return alias
+    return f"alias/{alias}"
+
+
+def _transform_grant_constraints(constraints: dict) -> dict:
+    """
+    Transform KMS grant constraints to Ansible format.
+
+    Preserves encryption context key-value pairs (user-provided data that should not be transformed).
+
+    Args:
+        constraints: Constraints dictionary from a KMS grant
+
+    Returns:
+        Transformed constraints with snake_case keys but preserved encryption context values
+    """
+    result = camel_dict_to_snake_dict(constraints, ignore_list=["EncryptionContextEquals", "EncryptionContextSubset"])
+    # Manually add back the encryption context fields with snake_case keys
+    if "EncryptionContextEquals" in constraints:
+        result["encryption_context_equals"] = constraints["EncryptionContextEquals"]
+    if "EncryptionContextSubset" in constraints:
+        result["encryption_context_subset"] = constraints["EncryptionContextSubset"]
+    return result
+
+
+def _transform_grants_list(grants: list[dict]) -> list[dict]:
+    """
+    Transform list of KMS grants to Ansible format.
+
+    Args:
+        grants: List of KMS grant dictionaries from boto3
+
+    Returns:
+        List of transformed grant dictionaries
+    """
+    return [
+        boto3_resource_to_ansible_dict(
+            grant,
+            transform_tags=False,
+            force_tags=False,
+            nested_transforms={"Constraints": _transform_grant_constraints},
+        )
+        for grant in grants
+    ]
+
+
+def _transform_key_policies(policies: list[str]) -> list[dict]:
+    """
+    Transform KMS policy documents from JSON strings to dictionaries.
+
+    Args:
+        policies: List of policy documents as JSON strings
+
+    Returns:
+        List of policy documents as dictionaries
+    """
+    return [json.loads(policy) for policy in policies]
+
+
+def camel_to_snake_grant(grant: dict) -> dict:
+    """
+    Convert KMS grant dict to snake_case Ansible format.
+
+    Preserves encryption context key-value pairs within Constraints field.
+
+    Args:
+        grant: KMS grant dictionary from boto3
+
+    Returns:
+        Transformed grant dictionary in Ansible format
+    """
+    return boto3_resource_to_ansible_dict(
+        grant, transform_tags=False, force_tags=False, nested_transforms={"Constraints": _transform_grant_constraints}
+    )
+
+
+def normalize_kms_key_details(key_details: dict) -> dict:
+    """
+    Normalize KMS key details to Ansible dictionary format.
+
+    Transforms the complete key details including metadata, grants, tags, and policies.
+    Similar to S3's normalize_* functions, provides consistent transformation.
+
+    Args:
+        key_details: KMS key details dictionary from boto3 (can include Grants, Tags, KeyPolicies)
+
+    Returns:
+        Normalized key details dictionary in Ansible format
+    """
+    nested_transforms = {
+        "Grants": _transform_grants_list,
+        "KeyPolicies": _transform_key_policies,
+    }
+
+    tagging_params = {
+        "tag_name_key_name": "TagKey",
+        "tag_value_key_name": "TagValue",
+    }
+
+    return boto3_resource_to_ansible_dict(
+        key_details,
+        transform_tags=True,
+        force_tags=False,
+        nested_transforms=nested_transforms,
+        tagging_params=tagging_params,
+    )

--- a/plugins/module_utils/kms.py
+++ b/plugins/module_utils/kms.py
@@ -3,6 +3,29 @@
 # Copyright: Contributors to the Ansible project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+"""
+Public API for KMS operations in Ansible modules.
+
+This module provides the main interface for working with AWS KMS from Ansible modules.
+It re-exports low-level API functions from _kms.api, exception classes from _kms.common,
+and transformation utilities from _kms.transformations.
+
+Primary functions:
+- get_key_details(): Get comprehensive key information including metadata, grants, tags, policies
+- get_kms_aliases_lookup(): Build key_id -> aliases mapping
+- get_kms_policy_as_dict(): Get a single policy as a parsed dictionary
+- get_kms_policies(): Get all policies for a key as JSON strings
+
+Low-level API functions (re-exported from _kms.api):
+All functions are decorated with error handling (KMSErrorHandler) and automatic retry (AWSRetry).
+Paginated operations use build_full_result() for consistency.
+
+Exception hierarchy:
+- AnsibleKMSError: Base exception for all KMS errors
+  - AnsibleKMSPermissionsError: Permission denied errors (AccessDeniedException)
+  - AnsibleKMSUnsupportedError: Unsupported operation errors (UnsupportedOperationException)
+"""
+
 from __future__ import annotations
 
 import json
@@ -11,32 +34,42 @@ import typing
 if typing.TYPE_CHECKING:
     from ansible_collections.amazon.aws.plugins.module_utils.botocore import ClientType
 
-from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+# Not intended for general re-use / re-import
+from ._kms import transformations as _transformations
 
 # Intended for general use / re-import
 # pylint: disable=unused-import,useless-import-alias
+from ._kms.api import cancel_key_deletion as cancel_key_deletion
+from ._kms.api import create_alias as create_alias
+from ._kms.api import create_grant as create_grant
+from ._kms.api import create_key as create_key
+from ._kms.api import disable_key as disable_key
+from ._kms.api import disable_key_rotation as disable_key_rotation
+from ._kms.api import enable_key as enable_key
+from ._kms.api import enable_key_rotation as enable_key_rotation
+from ._kms.api import get_key_policy as get_key_policy
+from ._kms.api import get_key_rotation_status as get_key_rotation_status
+from ._kms.api import get_kms_aliases as get_kms_aliases
+from ._kms.api import get_kms_grants as get_kms_grants
+from ._kms.api import get_kms_keys as get_kms_keys
+from ._kms.api import get_kms_metadata as get_kms_metadata
+from ._kms.api import get_kms_tags as get_kms_tags
+from ._kms.api import list_key_policies as list_key_policies
+from ._kms.api import list_resource_tags as list_resource_tags
+from ._kms.api import put_key_policy as put_key_policy
+from ._kms.api import retire_grant as retire_grant
+from ._kms.api import schedule_key_deletion as schedule_key_deletion
+from ._kms.api import tag_resource as tag_resource
+from ._kms.api import untag_resource as untag_resource
+from ._kms.api import update_key_description as update_key_description
 from ._kms.common import AnsibleKMSError as AnsibleKMSError
+from ._kms.common import AnsibleKMSPermissionsError as AnsibleKMSPermissionsError
+from ._kms.common import AnsibleKMSUnsupportedError as AnsibleKMSUnsupportedError
 from ._kms.common import KMSErrorHandler as KMSErrorHandler
+from ._kms.transformations import canonicalize_alias_name as canonicalize_alias_name
+from ._kms.transformations import normalize_kms_key_details as normalize_kms_key_details
 
 # pylint: enable=unused-import,useless-import-alias
-
-
-@KMSErrorHandler.common_error_handler("list KMS keys")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_keys(client: ClientType) -> dict:
-    paginator = client.get_paginator("list_keys")
-    return paginator.paginate().build_full_result()
-
-
-@KMSErrorHandler.common_error_handler("list KMS aliases")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_aliases(client: ClientType) -> dict:
-    paginator = client.get_paginator("list_aliases")
-    return paginator.paginate().build_full_result()
 
 
 def get_kms_aliases_lookup(client: ClientType) -> dict[str, list[str]]:
@@ -53,84 +86,76 @@ def get_kms_aliases_lookup(client: ClientType) -> dict[str, list[str]]:
     return _aliases
 
 
-@KMSErrorHandler.common_error_handler("list KMS resource tags")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def _list_resource_tags(client: ClientType, key_id: str, **kwargs) -> dict:
-    return client.list_resource_tags(KeyId=key_id, **kwargs)
+def get_kms_policy_as_dict(client: ClientType, key_id: str, policy_name: str = "default") -> dict | None:
+    """
+    Get a single KMS key policy document as a parsed dictionary.
 
+    Args:
+        client: boto3 KMS client
+        key_id: KMS key ID or ARN
+        policy_name: Name of the policy (default: "default")
 
-def get_kms_tags(client: ClientType, key_id: str) -> list[dict]:
-    """Get all tags for a KMS key, handling pagination"""
-    kwargs = {}
-    tags = []
-    more = True
-    while more:
-        try:
-            tag_response = _list_resource_tags(client, key_id, **kwargs)
-            tags.extend(tag_response["Tags"])
-        except is_boto3_error_code("AccessDeniedException"):
-            tag_response = {}
-        if tag_response.get("NextMarker"):
-            kwargs["Marker"] = tag_response["NextMarker"]
-        else:
-            more = False
-    return tags
+    Returns:
+        Policy document as a dictionary, or None if not found/permission denied
 
-
-@KMSErrorHandler.common_error_handler("list KMS grants")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_grants(client: ClientType, key_id: str) -> dict:
-    params = {"KeyId": key_id}
-    paginator = client.get_paginator("list_grants")
-    return paginator.paginate(**params).build_full_result()
-
-
-@KMSErrorHandler.list_error_handler("describe KMS key", default_value=None)
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_metadata(client: ClientType, key_id: str) -> dict | None:
-    result = client.describe_key(KeyId=key_id)
-    return result.get("KeyMetadata") if result else None
-
-
-@KMSErrorHandler.common_error_handler("list key policies")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def list_key_policies(client: ClientType, key_id: str) -> dict:
-    paginator = client.get_paginator("list_key_policies")
-    return paginator.paginate(KeyId=key_id).build_full_result()
-
-
-@KMSErrorHandler.list_error_handler("get key policy", default_value=None)
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_key_policy(client: ClientType, key_id: str, policy_name: str) -> dict | None:
-    return client.get_key_policy(KeyId=key_id, PolicyName=policy_name)
+    Raises:
+        AnsibleKMSPermissionsError: when permission denied
+    """
+    result = get_key_policy(client, key_id, policy_name)
+    if result is None:
+        return None
+    return json.loads(result["Policy"])
 
 
 def get_kms_policies(client: ClientType, key_id: str) -> list[str]:
-    """Get all policy documents for a KMS key"""
-    try:
-        policies = list_key_policies(client, key_id)["PolicyNames"]
-        return [get_key_policy(client, key_id, policy)["Policy"] for policy in policies]
-    except is_boto3_error_code("AccessDeniedException"):
-        return []
+    """
+    Get all policy documents for a KMS key as JSON strings.
+
+    Args:
+        client: boto3 KMS client
+        key_id: KMS key ID or ARN
+
+    Returns:
+        List of policy documents as JSON strings
+
+    Raises:
+        AnsibleKMSPermissionsError: when permission denied
+    """
+    policies = list_key_policies(client, key_id)["PolicyNames"]
+    return [get_key_policy(client, key_id, policy)["Policy"] for policy in policies]
 
 
-def camel_to_snake_grant(grant: dict) -> dict:
-    """Convert grant dict to snake_case, preserving encryption context"""
-    constraints = grant.get("Constraints", {})
-    result = camel_dict_to_snake_dict(grant)
-    if "EncryptionContextEquals" in constraints:
-        result["constraints"]["encryption_context_equals"] = constraints["EncryptionContextEquals"]
-    if "EncryptionContextSubset" in constraints:
-        result["constraints"]["encryption_context_subset"] = constraints["EncryptionContextSubset"]
-    return result
+def get_key_details(
+    client: ClientType, key_id: str, grant_tokens: list[str] | None = None, pending_deletion: bool = False
+) -> dict | None:
+    """
+    Get comprehensive details about a KMS key including metadata, grants, tags, and policies.
 
+    Args:
+        client: boto3 KMS client
+        key_id: KMS key ID, ARN, or alias
+        grant_tokens: optional list of grant tokens to include when fetching grants
+        pending_deletion: if True, returns minimal details (metadata only) for keys pending deletion
 
-def get_key_details(client: ClientType, key_id: str) -> dict:
-    """Get comprehensive details about a KMS key including metadata, grants, tags, and policies"""
+    Returns:
+        Dictionary with key details in Ansible format, or None if key not found
+
+    Raises:
+        AnsibleKMSError: when key not found or other errors occur
+        AnsibleKMSPermissionsError: when permission denied fetching grants, tags, or policies
+                                    (caller should handle and warn user if appropriate)
+        AnsibleKMSUnsupportedError: when operation not supported for key type
+
+    Note:
+        Permission errors for rotation status are caught and result in enable_key_rotation=None.
+        Permission errors for grants, tags, or policies will propagate to the caller.
+    """
     result = get_kms_metadata(client, key_id)
     if not result:
-        raise AnsibleKMSError(message=f"Key {key_id} not found")
+        return None
 
+    # Make sure we have the canonical ARN, we might have been passed an alias
+    key_id = result["Arn"]
     result["KeyArn"] = result.pop("Arn")
 
     try:
@@ -141,128 +166,19 @@ def get_key_details(client: ClientType, key_id: str) -> dict:
     try:
         current_rotation_status = get_key_rotation_status(client, key_id)
         result["enable_key_rotation"] = current_rotation_status.get("KeyRotationEnabled")
-    except is_boto3_error_code(["AccessDeniedException", "UnsupportedOperationException"]):
+    except (AnsibleKMSPermissionsError, AnsibleKMSUnsupportedError):
         result["enable_key_rotation"] = None
 
     result["aliases"] = aliases.get(result["KeyId"], [])
-    result = camel_dict_to_snake_dict(result)
 
-    # grants and tags get snakified differently
-    result["grants"] = [camel_to_snake_grant(grant) for grant in get_kms_grants(client, key_id)["Grants"]]
-    tags = get_kms_tags(client, key_id)
-    result["tags"] = boto3_tag_list_to_ansible_dict(tags, "TagKey", "TagValue")
-    policies = get_kms_policies(client, key_id)
-    result["key_policies"] = [json.loads(policy) for policy in policies]
+    # For keys pending deletion, return minimal details (metadata + aliases + rotation only)
+    if pending_deletion:
+        return _transformations.normalize_kms_key_details(result)
 
-    return result
+    # Fetch grants, tags, and policies (allow these to raise permission errors to caller)
+    result["Grants"] = get_kms_grants(client, key_id, grant_tokens=grant_tokens)["Grants"]
+    result["Tags"] = get_kms_tags(client, key_id).get("Tags", [])
+    result["KeyPolicies"] = get_kms_policies(client, key_id)
 
-
-# Key rotation operations
-
-
-@KMSErrorHandler.common_error_handler("get key rotation status")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_key_rotation_status(client: ClientType, key_id: str) -> dict:
-    return client.get_key_rotation_status(KeyId=key_id)
-
-
-@KMSErrorHandler.common_error_handler("enable key rotation")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def enable_key_rotation(client: ClientType, key_id: str) -> dict:
-    return client.enable_key_rotation(KeyId=key_id)
-
-
-@KMSErrorHandler.common_error_handler("disable key rotation")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def disable_key_rotation(client: ClientType, key_id: str) -> dict:
-    return client.disable_key_rotation(KeyId=key_id)
-
-
-# Key state operations
-
-
-@KMSErrorHandler.common_error_handler("enable key")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def enable_key(client: ClientType, key_id: str) -> dict:
-    return client.enable_key(KeyId=key_id)
-
-
-@KMSErrorHandler.common_error_handler("disable key")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def disable_key(client: ClientType, key_id: str) -> dict:
-    return client.disable_key(KeyId=key_id)
-
-
-@KMSErrorHandler.common_error_handler("schedule key deletion")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def schedule_key_deletion(client: ClientType, key_id: str, pending_window_in_days: int | None = None) -> dict:
-    params = {"KeyId": key_id}
-    if pending_window_in_days is not None:
-        params["PendingWindowInDays"] = pending_window_in_days
-    return client.schedule_key_deletion(**params)
-
-
-@KMSErrorHandler.common_error_handler("cancel key deletion")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def cancel_key_deletion(client: ClientType, key_id: str) -> dict:
-    return client.cancel_key_deletion(KeyId=key_id)
-
-
-# Key creation and modification
-
-
-@KMSErrorHandler.common_error_handler("create key")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def create_key(client: ClientType, **params) -> dict:
-    return client.create_key(**params)
-
-
-@KMSErrorHandler.common_error_handler("update key description")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def update_key_description(client: ClientType, key_id: str, description: str) -> dict:
-    return client.update_key_description(KeyId=key_id, Description=description)
-
-
-@KMSErrorHandler.common_error_handler("put key policy")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def put_key_policy(client: ClientType, key_id: str, policy_name: str, policy: str) -> dict:
-    return client.put_key_policy(KeyId=key_id, PolicyName=policy_name, Policy=policy)
-
-
-# Alias operations
-
-
-@KMSErrorHandler.common_error_handler("create alias")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def create_alias(client: ClientType, alias_name: str, target_key_id: str) -> dict:
-    return client.create_alias(AliasName=alias_name, TargetKeyId=target_key_id)
-
-
-# Tag operations
-
-
-@KMSErrorHandler.common_error_handler("tag resource")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def tag_resource(client: ClientType, key_id: str, tags: list[dict]) -> dict:
-    return client.tag_resource(KeyId=key_id, Tags=tags)
-
-
-@KMSErrorHandler.common_error_handler("untag resource")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def untag_resource(client: ClientType, key_id: str, tag_keys: list[str]) -> dict:
-    return client.untag_resource(KeyId=key_id, TagKeys=tag_keys)
-
-
-# Grant operations
-
-
-@KMSErrorHandler.common_error_handler("create grant")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def create_grant(client: ClientType, **params) -> dict:
-    return client.create_grant(**params)
-
-
-@KMSErrorHandler.common_error_handler("retire grant")
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def retire_grant(client: ClientType, key_id: str, grant_id: str) -> dict:
-    return client.retire_grant(KeyId=key_id, GrantId=grant_id)
+    # Transform everything to Ansible format in one go (includes JSON parsing for policies)
+    return _transformations.normalize_kms_key_details(result)

--- a/plugins/module_utils/kms.py
+++ b/plugins/module_utils/kms.py
@@ -13,12 +13,16 @@ if typing.TYPE_CHECKING:
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
-# pylint: disable-next=unused-import
-from ansible_collections.amazon.aws.plugins.module_utils._kms.common import AnsibleKMSError
-from ansible_collections.amazon.aws.plugins.module_utils._kms.common import KMSErrorHandler
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+
+# Intended for general use / re-import
+# pylint: disable=unused-import,useless-import-alias
+from ._kms.common import AnsibleKMSError as AnsibleKMSError
+from ._kms.common import KMSErrorHandler as KMSErrorHandler
+
+# pylint: enable=unused-import,useless-import-alias
 
 
 @KMSErrorHandler.common_error_handler("list KMS keys")

--- a/plugins/module_utils/kms.py
+++ b/plugins/module_utils/kms.py
@@ -139,7 +139,7 @@ def get_key_details(client: ClientType, key_id: str) -> dict:
         raise AnsibleKMSError(message="Failed to obtain aliases", exception=e.exception) from e
 
     try:
-        current_rotation_status = client.get_key_rotation_status(KeyId=key_id)
+        current_rotation_status = get_key_rotation_status(client, key_id)
         result["enable_key_rotation"] = current_rotation_status.get("KeyRotationEnabled")
     except is_boto3_error_code(["AccessDeniedException", "UnsupportedOperationException"]):
         result["enable_key_rotation"] = None
@@ -155,3 +155,114 @@ def get_key_details(client: ClientType, key_id: str) -> dict:
     result["key_policies"] = [json.loads(policy) for policy in policies]
 
     return result
+
+
+# Key rotation operations
+
+
+@KMSErrorHandler.common_error_handler("get key rotation status")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def get_key_rotation_status(client: ClientType, key_id: str) -> dict:
+    return client.get_key_rotation_status(KeyId=key_id)
+
+
+@KMSErrorHandler.common_error_handler("enable key rotation")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def enable_key_rotation(client: ClientType, key_id: str) -> dict:
+    return client.enable_key_rotation(KeyId=key_id)
+
+
+@KMSErrorHandler.common_error_handler("disable key rotation")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def disable_key_rotation(client: ClientType, key_id: str) -> dict:
+    return client.disable_key_rotation(KeyId=key_id)
+
+
+# Key state operations
+
+
+@KMSErrorHandler.common_error_handler("enable key")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def enable_key(client: ClientType, key_id: str) -> dict:
+    return client.enable_key(KeyId=key_id)
+
+
+@KMSErrorHandler.common_error_handler("disable key")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def disable_key(client: ClientType, key_id: str) -> dict:
+    return client.disable_key(KeyId=key_id)
+
+
+@KMSErrorHandler.common_error_handler("schedule key deletion")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def schedule_key_deletion(client: ClientType, key_id: str, pending_window_in_days: int | None = None) -> dict:
+    params = {"KeyId": key_id}
+    if pending_window_in_days is not None:
+        params["PendingWindowInDays"] = pending_window_in_days
+    return client.schedule_key_deletion(**params)
+
+
+@KMSErrorHandler.common_error_handler("cancel key deletion")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def cancel_key_deletion(client: ClientType, key_id: str) -> dict:
+    return client.cancel_key_deletion(KeyId=key_id)
+
+
+# Key creation and modification
+
+
+@KMSErrorHandler.common_error_handler("create key")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def create_key(client: ClientType, **params) -> dict:
+    return client.create_key(**params)
+
+
+@KMSErrorHandler.common_error_handler("update key description")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def update_key_description(client: ClientType, key_id: str, description: str) -> dict:
+    return client.update_key_description(KeyId=key_id, Description=description)
+
+
+@KMSErrorHandler.common_error_handler("put key policy")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def put_key_policy(client: ClientType, key_id: str, policy_name: str, policy: str) -> dict:
+    return client.put_key_policy(KeyId=key_id, PolicyName=policy_name, Policy=policy)
+
+
+# Alias operations
+
+
+@KMSErrorHandler.common_error_handler("create alias")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def create_alias(client: ClientType, alias_name: str, target_key_id: str) -> dict:
+    return client.create_alias(AliasName=alias_name, TargetKeyId=target_key_id)
+
+
+# Tag operations
+
+
+@KMSErrorHandler.common_error_handler("tag resource")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def tag_resource(client: ClientType, key_id: str, tags: list[dict]) -> dict:
+    return client.tag_resource(KeyId=key_id, Tags=tags)
+
+
+@KMSErrorHandler.common_error_handler("untag resource")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def untag_resource(client: ClientType, key_id: str, tag_keys: list[str]) -> dict:
+    return client.untag_resource(KeyId=key_id, TagKeys=tag_keys)
+
+
+# Grant operations
+
+
+@KMSErrorHandler.common_error_handler("create grant")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def create_grant(client: ClientType, **params) -> dict:
+    return client.create_grant(**params)
+
+
+@KMSErrorHandler.common_error_handler("retire grant")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def retire_grant(client: ClientType, key_id: str, grant_id: str) -> dict:
+    return client.retire_grant(KeyId=key_id, GrantId=grant_id)

--- a/plugins/module_utils/kms.py
+++ b/plugins/module_utils/kms.py
@@ -1,0 +1,153 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from __future__ import annotations
+
+import json
+import typing
+
+if typing.TYPE_CHECKING:
+    from ansible_collections.amazon.aws.plugins.module_utils.botocore import ClientType
+
+from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
+
+# pylint: disable-next=unused-import
+from ansible_collections.amazon.aws.plugins.module_utils._kms.common import AnsibleKMSError
+from ansible_collections.amazon.aws.plugins.module_utils._kms.common import KMSErrorHandler
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
+
+
+@KMSErrorHandler.common_error_handler("list KMS keys")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def get_kms_keys(client: ClientType) -> dict:
+    paginator = client.get_paginator("list_keys")
+    return paginator.paginate().build_full_result()
+
+
+@KMSErrorHandler.common_error_handler("list KMS aliases")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def get_kms_aliases(client: ClientType) -> dict:
+    paginator = client.get_paginator("list_aliases")
+    return paginator.paginate().build_full_result()
+
+
+def get_kms_aliases_lookup(client: ClientType) -> dict[str, list[str]]:
+    """Build a lookup dictionary of key_id -> list of aliases"""
+    _aliases = {}
+    for alias in get_kms_aliases(client)["Aliases"]:
+        # Not all aliases are actually associated with a key
+        if "TargetKeyId" in alias:
+            # strip off leading 'alias/' and add it to key's aliases
+            if alias["TargetKeyId"] in _aliases:
+                _aliases[alias["TargetKeyId"]].append(alias["AliasName"][6:])
+            else:
+                _aliases[alias["TargetKeyId"]] = [alias["AliasName"][6:]]
+    return _aliases
+
+
+@KMSErrorHandler.common_error_handler("list KMS resource tags")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def _list_resource_tags(client: ClientType, key_id: str, **kwargs) -> dict:
+    return client.list_resource_tags(KeyId=key_id, **kwargs)
+
+
+def get_kms_tags(client: ClientType, key_id: str) -> list[dict]:
+    """Get all tags for a KMS key, handling pagination"""
+    kwargs = {}
+    tags = []
+    more = True
+    while more:
+        try:
+            tag_response = _list_resource_tags(client, key_id, **kwargs)
+            tags.extend(tag_response["Tags"])
+        except is_boto3_error_code("AccessDeniedException"):
+            tag_response = {}
+        if tag_response.get("NextMarker"):
+            kwargs["Marker"] = tag_response["NextMarker"]
+        else:
+            more = False
+    return tags
+
+
+@KMSErrorHandler.common_error_handler("list KMS grants")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def get_kms_grants(client: ClientType, key_id: str) -> dict:
+    params = {"KeyId": key_id}
+    paginator = client.get_paginator("list_grants")
+    return paginator.paginate(**params).build_full_result()
+
+
+@KMSErrorHandler.list_error_handler("describe KMS key", default_value=None)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def get_kms_metadata(client: ClientType, key_id: str) -> dict | None:
+    result = client.describe_key(KeyId=key_id)
+    return result.get("KeyMetadata") if result else None
+
+
+@KMSErrorHandler.common_error_handler("list key policies")
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def list_key_policies(client: ClientType, key_id: str) -> dict:
+    paginator = client.get_paginator("list_key_policies")
+    return paginator.paginate(KeyId=key_id).build_full_result()
+
+
+@KMSErrorHandler.list_error_handler("get key policy", default_value=None)
+@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
+def get_key_policy(client: ClientType, key_id: str, policy_name: str) -> dict | None:
+    return client.get_key_policy(KeyId=key_id, PolicyName=policy_name)
+
+
+def get_kms_policies(client: ClientType, key_id: str) -> list[str]:
+    """Get all policy documents for a KMS key"""
+    try:
+        policies = list_key_policies(client, key_id)["PolicyNames"]
+        return [get_key_policy(client, key_id, policy)["Policy"] for policy in policies]
+    except is_boto3_error_code("AccessDeniedException"):
+        return []
+
+
+def camel_to_snake_grant(grant: dict) -> dict:
+    """Convert grant dict to snake_case, preserving encryption context"""
+    constraints = grant.get("Constraints", {})
+    result = camel_dict_to_snake_dict(grant)
+    if "EncryptionContextEquals" in constraints:
+        result["constraints"]["encryption_context_equals"] = constraints["EncryptionContextEquals"]
+    if "EncryptionContextSubset" in constraints:
+        result["constraints"]["encryption_context_subset"] = constraints["EncryptionContextSubset"]
+    return result
+
+
+def get_key_details(client: ClientType, key_id: str) -> dict:
+    """Get comprehensive details about a KMS key including metadata, grants, tags, and policies"""
+    result = get_kms_metadata(client, key_id)
+    if not result:
+        raise AnsibleKMSError(message=f"Key {key_id} not found")
+
+    result["KeyArn"] = result.pop("Arn")
+
+    try:
+        aliases = get_kms_aliases_lookup(client)
+    except AnsibleKMSError as e:
+        raise AnsibleKMSError(message="Failed to obtain aliases", exception=e.exception) from e
+
+    try:
+        current_rotation_status = client.get_key_rotation_status(KeyId=key_id)
+        result["enable_key_rotation"] = current_rotation_status.get("KeyRotationEnabled")
+    except is_boto3_error_code(["AccessDeniedException", "UnsupportedOperationException"]):
+        result["enable_key_rotation"] = None
+
+    result["aliases"] = aliases.get(result["KeyId"], [])
+    result = camel_dict_to_snake_dict(result)
+
+    # grants and tags get snakified differently
+    result["grants"] = [camel_to_snake_grant(grant) for grant in get_kms_grants(client, key_id)["Grants"]]
+    tags = get_kms_tags(client, key_id)
+    result["tags"] = boto3_tag_list_to_ansible_dict(tags, "TagKey", "TagValue")
+    policies = get_kms_policies(client, key_id)
+    result["key_policies"] = [json.loads(policy) for policy in policies]
+
+    return result

--- a/plugins/module_utils/transformation.py
+++ b/plugins/module_utils/transformation.py
@@ -173,6 +173,7 @@ def boto3_resource_to_ansible_dict(
     normalize: bool = True,
     ignore_list: Optional[Sequence[str]] = None,
     nested_transforms: Optional[Mapping[str, Callable]] = None,
+    tagging_params: Optional[Mapping[str, str]] = None,
 ) -> AnsibleAWSResource:
     """
     Transforms boto3-style (CamelCase) resource to the ansible-style (snake_case).
@@ -183,12 +184,14 @@ def boto3_resource_to_ansible_dict(
     :param ignore_list: a list of keys, the contents of which should not be transformed
     :param nested_transforms: a mapping of keys to Callable, the Callable will only be passed the value for the key
                               in the resource dictionary
+    :param tagging_params: optional dict with tag_name_key_name and tag_value_key_name for boto3_tag_list_to_ansible_dict
     :return: dictionary representing the transformed resource
     """
     if not resource:
         return resource
     ignore_list = ignore_list or []
     nested_transforms = nested_transforms or {}
+    tagging_params = tagging_params or {}
 
     transformed_resource = deepcopy(resource)
     if normalize:
@@ -197,7 +200,7 @@ def boto3_resource_to_ansible_dict(
     ignore_list = [*ignore_list, *nested_transforms]
     camel_resource = camel_dict_to_snake_dict(transformed_resource, ignore_list=ignore_list)
     if transform_tags and "Tags" in resource:
-        camel_resource["tags"] = boto3_tag_list_to_ansible_dict(resource["Tags"])
+        camel_resource["tags"] = boto3_tag_list_to_ansible_dict(resource["Tags"], **tagging_params)
     if force_tags and "Tags" not in resource:
         camel_resource["tags"] = {}
 
@@ -211,6 +214,7 @@ def boto3_resource_list_to_ansible_dict(
     normalize: bool = True,
     ignore_list: Optional[Sequence[str]] = None,
     nested_transforms: Optional[Mapping[str, Callable]] = None,
+    tagging_params: Optional[Mapping[str, str]] = None,
 ) -> AnsibleAWSResourceList:
     """
     Transforms a list of boto3-style (CamelCase) resources to the ansible-style (snake_case).
@@ -221,12 +225,15 @@ def boto3_resource_list_to_ansible_dict(
     :param ignore_list: a list of keys, the contents of which should not be transformed
     :param nested_transforms: a mapping of keys to Callable, the Callable will only be passed the value for the key
                               in the resource dictionary
+    :param tagging_params: optional dict with tag_name_key_name and tag_value_key_name for boto3_tag_list_to_ansible_dict
     :return: list of dictionaries representing the transformed resources
     """
     if not resource_list:
         return resource_list
     return [
-        boto3_resource_to_ansible_dict(resource, transform_tags, force_tags, normalize, ignore_list, nested_transforms)
+        boto3_resource_to_ansible_dict(
+            resource, transform_tags, force_tags, normalize, ignore_list, nested_transforms, tagging_params
+        )
         for resource in resource_list
     ]
 

--- a/plugins/modules/kms_key.py
+++ b/plugins/modules/kms_key.py
@@ -437,6 +437,7 @@ except ImportError:
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.kms import get_key_policy
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.policy import compare_policies
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
@@ -771,13 +772,17 @@ def update_policy(connection, module, key, policy):
         module.fail_json_aws(e, msg="Unable to parse new policy as JSON")
 
     key_id = key["key_arn"]
-    try:
-        keyret = connection.get_key_policy(KeyId=key_id, PolicyName="default")
-        original_policy = json.loads(keyret["Policy"])
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError):
-        # If we can't fetch the current policy assume we're making a change
-        # Could occur if we have PutKeyPolicy without GetKeyPolicy
+    # Use the retry-decorated error-handled function from module_utils
+    # This properly handles rate limiting and transient errors with automatic retry
+    keyret = get_key_policy(connection, key_id, "default")
+
+    # Handle case where we don't have permission to read the policy or key doesn't exist
+    if keyret is None:
+        # If we can't fetch the current policy, we need to attempt the update
+        # This can occur if we have PutKeyPolicy without GetKeyPolicy permissions
         original_policy = {}
+    else:
+        original_policy = json.loads(keyret["Policy"])
 
     if not compare_policies(original_policy, new_policy):
         return False

--- a/plugins/modules/kms_key.py
+++ b/plugins/modules/kms_key.py
@@ -429,161 +429,39 @@ key_spec:
 
 import json
 
-try:
-    import botocore
-except ImportError:
-    pass  # caught by AnsibleAWSModule
-
-from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
-from ansible_collections.amazon.aws.plugins.module_utils.kms import get_key_policy
+from ansible_collections.amazon.aws.plugins.module_utils._kms.grants import compare_grants
+from ansible_collections.amazon.aws.plugins.module_utils.kms import AnsibleKMSError
+from ansible_collections.amazon.aws.plugins.module_utils.kms import AnsibleKMSPermissionsError
+from ansible_collections.amazon.aws.plugins.module_utils.kms import AnsibleKMSUnsupportedError
+from ansible_collections.amazon.aws.plugins.module_utils.kms import cancel_key_deletion as cancel_key_deletion_api
+from ansible_collections.amazon.aws.plugins.module_utils.kms import canonicalize_alias_name
+from ansible_collections.amazon.aws.plugins.module_utils.kms import create_alias
+from ansible_collections.amazon.aws.plugins.module_utils.kms import create_grant
+from ansible_collections.amazon.aws.plugins.module_utils.kms import create_key as create_key_api
+from ansible_collections.amazon.aws.plugins.module_utils.kms import disable_key as disable_key_api
+from ansible_collections.amazon.aws.plugins.module_utils.kms import disable_key_rotation as disable_key_rotation_api
+from ansible_collections.amazon.aws.plugins.module_utils.kms import enable_key as enable_key_api
+from ansible_collections.amazon.aws.plugins.module_utils.kms import enable_key_rotation as enable_key_rotation_api
+from ansible_collections.amazon.aws.plugins.module_utils.kms import get_key_details
+from ansible_collections.amazon.aws.plugins.module_utils.kms import get_key_rotation_status
+from ansible_collections.amazon.aws.plugins.module_utils.kms import get_kms_aliases
+from ansible_collections.amazon.aws.plugins.module_utils.kms import get_kms_metadata
+from ansible_collections.amazon.aws.plugins.module_utils.kms import get_kms_policy_as_dict
+from ansible_collections.amazon.aws.plugins.module_utils.kms import put_key_policy
+from ansible_collections.amazon.aws.plugins.module_utils.kms import retire_grant
+from ansible_collections.amazon.aws.plugins.module_utils.kms import schedule_key_deletion as schedule_key_deletion_api
+from ansible_collections.amazon.aws.plugins.module_utils.kms import tag_resource
+from ansible_collections.amazon.aws.plugins.module_utils.kms import untag_resource
+from ansible_collections.amazon.aws.plugins.module_utils.kms import update_key_description as update_key_description_api
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.policy import compare_policies
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
-from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import compare_aws_tags
 
 
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_keys_with_backoff(connection):
-    paginator = connection.get_paginator("list_keys")
-    return paginator.paginate().build_full_result()
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_aliases_with_backoff(connection):
-    paginator = connection.get_paginator("list_aliases")
-    return paginator.paginate().build_full_result()
-
-
-def get_kms_aliases_lookup(connection):
-    _aliases = dict()
-    for alias in get_kms_aliases_with_backoff(connection)["Aliases"]:
-        # Not all aliases are actually associated with a key
-        if "TargetKeyId" in alias:
-            # strip off leading 'alias/' and add it to key's aliases
-            if alias["TargetKeyId"] in _aliases:
-                _aliases[alias["TargetKeyId"]].append(alias["AliasName"][6:])
-            else:
-                _aliases[alias["TargetKeyId"]] = [alias["AliasName"][6:]]
-    return _aliases
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_tags_with_backoff(connection, key_id, **kwargs):
-    return connection.list_resource_tags(KeyId=key_id, **kwargs)
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_grants_with_backoff(connection, key_id):
-    params = dict(KeyId=key_id)
-    paginator = connection.get_paginator("list_grants")
-    return paginator.paginate(**params).build_full_result()
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_metadata_with_backoff(connection, key_id):
-    return connection.describe_key(KeyId=key_id)
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def list_key_policies_with_backoff(connection, key_id):
-    paginator = connection.get_paginator("list_key_policies")
-    return paginator.paginate(KeyId=key_id).build_full_result()
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_key_policy_with_backoff(connection, key_id, policy_name):
-    return connection.get_key_policy(KeyId=key_id, PolicyName=policy_name)
-
-
-def get_kms_tags(connection, module, key_id):
-    # Handle pagination here as list_resource_tags does not have
-    # a paginator
-    kwargs = {}
-    tags = []
-    more = True
-    while more:
-        try:
-            tag_response = get_kms_tags_with_backoff(connection, key_id, **kwargs)
-            tags.extend(tag_response["Tags"])
-        except is_boto3_error_code("AccessDeniedException"):
-            tag_response = {}
-        except (
-            botocore.exceptions.ClientError,
-            botocore.exceptions.BotoCoreError,
-        ) as e:  # pylint: disable=duplicate-except
-            module.fail_json_aws(e, msg="Failed to obtain key tags")
-        if tag_response.get("NextMarker"):
-            kwargs["Marker"] = tag_response["NextMarker"]
-        else:
-            more = False
-    return tags
-
-
-def get_kms_policies(connection, module, key_id):
-    try:
-        policies = list_key_policies_with_backoff(connection, key_id)["PolicyNames"]
-        return [get_key_policy_with_backoff(connection, key_id, policy)["Policy"] for policy in policies]
-    except is_boto3_error_code("AccessDeniedException"):
-        return []
-    except (
-        botocore.exceptions.ClientError,
-        botocore.exceptions.BotoCoreError,
-    ) as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg="Failed to obtain key policies")
-
-
-def camel_to_snake_grant(grant):
-    """camel_to_snake_grant snakifies everything except the encryption context"""
-    constraints = grant.get("Constraints", {})
-    result = camel_dict_to_snake_dict(grant)
-    if "EncryptionContextEquals" in constraints:
-        result["constraints"]["encryption_context_equals"] = constraints["EncryptionContextEquals"]
-    if "EncryptionContextSubset" in constraints:
-        result["constraints"]["encryption_context_subset"] = constraints["EncryptionContextSubset"]
-    return result
-
-
-def get_key_details(connection, module, key_id):
-    try:
-        result = get_kms_metadata_with_backoff(connection, key_id)["KeyMetadata"]
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to obtain key metadata")
-    result["KeyArn"] = result.pop("Arn")
-
-    try:
-        aliases = get_kms_aliases_lookup(connection)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to obtain aliases")
-
-    try:
-        current_rotation_status = connection.get_key_rotation_status(KeyId=key_id)
-        result["enable_key_rotation"] = current_rotation_status.get("KeyRotationEnabled")
-    except is_boto3_error_code(["AccessDeniedException", "UnsupportedOperationException"]):
-        result["enable_key_rotation"] = None
-    result["aliases"] = aliases.get(result["KeyId"], [])
-
-    result = camel_dict_to_snake_dict(result)
-
-    # grants and tags get snakified differently
-    try:
-        result["grants"] = [
-            camel_to_snake_grant(grant) for grant in get_kms_grants_with_backoff(connection, key_id)["Grants"]
-        ]
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to obtain key grants")
-    tags = get_kms_tags(connection, module, key_id)
-    result["tags"] = boto3_tag_list_to_ansible_dict(tags, "TagKey", "TagValue")
-    policies = get_kms_policies(connection, module, key_id)
-    result["key_policies"] = [json.loads(policy) for policy in policies]
-    return result
-
-
 def convert_grant_params(grant, key):
-    grant_params = dict(KeyId=key["key_arn"], GranteePrincipal=grant["grantee_principal"])
+    """Convert module grant parameters to boto3 API format"""
+    grant_params = {"KeyId": key["key_arn"], "GranteePrincipal": grant["grantee_principal"]}
     if grant.get("operations"):
         grant_params["Operations"] = grant["operations"]
     if grant.get("retiring_principal"):
@@ -591,49 +469,12 @@ def convert_grant_params(grant, key):
     if grant.get("name"):
         grant_params["Name"] = grant["name"]
     if grant.get("constraints"):
-        grant_params["Constraints"] = dict()
+        grant_params["Constraints"] = {}
         if grant["constraints"].get("encryption_context_subset"):
             grant_params["Constraints"]["EncryptionContextSubset"] = grant["constraints"]["encryption_context_subset"]
         if grant["constraints"].get("encryption_context_equals"):
             grant_params["Constraints"]["EncryptionContextEquals"] = grant["constraints"]["encryption_context_equals"]
     return grant_params
-
-
-def different_grant(existing_grant, desired_grant):
-    if existing_grant.get("grantee_principal") != desired_grant.get("grantee_principal"):
-        return True
-    if existing_grant.get("retiring_principal") != desired_grant.get("retiring_principal"):
-        return True
-    if set(existing_grant.get("operations", [])) != set(desired_grant.get("operations")):
-        return True
-    if existing_grant.get("constraints") != desired_grant.get("constraints"):
-        return True
-    return False
-
-
-def compare_grants(existing_grants, desired_grants, purge_grants=False):
-    existing_dict = dict((eg["name"], eg) for eg in existing_grants)
-    desired_dict = dict((dg["name"], dg) for dg in desired_grants)
-    to_add_keys = set(desired_dict.keys()) - set(existing_dict.keys())
-    if purge_grants:
-        to_remove_keys = set(existing_dict.keys()) - set(desired_dict.keys())
-    else:
-        to_remove_keys = set()
-    to_change_candidates = set(existing_dict.keys()) & set(desired_dict.keys())
-    for candidate in to_change_candidates:
-        if different_grant(existing_dict[candidate], desired_dict[candidate]):
-            to_add_keys.add(candidate)
-            to_remove_keys.add(candidate)
-
-    to_add = []
-    to_remove = []
-    for key in to_add_keys:
-        grant = desired_dict[key]
-        to_add.append(grant)
-    for key in to_remove_keys:
-        grant = existing_dict[key]
-        to_remove.append(grant)
-    return to_add, to_remove
 
 
 def start_key_deletion(connection, module, key_metadata):
@@ -643,15 +484,8 @@ def start_key_deletion(connection, module, key_metadata):
     if module.check_mode:
         return True
 
-    deletion_params = {"KeyId": key_metadata["Arn"]}
-    if module.params.get("pending_window"):
-        deletion_params["PendingWindowInDays"] = module.params.get("pending_window")
-
-    try:
-        connection.schedule_key_deletion(**deletion_params)
-        return True
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to schedule key for deletion")
+    schedule_key_deletion_api(connection, key_metadata["Arn"], module.params.get("pending_window"))
+    return True
 
 
 def cancel_key_deletion(connection, module, key):
@@ -662,14 +496,10 @@ def cancel_key_deletion(connection, module, key):
     if module.check_mode:
         return True
 
-    try:
-        connection.cancel_key_deletion(KeyId=key_id)
-        # key is disabled after deletion cancellation
-        # set this so that ensure_enabled_disabled works correctly
-        key["key_state"] = "Disabled"
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to cancel key deletion")
-
+    cancel_key_deletion_api(connection, key_id)
+    # key is disabled after deletion cancellation
+    # set this so that ensure_enabled_disabled works correctly
+    key["key_state"] = "Disabled"
     return True
 
 
@@ -681,18 +511,14 @@ def ensure_enabled_disabled(connection, module, key, enabled):
     if key["key_state"] == desired_state:
         return False
 
+    if module.check_mode:
+        return True
+
     key_id = key["key_arn"]
-    if not module.check_mode:
-        if enabled:
-            try:
-                connection.enable_key(KeyId=key_id)
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                module.fail_json_aws(e, msg="Failed to enable key")
-        else:
-            try:
-                connection.disable_key(KeyId=key_id)
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                module.fail_json_aws(e, msg="Failed to disable key")
+    if enabled:
+        enable_key_api(connection, key_id)
+    else:
+        disable_key_api(connection, key_id)
 
     return True
 
@@ -704,17 +530,16 @@ def update_alias(connection, module, key, alias):
         return False
 
     key_id = key["key_arn"]
-    aliases = get_kms_aliases_with_backoff(connection)["Aliases"]
+    aliases = get_kms_aliases(connection)["Aliases"]
+
     # We will only add new aliases, not rename existing ones
     if alias in [_alias["AliasName"] for _alias in aliases]:
         return False
 
-    if not module.check_mode:
-        try:
-            connection.create_alias(TargetKeyId=key_id, AliasName=alias)
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg="Failed create key alias")
+    if module.check_mode:
+        return True
 
+    create_alias(connection, alias, key_id)
     return True
 
 
@@ -724,13 +549,11 @@ def update_description(connection, module, key, description):
     if key["description"] == description:
         return False
 
-    key_id = key["key_arn"]
-    if not module.check_mode:
-        try:
-            connection.update_key_description(KeyId=key_id, Description=description)
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg="Failed to update key description")
+    if module.check_mode:
+        return True
 
+    key_id = key["key_arn"]
+    update_key_description_api(connection, key_id, description)
     return True
 
 
@@ -742,23 +565,19 @@ def update_tags(connection, module, key, desired_tags, purge_tags):
     if not (bool(to_add) or bool(to_remove)):
         return False
 
+    if module.check_mode:
+        return True
+
     key_id = key["key_arn"]
-    if not module.check_mode:
-        if to_remove:
-            try:
-                connection.untag_resource(KeyId=key_id, TagKeys=to_remove)
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                module.fail_json_aws(e, msg="Unable to remove tag")
-        if to_add:
-            try:
-                tags = ansible_dict_to_boto3_tag_list(
-                    module.params["tags"],
-                    tag_name_key_name="TagKey",
-                    tag_value_key_name="TagValue",
-                )
-                connection.tag_resource(KeyId=key_id, Tags=tags)
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                module.fail_json_aws(e, msg="Unable to add tag to key")
+    if to_remove:
+        untag_resource(connection, key_id, to_remove)
+    if to_add:
+        tags = ansible_dict_to_boto3_tag_list(
+            module.params["tags"],
+            tag_name_key_name="TagKey",
+            tag_value_key_name="TagValue",
+        )
+        tag_resource(connection, key_id, tags)
 
     return True
 
@@ -774,25 +593,24 @@ def update_policy(connection, module, key, policy):
     key_id = key["key_arn"]
     # Use the retry-decorated error-handled function from module_utils
     # This properly handles rate limiting and transient errors with automatic retry
-    keyret = get_key_policy(connection, key_id, "default")
-
-    # Handle case where we don't have permission to read the policy or key doesn't exist
-    if keyret is None:
-        # If we can't fetch the current policy, we need to attempt the update
-        # This can occur if we have PutKeyPolicy without GetKeyPolicy permissions
+    try:
+        original_policy = get_kms_policy_as_dict(connection, key_id, "default")
+        # None means key/policy not found (handled by list_error_handler)
+        if original_policy is None:
+            original_policy = {}
+    except AnsibleKMSPermissionsError as e:
+        # Permission denied - we have PutKeyPolicy without GetKeyPolicy permissions
+        # Proceed with the update since we can't compare
+        module.warn(f"Unable to fetch current policy for comparison: {e}")
         original_policy = {}
-    else:
-        original_policy = json.loads(keyret["Policy"])
 
     if not compare_policies(original_policy, new_policy):
         return False
 
-    if not module.check_mode:
-        try:
-            connection.put_key_policy(KeyId=key_id, PolicyName="default", Policy=policy)
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg="Unable to update key policy")
+    if module.check_mode:
+        return True
 
+    put_key_policy(connection, key_id, "default", policy)
     return True
 
 
@@ -802,25 +620,21 @@ def update_key_rotation(connection, module, key, enable_key_rotation):
     key_id = key["key_arn"]
 
     try:
-        current_rotation_status = connection.get_key_rotation_status(KeyId=key_id)
+        current_rotation_status = get_key_rotation_status(connection, key_id)
         if current_rotation_status.get("KeyRotationEnabled") == enable_key_rotation:
             return False
-    except is_boto3_error_code("AccessDeniedException"):
-        pass
-    except (
-        botocore.exceptions.ClientError,
-        botocore.exceptions.BotoCoreError,
-    ) as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg="Unable to get current key rotation status")
+    except AnsibleKMSPermissionsError as e:
+        module.warn(f"Unable to get current key rotation status: {e}")
+    except AnsibleKMSUnsupportedError as e:
+        module.warn(f"Key rotation not supported for this key type: {e}")
 
-    if not module.check_mode:
-        try:
-            if enable_key_rotation:
-                connection.enable_key_rotation(KeyId=key_id)
-            else:
-                connection.disable_key_rotation(KeyId=key_id)
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg="Failed to enable/disable key rotation")
+    if module.check_mode:
+        return True
+
+    if enable_key_rotation:
+        enable_key_rotation_api(connection, key_id)
+    else:
+        disable_key_rotation_api(connection, key_id)
 
     return True
 
@@ -832,19 +646,15 @@ def update_grants(connection, module, key, desired_grants, purge_grants):
     if not (bool(to_add) or bool(to_remove)):
         return False
 
+    if module.check_mode:
+        return True
+
     key_id = key["key_arn"]
-    if not module.check_mode:
-        for grant in to_remove:
-            try:
-                connection.retire_grant(KeyId=key_id, GrantId=grant["grant_id"])
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                module.fail_json_aws(e, msg="Unable to retire grant")
-        for grant in to_add:
-            grant_params = convert_grant_params(grant, key)
-            try:
-                connection.create_grant(**grant_params)
-            except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                module.fail_json_aws(e, msg="Unable to create grant")
+    for grant in to_remove:
+        retire_grant(connection, key_id, grant["grant_id"])
+    for grant in to_add:
+        grant_params = convert_grant_params(grant, key)
+        create_grant(connection, **grant_params)
 
     return True
 
@@ -862,7 +672,7 @@ def update_key(connection, module, key):
     changed |= update_key_rotation(connection, module, key, module.params.get("enable_key_rotation"))
 
     # make results consistent with kms_facts before returning
-    result = get_key_details(connection, module, key["key_arn"])
+    result = get_key_details(connection, key["key_arn"])
     result["changed"] = changed
     return result
 
@@ -893,12 +703,10 @@ def create_key(connection, module):
         params["Description"] = module.params["description"]
     if module.params.get("policy"):
         params["Policy"] = module.params["policy"]
-    try:
-        result = connection.create_key(**params)["KeyMetadata"]
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to create initial key")
 
-    key = get_key_details(connection, module, result["KeyId"])
+    result = create_key_api(connection, **params)["KeyMetadata"]
+
+    key = get_key_details(connection, result["KeyId"])
     update_alias(connection, module, key, module.params["alias"])
     update_key_rotation(connection, module, key, module.params.get("enable_key_rotation"))
 
@@ -906,7 +714,7 @@ def create_key(connection, module):
     update_grants(connection, module, key, module.params.get("grants"), False)
 
     # make results consistent with kms_facts
-    result = get_key_details(connection, module, key["key_id"])
+    result = get_key_details(connection, key["key_id"])
     result["changed"] = True
     return result
 
@@ -916,17 +724,9 @@ def delete_key(connection, module, key_metadata):
 
     changed |= start_key_deletion(connection, module, key_metadata)
 
-    result = get_key_details(connection, module, key_metadata["Arn"])
+    result = get_key_details(connection, key_metadata["Arn"])
     result["changed"] = changed
     return result
-
-
-def canonicalize_alias_name(alias):
-    if alias is None:
-        return None
-    if alias.startswith("alias/"):
-        return alias
-    return "alias/" + alias
 
 
 def fetch_key_metadata(connection, module, key_id, alias):
@@ -938,17 +738,11 @@ def fetch_key_metadata(connection, module, key_id, alias):
 
     alias = canonicalize_alias_name(alias)
 
-    try:
-        # Fetch by key_id where possible
-        if key_id:
-            return get_kms_metadata_with_backoff(connection, key_id)["KeyMetadata"]
-        # Or try alias as a backup
-        return get_kms_metadata_with_backoff(connection, alias)["KeyMetadata"]
-
-    except connection.exceptions.NotFoundException:
-        return None
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, "Failed to fetch key metadata.")
+    # Fetch by key_id where possible, or try alias as a backup
+    # get_kms_metadata returns None if key not found (via list_error_handler decorator)
+    if key_id:
+        return get_kms_metadata(connection, key_id)
+    return get_kms_metadata(connection, alias)
 
 
 def validate_params(module, key_metadata):
@@ -1002,24 +796,27 @@ def main():
         required_one_of=[["alias", "key_id"]],
     )
 
-    kms = module.client("kms")
+    try:
+        kms = module.client("kms")
 
-    key_metadata = fetch_key_metadata(kms, module, module.params.get("key_id"), module.params.get("alias"))
-    validate_params(module, key_metadata)
+        key_metadata = fetch_key_metadata(kms, module, module.params.get("key_id"), module.params.get("alias"))
+        validate_params(module, key_metadata)
 
-    if module.params.get("state") == "absent":
-        if key_metadata is None:
-            module.exit_json(changed=False)
-        result = delete_key(kms, module, key_metadata)
+        if module.params.get("state") == "absent":
+            if key_metadata is None:
+                module.exit_json(changed=False)
+            result = delete_key(kms, module, key_metadata)
+            module.exit_json(**result)
+
+        if key_metadata:
+            key_details = get_key_details(kms, key_metadata["Arn"])
+            result = update_key(kms, module, key_details)
+            module.exit_json(**result)
+
+        result = create_key(kms, module)
         module.exit_json(**result)
-
-    if key_metadata:
-        key_details = get_key_details(kms, module, key_metadata["Arn"])
-        result = update_key(kms, module, key_details)
-        module.exit_json(**result)
-
-    result = create_key(kms, module)
-    module.exit_json(**result)
+    except AnsibleKMSError as e:
+        module.fail_json_aws_error(e)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/kms_key.py
+++ b/plugins/modules/kms_key.py
@@ -729,7 +729,7 @@ def delete_key(connection, module, key_metadata):
     return result
 
 
-def fetch_key_metadata(connection, module, key_id, alias):
+def fetch_key_metadata(connection, key_id, alias):
     # Note - fetching a key's metadata is very inconsistent shortly after any sort of update to a key has occurred.
     # Combinations of manual waiters, checking expecting key values to actual key value, and static sleeps
     #        have all been exhausted, but none of those available options have solved the problem.
@@ -799,7 +799,7 @@ def main():
     try:
         kms = module.client("kms")
 
-        key_metadata = fetch_key_metadata(kms, module, module.params.get("key_id"), module.params.get("alias"))
+        key_metadata = fetch_key_metadata(kms, module.params.get("key_id"), module.params.get("alias"))
         validate_params(module, key_metadata)
 
         if module.params.get("state") == "absent":

--- a/plugins/modules/kms_key_info.py
+++ b/plugins/modules/kms_key_info.py
@@ -279,126 +279,12 @@ kms_keys:
       sample: false
 """
 
-import json
-
-try:
-    import botocore
-except ImportError:
-    pass  # Handled by AnsibleAWSModule
-
-from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
-
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
+from ansible_collections.amazon.aws.plugins.module_utils.kms import AnsibleKMSError
+from ansible_collections.amazon.aws.plugins.module_utils.kms import AnsibleKMSPermissionsError
+from ansible_collections.amazon.aws.plugins.module_utils.kms import canonicalize_alias_name
+from ansible_collections.amazon.aws.plugins.module_utils.kms import get_key_details as _get_key_details
+from ansible_collections.amazon.aws.plugins.module_utils.kms import get_kms_keys
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
-from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
-
-# Caching lookup for aliases
-_aliases = dict()
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_keys_with_backoff(connection):
-    paginator = connection.get_paginator("list_keys")
-    return paginator.paginate().build_full_result()
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_aliases_with_backoff(connection):
-    paginator = connection.get_paginator("list_aliases")
-    return paginator.paginate().build_full_result()
-
-
-def get_kms_aliases_lookup(connection):
-    if not _aliases:
-        for alias in get_kms_aliases_with_backoff(connection)["Aliases"]:
-            # Not all aliases are actually associated with a key
-            if "TargetKeyId" in alias:
-                # strip off leading 'alias/' and add it to key's aliases
-                if alias["TargetKeyId"] in _aliases:
-                    _aliases[alias["TargetKeyId"]].append(alias["AliasName"][6:])
-                else:
-                    _aliases[alias["TargetKeyId"]] = [alias["AliasName"][6:]]
-    return _aliases
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_tags_with_backoff(connection, key_id, **kwargs):
-    return connection.list_resource_tags(KeyId=key_id, **kwargs)
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_grants_with_backoff(connection, key_id, **kwargs):
-    params = dict(KeyId=key_id)
-    if kwargs.get("tokens"):
-        params["GrantTokens"] = kwargs["tokens"]
-    paginator = connection.get_paginator("list_grants")
-    return paginator.paginate(**params).build_full_result()
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_kms_metadata_with_backoff(connection, key_id):
-    return connection.describe_key(KeyId=key_id)
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def list_key_policies_with_backoff(connection, key_id):
-    paginator = connection.get_paginator("list_key_policies")
-    return paginator.paginate(KeyId=key_id).build_full_result()
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_key_policy_with_backoff(connection, key_id, policy_name):
-    return connection.get_key_policy(KeyId=key_id, PolicyName=policy_name)
-
-
-@AWSRetry.jittered_backoff(retries=5, delay=5, backoff=2.0)
-def get_enable_key_rotation_with_backoff(connection, key_id):
-    try:
-        current_rotation_status = connection.get_key_rotation_status(KeyId=key_id)
-    except is_boto3_error_code(["AccessDeniedException", "UnsupportedOperationException"]):
-        return None
-
-    return current_rotation_status.get("KeyRotationEnabled")
-
-
-def canonicalize_alias_name(alias):
-    if alias is None:
-        return None
-    if alias.startswith("alias/"):
-        return alias
-    return "alias/" + alias
-
-
-def get_kms_tags(connection, module, key_id):
-    # Handle pagination here as list_resource_tags does not have
-    # a paginator
-    kwargs = {}
-    tags = []
-    more = True
-    while more:
-        try:
-            tag_response = get_kms_tags_with_backoff(connection, key_id, **kwargs)
-            tags.extend(tag_response["Tags"])
-        except is_boto3_error_code("AccessDeniedException"):
-            tag_response = {}
-        except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
-            module.fail_json_aws(e, msg="Failed to obtain key tags")
-        if tag_response.get("NextMarker"):
-            kwargs["Marker"] = tag_response["NextMarker"]
-        else:
-            more = False
-    return tags
-
-
-def get_kms_policies(connection, module, key_id):
-    try:
-        policies = list_key_policies_with_backoff(connection, key_id)["PolicyNames"]
-        return [get_key_policy_with_backoff(connection, key_id, policy)["Policy"] for policy in policies]
-    except is_boto3_error_code("AccessDeniedException"):
-        return []
-    except botocore.exceptions.ClientError as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg="Failed to obtain key policies")
 
 
 def key_matches_filter(key, filtr):
@@ -425,59 +311,28 @@ def key_matches_filters(key, filters):
 
 
 def get_key_details(connection, module, key_id, tokens=None):
+    """
+    Wrapper around module_utils get_key_details that handles permission errors with module warnings.
+
+    Args:
+        connection: boto3 KMS client
+        module: AnsibleAWSModule instance for warnings
+        key_id: KMS key ID, ARN, or alias
+        tokens: optional list of grant tokens
+
+    Returns:
+        Dictionary with key details or None if not found/permission denied
+    """
     if not tokens:
-        tokens = []
+        tokens = None  # Normalize empty list to None
+
     try:
-        result = get_kms_metadata_with_backoff(connection, key_id)["KeyMetadata"]
-        # Make sure we have the canonical ARN, we might have been passed an alias
-        key_id = result["Arn"]
-    except is_boto3_error_code("NotFoundException"):
+        return _get_key_details(
+            connection, key_id, grant_tokens=tokens, pending_deletion=module.params.get("pending_deletion", False)
+        )
+    except AnsibleKMSPermissionsError as e:
+        module.warn(str(e))
         return None
-    except is_boto3_error_code("AccessDeniedException"):  # pylint: disable=duplicate-except
-        module.warn(f"Permission denied fetching key metadata ({key_id})")
-        return None
-    except (
-        botocore.exceptions.ClientError,
-        botocore.exceptions.BotoCoreError,
-    ) as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg="Failed to obtain key metadata")
-    result["KeyArn"] = result.pop("Arn")
-
-    try:
-        aliases = get_kms_aliases_lookup(connection)
-    except is_boto3_error_code("AccessDeniedException"):
-        module.warn("Permission denied fetching key aliases")
-        aliases = {}
-    except (
-        botocore.exceptions.ClientError,
-        botocore.exceptions.BotoCoreError,
-    ) as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg="Failed to obtain aliases")
-    # We can only get aliases for our own account, so we don't need the full ARN
-    result["aliases"] = aliases.get(result["KeyId"], [])
-    result["enable_key_rotation"] = get_enable_key_rotation_with_backoff(connection, key_id)
-
-    if module.params.get("pending_deletion"):
-        return camel_dict_to_snake_dict(result)
-
-    try:
-        result["grants"] = get_kms_grants_with_backoff(connection, key_id, tokens=tokens)["Grants"]
-    except is_boto3_error_code("AccessDeniedException"):
-        module.warn(f"Permission denied fetching key grants ({key_id})")
-        result["grants"] = []
-    except (
-        botocore.exceptions.ClientError,
-        botocore.exceptions.BotoCoreError,
-    ) as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg="Failed to obtain key grants")
-
-    tags = get_kms_tags(connection, module, key_id)
-
-    result = camel_dict_to_snake_dict(result)
-    result["tags"] = boto3_tag_list_to_ansible_dict(tags, "TagKey", "TagValue")
-    policies = get_kms_policies(connection, module, key_id)
-    result["key_policies"] = [json.loads(policy) for policy in policies]
-    return result
 
 
 def get_kms_info(connection, module):
@@ -494,10 +349,7 @@ def get_kms_info(connection, module):
             return [details]
         return []
     else:
-        try:
-            keys = get_kms_keys_with_backoff(connection)["Keys"]
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg="Failed to obtain keys")
+        keys = get_kms_keys(connection)["Keys"]
         return [get_key_details(connection, module, key["KeyId"]) for key in keys]
 
 
@@ -515,14 +367,14 @@ def main():
 
     try:
         connection = module.client("kms")
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to connect to AWS")
 
-    all_keys = get_kms_info(connection, module)
-    filtered_keys = [key for key in all_keys if key_matches_filters(key, module.params["filters"])]
-    ret_params = dict(kms_keys=filtered_keys)
+        all_keys = get_kms_info(connection, module)
+        filtered_keys = [key for key in all_keys if key_matches_filters(key, module.params["filters"])]
+        ret_params = dict(kms_keys=filtered_keys)
 
-    module.exit_json(**ret_params)
+        module.exit_json(**ret_params)
+    except AnsibleKMSError as e:
+        module.fail_json_aws_error(e)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ line-length = 120
 target-version = ['py38', 'py39']
 extend-exclude = '''
 /(
-  | plugins/module_utils/_version.py
   | \.tox
   | tests/output
 )/
@@ -14,6 +13,7 @@ extend-exclude = '''
 revision = "origin/main.."
 
 src = [
+    "extensions",
     "plugins",
     "tests/unit",
     "tests/integration",
@@ -26,6 +26,7 @@ line_length = 120
 skip = [".tox", "tests/output"]
 
 src_paths = [
+    "extensions",
     "plugins",
     "tests/unit",
     "tests/integration",
@@ -58,16 +59,107 @@ disable_error_code = ["import-untyped"]
 
 [tool.ruff]
 line-length = 120
-exclude = [".tox", "tests/output"]
+target-version = "py39"
+exclude = [
+    ".tox",
+    "tests/output",
+]
 
 [tool.ruff.lint]
-# "F401" - unused-imports - We use these imports to maintain historic Interfaces
-# "E402" - import not at top of file - General Ansible style puts the documentation at the top.
-unfixable = ["F401"]
-ignore = ["F401", "E402"]
+# Enable rule categories
+select = [
+    "E",     # pycodestyle errors
+    "W",     # pycodestyle warnings
+    "F",     # pyflakes
+    "I",     # isort
+    "UP",    # pyupgrade
+    "C90",   # mccabe complexity
+    "N",     # pep8-naming
+    "RUF",   # ruff-specific rules
+]
+
+ignore = [
+    # Ansible-specific patterns
+    "E402",  # module-level-import-not-at-top-of-file - Ansible puts DOCUMENTATION first
+    "UP009", # utf-8-encoding-declaration - Ansible modules require this for compatibility
+
+    # Python 3.10+ syntax (we support 3.9+)
+    "UP007", # non-pep604-annotation-union - Use Union[X, Y] not X | Y (requires 3.10+)
+    "UP045", # non-pep604-annotation-optional - Use Optional[X] not X | None (requires 3.10+)
+
+    # TODO: Enable before 12.0.0 release (Sept/Oct 2026)
+    # These modernizations are valid for Python 3.9+ but complicate backporting
+    "UP006", # non-pep585-annotation - Use list[str] not List[str]
+    "UP035", # deprecated-import - Import from collections.abc, use builtin types
+
+    # TODO: Refactor complex functions (technical debt)
+    "C901",  # complex-structure - 29 functions exceed complexity threshold
+
+    # Flake8 compatibility (from existing config)
+    # E123, E125, W503 - Not implemented in ruff (deprecated/invalid PEP-8 rules)
+    "E203",  # whitespace before ':' (conflicts with formatter)
+    "E501",  # line too long (handled by formatter at 120 chars)
+    "E741",  # ambiguous variable name (too strict for AWS API names)
+    "F811",  # redefinition of unused name
+    "F841",  # local variable assigned but never used
+
+    # Naming exceptions for Ansible/AWS patterns
+    "N802",  # function name should be lowercase (AWS API methods use CamelCase)
+    "N803",  # argument name should be lowercase (AWS API parameters)
+    "N806",  # variable in function should be lowercase (AWS API responses)
+    "N818",  # exception name should end with Error - too disruptive to change existing exceptions
+]
+
+# Rules that cannot be auto-fixed (require manual intervention)
+unfixable = [
+    "F401",  # unused-import - Don't auto-remove due to historic interfaces
+    "F841",  # unused-variable - May break compatibility
+]
+
+[tool.ruff.lint.isort]
+# Match existing isort config
+force-single-line = true
+known-third-party = ["botocore", "boto3"]
+section-order = [
+    "future",
+    "standard-library",
+    "third-party",
+    "first-party",
+    "ansible-core",
+    "ansible-amazon-aws",
+    "ansible-community-aws",
+    "local-folder",
+]
+
+[tool.ruff.lint.isort.sections]
+"ansible-core" = ["ansible"]
+"ansible-amazon-aws" = ["ansible_collections.amazon.aws"]
+"ansible-community-aws" = ["ansible_collections.community.aws"]
+
+[tool.ruff.lint.mccabe]
+# Match existing pylint cyclomatic complexity setting
+max-complexity = 15
+
+[tool.ruff.format]
+# Match black config
+quote-style = "double"
+indent-style = "space"
+skip-magic-trailing-comma = false
+line-ending = "auto"
+
+[tool.ruff.lint.per-file-ignores]
+# ec2_metadata_facts supports Python < 3.9
+"plugins/modules/ec2_metadata_facts.py" = ["UP030", "UP031", "UP032"]
+# ec2_security_group list flattening needs broader refactoring
+"plugins/modules/ec2_security_group.py" = ["RUF017"]
+# Pytest fixtures must be imported to be available
+"tests/unit/plugins/conftest.py" = ["F401"]
 
 [tool.pylint.main]
 ignore = [".tox", "tests/output"]
+
+[tool.pylint.imports]
+allow-reexport-from-package = true
 
 [tool.pytest.ini_options]
 xfail_strict = true

--- a/tests/unit/plugins/module_utils/_kms/test_grants.py
+++ b/tests/unit/plugins/module_utils/_kms/test_grants.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible_collections.amazon.aws.plugins.module_utils._kms.grants import compare_grants
+from ansible_collections.amazon.aws.plugins.module_utils._kms.grants import different_grant
+
+
+class TestDifferentGrant:
+    def test_same_grant(self):
+        grant = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "operations": ["Decrypt", "Encrypt"],
+        }
+        assert different_grant(grant, grant) is False
+
+    def test_different_grantee(self):
+        grant1 = {"name": "test", "grantee_principal": "arn:aws:iam::123456789012:role/test1"}
+        grant2 = {"name": "test", "grantee_principal": "arn:aws:iam::123456789012:role/test2"}
+        assert different_grant(grant1, grant2) is True
+
+    def test_different_operations(self):
+        grant1 = {"name": "test", "grantee_principal": "arn:aws:iam::123456789012:role/test", "operations": ["Decrypt"]}
+        grant2 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "operations": ["Decrypt", "Encrypt"],
+        }
+        assert different_grant(grant1, grant2) is True
+
+    def test_operations_order_irrelevant(self):
+        grant1 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "operations": ["Decrypt", "Encrypt"],
+        }
+        grant2 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "operations": ["Encrypt", "Decrypt"],
+        }
+        assert different_grant(grant1, grant2) is False
+
+    def test_different_retiring_principal(self):
+        grant1 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "retiring_principal": "arn:aws:iam::123456789012:role/retire1",
+        }
+        grant2 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "retiring_principal": "arn:aws:iam::123456789012:role/retire2",
+        }
+        assert different_grant(grant1, grant2) is True
+
+    def test_different_constraints(self):
+        grant1 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "constraints": {"encryption_context_equals": {"Department": "Finance"}},
+        }
+        grant2 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "constraints": {"encryption_context_equals": {"Department": "Engineering"}},
+        }
+        assert different_grant(grant1, grant2) is True
+
+    def test_same_constraints(self):
+        grant1 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "constraints": {"encryption_context_equals": {"Department": "Finance"}},
+        }
+        grant2 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "constraints": {"encryption_context_equals": {"Department": "Finance"}},
+        }
+        assert different_grant(grant1, grant2) is False
+
+    def test_different_retiring_principal(self):
+        grant1 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "retiring_principal": "arn:aws:iam::123456789012:role/retire1",
+        }
+        grant2 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "retiring_principal": "arn:aws:iam::123456789012:role/retire2",
+        }
+        assert different_grant(grant1, grant2) is True
+
+    def test_different_constraints(self):
+        grant1 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "constraints": {"encryption_context_equals": {"Department": "Finance"}},
+        }
+        grant2 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "constraints": {"encryption_context_equals": {"Department": "Engineering"}},
+        }
+        assert different_grant(grant1, grant2) is True
+
+    def test_same_constraints(self):
+        grant1 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "constraints": {"encryption_context_equals": {"Department": "Finance"}},
+        }
+        grant2 = {
+            "name": "test",
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "constraints": {"encryption_context_equals": {"Department": "Finance"}},
+        }
+        assert different_grant(grant1, grant2) is False
+
+
+class TestCompareGrants:
+    def test_no_changes_needed(self):
+        existing = [{"name": "grant1", "grantee_principal": "arn:aws:iam::123456789012:role/test"}]
+        desired = [{"name": "grant1", "grantee_principal": "arn:aws:iam::123456789012:role/test"}]
+        to_add, to_remove = compare_grants(existing, desired)
+        assert to_add == []
+        assert to_remove == []
+
+    def test_add_new_grant(self):
+        existing = []
+        desired = [{"name": "grant1", "grantee_principal": "arn:aws:iam::123456789012:role/test"}]
+        to_add, to_remove = compare_grants(existing, desired)
+        assert len(to_add) == 1
+        assert to_add[0]["name"] == "grant1"
+        assert to_remove == []
+
+    def test_remove_grant_with_purge(self):
+        existing = [{"name": "grant1", "grantee_principal": "arn:aws:iam::123456789012:role/test"}]
+        desired = []
+        to_add, to_remove = compare_grants(existing, desired, purge_grants=True)
+        assert to_add == []
+        assert len(to_remove) == 1
+        assert to_remove[0]["name"] == "grant1"
+
+    def test_keep_grant_without_purge(self):
+        existing = [{"name": "grant1", "grantee_principal": "arn:aws:iam::123456789012:role/test"}]
+        desired = []
+        to_add, to_remove = compare_grants(existing, desired, purge_grants=False)
+        assert to_add == []
+        assert to_remove == []
+
+    def test_modify_grant(self):
+        existing = [{"name": "grant1", "grantee_principal": "arn:aws:iam::123456789012:role/test1"}]
+        desired = [{"name": "grant1", "grantee_principal": "arn:aws:iam::123456789012:role/test2"}]
+        to_add, to_remove = compare_grants(existing, desired)
+        # When a grant changes, we remove the old and add the new
+        assert len(to_add) == 1
+        assert to_add[0]["grantee_principal"] == "arn:aws:iam::123456789012:role/test2"
+        assert len(to_remove) == 1
+        assert to_remove[0]["grantee_principal"] == "arn:aws:iam::123456789012:role/test1"

--- a/tests/unit/plugins/module_utils/_kms/test_kms_common.py
+++ b/tests/unit/plugins/module_utils/_kms/test_kms_common.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+try:
+    import botocore
+except ImportError:
+    pass
+
+import pytest
+
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import HAS_BOTO3
+from ansible_collections.amazon.aws.plugins.module_utils.kms import AnsibleKMSError
+from ansible_collections.amazon.aws.plugins.module_utils.kms import AnsibleKMSPermissionsError
+from ansible_collections.amazon.aws.plugins.module_utils.kms import AnsibleKMSUnsupportedError
+from ansible_collections.amazon.aws.plugins.module_utils.kms import KMSErrorHandler
+
+if not HAS_BOTO3:
+    pytestmark = pytest.mark.skip("test_common.py requires the python modules 'boto3' and 'botocore'")
+
+
+class TestKMSCommonHandler:
+    def test_no_failures(self):
+        self.counter = 0
+
+        @KMSErrorHandler.common_error_handler("no error")
+        def no_failures():
+            self.counter += 1
+
+        no_failures()
+        assert self.counter == 1
+
+    def test_client_error(self):
+        self.counter = 0
+        err_response = {
+            "Error": {
+                "Code": "MalformedPolicyDocument",
+                "Message": "Policy document should not specify a principal.",
+            }
+        }
+
+        @KMSErrorHandler.common_error_handler("do something")
+        def raise_client_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Something bad")
+
+        with pytest.raises(AnsibleKMSError) as e_info:
+            raise_client_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "do something" in raised.message
+        assert "Something bad" in str(raised.exception)
+
+    def test_permissions_error(self):
+        self.counter = 0
+        err_response = {
+            "Error": {
+                "Code": "AccessDeniedException",
+                "Message": "User is not authorized to perform kms:GetKeyRotationStatus",
+            }
+        }
+
+        @KMSErrorHandler.common_error_handler("do something")
+        def raise_client_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Something bad")
+
+        with pytest.raises(AnsibleKMSPermissionsError) as e_info:
+            raise_client_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "do something" in raised.message
+        assert "permission denied" in raised.message
+        assert "Something bad" in str(raised.exception)
+
+    def test_unsupported_operation_error(self):
+        self.counter = 0
+        err_response = {
+            "Error": {
+                "Code": "UnsupportedOperationException",
+                "Message": "The request is not supported for the specified key",
+            }
+        }
+
+        @KMSErrorHandler.common_error_handler("do something")
+        def raise_client_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Something bad")
+
+        with pytest.raises(AnsibleKMSUnsupportedError) as e_info:
+            raise_client_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "do something" in raised.message
+        assert "operation not supported" in raised.message
+        assert "Something bad" in str(raised.exception)
+
+    def test_not_found_error(self):
+        self.counter = 0
+        err_response = {
+            "Error": {
+                "Code": "NotFoundException",
+                "Message": "Key not found",
+            }
+        }
+
+        @KMSErrorHandler.common_error_handler("do something")
+        def raise_client_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Something bad")
+
+        with pytest.raises(AnsibleKMSError) as e_info:
+            raise_client_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "do something" in raised.message
+        assert "Something bad" in str(raised.exception)
+
+    def test_invalid_key_id_error(self):
+        self.counter = 0
+        err_response = {
+            "Error": {
+                "Code": "InvalidKeyId",
+                "Message": "Invalid key id",
+            }
+        }
+
+        @KMSErrorHandler.common_error_handler("do something")
+        def raise_client_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Something bad")
+
+        with pytest.raises(AnsibleKMSError) as e_info:
+            raise_client_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "do something" in raised.message
+        assert "Something bad" in str(raised.exception)
+
+    def test_endpoint_error(self):
+        self.counter = 0
+
+        @KMSErrorHandler.common_error_handler("do something")
+        def raise_connection_error():
+            self.counter += 1
+            raise botocore.exceptions.EndpointConnectionError(endpoint_url="junk.endpoint")
+
+        with pytest.raises(AnsibleKMSError) as e_info:
+            raise_connection_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.BotoCoreError)
+        assert "do something" in raised.message
+        assert "junk.endpoint" in str(raised.exception)
+
+    def test_boto3_error(self):
+        self.counter = 0
+        err_response = {
+            "Error": {
+                "Code": "MalformedPolicyDocument",
+                "Message": "Policy document should not specify a principal.",
+            }
+        }
+
+        @KMSErrorHandler.common_error_handler("do something")
+        def raise_client_error():
+            self.counter += 1
+            raise botocore.exceptions.ClientError(err_response, "Something bad")
+
+        with pytest.raises(AnsibleKMSError) as e_info:
+            raise_client_error()
+        assert self.counter == 1
+        raised = e_info.value
+        assert isinstance(raised.exception, botocore.exceptions.ClientError)
+        assert "do something" in raised.message
+        assert "Something bad" in str(raised.exception)

--- a/tests/unit/plugins/module_utils/_kms/test_kms_transformations.py
+++ b/tests/unit/plugins/module_utils/_kms/test_kms_transformations.py
@@ -1,0 +1,178 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible_collections.amazon.aws.plugins.module_utils._kms.transformations import camel_to_snake_grant
+from ansible_collections.amazon.aws.plugins.module_utils._kms.transformations import canonicalize_alias_name
+from ansible_collections.amazon.aws.plugins.module_utils._kms.transformations import normalize_kms_key_details
+
+
+class TestCanonicalizeAliasName:
+    def test_none_input(self):
+        assert canonicalize_alias_name(None) is None
+
+    def test_already_prefixed(self):
+        assert canonicalize_alias_name("alias/myalias") == "alias/myalias"
+
+    def test_add_prefix(self):
+        assert canonicalize_alias_name("myalias") == "alias/myalias"
+
+    def test_empty_string(self):
+        assert canonicalize_alias_name("") == "alias/"
+
+    def test_with_slashes(self):
+        assert canonicalize_alias_name("my/complex/alias") == "alias/my/complex/alias"
+
+
+class TestCamelToSnakeGrant:
+    def test_basic_grant(self):
+        grant = {
+            "GrantId": "abc123",
+            "GranteePrincipal": "arn:aws:iam::123456789012:role/test",
+            "Operations": ["Decrypt", "Encrypt"],
+        }
+        result = camel_to_snake_grant(grant)
+        assert result["grant_id"] == "abc123"
+        assert result["grantee_principal"] == "arn:aws:iam::123456789012:role/test"
+        assert result["operations"] == ["Decrypt", "Encrypt"]
+
+    def test_grant_with_encryption_context_equals(self):
+        grant = {
+            "GrantId": "abc123",
+            "GranteePrincipal": "arn:aws:iam::123456789012:role/test",
+            "Constraints": {"EncryptionContextEquals": {"Department": "Finance"}},
+        }
+        result = camel_to_snake_grant(grant)
+        assert result["grant_id"] == "abc123"
+        assert result["constraints"]["encryption_context_equals"] == {"Department": "Finance"}
+
+    def test_grant_with_encryption_context_subset(self):
+        grant = {
+            "GrantId": "abc123",
+            "GranteePrincipal": "arn:aws:iam::123456789012:role/test",
+            "Constraints": {"EncryptionContextSubset": {"Project": "Alpha"}},
+        }
+        result = camel_to_snake_grant(grant)
+        assert result["grant_id"] == "abc123"
+        assert result["constraints"]["encryption_context_subset"] == {"Project": "Alpha"}
+
+    def test_grant_with_both_encryption_contexts(self):
+        grant = {
+            "GrantId": "abc123",
+            "GranteePrincipal": "arn:aws:iam::123456789012:role/test",
+            "Constraints": {
+                "EncryptionContextEquals": {"Department": "Finance"},
+                "EncryptionContextSubset": {"Project": "Alpha"},
+            },
+        }
+        result = camel_to_snake_grant(grant)
+        assert result["constraints"]["encryption_context_equals"] == {"Department": "Finance"}
+        assert result["constraints"]["encryption_context_subset"] == {"Project": "Alpha"}
+
+    def test_grant_without_constraints(self):
+        grant = {
+            "GrantId": "abc123",
+            "GranteePrincipal": "arn:aws:iam::123456789012:role/test",
+        }
+        result = camel_to_snake_grant(grant)
+        assert result["grant_id"] == "abc123"
+        assert result["grantee_principal"] == "arn:aws:iam::123456789012:role/test"
+        # Should have empty constraints dict from camel_dict_to_snake_dict
+        assert "constraints" not in result or result.get("constraints") == {}
+
+
+class TestNormalizeKmsKeyDetails:
+    def test_tags_transformation(self):
+        """Verify KMS tags with TagKey/TagValue are transformed to Ansible format."""
+        key_details = {
+            "KeyId": "abc123",
+            "Arn": "arn:aws:kms:us-east-1:123456789012:key/abc123",
+            "Tags": [{"TagKey": "Hello", "TagValue": "World"}, {"TagKey": "Environment", "TagValue": "Test"}],
+        }
+        result = normalize_kms_key_details(key_details)
+        assert result["tags"] == {"Hello": "World", "Environment": "Test"}
+        assert result["key_id"] == "abc123"
+
+    def test_empty_tags(self):
+        """Verify empty tags list is handled correctly."""
+        key_details = {
+            "KeyId": "abc123",
+            "Arn": "arn:aws:kms:us-east-1:123456789012:key/abc123",
+            "Tags": [],
+        }
+        result = normalize_kms_key_details(key_details)
+        assert result["tags"] == {}
+
+    def test_no_tags(self):
+        """Verify missing Tags key doesn't add tags field when force_tags=False."""
+        key_details = {
+            "KeyId": "abc123",
+            "Arn": "arn:aws:kms:us-east-1:123456789012:key/abc123",
+        }
+        result = normalize_kms_key_details(key_details)
+        assert "tags" not in result
+
+    def test_grants_transformation(self):
+        """Verify grants list is transformed correctly."""
+        key_details = {
+            "KeyId": "abc123",
+            "Arn": "arn:aws:kms:us-east-1:123456789012:key/abc123",
+            "Grants": [
+                {
+                    "GrantId": "grant123",
+                    "GranteePrincipal": "arn:aws:iam::123456789012:role/test",
+                    "Operations": ["Decrypt"],
+                }
+            ],
+        }
+        result = normalize_kms_key_details(key_details)
+        assert len(result["grants"]) == 1
+        assert result["grants"][0]["grant_id"] == "grant123"
+        assert result["grants"][0]["grantee_principal"] == "arn:aws:iam::123456789012:role/test"
+
+    def test_grants_with_constraints(self):
+        """Verify grants with constraints preserve encryption context."""
+        key_details = {
+            "KeyId": "abc123",
+            "Arn": "arn:aws:kms:us-east-1:123456789012:key/abc123",
+            "Grants": [
+                {
+                    "GrantId": "grant123",
+                    "GranteePrincipal": "arn:aws:iam::123456789012:role/test",
+                    "Constraints": {"EncryptionContextEquals": {"Department": "Finance"}},
+                }
+            ],
+        }
+        result = normalize_kms_key_details(key_details)
+        assert result["grants"][0]["constraints"]["encryption_context_equals"] == {"Department": "Finance"}
+
+    def test_key_policies_transformation(self):
+        """Verify policy JSON strings are parsed to dicts."""
+        key_details = {
+            "KeyId": "abc123",
+            "Arn": "arn:aws:kms:us-east-1:123456789012:key/abc123",
+            "KeyPolicies": ['{"Version": "2012-10-17", "Statement": []}', '{"Version": "2012-10-17", "Id": "custom"}'],
+        }
+        result = normalize_kms_key_details(key_details)
+        assert len(result["key_policies"]) == 2
+        assert result["key_policies"][0] == {"Version": "2012-10-17", "Statement": []}
+        assert result["key_policies"][1] == {"Version": "2012-10-17", "Id": "custom"}
+
+    def test_complete_key_details(self):
+        """Verify complete key with all fields transforms correctly."""
+        key_details = {
+            "KeyId": "abc123",
+            "Arn": "arn:aws:kms:us-east-1:123456789012:key/abc123",
+            "Description": "Test key",
+            "Tags": [{"TagKey": "Environment", "TagValue": "Test"}],
+            "Grants": [{"GrantId": "grant123", "GranteePrincipal": "arn:aws:iam::123456789012:role/test"}],
+            "KeyPolicies": ['{"Version": "2012-10-17"}'],
+        }
+        result = normalize_kms_key_details(key_details)
+        assert result["key_id"] == "abc123"
+        assert result["arn"] == "arn:aws:kms:us-east-1:123456789012:key/abc123"
+        assert result["description"] == "Test key"
+        assert result["tags"] == {"Environment": "Test"}
+        assert len(result["grants"]) == 1
+        assert len(result["key_policies"]) == 1

--- a/tests/unit/plugins/module_utils/test_kms.py
+++ b/tests/unit/plugins/module_utils/test_kms.py
@@ -1,0 +1,436 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+from ansible_collections.amazon.aws.plugins.module_utils.kms import AnsibleKMSError
+from ansible_collections.amazon.aws.plugins.module_utils.kms import AnsibleKMSPermissionsError
+from ansible_collections.amazon.aws.plugins.module_utils.kms import AnsibleKMSUnsupportedError
+from ansible_collections.amazon.aws.plugins.module_utils.kms import get_key_details
+from ansible_collections.amazon.aws.plugins.module_utils.kms import get_kms_aliases_lookup
+from ansible_collections.amazon.aws.plugins.module_utils.kms import get_kms_policies
+from ansible_collections.amazon.aws.plugins.module_utils.kms import get_kms_policy_as_dict
+from ansible_collections.amazon.aws.plugins.module_utils.kms import get_kms_tags
+
+
+class TestKmsCompatibility:
+    """Test suite for kms.py re-exports."""
+
+    def test_api_exports_exist(self):
+        """Verify all API re-exports are present."""
+        from ansible_collections.amazon.aws.plugins.module_utils import kms
+
+        # API functions
+        assert hasattr(kms, "cancel_key_deletion")
+        assert hasattr(kms, "create_alias")
+        assert hasattr(kms, "create_grant")
+        assert hasattr(kms, "create_key")
+        assert hasattr(kms, "disable_key")
+        assert hasattr(kms, "disable_key_rotation")
+        assert hasattr(kms, "enable_key")
+        assert hasattr(kms, "enable_key_rotation")
+        assert hasattr(kms, "get_key_policy")
+        assert hasattr(kms, "get_key_rotation_status")
+        assert hasattr(kms, "get_kms_aliases")
+        assert hasattr(kms, "get_kms_grants")
+        assert hasattr(kms, "get_kms_keys")
+        assert hasattr(kms, "get_kms_metadata")
+        assert hasattr(kms, "get_kms_tags")
+        assert hasattr(kms, "list_key_policies")
+        assert hasattr(kms, "list_resource_tags")
+        assert hasattr(kms, "put_key_policy")
+        assert hasattr(kms, "retire_grant")
+        assert hasattr(kms, "schedule_key_deletion")
+        assert hasattr(kms, "tag_resource")
+        assert hasattr(kms, "untag_resource")
+        assert hasattr(kms, "update_key_description")
+
+    def test_exception_exports_exist(self):
+        """Verify all exception re-exports are present."""
+        from ansible_collections.amazon.aws.plugins.module_utils import kms
+
+        assert hasattr(kms, "AnsibleKMSError")
+        assert hasattr(kms, "AnsibleKMSPermissionsError")
+        assert hasattr(kms, "AnsibleKMSUnsupportedError")
+        assert hasattr(kms, "KMSErrorHandler")
+
+    def test_transformation_exports_exist(self):
+        """Verify all transformation re-exports are present."""
+        from ansible_collections.amazon.aws.plugins.module_utils import kms
+
+        assert hasattr(kms, "canonicalize_alias_name")
+        assert hasattr(kms, "normalize_kms_key_details")
+
+    def test_helper_functions_exist(self):
+        """Verify helper functions are present."""
+        from ansible_collections.amazon.aws.plugins.module_utils import kms
+
+        assert hasattr(kms, "get_kms_aliases_lookup")
+        assert hasattr(kms, "get_kms_policy_as_dict")
+        assert hasattr(kms, "get_kms_policies")
+        assert hasattr(kms, "get_key_details")
+
+
+class TestGetKmsAliasesLookup:
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_aliases")
+    def test_empty_aliases(self, mock_get_aliases):
+        mock_get_aliases.return_value = {"Aliases": []}
+        client = MagicMock()
+        result = get_kms_aliases_lookup(client)
+        assert result == {}
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_aliases")
+    def test_aliases_without_target(self, mock_get_aliases):
+        # AWS-managed aliases like aws/s3 don't have TargetKeyId
+        mock_get_aliases.return_value = {
+            "Aliases": [
+                {"AliasName": "alias/aws/s3", "AliasArn": "arn:aws:kms:us-east-1:123456789012:alias/aws/s3"},
+            ]
+        }
+        client = MagicMock()
+        result = get_kms_aliases_lookup(client)
+        assert result == {}
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_aliases")
+    def test_single_alias_per_key(self, mock_get_aliases):
+        mock_get_aliases.return_value = {
+            "Aliases": [
+                {
+                    "AliasName": "alias/mykey",
+                    "AliasArn": "arn:aws:kms:us-east-1:123456789012:alias/mykey",
+                    "TargetKeyId": "key-123",
+                },
+            ]
+        }
+        client = MagicMock()
+        result = get_kms_aliases_lookup(client)
+        assert result == {"key-123": ["mykey"]}
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_aliases")
+    def test_multiple_aliases_per_key(self, mock_get_aliases):
+        mock_get_aliases.return_value = {
+            "Aliases": [
+                {
+                    "AliasName": "alias/mykey",
+                    "AliasArn": "arn:aws:kms:us-east-1:123456789012:alias/mykey",
+                    "TargetKeyId": "key-123",
+                },
+                {
+                    "AliasName": "alias/mykey2",
+                    "AliasArn": "arn:aws:kms:us-east-1:123456789012:alias/mykey2",
+                    "TargetKeyId": "key-123",
+                },
+            ]
+        }
+        client = MagicMock()
+        result = get_kms_aliases_lookup(client)
+        assert result == {"key-123": ["mykey", "mykey2"]}
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_aliases")
+    def test_alias_prefix_stripping(self, mock_get_aliases):
+        mock_get_aliases.return_value = {
+            "Aliases": [
+                {
+                    "AliasName": "alias/test-key",
+                    "AliasArn": "arn:aws:kms:us-east-1:123456789012:alias/test-key",
+                    "TargetKeyId": "key-456",
+                },
+            ]
+        }
+        client = MagicMock()
+        result = get_kms_aliases_lookup(client)
+        # Verify 'alias/' prefix is stripped
+        assert result == {"key-456": ["test-key"]}
+        assert "alias/test-key" not in result.get("key-456", [])
+
+
+class TestGetKmsTags:
+    def test_no_tags(self):
+        client = MagicMock()
+        paginator = MagicMock()
+        client.get_paginator.return_value = paginator
+        paginator.paginate.return_value.build_full_result.return_value = {"Tags": []}
+        result = get_kms_tags(client, "key-123")
+        assert result == {"Tags": []}
+        client.get_paginator.assert_called_once_with("list_resource_tags")
+        paginator.paginate.assert_called_once_with(KeyId="key-123")
+
+    def test_single_page_tags(self):
+        client = MagicMock()
+        paginator = MagicMock()
+        client.get_paginator.return_value = paginator
+        paginator.paginate.return_value.build_full_result.return_value = {
+            "Tags": [{"TagKey": "Environment", "TagValue": "Production"}]
+        }
+        result = get_kms_tags(client, "key-123")
+        assert result == {"Tags": [{"TagKey": "Environment", "TagValue": "Production"}]}
+
+    def test_paginated_tags(self):
+        # build_full_result handles pagination internally
+        client = MagicMock()
+        paginator = MagicMock()
+        client.get_paginator.return_value = paginator
+        paginator.paginate.return_value.build_full_result.return_value = {
+            "Tags": [{"TagKey": "Tag1", "TagValue": "Value1"}, {"TagKey": "Tag2", "TagValue": "Value2"}]
+        }
+        result = get_kms_tags(client, "key-123")
+        assert len(result["Tags"]) == 2
+        assert {"TagKey": "Tag1", "TagValue": "Value1"} in result["Tags"]
+        assert {"TagKey": "Tag2", "TagValue": "Value2"} in result["Tags"]
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils._kms.api.AWSRetry.jittered_backoff")
+    def test_permission_denied(self, mock_retry):
+        # Permission errors should propagate, not be caught
+        mock_retry.return_value = lambda f: f
+        client = MagicMock()
+        client.get_paginator.side_effect = AnsibleKMSPermissionsError(
+            message="Permission denied", exception=Exception("AccessDenied")
+        )
+        with pytest.raises(AnsibleKMSPermissionsError):
+            get_kms_tags(client, "key-123")
+
+
+class TestGetKmsPolicyAsDict:
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_key_policy")
+    def test_policy_found(self, mock_get_policy):
+        mock_get_policy.return_value = {"Policy": '{"Version": "2012-10-17", "Statement": []}'}
+        client = MagicMock()
+        result = get_kms_policy_as_dict(client, "key-123", "default")
+        assert result == {"Version": "2012-10-17", "Statement": []}
+        mock_get_policy.assert_called_once_with(client, "key-123", "default")
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_key_policy")
+    def test_policy_not_found(self, mock_get_policy):
+        mock_get_policy.return_value = None
+        client = MagicMock()
+        result = get_kms_policy_as_dict(client, "key-123", "default")
+        assert result is None
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_key_policy")
+    def test_permission_denied(self, mock_get_policy):
+        mock_get_policy.side_effect = AnsibleKMSPermissionsError(
+            message="Permission denied", exception=Exception("AccessDenied")
+        )
+        client = MagicMock()
+        with pytest.raises(AnsibleKMSPermissionsError):
+            get_kms_policy_as_dict(client, "key-123")
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_key_policy")
+    def test_default_policy_name(self, mock_get_policy):
+        mock_get_policy.return_value = {"Policy": '{"Version": "2012-10-17"}'}
+        client = MagicMock()
+        get_kms_policy_as_dict(client, "key-123")
+        # Should use "default" as policy name when not specified
+        mock_get_policy.assert_called_once_with(client, "key-123", "default")
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_key_policy")
+    def test_custom_policy_name(self, mock_get_policy):
+        mock_get_policy.return_value = {"Policy": '{"Version": "2012-10-17"}'}
+        client = MagicMock()
+        get_kms_policy_as_dict(client, "key-123", "custom")
+        mock_get_policy.assert_called_once_with(client, "key-123", "custom")
+
+
+class TestGetKmsPolicies:
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_key_policy")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.list_key_policies")
+    def test_no_policies(self, mock_list_policies, mock_get_policy):
+        mock_list_policies.return_value = {"PolicyNames": []}
+        client = MagicMock()
+        result = get_kms_policies(client, "key-123")
+        assert result == []
+        mock_get_policy.assert_not_called()
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_key_policy")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.list_key_policies")
+    def test_single_policy(self, mock_list_policies, mock_get_policy):
+        mock_list_policies.return_value = {"PolicyNames": ["default"]}
+        mock_get_policy.return_value = {"Policy": '{"Version": "2012-10-17"}'}
+        client = MagicMock()
+        result = get_kms_policies(client, "key-123")
+        assert result == ['{"Version": "2012-10-17"}']
+        mock_get_policy.assert_called_once_with(client, "key-123", "default")
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_key_policy")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.list_key_policies")
+    def test_multiple_policies(self, mock_list_policies, mock_get_policy):
+        mock_list_policies.return_value = {"PolicyNames": ["default", "custom"]}
+        mock_get_policy.side_effect = [
+            {"Policy": '{"Version": "2012-10-17", "Id": "default"}'},
+            {"Policy": '{"Version": "2012-10-17", "Id": "custom"}'},
+        ]
+        client = MagicMock()
+        result = get_kms_policies(client, "key-123")
+        assert len(result) == 2
+        assert '{"Version": "2012-10-17", "Id": "default"}' in result
+        assert '{"Version": "2012-10-17", "Id": "custom"}' in result
+
+
+class TestGetKeyDetails:
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_metadata")
+    def test_key_not_found(self, mock_metadata):
+        mock_metadata.return_value = None
+        client = MagicMock()
+        result = get_key_details(client, "key-123")
+        assert result is None
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms._transformations.normalize_kms_key_details")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_policies")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_tags")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_grants")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_key_rotation_status")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_aliases_lookup")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_metadata")
+    def test_full_key_details(
+        self,
+        mock_metadata,
+        mock_aliases,
+        mock_rotation,
+        mock_grants,
+        mock_tags,
+        mock_policies,
+        mock_normalize,
+    ):
+        mock_metadata.return_value = {"Arn": "arn:aws:kms:us-east-1:123456789012:key/abc", "KeyId": "abc"}
+        mock_aliases.return_value = {"abc": ["myalias"]}
+        mock_rotation.return_value = {"KeyRotationEnabled": True}
+        mock_grants.return_value = {"Grants": []}
+        mock_tags.return_value = {"Tags": []}
+        mock_policies.return_value = []
+        mock_normalize.return_value = {"key_id": "abc"}
+
+        client = MagicMock()
+        result = get_key_details(client, "key-123")
+
+        mock_metadata.assert_called_once_with(client, "key-123")
+        mock_aliases.assert_called_once_with(client)
+        mock_rotation.assert_called_once_with(client, "arn:aws:kms:us-east-1:123456789012:key/abc")
+        mock_grants.assert_called_once_with(client, "arn:aws:kms:us-east-1:123456789012:key/abc", grant_tokens=None)
+        mock_tags.assert_called_once_with(client, "arn:aws:kms:us-east-1:123456789012:key/abc")
+        mock_policies.assert_called_once_with(client, "arn:aws:kms:us-east-1:123456789012:key/abc")
+        mock_normalize.assert_called_once()
+        assert result == {"key_id": "abc"}
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms._transformations.normalize_kms_key_details")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_key_rotation_status")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_aliases_lookup")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_metadata")
+    def test_pending_deletion_skips_grants_tags_policies(
+        self, mock_metadata, mock_aliases, mock_rotation, mock_normalize
+    ):
+        mock_metadata.return_value = {"Arn": "arn:aws:kms:us-east-1:123456789012:key/abc", "KeyId": "abc"}
+        mock_aliases.return_value = {"abc": ["myalias"]}
+        mock_rotation.return_value = {"KeyRotationEnabled": False}
+        mock_normalize.return_value = {"key_id": "abc"}
+
+        client = MagicMock()
+        result = get_key_details(client, "key-123", pending_deletion=True)
+
+        mock_normalize.assert_called_once()
+        assert result == {"key_id": "abc"}
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms._transformations.normalize_kms_key_details")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_policies")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_tags")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_grants")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_key_rotation_status")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_aliases_lookup")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_metadata")
+    def test_rotation_permission_error_suppressed(
+        self,
+        mock_metadata,
+        mock_aliases,
+        mock_rotation,
+        mock_grants,
+        mock_tags,
+        mock_policies,
+        mock_normalize,
+    ):
+        mock_metadata.return_value = {"Arn": "arn:aws:kms:us-east-1:123456789012:key/abc", "KeyId": "abc"}
+        mock_aliases.return_value = {}
+        mock_rotation.side_effect = AnsibleKMSPermissionsError(message="denied", exception=Exception())
+        mock_grants.return_value = {"Grants": []}
+        mock_tags.return_value = {"Tags": []}
+        mock_policies.return_value = []
+        mock_normalize.return_value = {"key_id": "abc"}
+
+        client = MagicMock()
+        result = get_key_details(client, "key-123")
+
+        assert result == {"key_id": "abc"}
+        # Verify enable_key_rotation was set to None in the data passed to normalize
+        call_args = mock_normalize.call_args[0][0]
+        assert call_args["enable_key_rotation"] is None
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms._transformations.normalize_kms_key_details")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_policies")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_tags")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_grants")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_key_rotation_status")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_aliases_lookup")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_metadata")
+    def test_rotation_unsupported_error_suppressed(
+        self,
+        mock_metadata,
+        mock_aliases,
+        mock_rotation,
+        mock_grants,
+        mock_tags,
+        mock_policies,
+        mock_normalize,
+    ):
+        mock_metadata.return_value = {"Arn": "arn:aws:kms:us-east-1:123456789012:key/abc", "KeyId": "abc"}
+        mock_aliases.return_value = {}
+        mock_rotation.side_effect = AnsibleKMSUnsupportedError(message="unsupported", exception=Exception())
+        mock_grants.return_value = {"Grants": []}
+        mock_tags.return_value = {"Tags": []}
+        mock_policies.return_value = []
+        mock_normalize.return_value = {"key_id": "abc"}
+
+        client = MagicMock()
+        result = get_key_details(client, "key-123")
+
+        call_args = mock_normalize.call_args[0][0]
+        assert call_args["enable_key_rotation"] is None
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms._transformations.normalize_kms_key_details")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_policies")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_tags")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_grants")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_key_rotation_status")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_aliases_lookup")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_metadata")
+    def test_grants_tags_policies_permission_errors_propagate(
+        self,
+        mock_metadata,
+        mock_aliases,
+        mock_rotation,
+        mock_grants,
+        mock_tags,
+        mock_policies,
+        mock_normalize,
+    ):
+        mock_metadata.return_value = {"Arn": "arn:aws:kms:us-east-1:123456789012:key/abc", "KeyId": "abc"}
+        mock_aliases.return_value = {}
+        mock_rotation.return_value = {"KeyRotationEnabled": True}
+        mock_grants.return_value = {"Grants": []}
+        mock_tags.side_effect = AnsibleKMSPermissionsError(message="denied", exception=Exception())
+
+        client = MagicMock()
+        with pytest.raises(AnsibleKMSPermissionsError):
+            get_key_details(client, "key-123")
+
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_aliases_lookup")
+    @patch("ansible_collections.amazon.aws.plugins.module_utils.kms.get_kms_metadata")
+    def test_alias_lookup_error_reraised(self, mock_metadata, mock_aliases):
+        mock_metadata.return_value = {"Arn": "arn:aws:kms:us-east-1:123456789012:key/abc", "KeyId": "abc"}
+        mock_aliases.side_effect = AnsibleKMSError(message="error", exception=Exception("test"))
+
+        client = MagicMock()
+        with pytest.raises(AnsibleKMSError, match="Failed to obtain aliases"):
+            get_key_details(client, "key-123")

--- a/tests/unit/plugins/module_utils/transformation/test_boto3_resource_to_ansible_dict.py
+++ b/tests/unit/plugins/module_utils/transformation/test_boto3_resource_to_ansible_dict.py
@@ -135,3 +135,29 @@ class TestBoto3ResourceToAnsibleDict:
         if input_params and "Tags" not in input_params:
             del expected_value["tags"]
         assert boto3_resource_to_ansible_dict(input_params, force_tags=False) == expected_value
+
+    def test_tagging_params_tagkey_tagvalue(self):
+        # Test with KMS-style TagKey/TagValue tags
+        input_params = {
+            "ResourceId": "abc123",
+            "Tags": [{"TagKey": "Hello", "TagValue": "World"}, {"TagKey": "Environment", "TagValue": "Test"}],
+        }
+        expected_output = {
+            "resource_id": "abc123",
+            "tags": {"Hello": "World", "Environment": "Test"},
+        }
+        tagging_params = {"tag_name_key_name": "TagKey", "tag_value_key_name": "TagValue"}
+        assert boto3_resource_to_ansible_dict(input_params, tagging_params=tagging_params) == expected_output
+
+    def test_tagging_params_name_value(self):
+        # Test with name/value style tags
+        input_params = {
+            "ResourceId": "abc123",
+            "Tags": [{"name": "Hello", "value": "World"}, {"name": "Environment", "value": "Test"}],
+        }
+        expected_output = {
+            "resource_id": "abc123",
+            "tags": {"Hello": "World", "Environment": "Test"},
+        }
+        tagging_params = {"tag_name_key_name": "name", "tag_value_key_name": "value"}
+        assert boto3_resource_to_ansible_dict(input_params, tagging_params=tagging_params) == expected_output

--- a/tests/unit/plugins/modules/test_kms_key.py
+++ b/tests/unit/plugins/modules/test_kms_key.py
@@ -56,14 +56,14 @@ key_details = {
 }
 
 
-@patch(module_name + ".get_kms_metadata_with_backoff")
-def test_fetch_key_metadata(m_get_kms_metadata_with_backoff):
+@patch(module_name + ".get_kms_metadata")
+def test_fetch_key_metadata(m_get_kms_metadata):
     module = MagicMock()
     kms_client = MagicMock()
 
-    m_get_kms_metadata_with_backoff.return_value = key_details
+    m_get_kms_metadata.return_value = key_details["KeyMetadata"]
     kms_key.fetch_key_metadata(kms_client, module, "mrk-12345678", "mykey")
-    assert m_get_kms_metadata_with_backoff.call_count == 1
+    assert m_get_kms_metadata.call_count == 1
 
 
 def test_validate_params():
@@ -72,3 +72,83 @@ def test_validate_params():
 
     kms_key.validate_params(module, key_details["KeyMetadata"])
     module.fail_json.assert_called_with(msg="You cannot change the multi-region property on an existing key.")
+
+
+class TestConvertGrantParams:
+    def test_basic_grant(self):
+        grant = {"grantee_principal": "arn:aws:iam::123456789012:role/test"}
+        key = {"key_arn": "arn:aws:kms:us-east-1:123456789012:key/abc123"}
+        result = kms_key.convert_grant_params(grant, key)
+        assert result["KeyId"] == "arn:aws:kms:us-east-1:123456789012:key/abc123"
+        assert result["GranteePrincipal"] == "arn:aws:iam::123456789012:role/test"
+        assert "Operations" not in result
+        assert "Name" not in result
+
+    def test_grant_with_operations(self):
+        grant = {"grantee_principal": "arn:aws:iam::123456789012:role/test", "operations": ["Decrypt", "Encrypt"]}
+        key = {"key_arn": "arn:aws:kms:us-east-1:123456789012:key/abc123"}
+        result = kms_key.convert_grant_params(grant, key)
+        assert result["Operations"] == ["Decrypt", "Encrypt"]
+
+    def test_grant_with_name(self):
+        grant = {"grantee_principal": "arn:aws:iam::123456789012:role/test", "name": "MyGrant"}
+        key = {"key_arn": "arn:aws:kms:us-east-1:123456789012:key/abc123"}
+        result = kms_key.convert_grant_params(grant, key)
+        assert result["Name"] == "MyGrant"
+
+    def test_grant_with_retiring_principal(self):
+        grant = {
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "retiring_principal": "arn:aws:iam::123456789012:role/retire",
+        }
+        key = {"key_arn": "arn:aws:kms:us-east-1:123456789012:key/abc123"}
+        result = kms_key.convert_grant_params(grant, key)
+        assert result["RetiringPrincipal"] == "arn:aws:iam::123456789012:role/retire"
+
+    def test_grant_with_encryption_context_subset(self):
+        grant = {
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "constraints": {"encryption_context_subset": {"Department": "Finance"}},
+        }
+        key = {"key_arn": "arn:aws:kms:us-east-1:123456789012:key/abc123"}
+        result = kms_key.convert_grant_params(grant, key)
+        assert result["Constraints"]["EncryptionContextSubset"] == {"Department": "Finance"}
+
+    def test_grant_with_encryption_context_equals(self):
+        grant = {
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "constraints": {"encryption_context_equals": {"Project": "Alpha"}},
+        }
+        key = {"key_arn": "arn:aws:kms:us-east-1:123456789012:key/abc123"}
+        result = kms_key.convert_grant_params(grant, key)
+        assert result["Constraints"]["EncryptionContextEquals"] == {"Project": "Alpha"}
+
+    def test_grant_with_both_constraints(self):
+        grant = {
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "constraints": {
+                "encryption_context_subset": {"Department": "Finance"},
+                "encryption_context_equals": {"Project": "Alpha"},
+            },
+        }
+        key = {"key_arn": "arn:aws:kms:us-east-1:123456789012:key/abc123"}
+        result = kms_key.convert_grant_params(grant, key)
+        assert result["Constraints"]["EncryptionContextSubset"] == {"Department": "Finance"}
+        assert result["Constraints"]["EncryptionContextEquals"] == {"Project": "Alpha"}
+
+    def test_complete_grant(self):
+        grant = {
+            "grantee_principal": "arn:aws:iam::123456789012:role/test",
+            "retiring_principal": "arn:aws:iam::123456789012:role/retire",
+            "operations": ["Decrypt", "Encrypt", "GenerateDataKey"],
+            "name": "CompleteGrant",
+            "constraints": {"encryption_context_equals": {"Environment": "Production"}},
+        }
+        key = {"key_arn": "arn:aws:kms:us-east-1:123456789012:key/abc123"}
+        result = kms_key.convert_grant_params(grant, key)
+        assert result["KeyId"] == "arn:aws:kms:us-east-1:123456789012:key/abc123"
+        assert result["GranteePrincipal"] == "arn:aws:iam::123456789012:role/test"
+        assert result["RetiringPrincipal"] == "arn:aws:iam::123456789012:role/retire"
+        assert result["Operations"] == ["Decrypt", "Encrypt", "GenerateDataKey"]
+        assert result["Name"] == "CompleteGrant"
+        assert result["Constraints"]["EncryptionContextEquals"] == {"Environment": "Production"}

--- a/tests/unit/plugins/modules/test_kms_key.py
+++ b/tests/unit/plugins/modules/test_kms_key.py
@@ -58,11 +58,10 @@ key_details = {
 
 @patch(module_name + ".get_kms_metadata")
 def test_fetch_key_metadata(m_get_kms_metadata):
-    module = MagicMock()
     kms_client = MagicMock()
 
     m_get_kms_metadata.return_value = key_details["KeyMetadata"]
-    kms_key.fetch_key_metadata(kms_client, module, "mrk-12345678", "mykey")
+    kms_key.fetch_key_metadata(kms_client, "mrk-12345678", "mykey")
     assert m_get_kms_metadata.call_count == 1
 
 

--- a/tests/unit/plugins/modules/test_kms_key_info.py
+++ b/tests/unit/plugins/modules/test_kms_key_info.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from ansible_collections.amazon.aws.plugins.modules import kms_key_info
+
+
+class TestKeyMatchesFilter:
+    def test_key_id_match(self):
+        key = {"key_id": "abc123", "tags": {}, "aliases": []}
+        assert kms_key_info.key_matches_filter(key, ("key-id", "abc123")) is True
+
+    def test_key_id_no_match(self):
+        key = {"key_id": "abc123", "tags": {}, "aliases": []}
+        assert kms_key_info.key_matches_filter(key, ("key-id", "xyz789")) is False
+
+    def test_tag_key_match(self):
+        key = {"key_id": "abc123", "tags": {"Environment": "Test", "Owner": "Alice"}, "aliases": []}
+        assert kms_key_info.key_matches_filter(key, ("tag-key", "Environment")) is True
+
+    def test_tag_key_no_match(self):
+        key = {"key_id": "abc123", "tags": {"Environment": "Test"}, "aliases": []}
+        assert kms_key_info.key_matches_filter(key, ("tag-key", "Owner")) is False
+
+    def test_tag_value_match(self):
+        key = {"key_id": "abc123", "tags": {"Environment": "Test", "Owner": "Alice"}, "aliases": []}
+        assert kms_key_info.key_matches_filter(key, ("tag-value", "Test")) is True
+
+    def test_tag_value_no_match(self):
+        key = {"key_id": "abc123", "tags": {"Environment": "Test"}, "aliases": []}
+        assert kms_key_info.key_matches_filter(key, ("tag-value", "Production")) is False
+
+    def test_alias_match(self):
+        key = {"key_id": "abc123", "tags": {}, "aliases": ["mykey", "testkey"]}
+        assert kms_key_info.key_matches_filter(key, ("alias", "mykey")) is True
+
+    def test_alias_no_match(self):
+        key = {"key_id": "abc123", "tags": {}, "aliases": ["mykey"]}
+        assert kms_key_info.key_matches_filter(key, ("alias", "otherkey")) is False
+
+    def test_tag_specific_match(self):
+        key = {"key_id": "abc123", "tags": {"Environment": "Test", "Owner": "Alice"}, "aliases": []}
+        assert kms_key_info.key_matches_filter(key, ("tag:Environment", "Test")) is True
+
+    def test_tag_specific_no_match(self):
+        key = {"key_id": "abc123", "tags": {"Environment": "Test"}, "aliases": []}
+        assert kms_key_info.key_matches_filter(key, ("tag:Environment", "Production")) is False
+
+    def test_tag_specific_key_missing(self):
+        key = {"key_id": "abc123", "tags": {"Environment": "Test"}, "aliases": []}
+        assert kms_key_info.key_matches_filter(key, ("tag:Owner", "Alice")) is False
+
+
+class TestKeyMatchesFilters:
+    def test_no_filters(self):
+        key = {"key_id": "abc123", "tags": {}, "aliases": []}
+        assert kms_key_info.key_matches_filters(key, {}) is True
+
+    def test_none_filters(self):
+        key = {"key_id": "abc123", "tags": {}, "aliases": []}
+        assert kms_key_info.key_matches_filters(key, None) is True
+
+    def test_single_filter_match(self):
+        key = {"key_id": "abc123", "tags": {"Environment": "Test"}, "aliases": []}
+        filters = {"key-id": "abc123"}
+        assert kms_key_info.key_matches_filters(key, filters) is True
+
+    def test_single_filter_no_match(self):
+        key = {"key_id": "abc123", "tags": {"Environment": "Test"}, "aliases": []}
+        filters = {"key-id": "xyz789"}
+        assert kms_key_info.key_matches_filters(key, filters) is False
+
+    def test_multiple_filters_all_match(self):
+        key = {"key_id": "abc123", "tags": {"Environment": "Test", "Owner": "Alice"}, "aliases": ["mykey"]}
+        filters = {"key-id": "abc123", "tag:Environment": "Test", "alias": "mykey"}
+        assert kms_key_info.key_matches_filters(key, filters) is True
+
+    def test_multiple_filters_partial_match(self):
+        key = {"key_id": "abc123", "tags": {"Environment": "Test"}, "aliases": ["mykey"]}
+        filters = {"key-id": "abc123", "tag:Environment": "Production"}
+        assert kms_key_info.key_matches_filters(key, filters) is False
+
+    def test_multiple_filters_no_match(self):
+        key = {"key_id": "abc123", "tags": {"Environment": "Test"}, "aliases": []}
+        filters = {"key-id": "xyz789", "alias": "otherkey"}
+        assert kms_key_info.key_matches_filters(key, filters) is False

--- a/tox.ini
+++ b/tox.ini
@@ -90,6 +90,7 @@ passenv = DIFF_COMPARE_BRANCH
 set_env =
     DIFF_COMPARE_BRANCH={env:DIFF_COMPARE_BRANCH:origin/main}
 change_dir = {toxinidir}
+commands_pre =
 commands =
     sh -c 'COVERAGE_FILE=$(find .tox -path "*/ansible_collections/amazon/aws/coverage.xml" -type f -printf "%T@ %p\n" | sort -rn | head -1 | cut -d" " -f2-); \
            if [ -z "$COVERAGE_FILE" ]; then \


### PR DESCRIPTION
##### SUMMARY

Refactored KMS module_utils to improve maintainability, consistency, and reliability by consolidating duplicate code and following established S3 patterns.

**Key improvements:**
- Created `_kms/` submodule with clear separation of concerns (api, common, grants, transformations)
- Consolidated ~70 lines of duplicate code from kms_key and kms_key_info
- Added consistent retry logic and error handling to all KMS API operations
- Fixed bug where kms_key incorrectly reported 'changed' on transient policy fetch failures
- Added comprehensive unit test coverage (93 new tests, 100% coverage on module_utils)

**Architecture:**
- `_kms/api.py` - Thin boto3 wrappers with @KMSErrorHandler + @AWSRetry decorators
- `_kms/common.py` - Custom exceptions (AnsibleKMSError, AnsibleKMSPermissionsError, AnsibleKMSUnsupportedError) and error handlers
- `_kms/grants.py` - Grant comparison logic for idempotent grant management
- `_kms/transformations.py` - Data format conversions using boto3_resource_to_ansible_dict
- `kms.py` - Public API re-exporting all functions with helper functions

Changelog fragment included.

##### ISSUE TYPE
- Bugfix Pull Request
- Refactoring Pull Request
- Test Pull Request

##### COMPONENT NAME
- kms_key
- kms_key_info
- module_utils.kms
- module_utils.transformation

##### ADDITIONAL INFORMATION

**Bug fixes:**
1. **Policy comparison retry failure** - kms_key previously had no retry logic when fetching the current policy for comparison. This meant transient AWS API errors would cause the module to assume no policy exists and report `changed=True` even when the policy was identical. Now uses retry-decorated get_kms_policy_as_dict().

2. **Missing error warnings** - Added warnings when key rotation status cannot be fetched due to permissions or unsupported key types (e.g., asymmetric keys don't support rotation).

3. **Missing import** - kms_key_info was missing AnsibleKMSError import, causing runtime failures.

4. **Tag format handling** - KMS uses TagKey/TagValue format instead of Key/Value. Added tagging_params support to boto3_resource_to_ansible_dict to handle this cleanly.

**Testing:**
- 93 new unit tests added (18 files changed: +2028, -723 lines)
- 100% coverage on all module_utils code (common, grants, transformations, kms.py)
- Tests cover error handling, pagination, grant comparison, tag transformation, and all helper functions
- Integration tests pass (verified tag transformation fixes)

**Migration notes:**
- All existing imports remain compatible (re-exported from kms.py)
- No breaking changes to module interfaces
- Improved error messages with specific exception types

Assisted-by: Claude Sonnet 4.5
