### PR TITLE
[Manual Backport][Stable-10] ci(integration.yml): add strip to pre-test-cmd scalar

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -164,5 +164,5 @@ jobs:
             community.crypto
             ansible.windows
             ${{ steps.set-path.outputs.collection_dep }}
-          pre-test-cmd: |
+          pre-test-cmd: |-
             python3 -m pip install -r tests/integration/requirements.txt -r tests/integration/constraints.txt


### PR DESCRIPTION
## Summary

Manual backport of #3055 to `stable-10`.

- Fix YAML block scalar (`|`) to block-strip scalar (`|-`) for the `pre-test-cmd` input passed to `ansible-test-gh-action` in the integration workflow
- The `|` scalar includes a trailing newline, which the action's `format('set -x; {0}; set +x', ...)` call embeds into the generated shell script, producing a bare `; set +x` on its own line — a bash syntax error that fails all integration jobs

Cherry-picked from 1e3f0a828.