### PR TITLE
[Manual Backport][Stable 11]ci(tox): use matching community.aws branch for unit tests (#3014)

### DIFF
--- a/changelogs/fragments/3014-tox-community-aws-branch.yml
+++ b/changelogs/fragments/3014-tox-community-aws-branch.yml
@@ -1,0 +1,2 @@
+trivial:
+  - tox - Use matching community.aws branch for unit tests to fix dependency resolution on stable branches (https://github.com/ansible-collections/amazon.aws/pull/3014).

--- a/tox.ini
+++ b/tox.ini
@@ -15,6 +15,12 @@ collection_path = amazon/aws
 format_dirs = {toxinidir}/plugins {toxinidir}/tests
 lint_dirs = {toxinidir}/plugins {toxinidir}/tests
 
+community_aws_install = sh -c 'VERSION=$(grep "^version:" {toxinidir}/galaxy.yml | cut -d" " -f2); \
+       if echo "$VERSION" | grep -q -- "-dev"; then BRANCH="main"; \
+       else MAJOR=$(echo "$VERSION" | cut -d. -f1); BRANCH="stable-$MAJOR"; fi; \
+       ansible-galaxy collection install "git+https://github.com/ansible-collections/community.aws.git,$BRANCH" 2>/dev/null || \
+       ansible-galaxy collection install git+https://github.com/ansible-collections/community.aws.git'
+
 ansible_desc =
     ansible2.17: Ansible-core 2.17
     ansible2.18: Ansible-core 2.18
@@ -51,11 +57,11 @@ deps =
   ansible2.19: ansible-core>2.19,<2.20
   ansible2.20: ansible-core>2.20,<2.21
   with_constraints: -rtests/unit/constraints.txt
-allowlist_externals = rsync
+allowlist_externals = rsync, sh
 change_dir = {[common]full_collection_path}
 commands_pre =
-  rsync --delete --exclude=.tox -qraugpo {toxinidir}/ {[common]full_collection_path}/
-  ansible-galaxy collection install git+https://github.com/ansible-collections/community.aws.git,stable-11
+  rsync --delete --filter=':- .gitignore' --exclude=/.git -qraugpo {toxinidir}/ {[common]full_collection_path}/
+  {[common]community_aws_install}
 commands =
     pytest \
         --cov \
@@ -312,7 +318,7 @@ commands =
   ansible-test sanity
 
 [testenv:mypy-lint]
-allowlist_externals = rsync,ln
+allowlist_externals = rsync, ln, sh
 labels = future-lint
 description = Run mypi type tests
 set_env =
@@ -328,8 +334,8 @@ deps =
   placebo
   typing_extensions
 commands_pre =
-  rsync --delete --exclude=.tox -qraugpo {toxinidir}/ {[common]full_collection_path}/
-  ansible-galaxy collection install git+https://github.com/ansible-collections/community.aws.git
+  rsync --delete --filter=':- .gitignore' --exclude=/.git -qraugpo {toxinidir}/ {[common]full_collection_path}/
+  {[common]community_aws_install}
   ln -s {env_site_packages_dir}/ansible {[common]ansible_collections_path}/ansible
   ln -s {[common]ansible_home}/collections/ansible_collections {[common]ansible_home}/ansible_collections
 commands =


### PR DESCRIPTION
Summary

Fix tox unit test dependency resolution for stable branches Detect current git branch and install matching community.aws branch Fall back to main if the branch doesn't exist in community.aws

Problem
When running tox unit tests on stable branches (e.g., stable-11), the ansible-galaxy collection install command installs community.aws from main. However, community.aws main may require a newer amazon.aws version than the stable branch provides, causing dependency resolution failures: [ERROR]: Failed to resolve the requested dependencies map. Could not satisfy the following requirements:
* amazon.aws:>=12.0.0-dev0 (dependency of community.aws:12.0.0-dev0)

Solution
Use shell command to detect the current branch and install the matching community.aws branch: sh -c 'BRANCH=$(git -C {toxinidir} rev-parse --abbrev-ref HEAD 2>/dev/null || echo main); \
       ansible-galaxy collection install "git+https://github.com/ansible-collections/community.aws.git,$BRANCH" 2>/dev/null || \
       ansible-galaxy collection install git+https://github.com/ansible-collections/community.aws.git'
This works generically across all branches without hardcoding branch names. Test plan

 Verify tox unit tests pass on main
 Verify tox unit tests pass on stable-11 after backport

🤖 Generated with Claude Code

Reviewed-by: Mark Chappell
Reviewed-by: Rahmanim Benny <brahmani@redhat.com>
Reviewed-by: Bianca Henderson <beeankha@gmail.com>
(cherry picked from commit 1cec870374343f00c9c08909114e02247632b688)

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module/Plugin Pull Request
- Refactoring Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Integration tests should also be included where practical (tests/integration/targets) -->

<!--- Contributions created with the assistance of AI must include an 'Assisted-by: ...' declaration -->
<!--- Assisted-by: <AI model and version> -->
