### PR TITLE
ci: complete Dependabot updates and add security hardening

### DIFF
--- a/.github/workflows/all_green_check.yml
+++ b/.github/workflows/all_green_check.yml
@@ -30,7 +30,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   changelog-labeller:
-    uses: ansible-network/github_actions/.github/workflows/backport-labeller.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25
+    uses: ansible-network/github_actions/.github/workflows/backport-labeller.yml@4678c7401d0247aee67c880ddf21bf6fcf1aacc3 # @main as of 2026-07-31
     with:
       label_minor_release: backport-11
       label_bugfix_release: backport-10

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,4 +19,4 @@ on:
       - "*"
 jobs:
   changelog:
-    uses: ansible-network/github_actions/.github/workflows/changelog.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25
+    uses: ansible-network/github_actions/.github/workflows/changelog.yml@4678c7401d0247aee67c880ddf21bf6fcf1aacc3 # @main as of 2026-07-31

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     name: Validate Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-28
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-21
     with:
       init-lenient: false
       init-fail-on-error: true
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: read
     name: Build Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-28
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-21
     with:
       init-lenient: true
       init-fail-on-error: false
@@ -46,7 +46,7 @@ jobs:
     name: PR comments
     steps:
       - name: PR comment
-        uses: ansible-community/github-docs-build/actions/ansible-docs-build-comment@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-28
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-comment@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-21
         with:
           body-includes: "## Docs Build"
           reactions: heart

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     name: Build Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-21
     with:
       init-lenient: false
       init-fail-on-error: true
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     needs: [build-docs]
     name: Publish Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-gh-pages.yml@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-gh-pages.yml@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-21
     with:
       artifact-name: ${{ needs.build-docs.outputs.artifact-name }}
       publish-gh-pages-branch: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -48,27 +48,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source collection (on issue comment)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: "${{ env.amazon_dir }}"
           fetch-depth: 0
           ref: ${{ needs.retrieve-pr-info.outputs.head_ref }}
+          persist-credentials: false
         if: ${{ github.event_name == 'issue_comment' }}
 
       - name: Checkout the source collection (on other triggering method)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: "${{ env.amazon_dir }}"
           fetch-depth: 0
+          persist-credentials: false
         if: ${{ github.event_name != 'issue_comment' }}
 
       - name: Checkout community.aws collection
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ansible-collections/community.aws
           path: "${{ env.community_dir }}"
           fetch-depth: 0
           ref: ${{ needs.retrieve-pr-info.outputs.base_ref }}
+          persist-credentials: false
 
       - name: list changes for pull request
         id: compute
@@ -100,27 +103,30 @@ jobs:
     name: "${{ matrix.job-id }}"
     steps:
       - name: Checkout the source collection (on issue comment)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: "${{ env.amazon_dir }}"
           fetch-depth: 0
           ref: ${{ needs.retrieve-pr-info.outputs.head_ref }}
+          persist-credentials: false
         if: ${{ github.event_name == 'issue_comment' }}
 
       - name: Checkout the source collection (on other triggering method)
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: "${{ env.amazon_dir }}"
           fetch-depth: 0
+          persist-credentials: false
         if: ${{ github.event_name != 'issue_comment' }}
 
       - name: Checkout community.aws collection
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ansible-collections/community.aws
           path: "${{ env.community_dir }}"
           fetch-depth: 0
           ref: ${{ needs.retrieve-pr-info.outputs.base_ref }}
+          persist-credentials: false
 
       - name: Read job targets
         id: read-targets

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -5,7 +5,7 @@ on: [workflow_call] # allow this workflow to be called from other workflows
 
 jobs:
   linters:
-    uses: ansible-network/github_actions/.github/workflows/tox.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25
+    uses: ansible-network/github_actions/.github/workflows/tox.yml@4678c7401d0247aee67c880ddf21bf6fcf1aacc3 # @main as of 2026-07-31
     with:
       envname: ""
       labelname: lint

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,11 +37,12 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           show-progress: false
+          persist-credentials: false
 
       - name: Download coverage artifacts
         uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151  # v21
@@ -89,8 +90,7 @@ jobs:
           echo "SONAR_ARGS=${SONAR_ARGS}" >> $GITHUB_ENV
 
       - name: SonarCloud Scan
-        # a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 (v7)
-        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}
         with:

--- a/.github/workflows/update-variables.yml
+++ b/.github/workflows/update-variables.yml
@@ -13,4 +13,4 @@ on:
   pull_request_target:
 jobs:
   update-variables:
-    uses: ansible-network/github_actions/.github/workflows/update_aws_variables.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25
+    uses: ansible-network/github_actions/.github/workflows/update_aws_variables.yml@4678c7401d0247aee67c880ddf21bf6fcf1aacc3 # @main as of 2026-07-31


### PR DESCRIPTION
##### SUMMARY

Complete the incomplete Dependabot update from #3048 where version comment tags were not updated to match the new pinned commit SHAs. Additionally, update reusable workflow references to their latest commits and add `persist-credentials: false` to all checkout steps for security hardening.

##### ISSUE TYPE
- Refactoring Pull Request

##### COMPONENT NAME
GitHub Actions workflows

##### ADDITIONAL INFORMATION

**Changes:**
- Fixed version comments for `actions/checkout` (v4/v6 → v7.0.1)
- Fixed version comment for `SonarSource/sonarqube-scan-action` (v7 → v8.2.1)
- Updated `ansible-network/github_actions` workflows to 4678c74 (2026-07-31)
  - Includes security hardening for pwn request vulnerabilities
- Updated `ansible-community/github-docs-build` workflows to d69f901 (2026-07-21)
  - Includes checkout v7 and safety improvements
- Added `persist-credentials: false` to all `actions/checkout` steps to prevent credential leakage

**Background:**
Dependabot correctly updated the pinned commit SHAs in #3048 but failed to update the accompanying version comment tags. This left misleading comments like `# v4` and `# v6` even though the SHAs pointed to v7.0.1.

**Files modified:** 9 workflow files
**Lines changed:** +27, -19

Assisted-by: Claude Sonnet 4.5