### PR TITLE
Update Ansible lint configuration

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,6 +2,12 @@
 profile: production
 
 exclude_paths:
-  - changelogs/changelog.yaml
-  - .github/
+  - changelogs
+  - docs
   - tests/integration
+  - tests/unit
+  - .ansible
+  - .github
+
+warn_list:
+  - no-log-password

--- a/.ansible-lint
+++ b/.ansible-lint
@@ -5,6 +5,7 @@ exclude_paths:
   - changelogs
   - docs
   - tests/integration
+  - tests/sanity/ignore-*.txt # Ignore violations related to deprecated keys.
   - tests/unit
   - .ansible
   - .github

--- a/meta/extensions.yml
+++ b/meta/extensions.yml
@@ -1,3 +1,4 @@
+---
 extensions:
   - args:
       ext_dir: eda/plugins/event_source


### PR DESCRIPTION
##### SUMMARY
Brings the `.ansible-lint` configuration in line with the recommendation for certified content at: https://docs.ansible.com/projects/partner-certification-requirements/static-analysis/#ansible-lint-configuration

Also adds the `---` header to the `meta/extensions.yml` file.

##### ISSUE TYPE

- Bugfix Pull Request