### PR TITLE
fix: address failing sanity test checks from trailing newline

### DIFF
--- a/tests/unit/plugins/module_utils/rds/test_rds_api.py
+++ b/tests/unit/plugins/module_utils/rds/test_rds_api.py
@@ -714,4 +714,3 @@ class TestDescribeDbEngineVersions:
             Engine="postgres", DefaultOnly=True, DBParameterGroupFamily="postgres16",
         )
         assert len(result) == 1
-


### PR DESCRIPTION
##### SUMMARY

This change addresses the following `ansible-test sanity` check failure:

```
ERROR: Found 1 pylint issue(s) which need to be resolved:
ERROR: tests/unit/plugins/module_utils/rds/test_rds_api.py:717:0: trailing-newlines: Trailing newlines
```

##### ISSUE TYPE

- Bugfix Pull Request