### PR TITLE
Refactor/rds cluster snapshot

### DIFF
--- a/changelogs/fragments/rds_cluster_snapshot-refactor.yml
+++ b/changelogs/fragments/rds_cluster_snapshot-refactor.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rds_cluster_snapshot - Added docstrings to the module's helper functions, aligning the module with the style used by the shared ``module_utils/rds`` utilities (https://github.com/ansible-collections/amazon.aws/pull/3090).

--- a/changelogs/fragments/rds_cluster_snapshot-refactor.yml
+++ b/changelogs/fragments/rds_cluster_snapshot-refactor.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rds_cluster_snapshot - Added docstrings to the module's helper functions, aligning the module with the style used by the shared ``module_utils/rds`` utilities (https://github.com/ansible-collections/amazon.aws/pull/PLACEHOLDER).

--- a/changelogs/fragments/rds_cluster_snapshot-refactor.yml
+++ b/changelogs/fragments/rds_cluster_snapshot-refactor.yml
@@ -1,2 +1,0 @@
-minor_changes:
-  - rds_cluster_snapshot - Added docstrings to the module's helper functions, aligning the module with the style used by the shared ``module_utils/rds`` utilities (https://github.com/ansible-collections/amazon.aws/pull/PLACEHOLDER).

--- a/plugins/modules/rds_cluster_snapshot.py
+++ b/plugins/modules/rds_cluster_snapshot.py
@@ -235,6 +235,13 @@ from ansible_collections.amazon.aws.plugins.module_utils.rds import get_snapshot
 
 
 def ensure_snapshot_absent(client, module: AnsibleAWSModule) -> None:
+    """
+    Delete a DB cluster snapshot if it exists and is not already being deleted.
+
+    Args:
+        client: A boto3 RDS client.
+        module: The AnsibleAWSModule instance.
+    """
     snapshot_id = module.params.get("db_cluster_snapshot_identifier")
     changed = False
 
@@ -251,6 +258,17 @@ def ensure_snapshot_absent(client, module: AnsibleAWSModule) -> None:
 
 
 def copy_snapshot(client, module: AnsibleAWSModule, params: Dict[str, Any]) -> bool:
+    """
+    Copy a DB cluster snapshot from a source snapshot if the target snapshot does not already exist.
+
+    Args:
+        client: A boto3 RDS client.
+        module: The AnsibleAWSModule instance.
+        params: Snapshot parameters formatted for the boto3 RDS client.
+
+    Returns:
+        True if a change was made.
+    """
     changed = False
     snapshot_id = module.params.get("db_cluster_snapshot_identifier")
 
@@ -269,6 +287,14 @@ def copy_snapshot(client, module: AnsibleAWSModule, params: Dict[str, Any]) -> b
 
 
 def ensure_snapshot_present(client, module: AnsibleAWSModule, params: Dict[str, Any]) -> None:
+    """
+    Create, copy, or update a DB cluster snapshot to match the desired state.
+
+    Args:
+        client: A boto3 RDS client.
+        module: The AnsibleAWSModule instance.
+        params: Snapshot parameters formatted for the boto3 RDS client.
+    """
     source_id = module.params.get("source_db_cluster_snapshot_identifier")
     snapshot_id = module.params.get("db_cluster_snapshot_identifier")
     changed = False
@@ -299,6 +325,17 @@ def ensure_snapshot_present(client, module: AnsibleAWSModule, params: Dict[str, 
 
 
 def create_snapshot(client, module: AnsibleAWSModule, params: Dict[str, Any]) -> bool:
+    """
+    Create a new DB cluster snapshot.
+
+    Args:
+        client: A boto3 RDS client.
+        module: The AnsibleAWSModule instance.
+        params: Snapshot parameters formatted for the boto3 RDS client.
+
+    Returns:
+        True if a change was made.
+    """
     method_params = format_rds_client_method_parameters(
         client, module, params, "create_db_cluster_snapshot", format_tags=True
     )
@@ -308,6 +345,16 @@ def create_snapshot(client, module: AnsibleAWSModule, params: Dict[str, Any]) ->
 
 
 def modify_snapshot(client, module: AnsibleAWSModule) -> bool:
+    """
+    Update tags on an existing DB cluster snapshot.
+
+    Args:
+        client: A boto3 RDS client.
+        module: The AnsibleAWSModule instance.
+
+    Returns:
+        True if a change was made.
+    """
     # TODO - add other modifications aside from purely tags
     changed = False
     snapshot_id = module.params.get("db_cluster_snapshot_identifier")


### PR DESCRIPTION
##### SUMMARY
Add docstrings to `rds_cluster_snapshot`'s helper functions, matching the style used by the shared  `module_utils/rds` utilities and the same cleanup pass done for `rds_instance_snapshot` in #3080.
The module already uses the shared `get_snapshot`, `call_method`, `format_rds_client_method_parameters`,  `ensure_tags`, and `arg_spec_to_rds_params` helpers from a prior refactor (#2138), and its `absent` state logic has no redundant branches to simplify. No functional changes.

This is in service of https://redhat.atlassian.net/browse/ACA-2475.

##### ISSUE TYPE
- Refactoring Pull Request
 
##### COMPONENT NAME
rds_cluster_snapshot
  
##### ADDITIONAL INFORMATION

Assisted-by: Claude Code / Sonnet 5 (Anthropic)