### PR TITLE
fix(aws_ssm): suppress PowerShell progress output in file transfers

### DIFF
--- a/changelogs/fragments/ssm-suppress-progress-output.yml
+++ b/changelogs/fragments/ssm-suppress-progress-output.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - aws_ssm - suppress PowerShell progress output in Windows file transfers to prevent stdout pollution that causes transfer failures (https://github.com/ansible-collections/amazon.aws/pull/3013).

--- a/plugins/plugin_utils/ssm/s3clientmanager.py
+++ b/plugins/plugin_utils/ssm/s3clientmanager.py
@@ -88,6 +88,7 @@ class S3ClientManager:
                 escaped_in_path = in_path.replace("'", "''")
                 command = (
                     "$ErrorActionPreference = 'Stop' ; "
+                    "$ProgressPreference = 'SilentlyContinue' ; "
                     f"$fileContent = [System.IO.File]::ReadAllBytes('{escaped_in_path}') ; "
                     "Invoke-WebRequest -Method PUT "
                     # @{'key' = 'value'; 'key2' = 'value2'}
@@ -118,6 +119,7 @@ class S3ClientManager:
                 escaped_out_path = out_path.replace("'", "''")
                 command = (
                     "$ErrorActionPreference = 'Stop' ; "
+                    "$ProgressPreference = 'SilentlyContinue' ; "
                     f"$response = Invoke-WebRequest -Uri '{url}' -UseBasicParsing ; "
                     f"[System.IO.File]::WriteAllBytes('{escaped_out_path}', $response.Content)"
                 )  # fmt: skip

--- a/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
@@ -209,6 +209,7 @@ class TestS3ClientManager:
                 if is_windows:
                     assert test_command_generation.startswith(
                         "$ErrorActionPreference = 'Stop' ; "
+                        "$ProgressPreference = 'SilentlyContinue' ; "
                         "$fileContent = [System.IO.File]::ReadAllBytes('test/in/path') ; "
                         "Invoke-WebRequest -Method PUT -Headers @"
                     )
@@ -227,6 +228,7 @@ class TestS3ClientManager:
                 if is_windows:
                     assert (
                         "$ErrorActionPreference = 'Stop' ; "
+                        "$ProgressPreference = 'SilentlyContinue' ; "
                         "$response = Invoke-WebRequest -Uri 'https://test-url' -UseBasicParsing ; "
                         "[System.IO.File]::WriteAllBytes('test/out/path', $response.Content)"
                     ) == test_command_generation


### PR DESCRIPTION
## Summary
- Add `$ProgressPreference = 'SilentlyContinue'` to Windows file transfer commands
- Prevents PowerShell's Invoke-WebRequest progress messages from polluting stdout
- Fixes file transfer parsing failures with Unicode file paths

## Test plan
- [x] Unit tests updated and passing
- [ ] Integration test `connection_aws_ssm_windows` should pass (verified in backport PR #3013)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)