### PR TITLE
feat(ec2_tag): add resource_tags alias for tags parameter

### DIFF
--- a/changelogs/fragments/3063-ec2_tag-resource_tags-alias.yml
+++ b/changelogs/fragments/3063-ec2_tag-resource_tags-alias.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - ec2_tag - added ``resource_tags`` as an alias for the ``tags`` parameter, matching the convention already used by the ``ec2_instance`` module (https://github.com/ansible-collections/amazon.aws/issues/3063).
+  - ec2_tag - added ``resource_tags`` as an alias for the ``tags`` parameter, matching the convention already used by the ``ec2_instance`` module (https://github.com/ansible-collections/amazon.aws/pull/3085).

--- a/changelogs/fragments/3063-ec2_tag-resource_tags-alias.yml
+++ b/changelogs/fragments/3063-ec2_tag-resource_tags-alias.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - ec2_tag - added ``resource_tags`` as an alias for the ``tags`` parameter, matching the convention already used by the ``ec2_instance`` module (https://github.com/ansible-collections/amazon.aws/issues/3063).

--- a/plugins/modules/ec2_tag.py
+++ b/plugins/modules/ec2_tag.py
@@ -33,8 +33,13 @@ options:
     description:
       - A dictionary of tags to add or remove from the resource.
       - If the value provided for a key is not set and O(state=absent), the tag will be removed regardless of its current value.
+      - The O(resource_tags) alias was added in release 12.0.0, matching the naming used by
+        M(amazon.aws.ec2_instance). It is available for users who prefer to avoid the name
+        C(tags), which ansible-core treats as a reserved variable name. Both names are fully
+        supported and behave identically.
     type: dict
     required: true
+    aliases: ['resource_tags']
   purge_tags:
     description:
       - Whether unspecified tags should be removed from the resource.
@@ -58,6 +63,15 @@ EXAMPLES = r"""
     resource: vol-XXXXXX
     state: present
     tags:
+      Name: ubervol
+      env: prod
+
+- name: Ensure tags are present, using the resource_tags alias
+  amazon.aws.ec2_tag:
+    region: eu-west-1
+    resource: vol-XXXXXX
+    state: present
+    resource_tags:
       Name: ubervol
       env: prod
 
@@ -122,7 +136,7 @@ from ansible_collections.amazon.aws.plugins.module_utils.tagging import compare_
 def main():
     argument_spec = dict(
         resource=dict(required=True),
-        tags=dict(type="dict", required=True),
+        tags=dict(type="dict", required=True, aliases=["resource_tags"]),
         purge_tags=dict(type="bool", default=False),
         state=dict(default="present", choices=["present", "absent"]),
     )

--- a/tests/integration/targets/ec2_tag/tasks/main.yml
+++ b/tests/integration/targets/ec2_tag/tasks/main.yml
@@ -125,6 +125,47 @@
           - result is changed
           - result.tags | length == 0
 
+    - name: Set a tag using the resource_tags alias
+      amazon.aws.ec2_tag:
+        resource: "{{ volume.volume_id }}"
+        resource_tags:
+          alias_key: alias_value
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.added_tags | length == 1
+          - result.tags | length == 1
+          - result.tags.alias_key == 'alias_value'
+
+    - name: Set a tag using the resource_tags alias - idempotency
+      amazon.aws.ec2_tag:
+        resource: "{{ volume.volume_id }}"
+        resource_tags:
+          alias_key: alias_value
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is not changed
+          - result.tags | length == 1
+          - result.tags.alias_key == 'alias_value'
+
+    - name: Remove a tag set via the alias, using the tags parameter name
+      amazon.aws.ec2_tag:
+        resource: "{{ volume.volume_id }}"
+        state: absent
+        tags:
+          alias_key: alias_value
+      register: result
+
+    - ansible.builtin.assert:
+        that:
+          - result is changed
+          - result.removed_tags | length == 1
+          - "'alias_key' in result.removed_tags"
+
   always:
     - name: Remove the volume
       amazon.aws.ec2_vol:


### PR DESCRIPTION
##### SUMMARY

Adds `resource_tags` as an alias for the required `tags` parameter of the `ec2_tag` module, matching the convention already used by `ec2_instance`.

Refs #3063

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME

ec2_tag

##### ADDITIONAL INFORMATION

The functional change is a single line in the argument spec:

```python
tags=dict(type="dict", required=True, aliases=["resource_tags"]),
```

`AnsibleModule` resolves aliases before populating `module.params`, so no downstream logic needed changing and `required=True` is still satisfied by either name.

Also included: documentation of the alias, an example using it, and three integration tests — set via the alias, idempotency, and removal via `tags` of a tag that was set via `resource_tags`. That last one is the meaningful guard: it only passes if both names resolve to the same parameter rather than two parallel paths.

`ec2_tag_info` was reviewed and deliberately left unchanged — it has no `tags` input parameter, only `resource`.

**On the reserved-name warning**

Issue #3063 also asks that using the alias stop ansible-core's `Found variable using reserved name 'tags'` warning. This PR does not do that, and I don't think an alias can.

`warn_if_reserved()` is called from exactly four places, all in `ansible/vars/manager.py`, and each passes variables or facts — never module parameter names. Verified with a module using this exact argspec:

| Scenario | Warning? |
|---|---|
| Module param literally named `tags` | No |
| Module param via `resource_tags` alias | No |
| Alias used, but a variable named `tags` exists | **Yes** |

The trigger is a variable named `tags`, not the module parameter. Where that variable comes from the `aws_ec2` inventory plugin, #3028 looks like the relevant issue. I've raised this on #3063 so refinement can decide whether to rescope that item or move it.

The alias still stands on its own merits as a consistency fix with `ec2_instance`.

**Testing**

`ansible-test sanity` passes on the changed files — 26 tests including validate-modules, ansible-doc, pylint, pep8, yamllint, and changelog. `compile`/`import` ran on Python 3.13 and 3.14 only, as older interpreters weren't available locally; CI will cover the rest. Integration tests were not run locally since they require AWS credentials.

Assisted-by: Claude Opus 5
