### PR TITLE
refactor(rds_snapshot_info): add docstrings to helper functions

### DIFF
--- a/changelogs/fragments/rds_snapshot_info-refactor.yml
+++ b/changelogs/fragments/rds_snapshot_info-refactor.yml
@@ -1,2 +1,2 @@
 minor_changes:
-  - rds_snapshot_info - Added docstrings to the module's helper functions, aligning the module with the style used by the shared ``module_utils/rds`` utilities (https://github.com/ansible-collections/amazon.aws/pull/PLACEHOLDER).
+  - rds_snapshot_info - Added docstrings to the module's helper functions, aligning the module with the style used by the shared ``module_utils/rds`` utilities (https://github.com/ansible-collections/amazon.aws/pull/3091).

--- a/changelogs/fragments/rds_snapshot_info-refactor.yml
+++ b/changelogs/fragments/rds_snapshot_info-refactor.yml
@@ -1,0 +1,2 @@
+minor_changes:
+  - rds_snapshot_info - Added docstrings to the module's helper functions, aligning the module with the style used by the shared ``module_utils/rds`` utilities (https://github.com/ansible-collections/amazon.aws/pull/PLACEHOLDER).

--- a/plugins/modules/rds_snapshot_info.py
+++ b/plugins/modules/rds_snapshot_info.py
@@ -355,6 +355,19 @@ from ansible_collections.amazon.aws.plugins.module_utils.tagging import boto3_ta
 def common_snapshot_info(
     client, module: AnsibleAWSModule, describe_snapshots_method: Callable, params: Dict[str, Any]
 ) -> List[Dict[str, Any]]:
+    """
+    Retrieve and format snapshot information using the provided describe method.
+
+    Args:
+        client: A boto3 RDS client.
+        module: The AnsibleAWSModule instance.
+        describe_snapshots_method: The module_utils/rds function used to describe snapshots
+            (describe_db_cluster_snapshots or describe_db_snapshots).
+        params: Parameters formatted for the boto3 RDS client describe call.
+
+    Returns:
+        A list of snapshot attribute dicts, snake_cased and with tags converted to a dict.
+    """
     try:
         results = describe_snapshots_method(client, **params)
     except AnsibleRDSError as e:
@@ -368,6 +381,16 @@ def common_snapshot_info(
 
 
 def cluster_snapshot_info(client, module: AnsibleAWSModule) -> List[Dict[str, Any]]:
+    """
+    Retrieve information about DB cluster snapshots matching the module's parameters.
+
+    Args:
+        client: A boto3 RDS client.
+        module: The AnsibleAWSModule instance.
+
+    Returns:
+        A list of cluster snapshot attribute dicts.
+    """
     snapshot_id = module.params.get("db_cluster_snapshot_identifier")
     snapshot_type = module.params.get("snapshot_type")
     instance_name = module.params.get("db_cluster_identifier")
@@ -388,6 +411,16 @@ def cluster_snapshot_info(client, module: AnsibleAWSModule) -> List[Dict[str, An
 
 
 def instance_snapshot_info(client, module: AnsibleAWSModule) -> List[Dict[str, Any]]:
+    """
+    Retrieve information about DB instance snapshots matching the module's parameters.
+
+    Args:
+        client: A boto3 RDS client.
+        module: The AnsibleAWSModule instance.
+
+    Returns:
+        A list of instance snapshot attribute dicts.
+    """
     snapshot_id = module.params.get("db_snapshot_identifier")
     snapshot_type = module.params.get("snapshot_type")
     instance_name = module.params.get("db_instance_identifier")


### PR DESCRIPTION
##### SUMMARY

Add docstrings to `rds_snapshot_info`'s helper functions, matching the style used by the shared `module_utils/rds` utilities and the same cleanup pass done for `rds_instance_snapshot` in #3080.
 
The module already uses the shared `describe_db_cluster_snapshots`, `describe_db_snapshots`, and `AnsibleRDSError` helpers from a prior refactor (#2138), and has no redundant logic to simplify. This is a docstring-only pass, no functional changes.
  
##### ISSUE TYPE
- Refactoring Pull Request
  
##### COMPONENT NAME
rds_snapshot_info
  
##### ADDITIONAL INFORMATION

Assisted-by: Claude Code / Sonnet 5 (Anthropic)