### PR TITLE
Fix/aws rds refactor

### DIFF
--- a/changelogs/fragments/rds_cluster_param_group-refactor.yml
+++ b/changelogs/fragments/rds_cluster_param_group-refactor.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rds_cluster_param_group - Refactored shared ``describe_db_cluster_parameter_groups`` and ``describe_db_cluster_parameters`` in ``modules_utils/rds`` to use ``RDSErrorHandler`` decorator for consistent error handling following previous PRs. (https://github.com/ansible-collections/amazon.aws/pull/3069) 

--- a/changelogs/fragments/rds_cluster_param_group-refactor.yml
+++ b/changelogs/fragments/rds_cluster_param_group-refactor.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - rds_cluster_param_group - Refactored shared ``describe_db_cluster_parameter_groups`` and ``describe_db_cluster_parameters`` in ``module_utils/rds`` to use ``RDSErrorHandler`` decorator for consistent error handling following previous PRs. (https://github.com/ansible-collections/amazon.aws/pull/3069) 
+  - rds_cluster_param_group - Refactored shared ``describe_db_cluster_parameter_groups`` and ``describe_db_cluster_parameters`` in ``module_utils/rds`` to use ``RDSErrorHandler`` decorator for consistent error handling following previous PRs. (https://github.com/ansible-collections/amazon.aws/pull/3069)

--- a/changelogs/fragments/rds_cluster_param_group-refactor.yml
+++ b/changelogs/fragments/rds_cluster_param_group-refactor.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - rds_cluster_param_group - Refactored shared ``describe_db_cluster_parameter_groups`` and ``describe_db_cluster_parameters`` in ``modules_utils/rds`` to use ``RDSErrorHandler`` decorator for consistent error handling following previous PRs. (https://github.com/ansible-collections/amazon.aws/pull/3069) 
+  - rds_cluster_param_group - Refactored shared ``describe_db_cluster_parameter_groups`` and ``describe_db_cluster_parameters`` in ``module_utils/rds`` to use ``RDSErrorHandler`` decorator for consistent error handling following previous PRs. (https://github.com/ansible-collections/amazon.aws/pull/3069) 

--- a/changelogs/fragments/rds_cluster_param_group-refactor.yml
+++ b/changelogs/fragments/rds_cluster_param_group-refactor.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - rds_cluster_param_group - Refactored shared ``describe_db_cluster_parameter_groups`` and ``describe_db_cluster_parameters`` in ``module_utils/rds`` to use ``RDSErrorHandler`` decorator for consistent error handling following previous PRs. (https://github.com/ansible-collections/amazon.aws/pull/306))
+  - rds_cluster_param_group - Refactored shared ``describe_db_cluster_parameter_groups`` and ``describe_db_cluster_parameters`` in ``module_utils/rds`` to use ``RDSErrorHandler`` decorator for consistent error handling following previous PRs. (https://github.com/ansible-collections/amazon.aws/pull/3069)

--- a/changelogs/fragments/rds_cluster_param_group-refactor.yml
+++ b/changelogs/fragments/rds_cluster_param_group-refactor.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - rds_cluster_param_group - Refactored shared ``describe_db_cluster_parameter_groups`` and ``describe_db_cluster_parameters`` in ``module_utils/rds`` to use ``RDSErrorHandler`` decorator for consistent error handling following previous PRs. (https://github.com/ansible-collections/amazon.aws/pull/3069)
+  - rds_cluster_param_group - Refactored shared ``describe_db_cluster_parameter_groups`` and ``describe_db_cluster_parameters`` in ``module_utils/rds`` to use ``RDSErrorHandler`` decorator for consistent error handling following previous PRs. (https://github.com/ansible-collections/amazon.aws/pull/306))

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -246,15 +246,6 @@ class InventoryModule(AWSInventoryBase):
             hosts = source_data[group].get("hosts", [])
             for host in hosts:
                 self._populate_host_vars([host], hostvars.get(host, {}), group)
-                # Re-apply constructed groups from cache
-                strict = self.get_option("strict")
-                self._set_composite_vars(self.get_option("compose"), hostvars.get(host, {}), host, strict=strict)
-                self._add_host_to_composed_groups(
-                    self.get_option("groups"), hostvars.get(host, {}), host, strict=strict
-                )
-                self._add_host_to_keyed_groups(
-                    self.get_option("keyed_groups"), hostvars.get(host, {}), host, strict=strict
-                )
             self.inventory.add_child("all", group)
 
     def _format_inventory(self, hosts):

--- a/plugins/inventory/aws_rds.py
+++ b/plugins/inventory/aws_rds.py
@@ -246,6 +246,15 @@ class InventoryModule(AWSInventoryBase):
             hosts = source_data[group].get("hosts", [])
             for host in hosts:
                 self._populate_host_vars([host], hostvars.get(host, {}), group)
+                # Re-apply constructed groups from cache
+                strict = self.get_option("strict")
+                self._set_composite_vars(self.get_option("compose"), hostvars.get(host, {}), host, strict=strict)
+                self._add_host_to_composed_groups(
+                    self.get_option("groups"), hostvars.get(host, {}), host, strict=strict
+                )
+                self._add_host_to_keyed_groups(
+                    self.get_option("keyed_groups"), hostvars.get(host, {}), host, strict=strict
+                )
             self.inventory.add_child("all", group)
 
     def _format_inventory(self, hosts):

--- a/plugins/module_utils/_rds/api.py
+++ b/plugins/module_utils/_rds/api.py
@@ -328,7 +328,7 @@ def describe_db_cluster_parameters(
     module, connection: Any, group_name: str, source: str = "all"
 ) -> List[Dict[str, Any]]:
     paginator = connection.get_paginator("describe_db_cluster_parameters")
-    params = {"DBClusterParameterGroupName": groupName}
+    params = {"DBClusterParameterGroupName": group_name}
     if source != "all":
         params["Source"] = source
     return paginator.paginate(**params).build_full_result()["Parameters"]

--- a/plugins/module_utils/_rds/api.py
+++ b/plugins/module_utils/_rds/api.py
@@ -297,6 +297,7 @@ def describe_db_cluster_parameter_groups(module, connection: Any, group_name: Op
         params["DBClusterParameterGroupName"] = group_name
     paginator = connection.get_paginator("describe_db_cluster_parameter_groups")
     return paginator.paginate(**params).build_full_result()["DBClusterParameterGroups"]
+    
 
 @AWSRetry.jittered_backoff()
 def describe_db_instance_parameter_groups(connection: Any, module, db_parameter_group_name: str = None) -> List[dict]:

--- a/plugins/module_utils/_rds/api.py
+++ b/plugins/module_utils/_rds/api.py
@@ -291,9 +291,11 @@ def update_iam_roles(
 @RDSErrorHandler.list_error_handler("describe db cluster parameter groups", [])
 @AWSRetry.jittered_backoff()
 def describe_db_cluster_parameter_groups(module, connection: Any, group_name: Optional[str]) -> List[Dict[str, Any]]:
-    result = []
-    return result
-
+    params = {} 
+    if group_name is not None:
+        params["DBClusterParameterGroupName"] = group_name
+    paginator = connection.get_paginator("describe_db_cluster_parameter_groups")
+    return paginator.paginate(**params).build_full_result()["DBClusterParameterGroups"]
 
 @AWSRetry.jittered_backoff()
 def describe_db_instance_parameter_groups(connection: Any, module, db_parameter_group_name: str = None) -> List[dict]:
@@ -325,5 +327,8 @@ def describe_db_instance_parameter_groups(connection: Any, module, db_parameter_
 def describe_db_cluster_parameters(
     module, connection: Any, group_name: str, source: str = "all"
 ) -> List[Dict[str, Any]]:
-    result = []
-    return result
+    paginator = connection.get_paginator("describe_db_cluster_parameters")
+    params = {"DBClusterParameterGroupName": groupName}
+    if source != "all":
+        params["Source"] = source
+    return paginator.paginate(**params).build_full_result()["Parameters"]

--- a/plugins/module_utils/_rds/api.py
+++ b/plugins/module_utils/_rds/api.py
@@ -291,7 +291,7 @@ def update_iam_roles(
 @RDSErrorHandler.list_error_handler("describe db cluster parameter groups", [])
 @AWSRetry.jittered_backoff()
 def describe_db_cluster_parameter_groups(module, connection: Any, group_name: Optional[str]) -> List[Dict[str, Any]]:
-    params = {} 
+    params = {}
     if group_name is not None:
         params["DBClusterParameterGroupName"] = group_name
     paginator = connection.get_paginator("describe_db_cluster_parameter_groups")

--- a/plugins/module_utils/_rds/api.py
+++ b/plugins/module_utils/_rds/api.py
@@ -3,6 +3,7 @@
 # Copyright: (c) 2018, Ansible Project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
+from itertools import zip_longest
 from typing import Any
 from typing import Dict
 from typing import List
@@ -332,3 +333,23 @@ def describe_db_cluster_parameters(
     if source != "all":
         params["Source"] = source
     return paginator.paginate(**params).build_full_result()["Parameters"]
+
+
+@RDSErrorHandler.common_error_handler("create db cluster parameter group")
+def create_db_cluster_parameter_group(connection: Any, **params: Dict) -> Dict[str, Any]:
+    return connection.create_db_cluster_parameter_group(aws_retry=True, **params)
+
+
+@RDSErrorHandler.deletion_error_handler("delete db cluster parameter group")
+def delete_db_cluster_parameter_group(connection: Any, group_name: str) -> Dict[str, Any]:
+    return connection.delete_db_cluster_parameter_group(aws_retry=True, DBClusterParameterGroupName=group_name)
+
+
+@RDSErrorHandler.common_error_handler("modify db cluster parameter group")
+def modify_db_cluster_parameter_group(connection: Any, group_name: str, parameters: List[Dict[str, Any]]) -> None:
+    # A maximum of 20 parameters can be modified in a single request, so we chunk them.
+    for chunk in zip_longest(*[iter(parameters)] * 20, fillvalue=None):
+        non_empty_chunk = [item for item in chunk if item]
+        connection.modify_db_cluster_parameter_group(
+            aws_retry=True, DBClusterParameterGroupName=group_name, Parameters=non_empty_chunk
+        )

--- a/plugins/module_utils/_rds/api.py
+++ b/plugins/module_utils/_rds/api.py
@@ -288,19 +288,10 @@ def update_iam_roles(
     return changed
 
 
+@RDSErrorHandler.list_error_handler("describe db cluster parameter groups", [])
 @AWSRetry.jittered_backoff()
 def describe_db_cluster_parameter_groups(module, connection: Any, group_name: Optional[str]) -> List[Dict[str, Any]]:
     result = []
-    try:
-        params = {}
-        if group_name is not None:
-            params["DBClusterParameterGroupName"] = group_name
-        paginator = connection.get_paginator("describe_db_cluster_parameter_groups")
-        result = paginator.paginate(**params).build_full_result()["DBClusterParameterGroups"]
-    except is_boto3_error_code("DBParameterGroupNotFound"):
-        pass
-    except ClientError as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg="Couldn't access parameter groups information")
     return result
 
 
@@ -329,19 +320,10 @@ def describe_db_instance_parameter_groups(connection: Any, module, db_parameter_
     return result
 
 
+@RDSErrorHandler.list_error_handler("describe db cluster parameters", [])
 @AWSRetry.jittered_backoff()
 def describe_db_cluster_parameters(
     module, connection: Any, group_name: str, source: str = "all"
 ) -> List[Dict[str, Any]]:
     result = []
-    try:
-        paginator = connection.get_paginator("describe_db_cluster_parameters")
-        params = {"DBClusterParameterGroupName": group_name}
-        if source != "all":
-            params["Source"] = source
-        result = paginator.paginate(**params).build_full_result()["Parameters"]
-    except is_boto3_error_code("DBParameterGroupNotFound"):
-        pass
-    except ClientError as e:  # pylint: disable=duplicate-except
-        module.fail_json_aws(e, msg="Couldn't access RDS cluster parameters information")
     return result

--- a/plugins/module_utils/_rds/api.py
+++ b/plugins/module_utils/_rds/api.py
@@ -297,7 +297,7 @@ def describe_db_cluster_parameter_groups(module, connection: Any, group_name: Op
         params["DBClusterParameterGroupName"] = group_name
     paginator = connection.get_paginator("describe_db_cluster_parameter_groups")
     return paginator.paginate(**params).build_full_result()["DBClusterParameterGroups"]
-    
+
 
 @AWSRetry.jittered_backoff()
 def describe_db_instance_parameter_groups(connection: Any, module, db_parameter_group_name: str = None) -> List[dict]:

--- a/plugins/module_utils/_rds/common.py
+++ b/plugins/module_utils/_rds/common.py
@@ -22,6 +22,7 @@ class RDSErrorHandler(AWSErrorHandler):
         return is_boto3_error_code(
             [
                 "DBInstanceNotFound",
+                "DBParameterGroupNotFound",
                 "DBSnapshotNotFound",
                 "DBClusterNotFound",
                 "DBClusterNotFoundFault",

--- a/plugins/module_utils/_rds/common.py
+++ b/plugins/module_utils/_rds/common.py
@@ -21,15 +21,15 @@ class RDSErrorHandler(AWSErrorHandler):
     def _is_missing(cls):
         return is_boto3_error_code(
             [
-                "DBInstanceNotFound",
-                "DBParameterGroupNotFound",
-                "DBSnapshotNotFound",
                 "DBClusterNotFound",
                 "DBClusterNotFoundFault",
                 "DBClusterSnapshotNotFoundFault",
+                "DBInstanceNotFound",
+                "DBParameterGroupNotFound",
+                "DBSnapshotNotFound",
+                "DBSubnetGroupNotFoundFault",
                 "GlobalClusterNotFoundFault",
                 "OptionGroupNotFoundFault",
-                "DBSubnetGroupNotFoundFault",
             ]
         )
 

--- a/plugins/module_utils/rds.py
+++ b/plugins/module_utils/rds.py
@@ -36,6 +36,9 @@ update_iam_roles = _api.update_iam_roles
 describe_db_cluster_parameter_groups = _api.describe_db_cluster_parameter_groups
 describe_db_instance_parameter_groups = _api.describe_db_instance_parameter_groups
 describe_db_cluster_parameters = _api.describe_db_cluster_parameters
+create_db_cluster_parameter_group = _api.create_db_cluster_parameter_group
+delete_db_cluster_parameter_group = _api.delete_db_cluster_parameter_group
+modify_db_cluster_parameter_group = _api.modify_db_cluster_parameter_group
 
 # waiters.py re-exports
 wait_for_instance_status = _waiters.wait_for_instance_status

--- a/plugins/modules/rds_cluster_param_group.py
+++ b/plugins/modules/rds_cluster_param_group.py
@@ -174,7 +174,7 @@ def _get_changed_parameters(
             if param.get("ParameterName") == current_p.get("ParameterName"):
                 found = True
                 if not current_p["IsModifiable"]:
-                    module.fail_json(f"The parameter {param.get('ParameterName')} cannot be modified")
+                    module.fail_json(msg=f"The parameter {param.get('ParameterName')} cannot be modified")
                 changed |= any((current_p.get(k) != v for k, v in param.items()))
         if not found:
             module.fail_json(msg=f"Could not find parameter with name: {param.get('ParameterName')}")

--- a/plugins/modules/rds_cluster_param_group.py
+++ b/plugins/modules/rds_cluster_param_group.py
@@ -141,10 +141,10 @@ from ansible.module_utils.common.dict_transformations import camel_dict_to_snake
 from ansible.module_utils.common.dict_transformations import snake_dict_to_camel_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
-from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_cluster_parameter_groups
 from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
 from ansible_collections.amazon.aws.plugins.module_utils.rds import create_db_cluster_parameter_group
 from ansible_collections.amazon.aws.plugins.module_utils.rds import delete_db_cluster_parameter_group
+from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_cluster_parameter_groups
 from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_cluster_parameters
 from ansible_collections.amazon.aws.plugins.module_utils.rds import ensure_tags
 from ansible_collections.amazon.aws.plugins.module_utils.rds import get_tags
@@ -206,7 +206,7 @@ def modify_parameters(
 
 def ensure_present(module: AnsibleAWSModule, connection: Any) -> None:
     """Creates or updates an RDS cluster parameter group, including tags and parameters.
-    
+
     Parameters:
         module: AnsibleAWSModule
         connection: boto3 RDS client
@@ -264,7 +264,7 @@ def ensure_absent(module: AnsibleAWSModule, connection: Any) -> None:
         module: AnsibleAWSModule
         connection: boto3 RDS client
     """
-      
+
     group = module.params["name"]
     response = describe_db_cluster_parameter_groups(module=module, connection=connection, group_name=group)
     if not response:

--- a/plugins/modules/rds_cluster_param_group.py
+++ b/plugins/modules/rds_cluster_param_group.py
@@ -155,17 +155,16 @@ def modify_parameters(
 ) -> bool:
     """Compares desired parameters against current values and applies changes in chunks of 20.
 
-      Parameters:
-          module: AnsibleAWSModule
-          connection: boto3 RDS client
-          group_name (str): Name of the RDS cluster parameter group
-          parameters (list): List of parameter dicts with parameter_name, parameter_value, and
-  apply_method
+    Parameters:
+        module: AnsibleAWSModule
+        connection: boto3 RDS client
+        group_name (str): Name of the RDS cluster parameter group
+        parameters (list): List of parameter dicts with parameter_name, 
+            parameter_value, and apply_method
 
-      Returns:
-          changed (bool): True if any parameters were modified, False otherwise
-      """
-
+    Returns:
+        changed (bool): True if any parameters were modified, False otherwise
+    """
     current_params = describe_db_cluster_parameters(module, connection, group_name)
     parameters = snake_dict_to_camel_dict(parameters, capitalize_first=True)
     # compare current resource parameters with the value from module parameters

--- a/plugins/modules/rds_cluster_param_group.py
+++ b/plugins/modules/rds_cluster_param_group.py
@@ -197,13 +197,13 @@ def modify_parameters(
 
 
 def ensure_present(module: AnsibleAWSModule, connection: Any) -> None:
-      """Creates or updates an RDS cluster parameter group, including tags and parameters.
+    """Creates or updates an RDS cluster parameter group, including tags and parameters.
+    
+    Parameters:
+        module: AnsibleAWSModule
+        connection: boto3 RDS client
 
-      Parameters:
-          module: AnsibleAWSModule
-          connection: boto3 RDS client
-
-      """
+    """
 
     group_name = module.params["name"]
     db_parameter_group_family = module.params["db_parameter_group_family"]
@@ -253,12 +253,13 @@ def ensure_present(module: AnsibleAWSModule, connection: Any) -> None:
 
 
 def ensure_absent(module: AnsibleAWSModule, connection: Any) -> None:
-      """Deletes an RDS cluster parameter group if it exists.
 
-      Parameters:
-          module: AnsibleAWSModule
-          connection: boto3 RDS client
-      """
+    """Deletes an RDS cluster parameter group if it exists.
+
+    Parameters:
+        module: AnsibleAWSModule
+        connection: boto3 RDS client
+    """
       
     group = module.params["name"]
     response = describe_db_cluster_parameter_groups(module=module, connection=connection, group_name=group)

--- a/plugins/modules/rds_cluster_param_group.py
+++ b/plugins/modules/rds_cluster_param_group.py
@@ -128,7 +128,6 @@ db_cluster_parameter_group:
             }
 """
 
-from itertools import zip_longest
 from typing import Any
 from typing import Dict
 from typing import List
@@ -144,31 +143,30 @@ from ansible.module_utils.common.dict_transformations import snake_dict_to_camel
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_cluster_parameter_groups
 from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
+from ansible_collections.amazon.aws.plugins.module_utils.rds import create_db_cluster_parameter_group
+from ansible_collections.amazon.aws.plugins.module_utils.rds import delete_db_cluster_parameter_group
 from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_cluster_parameters
 from ansible_collections.amazon.aws.plugins.module_utils.rds import ensure_tags
 from ansible_collections.amazon.aws.plugins.module_utils.rds import get_tags
+from ansible_collections.amazon.aws.plugins.module_utils.rds import modify_db_cluster_parameter_group
 from ansible_collections.amazon.aws.plugins.module_utils.retries import AWSRetry
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_dict_to_boto3_tag_list
 
 
-def modify_parameters(
-    module: AnsibleAWSModule, connection: Any, group_name: str, parameters: List[Dict[str, Any]]
+def _get_changed_parameters(
+    module: AnsibleAWSModule, current_params: List[Dict[str, Any]], parameters: List[Dict[str, Any]]
 ) -> bool:
-    """Compares desired parameters against current values and applies changes in chunks of 20.
+    """Compares desired parameters against current values, failing the module if a
+    parameter is unknown or not modifiable.
 
     Parameters:
         module: AnsibleAWSModule
-        connection: boto3 RDS client
-        group_name (str): Name of the RDS cluster parameter group
-        parameters (list): List of parameter dicts with parameter_name, 
-            parameter_value, and apply_method
+        current_params (list): Parameters currently set on the RDS cluster parameter group
+        parameters (list): Desired parameters, camel-cased and capitalized
 
     Returns:
-        changed (bool): True if any parameters were modified, False otherwise
+        changed (bool): True if any parameters differ from their current value
     """
-    current_params = describe_db_cluster_parameters(module, connection, group_name)
-    parameters = snake_dict_to_camel_dict(parameters, capitalize_first=True)
-    # compare current resource parameters with the value from module parameters
     changed = False
     for param in parameters:
         found = False
@@ -180,19 +178,29 @@ def modify_parameters(
                 changed |= any((current_p.get(k) != v for k, v in param.items()))
         if not found:
             module.fail_json(msg=f"Could not find parameter with name: {param.get('ParameterName')}")
-    if changed:
-        if not module.check_mode:
-            # When calling modify_db_cluster_parameter_group() function
-            # A maximum of 20 parameters can be modified in a single request.
-            # This is why we are creating chunk containing at max 20 items
-            for chunk in zip_longest(*[iter(parameters)] * 20, fillvalue=None):
-                non_empty_chunk = [item for item in chunk if item]
-                try:
-                    connection.modify_db_cluster_parameter_group(
-                        aws_retry=True, DBClusterParameterGroupName=group_name, Parameters=non_empty_chunk
-                    )
-                except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-                    module.fail_json_aws(e, msg="Couldn't update RDS cluster parameters")
+    return changed
+
+
+def modify_parameters(
+    module: AnsibleAWSModule, connection: Any, group_name: str, parameters: List[Dict[str, Any]]
+) -> bool:
+    """Compares desired parameters against current values and applies changes in chunks of 20.
+
+    Parameters:
+        module: AnsibleAWSModule
+        connection: boto3 RDS client
+        group_name (str): Name of the RDS cluster parameter group
+        parameters (list): List of parameter dicts with parameter_name,
+            parameter_value, and apply_method
+
+    Returns:
+        changed (bool): True if any parameters were modified, False otherwise
+    """
+    current_params = describe_db_cluster_parameters(module, connection, group_name)
+    parameters = snake_dict_to_camel_dict(parameters, capitalize_first=True)
+    changed = _get_changed_parameters(module, current_params, parameters)
+    if changed and not module.check_mode:
+        modify_db_cluster_parameter_group(connection, group_name, parameters)
     return changed
 
 
@@ -223,11 +231,8 @@ def ensure_present(module: AnsibleAWSModule, connection: Any) -> None:
             params["Tags"] = ansible_dict_to_boto3_tag_list(tags)
         if module.check_mode:
             module.exit_json(changed=True, msg="Would have create RDS parameter group if not in check mode.")
-        try:
-            response = connection.create_db_cluster_parameter_group(aws_retry=True, **params)
-            changed = True
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg="Couldn't create parameter group")
+        response = create_db_cluster_parameter_group(connection, **params)
+        changed = True
     else:
         group = response[0]
         if db_parameter_group_family != group["DBParameterGroupFamily"]:
@@ -266,10 +271,7 @@ def ensure_absent(module: AnsibleAWSModule, connection: Any) -> None:
         module.exit_json(changed=False, msg="The RDS cluster parameter group does not exist.")
 
     if not module.check_mode:
-        try:
-            response = connection.delete_db_cluster_parameter_group(aws_retry=True, DBClusterParameterGroupName=group)
-        except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
-            module.fail_json_aws(e, msg="Couldn't delete RDS cluster parameter group")
+        delete_db_cluster_parameter_group(connection, group)
     module.exit_json(changed=True)
 
 

--- a/plugins/modules/rds_cluster_param_group.py
+++ b/plugins/modules/rds_cluster_param_group.py
@@ -143,6 +143,7 @@ from ansible.module_utils.common.dict_transformations import snake_dict_to_camel
 
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_cluster_parameter_groups
+from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
 from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_cluster_parameters
 from ansible_collections.amazon.aws.plugins.module_utils.rds import ensure_tags
 from ansible_collections.amazon.aws.plugins.module_utils.rds import get_tags
@@ -301,11 +302,13 @@ def main() -> None:
         connection = module.client("rds", retry_decorator=AWSRetry.jittered_backoff())
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to connect to AWS")
-
-    if module.params.get("state") == "present":
-        ensure_present(module=module, connection=connection)
-    else:
-        ensure_absent(module=module, connection=connection)
+    try:
+        if module.params.get("state") == "present":
+            ensure_present(module=module, connection=connection)
+        else:
+            ensure_absent(module=module, connection=connection)
+    except AnsibleRDSError as e:
+        module.fail_json_aws(e, msg="Failed to manage RDS cluster parameter group")
 
 
 if __name__ == "__main__":

--- a/plugins/modules/rds_cluster_param_group.py
+++ b/plugins/modules/rds_cluster_param_group.py
@@ -253,7 +253,6 @@ def ensure_present(module: AnsibleAWSModule, connection: Any) -> None:
 
 
 def ensure_absent(module: AnsibleAWSModule, connection: Any) -> None:
-
     """Deletes an RDS cluster parameter group if it exists.
 
     Parameters:

--- a/plugins/modules/rds_cluster_param_group.py
+++ b/plugins/modules/rds_cluster_param_group.py
@@ -153,6 +153,19 @@ from ansible_collections.amazon.aws.plugins.module_utils.tagging import ansible_
 def modify_parameters(
     module: AnsibleAWSModule, connection: Any, group_name: str, parameters: List[Dict[str, Any]]
 ) -> bool:
+    """Compares desired parameters against current values and applies changes in chunks of 20.
+
+      Parameters:
+          module: AnsibleAWSModule
+          connection: boto3 RDS client
+          group_name (str): Name of the RDS cluster parameter group
+          parameters (list): List of parameter dicts with parameter_name, parameter_value, and
+  apply_method
+
+      Returns:
+          changed (bool): True if any parameters were modified, False otherwise
+      """
+
     current_params = describe_db_cluster_parameters(module, connection, group_name)
     parameters = snake_dict_to_camel_dict(parameters, capitalize_first=True)
     # compare current resource parameters with the value from module parameters
@@ -184,6 +197,14 @@ def modify_parameters(
 
 
 def ensure_present(module: AnsibleAWSModule, connection: Any) -> None:
+      """Creates or updates an RDS cluster parameter group, including tags and parameters.
+
+      Parameters:
+          module: AnsibleAWSModule
+          connection: boto3 RDS client
+
+      """
+
     group_name = module.params["name"]
     db_parameter_group_family = module.params["db_parameter_group_family"]
     tags = module.params.get("tags")
@@ -232,6 +253,13 @@ def ensure_present(module: AnsibleAWSModule, connection: Any) -> None:
 
 
 def ensure_absent(module: AnsibleAWSModule, connection: Any) -> None:
+      """Deletes an RDS cluster parameter group if it exists.
+
+      Parameters:
+          module: AnsibleAWSModule
+          connection: boto3 RDS client
+      """
+      
     group = module.params["name"]
     response = describe_db_cluster_parameter_groups(module=module, connection=connection, group_name=group)
     if not response:

--- a/plugins/modules/rds_cluster_param_group_info.py
+++ b/plugins/modules/rds_cluster_param_group_info.py
@@ -112,6 +112,7 @@ except ImportError:
 from ansible.module_utils.common.dict_transformations import camel_dict_to_snake_dict
 
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
+from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
 from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_cluster_parameter_groups
 from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_cluster_parameters
 from ansible_collections.amazon.aws.plugins.module_utils.rds import get_tags
@@ -149,8 +150,10 @@ def main() -> None:
         client = module.client("rds", retry_decorator=AWSRetry.jittered_backoff(retries=10))
     except (botocore.exceptions.ClientError, botocore.exceptions.BotoCoreError) as e:
         module.fail_json_aws(e, msg="Failed to connect to AWS.")
-
-    describe_rds_cluster_parameter_group(client, module)
+    try:
+        describe_rds_cluster_parameter_group(client, module)
+    except AnsibleRDSError as e:
+        module.fail_json_aws(e, msg="Failed to describe RDS cluster parameter groups")
 
 
 if __name__ == "__main__":

--- a/plugins/modules/rds_engine_versions_info.py
+++ b/plugins/modules/rds_engine_versions_info.py
@@ -299,7 +299,9 @@ from ansible.module_utils.common.dict_transformations import camel_dict_to_snake
 
 from ansible_collections.amazon.aws.plugins.module_utils.modules import AnsibleAWSModule
 from ansible_collections.amazon.aws.plugins.module_utils.rds import AnsibleRDSError
-from ansible_collections.amazon.aws.plugins.module_utils.rds import describe_db_engine_versions as _describe_db_engine_versions
+from ansible_collections.amazon.aws.plugins.module_utils.rds import (
+    describe_db_engine_versions as _describe_db_engine_versions,
+)
 from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_tag_list_to_ansible_dict
 
 

--- a/plugins/modules/rds_global_cluster_info.py
+++ b/plugins/modules/rds_global_cluster_info.py
@@ -198,7 +198,10 @@ def main():
     client = module.client("rds")
 
     try:
-        module.exit_json(changed=False, global_clusters=global_cluster_info(client, module, module.params.get("global_cluster_identifier")))
+        module.exit_json(
+            changed=False,
+            global_clusters=global_cluster_info(client, module, module.params.get("global_cluster_identifier")),
+        )
     except AnsibleRDSError as e:
         module.fail_json_aws(e, msg="Could not describe global clusters.")
 

--- a/tests/unit/plugins/module_utils/rds/test_rds_api.py
+++ b/tests/unit/plugins/module_utils/rds/test_rds_api.py
@@ -708,11 +708,16 @@ class TestDescribeDbEngineVersions:
         }
 
         result = describe_db_engine_versions(
-            client, Engine="postgres", DefaultOnly=True, DBParameterGroupFamily="postgres16",
+            client,
+            Engine="postgres",
+            DefaultOnly=True,
+            DBParameterGroupFamily="postgres16",
         )
 
         paginator.paginate.assert_called_with(
-            Engine="postgres", DefaultOnly=True, DBParameterGroupFamily="postgres16",
+            Engine="postgres",
+            DefaultOnly=True,
+            DBParameterGroupFamily="postgres16",
         )
         assert len(result) == 1
 

--- a/tests/unit/plugins/modules/test_rds_engine_versions_info.py
+++ b/tests/unit/plugins/modules/test_rds_engine_versions_info.py
@@ -28,8 +28,13 @@ def test_engine_versions_info_with_engine(m_describe):
     ]
 
     result = engine_versions_info(
-        conn, module, engine="aurora-postgresql", engine_version=None,
-        db_parameter_group_family=None, default_only=False, filters=None,
+        conn,
+        module,
+        engine="aurora-postgresql",
+        engine_version=None,
+        db_parameter_group_family=None,
+        default_only=False,
+        filters=None,
     )
 
     assert result == [
@@ -58,15 +63,23 @@ def test_engine_versions_info_default_only(m_describe):
     ]
 
     result = engine_versions_info(
-        conn, module, engine="postgres", engine_version=None,
-        db_parameter_group_family="postgres16", default_only=True, filters=None,
+        conn,
+        module,
+        engine="postgres",
+        engine_version=None,
+        db_parameter_group_family="postgres16",
+        default_only=True,
+        filters=None,
     )
 
     assert len(result) == 1
     assert result[0]["engine"] == "postgres"
     assert result[0]["tags"] == {}
     m_describe.assert_called_with(
-        conn, DefaultOnly=True, Engine="postgres", DBParameterGroupFamily="postgres16",
+        conn,
+        DefaultOnly=True,
+        Engine="postgres",
+        DBParameterGroupFamily="postgres16",
     )
 
 
@@ -77,8 +90,13 @@ def test_engine_versions_info_no_results(m_describe):
     m_describe.return_value = []
 
     result = engine_versions_info(
-        conn, module, engine="mysql", engine_version="99.99",
-        db_parameter_group_family=None, default_only=False, filters=None,
+        conn,
+        module,
+        engine="mysql",
+        engine_version="99.99",
+        db_parameter_group_family=None,
+        default_only=False,
+        filters=None,
     )
 
     assert result == []
@@ -96,8 +114,13 @@ def test_engine_versions_info_no_tag_list_key(m_describe):
     ]
 
     result = engine_versions_info(
-        conn, module, engine="mysql", engine_version=None,
-        db_parameter_group_family=None, default_only=False, filters=None,
+        conn,
+        module,
+        engine="mysql",
+        engine_version=None,
+        db_parameter_group_family=None,
+        default_only=False,
+        filters=None,
     )
 
     assert result[0]["tags"] == {}
@@ -111,8 +134,13 @@ def test_engine_versions_info_with_filters(m_describe):
     filters = {"engine-mode": "provisioned"}
 
     engine_versions_info(
-        conn, module, engine=None, engine_version=None,
-        db_parameter_group_family=None, default_only=False, filters=filters,
+        conn,
+        module,
+        engine=None,
+        engine_version=None,
+        db_parameter_group_family=None,
+        default_only=False,
+        filters=filters,
     )
 
     m_describe.assert_called_with(conn, DefaultOnly=False, Filters=filters)


### PR DESCRIPTION
##### SUMMARY

  Refactor `rds_cluster_param_group` module to align error handling with patterns established in #2119 and
  #2138. Part of https://github.com/ansible-collections/amazon.aws/issues/2003.

##### ISSUE TYPE
Refactoring Pull Request

##### COMPONENT NAME

`rds_cluster_param_group`
`module_utils/_rds/api.py`
`module_utils/_rds/common.py`

##### ADDITIONAL INFORMATION

  module_utils/_rds/common.py:
  - Add DBParameterGroupNotFound to RDSErrorHandler._is_missing() error code list

  module_utils/_rds/api.py:
  - Refactor `describe_db_cluster_parameter_groups()` to use `@RDSErrorHandler.list_error_handler` decorator
  instead of manual `try/except` with `is_boto3_error_code`
  - Refactor `describe_db_cluster_parameters()` to use `@RDSErrorHandler.list_error_handler decorator`
  instead of manual `try/except `with i`s_boto3_error_code`

  rds_cluster_param_group module:
  - Add PEP 257 docstrings to `modify_parameters()`, `ensure_present()`, and `ensure_absent()` functions

Assisted by Claude opus 4.6

