### PR TITLE
ci: complete Dependabot updates and add security hardening 

### DIFF
--- a/.github/workflows/all_green_check.yml
+++ b/.github/workflows/all_green_check.yml
@@ -30,10 +30,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
 
@@ -61,7 +63,7 @@ jobs:
           export COVERAGE_FILE
           echo "COVERAGE_FILE=$COVERAGE_FILE" >> $GITHUB_ENV
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage
           path: ${{ env.COVERAGE_FILE }}

--- a/.github/workflows/ansible-test.yml
+++ b/.github/workflows/ansible-test.yml
@@ -53,7 +53,7 @@ jobs:
             python-version: "3.14"
     steps:
       - name: Perform sanity testing
-        uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e # v1.17.0
+        uses: ansible-community/ansible-test-gh-action@6ded727edb598e670ac056a8e680ca4050bac0a3 # v1.18.0
         with:
           ansible-core-version: ${{ matrix.ansible-core-version }}
           testing-type: sanity
@@ -113,7 +113,7 @@ jobs:
             python-version: "3.14"
     steps:
       - name: Perform unit testing
-        uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e # v1.17.0
+        uses: ansible-community/ansible-test-gh-action@6ded727edb598e670ac056a8e680ca4050bac0a3 # v1.18.0
         with:
           ansible-core-version: ${{ matrix.ansible-core-version }}
           testing-type: units

--- a/.github/workflows/backports.yml
+++ b/.github/workflows/backports.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   changelog-labeller:
-    uses: ansible-network/github_actions/.github/workflows/backport-labeller.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25
+    uses: ansible-network/github_actions/.github/workflows/backport-labeller.yml@4678c7401d0247aee67c880ddf21bf6fcf1aacc3 # @main as of 2026-07-31
     with:
       label_minor_release: backport-10
       label_bugfix_release: backport-9

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -19,4 +19,4 @@ on:
       - "*"
 jobs:
   changelog:
-    uses: ansible-network/github_actions/.github/workflows/changelog.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25
+    uses: ansible-network/github_actions/.github/workflows/changelog.yml@4678c7401d0247aee67c880ddf21bf6fcf1aacc3 # @main as of 2026-07-31

--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       contents: read
     name: Validate Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-21
     with:
       init-lenient: false
       init-fail-on-error: true
@@ -29,7 +29,7 @@ jobs:
     permissions:
       contents: read
     name: Build Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-pr.yml@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-21
     with:
       init-lenient: true
       init-fail-on-error: false
@@ -46,7 +46,7 @@ jobs:
     name: PR comments
     steps:
       - name: PR comment
-        uses: ansible-community/github-docs-build/actions/ansible-docs-build-comment@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
+        uses: ansible-community/github-docs-build/actions/ansible-docs-build-comment@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-21
         with:
           body-includes: "## Docs Build"
           reactions: heart

--- a/.github/workflows/docs-push.yml
+++ b/.github/workflows/docs-push.yml
@@ -18,7 +18,7 @@ jobs:
     permissions:
       contents: read
     name: Build Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-push.yml@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-21
     with:
       init-lenient: false
       init-fail-on-error: true
@@ -36,7 +36,7 @@ jobs:
       id-token: write
     needs: [build-docs]
     name: Publish Ansible Docs
-    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-gh-pages.yml@ea28abedf20b2db685a934b54d9833b9da24fe37 # @main as of 2026-03-25
+    uses: ansible-community/github-docs-build/.github/workflows/_shared-docs-build-publish-gh-pages.yml@d69f901cce9fdaef22209a45db4787ce9c6d869b # @main as of 2026-07-21
     with:
       artifact-name: ${{ needs.build-docs.outputs.artifact-name }}
       publish-gh-pages-branch: true

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Retrieve pull request base ref
         id: retrieve-pr-info
-        uses: actions/github-script@v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const pr = await github.rest.pulls.get({
@@ -48,31 +48,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the source collection (on issue comment)
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: "${{ env.amazon_dir }}"
           fetch-depth: 0
           ref: ${{ needs.retrieve-pr-info.outputs.head_ref }}
+          persist-credentials: false
         if: ${{ github.event_name == 'issue_comment' }}
 
       - name: Checkout the source collection (on other triggering method)
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: "${{ env.amazon_dir }}"
           fetch-depth: 0
+          persist-credentials: false
         if: ${{ github.event_name != 'issue_comment' }}
 
       - name: Checkout community.aws collection
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ansible-collections/community.aws
           path: "${{ env.community_dir }}"
           fetch-depth: 0
           ref: ${{ needs.retrieve-pr-info.outputs.base_ref }}
+          persist-credentials: false
 
       - name: list changes for pull request
         id: compute
-        uses: ansible/cloud-content-ci-automation/.github/actions/ansible_test_splitter@0b891487c4170ef856f02313c66cb1c776814c42
+        uses: ansible/cloud-content-ci-automation/.github/actions/ansible_test_splitter@6659b608aab58bf1d20641b805eb9cb4fd2b771f
         with:
           collections_to_test: "${{ env.amazon_dir}}, ${{ env.community_dir }}"
           total_jobs: 24
@@ -80,7 +83,7 @@ jobs:
 
   run-tests:
     needs:
-      - retrieve-pr-info 
+      - retrieve-pr-info
       - splitter
     permissions:
       pull-requests: read
@@ -89,41 +92,45 @@ jobs:
       community_dir: "./community_aws"
       all_targets: "${{ needs.splitter.outputs.targets }}"
       tarball_dir: "./tarballs"
-      ansible_version: milestone
+      ansible_version: stable-2.18
       python_version: 3.12
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
+      max-parallel: 8
       matrix:
         job-id: ${{ fromJson(needs.splitter.outputs.jobs) }}
     name: "${{ matrix.job-id }}"
     steps:
       - name: Checkout the source collection (on issue comment)
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: "${{ env.amazon_dir }}"
           fetch-depth: 0
           ref: ${{ needs.retrieve-pr-info.outputs.head_ref }}
+          persist-credentials: false
         if: ${{ github.event_name == 'issue_comment' }}
 
       - name: Checkout the source collection (on other triggering method)
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           path: "${{ env.amazon_dir }}"
           fetch-depth: 0
+          persist-credentials: false
         if: ${{ github.event_name != 'issue_comment' }}
 
       - name: Checkout community.aws collection
-        uses: actions/checkout@v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           repository: ansible-collections/community.aws
           path: "${{ env.community_dir }}"
           fetch-depth: 0
           ref: ${{ needs.retrieve-pr-info.outputs.base_ref }}
+          persist-credentials: false
 
       - name: Read job targets
         id: read-targets
-        uses: ansible/cloud-content-ci-automation/.github/actions/ansible_read_targets@0b891487c4170ef856f02313c66cb1c776814c42
+        uses: ansible/cloud-content-ci-automation/.github/actions/ansible_read_targets@6659b608aab58bf1d20641b805eb9cb4fd2b771f
         with:
           job_id: "${{ matrix.job-id }}"
           all_targets: "${{ env.all_targets }}"
@@ -142,7 +149,7 @@ jobs:
       - uses: ansible/ansible-test-auth@008750a5bf07124c3ab86d30d73d7319d7518f36
 
       - name: Run integration tests
-        uses: ansible-community/ansible-test-gh-action@d3a8ec7a59694e25e210fcd44738910149537f0e
+        uses: ansible-community/ansible-test-gh-action@6ded727edb598e670ac056a8e680ca4050bac0a3
         with:
           ansible-core-version: ${{ env.ansible_version }}
           origin-python-version: ${{ env.python_version }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -5,7 +5,7 @@ on: [workflow_call] # allow this workflow to be called from other workflows
 
 jobs:
   linters:
-    uses: ansible-network/github_actions/.github/workflows/tox.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25
+    uses: ansible-network/github_actions/.github/workflows/tox.yml@4678c7401d0247aee67c880ddf21bf6fcf1aacc3 # @main as of 2026-07-31
     with:
       envname: ""
       labelname: lint

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -37,14 +37,15 @@ jobs:
     if: github.event.workflow_run.conclusion == 'success'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
           show-progress: false
+          persist-credentials: false
 
       - name: Download coverage artifacts
-        uses: dawidd6/action-download-artifact@2536c51d3d126276eb39f74d6bc9c72ac6ef30d3  # v16
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151  # v21
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           workflow: all_green
@@ -89,8 +90,7 @@ jobs:
           echo "SONAR_ARGS=${SONAR_ARGS}" >> $GITHUB_ENV
 
       - name: SonarCloud Scan
-        # a31c9398be7ace6bbfaf30c0bd5d415f843d45e9 (v7)
-        uses: SonarSource/sonarqube-scan-action@a31c9398be7ace6bbfaf30c0bd5d415f843d45e9
+        uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
         env:
           SONAR_TOKEN: ${{ secrets.ANSIBLE_COLLECTIONS_ORG_SONAR_TOKEN_CICD_BOT }}
         with:

--- a/.github/workflows/update-variables.yml
+++ b/.github/workflows/update-variables.yml
@@ -13,4 +13,4 @@ on:
   pull_request_target:
 jobs:
   update-variables:
-    uses: ansible-network/github_actions/.github/workflows/update_aws_variables.yml@446d4586bcde8bf6e1a9c085983bf172b59bd7b2 # @main as of 2026-03-25
+    uses: ansible-network/github_actions/.github/workflows/update_aws_variables.yml@4678c7401d0247aee67c880ddf21bf6fcf1aacc3 # @main as of 2026-07-31


### PR DESCRIPTION
##### SUMMARY
Backport of PRs #3048 and #3049 from main to stable-10.

Complete the Dependabot update cycle started in #3029/#3047 by updating all GitHub Actions to their latest versions and adding security hardening with persist-credentials: false.

##### ISSUE TYPE
Refactoring Pull Request

##### COMPONENT NAME
GitHub Actions / CI Workflows

##### ADDITIONAL INFORMATION

**Changes:**
- actions/checkout: v4/v6 → v7.0.1
- actions/setup-python: v5 → v7.0.0
- actions/upload-artifact: v4 → v7.0.1
- actions/github-script: v7 → v9.0.0
- ansible-test-gh-action: v1.17.0 → v1.18.0
- dawidd6/action-download-artifact: v16 → v21
- SonarSource/sonarqube-scan-action: unversioned → v8.2.1
- ansible-network/github_actions workflows: 446d458 → 4678c74 (2026-07-31)
- ansible-community/github-docs-build: ea28abe → d69f901 (2026-07-21)

**Security improvements:**
- Add persist-credentials: false to all checkout actions to prevent credential leakage

**Integration workflow adjustments:**
- Lock ansible_version to stable-2.18 to prevent breaking changes in newer ansible-core versions from blocking stable-10 backports
- Use Python 3.12 (stable version for stable-10 compatibility)

Assisted-by: Claude Sonnet 4.5