### PR TITLE
[Manual Backport][Stable-11]fix(aws_ssm): suppress PowerShell progress output in file transfers (…

### DIFF
--- a/changelogs/fragments/ssm-suppress-progress-output.yml
+++ b/changelogs/fragments/ssm-suppress-progress-output.yml
@@ -1,0 +1,3 @@
+---
+bugfixes:
+  - aws_ssm - suppress PowerShell progress output in Windows file transfers to prevent stdout pollution that causes transfer failures (https://github.com/ansible-collections/amazon.aws/pull/3013).

--- a/plugins/plugin_utils/ssm/s3clientmanager.py
+++ b/plugins/plugin_utils/ssm/s3clientmanager.py
@@ -153,6 +153,7 @@ class S3ClientManager:
             if is_windows:
                 put_command_headers = "; ".join([f"'{h}' = '{v}'" for h, v in put_headers.items()])
                 command = (
+                    "$ProgressPreference = 'SilentlyContinue' ; "
                     "Invoke-WebRequest -Method PUT "
                     # @{'key' = 'value'; 'key2' = 'value2'}
                     f"-Headers @{{{put_command_headers}}} "
@@ -177,6 +178,7 @@ class S3ClientManager:
             url = self.get_url("get_object", bucket_name, s3_path, "GET")
             if is_windows:
                 command = (
+                    "$ProgressPreference = 'SilentlyContinue' ; "
                     "Invoke-WebRequest "
                     f"'{url}' "
                     f"-OutFile '{out_path}'"

--- a/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_aws_ssm.py
@@ -231,7 +231,9 @@ class TestS3ClientManager:
             if method == "get":
                 m_generate_encryption_settings.assert_called_once_with(bucket_sse_mode, bucket_sse_kms_key_id)
                 if is_windows:
-                    assert test_command_generation.startswith("Invoke-WebRequest -Method PUT -Headers @")
+                    assert test_command_generation.startswith(
+                        "$ProgressPreference = 'SilentlyContinue' ; Invoke-WebRequest -Method PUT -Headers @"
+                    )
                     assert test_command_generation.endswith(
                         "-InFile 'test/in/path' -Uri 'https://test-url' -UseBasicParsing"
                     )
@@ -245,7 +247,8 @@ class TestS3ClientManager:
             elif method == "put":
                 m_generate_encryption_settings.assert_not_called()
                 if is_windows:
-                    assert "Invoke-WebRequest 'https://test-url' -OutFile 'test/out/path'" == test_command_generation
+                    expected = "$ProgressPreference = 'SilentlyContinue' ; Invoke-WebRequest 'https://test-url' -OutFile 'test/out/path'"
+                    assert expected == test_command_generation
                 else:
                     assert "curl -o 'test/out/path' 'https://test-url';touch 'test/out/path'" == test_command_generation
                 assert put_args is None


### PR DESCRIPTION
…#3021)

Summary

Add $ProgressPreference = 'SilentlyContinue' to Windows file transfer commands Prevents PowerShell's Invoke-WebRequest progress messages from polluting stdout Fixes file transfer parsing failures with Unicode file paths

Test plan

 Unit tests updated and passing
 Integration test connection_aws_ssm_windows should pass (verified in backport PR #3013)

🤖 Generated with Claude Code

Reviewed-by: Mark Chappell
(cherry picked from commit 1010e1950e4d3630a6fb5709cda4321c604dd77e)

rh-pre-commit.version: 2.3.2
rh-pre-commit.check-secrets: ENABLED

##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->

<!--- Please do not forget to include a changelog fragment:
      https://docs.ansible.com/projects/ansible/devel/community/collection_development_process.html#creating-changelog-fragments
      No need to include one for docs-only or test-only PR, and for new plugin/module PRs.
      Read about more details in CONTRIBUTING.md.
      -->

##### ISSUE TYPE
<!--- Pick one or more below and delete the rest.
      'Test Pull Request' is for PRs that add/extend tests without code changes. -->
- Bugfix Pull Request
- Docs Pull Request
- Feature Pull Request
- New Module/Plugin Pull Request
- Refactoring Pull Request
- Test Pull Request

##### COMPONENT NAME
<!--- Write the SHORT NAME of the module, plugin, task or feature below. -->

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
<!--- Integration tests should also be included where practical (tests/integration/targets) -->

<!--- Contributions created with the assistance of AI must include an 'Assisted-by: ...' declaration -->
<!--- Assisted-by: <AI model and version> -->
