### PR TITLE
event_query: 13 of 15 audit queries report no node at all -- 2 raise a jq error that discards the whole event, and status/tags in the dedup key re-count every resource

### DIFF
--- a/changelogs/fragments/event_query-contract-tests.yml
+++ b/changelogs/fragments/event_query-contract-tests.yml
@@ -1,0 +1,5 @@
+---
+trivial:
+  - tests - add unit tests asserting the ``extensions/audit/event_query.yml`` output contract
+    (non-null top-level ``name``, complete taxonomy, normalized taxonomy values) and correct the
+    ``event_query_parser`` return sample to match that contract.

--- a/changelogs/fragments/event_query-contract-tests.yml
+++ b/changelogs/fragments/event_query-contract-tests.yml
@@ -1,5 +1,30 @@
 ---
+bugfixes:
+  - event_query - emit a non-null top-level ``name`` from every query. Thirteen of the fifteen
+    queries emitted none at all, and the indirect node counting consumer discards any record
+    without one (https://github.com/ansible-collections/amazon.aws/pull/3092).
+  - event_query - guard the source array of every query with ``[]?``. ``.object_info[]`` and
+    ``.internet_gateways[] | .attachments | map(...)`` raised "Cannot iterate over null" for
+    result shapes both modules routinely return, and a jq error is handled at the event, so it
+    discarded the audit records of every other module in the same event
+    (https://github.com/ansible-collections/amazon.aws/pull/3092).
+  - event_query - move ``status``, ``tags`` and the user-supplied RDS identifiers out of
+    ``canonical_facts`` and into ``facts``. ``canonical_facts`` is the sole deduplication key, so
+    stopping an instance, editing a tag or renaming a database counted the resource again
+    (https://github.com/ansible-collections/amazon.aws/pull/3092).
+  - event_query - key ``elb_application_lb_info`` on the load balancer ARN rather than its name,
+    which can be reused after the load balancer is deleted
+    (https://github.com/ansible-collections/amazon.aws/pull/3092).
+minor_changes:
+  - event_query - normalize every ``infra_type``, ``infra_bucket`` and ``device_type`` value to
+    ``lowercase_with_underscores``. ``PublicCloud`` and ``public_cloud`` are two separate buckets
+    downstream, and ``NAT Gateway`` and ``Route table`` matched no bucket at all. The two
+    ambiguous RDS values are now ``database_instance`` and ``database_cluster``
+    (https://github.com/ansible-collections/amazon.aws/pull/3092).
 trivial:
   - tests - add unit tests asserting the ``extensions/audit/event_query.yml`` output contract
-    (non-null top-level ``name``, complete taxonomy, normalized taxonomy values) and correct the
-    ``event_query_parser`` return sample to match that contract.
+    (non-null top-level ``name``, non-null and identity-only ``canonical_facts``, complete and
+    normalized taxonomy) and correct the ``event_query_parser`` return sample to match it.
+  - tests - update the ``node_query_*`` integration targets to the corrected contract. Their
+    expected results were derived from the queries' own output, so they agreed with every defect
+    above by construction.

--- a/extensions/audit/event_query.yml
+++ b/extensions/audit/event_query.yml
@@ -1,178 +1,247 @@
 ---
+# Indirect node counting queries for the amazon.aws collection.
+#
+# These jq expressions run inside the Automation Platform controller
+# (awx/main/tasks/host_indirect.py) against each module's result, and their
+# output feeds subscription node counting. Nothing in this repository executes
+# them against a real module result, so
+# tests/unit/extensions/audit/test_event_query_contract.py asserts the contract
+# the controller imposes on the output.
+#
+# THE CONTRACT
+# ------------
+# name             must be present and never null. `if name is None: continue`
+#                  -- a record with no top-level `name` key is discarded.
+# canonical_facts  must be present, truthy, and free of null at ANY depth.
+#                  get_hashable_form() accepts int/float/str/bool/dict/list/
+#                  tuple and raises UnhashableFacts on anything else, including
+#                  null; the caller catches it and skips the record. A single
+#                  null field silently discards the whole node, with the job
+#                  still green.
+# canonical_facts  is the ONLY dedup key (`results[hashable_facts]`), so it must
+#                  hold identity and nothing else. Anything in it that changes
+#                  over the life of a resource counts that resource again.
+# facts            must carry infra_type, infra_bucket and device_type, and
+#                  their values must be lowercase_with_underscores
+#                  (^[a-z0-9]+(_[a-z0-9]+)*$) so the rollup can bucket them.
+#                  `facts` is not hashed, so volatile attributes belong here.
+#
+# A jq *error* is caught one level up, at the event, so a single query that
+# raises discards the audit records of every other module in that event too.
+# `.instances[]` raises "Cannot iterate over null" whenever the module did not
+# return that key; every source below is therefore `[]?`-guarded and the
+# result is type-checked before it is indexed.
+
 # COMPUTE
 
+# .name is not a key of ec2_instance_info's return; the display name is the
+# Name tag, falling back to the instance id so it is never null.
+# state.name and tags were in canonical_facts: stopping and starting an
+# instance, or editing a tag, counted the same instance again. Both moved to
+# facts, which is not hashed.
 amazon.aws.ec2_instance_info:
   query: >-
-    .instances[] | select(. != null) | {
-      name: (.name // .tags.Name // "UNKNOWN"),  # unique identifier for the resource
+    .instances[]? | select(type == "object") | select(.instance_id != null) |
+    {
+      name: (.tags.Name // .instance_id),
       canonical_facts: {
-      id: .instance_id,
-      status: .state.name,
-      tags: (.tags // {}),
+        instance_id: .instance_id
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Compute",
-        device_type: "EC2"
-        },
+        infra_type: "public_cloud",
+        infra_bucket: "compute",
+        device_type: "ec2",
+        status: (.state.name // "unknown"),
+        tags: (.tags // {})
       }
+    }
 
 # NETWORKING
 
+# No top-level `name` was emitted, so every load balancer was discarded by the
+# controller. The ARN is the stable identity; the name can be reused after a
+# load balancer is deleted.
 amazon.aws.elb_application_lb_info:
   query: >-
-    .load_balancers[] | select(. != null) |
+    .load_balancers[]? | select(type == "object") |
+    select(.load_balancer_arn != null) |
     {
+      name: (.load_balancer_name // .load_balancer_arn),
       canonical_facts: {
-        name: .load_balancer_name,
-        status: .state.code,
-        tags: (.tags // {}),
+        load_balancer_arn: .load_balancer_arn
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Networking",
-        device_type: "ApplicationLoadBalancer"
-      },
+        infra_type: "public_cloud",
+        infra_bucket: "networking",
+        device_type: "application_load_balancer",
+        status: (.state.code // "unknown"),
+        tags: (.tags // {})
+      }
     }
 
+# A classic load balancer's return carries no ARN, so the name is the only
+# available identity.
 amazon.aws.elb_classic_lb_info:
   query: >-
-    .elbs[] | select(. != null) |
+    .elbs[]? | select(type == "object") |
+    select(.load_balancer_name != null) |
     {
+      name: .load_balancer_name,
       canonical_facts: {
-        name: .load_balancer_name,
-        tags: (.tags // {}),
+        load_balancer_name: .load_balancer_name
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Networking",
-        device_type: "ClassicLoadBalancer"
-      },
+        infra_type: "public_cloud",
+        infra_bucket: "networking",
+        device_type: "classic_load_balancer",
+        tags: (.tags // {})
+      }
     }
 
 amazon.aws.ec2_vpc_net_info:
   query: >-
-    .vpcs[] | select(. != null) | {
-        name: (.name // .tags.Name // "UNKNOWN"),
-        canonical_facts: {
-          id: .id,
-          status: .state,
-          tags: (.tags // {})
-        },
-        facts: {
-          infra_type: "PublicCloud",
-          infra_bucket: "Networking",
-          device_type: "VPC"
-        }
+    .vpcs[]? | select(type == "object") |
+    select((.vpc_id // .id) != null) |
+    {
+      name: (.tags.Name // .vpc_id // .id),
+      canonical_facts: {
+        vpc_id: (.vpc_id // .id)
+      },
+      facts: {
+        infra_type: "public_cloud",
+        infra_bucket: "networking",
+        device_type: "vpc",
+        status: (.state // "unknown"),
+        tags: (.tags // {})
       }
+    }
 
 amazon.aws.ec2_vpc_subnet_info:
   query: >-
-    .subnets[] | select(. != null) | {
+    .subnets[]? | select(type == "object") |
+    select((.subnet_id // .id) != null) |
+    {
+      name: (.tags.Name // .subnet_id // .id),
       canonical_facts: {
-        id: .id,
-        status: .state,
-        tags: (.tags // {})
+        subnet_id: (.subnet_id // .id)
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Networking",
-        device_type: "Subnet"
+        infra_type: "public_cloud",
+        infra_bucket: "networking",
+        device_type: "subnet",
+        status: (.state // "unknown"),
+        tags: (.tags // {})
       }
     }
 
 amazon.aws.ec2_vpc_nat_gateway_info:
   query: >-
-    .result[] | select(. != null) |
+    .result[]? | select(type == "object") |
+    select(.nat_gateway_id != null) |
     {
+      name: (.tags.Name // .nat_gateway_id),
       canonical_facts: {
-        id: .nat_gateway_id,
-        status: .state,
-        tags: (.tags // {})
+        nat_gateway_id: .nat_gateway_id
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Networking",
-        device_type: "NAT Gateway"
+        infra_type: "public_cloud",
+        infra_bucket: "networking",
+        device_type: "nat_gateway",
+        status: (.state // "unknown"),
+        tags: (.tags // {})
       }
     }
 
+# `.attachments | map(...)` raised "Cannot iterate over null" for a detached
+# gateway, which discarded the audit records of every module in that event,
+# not just this one. The attachment list is also not identity -- attaching a
+# gateway to a VPC counted it again -- so it is now a fact, built with `[]?`.
 amazon.aws.ec2_vpc_igw_info:
   query: >-
-    .internet_gateways[] | select(. != null) |
+    .internet_gateways[]? | select(type == "object") |
+    select(.internet_gateway_id != null) |
     {
+      name: (.tags.Name // .internet_gateway_id),
       canonical_facts: {
-        id: .internet_gateway_id,
-        status: (.attachments | map({vpc_id: .vpc_id, status: .state})),
-        tags: (.tags // {})
+        internet_gateway_id: .internet_gateway_id
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Networking",
-        device_type: "Internet Gateway"
+        infra_type: "public_cloud",
+        infra_bucket: "networking",
+        device_type: "internet_gateway",
+        attached_vpc_ids: [.attachments[]? | .vpc_id? // empty],
+        tags: (.tags // {})
       }
     }
 
 amazon.aws.ec2_vpc_vgw_info:
   query: >-
-    .virtual_gateways[] | select(. != null) |
+    .virtual_gateways[]? | select(type == "object") |
+    select(.vpn_gateway_id != null) |
     {
+      name: (.resource_tags.Name // .tags.Name // .vpn_gateway_id),
       canonical_facts: {
-        id: .vpn_gateway_id,
-        status: .state,
-        tags: (.resource_tags // {})
+        vpn_gateway_id: .vpn_gateway_id
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Networking",
-        device_type: "Virtual Gateway"
+        infra_type: "public_cloud",
+        infra_bucket: "networking",
+        device_type: "virtual_gateway",
+        status: (.state // "unknown"),
+        tags: (.resource_tags // {})
       }
     }
 
 amazon.aws.ec2_vpc_route_table_info:
   query: >-
-    .route_tables[] | select(. != null) |
+    .route_tables[]? | select(type == "object") |
+    select((.route_table_id // .id) != null) |
     {
+      name: (.tags.Name // .route_table_id // .id),
       canonical_facts: {
-        id: .route_table_id,
-        tags: (.tags // {})
+        route_table_id: (.route_table_id // .id)
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Networking",
-        device_type: "Route table"
+        infra_type: "public_cloud",
+        infra_bucket: "networking",
+        device_type: "route_table",
+        tags: (.tags // {})
       }
     }
 
 amazon.aws.ec2_vpc_vpn_info:
   query: >-
-    .vpn_connections[] | select(. != null) |
+    .vpn_connections[]? | select(type == "object") |
+    select(.vpn_connection_id != null) |
     {
+      name: (.tags.Name // .vpn_connection_id),
       canonical_facts: {
-        id: .vpn_connection_id,
-        status: .state,
-        tags: (.tags // {})
+        vpn_connection_id: .vpn_connection_id
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Networking",
-        device_type: "VPN Connection"
+        infra_type: "public_cloud",
+        infra_bucket: "networking",
+        device_type: "vpn_connection",
+        status: (.state // "unknown"),
+        tags: (.tags // {})
       }
     }
 
 amazon.aws.ec2_vpc_peering_info:
   query: >-
-    .vpc_peering_connections[] | select(. != null) |
+    .vpc_peering_connections[]? | select(type == "object") |
+    select(.vpc_peering_connection_id != null) |
     {
+      name: (.tags.Name // .vpc_peering_connection_id),
       canonical_facts: {
-        id: .vpc_peering_connection_id,
-        status: .status.code,
-        tags: (.tags // {})
+        vpc_peering_connection_id: .vpc_peering_connection_id
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Networking",
-        device_type: "VPC Peering"
+        infra_type: "public_cloud",
+        infra_bucket: "networking",
+        device_type: "vpc_peering",
+        status: (.status.code // "unknown"),
+        tags: (.tags // {})
       }
     }
 
@@ -180,68 +249,83 @@ amazon.aws.ec2_vpc_peering_info:
 
 amazon.aws.s3_bucket_info:
   query: >-
-    .buckets[] | select(. != null) |
+    .buckets[]? | select(type == "object") | select(.name != null) |
     {
+      name: .name,
       canonical_facts: {
-        name: .name,
-        tags: (.bucket_tagging // {})
+        bucket_name: .name
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Storage",
-        device_type: "Bucket"
+        infra_type: "public_cloud",
+        infra_bucket: "storage",
+        device_type: "bucket",
+        tags: (.bucket_tagging // {})
       }
     }
 
+# object_info is only returned when both bucket_name and object_name are set;
+# otherwise the module returns s3_keys and `.object_info[]` raised "Cannot
+# iterate over null", discarding the whole event. object_name is set by
+# describe_s3_object() at runtime but is absent from the RETURN block, so the
+# guard below is what proves it is present rather than the documentation.
 amazon.aws.s3_object_info:
   query: >-
-    .object_info[] | select(. != null) |
+    .object_info[]? | select(type == "object") |
+    select(.object_name != null) |
     {
+      name: .object_name,
       canonical_facts: {
-        name: .object_name,
-        tags: (.object_tagging // {})
+        object_name: .object_name
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Storage",
-        device_type: "Object"
+        infra_type: "public_cloud",
+        infra_bucket: "storage",
+        device_type: "object",
+        tags: (.object_tagging // {})
       }
     }
 
 # DATABASE
 
+# dbi_resource_id is the Region-unique immutable identifier.
+# db_instance_identifier is user-supplied and can be changed, so keeping both
+# in canonical_facts counted a renamed instance twice; the identifier is now
+# the display name and the fact, and the resource id alone is the key.
 amazon.aws.rds_instance_info:
   query: >-
-    .instances[] | select(. != null) |
+    .instances[]? | select(type == "object") |
+    select((.dbi_resource_id // .db_instance_arn) != null) |
     {
+      name: (.db_instance_identifier // .dbi_resource_id // .db_instance_arn),
       canonical_facts: {
-        id: .dbi_resource_id,  # AWS Region-unique, immutable identifier for the DB instance.
-        name: .db_instance_identifier,  # The user-supplied DB cluster identifier.
-        tags: (.tags // {}),
-        status: .db_instance_status
-
+        dbi_resource_id: (.dbi_resource_id // .db_instance_arn)
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Database",
-        device_type: "Instance"
+        infra_type: "public_cloud",
+        infra_bucket: "database",
+        device_type: "database_instance",
+        db_instance_identifier: (.db_instance_identifier // "unknown"),
+        status: (.db_instance_status // "unknown"),
+        tags: (.tags // {})
       }
     }
 
 amazon.aws.rds_cluster_info:
   query: >-
-    .clusters[] | select(. != null) |
+    .clusters[]? | select(type == "object") |
+    select((.db_cluster_resource_id // .db_cluster_arn) != null) |
     {
+      name: (.db_cluster_identifier // .db_cluster_resource_id //
+             .db_cluster_arn),
       canonical_facts: {
-        id: .db_cluster_resource_id,  # The AWS Region-unique, immutable identifier for the DB cluster.
-        name: .db_cluster_identifier,  # The user-supplied DB cluster identifier.
-        tags: (.tags // {}),
-        status: .status
-
+        db_cluster_resource_id: (.db_cluster_resource_id // .db_cluster_arn)
       },
       facts: {
-        infra_type: "PublicCloud",
-        infra_bucket: "Database",
-        device_type: "Cluster"
+        infra_type: "public_cloud",
+        infra_bucket: "database",
+        device_type: "database_cluster",
+        db_cluster_identifier: (.db_cluster_identifier // "unknown"),
+        status: (.status // "unknown"),
+        tags: (.tags // .tag_list // {})
       }
     }

--- a/tests/integration/targets/node_query_database_cluster/play.yaml
+++ b/tests/integration/targets/node_query_database_cluster/play.yaml
@@ -23,10 +23,13 @@
           Created_By: Ansible Indirect NodeQuery Count integration tests
       - name: "{{ resource_prefix }}-cluster-2"
 
+    # Taxonomy values must be lowercase_with_underscores or the indirect-node
+    # rollup cannot bucket them. "Cluster" is also ambiguous across
+    # collections; "database_cluster" says which kind.
     rds_cluster_facts:
-      device_type: "Cluster"
-      infra_bucket: "Database"
-      infra_type: "PublicCloud"
+      device_type: "database_cluster"
+      infra_bucket: "database"
+      infra_type: "public_cloud"
 
   tasks:
     - block:
@@ -63,21 +66,25 @@
             that:
               - node_count == expected_result  
           vars:
-            expected_result: 
-              - canonical_facts:
-                  id: "{{ cluster_1.db_cluster_resource_id }}"
-                  name: "{{ resource_prefix }}-cluster-1"
-                  status: "{{ cluster_1.status }}"
-                  tags:
-                    Name: "{{ resource_prefix }}-cluster-1"
-                    Created_By: Ansible Indirect NodeQuery Count integration tests
-                facts: "{{ rds_cluster_facts }}"
-              - canonical_facts:
-                  id: "{{ cluster_2.db_cluster_resource_id }}"
-                  name: "{{ resource_prefix }}-cluster-2"
-                  status: "{{ cluster_2.status }}"
-                  tags: {}
-                facts: "{{ rds_cluster_facts }}"
+            # db_cluster_identifier is user-supplied and can be changed, so
+            # it is a fact rather than part of the dedup key; the Region-unique
+            # db_cluster_resource_id is the identity.
+            cluster_1_tags:
+              Name: "{{ resource_prefix }}-cluster-1"
+              Created_By: Ansible Indirect NodeQuery Count integration tests
+            expected_result:
+              - name: "{{ resource_prefix }}-cluster-1"
+                canonical_facts:
+                  db_cluster_resource_id: "{{ cluster_1.db_cluster_resource_id }}"
+                facts: >-
+                  {{ rds_cluster_facts | combine({'db_cluster_identifier': resource_prefix ~ '-cluster-1',
+                                                  'status': cluster_1.status, 'tags': cluster_1_tags}) }}
+              - name: "{{ resource_prefix }}-cluster-2"
+                canonical_facts:
+                  db_cluster_resource_id: "{{ cluster_2.db_cluster_resource_id }}"
+                facts: >-
+                  {{ rds_cluster_facts | combine({'db_cluster_identifier': resource_prefix ~ '-cluster-2',
+                                                  'status': cluster_2.status, 'tags': {}}) }}
 
       always:      
         - name: Delete RDS clusters

--- a/tests/integration/targets/node_query_database_instance/play.yaml
+++ b/tests/integration/targets/node_query_database_instance/play.yaml
@@ -26,10 +26,13 @@
           Created_by: Ansible Indirect NodeQuery Count integration tests
       - name: "{{ resource_prefix }}-instance-2"
 
+    # Taxonomy values must be lowercase_with_underscores or the indirect-node
+    # rollup cannot bucket them. "Instance" is also ambiguous across
+    # collections; "database_instance" says which kind.
     rds_instance_facts:
-      device_type: "Instance"
-      infra_bucket: "Database"
-      infra_type: "PublicCloud"
+      device_type: "database_instance"
+      infra_bucket: "database"
+      infra_type: "public_cloud"
 
   tasks:
     - block:
@@ -69,21 +72,25 @@
             that:
               - node_count == expected_result  
           vars:
-            expected_result: 
-              - canonical_facts:
-                  id: "{{ instance_1.dbi_resource_id }}"
-                  name: "{{ resource_prefix }}-instance-1"
-                  status: "{{ instance_1.db_instance_status }}"
-                  tags:
-                    Name: "{{ resource_prefix }}-instance-1"
-                    Created_by: Ansible Indirect NodeQuery Count integration tests
-                facts: "{{ rds_instance_facts }}"
-              - canonical_facts:
-                  id: "{{ instance_2.dbi_resource_id }}"
-                  name: "{{ resource_prefix }}-instance-2"
-                  status: "{{ instance_2.db_instance_status }}"
-                  tags: {}
-                facts: "{{ rds_instance_facts }}"
+            # db_instance_identifier is user-supplied and can be changed, so
+            # it is a fact rather than part of the dedup key; the Region-unique
+            # dbi_resource_id is the identity.
+            instance_1_tags:
+              Name: "{{ resource_prefix }}-instance-1"
+              Created_by: Ansible Indirect NodeQuery Count integration tests
+            expected_result:
+              - name: "{{ resource_prefix }}-instance-1"
+                canonical_facts:
+                  dbi_resource_id: "{{ instance_1.dbi_resource_id }}"
+                facts: >-
+                  {{ rds_instance_facts | combine({'db_instance_identifier': resource_prefix ~ '-instance-1',
+                                                   'status': instance_1.db_instance_status, 'tags': instance_1_tags}) }}
+              - name: "{{ resource_prefix }}-instance-2"
+                canonical_facts:
+                  dbi_resource_id: "{{ instance_2.dbi_resource_id }}"
+                facts: >-
+                  {{ rds_instance_facts | combine({'db_instance_identifier': resource_prefix ~ '-instance-2',
+                                                   'status': instance_2.db_instance_status, 'tags': {}}) }}
 
       always:        
         - name: Delete RDS instances

--- a/tests/integration/targets/node_query_instance_ec2/play.yaml
+++ b/tests/integration/targets/node_query_instance_ec2/play.yaml
@@ -18,10 +18,12 @@
       name: "instance-{{ resource_prefix }}"
       tags:
         resource_prefix: "{{ resource_prefix }}"
+    # Taxonomy values must be lowercase_with_underscores or the indirect-node
+    # rollup cannot bucket them.
     ec2_instance_facts:
-      device_type: "EC2"
-      infra_bucket: "Compute"
-      infra_type: "PublicCloud"
+      device_type: "ec2"
+      infra_bucket: "compute"
+      infra_type: "public_cloud"
 
   tasks:
     - block:
@@ -52,11 +54,12 @@
             that:
               - node_count == expected_result  
           vars:
-            expected_result: 
+            # canonical_facts is the only dedup key, so it holds the instance
+            # id and nothing else: state and tags both change over the life of
+            # an instance and would each re-count it.
+            expected_result:
               - name: "{{ ec2_instance_buckets.name }}"
                 canonical_facts:
-                  id: "{{ _instances.instances.0.instance_id }}"
-                  status: "{{ _instances.instances.0.state.name }}"
-                  tags: "{{ _instances.instances.0.tags }}"
-                facts: "{{ ec2_instance_facts }}"
+                  instance_id: "{{ _instances.instances.0.instance_id }}"
+                facts: "{{ ec2_instance_facts | combine({'status': _instances.instances.0.state.name, 'tags': _instances.instances.0.tags}) }}"
                 

--- a/tests/integration/targets/node_query_networking/tasks/validate_igw.yml
+++ b/tests/integration/targets/node_query_networking/tasks/validate_igw.yml
@@ -14,7 +14,7 @@
     - name: Validate result is as expected
       ansible.builtin.assert:
         that:
-          - node_count | sort(attribute='canonical_facts.id') == expected_result | sort(attribute='canonical_facts.id')
+          - node_count | sort(attribute='canonical_facts.internet_gateway_id') == expected_result | sort(attribute='canonical_facts.internet_gateway_id')
       register: test_result
   always:
     - name: Display expected result

--- a/tests/integration/targets/node_query_networking/tasks/validate_natgw.yml
+++ b/tests/integration/targets/node_query_networking/tasks/validate_natgw.yml
@@ -14,7 +14,7 @@
     - name: Validate result is as expected
       ansible.builtin.assert:
         that:
-          - node_count | sort(attribute='canonical_facts.id') == expected_result | sort(attribute='canonical_facts.id')
+          - node_count | sort(attribute='canonical_facts.nat_gateway_id') == expected_result | sort(attribute='canonical_facts.nat_gateway_id')
       register: test_result
   always:
     - name: Display expected result

--- a/tests/integration/targets/node_query_networking/tasks/validate_peering.yml
+++ b/tests/integration/targets/node_query_networking/tasks/validate_peering.yml
@@ -14,7 +14,9 @@
     - name: Validate result is as expected
       ansible.builtin.assert:
         that:
-          - node_count | sort(attribute='canonical_facts.id') == expected_result | sort(attribute='canonical_facts.id')
+          - >-
+            node_count | sort(attribute='canonical_facts.vpc_peering_connection_id')
+            == expected_result | sort(attribute='canonical_facts.vpc_peering_connection_id')
       register: test_result
   always:
     - name: Display expected result

--- a/tests/integration/targets/node_query_networking/tasks/validate_route_table.yml
+++ b/tests/integration/targets/node_query_networking/tasks/validate_route_table.yml
@@ -15,7 +15,7 @@
     - name: Validate result is as expected
       ansible.builtin.assert:
         that:
-          - node_count | sort(attribute='canonical_facts.id') == expected_result | sort(attribute='canonical_facts.id')
+          - node_count | sort(attribute='canonical_facts.route_table_id') == expected_result | sort(attribute='canonical_facts.route_table_id')
       register: test_result
   always:
     - name: Display expected result

--- a/tests/integration/targets/node_query_networking/tasks/validate_subnets.yml
+++ b/tests/integration/targets/node_query_networking/tasks/validate_subnets.yml
@@ -15,7 +15,7 @@
     - name: Validate result is as expected
       ansible.builtin.assert:
         that:
-          - node_count | sort(attribute='canonical_facts.id') == expected_result | sort(attribute='canonical_facts.id')
+          - node_count | sort(attribute='canonical_facts.subnet_id') == expected_result | sort(attribute='canonical_facts.subnet_id')
       register: test_result
   always:
     - name: Display expected result

--- a/tests/integration/targets/node_query_networking/tasks/validate_vgw.yml
+++ b/tests/integration/targets/node_query_networking/tasks/validate_vgw.yml
@@ -14,7 +14,7 @@
     - name: Validate result is as expected
       ansible.builtin.assert:
         that:
-          - node_count | sort(attribute='canonical_facts.id') == expected_result | sort(attribute='canonical_facts.id')
+          - node_count | sort(attribute='canonical_facts.vpn_gateway_id') == expected_result | sort(attribute='canonical_facts.vpn_gateway_id')
       register: test_result
   always:
     - name: Display expected result

--- a/tests/integration/targets/node_query_networking/tasks/validate_vpn.yml
+++ b/tests/integration/targets/node_query_networking/tasks/validate_vpn.yml
@@ -14,7 +14,7 @@
     - name: Validate result is as expected
       ansible.builtin.assert:
         that:
-          - node_count | sort(attribute='canonical_facts.id') == expected_result | sort(attribute='canonical_facts.id')
+          - node_count | sort(attribute='canonical_facts.vpn_connection_id') == expected_result | sort(attribute='canonical_facts.vpn_connection_id')
       register: test_result
   always:
     - name: Display expected result

--- a/tests/integration/targets/node_query_networking/templates/igw.j2
+++ b/tests/integration/targets/node_query_networking/templates/igw.j2
@@ -1,12 +1,14 @@
 {% for item in igw_facts.internet_gateways %}
-- canonical_facts:
-    id: "{{ item.internet_gateway_id }}"
-    status:
-{% for attach in item.attachments %}
-    - vpc_id: {{ attach.vpc_id }}
-      status: {{ attach.state }}
+- name: "{{ item.tags.Name | default(item.internet_gateway_id) }}"
+  canonical_facts:
+    internet_gateway_id: "{{ item.internet_gateway_id }}"
+  facts:
+    device_type: {{ networking_facts.igw }}
+{% for key, value in networking_common_facts.items() %}
+    {{ key }}: {{ value }}
 {% endfor %}
-{% if item.tags != {} %}
+    attached_vpc_ids: {{ item.attachments | default([]) | map(attribute='vpc_id') | list }}
+{% if item.tags %}
     tags:
 {% for key, value in item.tags.items() %}
       {{ key }}: {{ value }}
@@ -14,9 +16,4 @@
 {% else %}
     tags: {}
 {% endif %}
-  facts:
-    device_type: {{ networking_facts.igw }}
-{% for key, value in networking_common_facts.items()%}
-    {{ key }}: {{ value }}
-{% endfor %}
 {% endfor %}

--- a/tests/integration/targets/node_query_networking/templates/natgw.j2
+++ b/tests/integration/targets/node_query_networking/templates/natgw.j2
@@ -1,8 +1,14 @@
 {% for item in natgw_facts.result %}
-- canonical_facts:
-    id: "{{ item.nat_gateway_id }}"
+- name: "{{ item.tags.Name | default(item.nat_gateway_id) }}"
+  canonical_facts:
+    nat_gateway_id: "{{ item.nat_gateway_id }}"
+  facts:
+    device_type: {{ networking_facts.nat_gateway }}
+{% for key, value in networking_common_facts.items() %}
+    {{ key }}: {{ value }}
+{% endfor %}
     status: "{{ item.state }}"
-{% if item.tags != {} %}
+{% if item.tags %}
     tags:
 {% for key, value in item.tags.items() %}
       {{ key }}: {{ value }}
@@ -10,9 +16,4 @@
 {% else %}
     tags: {}
 {% endif %}
-  facts:
-    device_type: {{ networking_facts.nat_gateway }}
-{% for key, value in networking_common_facts.items()%}
-    {{ key }}: {{ value }}
-{% endfor %}
 {% endfor %}

--- a/tests/integration/targets/node_query_networking/templates/peering.j2
+++ b/tests/integration/targets/node_query_networking/templates/peering.j2
@@ -1,8 +1,14 @@
 {% for item in peering_facts.vpc_peering_connections %}
-- canonical_facts:
-    id: "{{ item.vpc_peering_connection_id }}"
+- name: "{{ item.tags.Name | default(item.vpc_peering_connection_id) }}"
+  canonical_facts:
+    vpc_peering_connection_id: "{{ item.vpc_peering_connection_id }}"
+  facts:
+    device_type: {{ networking_facts.peering }}
+{% for key, value in networking_common_facts.items() %}
+    {{ key }}: {{ value }}
+{% endfor %}
     status: "{{ item.status.code }}"
-{% if item.tags != {} %}
+{% if item.tags %}
     tags:
 {% for key, value in item.tags.items() %}
       {{ key }}: {{ value }}
@@ -10,9 +16,4 @@
 {% else %}
     tags: {}
 {% endif %}
-  facts:
-    device_type: {{ networking_facts.peering }}
-{% for key, value in networking_common_facts.items()%}
-    {{ key }}: {{ value }}
-{% endfor %}
 {% endfor %}

--- a/tests/integration/targets/node_query_networking/templates/route_table.j2
+++ b/tests/integration/targets/node_query_networking/templates/route_table.j2
@@ -1,7 +1,13 @@
 {% for item in route_table_facts.route_tables %}
-- canonical_facts:
-    id: "{{ item.id }}"
-{% if item.tags != {} %}
+- name: "{{ item.tags.Name | default(item.route_table_id | default(item.id)) }}"
+  canonical_facts:
+    route_table_id: "{{ item.route_table_id | default(item.id) }}"
+  facts:
+    device_type: {{ networking_facts.route_table }}
+{% for key, value in networking_common_facts.items() %}
+    {{ key }}: {{ value }}
+{% endfor %}
+{% if item.tags %}
     tags:
 {% for key, value in item.tags.items() %}
       {{ key }}: {{ value }}
@@ -9,9 +15,4 @@
 {% else %}
     tags: {}
 {% endif %}
-  facts:
-    device_type: {{ networking_facts.route_table }}
-{% for key, value in networking_common_facts.items()%}
-    {{ key }}: {{ value }}
-{% endfor %}
 {% endfor %}

--- a/tests/integration/targets/node_query_networking/templates/subnets.j2
+++ b/tests/integration/targets/node_query_networking/templates/subnets.j2
@@ -1,8 +1,14 @@
 {% for item in subnets_facts.subnets %}
-- canonical_facts:
-    id: "{{ item.subnet_id }}"
+- name: "{{ item.tags.Name | default(item.subnet_id) }}"
+  canonical_facts:
+    subnet_id: "{{ item.subnet_id }}"
+  facts:
+    device_type: {{ networking_facts.subnet }}
+{% for key, value in networking_common_facts.items() %}
+    {{ key }}: {{ value }}
+{% endfor %}
     status: "{{ item.state }}"
-{% if item.tags != {} %}
+{% if item.tags %}
     tags:
 {% for key, value in item.tags.items() %}
       {{ key }}: {{ value }}
@@ -10,9 +16,4 @@
 {% else %}
     tags: {}
 {% endif %}
-  facts:
-    device_type: {{ networking_facts.subnet }}
-{% for key, value in networking_common_facts.items()%}
-    {{ key }}: {{ value }}
-{% endfor %}
 {% endfor %}

--- a/tests/integration/targets/node_query_networking/templates/vgw.j2
+++ b/tests/integration/targets/node_query_networking/templates/vgw.j2
@@ -1,18 +1,19 @@
 {% for item in vgw_facts.virtual_gateways %}
-- canonical_facts:
-    id: "{{ item.vpn_gateway_id }}"
+- name: "{{ item.resource_tags.Name | default(item.vpn_gateway_id) }}"
+  canonical_facts:
+    vpn_gateway_id: "{{ item.vpn_gateway_id }}"
+  facts:
+    device_type: {{ networking_facts.vgw }}
+{% for key, value in networking_common_facts.items() %}
+    {{ key }}: {{ value }}
+{% endfor %}
     status: "{{ item.state }}"
-{% if item.tags != {} %}
+{% if item.resource_tags %}
     tags:
-{% for item in item.tags %}
-      {{ item['key'] }}: {{ item['value'] }}
+{% for key, value in item.resource_tags.items() %}
+      {{ key }}: {{ value }}
 {% endfor %}
 {% else %}
     tags: {}
 {% endif %}
-  facts:
-    device_type: {{ networking_facts.vgw }}
-{% for key, value in networking_common_facts.items()%}
-    {{ key }}: {{ value }}
-{% endfor %}
 {% endfor %}

--- a/tests/integration/targets/node_query_networking/templates/vpcs.j2
+++ b/tests/integration/targets/node_query_networking/templates/vpcs.j2
@@ -1,15 +1,19 @@
 {% for item in vpcs_facts.vpcs %}
-- canonical_facts:
-    id: "{{ item.id }}"
-    status: "{{ item.state }}"
-    tags:
-{% for key, value in item.tags.items()%}
-      {{ key }}: {{ value }}
-{% endfor %}
-  name: "{{ item.tags.Name }}"
+- name: "{{ item.tags.Name | default(item.vpc_id | default(item.id)) }}"
+  canonical_facts:
+    vpc_id: "{{ item.vpc_id | default(item.id) }}"
   facts:
     device_type: {{ networking_facts.vpc }}
-{% for key, value in networking_common_facts.items()%}
+{% for key, value in networking_common_facts.items() %}
     {{ key }}: {{ value }}
 {% endfor %}
+    status: "{{ item.state }}"
+{% if item.tags %}
+    tags:
+{% for key, value in item.tags.items() %}
+      {{ key }}: {{ value }}
+{% endfor %}
+{% else %}
+    tags: {}
+{% endif %}
 {% endfor %}

--- a/tests/integration/targets/node_query_networking/templates/vpn.j2
+++ b/tests/integration/targets/node_query_networking/templates/vpn.j2
@@ -1,8 +1,14 @@
 {% for item in vpn_facts.vpn_connections %}
-- canonical_facts:
-    id: "{{ item.vpn_connection_id }}"
+- name: "{{ item.tags.Name | default(item.vpn_connection_id) }}"
+  canonical_facts:
+    vpn_connection_id: "{{ item.vpn_connection_id }}"
+  facts:
+    device_type: {{ networking_facts.vpn }}
+{% for key, value in networking_common_facts.items() %}
+    {{ key }}: {{ value }}
+{% endfor %}
     status: "{{ item.state }}"
-{% if item.tags != {} %}
+{% if item.tags %}
     tags:
 {% for key, value in item.tags.items() %}
       {{ key }}: {{ value }}
@@ -10,9 +16,4 @@
 {% else %}
     tags: {}
 {% endif %}
-  facts:
-    device_type: {{ networking_facts.vpn }}
-{% for key, value in networking_common_facts.items()%}
-    {{ key }}: {{ value }}
-{% endfor %}
 {% endfor %}

--- a/tests/integration/targets/node_query_networking/vars.yml
+++ b/tests/integration/targets/node_query_networking/vars.yml
@@ -1,16 +1,19 @@
 ---
+# Taxonomy values must be lowercase_with_underscores (^[a-z0-9]+(_[a-z0-9]+)*$)
+# or the indirect-node rollup cannot bucket them; "PublicCloud" and
+# "public_cloud" become two separate buckets downstream.
 networking_common_facts:
-  infra_type: "PublicCloud"
-  infra_bucket: "Networking"
+  infra_type: "public_cloud"
+  infra_bucket: "networking"
 networking_facts:
-  vpc: "VPC"
-  subnet: "Subnet"
-  nat_gateway: "NAT Gateway"
-  igw: "Internet Gateway"
-  vgw: "Virtual Gateway"
-  route_table: "Route table"
-  vpn: "VPN Connection"
-  peering: "VPC Peering"
+  vpc: "vpc"
+  subnet: "subnet"
+  nat_gateway: "nat_gateway"
+  igw: "internet_gateway"
+  vgw: "virtual_gateway"
+  route_table: "route_table"
+  vpn: "vpn_connection"
+  peering: "vpc_peering"
 
 vpcs_info:
   - name: "{{ resource_prefix }}-1"

--- a/tests/integration/targets/node_query_networking_elb/play.yaml
+++ b/tests/integration/targets/node_query_networking_elb/play.yaml
@@ -25,14 +25,16 @@
     classic_elb_tags:
       resource_prefix: "{{ resource_prefix }}"
       test_type: "node_query_classic"
+    # Taxonomy values must be lowercase_with_underscores or the indirect-node
+    # rollup cannot bucket them.
     alb_facts:
-      device_type: "ApplicationLoadBalancer"
-      infra_bucket: "Networking"
-      infra_type: "PublicCloud"
+      device_type: "application_load_balancer"
+      infra_bucket: "networking"
+      infra_type: "public_cloud"
     classic_elb_facts:
-      device_type: "ClassicLoadBalancer"
-      infra_bucket: "Networking"
-      infra_type: "PublicCloud"
+      device_type: "classic_load_balancer"
+      infra_bucket: "networking"
+      infra_type: "public_cloud"
     default_listeners:
       - protocol: http
         load_balancer_port: 80
@@ -170,9 +172,18 @@
           ansible.builtin.assert:
             that:
               - alb_node_result | length == 1
-              - alb_node_result[0].canonical_facts.name == alb_name
-              - alb_node_result[0].canonical_facts.tags == alb_tags
-              - alb_node_result[0].facts == alb_facts
+              - alb_node_result[0].name == alb_name
+              # The ARN is the identity: a load balancer name can be reused
+              # after the load balancer is deleted, and the tags that used to
+              # live here re-counted the load balancer on every tag edit.
+              - alb_node_result[0].canonical_facts | list == ["load_balancer_arn"]
+              - >-
+                alb_node_result[0].canonical_facts.load_balancer_arn
+                == _alb_info.load_balancers[0].load_balancer_arn
+              - alb_node_result[0].facts.tags == alb_tags
+              - >-
+                alb_node_result[0].facts == alb_facts
+                | combine({"status": _alb_info.load_balancers[0].state.code, "tags": alb_tags})
 
         # Test Classic Load Balancer node query
         - name: Get Classic ELB info
@@ -189,9 +200,14 @@
           ansible.builtin.assert:
             that:
               - classic_elb_node_result | length == 1
-              - classic_elb_node_result[0].canonical_facts.name == classic_elb_name
-              - classic_elb_node_result[0].canonical_facts.tags == classic_elb_tags
-              - classic_elb_node_result[0].facts == classic_elb_facts
+              - classic_elb_node_result[0].name == classic_elb_name
+              # A classic load balancer's return carries no ARN, so the name
+              # is the only available identity.
+              - classic_elb_node_result[0].canonical_facts | list == ["load_balancer_name"]
+              - classic_elb_node_result[0].canonical_facts.load_balancer_name == classic_elb_name
+              - >-
+                classic_elb_node_result[0].facts == classic_elb_facts
+                | combine({"tags": classic_elb_tags})
 
         - name: Create an ALB without tags
           amazon.aws.elb_application_lb:
@@ -227,9 +243,15 @@
           ansible.builtin.assert:
             that:
               - alb_notags_result | length == 1
-              - alb_notags_result[0].canonical_facts.name == alb_name + "-notags"
-              - alb_notags_result[0].canonical_facts.tags == {}
-              - alb_notags_result[0].facts == alb_facts
+              - alb_notags_result[0].name == alb_name + "-notags"
+              - alb_notags_result[0].canonical_facts | list == ["load_balancer_arn"]
+              - >-
+                alb_notags_result[0].canonical_facts.load_balancer_arn
+                == _alb_notags_info.load_balancers[0].load_balancer_arn
+              - alb_notags_result[0].facts.tags == {}
+              - >-
+                alb_notags_result[0].facts == alb_facts
+                | combine({"status": _alb_notags_info.load_balancers[0].state.code, "tags": {}})
 
         - name: Create a Classic ELB without tags
           amazon.aws.elb_classic_lb:
@@ -258,9 +280,12 @@
           ansible.builtin.assert:
             that:
               - classic_elb_notags_result | length == 1
-              - classic_elb_notags_result[0].canonical_facts.name == classic_elb_name + "-notags"
-              - classic_elb_notags_result[0].canonical_facts.tags == {}
-              - classic_elb_notags_result[0].facts == classic_elb_facts
+              - classic_elb_notags_result[0].name == classic_elb_name + "-notags"
+              - classic_elb_notags_result[0].canonical_facts | list == ["load_balancer_name"]
+              - classic_elb_notags_result[0].canonical_facts.load_balancer_name == classic_elb_name + "-notags"
+              - >-
+                classic_elb_notags_result[0].facts == classic_elb_facts
+                | combine({"tags": {}})
 
       always:
         - name: Delete ALB without tags

--- a/tests/integration/targets/node_query_storage_s3/play.yaml
+++ b/tests/integration/targets/node_query_storage_s3/play.yaml
@@ -22,14 +22,16 @@
         tags:
           resource_prefix: "{{ resource_prefix }}"
       - name: "object_2.txt"
+    # Taxonomy values must be lowercase_with_underscores or the indirect-node
+    # rollup cannot bucket them.
     s3_bucket_facts:
-      device_type: "Bucket"
-      infra_bucket: "Storage"
-      infra_type: "PublicCloud"
+      device_type: "bucket"
+      infra_bucket: "storage"
+      infra_type: "public_cloud"
     s3_object_facts:
-      device_type: "Object"
-      infra_bucket: "Storage"
-      infra_type: "PublicCloud"
+      device_type: "object"
+      infra_bucket: "storage"
+      infra_type: "public_cloud"
   tasks:
     - block:
         # S3 buckets
@@ -56,16 +58,15 @@
             that:
               - node_count == expected_result  
           vars:
-            expected_result: 
-              - canonical_facts:
-                  name: "bucket-{{ resource_prefix }}-1"
-                  tags:
-                    resource_prefix: "{{ resource_prefix }}"
-                facts: "{{ s3_bucket_facts }}"
-              - canonical_facts:
-                  name: "bucket-{{ resource_prefix }}-2"
-                  tags: {}
-                facts: "{{ s3_bucket_facts }}"
+            expected_result:
+              - name: "bucket-{{ resource_prefix }}-1"
+                canonical_facts:
+                  bucket_name: "bucket-{{ resource_prefix }}-1"
+                facts: "{{ s3_bucket_facts | combine({'tags': {'resource_prefix': resource_prefix}}) }}"
+              - name: "bucket-{{ resource_prefix }}-2"
+                canonical_facts:
+                  bucket_name: "bucket-{{ resource_prefix }}-2"
+                facts: "{{ s3_bucket_facts | combine({'tags': {}}) }}"
 
         # S3 objects
         - name: Create S3 objects
@@ -94,16 +95,15 @@
             that:
               - node_count == expected_result  
           vars:
-            expected_result: 
-              - canonical_facts:
-                  name: "{{ s3_objects.0.name }}"
-                  tags:
-                    resource_prefix: "{{ resource_prefix }}"
-                facts: "{{ s3_object_facts }}"
-              - canonical_facts:
-                  name: "{{ s3_objects.1.name }}"
-                  tags: {}
-                facts: "{{ s3_object_facts }}"
+            expected_result:
+              - name: "{{ s3_objects.0.name }}"
+                canonical_facts:
+                  object_name: "{{ s3_objects.0.name }}"
+                facts: "{{ s3_object_facts | combine({'tags': {'resource_prefix': resource_prefix}}) }}"
+              - name: "{{ s3_objects.1.name }}"
+                canonical_facts:
+                  object_name: "{{ s3_objects.1.name }}"
+                facts: "{{ s3_object_facts | combine({'tags': {}}) }}"
 
       always:
         - name: Delete s3 objects from bucket

--- a/tests/integration/targets/setup_node_query/library/event_query_parser.py
+++ b/tests/integration/targets/setup_node_query/library/event_query_parser.py
@@ -32,16 +32,16 @@ node_queries:
     sample:
         {
           "s3_bucket_info":
-            '.buckets[] | select(. != null) | {
-                name: (.name // "UNKNOWN"),
+            '.buckets[]? | select(type == "object") | select(.name != null) | {
+                name: .name,
                 canonical_facts: {
-                    name: .name,
-                    tags: (.bucket_tagging // {})
+                    bucket_name: .name
                 },
                 facts: {
                     infra_type: "public_cloud",
                     infra_bucket: "storage",
-                    device_type: "object_storage"
+                    device_type: "bucket",
+                    tags: (.bucket_tagging // {})
                 }
             }'
         }

--- a/tests/integration/targets/setup_node_query/library/event_query_parser.py
+++ b/tests/integration/targets/setup_node_query/library/event_query_parser.py
@@ -32,15 +32,16 @@ node_queries:
     sample:
         {
           "s3_bucket_info":
-            '.buckets[] | select(. != null) |
+            '.buckets[] | select(. != null) | {
+                name: (.name // "UNKNOWN"),
                 canonical_facts: {
                     name: .name,
                     tags: (.bucket_tagging // {})
                 },
                 facts: {
-                    infra_type: "PublicCloud",
-                    infra_bucket: "Storage",
-                    device_type: "Bucket"
+                    infra_type: "public_cloud",
+                    infra_bucket: "storage",
+                    device_type: "object_storage"
                 }
             }'
         }

--- a/tests/unit/extensions/audit/test_event_query_contract.py
+++ b/tests/unit/extensions/audit/test_event_query_contract.py
@@ -71,12 +71,17 @@ VOLATILE_KEYS = frozenset([
     "firmware",
 ])
 
-# Stable identifiers. A display `name` alongside one of these is redundant and
+# Stable identifiers. A display name alongside one of these is redundant and
 # mutable -- renaming the object produces a second audit row for one node.
 IDENTITY_KEYS = frozenset([
     "id", "moid", "serial", "serial_number", "object_guid", "guid", "uuid",
     "ansible_product_serial", "instance_id", "arn",
 ])
+
+# Human-facing labels. Not volatile enough to reject on their own -- for some
+# resources a name is the only identity there is -- but redundant and harmful
+# next to a stable identifier.
+DISPLAY_NAME_KEYS = frozenset(["name", "host_name", "hostname", "display_name"])
 
 
 def load_queries():
@@ -214,15 +219,39 @@ def sub_object(expression):
     return dict(split_pairs(block)) if block else {}
 
 
-def emitted_literals(expression):
-    """String literals the expression can emit.
+READERS = re.compile(r"\b(?:test|match|capture|contains|split|startswith"
+                     r"|endswith|ltrimstr|rtrimstr|sub|gsub|inside)\s*\(")
 
-    Excludes arguments to test()/match()/split() and friends -- those are
-    patterns being read, not taxonomy values being written.
+
+def strip_reader_calls(expression):
+    """Blank out the arguments of test()/gsub()/match() and friends.
+
+    Those are patterns being read, not taxonomy values being written. The
+    arguments are found by matching parens rather than by a regex, because a
+    jq regex routinely contains its own -- ``gsub("(?<c>[A-Z])"; "_" + (.c |
+    ascii_downcase))`` would otherwise be cut short at the first ``)`` and
+    leave ``"(?<c>[A-Z])"`` looking like an emitted literal.
     """
-    readers = (r"\b(test|match|contains|split|startswith|endswith|ltrimstr"
-               r"|rtrimstr|sub|gsub|inside)\s*\([^()]*\)")
-    return re.findall(r'"([^"\\]*)"', re.sub(readers, " ", expression or ""))
+    text = expression or ""
+    while True:
+        found = READERS.search(text)
+        if not found:
+            return text
+        depth, index = 0, found.end() - 1
+        while index < len(text):
+            if text[index] == "(":
+                depth += 1
+            elif text[index] == ")":
+                depth -= 1
+                if depth == 0:
+                    break
+            index += 1
+        text = text[:found.start()] + " " + text[index + 1:]
+
+
+def emitted_literals(expression):
+    """String literals the expression can emit."""
+    return re.findall(r'"([^"\\]*)"', strip_reader_calls(expression))
 
 
 PATH = re.compile(
@@ -555,11 +584,12 @@ def test_canonical_facts_holds_identity_only(module):
     )
 
     identifiers = sorted(lowered & IDENTITY_KEYS)
-    assert not ("name" in lowered and identifiers), (
-        "%s: canonical_facts contains both `name` and the stable identifier(s) "
-        "%s. `name` is mutable, so renaming the object counts it as a second "
-        "node. Keep the identifier, move `name` to `facts`."
-        % (module, ", ".join(identifiers))
+    labels = sorted(lowered & DISPLAY_NAME_KEYS)
+    assert not (labels and identifiers), (
+        "%s: canonical_facts contains both the label(s) %s and the stable "
+        "identifier(s) %s. A label is mutable, so renaming the object counts it "
+        "as a second node. Keep the identifier, move the label to `facts`."
+        % (module, ", ".join(labels), ", ".join(identifiers))
     )
 
     module_name = module.split(".")[-1]

--- a/tests/unit/extensions/audit/test_event_query_contract.py
+++ b/tests/unit/extensions/audit/test_event_query_contract.py
@@ -1,173 +1,609 @@
 # -*- coding: utf-8 -*-
-
 # Copyright: Contributors to the Ansible project
 # GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
 
-"""Contract tests for ``extensions/audit/event_query.yml``.
+"""Contract tests for the indirect-node audit query file.
 
-The jq queries in that file do not just have to be valid jq -- their *output* has to satisfy a
-contract imposed by the consumer, ansible-automation-platform's indirect node counting. Output that
-violates the contract is silently discarded or mis-bucketed at ingest; the collection itself sees no
-error, and neither does any existing integration test, because those assert against hand-written
-literals rather than against the contract.
+The query file in ``extensions/audit/`` is executable code that runs inside the
+Automation Platform controller, and its output feeds subscription node counting.
+Nothing else in this repository executes it, so a change to it ships with a green
+CI run no matter what it does.
 
-Three requirements, checked here:
+These tests assert the contract that ``awx/main/tasks/host_indirect.py`` actually
+imposes -- not the output the query happens to produce today. That distinction is
+the whole point: an assertion captured from real output agrees with that output
+by construction, so it can only detect drift, never wrongness.
 
-1. A non-null top-level ``name``. The consumer cannot persist a record without one and drops it.
-2. ``infra_type``, ``infra_bucket`` and ``device_type`` are all emitted. Without them a node is
-   counted but cannot be bucketed, so it disappears from every rollup.
-3. Taxonomy values are normalized ``lowercase_with_underscores``. ``PublicCloud`` and
-   ``public_cloud`` become two distinct buckets downstream.
+The contract, read off the consumer:
 
-These are static checks by design: they need no AWS credentials and no live resources, so they run
-in the units job on every pull request -- including pull requests that touch only
-``extensions/audit/``, which the integration test splitter does not select targets for.
+* ``name``            must be present and must never be null.
+                      ``if name is None: continue``
+* ``canonical_facts`` must be present and truthy.
+                      ``if not data.get('canonical_facts'): continue``
+* ``canonical_facts`` must contain no null at any depth. ``get_hashable_form()``
+                      accepts int/float/str/bool/dict/list/tuple and raises
+                      ``UnhashableFacts`` on anything else, including ``None``;
+                      the caller catches it and skips the record. One null in one
+                      field silently discards the whole node.
+* ``canonical_facts`` is the *sole* dedup key -- ``results[hashable_facts]``. It
+                      must therefore hold identity and nothing else. A mutable
+                      field in it re-counts the same node every time it changes.
+* ``facts``           must carry ``infra_type``, ``infra_bucket`` and
+                      ``device_type``, normalised ``lowercase_with_underscores``.
+                      A node without them is counted but cannot be bucketed, so
+                      it is invisible in every rollup.
+
+These are static checks over the query source. They need no credentials, no live
+endpoint and no recorded fixture, so they run in ``ansible-test units`` on every
+change and cannot be skipped by path filtering.
 """
 
-from __future__ import annotations
+from __future__ import absolute_import, division, print_function
 
+__metaclass__ = type
+
+import os
 import re
-from pathlib import Path
 
 import pytest
 import yaml
 
-# tests/unit/extensions/audit/<this file> -> collection root
-COLLECTION_ROOT = Path(__file__).resolve().parents[4]
-EVENT_QUERY_PATH = COLLECTION_ROOT / "extensions" / "audit" / "event_query.yml"
+# --------------------------------------------------------------------------
+# Locate the query file
+# --------------------------------------------------------------------------
 
+COLLECTION_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), "..", "..", "..", "..")
+)
+AUDIT_DIR = os.path.join(COLLECTION_ROOT, "extensions", "audit")
+QUERY_FILE = os.path.join(AUDIT_DIR, "event_query.yml")
+
+NORMALIZED = re.compile(r"^[a-z0-9]+(_[a-z0-9]+)*$")
 TAXONOMY_KEYS = ("infra_type", "infra_bucket", "device_type")
 
-# The normalized form the consumer's taxonomy expects: lowercase alphanumerics, underscore separated.
-NORMALIZED = re.compile(r"^[a-z0-9]+(_[a-z0-9]+)*$")
+# Field names that change over the life of a node. Anything here inside
+# canonical_facts is an overcount: the same node is re-counted as a new one
+# every time the value changes. These belong in `facts`, which is not hashed.
+VOLATILE_KEYS = frozenset([
+    "status", "state", "tags", "hostname", "ip", "ipv4", "ipv6", "lanip",
+    "lan_ip", "mac", "management_ip", "managementip", "interface_ip",
+    "interfaceip", "address", "power_state", "powerstate", "role", "version",
+    "firmware",
+])
+
+# Stable identifiers. A display `name` alongside one of these is redundant and
+# mutable -- renaming the object produces a second audit row for one node.
+IDENTITY_KEYS = frozenset([
+    "id", "moid", "serial", "serial_number", "object_guid", "guid", "uuid",
+    "ansible_product_serial", "instance_id", "arn",
+])
 
 
 def load_queries():
-    """Return ``{module_name: jq_query}`` for every entry in event_query.yml."""
-    with EVENT_QUERY_PATH.open(encoding="utf-8") as handle:
+    with open(QUERY_FILE) as handle:
         document = yaml.safe_load(handle) or {}
-    return {name: spec["query"] for name, spec in document.items() if isinstance(spec, dict) and "query" in spec}
+    return {
+        key: (value["query"] if isinstance(value, dict) else value)
+        for key, value in document.items()
+    }
 
 
 QUERIES = load_queries()
+MODULES = sorted(QUERIES)
 
 
-def brace_blocks(query):
-    """Yield ``(start, end, inner_text)`` for every balanced ``{...}`` block in ``query``."""
-    stack = []
-    for index, character in enumerate(query):
-        if character == "{":
-            stack.append(index)
-        elif character == "}" and stack:
-            start = stack.pop()
-            yield start, index, query[start + 1 : index]
+# --------------------------------------------------------------------------
+# Minimal jq source handling -- brace matching, not a parser. Enough to find
+# two object literals and enumerate their value expressions.
+# --------------------------------------------------------------------------
+
+def strip_comments(source):
+    lines = []
+    for line in source.splitlines():
+        in_string = False
+        for index, char in enumerate(line):
+            if char == '"':
+                in_string = not in_string
+            elif char == "#" and not in_string:
+                line = line[:index]
+                break
+        lines.append(line)
+    return "\n".join(lines)
 
 
-def emitted_object(query):
-    """Return the inner text of the object the query emits.
-
-    A query may build helper objects (lookup tables keyed by resource type, for example) before
-    emitting its result, so the first ``{`` is not reliably the emitted object. The emitted object is
-    the outermost block that contains ``canonical_facts``; fall back to the outermost block overall.
-    """
-    blocks = list(brace_blocks(query))
-    if not blocks:
-        return ""
-    with_canonical_facts = [block for block in blocks if "canonical_facts" in block[2]]
-    candidates = with_canonical_facts or blocks
-    return max(candidates, key=lambda block: block[1] - block[0])[2]
-
-
-def top_level_keys(query):
-    """Return the keys declared at the top level of the emitted object."""
-    body = emitted_object(query)
+def balanced_block(source, start=0):
+    """Return the ``{...}`` block beginning at the first brace at or after start."""
+    open_at = source.find("{", start)
+    if open_at < 0:
+        return None, -1
     depth = 0
-    top_level = ""
-    for character in body:
-        if character == "{":
+    in_string = False
+    index = open_at
+    while index < len(source):
+        char = source[index]
+        if in_string:
+            if char == "\\":
+                index += 2
+                continue
+            if char == '"':
+                in_string = False
+        elif char == '"':
+            in_string = True
+        elif char == "{":
             depth += 1
-        elif character == "}":
+        elif char == "}":
             depth -= 1
-        elif depth == 0:
-            top_level += character
-    return re.findall(r"([A-Za-z_][A-Za-z0-9_]*)\s*:", top_level)
+            if depth == 0:
+                return source[open_at:index + 1], index
+        index += 1
+    return source[open_at:], len(source)
 
 
-def taxonomy_literals(query, key):
-    """Return the string literals ``key`` can be assigned in the emitted object.
+def split_pairs(block):
+    """Split a jq object literal into ``(key, value-expression)`` pairs."""
+    body = block[1:-1]
+    parts = []
+    depth = 0
+    in_string = False
+    buffer_ = []
+    for char in body:
+        if in_string:
+            buffer_.append(char)
+            if char == '"':
+                in_string = False
+            continue
+        if char == '"':
+            in_string = True
+        elif char in "{[(":
+            depth += 1
+        elif char in "}])":
+            depth -= 1
+        elif char == "," and depth == 0:
+            parts.append("".join(buffer_))
+            buffer_ = []
+            continue
+        buffer_.append(char)
+    parts.append("".join(buffer_))
 
-    A literal assignment yields one value. A computed assignment -- typically a lookup into a mapping
-    object defined earlier in the query -- yields every literal that lookup can resolve to, so
-    table-driven queries are still checked against their own tables. Returns ``None`` when the key is
-    not emitted at all.
+    pairs = []
+    for part in parts:
+        part = part.strip()
+        if not part:
+            continue
+        depth = 0
+        in_string = False
+        cut = -1
+        for index, char in enumerate(part):
+            if in_string:
+                if char == '"':
+                    in_string = False
+                continue
+            if char == '"':
+                in_string = True
+            elif char in "{[(":
+                depth += 1
+            elif char in "}])":
+                depth -= 1
+            elif char == ":" and depth == 0:
+                cut = index
+                break
+        if cut < 0:
+            pairs.append((part.strip('"'), None))
+        else:
+            pairs.append((part[:cut].strip().strip('"'), part[cut + 1:].strip()))
+    return pairs
+
+
+def emitted_record(query):
+    """The object the query emits: the last balanced block mentioning canonical_facts."""
+    source = strip_comments(query)
+    position = 0
+    found = None
+    while True:
+        block, end = balanced_block(source, position)
+        if block is None:
+            break
+        if "canonical_facts" in block:
+            found = block
+        position = end + 1
+    return found
+
+
+def sub_object(expression):
+    block, _ = balanced_block(expression or "", 0)
+    return dict(split_pairs(block)) if block else {}
+
+
+def emitted_literals(expression):
+    """String literals the expression can emit.
+
+    Excludes arguments to test()/match()/split() and friends -- those are
+    patterns being read, not taxonomy values being written.
     """
-    body = emitted_object(query)
-    match = re.search(rf'{key}\s*:\s*("([^"]*)"|\(([^)]*)\)|([^,\n}}]+))', body)
-    if not match:
-        return None
-    if match.group(2) is not None:
-        return [match.group(2)]
-    expression = (match.group(3) or match.group(4) or "").strip()
-    literals = re.findall(r'"([^"]*)"', expression)
-    if "mapping" in expression:
-        # Resolve through the lookup table the expression indexes into.
-        literals += re.findall(r':\s*"([^"]*)"', query)
-    return literals
+    readers = (r"\b(test|match|contains|split|startswith|endswith|ltrimstr"
+               r"|rtrimstr|sub|gsub|inside)\s*\([^()]*\)")
+    return re.findall(r'"([^"\\]*)"', re.sub(readers, " ", expression or ""))
 
 
-def test_event_query_file_is_present_and_parses():
-    assert EVENT_QUERY_PATH.is_file(), f"{EVENT_QUERY_PATH} is missing"
-    assert QUERIES, "event_query.yml declares no module queries"
+PATH = re.compile(
+    r"(?:\$[A-Za-z_]\w*|(?<![\w)\]\"])\.)"
+    r"(?:[A-Za-z_]\w*|\[[^\]]*\])(?:\.[A-Za-z_]\w*|\[[^\]]*\])*"
+)
 
 
-@pytest.mark.parametrize("module_name", sorted(QUERIES))
-def test_query_emits_top_level_name(module_name):
-    """Records without a top-level ``name`` are discarded by the consumer."""
-    keys = top_level_keys(QUERIES[module_name])
-    assert "name" in keys, (
-        f"{module_name}: the emitted object has no top-level 'name'. Records without one are dropped "
-        f"at ingest, so this module contributes no node data. Emitted top-level keys: {sorted(set(keys))}"
+def outer_parens_match(text):
+    """True if text[0] is the paren closed by text[-1]."""
+    if not text.startswith("(") or not text.endswith(")"):
+        return False
+    depth = 0
+    for index, char in enumerate(text):
+        if char == "(":
+            depth += 1
+        elif char == ")":
+            depth -= 1
+            if depth == 0:
+                return index == len(text) - 1
+    return False
+
+
+def split_alternatives(expression):
+    """Split a jq ``a // b // c`` chain at depth 0, outermost parens removed."""
+    text = " ".join((expression or "").split())
+    while outer_parens_match(text):
+        text = text[1:-1].strip()
+    parts = []
+    depth = 0
+    in_string = False
+    start = 0
+    index = 0
+    while index < len(text):
+        char = text[index]
+        if in_string:
+            if char == "\\":
+                index += 2
+                continue
+            if char == '"':
+                in_string = False
+        elif char == '"':
+            in_string = True
+        elif char in "{[(":
+            depth += 1
+        elif char in "}])":
+            depth -= 1
+        elif char == "/" and depth == 0 and text[index:index + 2] == "//":
+            parts.append(text[start:index].strip())
+            index += 2
+            start = index
+            continue
+        index += 1
+    parts.append(text[start:].strip())
+    return [part for part in parts if part]
+
+
+def split_top(text, operator):
+    """Split ``text`` on a depth-0 occurrence of a single-character operator."""
+    parts = []
+    depth = 0
+    in_string = False
+    start = 0
+    for index, char in enumerate(text):
+        if in_string:
+            if char == '"':
+                in_string = False
+        elif char == '"':
+            in_string = True
+        elif char in "{[(":
+            depth += 1
+        elif char in "}])":
+            depth -= 1
+        elif char == operator and depth == 0:
+            parts.append(text[start:index])
+            start = index + 1
+    parts.append(text[start:])
+    return [part.strip() for part in parts]
+
+
+def concatenates_a_literal(expression):
+    """True for a ``+`` concatenation with a string-literal operand.
+
+    jq treats null as the identity for ``+``, so ``null + ":" + null`` is
+    ``":"``, not null. Without this, every ``(.a + ":" + .b)`` name reads as a
+    null risk.
+    """
+    text = " ".join((expression or "").split())
+    while outer_parens_match(text):
+        text = text[1:-1].strip()
+    operands = split_top(text, "+")
+    if len(operands) < 2:
+        return False
+    return any(re.fullmatch(r'"[^"]*"', operand) for operand in operands)
+
+
+SAFE_FILTERS = ("ascii_downcase", "ascii_upcase", "tostring", "tojson",
+                "tonumber", "length", "ltrimstr", "rtrimstr")
+
+
+def balanced_prefix(text, close):
+    """Inner text of the parenthesised group whose ``)`` is at index ``close``.
+
+    Scans backwards, so it copes with the parens inside a jq regex literal such
+    as ``capture("(?<t>[^/]+)")`` -- those are balanced, which is what matters.
+    """
+    depth = 0
+    index = close
+    while index >= 0:
+        if text[index] == ")":
+            depth += 1
+        elif text[index] == "(":
+            depth -= 1
+            if depth == 0:
+                return text[index + 1:close]
+        index -= 1
+    return None
+
+
+def pipeline_is_safe(alternative, paths):
+    """``X | ascii_downcase`` cannot be null when ``X`` is proven non-null."""
+    stages = split_top(alternative, "|")
+    if len(stages) < 2:
+        return False
+    head = stages[0]
+    while outer_parens_match(head):
+        head = head[1:-1].strip()
+    if head not in paths:
+        return False
+    return all(
+        any(stage.startswith(name) for name in SAFE_FILTERS)
+        for stage in stages[1:]
     )
 
 
-@pytest.mark.parametrize("module_name", sorted(QUERIES))
-def test_query_emits_full_taxonomy(module_name):
-    """All three taxonomy keys are required to bucket a node."""
-    query = QUERIES[module_name]
-    missing = [key for key in TAXONOMY_KEYS if taxonomy_literals(query, key) is None]
-    assert not missing, (
-        f"{module_name}: taxonomy keys {missing} are not emitted. Nodes from this module are counted "
-        f"but cannot be bucketed, so they are absent from every rollup."
+def proven_non_null(query):
+    """What the query proves before it builds the record.
+
+    Returns ``(paths, chains)``. ``paths`` are individually non-null. ``chains``
+    are alternative sets proven non-null *collectively*: ``select((.a // .b //
+    null) != null)`` does not prove either ``.a`` or ``.b`` on its own, but it
+    does prove that ``.a // .b`` is never null.
+    """
+    source = strip_comments(query)
+    paths = set()
+    chains = []
+
+    def record(candidate):
+        alternatives = [
+            alternative for alternative in split_alternatives(candidate)
+            if alternative and alternative != "null"
+        ]
+        if len(alternatives) == 1:
+            paths.add(alternatives[0])
+        elif alternatives:
+            chains.append(frozenset(alternatives))
+
+    for match in re.finditer(r"select\s*\(([^()]*(?:\([^()]*\)[^()]*)*)\)", source):
+        condition = match.group(1)
+        for inner in re.finditer(
+            r"(\([^()]*\)|\$?[\w.\[\]]+)\s*!=\s*null", condition
+        ):
+            record(inner.group(1))
+        if re.search(r"(?:^|[\s(])\.\s*!=\s*null", condition):
+            paths.add(".")
+        # `select((.x | type) == "string")` -- null has type "null", so passing
+        # this proves .x is not null.
+        for inner in re.finditer(
+            r"\(\s*(\$?[\w.\[\]]+)\s*\|\s*type\s*\)\s*==", condition
+        ):
+            paths.add(inner.group(1))
+        # `select(.x | test("..."))` -- test() raises on null, so reaching the
+        # record at all proves .x was a string.
+        for inner in re.finditer(
+            r"^\s*(\$?[\w.\[\]]+)\s*\|\s*(?:test|startswith|endswith)\b",
+            condition,
+        ):
+            paths.add(inner.group(1))
+    # `if (.a // null) != null and (.b // null) != null then ...`
+    for match in re.finditer(r"(\([^()]*\))\s*!=\s*null", source):
+        record(match.group(1))
+
+    # Variable bindings. `(.kind // "missing") as $kind` cannot be null, and
+    # neither can `($data.id | ascii_downcase) as $arm_id` once `$data.id` is
+    # proven. A binding can depend on an earlier binding, so iterate to a fixed
+    # point rather than making a single pass.
+    bindings = []
+    for match in re.finditer(r"\)\s+as\s+(\$[A-Za-z_]\w*)", source):
+        inner = balanced_prefix(source, match.start())
+        if inner is not None:
+            bindings.append((inner.strip(), match.group(1)))
+    for match in re.finditer(
+        r"(?<![)\w])(\$?[\w.\[\]]+)\s+as\s+(\$[A-Za-z_]\w*)", source
+    ):
+        bindings.append((match.group(1), match.group(2)))
+
+    while True:
+        before = len(paths)
+        for expression, variable in bindings:
+            if variable not in paths and not can_be_null(expression, (paths, chains)):
+                paths.add(variable)
+        if len(paths) == before:
+            return paths, chains
+
+
+def can_be_null(expression, proven):
+    """True if this value expression can evaluate to null.
+
+    jq's ``//`` yields the first alternative that is neither null nor false, so
+    a chain is non-null as soon as *any one* of its alternatives is non-null.
+    Treating the whole expression as a single reference -- which is what a naive
+    check does -- reports a false positive on every guarded fallback chain.
+    """
+    if expression is None:
+        return True
+    paths, chains = proven
+    alternatives = split_alternatives(expression)
+
+    for alternative in alternatives:
+        if alternative == "null":
+            continue
+        if re.fullmatch(r'"[^"]*"|\{\}|\[\]|-?\d+|true|false', alternative):
+            return False            # a non-null literal ends the chain
+        if concatenates_a_literal(alternative):
+            return False            # null is the identity for jq's `+`
+        if alternative in paths:
+            return False            # proven non-null by an earlier guard
+        if "tostring" in alternative or "tojson" in alternative:
+            return False            # coerced to a string
+        if pipeline_is_safe(alternative, paths):
+            return False            # `<proven> | ascii_downcase` and friends
+        if not PATH.findall(alternative):
+            return False            # no path reference, cannot be null
+
+    if any(chain <= set(alternatives) for chain in chains):
+        return False                # a guard proved this exact chain non-null
+
+    return True
+
+
+# --------------------------------------------------------------------------
+# Tests
+# --------------------------------------------------------------------------
+
+def test_query_file_exists_and_parses():
+    assert os.path.isfile(QUERY_FILE), "%s is missing" % QUERY_FILE
+    assert QUERIES, "%s declares no queries" % QUERY_FILE
+
+
+@pytest.mark.parametrize("module", MODULES)
+def test_module_key_is_fully_qualified(module):
+    parts = module.split(".")
+    assert len(parts) == 3, (
+        "'%s' is not of the form namespace.collection.module. host_indirect.py "
+        "skips any key that does not split into exactly three parts, so this "
+        "query would never run." % module
     )
 
 
-@pytest.mark.parametrize("module_name", sorted(QUERIES))
-def test_taxonomy_values_are_normalized(module_name):
-    """Taxonomy values must be lowercase_with_underscores.
+@pytest.mark.parametrize("module", MODULES)
+def test_emits_a_name_that_cannot_be_null(module):
+    record = emitted_record(QUERIES[module])
+    assert record is not None, "%s: could not find the emitted record object" % module
+    pairs = dict(split_pairs(record))
 
-    This is a shape assertion rather than an equality assertion on purpose. Equality against a
-    hand-written expected value only ever describes the resource types someone wrote a fixture for,
-    so it cannot catch an unmapped resource type falling through to a raw fallback.
-    """
-    query = QUERIES[module_name]
-    offenders = {}
-    for key in TAXONOMY_KEYS:
-        literals = taxonomy_literals(query, key) or []
-        bad = sorted({value for value in literals if value and not NORMALIZED.match(value)})
-        if bad:
-            offenders[key] = bad
-    assert not offenders, (
-        f"{module_name}: taxonomy values are not normalized: {offenders}. The consumer treats "
-        f"'PublicCloud' and 'public_cloud' as two different buckets, which splits the node count."
+    assert "name" in pairs, (
+        "%s emits no top-level `name`. host_indirect.py does `if name is None: "
+        "continue`, so every node this module reports is discarded." % module
+    )
+    assert not can_be_null(pairs["name"], proven_non_null(QUERIES[module])), (
+        "%s: `name` can evaluate to null (%s). Give it a non-null fallback or "
+        "guard the record with select()." % (module, pairs["name"])
     )
 
 
-@pytest.mark.parametrize("module_name", sorted(QUERIES))
-def test_query_compiles_as_jq(module_name):
-    """Guard against a query that is syntactically invalid jq.
+@pytest.mark.parametrize("module", MODULES)
+def test_canonical_facts_is_present_and_non_empty(module):
+    pairs = dict(split_pairs(emitted_record(QUERIES[module])))
+    assert "canonical_facts" in pairs, (
+        "%s emits no `canonical_facts`. host_indirect.py does "
+        "`if not data.get('canonical_facts'): continue`." % module
+    )
+    assert sub_object(pairs["canonical_facts"]), (
+        "%s emits an empty `canonical_facts`. An empty dict is falsy, so the "
+        "record is discarded." % module
+    )
 
-    Skipped where the jq bindings are unavailable; they are an integration test dependency, not a
-    unit test one, so this check is opportunistic.
+
+@pytest.mark.parametrize("module", MODULES)
+def test_no_field_in_canonical_facts_can_be_null(module):
+    """The defect class that has no name in any documentation.
+
+    ``get_hashable_form()`` raises ``UnhashableFacts`` on ``None``. The caller
+    catches it and skips the record -- silently, logged once per job at INFO,
+    with the job still green. A single optional field referenced without a
+    fallback discards the entire node.
+
+    Note that ``// null`` does not make a field optional. It guarantees the
+    drop. If a field may be absent, either omit the key or move it to ``facts``.
     """
-    jq = pytest.importorskip("jq", reason="jq bindings not installed")
-    jq.compile(QUERIES[module_name])
+    query = QUERIES[module]
+    pairs = dict(split_pairs(emitted_record(query)))
+    proven = proven_non_null(query)
+    nullable = [
+        "canonical_facts.%s = %s" % (key, value)
+        for key, value in sub_object(pairs.get("canonical_facts", "")).items()
+        if can_be_null(value, proven)
+    ]
+    assert not nullable, (
+        "%s: these canonical_facts fields can evaluate to null, which discards "
+        "the whole record:\n    %s\nGuard the source with select(... != null), "
+        "give a non-null fallback, or move the field to `facts` (not hashed)."
+        % (module, "\n    ".join(nullable))
+    )
+
+
+@pytest.mark.parametrize("module", MODULES)
+def test_canonical_facts_holds_identity_only(module):
+    """canonical_facts is the sole dedup key, so anything mutable in it overcounts."""
+    pairs = dict(split_pairs(emitted_record(QUERIES[module])))
+    fields = sub_object(pairs.get("canonical_facts", ""))
+    lowered = set(key.lower() for key in fields)
+
+    volatile = sorted(lowered & VOLATILE_KEYS)
+    assert not volatile, (
+        "%s: canonical_facts contains mutable field(s) %s. canonical_facts is "
+        "the only dedup key (results[hashable_facts]), so the same node is "
+        "counted again every time one of these changes. Move them to `facts`, "
+        "which is not hashed." % (module, ", ".join(volatile))
+    )
+
+    identifiers = sorted(lowered & IDENTITY_KEYS)
+    assert not ("name" in lowered and identifiers), (
+        "%s: canonical_facts contains both `name` and the stable identifier(s) "
+        "%s. `name` is mutable, so renaming the object counts it as a second "
+        "node. Keep the identifier, move `name` to `facts`."
+        % (module, ", ".join(identifiers))
+    )
+
+    module_name = module.split(".")[-1]
+    discriminators = sorted(
+        key for key, value in fields.items()
+        if re.fullmatch(r'"%s"' % re.escape(module_name), (value or "").strip())
+    )
+    assert not discriminators, (
+        "%s: canonical_facts.%s is the module's own name. One physical node "
+        "touched by two modules in this collection then produces two audit "
+        "rows. Move it to `facts`."
+        % (module, ", ".join(discriminators))
+    )
+
+
+@pytest.mark.parametrize("module", MODULES)
+def test_facts_carry_the_full_taxonomy(module):
+    pairs = dict(split_pairs(emitted_record(QUERIES[module])))
+    assert "facts" in pairs, (
+        "%s emits no `facts`. The node is counted but cannot be bucketed, so it "
+        "is invisible in every rollup." % module
+    )
+    facts = sub_object(pairs["facts"])
+    missing = [key for key in TAXONOMY_KEYS if key not in facts]
+    assert not missing, "%s: facts is missing %s" % (module, ", ".join(missing))
+
+
+@pytest.mark.parametrize("module", MODULES)
+def test_taxonomy_values_are_normalized(module):
+    """Assert the shape, not the value.
+
+    An equality assertion against a captured literal cannot catch a value that
+    only appears for a resource type nobody wrote a fixture for -- which is
+    exactly where ``mapping[$x] // $x`` fallbacks leak raw API strings.
+    """
+    facts = sub_object(dict(split_pairs(emitted_record(QUERIES[module]))).get("facts", ""))
+    bad = [
+        "facts.%s = %r" % (key, literal)
+        for key in TAXONOMY_KEYS
+        for literal in emitted_literals(facts.get(key))
+        if literal and not NORMALIZED.match(literal)
+    ]
+    assert not bad, (
+        "%s: taxonomy values must match %s (lowercase_with_underscores). "
+        "Unnormalised values become separate buckets downstream:\n    %s"
+        % (module, NORMALIZED.pattern, "\n    ".join(bad))
+    )

--- a/tests/unit/extensions/audit/test_event_query_contract.py
+++ b/tests/unit/extensions/audit/test_event_query_contract.py
@@ -1,0 +1,173 @@
+# -*- coding: utf-8 -*-
+
+# Copyright: Contributors to the Ansible project
+# GNU General Public License v3.0+ (see COPYING or https://www.gnu.org/licenses/gpl-3.0.txt)
+
+"""Contract tests for ``extensions/audit/event_query.yml``.
+
+The jq queries in that file do not just have to be valid jq -- their *output* has to satisfy a
+contract imposed by the consumer, ansible-automation-platform's indirect node counting. Output that
+violates the contract is silently discarded or mis-bucketed at ingest; the collection itself sees no
+error, and neither does any existing integration test, because those assert against hand-written
+literals rather than against the contract.
+
+Three requirements, checked here:
+
+1. A non-null top-level ``name``. The consumer cannot persist a record without one and drops it.
+2. ``infra_type``, ``infra_bucket`` and ``device_type`` are all emitted. Without them a node is
+   counted but cannot be bucketed, so it disappears from every rollup.
+3. Taxonomy values are normalized ``lowercase_with_underscores``. ``PublicCloud`` and
+   ``public_cloud`` become two distinct buckets downstream.
+
+These are static checks by design: they need no AWS credentials and no live resources, so they run
+in the units job on every pull request -- including pull requests that touch only
+``extensions/audit/``, which the integration test splitter does not select targets for.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+# tests/unit/extensions/audit/<this file> -> collection root
+COLLECTION_ROOT = Path(__file__).resolve().parents[4]
+EVENT_QUERY_PATH = COLLECTION_ROOT / "extensions" / "audit" / "event_query.yml"
+
+TAXONOMY_KEYS = ("infra_type", "infra_bucket", "device_type")
+
+# The normalized form the consumer's taxonomy expects: lowercase alphanumerics, underscore separated.
+NORMALIZED = re.compile(r"^[a-z0-9]+(_[a-z0-9]+)*$")
+
+
+def load_queries():
+    """Return ``{module_name: jq_query}`` for every entry in event_query.yml."""
+    with EVENT_QUERY_PATH.open(encoding="utf-8") as handle:
+        document = yaml.safe_load(handle) or {}
+    return {name: spec["query"] for name, spec in document.items() if isinstance(spec, dict) and "query" in spec}
+
+
+QUERIES = load_queries()
+
+
+def brace_blocks(query):
+    """Yield ``(start, end, inner_text)`` for every balanced ``{...}`` block in ``query``."""
+    stack = []
+    for index, character in enumerate(query):
+        if character == "{":
+            stack.append(index)
+        elif character == "}" and stack:
+            start = stack.pop()
+            yield start, index, query[start + 1 : index]
+
+
+def emitted_object(query):
+    """Return the inner text of the object the query emits.
+
+    A query may build helper objects (lookup tables keyed by resource type, for example) before
+    emitting its result, so the first ``{`` is not reliably the emitted object. The emitted object is
+    the outermost block that contains ``canonical_facts``; fall back to the outermost block overall.
+    """
+    blocks = list(brace_blocks(query))
+    if not blocks:
+        return ""
+    with_canonical_facts = [block for block in blocks if "canonical_facts" in block[2]]
+    candidates = with_canonical_facts or blocks
+    return max(candidates, key=lambda block: block[1] - block[0])[2]
+
+
+def top_level_keys(query):
+    """Return the keys declared at the top level of the emitted object."""
+    body = emitted_object(query)
+    depth = 0
+    top_level = ""
+    for character in body:
+        if character == "{":
+            depth += 1
+        elif character == "}":
+            depth -= 1
+        elif depth == 0:
+            top_level += character
+    return re.findall(r"([A-Za-z_][A-Za-z0-9_]*)\s*:", top_level)
+
+
+def taxonomy_literals(query, key):
+    """Return the string literals ``key`` can be assigned in the emitted object.
+
+    A literal assignment yields one value. A computed assignment -- typically a lookup into a mapping
+    object defined earlier in the query -- yields every literal that lookup can resolve to, so
+    table-driven queries are still checked against their own tables. Returns ``None`` when the key is
+    not emitted at all.
+    """
+    body = emitted_object(query)
+    match = re.search(rf'{key}\s*:\s*("([^"]*)"|\(([^)]*)\)|([^,\n}}]+))', body)
+    if not match:
+        return None
+    if match.group(2) is not None:
+        return [match.group(2)]
+    expression = (match.group(3) or match.group(4) or "").strip()
+    literals = re.findall(r'"([^"]*)"', expression)
+    if "mapping" in expression:
+        # Resolve through the lookup table the expression indexes into.
+        literals += re.findall(r':\s*"([^"]*)"', query)
+    return literals
+
+
+def test_event_query_file_is_present_and_parses():
+    assert EVENT_QUERY_PATH.is_file(), f"{EVENT_QUERY_PATH} is missing"
+    assert QUERIES, "event_query.yml declares no module queries"
+
+
+@pytest.mark.parametrize("module_name", sorted(QUERIES))
+def test_query_emits_top_level_name(module_name):
+    """Records without a top-level ``name`` are discarded by the consumer."""
+    keys = top_level_keys(QUERIES[module_name])
+    assert "name" in keys, (
+        f"{module_name}: the emitted object has no top-level 'name'. Records without one are dropped "
+        f"at ingest, so this module contributes no node data. Emitted top-level keys: {sorted(set(keys))}"
+    )
+
+
+@pytest.mark.parametrize("module_name", sorted(QUERIES))
+def test_query_emits_full_taxonomy(module_name):
+    """All three taxonomy keys are required to bucket a node."""
+    query = QUERIES[module_name]
+    missing = [key for key in TAXONOMY_KEYS if taxonomy_literals(query, key) is None]
+    assert not missing, (
+        f"{module_name}: taxonomy keys {missing} are not emitted. Nodes from this module are counted "
+        f"but cannot be bucketed, so they are absent from every rollup."
+    )
+
+
+@pytest.mark.parametrize("module_name", sorted(QUERIES))
+def test_taxonomy_values_are_normalized(module_name):
+    """Taxonomy values must be lowercase_with_underscores.
+
+    This is a shape assertion rather than an equality assertion on purpose. Equality against a
+    hand-written expected value only ever describes the resource types someone wrote a fixture for,
+    so it cannot catch an unmapped resource type falling through to a raw fallback.
+    """
+    query = QUERIES[module_name]
+    offenders = {}
+    for key in TAXONOMY_KEYS:
+        literals = taxonomy_literals(query, key) or []
+        bad = sorted({value for value in literals if value and not NORMALIZED.match(value)})
+        if bad:
+            offenders[key] = bad
+    assert not offenders, (
+        f"{module_name}: taxonomy values are not normalized: {offenders}. The consumer treats "
+        f"'PublicCloud' and 'public_cloud' as two different buckets, which splits the node count."
+    )
+
+
+@pytest.mark.parametrize("module_name", sorted(QUERIES))
+def test_query_compiles_as_jq(module_name):
+    """Guard against a query that is syntactically invalid jq.
+
+    Skipped where the jq bindings are unavailable; they are an integration test dependency, not a
+    unit test one, so this check is opportunistic.
+    """
+    jq = pytest.importorskip("jq", reason="jq bindings not installed")
+    jq.compile(QUERIES[module_name])


### PR DESCRIPTION
##### SUMMARY

`extensions/audit/event_query.yml` is executable code that runs inside the Automation Platform controller (`awx/main/tasks/host_indirect.py`) and feeds subscription node counting. Nothing in this repository executes it against a real module result, so it has shipped green regardless of what it does.

Running each query against the shape its module actually returns, **only 2 of the 15 produce a countable node**:

```
before                          after
  COUNTED       2                 COUNTED      15
  DROPPED      11
  EVENT ERROR   2
```

<details>
<summary>Full before / after, per module</summary>

```
================ BEFORE
ec2_instance_info         COUNTED      {"id": "i-0abc...", "status": "running", "tags": {...}}
ec2_vpc_igw_info          EVENT ERROR  jq: error: Cannot iterate over null (null)
ec2_vpc_nat_gateway_info  DROPPED      no non-null top-level `name`
ec2_vpc_net_info          COUNTED      {"id": "vpc-0123...", "status": "available", "tags": {...}}
ec2_vpc_peering_info      DROPPED      no non-null top-level `name`
ec2_vpc_route_table_info  DROPPED      no non-null top-level `name`
ec2_vpc_subnet_info       DROPPED      no non-null top-level `name`
ec2_vpc_vgw_info          DROPPED      no non-null top-level `name`
ec2_vpc_vpn_info          DROPPED      no non-null top-level `name`
elb_application_lb_info   DROPPED      no non-null top-level `name`
elb_classic_lb_info       DROPPED      no non-null top-level `name`
rds_cluster_info          DROPPED      no non-null top-level `name`
rds_instance_info         DROPPED      no non-null top-level `name`
s3_bucket_info            DROPPED      no non-null top-level `name`
s3_object_info            EVENT ERROR  jq: error: Cannot iterate over null (null)

================ AFTER
ec2_instance_info         COUNTED      {"instance_id": "i-0abc1234def567890"}
ec2_vpc_igw_info          COUNTED      {"internet_gateway_id": "igw-0123456789abcdef0"}
ec2_vpc_nat_gateway_info  COUNTED      {"nat_gateway_id": "nat-0123456789abcdef0"}
ec2_vpc_net_info          COUNTED      {"vpc_id": "vpc-0123456789abcdef0"}
ec2_vpc_peering_info      COUNTED      {"vpc_peering_connection_id": "pcx-0123456789abcdef0"}
ec2_vpc_route_table_info  COUNTED      {"route_table_id": "rtb-0123456789abcdef0"}
ec2_vpc_subnet_info       COUNTED      {"subnet_id": "subnet-0123456789abcdef0"}
ec2_vpc_vgw_info          COUNTED      {"vpn_gateway_id": "vgw-0123456789abcdef0"}
ec2_vpc_vpn_info          COUNTED      {"vpn_connection_id": "vpn-0123456789abcdef0"}
elb_application_lb_info   COUNTED      {"load_balancer_arn": "arn:aws:elasticloadbalancing:..."}
elb_classic_lb_info       COUNTED      {"load_balancer_name": "legacy-elb"}
rds_cluster_info          COUNTED      {"db_cluster_resource_id": "cluster-ABCDEFGHIJKLMNOP"}
rds_instance_info         COUNTED      {"dbi_resource_id": "db-ABCDEFGHIJKLMNOP"}
s3_bucket_info            COUNTED      {"bucket_name": "example-prod-bucket"}
s3_object_info            COUNTED      {"object_name": "data/a.json"}   (with object_details set)
```
</details>

##### Four independent defects

**1. No top-level `name` — 13 queries.** `host_indirect.py` does `if name is None: continue`. Thirteen queries emit no `name` key at all, so every load balancer, subnet, NAT gateway, internet gateway, virtual gateway, route table, VPN connection, VPC peering, S3 bucket, S3 object, RDS instance and RDS cluster is discarded on arrival. Only `ec2_instance_info` and `ec2_vpc_net_info` emit one.

**2. A jq error takes the whole event — 2 queries.** A jq error is caught one level up, at the event, so it discards the audit records of *every other module in that event* too, not just its own.

* `.object_info[]` — `s3_object_info` returns `object_info` only when `object_details` is set. Called with `bucket_name` alone, which is its most common form, it returns `s3_keys` and the query raises `Cannot iterate over null`. Called with `object_name` but no `object_details` it returns `object_data` only, with no `object_name` key anywhere, so `canonical_facts.name` is null and the record is dropped for reason 3 instead.
* `.attachments | map(...)` — a detached internet gateway has no `attachments` key, which is the normal state of a freshly created gateway.

Every source array is now `[]?`-guarded and type-checked before it is indexed.

**3. Volatile fields in the dedup key.** `canonical_facts` is the sole dedup key — `results[hashable_facts]` — so anything in it that changes re-counts the same resource as a new one. `status` and `tags` were in all fifteen:

```
ONE EC2 instance (i-0abc1234def567890) seen running, stopped, and re-tagged
  -> distinct audit rows: 3 (expected 1)
     {"id": "i-...", "status": "running", "tags": [["Name","web-01"],["env","prod"]]}
     {"id": "i-...", "status": "running", "tags": [["Name","web-01"],["env","prod"],["owner","team-a"]]}
     {"id": "i-...", "status": "stopped", "tags": [["Name","web-01"],["env","prod"]]}
```

`rds_instance_info` and `rds_cluster_info` additionally carried the user-supplied identifier alongside the immutable resource id, so a rename counted the database twice. `elb_application_lb_info` was keyed on the load balancer *name*, which AWS allows to be reused after deletion. All of these moved to `facts`, which is not hashed.

**4. Taxonomy not normalized — all 15.** Values must be `lowercase_with_underscores` (`^[a-z0-9]+(_[a-z0-9]+)*$`). `PublicCloud` and `public_cloud` are two separate buckets downstream, and `NAT Gateway`, `Route table`, `Internet Gateway`, `Virtual Gateway`, `VPN Connection` and `VPC Peering` match no bucket at all.

One judgement call worth flagging: the two ambiguous RDS values `Instance` and `Cluster` became `database_instance` and `database_cluster` rather than `instance`/`cluster`, because those collide with unrelated resource kinds in a cross-collection rollup. Happy to change them to the literal normalization if you would rather keep the mapping one-to-one.

##### Why no test caught any of this

The `node_query_*` integration targets assert equality against expected results that were derived from the queries' own output — `templates/*.j2` literally reproduce the query logic and then compare it to the query. An assertion captured from output agrees with that output by construction: it can detect drift, never wrongness. They are also never selected on a change that touches only `extensions/audit/`, because the test splitter maps changed files to targets by module path.

This PR adds `tests/unit/extensions/audit/test_event_query_contract.py`, which asserts the contract the *consumer* imposes rather than the output the query happens to produce. It is static, needs no AWS credentials and no live resources, so it runs in the units job on every pull request including query-file-only ones. It fails on `main` and passes here.

The integration targets are updated to the corrected contract as well. Every one of their new expected results was checked locally against the queries by rendering the templates against the real module return shapes.

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
extensions/audit/event_query.yml

##### ADDITIONAL INFORMATION

Same class of defect as ansible-collections/vmware.vmware#414, ansible-collections/google.cloud#781, ansible-collections/azure#2365 and CiscoDevNet/intersight-ansible#354 — nine collections ship a query file and none of them execute it in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
