### PR TITLE
fix(aws_ssm): handle ValidationException when terminating disconnected sessions

### DIFF
--- a/changelogs/fragments/3044-aws-ssm-reboot-validation-exception.yml
+++ b/changelogs/fragments/3044-aws-ssm-reboot-validation-exception.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - aws_ssm connection plugin - fix hang on reboot by handling ValidationException when terminating already-disconnected sessions (https://github.com/ansible-collections/amazon.aws/issues/3044).

--- a/plugins/plugin_utils/ssm/sessionmanager.py
+++ b/plugins/plugin_utils/ssm/sessionmanager.py
@@ -27,6 +27,7 @@ if typing.TYPE_CHECKING:
 from ansible.errors import AnsibleConnectionFailure
 from ansible.module_utils.common.text.converters import to_text
 
+from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.plugin_utils.text import filter_ansi
 
 
@@ -405,11 +406,15 @@ class SSMSessionManager:
         )
 
     def terminate(self) -> None:
+        self.verbosity_display(2, f"TERMINATING SSM CONNECTION TO: {self.instance_id}")
+
         if self._process_mgr:
             self._process_mgr.terminate()
         if self._session_id and self._client:
             try:
                 self._client.terminate_session(SessionId=self._session_id)
+            except is_boto3_error_code("ValidationException") as e:
+                self.verbosity_display(3, f"TERMINATING SSM CONNECTION: ValidationException - {to_text(e)}")
             except ReferenceError:
                 # Client may have been garbage collected during cleanup
                 pass

--- a/tests/unit/plugins/connection/aws_ssm/test_ssm_session_manager.py
+++ b/tests/unit/plugins/connection/aws_ssm/test_ssm_session_manager.py
@@ -266,6 +266,43 @@ class TestSSMSessionManager:
         session._client.terminate_session.assert_called_once_with(SessionId=session_id)
         assert not session._session_id
 
+    def test_terminate_with_validation_exception(self):
+        """Test that ValidationException is caught when terminating already-disconnected session."""
+        from botocore.exceptions import ClientError
+
+        session = self.create_session_manager()
+        session_id = MagicMock()
+        session._session_id = session_id
+        session._process_mgr = MagicMock()
+
+        # Simulate AWS throwing ValidationException when session is already terminated
+        session._client.terminate_session.side_effect = ClientError(
+            {"Error": {"Code": "ValidationException", "Message": "Session is not connected"}},
+            "TerminateSession",
+        )
+
+        # Should not raise exception, just log and clear session_id
+        session.terminate()
+        session._process_mgr.terminate.assert_called_once()
+        session._client.terminate_session.assert_called_once_with(SessionId=session_id)
+        assert not session._session_id
+
+    def test_terminate_with_reference_error(self):
+        """Test that ReferenceError is caught when client has been garbage collected."""
+        session = self.create_session_manager()
+        session_id = MagicMock()
+        session._session_id = session_id
+        session._process_mgr = MagicMock()
+
+        # Simulate client being garbage collected during cleanup
+        session._client.terminate_session.side_effect = ReferenceError("weakly-referenced object no longer exists")
+
+        # Should not raise exception, just clear session_id
+        session.terminate()
+        session._process_mgr.terminate.assert_called_once()
+        session._client.terminate_session.assert_called_once_with(SessionId=session_id)
+        assert not session._session_id
+
     @pytest.mark.parametrize("parameters", [None, {"Session": "Parameters"}])
     @pytest.mark.parametrize("document_name", [True, False])
     @patch("json.dumps")


### PR DESCRIPTION
##### SUMMARY
AWS recently changed behaviour to throw ValidationException when attempting to terminate an already-disconnected SSM session (e.g., after a reboot). This caused the connection plugin to hang in a loop.

This PR catches ValidationException during session termination and logs it at verbosity level 3 instead of propagating the exception. Also adds test coverage for both ValidationException and ReferenceError exception handling.

Fixes https://github.com/ansible-collections/amazon.aws/issues/3044
Fixes https://github.com/ansible-collections/amazon.aws/issues/3045

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
aws_ssm connection plugin

##### ADDITIONAL INFORMATION
The fix properly uses the `is_boto3_error_code` context manager to catch ValidationException, which is the standard pattern used throughout the collection. Unit tests verify both ValidationException and ReferenceError are handled correctly.

Assisted-by: Claude Sonnet 4.5