### PR TITLE
Refactor for rds_cluster_info

### DIFF
--- a/changelogs/fragments/rds_cluster_info-refactor.yml
+++ b/changelogs/fragments/rds_cluster_info-refactor.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - rds_cluster_info - Refactored module to use shared ``describe_db_clusters`` from ``module_utils/rds.py`` and ``AnsibleRDSError`` for consistent error handling (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
-  - module_utils/rds - Added ``describe_db_clusters`` centralized wrapper with ``@RDSErrorHandler`` and ``@AWSRetry`` decorators (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - rds_cluster_info - Refactored module to use shared ``describe_db_clusters`` from ``module_utils/rds.py`` and ``AnsibleRDSError`` for consistent error handling (https://github.com/ansible-collections/amazon.aws/pull/3040).
+  - module_utils/rds - Added ``describe_db_clusters`` centralized wrapper with ``@RDSErrorHandler`` and ``@AWSRetry`` decorators (https://github.com/ansible-collections/amazon.aws/pull/3040).

--- a/changelogs/fragments/rds_cluster_info-refactor.yml
+++ b/changelogs/fragments/rds_cluster_info-refactor.yml
@@ -1,0 +1,3 @@
+minor_changes:
+  - rds_cluster_info - Refactored module to use shared ``describe_db_clusters`` from ``module_utils/rds.py`` and ``AnsibleRDSError`` for consistent error handling (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - module_utils/rds - Added ``describe_db_clusters`` centralized wrapper with ``@RDSErrorHandler`` and ``@AWSRetry`` decorators (https://github.com/ansible-collections/amazon.aws/pull/XXXX).

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -99,7 +99,13 @@ class RDSErrorHandler(AWSErrorHandler):
     @classmethod
     def _is_missing(cls):
         return is_boto3_error_code(
-            ["DBInstanceNotFound", "DBSnapshotNotFound", "DBClusterNotFound", "DBClusterSnapshotNotFoundFault"]
+            [
+                "DBInstanceNotFound",
+                "DBSnapshotNotFound",
+                "DBClusterNotFound",
+                "DBClusterNotFoundFault",
+                "DBClusterSnapshotNotFoundFault",
+            ]
         )
 
 
@@ -108,6 +114,13 @@ class RDSErrorHandler(AWSErrorHandler):
 def describe_db_cluster_snapshots(client, **params: Dict) -> List[Dict[str, Any]]:
     paginator = client.get_paginator("describe_db_cluster_snapshots")
     return paginator.paginate(**params).build_full_result()["DBClusterSnapshots"]
+
+
+@RDSErrorHandler.list_error_handler("describe db clusters", [])
+@AWSRetry.jittered_backoff()
+def describe_db_clusters(client, **params: Dict) -> List[Dict[str, Any]]:
+    paginator = client.get_paginator("describe_db_clusters")
+    return paginator.paginate(**params).build_full_result()["DBClusters"]
 
 
 @RDSErrorHandler.list_error_handler("describe db instances", [])
@@ -274,6 +287,7 @@ def handle_errors(module: AnsibleAWSModule, exception: Any, method_name: str, pa
     """
     if not isinstance(exception, ClientError):
         module.fail_json_aws(exception, msg=f"Unexpected failure for method {method_name} with parameters {parameters}")
+        return True
 
     changed = True
     error_code = exception.response["Error"]["Code"]

--- a/plugins/modules/rds_cluster_info.py
+++ b/plugins/modules/rds_cluster_info.py
@@ -245,48 +245,47 @@ clusters:
 """
 
 
-try:
-    import botocore
-except ImportError:
-    pass  # handled by AnsibleAWSModule
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Union
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
+from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_clusters
 from ansible_collections.amazon.aws.plugins.module_utils.rds import get_tags
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.transformation import ansible_dict_to_boto3_filter_list
 
 
-@AWSRetry.jittered_backoff(retries=10)
-def _describe_db_clusters(client, **params):
-    try:
-        paginator = client.get_paginator("describe_db_clusters")
-        return paginator.paginate(**params).build_full_result()["DBClusters"]
-    except is_boto3_error_code("DBClusterNotFoundFault"):
-        return []
+def cluster_info(
+    client, module: AnsibleAWSModule, cluster_id: Optional[str], filters: Optional[Dict[str, Union[str, List]]]
+) -> List[Dict[str, Any]]:
+    """Returns attributes of DB cluster(s), optionally filtered by ID and filters.
 
+    Parameters:
+        client: boto3 rds client
+        module: AnsibleAWSModule
+        cluster_id: Unique identifier of DB cluster to describe
+        filters: Additional boto3-supported filters
 
-def cluster_info(client, module):
-    cluster_id = module.params.get("db_cluster_identifier")
-    filters = module.params.get("filters")
-
-    params = dict()
+    Returns:
+        List of cluster attribute dicts in snake_case format
+    """
+    params = {}
     if cluster_id:
         params["DBClusterIdentifier"] = cluster_id
     if filters:
         params["Filters"] = ansible_dict_to_boto3_filter_list(filters)
 
-    try:
-        result = _describe_db_clusters(client, **params)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, "Couldn't get RDS cluster information.")
+    results = describe_db_clusters(client, **params)
 
-    for cluster in result:
+    for cluster in results:
         cluster["Tags"] = get_tags(client, module, cluster["DBClusterArn"])
 
-    return dict(changed=False, clusters=[camel_dict_to_snake_dict(cluster, ignore_list=["Tags"]) for cluster in result])
+    return [camel_dict_to_snake_dict(cluster, ignore_list=["Tags"]) for cluster in results]
 
 
 def main():
@@ -300,12 +299,15 @@ def main():
         supports_check_mode=True,
     )
 
-    try:
-        client = module.client("rds", retry_decorator=AWSRetry.jittered_backoff(retries=10))
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to connect to AWS.")
+    client = module.client("rds")
 
-    module.exit_json(**cluster_info(client, module))
+    cluster_id = module.params.get("db_cluster_identifier")
+    filters = module.params.get("filters")
+
+    try:
+        module.exit_json(changed=False, clusters=cluster_info(client, module, cluster_id, filters))
+    except AnsibleRDSError as e:
+        module.fail_json_aws(e)
 
 
 if __name__ == "__main__":

--- a/plugins/modules/rds_cluster_info.py
+++ b/plugins/modules/rds_cluster_info.py
@@ -307,7 +307,7 @@ def main():
     try:
         module.exit_json(changed=False, clusters=cluster_info(client, module, cluster_id, filters))
     except AnsibleRDSError as e:
-        module.fail_json_aws(e)
+        module.fail_json_aws(e, msg="Could not get RDS cluster information.")
 
 
 if __name__ == "__main__":

--- a/tests/unit/plugins/module_utils/test_rds.py
+++ b/tests/unit/plugins/module_utils/test_rds.py
@@ -945,3 +945,44 @@ class TestRdsUtils:
         roles_to_add, roles_to_delete = rds.compare_iam_roles(existing_list, self.target_role_list, purge_roles=True)
         assert self.target_role_list == roles_to_add
         assert existing_list == roles_to_delete
+
+
+class TestDescribeDbClusters:
+    def test_describe_db_clusters_returns_list(self):
+        client = MagicMock()
+        paginator = MagicMock()
+        client.get_paginator.return_value = paginator
+        paginator.paginate.return_value.build_full_result.return_value = {
+            "DBClusters": [
+                {"DBClusterIdentifier": "cluster-1"},
+                {"DBClusterIdentifier": "cluster-2"},
+            ]
+        }
+
+        result = rds.describe_db_clusters(client, DBClusterIdentifier="cluster-1")
+
+        client.get_paginator.assert_called_with("describe_db_clusters")
+        paginator.paginate.assert_called_with(DBClusterIdentifier="cluster-1")
+        assert len(result) == 2
+        assert result[0]["DBClusterIdentifier"] == "cluster-1"
+
+    def test_describe_db_clusters_empty(self):
+        client = MagicMock()
+        paginator = MagicMock()
+        client.get_paginator.return_value = paginator
+        paginator.paginate.return_value.build_full_result.return_value = {"DBClusters": []}
+
+        result = rds.describe_db_clusters(client)
+
+        assert result == []
+
+    def test_describe_db_clusters_not_found_returns_empty(self):
+        client = MagicMock()
+        client.get_paginator.side_effect = botocore.exceptions.ClientError(
+            {"Error": {"Code": "DBClusterNotFoundFault", "Message": "not found"}},
+            "DescribeDBClusters",
+        )
+
+        result = rds.describe_db_clusters(client, DBClusterIdentifier="nonexistent")
+
+        assert result == []

--- a/tests/unit/plugins/modules/test_rds_cluster_info.py
+++ b/tests/unit/plugins/modules/test_rds_cluster_info.py
@@ -1,0 +1,112 @@
+# (c) 2026 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
+from ansible_collections.amazon.aws.plugins.modules import rds_cluster_info
+from ansible_collections.amazon.aws.plugins.modules.rds_cluster_info import cluster_info
+
+mod_name = "ansible_collections.amazon.aws.plugins.modules.rds_cluster_info"
+
+
+@patch(mod_name + ".get_tags")
+@patch(mod_name + ".describe_db_clusters")
+def test_cluster_info_one_cluster(m_describe_db_clusters, m_get_tags):
+    conn = MagicMock()
+    module = MagicMock()
+    cluster_id = "my-cluster"
+    m_describe_db_clusters.return_value = [
+        {
+            "DBClusterIdentifier": cluster_id,
+            "DBClusterArn": "arn:aws:rds:us-east-2:123456789012:cluster:" + cluster_id,
+            "Engine": "aurora-mysql",
+        }
+    ]
+    m_get_tags.return_value = {"Name": "my-cluster"}
+
+    result = cluster_info(conn, module, cluster_id, filters=None)
+
+    assert result == [
+        {
+            "db_cluster_identifier": cluster_id,
+            "db_cluster_arn": "arn:aws:rds:us-east-2:123456789012:cluster:" + cluster_id,
+            "engine": "aurora-mysql",
+            "tags": {"Name": "my-cluster"},
+        }
+    ]
+    m_describe_db_clusters.assert_called_with(conn, DBClusterIdentifier=cluster_id)
+    m_get_tags.assert_called_once_with(
+        conn, module, "arn:aws:rds:us-east-2:123456789012:cluster:" + cluster_id
+    )
+
+
+@patch(mod_name + ".get_tags")
+@patch(mod_name + ".describe_db_clusters")
+def test_cluster_info_all_clusters_with_filters(m_describe_db_clusters, m_get_tags):
+    conn = MagicMock()
+    module = MagicMock()
+    m_describe_db_clusters.return_value = [
+        {
+            "DBClusterIdentifier": "first-cluster",
+            "DBClusterArn": "arn:aws:rds:us-east-2:123456789012:cluster:first-cluster",
+            "Engine": "aurora-mysql",
+        },
+        {
+            "DBClusterIdentifier": "second-cluster",
+            "DBClusterArn": "arn:aws:rds:us-east-2:123456789012:cluster:second-cluster",
+            "Engine": "aurora-mysql",
+        },
+    ]
+    m_get_tags.return_value = {}
+
+    result = cluster_info(conn, module, cluster_id=None, filters={"engine": "aurora-mysql"})
+
+    assert len(result) == 2
+    assert result[0]["db_cluster_identifier"] == "first-cluster"
+    assert result[1]["db_cluster_identifier"] == "second-cluster"
+    m_describe_db_clusters.assert_called_with(
+        conn, Filters=[{"Name": "engine", "Values": ["aurora-mysql"]}]
+    )
+    assert m_get_tags.call_count == 2
+
+
+@patch(mod_name + ".get_tags")
+@patch(mod_name + ".describe_db_clusters")
+def test_cluster_info_no_results(m_describe_db_clusters, m_get_tags):
+    conn = MagicMock()
+    module = MagicMock()
+    m_describe_db_clusters.return_value = []
+
+    result = cluster_info(conn, module, cluster_id="nonexistent", filters=None)
+
+    assert result == []
+    m_get_tags.assert_not_called()
+
+
+@patch(mod_name + ".AnsibleAWSModule")
+def test_main_success(m_AnsibleAWSModule):
+    m_module = MagicMock()
+    m_AnsibleAWSModule.return_value = m_module
+
+    rds_cluster_info.main()
+
+    m_module.client.assert_called_with("rds")
+    m_module.exit_json.assert_called_with(changed=False, clusters=[])
+
+
+@patch(mod_name + ".describe_db_clusters")
+@patch(mod_name + ".AnsibleAWSModule")
+def test_main_failure(m_AnsibleAWSModule, m_describe_db_clusters):
+    m_module = MagicMock()
+    m_AnsibleAWSModule.return_value = m_module
+    e = AnsibleRDSError()
+    m_describe_db_clusters.side_effect = e
+
+    rds_cluster_info.main()
+
+    m_module.client.assert_called_with("rds")
+    m_module.fail_json_aws.assert_called_with(e)

--- a/tests/unit/plugins/modules/test_rds_cluster_info.py
+++ b/tests/unit/plugins/modules/test_rds_cluster_info.py
@@ -87,14 +87,20 @@ def test_cluster_info_no_results(m_describe_db_clusters, m_get_tags):
     m_get_tags.assert_not_called()
 
 
+@patch(mod_name + ".get_tags")
+@patch(mod_name + ".describe_db_clusters")
 @patch(mod_name + ".AnsibleAWSModule")
-def test_main_success(m_AnsibleAWSModule):
+def test_main_success(m_AnsibleAWSModule, m_describe_db_clusters, m_get_tags):
     m_module = MagicMock()
     m_AnsibleAWSModule.return_value = m_module
+    m_module.params.get.return_value = None
+    m_describe_db_clusters.return_value = []
 
     rds_cluster_info.main()
 
     m_module.client.assert_called_with("rds")
+    m_describe_db_clusters.assert_called_once()
+    m_get_tags.assert_not_called()
     m_module.exit_json.assert_called_with(changed=False, clusters=[])
 
 
@@ -109,4 +115,4 @@ def test_main_failure(m_AnsibleAWSModule, m_describe_db_clusters):
     rds_cluster_info.main()
 
     m_module.client.assert_called_with("rds")
-    m_module.fail_json_aws.assert_called_with(e)
+    m_module.fail_json_aws.assert_called_with(e, msg="Could not get RDS cluster information.")


### PR DESCRIPTION
##### SUMMARY

This work is largely based on the work done in https://github.com/ansible-collections/amazon.aws/pull/3033 and https://github.com/ansible-collections/amazon.aws/pull/2782. It was written to address ACA-2472.


Adds centralized describe_db_clusters() to module_utils/rds.py with @RDSErrorHandler and @AWSRetry decorators, matching  the existing pattern for describe_db_instances, describe_db_snapshots, and describe_db_cluster_snapshots:

- Refactor rds_cluster_info to use the shared describe_db_clusters and AnsibleRDSError, matching the rds_instance_info pattern
- Add DBClusterNotFoundFault to RDSErrorHandler._is_missing() so the error handler covers the actual AWS error code used by DescribeDBClusters
- Add defensive return True after fail_json_aws in handle_errors for the non-ClientError path (from PR #3033 review feedback)

What was removed from rds_cluster_info

- Local _describe_db_clusters function (duplicated across 3 files)
- try: import botocore and raw botocore.exceptions handling
- is_boto3_error_code import
- Double retry wrapping (was on both the client and the local function)
- Unnecessary try/except around module.client("rds")

What was added

- Type hints and docstring on cluster_info()
- AnsibleRDSError error handling in main() (matching rds_instance_info)
- Unit tests for rds_cluster_info (5 tests) and describe_db_clusters (3 tests)

Co-Authored-By: Claude Opus 4.6

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME
rds_cluster_info

##### ADDITIONAL INFORMATION

Assisted-by: Claude Opus 4.6
