### PR TITLE
event_query: emit a non-null top-level name for every module

### DIFF
--- a/changelogs/fragments/event_query-top-level-name.yml
+++ b/changelogs/fragments/event_query-top-level-name.yml
@@ -1,0 +1,2 @@
+bugfixes:
+  - event_query.yml - add a non-null top-level ``name`` to every module's indirect-node audit query so records are never dropped. Previously 13 of 15 modules (all networking, storage, and database ``*_info`` queries) emitted only ``canonical_facts.name`` or no name at all; the controller's ``main_indirectmanagednodeaudit.name`` column is ``NOT NULL``, so those records raised an integrity error that aborted the whole job's ``bulk_create`` and silently discarded every indirect node counted by the job.

--- a/extensions/audit/README.md
+++ b/extensions/audit/README.md
@@ -81,6 +81,18 @@ The table below details how AWS resources are mapped to these canonical facts.
 | **Networking** | **VPC Peering Connection** | `ec2_vpc_peering_info` | `.vpc_peering_connection_id` → **id**<br>`.state.code` → **status**<br>`.tags` → **tags**|
 | **Networking** | **VPN Connection** | `ec2_vpc_vpn_info` | `.vpn_connection_id` → **id**<br>`.state` → **status**<br>`.tags` → **tags** |
 
+## Top-Level `name`
+
+In addition to the `canonical_facts` above, every emitted record carries a required, non-null top-level `name` — a human-readable label for the resource. This is mandatory: the controller stores each record in a column that is `NOT NULL`, so a record without a `name` is rejected.
+
+Each query derives `name` from the most descriptive field available and falls back to the resource's unique identifier, so a resource with no name or tags is still labelled rather than dropped. For example:
+
+- `ec2_instance_info`: `.name // .tags.Name // .instance_id`
+- `ec2_vpc_net_info`: `.name // .tags.Name // .id`
+- Tag-based networking resources (subnet, NAT/Internet/VPN gateway, route table, peering): `.tags.Name // .<resource>_id`
+
+As a last resort, `name` is set to `"UNKNOWN"` so the record is always emitted.
+
 ## Testing and Validation
 
 Reliability is ensured through integration testing. The **extensions/audit/event_query.yml** file is explicitly tested in this collection to verify that the node counting logic works as expected against the supported resources.

--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -4,7 +4,7 @@
 amazon.aws.ec2_instance_info:
   query: >-
     .instances[] | select(. != null) | {
-      name: (.name // .tags.Name // "UNKNOWN"),  # unique identifier for the resource
+      name: (.name // .tags.Name // .instance_id // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
       id: .instance_id,
       status: .state.name,
@@ -23,6 +23,7 @@ amazon.aws.elb_application_lb_info:
   query: >-
     .load_balancers[] | select(. != null) |
     {
+      name: (.load_balancer_name // .tags.Name // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         name: .load_balancer_name,
         status: .state.code,
@@ -39,6 +40,7 @@ amazon.aws.elb_classic_lb_info:
   query: >-
     .elbs[] | select(. != null) |
     {
+      name: (.load_balancer_name // .tags.Name // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         name: .load_balancer_name,
         tags: (.tags // {}),
@@ -53,7 +55,7 @@ amazon.aws.elb_classic_lb_info:
 amazon.aws.ec2_vpc_net_info:
   query: >-
     .vpcs[] | select(. != null) | {
-        name: (.name // .tags.Name // "UNKNOWN"),
+        name: (.name // .tags.Name // .id // "UNKNOWN"),
         canonical_facts: {
           id: .id,
           status: .state,
@@ -69,6 +71,7 @@ amazon.aws.ec2_vpc_net_info:
 amazon.aws.ec2_vpc_subnet_info:
   query: >-
     .subnets[] | select(. != null) | {
+      name: (.tags.Name // .id // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         id: .id,
         status: .state,
@@ -85,6 +88,7 @@ amazon.aws.ec2_vpc_nat_gateway_info:
   query: >-
     .result[] | select(. != null) |
     {
+      name: (.tags.Name // .nat_gateway_id // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         id: .nat_gateway_id,
         status: .state,
@@ -101,6 +105,7 @@ amazon.aws.ec2_vpc_igw_info:
   query: >-
     .internet_gateways[] | select(. != null) |
     {
+      name: (.tags.Name // .internet_gateway_id // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         id: .internet_gateway_id,
         status: (.attachments | map({vpc_id: .vpc_id, status: .state})),
@@ -117,6 +122,7 @@ amazon.aws.ec2_vpc_vgw_info:
   query: >-
     .virtual_gateways[] | select(. != null) |
     {
+      name: (.resource_tags.Name // .vpn_gateway_id // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         id: .vpn_gateway_id,
         status: .state,
@@ -133,6 +139,7 @@ amazon.aws.ec2_vpc_route_table_info:
   query: >-
     .route_tables[] | select(. != null) |
     {
+      name: (.tags.Name // .route_table_id // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         id: .route_table_id,
         tags: (.tags // {})
@@ -148,6 +155,7 @@ amazon.aws.ec2_vpc_vpn_info:
   query: >-
     .vpn_connections[] | select(. != null) |
     {
+      name: (.tags.Name // .vpn_connection_id // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         id: .vpn_connection_id,
         status: .state,
@@ -164,6 +172,7 @@ amazon.aws.ec2_vpc_peering_info:
   query: >-
     .vpc_peering_connections[] | select(. != null) |
     {
+      name: (.tags.Name // .vpc_peering_connection_id // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         id: .vpc_peering_connection_id,
         status: .status.code,
@@ -182,6 +191,7 @@ amazon.aws.s3_bucket_info:
   query: >-
     .buckets[] | select(. != null) |
     {
+      name: (.name // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         name: .name,
         tags: (.bucket_tagging // {})
@@ -197,6 +207,7 @@ amazon.aws.s3_object_info:
   query: >-
     .object_info[] | select(. != null) |
     {
+      name: (.object_name // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         name: .object_name,
         tags: (.object_tagging // {})
@@ -214,6 +225,7 @@ amazon.aws.rds_instance_info:
   query: >-
     .instances[] | select(. != null) |
     {
+      name: (.db_instance_identifier // .dbi_resource_id // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         id: .dbi_resource_id,  # AWS Region-unique, immutable identifier for the DB instance.
         name: .db_instance_identifier,  # The user-supplied DB cluster identifier.
@@ -232,6 +244,7 @@ amazon.aws.rds_cluster_info:
   query: >-
     .clusters[] | select(. != null) |
     {
+      name: (.db_cluster_identifier // .db_cluster_resource_id // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         id: .db_cluster_resource_id,  # The AWS Region-unique, immutable identifier for the DB cluster.
         name: .db_cluster_identifier,  # The user-supplied DB cluster identifier.

--- a/tests/integration/targets/node_query_database_cluster/play.yaml
+++ b/tests/integration/targets/node_query_database_cluster/play.yaml
@@ -63,8 +63,9 @@
             that:
               - node_count == expected_result  
           vars:
-            expected_result: 
-              - canonical_facts:
+            expected_result:
+              - name: "{{ resource_prefix }}-cluster-1"
+                canonical_facts:
                   id: "{{ cluster_1.db_cluster_resource_id }}"
                   name: "{{ resource_prefix }}-cluster-1"
                   status: "{{ cluster_1.status }}"
@@ -72,7 +73,8 @@
                     Name: "{{ resource_prefix }}-cluster-1"
                     Created_By: Ansible Indirect NodeQuery Count integration tests
                 facts: "{{ rds_cluster_facts }}"
-              - canonical_facts:
+              - name: "{{ resource_prefix }}-cluster-2"
+                canonical_facts:
                   id: "{{ cluster_2.db_cluster_resource_id }}"
                   name: "{{ resource_prefix }}-cluster-2"
                   status: "{{ cluster_2.status }}"

--- a/tests/integration/targets/node_query_database_instance/play.yaml
+++ b/tests/integration/targets/node_query_database_instance/play.yaml
@@ -69,8 +69,9 @@
             that:
               - node_count == expected_result  
           vars:
-            expected_result: 
-              - canonical_facts:
+            expected_result:
+              - name: "{{ resource_prefix }}-instance-1"
+                canonical_facts:
                   id: "{{ instance_1.dbi_resource_id }}"
                   name: "{{ resource_prefix }}-instance-1"
                   status: "{{ instance_1.db_instance_status }}"
@@ -78,7 +79,8 @@
                     Name: "{{ resource_prefix }}-instance-1"
                     Created_by: Ansible Indirect NodeQuery Count integration tests
                 facts: "{{ rds_instance_facts }}"
-              - canonical_facts:
+              - name: "{{ resource_prefix }}-instance-2"
+                canonical_facts:
                   id: "{{ instance_2.dbi_resource_id }}"
                   name: "{{ resource_prefix }}-instance-2"
                   status: "{{ instance_2.db_instance_status }}"

--- a/tests/integration/targets/node_query_networking/templates/igw.j2
+++ b/tests/integration/targets/node_query_networking/templates/igw.j2
@@ -14,6 +14,7 @@
 {% else %}
     tags: {}
 {% endif %}
+  name: "{{ item.tags.Name | default(item.internet_gateway_id) }}"
   facts:
     device_type: {{ networking_facts.igw }}
 {% for key, value in networking_common_facts.items()%}

--- a/tests/integration/targets/node_query_networking/templates/natgw.j2
+++ b/tests/integration/targets/node_query_networking/templates/natgw.j2
@@ -10,6 +10,7 @@
 {% else %}
     tags: {}
 {% endif %}
+  name: "{{ item.tags.Name | default(item.nat_gateway_id) }}"
   facts:
     device_type: {{ networking_facts.nat_gateway }}
 {% for key, value in networking_common_facts.items()%}

--- a/tests/integration/targets/node_query_networking/templates/peering.j2
+++ b/tests/integration/targets/node_query_networking/templates/peering.j2
@@ -10,6 +10,7 @@
 {% else %}
     tags: {}
 {% endif %}
+  name: "{{ item.tags.Name | default(item.vpc_peering_connection_id) }}"
   facts:
     device_type: {{ networking_facts.peering }}
 {% for key, value in networking_common_facts.items()%}

--- a/tests/integration/targets/node_query_networking/templates/route_table.j2
+++ b/tests/integration/targets/node_query_networking/templates/route_table.j2
@@ -9,6 +9,7 @@
 {% else %}
     tags: {}
 {% endif %}
+  name: "{{ item.tags.Name | default(item.route_table_id) }}"
   facts:
     device_type: {{ networking_facts.route_table }}
 {% for key, value in networking_common_facts.items()%}

--- a/tests/integration/targets/node_query_networking/templates/subnets.j2
+++ b/tests/integration/targets/node_query_networking/templates/subnets.j2
@@ -10,6 +10,7 @@
 {% else %}
     tags: {}
 {% endif %}
+  name: "{{ item.tags.Name | default(item.subnet_id) }}"
   facts:
     device_type: {{ networking_facts.subnet }}
 {% for key, value in networking_common_facts.items()%}

--- a/tests/integration/targets/node_query_networking/templates/vgw.j2
+++ b/tests/integration/targets/node_query_networking/templates/vgw.j2
@@ -10,6 +10,7 @@
 {% else %}
     tags: {}
 {% endif %}
+  name: "{{ (item.resource_tags | default({})).Name | default(item.vpn_gateway_id) }}"
   facts:
     device_type: {{ networking_facts.vgw }}
 {% for key, value in networking_common_facts.items()%}

--- a/tests/integration/targets/node_query_networking/templates/vpn.j2
+++ b/tests/integration/targets/node_query_networking/templates/vpn.j2
@@ -10,6 +10,7 @@
 {% else %}
     tags: {}
 {% endif %}
+  name: "{{ item.tags.Name | default(item.vpn_connection_id) }}"
   facts:
     device_type: {{ networking_facts.vpn }}
 {% for key, value in networking_common_facts.items()%}

--- a/tests/integration/targets/node_query_networking_elb/play.yaml
+++ b/tests/integration/targets/node_query_networking_elb/play.yaml
@@ -170,6 +170,7 @@
           ansible.builtin.assert:
             that:
               - alb_node_result | length == 1
+              - alb_node_result[0].name == alb_name
               - alb_node_result[0].canonical_facts.name == alb_name
               - alb_node_result[0].canonical_facts.tags == alb_tags
               - alb_node_result[0].facts == alb_facts
@@ -189,6 +190,7 @@
           ansible.builtin.assert:
             that:
               - classic_elb_node_result | length == 1
+              - classic_elb_node_result[0].name == classic_elb_name
               - classic_elb_node_result[0].canonical_facts.name == classic_elb_name
               - classic_elb_node_result[0].canonical_facts.tags == classic_elb_tags
               - classic_elb_node_result[0].facts == classic_elb_facts
@@ -227,6 +229,7 @@
           ansible.builtin.assert:
             that:
               - alb_notags_result | length == 1
+              - alb_notags_result[0].name == alb_name + "-notags"
               - alb_notags_result[0].canonical_facts.name == alb_name + "-notags"
               - alb_notags_result[0].canonical_facts.tags == {}
               - alb_notags_result[0].facts == alb_facts
@@ -258,6 +261,7 @@
           ansible.builtin.assert:
             that:
               - classic_elb_notags_result | length == 1
+              - classic_elb_notags_result[0].name == classic_elb_name + "-notags"
               - classic_elb_notags_result[0].canonical_facts.name == classic_elb_name + "-notags"
               - classic_elb_notags_result[0].canonical_facts.tags == {}
               - classic_elb_notags_result[0].facts == classic_elb_facts

--- a/tests/integration/targets/node_query_storage_s3/play.yaml
+++ b/tests/integration/targets/node_query_storage_s3/play.yaml
@@ -56,13 +56,15 @@
             that:
               - node_count == expected_result  
           vars:
-            expected_result: 
-              - canonical_facts:
+            expected_result:
+              - name: "bucket-{{ resource_prefix }}-1"
+                canonical_facts:
                   name: "bucket-{{ resource_prefix }}-1"
                   tags:
                     resource_prefix: "{{ resource_prefix }}"
                 facts: "{{ s3_bucket_facts }}"
-              - canonical_facts:
+              - name: "bucket-{{ resource_prefix }}-2"
+                canonical_facts:
                   name: "bucket-{{ resource_prefix }}-2"
                   tags: {}
                 facts: "{{ s3_bucket_facts }}"
@@ -94,13 +96,15 @@
             that:
               - node_count == expected_result  
           vars:
-            expected_result: 
-              - canonical_facts:
+            expected_result:
+              - name: "{{ s3_objects.0.name }}"
+                canonical_facts:
                   name: "{{ s3_objects.0.name }}"
                   tags:
                     resource_prefix: "{{ resource_prefix }}"
                 facts: "{{ s3_object_facts }}"
-              - canonical_facts:
+              - name: "{{ s3_objects.1.name }}"
+                canonical_facts:
                   name: "{{ s3_objects.1.name }}"
                   tags: {}
                 facts: "{{ s3_object_facts }}"


### PR DESCRIPTION
##### SUMMARY

Every module's `extensions/audit/event_query.yml` entry should emit a **non-null top-level `name`** for the indirect-node audit path, but currently only `ec2_instance_info` and `ec2_vpc_net_info` do. The other **13 modules** (all networking, storage, and database `*_info` queries) place `name` only under `canonical_facts` or omit it entirely.

The controller persists each jq result into `main_indirectmanagednodeaudit`, whose `name` column is **`NOT NULL`**, using a single `bulk_create`. A record with a null top-level `name` raises an integrity error that aborts the **entire** statement — so a job that gathers even one such resource (e.g. a subnet, S3 bucket, or RDS instance) silently discards **all** of the indirect nodes it counted, while the job still reports success.

This PR adds a top-level `name` to each of the 13 remaining modules, mirroring the existing `(.name // .tags.Name // "UNKNOWN")` fallback already used by `ec2_instance_info`/`ec2_vpc_net_info`, deriving the value from the resource's own tag/identifier so it is never null.

##### ISSUE TYPE

- Bugfix Pull Request

##### COMPONENT NAME

event_query (`extensions/audit/event_query.yml`)

##### ADDITIONAL INFORMATION

**Modules fixed** (13): `elb_application_lb_info`, `elb_classic_lb_info`, `ec2_vpc_subnet_info`, `ec2_vpc_nat_gateway_info`, `ec2_vpc_igw_info`, `ec2_vpc_vgw_info`, `ec2_vpc_route_table_info`, `ec2_vpc_vpn_info`, `ec2_vpc_peering_info`, `s3_bucket_info`, `s3_object_info`, `rds_instance_info`, `rds_cluster_info`.

Example (subnet):
```diff
     .subnets[] | select(. != null) | {
+      name: (.tags.Name // .id // "UNKNOWN"),  # unique identifier for the resource
       canonical_facts: {
         id: .id,
```

**Tests:** the `node_query_*` integration targets are updated so their expected results / templates now assert the new top-level `name` (networking templates gain a `name:` line matching `vpcs.j2`'s existing precedent; the storage/database/elb targets assert it directly, including the existing no-tags fallback cases).

**Verification:** the jq for all 15 modules was validated offline against representative `*_info` fixtures (tagged and untagged resources) confirming a non-null top-level `name` in every case; the same check fails on `main` for the 13 offending modules. The live-AWS integration run is left to CI.

**Related:** this is the collection half of a two-part fix — the controller should additionally be resilient to a null `name` (skip/derive rather than abort the whole batch) so collections that ship no `event_query.yml` are also protected; that is being tracked separately on the controller side. Also touches the same file as the in-flight taxonomy work in #3042 (cc @stevefulme1) — no overlap in the lines changed.
