### PR TITLE
[stable-10]: Update Ansible lint configuration (#3067)

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -2,6 +2,13 @@
 profile: production
 
 exclude_paths:
-  - changelogs/changelog.yaml
-  - .github/
+  - changelogs
+  - docs
   - tests/integration
+  - tests/sanity/ignore-*.txt # Ignore violations related to deprecated keys.
+  - tests/unit
+  - .ansible
+  - .github
+
+warn_list:
+  - no-log-password


### PR DESCRIPTION
Backport of https://github.com/ansible-collections/amazon.aws/pull/3067

Brings the .ansible-lint configuration in line with the recommendation for certified content at: https://docs.ansible.com/projects/partner-certification-requirements/static-analysis/#ansible-lint-configuration Also adds the --- header to the meta/extensions.yml file.

Reviewed-by: Mark Chappell
Reviewed-by: Alina Buzachis
Reviewed-by: Bikouo Aubin
(cherry picked from commit f9a2dc6670a088ea5119d3e93a5dcd99a3753bfe)
