### PR TITLE
ci: add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+---
+# Dependabot configuration for GitHub Actions updates
+# See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Monitor GitHub Actions for version updates
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    # Group all GitHub Actions updates into a single PR to reduce noise
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    # Keep commit messages conventional and concise
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    # Limit number of open PRs
+    open-pull-requests-limit: 5
+    # Add labels for easy identification
+    labels:
+      - "dependencies"
+      - "github_actions"

--- a/.github/workflows/all_green_check.yml
+++ b/.github/workflows/all_green_check.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
           python-version: "3.14"
 
@@ -61,7 +61,7 @@ jobs:
           export COVERAGE_FILE
           echo "COVERAGE_FILE=$COVERAGE_FILE" >> $GITHUB_ENV
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage
           path: ${{ env.COVERAGE_FILE }}

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Retrieve pull request base ref
         id: retrieve-pr-info
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source collection (on issue comment)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           path: "${{ env.amazon_dir }}"
           fetch-depth: 0
@@ -56,14 +56,14 @@ jobs:
         if: ${{ github.event_name == 'issue_comment' }}
 
       - name: Checkout the source collection (on other triggering method)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           path: "${{ env.amazon_dir }}"
           fetch-depth: 0
         if: ${{ github.event_name != 'issue_comment' }}
 
       - name: Checkout community.aws collection
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: ansible-collections/community.aws
           path: "${{ env.community_dir }}"
@@ -100,7 +100,7 @@ jobs:
     name: "${{ matrix.job-id }}"
     steps:
       - name: Checkout the source collection (on issue comment)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           path: "${{ env.amazon_dir }}"
           fetch-depth: 0
@@ -108,14 +108,14 @@ jobs:
         if: ${{ github.event_name == 'issue_comment' }}
 
       - name: Checkout the source collection (on other triggering method)
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           path: "${{ env.amazon_dir }}"
           fetch-depth: 0
         if: ${{ github.event_name != 'issue_comment' }}
 
       - name: Checkout community.aws collection
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           repository: ansible-collections/community.aws
           path: "${{ env.community_dir }}"

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,7 +37,7 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0


### PR DESCRIPTION
##### SUMMARY
Add Dependabot configuration to automatically monitor and update GitHub Actions dependencies. Pin all tag-based action references to commit SHAs for supply chain security.

- Add .github/dependabot.yml with weekly update schedule
- Pin actions/checkout@v4 to commit SHA
- Pin actions/checkout@v6 to commit SHA
- Pin actions/setup-python@v5 to commit SHA
- Pin actions/upload-artifact@v4 to commit SHA
- Pin actions/github-script@v7 to commit SHA
- Configure grouped updates to reduce PR noise

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME
GitHub Actions / Dependabot

##### ADDITIONAL INFORMATION
This change enhances supply chain security by pinning GitHub Actions to specific commit SHAs instead of mutable tags. Dependabot will automatically create PRs to update these pinned versions.

Assisted-by: Claude Sonnet 4.5