### PR TITLE
fix: add UUID validation to aws_sqs_queue EDA source plugin

### DIFF
--- a/changelogs/fragments/3034-aws_sqs_queue-uuid-validation.yml
+++ b/changelogs/fragments/3034-aws_sqs_queue-uuid-validation.yml
@@ -1,0 +1,4 @@
+bugfixes:
+  - aws_sqs_queue - Fix UUID generation in EDA event source plugin to set ``meta.uuid`` as a flat key readable by ansible-rulebook, validate the SQS ``MessageId`` as a proper RFC 4122 UUID, and fall back to a deterministic UUID5 when invalid (https://github.com/ansible-collections/amazon.aws/pull/3034).
+trivial:
+  - aws_sqs_queue - Add unit tests for UUID validation, valid UUID passthrough, and invalid UUID fallback behaviour in the EDA event source plugin (https://github.com/ansible-collections/amazon.aws/pull/3034).

--- a/extensions/eda/plugins/event_source/aws_sqs_queue.py
+++ b/extensions/eda/plugins/event_source/aws_sqs_queue.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import logging
+import uuid
 from typing import Any
 from typing import TypedDict
 
@@ -15,6 +16,10 @@ description:
   - >
     This supports all the authentication methods supported by boto3 library:
     U(https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html).
+  - Each event is assigned a valid RFC 4122 UUID under meta.uuid.
+  - The SQS MessageId is used directly if it is a valid UUID (AWS guarantees this).
+  - If the MessageId is not a valid UUID, a deterministic UUID5 is generated from the
+    MessageId value. The original value remains accessible under meta.MessageId.
 options:
   access_key:
     description:
@@ -100,6 +105,39 @@ EXAMPLES = r"""
 
 
 DEFAULT_FEEDBACK_TIMEOUT = 120
+
+_uuid_warning = {"emitted": False}
+
+
+def is_valid_uuid(value: str) -> bool:
+    """Check if a string is a valid RFC 4122 UUID."""
+    try:
+        uuid.UUID(value)
+        return True  # noqa: TRY300
+    except (ValueError, AttributeError):
+        return False
+
+
+def _process_sqs_uuid(message_id: str, meta: dict[str, Any]) -> None:
+    """Assign a valid UUID to meta["uuid"].
+
+    Uses the SQS MessageId directly if it is a valid UUID (AWS guarantees this).
+    If not, generates a deterministic UUID5 from the MessageId string and
+    preserves the original under meta["message_id"] for tracking.
+    """
+    logger = logging.getLogger()
+
+    if is_valid_uuid(message_id):
+        meta["uuid"] = message_id
+    else:
+        meta["uuid"] = str(uuid.uuid5(uuid.NAMESPACE_OID, message_id))
+        if not _uuid_warning["emitted"]:
+            _uuid_warning["emitted"] = True
+            logger.warning(
+                "Provided MessageId is not a valid UUID,"
+                " using generated UUID. The original value is preserved"
+                " under event.meta.MessageId for tracking.",
+            )
 
 
 class DeleteMessageBatchRequestEntryTypeDef(TypedDict):
@@ -281,10 +319,10 @@ async def _process_message(
         ReceiptHandle=entry["ReceiptHandle"],
     )
 
-    meta = {
+    meta: dict[str, Any] = {
         "MessageId": entry["MessageId"],
-        "event": {"uuid": entry["MessageId"]},
     }
+    _process_sqs_uuid(entry["MessageId"], meta)
 
     msg_body = _parse_message_body(entry)
 

--- a/tests/unit/event_source/test_aws_sqs_queue.py
+++ b/tests/unit/event_source/test_aws_sqs_queue.py
@@ -1,4 +1,5 @@
 import asyncio
+import uuid
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -8,8 +9,19 @@ from asyncmock import AsyncMock
 pytest.importorskip("aiobotocore")
 
 from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue import _delete_messages
+from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue import _uuid_warning
 from ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue import main as sqs_main
 from ansible_collections.amazon.aws.tests.unit.utils.event import ListQueue
+
+VALID_UUID = "5fea7756-0ea4-451a-a703-a558b933e274"
+PATCH_SESSION = "ansible_collections.amazon.aws.extensions.eda.plugins.event_source.aws_sqs_queue.get_session"
+
+
+@pytest.fixture(autouse=True)
+def reset_uuid_warning():
+    _uuid_warning["emitted"] = False
+    yield
+    _uuid_warning["emitted"] = False
 
 
 @pytest.mark.asyncio
@@ -68,11 +80,17 @@ async def test_receive_from_sqs(eda_queue: ListQueue) -> None:
             )
         assert eda_queue.queue[0] == {
             "body": "Hello World",
-            "meta": {"MessageId": "1", "event": {"uuid": "1"}},
+            "meta": {
+                "MessageId": "1",
+                "uuid": str(uuid.uuid5(uuid.NAMESPACE_OID, "1")),
+            },
         }
         assert eda_queue.queue[1] == {
             "body": {"Say": "Hello World"},
-            "meta": {"MessageId": "2", "event": {"uuid": "2"}},
+            "meta": {
+                "MessageId": "2",
+                "uuid": str(uuid.uuid5(uuid.NAMESPACE_OID, "2")),
+            },
         }
         assert len(eda_queue.queue) == 2
 
@@ -327,6 +345,7 @@ async def test_unicode_error_handling(eda_queue: ListQueue) -> None:
         assert len(eda_queue.queue) == 1
         assert eda_queue.queue[0]["body"] is None
         assert eda_queue.queue[0]["meta"]["MessageId"] == "1"
+        assert "uuid" in eda_queue.queue[0]["meta"]
 
 
 @pytest.mark.asyncio
@@ -382,3 +401,68 @@ async def test_delete_failure_in_feedback_mode(eda_queue: ListQueue) -> None:
 
         # Verify the message was put in the queue
         assert len(eda_queue.queue) == 1
+
+
+@pytest.mark.asyncio
+async def test_valid_uuid_message_id(eda_queue: ListQueue) -> None:
+    """Valid UUID MessageId is used directly as meta.uuid; no meta.message_id added."""
+    session = AsyncMock()
+    with patch(PATCH_SESSION, return_value=session):
+        client = AsyncMock()
+        client.get_queue_url.return_value = {"QueueUrl": "sqs_url"}
+
+        message = {
+            "MessageId": VALID_UUID,
+            "Body": '{"data": "test"}',
+            "ReceiptHandle": "handle1",
+        }
+        response = {"Messages": [message]}
+        delete_response = {"Successful": [{"Id": VALID_UUID, "ReceiptHandle": "handle1"}]}
+
+        client.receive_message = AsyncMock(side_effect=[response, ValueError()])
+        client.delete_message_batch = AsyncMock(return_value=delete_response)
+        session.create_client.return_value = client
+        session.create_client.not_async = True
+
+        with pytest.raises(ValueError):
+            await sqs_main(
+                eda_queue,
+                {"region": "us-east-1", "name": "eda", "delay_seconds": 1},
+            )
+
+        assert len(eda_queue.queue) == 1
+        assert eda_queue.queue[0]["meta"]["uuid"] == VALID_UUID
+        assert eda_queue.queue[0]["meta"]["MessageId"] == VALID_UUID
+
+
+@pytest.mark.asyncio
+async def test_invalid_uuid_message_id_falls_back(eda_queue: ListQueue) -> None:
+    """Non-UUID MessageId falls back to UUID5; original preserved in meta.message_id."""
+    session = AsyncMock()
+    with patch(PATCH_SESSION, return_value=session):
+        client = AsyncMock()
+        client.get_queue_url.return_value = {"QueueUrl": "sqs_url"}
+
+        message = {
+            "MessageId": "not-a-valid-uuid",
+            "Body": '{"data": "test"}',
+            "ReceiptHandle": "handle1",
+        }
+        response = {"Messages": [message]}
+        delete_response = {"Successful": [{"Id": "not-a-valid-uuid", "ReceiptHandle": "handle1"}]}
+
+        client.receive_message = AsyncMock(side_effect=[response, ValueError()])
+        client.delete_message_batch = AsyncMock(return_value=delete_response)
+        session.create_client.return_value = client
+        session.create_client.not_async = True
+
+        with pytest.raises(ValueError):
+            await sqs_main(
+                eda_queue,
+                {"region": "us-east-1", "name": "eda", "delay_seconds": 1},
+            )
+
+        assert len(eda_queue.queue) == 1
+        expected_uuid = str(uuid.uuid5(uuid.NAMESPACE_OID, "not-a-valid-uuid"))
+        assert eda_queue.queue[0]["meta"]["uuid"] == expected_uuid
+        assert eda_queue.queue[0]["meta"]["MessageId"] == "not-a-valid-uuid"


### PR DESCRIPTION
The plugin was writing to meta["event"]["uuid"], which is a nested sub-dict that ansible-rulebook's insert_meta_info filter never reads, causing every event to receive a random UUID4 and eda-server validation failures when the SQS MessageId was not a valid RFC 4122 UUID.

Fixes:
- Set meta["uuid"] (flat) to match the schema expected by ansible-rulebook and eda-server
- Validate the SQS MessageId before use; fall back to a deterministic UUID5 when invalid (AWS guarantees MessageId is always a valid UUID in practice, so the fallback is defensive)
- Preserve the original MessageId under the existing meta["MessageId"] key; no additional key is added since the value is already present there
- Emit a one-time warning when an invalid MessageId triggers the fallback

Refs: AAP-77079

Assisted-by: Claude

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
EDA