### PR TITLE
chore: bump python to 3.13 for milestone integration tests

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,7 +90,7 @@ jobs:
       all_targets: "${{ needs.splitter.outputs.targets }}"
       tarball_dir: "./tarballs"
       ansible_version: milestone
-      python_version: 3.12
+      python_version: 3.13
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
##### SUMMARY

Milestone releases track ansible-core devel which requires Python 3.13 or later.

##### ISSUE TYPE

- Test Pull Request

##### COMPONENT NAME

```
.github/workflows/integration.yml
```
