### PR TITLE
ci(docs-pr): bump pin to latest main

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     name: Validate Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-28
     with:
       init-lenient: false
       init-fail-on-error: true
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: read
     name: Build Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-28
     with:
       init-lenient: true
       init-fail-on-error: false
@@ -46,7 +46,7 @@ jobs:
     name: PR comments
     steps:
       - name: PR comment
-        uses: ansible-community/github-docs-build/actions/ansible-docs-build-comment@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-comment@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-28
         with:
           body-includes: "## Docs Build"
           reactions: heart


### PR DESCRIPTION
##### SUMMARY

This change bumps the pin for the github-docs-build repo to main: https://github.com/ansible-community/github-docs-build/commits/main/

`actions/checkout` no longer checks out fork PR with `pull_request_target` without `allow-unsafe-pr-checkout: true`. This bump picks up that change.

##### ISSUE TYPE

- Bugfix Pull Request