### PR TITLE
ci(integration.yml): add strip to pre-test-cmd scalar

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -164,5 +164,5 @@ jobs:
             community.crypto
             ansible.windows
             ${{ steps.set-path.outputs.collection_dep }}
-          pre-test-cmd: |
+          pre-test-cmd: >-
             python3 -m pip install -r tests/integration/requirements.txt -r tests/integration/constraints.txt

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -164,5 +164,5 @@ jobs:
             community.crypto
             ansible.windows
             ${{ steps.set-path.outputs.collection_dep }}
-          pre-test-cmd: >-
+          pre-test-cmd: |-
             python3 -m pip install -r tests/integration/requirements.txt -r tests/integration/constraints.txt


### PR DESCRIPTION
## Summary

- Fix YAML block scalar (`|`) to block-strip scalar (`|-`) for the `pre-test-cmd` input passed to `ansible-test-gh-action` in the integration workflow
- The `|` scalar includes a trailing newline, which the action's `format('set -x; {0}; set +x', ...)` call embeds into the generated shell script, producing a bare `; set +x` on its own line — a bash syntax error that fails all integration jobs
- Also restores the missing trailing newline at end of file

### Root cause

`ansible-test-gh-action` wraps the `pre-test-cmd` value with `format('set -x; {0}; set +x', inputs.pre-test-cmd)`. When the input contains a trailing newline (from YAML `|`), the generated script becomes:

```bash
set -x; python3 -m pip install -r tests/integration/requirements.txt -r tests/integration/constraints.txt
; set +x
```

The bare `; set +x` is a bash syntax error (`syntax error near unexpected token ';'`).

### Fix

Changing `|` to `|-` strips the trailing newline while keeping the block scalar style — the minimal change from the original.

### Affected runs

All integration jobs fail with this error — example: https://github.com/ansible-collections/amazon.aws/actions/runs/30841816931/job/91780607096?pr=3053

## Test plan

- [x] Verify integration CI passes on this PR (the workflow change itself is exercised)
- [ ] Backport to stable-10 and stable-11

🤖 Generated with [Claude Code](https://claude.com/claude-code)