### PR TITLE
refactor(rds): rds_global_cluster_info 

### DIFF
--- a/changelogs/fragments/rds_global_cluster_info-refactor.yml
+++ b/changelogs/fragments/rds_global_cluster_info-refactor.yml
@@ -1,3 +1,3 @@
 minor_changes:
-  - rds_global_cluster_info - Refactored module to use shared ``describe_global_clusters``from ``module_utils/rds`` and ``AnsibleRDSError`` for consistent error handling (https://github.com/ansible-collections/amazon.aws/pull/3068).
+  - rds_global_cluster_info - Refactored module to use shared ``describe_global_clusters`` from ``module_utils/rds`` and ``AnsibleRDSError`` for consistent error handling (https://github.com/ansible-collections/amazon.aws/pull/3068).
   - module_utils/rds - Added ``describe_global_clusters`` centralized wrapper with ``@RDSErrorHandler`` and ``@AWSRetry`` decorators, and added ``GlobalClusterNotFoundFault`` to the error handler (https://github.com/ansible-collections/amazon.aws/pull/3068).

--- a/changelogs/fragments/rds_global_cluster_info-refactor.yml
+++ b/changelogs/fragments/rds_global_cluster_info-refactor.yml
@@ -1,8 +1,4 @@
 minor_changes:
-  - rds_global_cluster_info - Refactored module to use shared ``describe_global_clusters``
-    from ``module_utils/rds`` and ``AnsibleRDSError`` for consistent error handling
-    (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
-  - module_utils/rds - Added ``describe_global_clusters`` centralized wrapper with
-    ``@RDSErrorHandler`` and ``@AWSRetry`` decorators, and added
-    ``GlobalClusterNotFoundFault`` to the error handler
-    (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - rds_global_cluster_info - Refactored module to use shared ``describe_global_clusters``from ``module_utils/rds`` and ``AnsibleRDSError`` for consistent error handling (https://github.com/ansible-collections/amazon.aws/pull/3068).
+  - module_utils/rds - Added ``describe_global_clusters`` centralized wrapper with ``@RDSErrorHandler`` and ``@AWSRetry`` decorators, and added ``GlobalClusterNotFoundFault`` to the error handler (https://github.com/ansible-collections/amazon.aws/pull/3068).
+  

--- a/changelogs/fragments/rds_global_cluster_info-refactor.yml
+++ b/changelogs/fragments/rds_global_cluster_info-refactor.yml
@@ -1,4 +1,3 @@
 minor_changes:
   - rds_global_cluster_info - Refactored module to use shared ``describe_global_clusters``from ``module_utils/rds`` and ``AnsibleRDSError`` for consistent error handling (https://github.com/ansible-collections/amazon.aws/pull/3068).
   - module_utils/rds - Added ``describe_global_clusters`` centralized wrapper with ``@RDSErrorHandler`` and ``@AWSRetry`` decorators, and added ``GlobalClusterNotFoundFault`` to the error handler (https://github.com/ansible-collections/amazon.aws/pull/3068).
-  

--- a/changelogs/fragments/rds_global_cluster_info-refactor.yml
+++ b/changelogs/fragments/rds_global_cluster_info-refactor.yml
@@ -1,0 +1,8 @@
+minor_changes:
+  - rds_global_cluster_info - Refactored module to use shared ``describe_global_clusters``
+    from ``module_utils/rds`` and ``AnsibleRDSError`` for consistent error handling
+    (https://github.com/ansible-collections/amazon.aws/pull/XXXX).
+  - module_utils/rds - Added ``describe_global_clusters`` centralized wrapper with
+    ``@RDSErrorHandler`` and ``@AWSRetry`` decorators, and added
+    ``GlobalClusterNotFoundFault`` to the error handler
+    (https://github.com/ansible-collections/amazon.aws/pull/XXXX).

--- a/plugins/module_utils/_rds/api.py
+++ b/plugins/module_utils/_rds/api.py
@@ -61,6 +61,13 @@ def describe_db_snapshots(client, **params: Dict) -> List[Dict]:
     return paginator.paginate(**params).build_full_result()["DBSnapshots"]
 
 
+@RDSErrorHandler.list_error_handler("describe global clusters", [])
+@AWSRetry.jittered_backoff()
+def describe_global_clusters(client, **params: Dict) -> List[Dict[str, Any]]:
+    paginator = client.get_paginator("describe_global_clusters")
+    return paginator.paginate(**params).build_full_result()["GlobalClusters"]
+
+
 @RDSErrorHandler.list_error_handler("describe option groups", [])
 @AWSRetry.jittered_backoff()
 def describe_option_groups(client, **params: Dict) -> List[Dict[str, Any]]:

--- a/plugins/module_utils/_rds/common.py
+++ b/plugins/module_utils/_rds/common.py
@@ -20,7 +20,7 @@ class RDSErrorHandler(AWSErrorHandler):
     @classmethod
     def _is_missing(cls):
         return is_boto3_error_code(
-            ["DBInstanceNotFound", "DBSnapshotNotFound", "DBClusterNotFound", "DBClusterNotFoundFault", "DBClusterSnapshotNotFoundFault", "OptionGroupNotFoundFault"]
+            ["DBInstanceNotFound", "DBSnapshotNotFound", "DBClusterNotFound", "DBClusterNotFoundFault", "DBClusterSnapshotNotFoundFault", "GlobalClusterNotFoundFault", "OptionGroupNotFoundFault"]
         )
 
 

--- a/plugins/module_utils/_rds/common.py
+++ b/plugins/module_utils/_rds/common.py
@@ -20,7 +20,15 @@ class RDSErrorHandler(AWSErrorHandler):
     @classmethod
     def _is_missing(cls):
         return is_boto3_error_code(
-            ["DBInstanceNotFound", "DBSnapshotNotFound", "DBClusterNotFound", "DBClusterNotFoundFault", "DBClusterSnapshotNotFoundFault", "GlobalClusterNotFoundFault", "OptionGroupNotFoundFault"]
+            [
+                "DBInstanceNotFound",
+                "DBSnapshotNotFound",
+                "DBClusterNotFound",
+                "DBClusterNotFoundFault",
+                "DBClusterSnapshotNotFoundFault",
+                "GlobalClusterNotFoundFault",
+                "OptionGroupNotFoundFault",
+            ]
         )
 
 

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -24,6 +24,7 @@ describe_db_clusters = _api.describe_db_clusters
 describe_db_engine_versions = _api.describe_db_engine_versions
 describe_db_instances = _api.describe_db_instances
 describe_db_snapshots = _api.describe_db_snapshots
+describe_global_clusters = _api.describe_global_clusters
 describe_option_groups = _api.describe_option_groups
 list_tags_for_resource = _api.list_tags_for_resource
 get_final_identifier = _api.get_final_identifier

--- a/plugins/modules/rds_global_cluster_info.py
+++ b/plugins/modules/rds_global_cluster_info.py
@@ -153,43 +153,36 @@ global_clusters:
                 sample: false
 """
 
-
-try:
-    import botocore
-except ImportError:
-    pass  # handled by AnsibleAWSModule
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
 
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
-from ansible_collections.amazon.aws.plugins.module_utils.botocore import is_boto3_error_code
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
+from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
+from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_global_clusters
 
 
-@AWSRetry.jittered_backoff(retries=10)
-def _describe_global_clusters(client, **params):
-    try:
-        paginator = client.get_paginator("describe_global_clusters")
-        return paginator.paginate(**params).build_full_result()["GlobalClusters"]
-    except is_boto3_error_code("GlobalClusterNotFoundFault"):
-        return []
+def global_cluster_info(client, module: AnsibleAWSModule, global_cluster_id: Optional[str]) -> List[Dict[str, Any]]:
+    """Return attributes of Aurora global database cluster(s).
 
+    Parameters:
+        client: boto3 rds client
+        module: AnsibleAWSModule
+        global_cluster_id: Unique identifier of global cluster to describe
 
-def cluster_info(client, module):
-    global_cluster_id = module.params.get("global_cluster_identifier")
-
-    params = dict()
+    Returns:
+        List of global cluster attribute dicts in snake_case format
+    """
+    params = {}
     if global_cluster_id:
         params["GlobalClusterIdentifier"] = global_cluster_id
 
-    try:
-        result = _describe_global_clusters(client, **params)
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, "Couldn't get Global cluster information.")
+    results = describe_global_clusters(client, **params)
 
-    return dict(
-        changed=False, global_clusters=[camel_dict_to_snake_dict(cluster, ignore_list=["Tags"]) for cluster in result]
-    )
+    return [camel_dict_to_snake_dict(cluster, ignore_list=["Tags"]) for cluster in results]
 
 
 def main():
@@ -202,12 +195,12 @@ def main():
         supports_check_mode=True,
     )
 
-    try:
-        client = module.client("rds", retry_decorator=AWSRetry.jittered_backoff(retries=10))
-    except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-        module.fail_json_aws(e, msg="Failed to connect to AWS.")
+    client = module.client("rds")
 
-    module.exit_json(**cluster_info(client, module))
+    try:
+        module.exit_json(changed=False, global_clusters=global_cluster_info(client, module, module.params.get("global_cluster_identifier")))
+    except AnsibleRDSError as e:
+        module.fail_json_aws(e, msg="Could not describe global clusters.")
 
 
 if __name__ == "__main__":

--- a/tests/unit/plugins/module_utils/rds/test_rds_api.py
+++ b/tests/unit/plugins/module_utils/rds/test_rds_api.py
@@ -19,6 +19,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.rds import Boto3ClientM
 from ansible_collections.amazon.aws.plugins.module_utils.rds import call_method
 from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_clusters
 from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_engine_versions
+from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_global_clusters
 from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_option_groups
 from ansible_collections.amazon.aws.plugins.module_utils.rds import get_final_identifier
 from ansible_collections.amazon.aws.plugins.module_utils.rds import get_snapshot
@@ -565,6 +566,52 @@ class TestDescribeDbClusters:
         )
 
         result = describe_db_clusters(client, DBClusterIdentifier="nonexistent")
+
+        assert result == []
+
+
+# =============================================================================
+# describe_global_clusters
+# =============================================================================
+
+
+class TestDescribeGlobalClusters:
+    def test_describe_global_clusters_returns_list(self):
+        client = MagicMock()
+        paginator = MagicMock()
+        client.get_paginator.return_value = paginator
+        paginator.paginate.return_value.build_full_result.return_value = {
+            "GlobalClusters": [
+                {"GlobalClusterIdentifier": "gc-1"},
+                {"GlobalClusterIdentifier": "gc-2"},
+            ]
+        }
+
+        result = describe_global_clusters(client, GlobalClusterIdentifier="gc-1")
+
+        client.get_paginator.assert_called_with("describe_global_clusters")
+        paginator.paginate.assert_called_with(GlobalClusterIdentifier="gc-1")
+        assert len(result) == 2
+        assert result[0]["GlobalClusterIdentifier"] == "gc-1"
+
+    def test_describe_global_clusters_empty(self):
+        client = MagicMock()
+        paginator = MagicMock()
+        client.get_paginator.return_value = paginator
+        paginator.paginate.return_value.build_full_result.return_value = {"GlobalClusters": []}
+
+        result = describe_global_clusters(client)
+
+        assert result == []
+
+    def test_describe_global_clusters_not_found_returns_empty(self):
+        client = MagicMock()
+        client.get_paginator.side_effect = botocore.exceptions.ClientError(
+            {"Error": {"Code": "GlobalClusterNotFoundFault", "Message": "not found"}},
+            "DescribeGlobalClusters",
+        )
+
+        result = describe_global_clusters(client, GlobalClusterIdentifier="nonexistent")
 
         assert result == []
 

--- a/tests/unit/plugins/modules/test_rds_global_cluster_info.py
+++ b/tests/unit/plugins/modules/test_rds_global_cluster_info.py
@@ -1,0 +1,93 @@
+# (c) 2026 Red Hat Inc.
+#
+# This file is part of Ansible
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
+from ansible_collections.amazon.aws.plugins.modules import rds_global_cluster_info
+from ansible_collections.amazon.aws.plugins.modules.rds_global_cluster_info import global_cluster_info
+
+mod_name = "ansible_collections.amazon.aws.plugins.modules.rds_global_cluster_info"
+
+
+@patch(mod_name + ".describe_global_clusters")
+def test_global_cluster_info_one_cluster(m_describe):
+    conn = MagicMock()
+    module = MagicMock()
+    m_describe.return_value = [
+        {
+            "GlobalClusterIdentifier": "my-global-cluster",
+            "GlobalClusterArn": "arn:aws:rds::123456789012:global-cluster:my-global-cluster",
+            "Engine": "aurora-postgresql",
+            "EngineVersion": "14.8",
+            "Status": "available",
+        }
+    ]
+
+    result = global_cluster_info(conn, module, "my-global-cluster")
+
+    assert len(result) == 1
+    assert result[0]["global_cluster_identifier"] == "my-global-cluster"
+    assert result[0]["engine"] == "aurora-postgresql"
+    m_describe.assert_called_with(conn, GlobalClusterIdentifier="my-global-cluster")
+
+
+@patch(mod_name + ".describe_global_clusters")
+def test_global_cluster_info_no_results(m_describe):
+    conn = MagicMock()
+    module = MagicMock()
+    m_describe.return_value = []
+
+    result = global_cluster_info(conn, module, "nonexistent")
+
+    assert result == []
+    m_describe.assert_called_with(conn, GlobalClusterIdentifier="nonexistent")
+
+
+@patch(mod_name + ".describe_global_clusters")
+def test_global_cluster_info_all(m_describe):
+    conn = MagicMock()
+    module = MagicMock()
+    m_describe.return_value = [
+        {"GlobalClusterIdentifier": "cluster-1", "Engine": "aurora-mysql"},
+        {"GlobalClusterIdentifier": "cluster-2", "Engine": "aurora-postgresql"},
+    ]
+
+    result = global_cluster_info(conn, module, None)
+
+    assert len(result) == 2
+    assert result[0]["global_cluster_identifier"] == "cluster-1"
+    assert result[1]["global_cluster_identifier"] == "cluster-2"
+    m_describe.assert_called_with(conn)
+
+
+@patch(mod_name + ".AnsibleAWSModule")
+def test_main_success(m_AnsibleAWSModule):
+    m_module = MagicMock()
+    m_AnsibleAWSModule.return_value = m_module
+    m_module.params = {"global_cluster_identifier": None}
+
+    rds_global_cluster_info.main()
+
+    m_module.client.assert_called_with("rds")
+    call_kwargs = m_module.exit_json.call_args[1]
+    assert call_kwargs["changed"] is False
+    assert "global_clusters" in call_kwargs
+
+
+@patch(mod_name + ".describe_global_clusters")
+@patch(mod_name + ".AnsibleAWSModule")
+def test_main_failure(m_AnsibleAWSModule, m_describe):
+    m_module = MagicMock()
+    m_AnsibleAWSModule.return_value = m_module
+    m_module.params = {"global_cluster_identifier": None}
+    e = AnsibleRDSError()
+    m_describe.side_effect = e
+
+    rds_global_cluster_info.main()
+
+    m_module.client.assert_called_with("rds")
+    m_module.fail_json_aws.assert_called_with(e, msg="Could not describe global clusters.")


### PR DESCRIPTION
##### SUMMARY
This PR is for the refactor of `rds_global_cluster_info` to use shared utilities from  `module_utils/rds`.

- Add `describe_global_clusters()` to `module_utils/_rds/api.py` with `@RDSErrorHandler` and `@AWSRetry` decorators
- Add `GlobalClusterNotFoundFault` to `RDSErrorHandler._is_missing()`
- Re-export `describe_global_clusters` via the `module_utils/rds` facade
- Replace local `_describe_global_clusters()` with the shared function
- Standardize error handling with `AnsibleRDSError` caught in `main()`
- Simplify client creation (retry lives in the shared describe function)
- Refactor `cluster_info()` to accept explicit parameters instead of reading from `module.params`, return data only (not `changed` state), and add type annotations
- Add unit tests for the module and the shared API function

Fixes ACA-2476

##### ISSUE TYPE

- Refactoring Pull Request

##### COMPONENT NAME

rds_global_cluster_info
module_utils/rds


Assisted-by: Claude Opus 4.6 